### PR TITLE
[BG-2402] swiftmailer setting delivery_address renamed to delivery_addresses

### DIFF
--- a/project-base/CHANGELOG.md
+++ b/project-base/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Dependency Injection strict mode is now enabled (@EdoBarnas)
     - disables autowiring features that were removed in Symfony 4
 
+### Fixed
+- swiftmailer setting `delivery_address` renamed to `delivery_addresses` as the former does not exist anymore in version 3.* (@vitek-rostislav)
+    - see https://github.com/symfony/swiftmailer-bundle/commit/5edfbd39eaefb176922a346c16b0ae3aaeec87e0
+    - the new setting requires array instead of string so the parameter `mailer_master_email_address` is wrapped into array in config
+
 ## 7.0.0-alpha1 - 2018-04-12
 - We are releasing version 7 (open-source project known as Shopsys Framework) to better distinguish it from Shopsys 6
   (internal platform of Shopsys company) and older versions that we have been developing and improving for 15 years.

--- a/project-base/app/config/config.yml
+++ b/project-base/app/config/config.yml
@@ -175,7 +175,7 @@ swiftmailer:
   password: "%mailer_password%"
   spool: { type: memory }
   disable_delivery: "%mailer_disable_delivery%"
-  delivery_address: "%mailer_master_email_address%"
+  delivery_addresses: ["%mailer_master_email_address%"]
   delivery_whitelist: "%mailer_delivery_whitelist%"
 
 twig:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the former setting does not exist anymore in version 3.* (see https://github.com/symfony/swiftmailer-bundle/commit/5edfbd39eaefb176922a346c16b0ae3aaeec87e0) and causes failing of application build when delivery_address is set to null in parameters.yml
|New feature| Yes/No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes/No
|License| MIT
|Have you read and signed our [License Agreement for contributions](https://www.shopsys-framework.com/license-agreement)?| Yes/No
