### PR TITLE
database tests are customized for usage with only one domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - the use of jQuery plugin for selectboxes was modified on Shopsys Framework side so options will now be seen 
 - [#243 - Admin: changed domain icon in e-shop domain administration can be saved](https://github.com/shopsys/shopsys/pull/243)
     - changed domain icon in e-shop domain administration can be saved 
+- [#277 - Tests fail when only one domain is set](https://github.com/shopsys/shopsys/issues/277)
 
 ### [shopsys/project-base]
 #### Changed

--- a/project-base/tests/ShopBundle/Database/Model/Category/CategoryDomainTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Category/CategoryDomainTest.php
@@ -64,6 +64,9 @@ class CategoryDomainTest extends DatabaseTestCase
         $this->assertFalse($refreshedCategory->isEnabled(self::FIRST_DOMAIN_ID));
     }
 
+    /**
+     * @group multidomain
+     */
     public function testCreateCategoryWithDifferentVisibilityOnDomains()
     {
         $categoryData = $this->categoryDataFactory->createDefault();
@@ -79,6 +82,9 @@ class CategoryDomainTest extends DatabaseTestCase
         $this->assertFalse($refreshedCategory->isEnabled(self::SECOND_DOMAIN_ID));
     }
 
+    /**
+     * @group multidomain
+     */
     public function testCreateCategoryDomainWithData()
     {
         $categoryData = $this->categoryDataFactory->createDefault();
@@ -97,6 +103,26 @@ class CategoryDomainTest extends DatabaseTestCase
         $this->assertNull($refreshedCategory->getSeoMetaDescription(self::FIRST_DOMAIN_ID));
         $this->assertSame(self::DEMONSTRATIVE_SEO_H1, $refreshedCategory->getSeoH1(self::FIRST_DOMAIN_ID));
         $this->assertNull($refreshedCategory->getSeoH1(self::SECOND_DOMAIN_ID));
+    }
+
+    /**
+     * @group singledomain
+     */
+    public function testCreateCategoryDomainWithDataForSingleDomain()
+    {
+        $categoryData = $this->categoryDataFactory->createDefault();
+
+        $categoryData->seoTitles[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_TITLE;
+        $categoryData->seoMetaDescriptions[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_META_DESCRIPTION;
+        $categoryData->seoH1s[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_H1;
+
+        $category = $this->categoryFactory->create($categoryData);
+
+        $refreshedCategory = $this->getRefreshedCategoryFromDatabase($category);
+
+        $this->assertSame(self::DEMONSTRATIVE_SEO_TITLE, $refreshedCategory->getSeoTitle(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_SEO_META_DESCRIPTION, $refreshedCategory->getSeoMetaDescription(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_SEO_H1, $refreshedCategory->getSeoH1(self::FIRST_DOMAIN_ID));
     }
 
     /**

--- a/project-base/tests/ShopBundle/Database/Model/Product/Brand/BrandDomainTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Product/Brand/BrandDomainTest.php
@@ -37,6 +37,9 @@ class BrandDomainTest extends DatabaseTestCase
         $this->em = $this->getEntityManager();
     }
 
+    /**
+     * @group multidomain
+     */
     public function testCreateBrandDomain()
     {
         $brandData = $this->brandDataFactory->createDefault();
@@ -52,6 +55,24 @@ class BrandDomainTest extends DatabaseTestCase
         $this->assertNull($refreshedBrand->getSeoTitle(self::SECOND_DOMAIN_ID));
         $this->assertSame(self::DEMONSTRATIVE_SEO_H1, $refreshedBrand->getSeoH1(self::SECOND_DOMAIN_ID));
         $this->assertNull($refreshedBrand->getSeoH1(self::FIRST_DOMAIN_ID));
+    }
+
+    /**
+     * @group singledomain
+     */
+    public function testCreateBrandDomainForSingleDomain()
+    {
+        $brandData = $this->brandDataFactory->createDefault();
+
+        $brandData->seoTitles[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_TITLE;
+        $brandData->seoH1s[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_H1;
+
+        $brand = $this->brandFactory->create($brandData);
+
+        $refreshedBrand = $this->getRefreshedBrandFromDatabase($brand);
+
+        $this->assertSame(self::DEMONSTRATIVE_SEO_TITLE, $refreshedBrand->getSeoTitle(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_SEO_H1, $refreshedBrand->getSeoH1(self::FIRST_DOMAIN_ID));
     }
 
     /**

--- a/project-base/tests/ShopBundle/Database/Model/Product/ProductDomainTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Product/ProductDomainTest.php
@@ -41,6 +41,9 @@ class ProductDomainTest extends DatabaseTestCase
         $this->em = $this->getEntityManager();
     }
 
+    /**
+     * @group multidomain
+     */
     public function testCreateProductDomainWithData()
     {
         $productData = $this->productDataFactory->createDefault();
@@ -67,6 +70,32 @@ class ProductDomainTest extends DatabaseTestCase
         $this->assertNull($refreshedProduct->getDescription(self::FIRST_DOMAIN_ID));
         $this->assertSame(self::DEMONSTRATIVE_SHORT_DESCRIPTION, $refreshedProduct->getShortDescription(self::FIRST_DOMAIN_ID));
         $this->assertNull($refreshedProduct->getShortDescription(self::SECOND_DOMAIN_ID));
+    }
+
+    /**
+     * @group singledomain
+     */
+    public function testCreateProductDomainWithDataForSingleDomain()
+    {
+        $productData = $this->productDataFactory->createDefault();
+
+        $productData->seoTitles[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_TITLE;
+        $productData->seoMetaDescriptions[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_META_DESCRIPTION;
+        $productData->seoH1s[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SEO_H1;
+        $productData->descriptions[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_DESCRIPTION;
+        $productData->shortDescriptions[self::FIRST_DOMAIN_ID] = self::DEMONSTRATIVE_SHORT_DESCRIPTION;
+        $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK);
+        $productData->outOfStockAvailability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_OUT_OF_STOCK);
+
+        $product = $this->productFactory->create($productData);
+
+        $refreshedProduct = $this->getRefreshedProductFromDatabase($product);
+
+        $this->assertSame(self::DEMONSTRATIVE_SEO_TITLE, $refreshedProduct->getSeoTitle(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_SEO_META_DESCRIPTION, $refreshedProduct->getSeoMetaDescription(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_SEO_H1, $refreshedProduct->getSeoH1(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_DESCRIPTION, $refreshedProduct->getDescription(self::FIRST_DOMAIN_ID));
+        $this->assertSame(self::DEMONSTRATIVE_SHORT_DESCRIPTION, $refreshedProduct->getShortDescription(self::FIRST_DOMAIN_ID));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After the extensive changes in the multidomain behaviour there need to be modified the tests so that they can be used even when configuration contains only one domain
|New feature| No 
|BC breaks| No 
|Fixes issues| #277
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
