### PR TITLE
upgrade to PHPUnit 7 and codeception 2.4.0 in project-base

### DIFF
--- a/project-base/CHANGELOG.md
+++ b/project-base/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - styles related to admin extracted into [shopsys/framework](https://github.com/shopsys/framework) package (@MattCzerner)
     - this will allow styles to be upgraded via `composer update` in project implementations
 - grunt now compiles less files also from [shopsys/framework](https://github.com/shopsys/framework) package (@MattCzerner)
+- updated phpunit/phpunit to version 7 (@simara-svatopluk)
 
 ## 2.0.0-beta.21.0 - 2018-03-05
 ### Added

--- a/project-base/UPGRADE.md
+++ b/project-base/UPGRADE.md
@@ -7,6 +7,7 @@
     - the upgrade will require overriding or extending of all classes now located in
     [shopsys/framework](https://github.com/shopsys/framework) that you customized in your forked repository
     - it would be wise to wait with the upgrade until the newly build architecture has matured
+- update custom tests to be compatible with phpunit 7. For further details visit phpunit release announcements [phpunit 6](https://phpunit.de/announcements/phpunit-6.html) and [phpunit 7](https://phpunit.de/announcements/phpunit-7.html)
 
 ## From 2.0.0-beta.20.0 to 2.0.0-beta.21.0
 - do not longer use Phing targets standards-ci and standards-ci-diff, use standards and standards-diff instead

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -109,11 +109,11 @@
     "require-dev": {
         "ext-pgsql": "*",
         "ext-zip": "*",
-        "codeception/codeception": "2.3.6",
+        "codeception/codeception": "2.4.0",
         "shopsys/coding-standards": "3.1.1",
-        "shopsys/http-smoke-testing": "^1.1.0",
+        "shopsys/http-smoke-testing": "dev-master",
         "phpstan/phpstan": "0.7",
-        "phpunit/phpunit": "^5.1"
+        "phpunit/phpunit": "^7.0"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
- shopsys/http-smoke-testing package has to be required as the master because only the master branch is phpunit 7 compatible and no release tag is currently released

| Q             | A
| ------------- | ---
|Description, reason for the PR| Upgrade to phpunit 7
|New feature| No
|BC breaks| Yes
|Fixes issues| 
|Standards and tests pass| Yes
|License| MIT
|Have you read and signed our [License Agreement for contributions](https://www.shopsys-framework.com/license-agreement)?| Yes
