### PR TITLE
docker-sync.yml.dist: fix relative path to postgres-data folder

### DIFF
--- a/docker/conf/docker-sync.yml.dist
+++ b/docker/conf/docker-sync.yml.dist
@@ -6,4 +6,4 @@ syncs:
         sync_excludes: ['project-base/docker/']
 
     shopsys-framework-postgres-data-sync:
-        src: './var/postgres-data/'
+        src: './project-base/var/postgres-data/'

--- a/docker/conf/docker-sync.yml.dist
+++ b/docker/conf/docker-sync.yml.dist
@@ -6,4 +6,4 @@ syncs:
         sync_excludes: ['project-base/docker/']
 
     shopsys-framework-postgres-data-sync:
-        src: './project-base/var/postgres-data/'
+        src: './var/postgres-data/'

--- a/project-base/docker/conf/docker-sync.yml.dist
+++ b/project-base/docker/conf/docker-sync.yml.dist
@@ -3,7 +3,7 @@ syncs:
     shopsys-framework-sync:
         sync_userid: 501
         src: './'
-        sync_excludes: ['project-base/docker/']
+        sync_excludes: ['docker/']
 
     shopsys-framework-postgres-data-sync:
-        src: './project-base/var/postgres-data/'
+        src: './var/postgres-data/'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Docker sync fails due to non-existent directory path: `Starting native_osx for sync shopsys-framework-postgres-data-sync``/Library/Ruby/Gems/2.3.0/gems/docker-sync-0.5.7/lib/docker-sync/sync_strategy/native_osx.rb:41:in 'realpath': No such file or directory @ realpath_rec - /Users/davidkuna/www/project-base/project-base (Errno::ENOENT)`
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
