### PR TITLE
Symlink from root/bin to root/project-base/bin

### DIFF
--- a/bin
+++ b/bin
@@ -1,0 +1,1 @@
+/var/www/shopsys-framework/project-base/bin

--- a/project-base/CHANGELOG.md
+++ b/project-base/CHANGELOG.md
@@ -56,7 +56,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - updated presta/sitemap-bundle to version 1.5.2 in order to avoid deprecated calls (@TomasLudvik)
  - updated SitemapListener to avoid using of deprecated SitemapListenerInterface
 - updated symfony/swiftmailer-bundle to version 3.2.0 in order to fix deprecated calls (@TomasLudvik)
-- all calls of Fom::isValid() are called only on submitted forms in order to prevent deprecated call (@TomasLudvik) 
+- all calls of Fom::isValid() are called only on submitted forms in order to prevent deprecated call (@TomasLudvik)
+- symlink so root/bin acts like root/project-base/bin (@TomasLudvik) 
 
 ### Fixed
 - `BrandFacade::create()` now generates friendly URL for all domains (@sspooky13)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Most symfony developers is used to run php bin/console and running php project-base/bin/console is too long to type
|New feature| Yes
|BC breaks| No
|Fixes issues| None
|Standards and tests pass| Yes
|License| MIT

