### PR TITLE
URL for submitting newsletter subscription should not be visible for robots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - all occurrences of netdevelo were changed to shopsys
 - [#165 Different approach to multidomain entities](https://github.com/shopsys/shopsys/pull/165)
     - multi-domain attributes are accessed via their main entities (instead of usual entity details)
+- [#273 URL for submitting newsletter subscription should not be visible for robots](https://github.com/shopsys/shopsys/pull/273)
+    - newsletter subscription form looks like GET form without URL, but is POSTed by AJAX 
 
 #### Fixed
 - [#131 - correct rendering of checkbox label](https://github.com/shopsys/shopsys/pull/131):

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/newsletterSubscriptionForm.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/newsletterSubscriptionForm.js
@@ -13,7 +13,7 @@
     Shopsys.newsletterSubscriptionForm.ajaxSubmit = function () {
         Shopsys.ajax({
             loaderElement: 'body',
-            url: $(this).attr('action'),
+            url: $(this).data('action'),
             method: 'post',
             data: $(this).serialize(),
             success: onSuccess

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Newsletter/subscription.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Newsletter/subscription.html.twig
@@ -1,4 +1,12 @@
-{{ form_start(form, { attr: { 'data-on-submit': 'ajaxSubmit', 'data-success': success ? 'true' : 'false' }}) }}
+{{ form_start(form, {
+    attr: {
+        'data-on-submit': 'ajaxSubmit',
+        'method': 'GET',
+        'action': '',
+        'data-action': url('front_newsletter_send'),
+        'data-success': success ? 'true' : 'false'
+    }
+}) }}
     <div class="footer__newsletter">
         <div class="footer__newsletter__text">
             <p>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| MethodNotAllowed is very often logged in production as robots trying to access URL that is dedicated for ajax newsletter registration (taken from https://git.shopsys-framework.com/jakub.dolba/shopsys-framework/commit/d9f353819f8d311dcd621a65f706c02e1953c802)
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
