### PR TITLE
monorepo-tools: Fix scripts to work on OS X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `PaymentDomain` and `TransportDomain` are now created even for domains on which the entity should not be visible (to allow for other multi-domain entities and in the sake of consistency)
 
 #### Fixed
+- [#281 - monorepo-tools: rewrite_history_into.sh has a non-portable implementation of tab](https://github.com/shopsys/shopsys/pull/xxx)
+    - monorepo-tools: fixes non-portable use of tab to function on OS X
 - [#246 - docker-sync.yml.dist: fixed not existing relative paths](https://github.com/shopsys/shopsys/pull/246) [@DavidKuna]
 - [#132 - Admin: brand edit page: URLs setting rendering](https://github.com/shopsys/shopsys/pull/132):
     - admin: brand detail page: rendering of URLs setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `PaymentDomain` and `TransportDomain` are now created even for domains on which the entity should not be visible (to allow for other multi-domain entities and in the sake of consistency)
 
 #### Fixed
-- [#281 - monorepo-tools: rewrite_history_into.sh has a non-portable implementation of tab](https://github.com/shopsys/shopsys/pull/xxx)
+- [#281 - monorepo-tools: rewrite_history_into.sh has a non-portable implementation of tab](https://github.com/shopsys/shopsys/pull/282)
     - monorepo-tools: fixes non-portable use of tab to function on OS X
 - [#246 - docker-sync.yml.dist: fixed not existing relative paths](https://github.com/shopsys/shopsys/pull/246) [@DavidKuna]
 - [#132 - Admin: brand edit page: URLs setting rendering](https://github.com/shopsys/shopsys/pull/132):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - `PaymentDomain` and `TransportDomain` are now created even for domains on which the entity should not be visible (to allow for other multi-domain entities and in the sake of consistency)
 
 #### Fixed
-- [#281 - monorepo-tools: rewrite_history_into.sh has a non-portable implementation of tab](https://github.com/shopsys/shopsys/pull/282)
+- [#281 - monorepo-tools: Fix scripts to work on OS X](https://github.com/shopsys/shopsys/pull/282) [@lukaso]
     - monorepo-tools: fixes non-portable use of tab to function on OS X
 - [#246 - docker-sync.yml.dist: fixed not existing relative paths](https://github.com/shopsys/shopsys/pull/246) [@DavidKuna]
 - [#132 - Admin: brand edit page: URLs setting rendering](https://github.com/shopsys/shopsys/pull/132):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1163,3 +1163,4 @@ That's why is this section formatted differently.
 [@stanoMilan]: https://github.com/stanoMilan
 [@EdoBarnas]: https://github.com/EdoBarnas
 [@DavidKuna]: https://github.com/DavidKuna
+[@lukaso]: https://github.com/lukaso

--- a/packages/monorepo-tools/rewrite_history_from.sh
+++ b/packages/monorepo-tools/rewrite_history_from.sh
@@ -13,7 +13,7 @@ SUBDIRECTORY=$1
 REV_LIST_PARAMS=${@:2}
 echo "Rewriting history from a subdirectory '$SUBDIRECTORY'"
 # All paths in the index that are not prefixed with a subdirectory are removed via "git rm --cached"
-# Piping through 'printf "%s "' is needed to resolve pathnames containing unicode characters
+# Piping through 'printf "%b "' is needed to unescape pathnames containing unicode characters
 # If there are any files in the index all paths have the subdirectory prefix removed and the index is updated
 # Previous index file is replaced by a new one (otherwise each file would be in the index twice)
 # Only non-empty are filtered by the commit-filter
@@ -27,7 +27,7 @@ else
 fi
 SUBDIRECTORY=$SUBDIRECTORY SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' XARGS_OPTS=$XARGS_OPTS SED_OPTS=$SED_OPTS git filter-branch \
     --index-filter '
-    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%s " | xargs $XARGS_OPTS git rm -q --cached
+    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%b " | xargs $XARGS_OPTS git rm -q --cached
     if [ "$(git ls-files)" != "" ]; then
         git ls-files -s | sed $SED_OPTS "s-($TAB\"*)$SUBDIRECTORY_SED/-\1-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE
     fi' \

--- a/packages/monorepo-tools/rewrite_history_from.sh
+++ b/packages/monorepo-tools/rewrite_history_from.sh
@@ -27,9 +27,9 @@ else
 fi
 SUBDIRECTORY=$SUBDIRECTORY SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' XARGS_OPTS=$XARGS_OPTS SED_OPTS=$SED_OPTS git filter-branch \
     --index-filter '
-    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%s " | xargs ${XARGS_OPTS} git rm -q --cached
+    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%s " | xargs $XARGS_OPTS git rm -q --cached
     if [ "$(git ls-files)" != "" ]; then
-        git ls-files -s | sed ${SED_OPTS} "s-(${TAB}\"*)$SUBDIRECTORY_SED/-\1-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE
+        git ls-files -s | sed $SED_OPTS "s-($TAB\"*)$SUBDIRECTORY_SED/-\1-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE
     fi' \
     --commit-filter 'git_commit_non_empty_tree "$@"' \
     --tag-name-filter 'cat' \

--- a/packages/monorepo-tools/rewrite_history_from.sh
+++ b/packages/monorepo-tools/rewrite_history_from.sh
@@ -13,21 +13,23 @@ SUBDIRECTORY=$1
 REV_LIST_PARAMS=${@:2}
 echo "Rewriting history from a subdirectory '$SUBDIRECTORY'"
 # All paths in the index that are not prefixed with a subdirectory are removed via "git rm --cached"
-# Piping through "echo -e" is needed to resolve pathnames containing unicode characters
+# Piping through 'printf "%s "' is needed to resolve pathnames containing unicode characters
 # If there are any files in the index all paths have the subdirectory prefix removed and the index is updated
 # Previous index file is replaced by a new one (otherwise each file would be in the index twice)
 # Only non-empty are filtered by the commit-filter
 # The tags are rewritten as well as commits (the "cat" command will use original name without any change)
 if [ $(uname) == "Darwin" ]; then
-    XARGS=""
+    XARGS_OPTS=""
+    SED_OPTS="-E"
 else
-    XARGS="-r"
+    XARGS_OPTS="-r"
+    SED_OPTS="-r"
 fi
-SUBDIRECTORY=$SUBDIRECTORY SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
+SUBDIRECTORY=$SUBDIRECTORY SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' XARGS_OPTS=$XARGS_OPTS SED_OPTS=$SED_OPTS git filter-branch \
     --index-filter '
-    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%s " | xargs ${XARGS} git rm -q --cached
+    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%s " | xargs ${XARGS_OPTS} git rm -q --cached
     if [ "$(git ls-files)" != "" ]; then
-        git ls-files -s | sed -E "s-(${TAB}\"*)$SUBDIRECTORY_SED/-\1-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE
+        git ls-files -s | sed ${SED_OPTS} "s-(${TAB}\"*)$SUBDIRECTORY_SED/-\1-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE
     fi' \
     --commit-filter 'git_commit_non_empty_tree "$@"' \
     --tag-name-filter 'cat' \

--- a/packages/monorepo-tools/rewrite_history_from.sh
+++ b/packages/monorepo-tools/rewrite_history_from.sh
@@ -13,7 +13,7 @@ SUBDIRECTORY=$1
 REV_LIST_PARAMS=${@:2}
 echo "Rewriting history from a subdirectory '$SUBDIRECTORY'"
 # All paths in the index that are not prefixed with a subdirectory are removed via "git rm --cached"
-# Piping through 'printf "%b "' is needed to unescape pathnames containing unicode characters
+# Setting quotepath to false is needed to handle path and file names containing unicode characters
 # If there are any files in the index all paths have the subdirectory prefix removed and the index is updated
 # Previous index file is replaced by a new one (otherwise each file would be in the index twice)
 # Only non-empty are filtered by the commit-filter
@@ -27,7 +27,7 @@ else
 fi
 SUBDIRECTORY=$SUBDIRECTORY SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' XARGS_OPTS=$XARGS_OPTS SED_OPTS=$SED_OPTS git filter-branch \
     --index-filter '
-    git ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs printf "%b " | xargs $XARGS_OPTS git rm -q --cached
+    git -c core.quotepath=false ls-files | grep -vE "^\"*$SUBDIRECTORY/" | xargs $XARGS_OPTS git rm -q --cached
     if [ "$(git ls-files)" != "" ]; then
         git ls-files -s | sed $SED_OPTS "s-($TAB\"*)$SUBDIRECTORY_SED/-\1-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE
     fi' \

--- a/packages/monorepo-tools/rewrite_history_into.sh
+++ b/packages/monorepo-tools/rewrite_history_into.sh
@@ -17,7 +17,7 @@ echo "Rewriting history into a subdirectory '$SUBDIRECTORY'"
 # The tags are rewritten as well as commits (the "cat" command will use original name without any change)
 SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
     --index-filter '
-    git ls-files -s | sed "s-${TAB}\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE' \
+    git ls-files -s | sed "s-$TAB\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE' \
     --tag-name-filter 'cat' \
     -- $REV_LIST_PARAMS
 

--- a/packages/monorepo-tools/rewrite_history_into.sh
+++ b/packages/monorepo-tools/rewrite_history_into.sh
@@ -15,9 +15,9 @@ echo "Rewriting history into a subdirectory '$SUBDIRECTORY'"
 # All paths in the index are prefixed with a subdirectory and the index is updated
 # Previous index file is replaced by a new one (otherwise each file would be in the index twice)
 # The tags are rewritten as well as commits (the "cat" command will use original name without any change)
-SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} git filter-branch \
+SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
     --index-filter '
-    git ls-files -s | sed "s-\t\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE' \
+    git ls-files -s | sed "s-${TAB}\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE' \
     --tag-name-filter 'cat' \
     -- $REV_LIST_PARAMS
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes non-portable tabs so they work on OS X
|New feature| No
|BC breaks| No
|Fixes issues| #281
|Standards and tests pass| Not tested - no changes to main framework
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
