### PR TITLE
[BG-2648] admin: brand edit page: URLs setting rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### [shopsys/project-base]
+#### Fixed
+- [#131 - correct rendering of checkbox label](https://github.com/shopsys/shopsys/pull/131):
+    - `Front/Form/theme.html.twig`: block `checkbox_row` now uses block `form_label` for proper label rendering
+        - the absence of `label` html tag was causing problems with JS validation (the error message was not included in the popup overview)
 
 ## [7.0.0-alpha2] - 2018-05-24
 ### [shopsys/framework]
@@ -100,7 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
         - see https://github.com/symfony/swiftmailer-bundle/commit/5edfbd39eaefb176922a346c16b0ae3aaeec87e0
         - the new setting requires array instead of string so the parameter `mailer_master_email_address` is wrapped into array in config
 - [`FpJsFormValidator` error in console on FE order pages](https://github.com/shopsys/shopsys/commit/fbadde0966e92941dd470591d6a8a4924a798aa8)
-- [failure during Docker image build triggered by `E: Unable to locate package postgresql-client-9.5`](https://github.com/shopsys/shopsys/pull/110)
+- [failure during Docker image build triggered by `E: Unable to locate package postgresql-client-9.5`](https://github.com/shopsys/shopsys/pull/110) 
 
 #### Removed
 - [#94 - Installation guide update](https://github.com/shopsys/shopsys/pull/94): 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### [shopsys/framework]
+#### Fixed
+- [#132 - Admin: brand edit page: URLs setting rendering](https://github.com/shopsys/shopsys/pull/132):
+    - admin: brand detail page: rendering of URLs setting
+        - brand creation: URLs setting is not rendered at all
+        - brand editing: URLs section is rendered in the SEO section
+
 ### [shopsys/project-base]
 #### Fixed
 - [#131 - correct rendering of checkbox label](https://github.com/shopsys/shopsys/pull/131):
@@ -83,7 +90,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - command `shopsys:server:run` for running PHP built-in web server for a chosen domain
 - [#108 - demo entity extension](https://github.com/shopsys/shopsys/pull/108)
     - db indices for product name are now created for translations in all locales 
-    - `LoadDataFixturesCommand` - fixed the `--fixtures` option description 
+    - `LoadDataFixturesCommand` - fixed the `--fixtures` option description
 
 ### [shopsys/project-base]
 #### Added

--- a/packages/framework/src/Resources/views/Admin/Content/Brand/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Brand/detail.html.twig
@@ -24,6 +24,7 @@
                 {{ seoFormRowMacros.multidomainRow(form.seoTitles, 'Page title'|trans, 60) }}
                 {{ seoFormRowMacros.multidomainRow(form.seoMetaDescriptions, 'Meta description'|trans, 155, 'input--domain') }}
                 {{ seoFormRowMacros.multidomainRow(form.seoH1s, 'Heading (H1)'|trans) }}
+                {% block brand_urls %}{% endblock %}
             </div>
         </div>
 

--- a/packages/framework/src/Resources/views/Admin/Content/Brand/new.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Brand/new.html.twig
@@ -2,3 +2,7 @@
 
 {% block title %}- {{ 'New brand'|trans }}{% endblock %}
 {% block h1 %}{{ 'New brand'|trans }}{% endblock %}
+
+{% block brand_urls %}
+    {% do form.brandData.urls.setRendered %}
+{% endblock %}

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig
@@ -57,11 +57,7 @@
                     {{ form_widget(form) }}
                 </div>
                 <div class="form-choice__label">
-                    {% if rawLabel is defined and rawLabel %}
-                        {{ label|raw }}
-                    {% else %}
-                        {{ label }}
-                    {% endif %}
+                    {{ form_label(form, label) }}
                     {% set errors_attr = errors_attr|default({})|merge({'class': (errors_attr.class|default('form-error--choice'))}) %}
                     {{ form_errors(form, { errors_attr: errors_attr } ) }}
                     {{ block('icon') }}
@@ -97,7 +93,11 @@
                 {% set label = name|humanize %}
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-                {{ label }}
+                {% if rawLabel is defined and rawLabel %}
+                    {{ label|raw }}
+                {% else %}
+                    {{ label }}
+                {% endif %}
                 {% if not withoutColon|default(false) %}:{% endif %}
                 {% if required %}<span class="form-input-required">*</span>{% endif %}
             </label>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| admin: brand detail page: fixed rendering of URLs setting - brand creation: URLs setting is not rendered at all; brand editing: URLs section is rendered in the SEO section
|New feature| Yes
|BC breaks| Yes
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
