### PR TITLE
[WIP] Moving price management logic from facade to entity

### DIFF
--- a/packages/framework/src/Migrations/Version20180613140827.php
+++ b/packages/framework/src/Migrations/Version20180613140827.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20180613140827 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->sql('
+            ALTER TABLE payment_prices
+            DROP CONSTRAINT "payment_prices_pkey",
+            ADD id SERIAL NOT NULL,
+            ADD PRIMARY KEY (id)
+        ');
+        $this->sql('CREATE UNIQUE INDEX payment_prices_uni ON payment_prices (payment_id, currency_id)');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -106,7 +106,6 @@ class PaymentFacade
         $payment = $this->paymentFactory->create($paymentData);
         $this->em->persist($payment);
         $this->em->flush();
-        $this->updatePaymentPrices($payment, $paymentData->pricesByCurrencyId);
         $this->setAdditionalDataAndFlush($payment, $paymentData);
 
         return $payment;
@@ -118,8 +117,7 @@ class PaymentFacade
      */
     public function edit(Payment $payment, PaymentData $paymentData)
     {
-        $payment->edit($paymentData);
-        $this->updatePaymentPrices($payment, $paymentData->pricesByCurrencyId);
+        $payment->edit($paymentData, $this->currencyFacade->getAll(), $this->paymentPriceFactory);
         $this->setAdditionalDataAndFlush($payment, $paymentData);
     }
 
@@ -171,18 +169,6 @@ class PaymentFacade
         $allPayments = $this->paymentRepository->getAll();
 
         return $this->paymentVisibilityCalculation->filterVisible($allPayments, $domainId);
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Payment\Payment $payment
-     * @param string[] $pricesByCurrencyId
-     */
-    protected function updatePaymentPrices(Payment $payment, $pricesByCurrencyId)
-    {
-        foreach ($this->currencyFacade->getAll() as $currency) {
-            $price = $pricesByCurrencyId[$currency->getId()];
-            $payment->setPrice($this->paymentPriceFactory, $currency, $price);
-        }
     }
 
     /**

--- a/packages/framework/src/Model/Payment/PaymentFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentFactory.php
@@ -2,8 +2,29 @@
 
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
+
 class PaymentFactory implements PaymentFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade
+     */
+    protected $currencyFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactoryInterface
+     */
+    protected $paymentPriceFactory;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactoryInterface $paymentPriceFactory
+     */
+    public function __construct(CurrencyFacade $currencyFacade, PaymentPriceFactoryInterface $paymentPriceFactory)
+    {
+        $this->currencyFacade = $currencyFacade;
+        $this->paymentPriceFactory = $paymentPriceFactory;
+    }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $data
@@ -11,6 +32,6 @@ class PaymentFactory implements PaymentFactoryInterface
      */
     public function create(PaymentData $data): Payment
     {
-        return new Payment($data);
+        return new Payment($data, $this->currencyFacade->getAll(), $this->paymentPriceFactory);
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentPrice.php
+++ b/packages/framework/src/Model/Payment/PaymentPrice.php
@@ -6,15 +6,28 @@ use Doctrine\ORM\Mapping as ORM;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 /**
- * @ORM\Table(name="payment_prices")
+ * @ORM\Table(
+ *     name="payment_prices",
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(name="payment_prices_uni",columns={"payment_id", "currency_id"})
+ *     }
+ * )
  * @ORM\Entity
  */
 class PaymentPrice
 {
     /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\Payment
      *
-     * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Payment\Payment", inversedBy="prices")
      * @ORM\JoinColumn(nullable=false)
      */
@@ -23,7 +36,6 @@ class PaymentPrice
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency
      *
-     * @ORM\Id
      * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency")
      * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
      */

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -166,3 +166,5 @@ services:
   Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade: ~
 
   Shopsys\FrameworkBundle\Model\Localization\Localization: ~
+
+  Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory: ~

--- a/packages/framework/tests/Unit/Model/Customer/CustomerServiceTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerServiceTest.php
@@ -22,6 +22,7 @@ use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportData;
 
@@ -167,6 +168,7 @@ class CustomerServiceTest extends TestCase
     public function testGetAmendedCustomerDataByOrderWithoutChanges()
     {
         $customerService = $this->getCustomerService();
+        $paymentPriceFactoryMock = $this->createMock(PaymentPriceFactory::class);
 
         $userData = new UserData();
         $userData->firstName = 'firstName';
@@ -202,7 +204,7 @@ class CustomerServiceTest extends TestCase
         $user = new User($userData, $billingAddress, $deliveryAddress);
 
         $transport = new Transport(new TransportData(['cs' => 'transportName']));
-        $payment = new Payment(new PaymentData(['cs' => 'paymentName']));
+        $payment = new Payment(new PaymentData(['cs' => 'paymentName']), [], $paymentPriceFactoryMock);
         $orderStatus = new OrderStatus(new OrderStatusData(['en' => 'orderStatusName']), OrderStatus::TYPE_NEW);
         $orderData = new OrderData();
         $orderData->transport = $transport;
@@ -247,6 +249,7 @@ class CustomerServiceTest extends TestCase
     public function testGetAmendedCustomerDataByOrder()
     {
         $customerService = $this->getCustomerService();
+        $paymentPriceFactoryMock = $this->createMock(PaymentPriceFactory::class);
 
         $billingCountry = new Country(new CountryData('Česká republika'), self::DOMAIN_ID);
         $deliveryCountry = new Country(new CountryData('Slovenská republika'), self::DOMAIN_ID);
@@ -259,7 +262,7 @@ class CustomerServiceTest extends TestCase
         $user = new User($userData, $billingAddress, null);
 
         $transport = new Transport(new TransportData(['cs' => 'transportName']));
-        $payment = new Payment(new PaymentData(['cs' => 'paymentName']));
+        $payment = new Payment(new PaymentData(['cs' => 'paymentName']), [], $paymentPriceFactoryMock);
         $orderStatus = new OrderStatus(new OrderStatusData(['en' => 'orderStatusName']), OrderStatus::TYPE_NEW);
         $orderData = new OrderData();
         $orderData->transport = $transport;

--- a/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
@@ -64,7 +65,8 @@ class OrderPriceCalculationTest extends TestCase
     {
         $paymentData = new PaymentData();
         $paymentData->czkRounding = true;
-        $payment = new Payment($paymentData);
+        $paymentPriceFactory = $this->createMock(PaymentPriceFactory::class);
+        $payment = new Payment($paymentData, [], $paymentPriceFactory);
 
         $currency = new Currency(new CurrencyData('currencyName', Currency::CODE_EUR, 1.0));
         $orderTotalPrice = new Price(100, 120);
@@ -82,7 +84,8 @@ class OrderPriceCalculationTest extends TestCase
     {
         $paymentData = new PaymentData();
         $paymentData->czkRounding = false;
-        $payment = new Payment($paymentData);
+        $paymentPriceFactory = $this->createMock(PaymentPriceFactory::class);
+        $payment = new Payment($paymentData, [], $paymentPriceFactory);
 
         $currency = new Currency(new CurrencyData('currencyName', Currency::CODE_CZK, 1.0));
         $orderTotalPrice = new Price(100, 120);
@@ -100,7 +103,8 @@ class OrderPriceCalculationTest extends TestCase
     {
         $paymentData = new PaymentData();
         $paymentData->czkRounding = true;
-        $payment = new Payment($paymentData);
+        $paymentPriceFactory = $this->createMock(PaymentPriceFactory::class);
+        $payment = new Payment($paymentData, [], $paymentPriceFactory);
 
         $currency = new Currency(new CurrencyData('currencyName', Currency::CODE_CZK, 1.0));
         $orderTotalPrice = new Price(100, 120.3);
@@ -125,7 +129,8 @@ class OrderPriceCalculationTest extends TestCase
     {
         $paymentData = new PaymentData();
         $paymentData->czkRounding = true;
-        $payment = new Payment($paymentData);
+        $paymentPriceFactory = $this->createMock(PaymentPriceFactory::class);
+        $payment = new Payment($paymentData, [], $paymentPriceFactory);
 
         $currency = new Currency(new CurrencyData('currencyName', Currency::CODE_CZK, 1.0));
         $orderTotalPrice = new Price(100, 120.9);

--- a/packages/framework/tests/Unit/Model/Order/OrderTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderTest.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderData;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 
 class OrderTest extends TestCase
@@ -21,7 +22,8 @@ class OrderTest extends TestCase
 
     public function testGetProductItems()
     {
-        $payment = new Payment(new PaymentData());
+        $paymentPriceFactory = $this->createMock(PaymentPriceFactory::class);
+        $payment = new Payment(new PaymentData(), [], $paymentPriceFactory);
         $orderData = new OrderData();
         $paymentPrice = new Price(0, 0);
 
@@ -39,7 +41,8 @@ class OrderTest extends TestCase
 
     public function testGetProductItemsCount()
     {
-        $payment = new Payment(new PaymentData());
+        $paymentPriceFactory = $this->createMock(PaymentPriceFactory::class);
+        $payment = new Payment(new PaymentData(), [], $paymentPriceFactory);
         $paymentItemPrice = new Price(0, 0);
         $orderData = new OrderData();
 

--- a/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
@@ -81,6 +81,7 @@ class PaymentPriceCalculationTest extends TestCase
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
                 ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+        $paymentPriceFactoryMock = $this->createMock(PaymentPriceFactory::class);
 
         $rounding = new Rounding($pricingSettingMock);
 
@@ -92,7 +93,7 @@ class PaymentPriceCalculationTest extends TestCase
         $vat = new Vat(new VatData('vat', $vatPercent));
         $currency = new Currency(new CurrencyData());
 
-        $payment = new Payment(new PaymentData(['cs' => 'paymentName'], $vat));
+        $payment = new Payment(new PaymentData(['cs' => 'paymentName'], $vat), [], $paymentPriceFactoryMock);
         $payment->setPrice(new PaymentPriceFactory(), $currency, $inputPrice);
 
         $price = $paymentPriceCalculation->calculateIndependentPrice($payment, $currency);
@@ -126,6 +127,7 @@ class PaymentPriceCalculationTest extends TestCase
         $pricingSettingMock
             ->expects($this->any())->method('getFreeTransportAndPaymentPriceLimit')
                 ->will($this->returnValue($priceLimit));
+        $paymentPriceFactoryMock = $this->createMock(PaymentPriceFactory::class);
 
         $rounding = new Rounding($pricingSettingMock);
 
@@ -137,7 +139,7 @@ class PaymentPriceCalculationTest extends TestCase
         $vat = new Vat(new VatData('vat', $vatPercent));
         $currency = new Currency(new CurrencyData());
 
-        $payment = new Payment(new PaymentData(['cs' => 'paymentName'], $vat));
+        $payment = new Payment(new PaymentData(['cs' => 'paymentName'], $vat), [], $paymentPriceFactoryMock);
         $payment->setPrice(new PaymentPriceFactory(), $currency, $inputPrice);
 
         $price = $paymentPriceCalculation->calculatePrice($payment, $currency, $productsPrice, 1);

--- a/packages/framework/tests/Unit/Model/Transport/TransportTest.php
+++ b/packages/framework/tests/Unit/Model/Transport/TransportTest.php
@@ -5,6 +5,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Transport;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
@@ -29,8 +30,13 @@ class TransportTest extends TestCase
      */
     private function createPayment()
     {
+        $paymentPriceFactoryMock = $this->createMock(PaymentPriceFactory::class);
         $vat = new Vat(new VatData('vat', 21));
-        $payment = new Payment(new PaymentData(['cs' => 'paymentName', 'en' => 'paymentName'], $vat, [], [], true));
+        $payment = new Payment(
+            new PaymentData(['cs' => 'paymentName', 'en' => 'paymentName'], $vat, [], [], true),
+            [],
+            $paymentPriceFactoryMock
+        );
 
         return $payment;
     }

--- a/project-base/tests/ShopBundle/Database/Model/Order/OrderTransportAndPaymentTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Order/OrderTransportAndPaymentTest.php
@@ -5,6 +5,8 @@ namespace Tests\ShopBundle\Database\Model\Order;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
@@ -378,6 +380,8 @@ class OrderTransportAndPaymentTest extends DatabaseTestCase
     public function getDefaultPayment(Vat $vat, $enabledForDomains, $hidden)
     {
         $paymentDataFactory = $this->getPaymentDataFactory();
+        $currencyFacade = $this->getCurrencyFacade();
+        $paymentPriceFactory = $this->getPaymentPriceFactory();
 
         $paymentData = $paymentDataFactory->createDefault();
         $paymentData->name = [
@@ -388,7 +392,7 @@ class OrderTransportAndPaymentTest extends DatabaseTestCase
         $paymentData->hidden = $hidden;
         $paymentData->enabled = $enabledForDomains;
 
-        return new Payment($paymentData);
+        return new Payment($paymentData, $currencyFacade->getAll(), $paymentPriceFactory);
     }
 
     /**
@@ -436,5 +440,21 @@ class OrderTransportAndPaymentTest extends DatabaseTestCase
     public function getTransportDataFactory()
     {
         return $this->getContainer()->get(TransportDataFactory::class);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory
+     */
+    public function getPaymentPriceFactory()
+    {
+        return $this->getContainer()->get(PaymentPriceFactory::class);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade
+     */
+    public function getCurrencyFacade()
+    {
+        return $this->getContainer()->get(CurrencyFacade::class);
     }
 }

--- a/project-base/tests/ShopBundle/Database/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
@@ -5,6 +5,8 @@ namespace Tests\ShopBundle\Database\Model\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData;
 use Tests\ShopBundle\Test\DatabaseTestCase;
@@ -38,6 +40,8 @@ class IndependentPaymentVisibilityCalculationTest extends DatabaseTestCase
 
     public function testIsIndependentlyVisibleEmptyName()
     {
+        $currencyFacade = $this->getCurrencyFacade();
+        $paymentPriceFactory = $this->getPaymentPriceFactory();
         $em = $this->getEntityManager();
         $vat = $this->getDefaultVat();
 
@@ -53,7 +57,7 @@ class IndependentPaymentVisibilityCalculationTest extends DatabaseTestCase
             self::SECOND_DOMAIN_ID => false,
         ];
 
-        $payment = new Payment($paymentData);
+        $payment = new Payment($paymentData, $currencyFacade->getAll(), $paymentPriceFactory);
 
         $em->persist($vat);
         $em->persist($payment);
@@ -119,6 +123,8 @@ class IndependentPaymentVisibilityCalculationTest extends DatabaseTestCase
     public function getDefaultPayment(Vat $vat, $enabledForDomains, $hidden)
     {
         $paymentDataFactory = $this->getPaymentDataFactory();
+        $currencyFacade = $this->getCurrencyFacade();
+        $paymentPriceFactory = $this->getPaymentPriceFactory();
 
         $paymentData = $paymentDataFactory->createDefault();
         $paymentData->name = [
@@ -129,7 +135,7 @@ class IndependentPaymentVisibilityCalculationTest extends DatabaseTestCase
         $paymentData->hidden = $hidden;
         $paymentData->enabled = $enabledForDomains;
 
-        return new Payment($paymentData);
+        return new Payment($paymentData, $currencyFacade->getAll(), $paymentPriceFactory);
     }
 
     /**
@@ -146,5 +152,21 @@ class IndependentPaymentVisibilityCalculationTest extends DatabaseTestCase
     public function getPaymentDataFactory()
     {
         return $this->getContainer()->get(PaymentDataFactory::class);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory
+     */
+    public function getPaymentPriceFactory()
+    {
+        return $this->getContainer()->get(PaymentPriceFactory::class);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade
+     */
+    public function getCurrencyFacade()
+    {
+        return $this->getContainer()->get(CurrencyFacade::class);
     }
 }

--- a/project-base/tests/ShopBundle/Database/Model/Payment/PaymentTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Payment/PaymentTest.php
@@ -4,6 +4,8 @@ namespace Tests\ShopBundle\Database\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceFactory;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
@@ -18,6 +20,8 @@ class PaymentTest extends DatabaseTestCase
         $paymentDataFactory = $this->getContainer()->get(PaymentDataFactory::class);
         $transportDataFactory = $this->getContainer()->get(TransportDataFactory::class);
         $em = $this->getEntityManager();
+        $currencyFacade = $this->getContainer()->get(CurrencyFacade::class);
+        $paymentPriceFactory = $this->getContainer()->get(PaymentPriceFactory::class);
 
         $vat = new Vat(new VatData('vat', 21));
         $transportData = $transportDataFactory->createDefault();
@@ -29,7 +33,11 @@ class PaymentTest extends DatabaseTestCase
         $paymentData->name['cs'] = 'name';
         $paymentData->vat = $vat;
 
-        $payment = new Payment($paymentData);
+        $payment = new Payment(
+            $paymentData,
+            $currencyFacade->getAll(),
+            $paymentPriceFactory
+        );
         $payment->addTransport($transport);
 
         $em->persist($vat);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It makes much more sense when entity is responsible for its own prices management. At least, it should make the entity extension easier. I tried to refactor the `Payment` entity in that flavor to provide functional prototype.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
