### PR TITLE
CartWatcherFacade: fixed swapped messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#316 - Admin: feed items on feeds generation page contain clickable link and datetime](https://github.com/shopsys/shopsys/pull/316)
     - checks for existing file and for modified time of file use abstract filesystem methods
 - [#291 - Dropped triggers before creation](https://github.com/shopsys/shopsys/pull/314)
+- [#263 - CartWatcherFacade: fixed swapped messages](https://github.com/shopsys/shopsys/pull/263)
 
 ### [shopsys/shopsys]
 #### Changed

--- a/packages/framework/src/Model/Cart/Watcher/CartWatcherFacade.php
+++ b/packages/framework/src/Model/Cart/Watcher/CartWatcherFacade.php
@@ -59,7 +59,7 @@ class CartWatcherFacade
 
         foreach ($modifiedItems as $cartItem) {
             $this->flashMessageSender->addInfoFlashTwig(
-                t('Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order.'),
+                t('The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order.'),
                 ['name' => $cartItem->getName()]
             );
         }
@@ -81,7 +81,7 @@ class CartWatcherFacade
             try {
                 $productName = $cartItem->getName();
                 $this->flashMessageSender->addErrorFlashTwig(
-                    t('The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order.'),
+                    t('Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order.'),
                     ['name' => $productName]
                 );
             } catch (\Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException $e) {


### PR DESCRIPTION
| Q             | A 
| ------------- | 
|Description, reason for the PR| Messages in CartWatcherFacade has been switched
|New feature| No
|BC breaks| No
|Fixes issues| No
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
