### PR TITLE
javascript compiling: lower memory consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - framework doesn't use Elasticsearch directly anymore
     - feeds Elasticsearch via Product Search Export microservice
 - [#438 - Attribute telephone moved from a billing address to the personal data of a user](https://github.com/shopsys/shopsys/pull/438)
+- [#295 - Javascript compiling: lower memory consumption](https://github.com/shopsys/shopsys/pull/295), thanks to [@pk16011990]
 
 #### Fixed
 - [#420 - Order flow fix](https://github.com/shopsys/shopsys/pull/420)

--- a/packages/framework/src/Component/Javascript/Compiler/JsCompiler.php
+++ b/packages/framework/src/Component/Javascript/Compiler/JsCompiler.php
@@ -33,6 +33,11 @@ class JsCompiler
             $compilerPass->process($node);
         }
 
-        return $node->format();
+        $format = $node->format();
+        $node->free_memory();
+        $node->destroy();
+        unset($node);
+
+        return $format;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| compiling of javascript consumes a lot of memory. It takes over 256 MB during `phing error-pages-generate` on eshop with 5 domains and a lot of javascripts.
|New feature| No
|BC breaks| No
|Fixes issues| Yes
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

I did not update CHANGELOG.md, I did not know link to this futured pull request :( I am demotivated about updating of it twice (befor pull request and after their creating...)
