### PR TITLE
[US-3646] docs: coding-standards: visibility of all properties and me…

### DIFF
--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -95,3 +95,4 @@ Besides the rules that are checked by automatic tools, we have few rules for whi
     }
     ```
 - Entities have to be created by factories. Only allowed exception are `*Translation` entities that are created by their owner entity.
+- Visibility of all properties and methods of entities must be protected or public to enable extensibility. 


### PR DESCRIPTION
…thods of entities must be protected or public to enable extensibility

| Q             | A
| ------------- | ---
|Description, reason for the PR| [US-3646] Rule about visibility of all properties and methods of entities must be protected or public is not checked automatically
|New feature| No 
|BC breaks| No 
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
