### PR TITLE
services_test.yml: added services used in tests so they are marked as public

### DIFF
--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -61,6 +61,16 @@ services:
 
   Shopsys\FrameworkBundle\Model\Feed\Delivery\DeliveryFeedItemRepository: ~
 
+  Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade:
+    arguments:
+      - '%shopsys.default_db_schema_filepath%'
+
+  Shopsys\FrameworkBundle\Component\Domain\Domain:
+    factory: ['@Shopsys\FrameworkBundle\Component\Domain\DomainFactory', create]
+    arguments:
+      - '%shopsys.domain_config_filepath%'
+      - '%shopsys.domain_urls_config_filepath%'
+
   Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader: ~
 
   Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| services loaded from service container directly must be public
|New feature| No
|BC breaks| No
|Fixes issues| No
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
