### PR TITLE
order step 3: legal conditions text is not HTML escaped anymore

### DIFF
--- a/project-base/CHANGELOG.md
+++ b/project-base/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - CategoryRepository::getCategoriesWithVisibleChildren() checks visibility of children (@petr.kadlec)
 - added missing migration for privacy policy article (@MattCzerner)
 - OrderStatusFilter: show names in labels instead of ids (@simara-svatopluk)
+- legal conditions text in order 3rd step is not HTML escaped anymore (@vitek-rostislav)  
 
 ### Removed
 - PHPStorm Inspect is no longer used for static analysis of source code (@TomasLudvik)

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/legalConditions.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/legalConditions.html.twig
@@ -6,6 +6,6 @@
 
 {% block html_body %}
     <div>
-        {{ termsAndConditionsArticle.text }}
+        {{ termsAndConditionsArticle.text|raw }}
     </div>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Legal conditions text can be edited and formatted using wysiwyg in admin but the text was HTML escaped on FE
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|License| MIT
|Have you read and signed our [License Agreement for contributions](https://www.shopsys-framework.com/license-agreement)?| Yes
