### PR TITLE
admin: fixed missing order number in order detail

### DIFF
--- a/packages/framework/src/Form/Admin/Order/OrderFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderFormType.php
@@ -80,7 +80,10 @@ class OrderFormType extends AbstractType
         }
 
         $builder
-            ->add('orderNumber', DisplayOnlyType::class)
+            ->add('orderNumber', DisplayOnlyType::class, [
+                'label' => t('Order number'),
+                'data' => $options['order']->getNumber(),
+            ])
             ->add('status', ChoiceType::class, [
                 'required' => true,
                 'choices' => $this->orderStatusFacade->getAll(),


### PR DESCRIPTION
- orderNumber in order detail form is solved as DisplayOnlyType that
requires label and data

| Q             | A
| ------------- | ---
|Description, reason for the PR| #279
|New feature| No
|BC breaks| No
|Fixes issues| #279
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
