### PR TITLE
OrderStatusFilter: show names in labels instead of ids

### DIFF
--- a/project-base/CHANGELOG.md
+++ b/project-base/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CurrentPromoCodeFacace: promo code is not searched in database if code is empty (@petr.kadlec)
 - CategoryRepository::getCategoriesWithVisibleChildren() checks visibility of children (@petr.kadlec)
 - added missing migration for privacy policy article (@MattCzerner)
+- OrderStatusFilter: show names in labels instead of ids (@simara-svatopluk)
 
 ### Removed
 - PHPStorm Inspect is no longer used for static analysis of source code (@TomasLudvik)

--- a/project-base/src/Shopsys/ShopBundle/Model/AdvancedSearchOrder/Filter/OrderStatusFilter.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/AdvancedSearchOrder/Filter/OrderStatusFilter.php
@@ -53,7 +53,7 @@ class OrderStatusFilter implements AdvancedSearchFilterInterface
     {
         return [
             'choices' => $this->orderStatusFacade->getAll(),
-            'choice_name' => 'name',
+            'choice_label' => 'name',
             'choice_value' => 'id',
             'expanded' => false,
             'multiple' => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Order status in filter shows ids but have to show names
|New feature| No
|BC breaks| No
|Fixes issues| BG-2275
|Standards and tests pass| Yes
|License| MIT
|Have you read and signed our [License Agreement for contributions](https://www.shopsys-framework.com/license-agreement)?| Yes
