### PR TITLE
monorepo: package-lock.json is gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /docker-compose.yml
 /docker-sync.yml
 /project-base/composer.lock
+/project-base/package-lock.json


### PR DESCRIPTION
- the file is automatically generated during npm install, see https://docs.npmjs.com/files/package-lock.json
- the principle is the same as with composer.lock that is also gitignored in monorepo

| Q             | A
| ------------- | ---
|Description, reason for the PR| we want to unify the approach to generated lock files with composer and prevent developers from accidentally committing the generated file
|New feature| Yes/No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes/No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes/No
