### PR TITLE
docs: commit msgs should not contain references to internal issues

### DIFF
--- a/docs/contributing/guidelines-for-creating-commits.md
+++ b/docs/contributing/guidelines-for-creating-commits.md
@@ -46,7 +46,7 @@ OrderFlowFacade: removed unused uses
 * Never start the message with the phrase "fix:". Again, it prevents developers from getting confused between description of the fixed error and description of the current state.
 * Method or function name should be always followed by parentheses.
 * Property or variable name should be always prefixed with a dollar sign.
-* When merging a modification from the SSFW internal backlog, we use our identifier of user story or bug in the beginning of merge commit message.
+* When merging a modification from the SSFW internal backlog, we use our identifier of the user story in the beginning of merge commit message.
 
 ```
 [US-2022] OrderFlow is not autowired anymore
@@ -54,10 +54,6 @@ OrderFlowFacade: removed unused uses
 
 ```
 [US-1023] [US-1024] acceptance tests for customer registration and login
-```
-
-```
-[BG-1598] category translations are now correctly saved on category edit`
 ```
 
 ### Rules for specific use cases


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|  we don't use internal backlog for issues anymore, issues are kept on GitHub
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
