### PR TITLE
Js validation: fix dynamically added item to collection from prototype

### DIFF
--- a/packages/framework/src/Resources/scripts/common/validation/customizeBundle.js
+++ b/packages/framework/src/Resources/scripts/common/validation/customizeBundle.js
@@ -115,6 +115,22 @@
         Shopsys.timeout.setTimeoutAndClearPrevious('Shopsys.validation.validateWithParentsDelayed', executeDelayedValidators, 100);
     };
 
+    // Issue in dynamic collections validation
+    // https://github.com/formapro/JsFormValidatorBundle/issues/139
+    FpJsFormValidator._preparePrototype = FpJsFormValidator.preparePrototype;
+    FpJsFormValidator.preparePrototype = function (prototype, name, id) {
+        prototype.name = prototype.name.replace(/__name__/g, name);
+        prototype.id = prototype.id.replace(/__name__/g, name);
+
+        if (typeof prototype.children === 'object') {
+            for (var childName in prototype.children) {
+                prototype[childName] = this.preparePrototype(prototype.children[childName], name, id);
+            }
+        }
+
+        return prototype;
+    };
+
     Shopsys.validation.removeDelayedValidationWithParents = function (jsFormValidator) {
         do {
             delete delayedValidators[jsFormValidator.id];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| JS validation on new item in collection from prototype does not work. Eg new product parameter on product editation.
|New feature| No
|BC breaks| No
|Fixes issues| Not, only one issue
|Standards and tests pass| I hope
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

I did not update CHANGELOG.md, I did not know link to this futured pull request :( I am demotivated about updating of it twice (befor pull request and after creating...)