### PR TITLE
monorepo_*.sh: fix check for number of parameters

### DIFF
--- a/packages/monorepo-tools/monorepo_build.sh
+++ b/packages/monorepo-tools/monorepo_build.sh
@@ -10,7 +10,7 @@
 # Example: monorepo_build.sh main-repository package-alpha:packages/alpha package-beta:packages/beta
 
 # Check provided arguments
-if [ "$#" -le "2" ]; then
+if [ "$#" -lt "2" ]; then
     echo 'Please provide at least 2 remotes to be merged into a new monorepo'
     echo 'Usage: monorepo_build.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...'
     echo 'Example: monorepo_build.sh main-repository package-alpha:packages/alpha package-beta:packages/beta'

--- a/packages/monorepo-tools/monorepo_split.sh
+++ b/packages/monorepo-tools/monorepo_split.sh
@@ -9,7 +9,7 @@
 # Example: monorepo_split.sh main-repository package-alpha:packages/alpha package-beta:packages/beta
 
 # Check provided arguments
-if [ "$#" -le "2" ]; then
+if [ "$#" -lt "2" ]; then
     echo 'Please provide at least 2 remotes for splitting'
     echo 'Usage: monorepo_split.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...'
     echo 'Example: monorepo_split.sh main-repository package-alpha:packages/alpha package-beta:packages/beta'


### PR DESCRIPTION
use "less than 2" rather than "less or equal 2" in the condition

this allows to run monorepo_build.sh and monorepo_split.sh with 2 parameters