### PR TITLE
JsFormValidatorBundle security issue with Ajax validation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `Front/Form/theme.html.twig`: block `checkbox_row` now uses block `form_label` for proper label rendering
         - the absence of `label` html tag was causing problems with JS validation (the error message was not included in the popup overview)
 
+#### Security
+- [#178 - JsFormValidatorBundle security issue with Ajax validation](https://github.com/shopsys/shopsys/pull/178)
+    - removed the bundle's public route that allowed lookup any DB table by any field
+    - the purpose of the route is for ajax validation of an entity uniqueness but the feature is not used anyway  
+
 ## [7.0.0-alpha2] - 2018-05-24
 ### [shopsys/framework]
 #### Added

--- a/project-base/app/config/routing.yml
+++ b/project-base/app/config/routing.yml
@@ -7,7 +7,3 @@ shopsys_framework:
   
 elfinder:
   resource: "@FMElfinderBundle/Resources/config/routing.yml"
-  
-fp_js_form_validator:
-  resource: "@FpJsFormValidatorBundle/Resources/config/routing.xml"
-  prefix: /fp_js_form_validator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We do not want to expose public route that allows anyone to lookup any DB table by any field
|New feature| No
|BC breaks| Yes
|Fixes issues| #177
|Standards and tests pass| No - due to the issue in doctrine-translatable-bundle, see https://github.com/Prezent/doctrine-translatable-bundle/pull/21
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
