### PR TITLE
Flush is not called if the array off entities intended to by flushed …

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -174,6 +174,7 @@ class FriendlyUrlFacade
             foreach ($friendlyUrls as $friendlyUrl) {
                 if (!$friendlyUrl->isMain()) {
                     $this->em->remove($friendlyUrl);
+                    $toFlush[] = $friendlyUrl;
                 }
             }
         }
@@ -186,7 +187,9 @@ class FriendlyUrlFacade
             $toFlush[] = $newFriendlyUrl;
         }
 
-        $this->em->flush($toFlush);
+        if (count($toFlush) > 0) {
+            $this->em->flush($toFlush);
+        }
     }
 
     /**

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyFacade.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyFacade.php
@@ -251,6 +251,8 @@ class CurrencyFacade
             $toFlush[] = $transportPrice;
         }
 
-        $this->em->flush($toFlush);
+        if (count($toFlush) > 0) {
+            $this->em->flush($toFlush);
+        }
     }
 }

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -326,7 +326,10 @@ class ProductFacade
             $this->em->persist($productParameterValue);
             $toFlush[] = $productParameterValue;
         }
-        $this->em->flush($toFlush);
+
+        if (count($toFlush) > 0) {
+            $this->em->flush($toFlush);
+        }
     }
 
     /**
@@ -370,7 +373,10 @@ class ProductFacade
                 $toFlush[] = $productVisibility;
             }
         }
-        $this->em->flush($toFlush);
+
+        if (count($toFlush) > 0) {
+            $this->em->flush($toFlush);
+        }
     }
 
     /**
@@ -391,7 +397,10 @@ class ProductFacade
             $this->em->persist($newProductAccessory);
             $toFlush[] = $newProductAccessory;
         }
-        $this->em->flush($toFlush);
+
+        if (count($toFlush) > 0) {
+            $this->em->flush($toFlush);
+        }
     }
 
     /**


### PR DESCRIPTION
…is empty

| Q             | A
| ------------- | ---
|Description, reason for the PR| Hidden call of ObjectManager::flush() without parameter #145
|New feature| No
|BC breaks| No 
|Fixes issues| #145
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
