### PR TITLE
php-fpm/Dockerfile: switch to another mirror of alpine linux repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#131 - correct rendering of checkbox label](https://github.com/shopsys/shopsys/pull/131):
     - `Front/Form/theme.html.twig`: block `checkbox_row` now uses block `form_label` for proper label rendering
         - the absence of `label` html tag was causing problems with JS validation (the error message was not included in the popup overview)
+- [#229 - php-fpm/Dockerfile: switch to another mirror of alpine linux repository](https://github.com/shopsys/shopsys/pull/229):
+    - fix uninstallable postgres 9.5 by using repository https://dl-cdn.alpinelinux.org/alpine/ instead of https://dl-3.alpinelinux.org/alpine/
 
 #### Security
 - [#178 - JsFormValidatorBundle security issue with Ajax validation](https://github.com/shopsys/shopsys/pull/178)

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -49,11 +49,11 @@ RUN apk add --update nodejs-npm
 RUN npm install -g grunt-cli
 
 # install postgresql to allow execution of pg_dump for acceptance tests (using older repository to install version 9.5)
-RUN apk add --update --no-cache --repository https://dl-3.alpinelinux.org/alpine/v3.4/main "postgresql<9.6"
+RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.4/main "postgresql<9.6"
 
 # install locales and switch to en_US.utf8 in order to enable UTF-8 support
 # see https://github.com/docker-library/php/issues/240#issuecomment-305038173
-RUN apk add --update --no-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing gnu-libiconv
+RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing gnu-libiconv
 ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
 ENV LC_ALL=en_US.utf8 LANG=en_US.utf8 LANGUAGE=en_US.utf8
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| seems like our Docker build broke again (remove your cached images if you cannot duplicate the issue and run `docker-compose up -d --force-recreate --build`)
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| the originally used mirror https://dl-3.alpinelinux.org/alpine/ doesn't have the v3.4 directory anymore and the Docker build ends in an error
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
