### PR TITLE
disallow clearing of associations between Transports and Payments

### DIFF
--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -119,10 +119,14 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
      */
     public function setTransports(array $transports)
     {
-        $this->clearTransports();
+        foreach ($this->transports as $currentTransport) {
+            if (!in_array($currentTransport, $transports, true)) {
+                $this->removeTransport($currentTransport);
+            }
+        }
 
-        foreach ($transports as $transport) {
-            $this->addTransport($transport);
+        foreach ($transports as $newTransport) {
+            $this->addTransport($newTransport);
         }
     }
 
@@ -134,13 +138,6 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
         if ($this->transports->contains($transport)) {
             $this->transports->removeElement($transport);
             $transport->removePayment($this);
-        }
-    }
-
-    protected function clearTransports()
-    {
-        foreach ($this->transports as $transport) {
-            $this->removeTransport($transport);
         }
     }
 

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -268,10 +268,14 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
      */
     public function setPayments(array $payments)
     {
-        $this->clearPayments();
+        foreach ($this->payments as $currentPayment) {
+            if (!in_array($currentPayment, $payments, true)) {
+                $this->removePayment($currentPayment);
+            }
+        }
 
-        foreach ($payments as $payment) {
-            $this->addPayment($payment);
+        foreach ($payments as $newPayment) {
+            $this->addPayment($newPayment);
         }
     }
 
@@ -283,13 +287,6 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
         if ($this->payments->contains($payment)) {
             $this->payments->removeElement($payment);
             $payment->removeTransport($this);
-        }
-    }
-
-    protected function clearPayments()
-    {
-        foreach ($this->payments as $payment) {
-            $this->removePayment($payment);
         }
     }
 


### PR DESCRIPTION
- the clearTransports / clearPayments method was used only once and shouldn't be a part of the class' interface
- it isn't necessary to clear the transports / payments while setting the associations

| Q             | A
| ------------- | ---
|Description, reason for the PR| the clear method was unnecessary (KISS, YAGNI), the associations shouldn't be removed and then added when calling `$transport->setPayments($transport->getPayments())` - no actual changes should be made
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
