### PR TITLE
coding-standards package is now up to date with new PHP_codesniffer v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#143](https://github.com/shopsys/shopsys/pull/143) [EasyCodingStandard v4.3.0](https://github.com/Symplify/EasyCodingStandard/tree/4.3) is now used
     - rules config file changed its format from neon to yaml
 
+##### Fixed
+- [#222 - coding-standards package is now up to date with new PHP_codesniffer v3.3.0](https://github.com/shopsys/shopsys/pull/222)
+    - import of parent class of ForbiddenExitSniff was corrected
+
 ### [shopsys/form-types-bundle]
 #### Changed
 - [#143 - Shopsys framework now uses latest version of Shopsys coding standards](https://github.com/shopsys/shopsys/pull/143) [Shopsys Coding Standards dev-master](./packages/coding-standards/) is now used

--- a/packages/coding-standards/src/Sniffs/ForbiddenExitSniff.php
+++ b/packages/coding-standards/src/Sniffs/ForbiddenExitSniff.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\CodingStandards\Sniffs;
 
-use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\ForbiddenFunctionsSniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff;
 
 final class ForbiddenExitSniff extends ForbiddenFunctionsSniff
 {


### PR DESCRIPTION
…ackage v3.3.0

- import of parent class of ForbiddenExitSniff was corrected

| Q             | A
| ------------- | ---
|Description, reason for the PR| fix build and ecs checks
|New feature| No
|BC breaks| No
|Fixes issues| #221 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
