### PR TITLE
Product name indices for all domains are now created during CreateDomainsDataCommand

### DIFF
--- a/packages/framework/CHANGELOG.md
+++ b/packages/framework/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - choiceList values are prepared for js Choice(s)ToBooleanArrayTransformer (@Miroslav-Stopka)
     - fixed "The choices were not found" console js error in the params filter
 - command `shopsys:server:run` for running PHP built-in web server for a chosen domain (@TomasLudvik)
+- db indices for product name are now created for translations in all locales (@vitek-rostislav) 
 
 ## 7.0.0-alpha1 - 2018-04-12
 - We are releasing the Shopsys Framework in version 7 and we are synchronizing versions because

--- a/packages/framework/src/Command/CreateDomainsDataCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDataCommand.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator;
 use Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade;
+use Shopsys\FrameworkBundle\Model\Localization\DbIndicesFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -39,21 +40,29 @@ class CreateDomainsDataCommand extends Command
     private $multidomainEntityClassFinderFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Localization\DbIndicesFacade
+     */
+    private $dbIndicesFacade;
+
+    /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade $domainDbFunctionsFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator $domainDataCreator
      * @param \Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade $multidomainEntityClassFinderFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\DbIndicesFacade $dbIndicesFacade
      */
     public function __construct(
         EntityManagerInterface $em,
         DomainDbFunctionsFacade $domainDbFunctionsFacade,
         DomainDataCreator $domainDataCreator,
-        MultidomainEntityClassFinderFacade $multidomainEntityClassFinderFacade
+        MultidomainEntityClassFinderFacade $multidomainEntityClassFinderFacade,
+        DbIndicesFacade $dbIndicesFacade
     ) {
         $this->em = $em;
         $this->domainDbFunctionsFacade = $domainDbFunctionsFacade;
         $this->domainDataCreator = $domainDataCreator;
         $this->multidomainEntityClassFinderFacade = $multidomainEntityClassFinderFacade;
+        $this->dbIndicesFacade = $dbIndicesFacade;
 
         parent::__construct();
     }
@@ -89,5 +98,7 @@ class CreateDomainsDataCommand extends Command
         foreach ($multidomainEntitiesNames as $multidomainEntityName) {
             $output->writeln($multidomainEntityName);
         }
+        $this->dbIndicesFacade->updateLocaleSpecificIndices();
+        $output->writeln('<fg=green>All locale specific db indices updated.</fg=green>');
     }
 }

--- a/packages/framework/src/DataFixtures/Base/DbIndicesDataFixture.php
+++ b/packages/framework/src/DataFixtures/Base/DbIndicesDataFixture.php
@@ -5,21 +5,18 @@ namespace Shopsys\FrameworkBundle\DataFixtures\Base;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractNativeFixture;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Localization\DbIndicesFacade;
 
 class DbIndicesDataFixture extends AbstractNativeFixture implements DependentFixtureInterface
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
+     * @var \Shopsys\FrameworkBundle\Model\Localization\DbIndicesFacade
      */
-    private $localization;
+    private $dbIndicesFacade;
 
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
-     */
-    public function __construct(Localization $localization)
+    public function __construct(DbIndicesFacade $dbIndicesFacade)
     {
-        $this->localization = $localization;
+        $this->dbIndicesFacade = $dbIndicesFacade;
     }
 
     /**
@@ -27,11 +24,7 @@ class DbIndicesDataFixture extends AbstractNativeFixture implements DependentFix
      */
     public function load(ObjectManager $manager)
     {
-        foreach ($this->localization->getLocalesOfAllDomains() as $locale) {
-            $domainCollation = $this->localization->getCollationByLocale($locale);
-            $this->executeNativeQuery('CREATE INDEX product_translations_name_' . $locale . '_idx
-                ON product_translations (name COLLATE "' . $domainCollation . '") WHERE locale = \'' . $locale . '\'');
-        }
+        $this->dbIndicesFacade->updateLocaleSpecificIndices();
 
         $this->executeNativeQuery('CREATE INDEX product_translations_name_normalize_idx
             ON product_translations (NORMALIZE(name))');

--- a/packages/framework/src/Model/Localization/DbIndicesFacade.php
+++ b/packages/framework/src/Model/Localization/DbIndicesFacade.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Model\Localization;
+
+class DbIndicesFacade
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
+     */
+    private $localization;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Localization\DbIndicesRepository
+     */
+    private $dbIndicesRepository;
+
+    public function __construct(Localization $localization, DbIndicesRepository $dbIndicesRepository)
+    {
+        $this->localization = $localization;
+        $this->dbIndicesRepository = $dbIndicesRepository;
+    }
+
+    public function updateLocaleSpecificIndices(): void
+    {
+        foreach ($this->localization->getLocalesOfAllDomains() as $locale) {
+            $domainCollation = $this->localization->getCollationByLocale($locale);
+            $this->dbIndicesRepository->updateProductTranslationNameIndexForLocaleAndCollation($locale, $domainCollation);
+        }
+    }
+}

--- a/packages/framework/src/Model/Localization/DbIndicesRepository.php
+++ b/packages/framework/src/Model/Localization/DbIndicesRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Model\Localization;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\ResultSetMapping;
+
+class DbIndicesRepository
+{
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @param string $locale
+     * @param string $collation
+     */
+    public function updateProductTranslationNameIndexForLocaleAndCollation(string $locale, string $collation)
+    {
+        $this->em->createNativeQuery(
+            'CREATE INDEX IF NOT EXISTS product_translations_name_' . $locale . '_idx
+                ON product_translations (name COLLATE "' . $collation . '") WHERE locale = \':locale\'',
+            new ResultSetMapping()
+        )->execute(['locale' => $locale]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Db indices for product name were created only for the locale of the first domain (at the time of the creation, there were no other locales yet). Now indices are created after another domain (and locale) is added, see https://app.yodiz.com/plan/pages/board.vz?cid=10273#/app/bg-1710
|New feature| Yes
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
