### PR TITLE
grid: drag&drop is supported with enabled gridInlineEdit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `ProductDetail` and `ProductDetailFactory` were removed - new `ProductCachedAttributesFacade` is now responsible for caching of products selling prices and parameters 
     - `CategoryDetail` was renamed to `CategoryWithPreloadedChildren` and methods for it's creation were moved from `CategoryDetailFactory` to new `CategoryWithPreloadedChildrenFactory` 
     - `LazyLoadedCategoryDetail` was renamed to `CategoryWithLazyLoadedVisibleChildren` and methods for it's creation were moved from deleted `CategoryDetailFactory` to new `CategoryWithLazyLoadedVisibleChildrenFactory` 
+- [#274 grid: drag&drop is supported with enabled gridInlineEdit](https://github.com/shopsys/shopsys/pull/274)
 
 #### Changed
 - [#171 - Update to twig 2.x](https://github.com/shopsys/shopsys/pull/171):

--- a/packages/framework/src/Resources/scripts/admin/components/grid.inlineEdit.js
+++ b/packages/framework/src/Resources/scripts/admin/components/grid.inlineEdit.js
@@ -43,6 +43,7 @@
 
         $grid.on('click', '.js-inline-edit-save', function () {
             Shopsys.grid.inlineEdit.saveRow($(this).closest('.js-grid-editing-row'), $grid);
+            $grid.find('.js-drag-and-drop-grid-rows').sortable('enable');
             return false;
         });
 
@@ -132,6 +133,7 @@
                 Shopsys.register.registerNewContent($formRow);
                 $grid.find('.js-inline-edit-rows').prepend($formRow);
                 $formRow.find('input[type=text]:first').focus();
+                $grid.find('.js-drag-and-drop-grid-rows').sortable('disable');
             }
         });
     };

--- a/packages/framework/src/Resources/views/Admin/Grid/Grid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Grid/Grid.html.twig
@@ -134,11 +134,11 @@
 {% block grid_row %}
     <tr class="table-grid__row {{ cycle(['odd', 'even'], loopIndex) }} js-grid-row"
             {% if grid.inlineEdit and row is not null%} data-inline-edit-row-id="{{ grid.getRowId(row)|json_encode() }}"{% endif %}
-            {% if grid.dragAndDrop or grid.multipleDragAndDrop %} data-drag-and-drop-grid-row-id="{{ grid.getRowId(row)|json_encode() }}"{% endif %}
+            {% if (grid.dragAndDrop or grid.multipleDragAndDrop)  and row is not null  %} data-drag-and-drop-grid-row-id="{{ grid.getRowId(row)|json_encode() }}"{% endif %}
     >
-        {% if grid.dragAndDrop or grid.multipleDragAndDrop %}
-            <td class="table-grid__cell table-grid__cell--move">
-                <i class="cursor-move svg svg-move"></i>
+        {% if (grid.dragAndDrop or grid.multipleDragAndDrop)%}
+            <td class="table-grid__cell {% if (row is not null) %}table-grid__cell--move{% endif %}">
+                {% if (row is not null) %}<i class="cursor-move svg svg-move"></i>{% endif %}
             </td>
         {% endif %}
         {% if grid.enabledSelecting %}


### PR DESCRIPTION
- solved problem with failing of creation of a new row if gridInlineEdit is enabled
- drag&drob is disabled until new row is saved

| Q             | A
| ------------- | ---
|Description, reason for the PR| #179 
|New feature| No 
|BC breaks| No 
|Fixes issues| #179 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
