### PR TITLE
Add forgotten dependency on joschi127/doctrine-entity-override-bundle in packages

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -64,6 +64,7 @@
         "intaro/postgres-search-bundle": "dev-master#06625bdc1d",
         "intervention/image": "2.3.14",
         "jms/translation-bundle": "1.4.1",
+        "joschi127/doctrine-entity-override-bundle": "0.5.0",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable-bundle": "1.0.3",
         "sensio/distribution-bundle": "5.0.21",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -77,6 +77,7 @@
         "intaro/postgres-search-bundle": "dev-master#06625bdc1d",
         "intervention/image": "2.3.14",
         "jms/translation-bundle": "1.4.1",
+        "joschi127/doctrine-entity-override-bundle": "0.5.0",
         "phing/phing": "2.16.1",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable-bundle": "1.0.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The dependency is only in the monorepo's composer.json, but is missing from the packages that actually use it (thus making shopsys/project-base fail on build)
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| shopsys/project-base build fails
|Standards and tests pass| Yes
|License| MIT
|Have you read and signed our [License Agreement for contributions](https://www.shopsys-framework.com/license-agreement)?| Yes