### PR TITLE
composer-dev updates dependencies if composer.json was changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#143](https://github.com/shopsys/shopsys/pull/143) [Shopsys Coding Standards dev-master](./packages/coding-standards/) is now used
     - php-cs-fixer, phpcs, phpmd binaries replaced by ecs binaries
     - build scripts were modified to work with new easy-coding-standard checker 
+- [#230 - composer-dev updates dependencies if composer.json was changed](https://github.com/shopsys/shopsys/pull/230)
  
 ### [shopsys/coding-standards]
 ##### Changed

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,29 @@
     <import file="project-base/build-dev.xml" />
     <import file="project-base/build.xml" />
 
+    <target name="composer-dev" description="Installs dependencies for development if composer.lock is valid, otherwise runs composer update.">
+        <exec executable="${path.composer.executable}" returnProperty="composer.validate.returnCode">
+            <arg value="validate" />
+            <arg value="--no-check-all" />
+            <arg value="--no-check-publish" />
+        </exec>
+        <if>
+            <equals arg1="${composer.validate.returnCode}" arg2="0"/>
+            <then>
+                <echo message="The lock file is valid, installing dependencies..."/>
+                <property name="composer.action" value="install"/>
+            </then>
+            <else>
+                <echo message="The lock file is invalid, updating dependencies..."/>
+                <property name="composer.action" value="update"/>
+            </else>
+        </if>
+        <exec executable="${path.composer.executable}" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="${composer.action}"/>
+        </exec>
+        <phingcall target="composer-check" />
+    </target>
+
     <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check,standards-packages" description="Checks coding standards in both project-base and packages."/>
     <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff,standards-packages" description="Checks coding standards on changed files in project-base and all files in packages."/>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Because we do not commit the composer.lock in monorepo it was necessary to execute "composer update" manually whenever composer.json was changed and that felt weird to me as it is a part of the usual workflow. Phing target "composer-dev" (e.g. as a part of "build-demo-dev") executed in monorepo will now run "composer update" instead of "composer install" if composer.lock is out-dated.
|New feature| Kinda <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| Running "build-demo-dev" in monorepo now results in correct build of the application even if composer.json changes were fetched.
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
