### PR TITLE
[US-3766] Concrete version of docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - all installation guides verified and tweaked (@TomasLudvik)
     - Docker installation supported on Linux, MacOS and Windows 10 Pro and higher (recommended way of installing the application)
     - native installation is also supported (recommended on Windows 10 Home and lower)
+- as a rule, using minor versions of docker images (eg. `1.2` or `1.2-alpine`) if possible (@MattCzerner)
 
 ## 7.0.0-alpha1 - 2018-04-12
 ### Added

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -11,7 +11,7 @@ services:
             - POSTGRES_DB=shopsys
 
     webserver:
-        image: nginx:1-alpine
+        image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
         working_dir: /var/www/shopsys-framework
         volumes:
@@ -40,11 +40,11 @@ services:
             - redis
 
     redis:
-        image: redis:4-alpine
+        image: redis:4.0-alpine
         container_name: shopsys-framework-redis
 
     redis-admin:
-        image: erikdubbelboer/phpredisadmin:latest
+        image: erikdubbelboer/phpredisadmin:v1.10.2
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome
+        image: selenium/standalone-chrome:3.11
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"
@@ -67,7 +67,7 @@ services:
             - webserver
 
     adminer:
-        image: adminer:latest
+        image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
@@ -77,7 +77,7 @@ services:
             - postgres
 
     smtp-server:
-        image: namshi/smtp
+        image: namshi/smtp:latest
         container_name: shopsys-framework-smtp-server
 
 volumes:

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -11,7 +11,7 @@ services:
             - POSTGRES_DB=shopsys
 
     webserver:
-        image: nginx:1-alpine
+        image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
         working_dir: /var/www/shopsys-framework
         volumes:
@@ -40,11 +40,11 @@ services:
             - redis
 
     redis:
-        image: redis:4-alpine
+        image: redis:4.0-alpine
         container_name: shopsys-framework-redis
 
     redis-admin:
-        image: erikdubbelboer/phpredisadmin:latest
+        image: erikdubbelboer/phpredisadmin:v1.10.2
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome
+        image: selenium/standalone-chrome:3.11
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"
@@ -67,7 +67,7 @@ services:
             - webserver
 
     adminer:
-        image: adminer:latest
+        image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
@@ -77,5 +77,5 @@ services:
             - postgres
 
     smtp-server:
-        image: namshi/smtp
+        image: namshi/smtp:latest
         container_name: shopsys-framework-smtp-server

--- a/project-base/CHANGELOG.md
+++ b/project-base/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - moved from `\Shopsys\Environment` to `\Shopsys\FrameworkBundle\Component\Environment\EnvironmentType`
 - Dependency Injection strict mode is now enabled (@EdoBarnas)
     - disables autowiring features that were removed in Symfony 4
+- as a rule, using minor versions of docker images (eg. `1.2` or `1.2-alpine`) if possible (@MattCzerner)
 
 ### Removed
 - support of installation using Docker for Windows 10 Home and lower (@TomasLudvik)

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -11,7 +11,7 @@ services:
             - POSTGRES_DB=shopsys
 
     webserver:
-        image: nginx:1-alpine
+        image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
         working_dir: /var/www/shopsys-framework
         volumes:
@@ -40,11 +40,11 @@ services:
             - redis
 
     redis:
-        image: redis:4-alpine
+        image: redis:4.0-alpine
         container_name: shopsys-framework-redis
 
     redis-admin:
-        image: erikdubbelboer/phpredisadmin:latest
+        image: erikdubbelboer/phpredisadmin:v1.10.2
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome
+        image: selenium/standalone-chrome:3.11
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"
@@ -67,7 +67,7 @@ services:
             - webserver
 
     adminer:
-        image: adminer:latest
+        image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
@@ -77,11 +77,12 @@ services:
             - postgres
 
     smtp-server:
-        image: namshi/smtp
+        image: namshi/smtp:latest
         container_name: shopsys-framework-smtp-server
 
 volumes:
     shopsys-framework-sync:
         external: true
+
     shopsys-framework-postgres-data-sync:
         external: true

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -11,7 +11,7 @@ services:
             - POSTGRES_DB=shopsys
 
     webserver:
-        image: nginx:1-alpine
+        image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
         working_dir: /var/www/shopsys-framework
         volumes:
@@ -40,11 +40,11 @@ services:
             - redis
 
     redis:
-        image: redis:4-alpine
+        image: redis:4.0-alpine
         container_name: shopsys-framework-redis
 
     redis-admin:
-        image: erikdubbelboer/phpredisadmin:latest
+        image: erikdubbelboer/phpredisadmin:v1.10.2
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome
+        image: selenium/standalone-chrome:3.11
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"
@@ -67,7 +67,7 @@ services:
             - webserver
 
     adminer:
-        image: adminer:latest
+        image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
@@ -77,5 +77,5 @@ services:
             - postgres
 
     smtp-server:
-        image: namshi/smtp
+        image: namshi/smtp:latest
         container_name: shopsys-framework-smtp-server


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Images are now in concrete version, which assures that users will always download same version of environment.
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
