### PR TITLE
.travis.yml: added GitHub oAuth token for Composer

### DIFF
--- a/packages/framework/.travis.yml
+++ b/packages/framework/.travis.yml
@@ -4,6 +4,13 @@ php:
   - 7.1
   - 7.2
 
+cache:
+  directories:
+    - ~/.composer/cache
+
+before_install:
+  - composer config github-oauth.github.com $GITHUB_TOKEN
+
 install:
   - composer install
 


### PR DESCRIPTION
- composer install failed on Travis due to GitHub API limits
- uses environment variable GITHUB_TOKEN

| Q             | A
| ------------- | ---
|Description, reason for the PR| failing build of shopsys/framework on Travis CI: https://travis-ci.org/shopsys/framework
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| the build passed in a test branch: https://travis-ci.org/shopsys/framework/builds/365970575
|Standards and tests pass| Yes
|License| MIT
|Have you read and signed our [License Agreement for contributions](https://www.shopsys-framework.com/license-agreement)?| Yes