### PR TITLE
autocomplete returns results when search text contains slash

### DIFF
--- a/packages/framework/src/Component/String/TsqueryFactory.php
+++ b/packages/framework/src/Component/String/TsqueryFactory.php
@@ -77,7 +77,7 @@ class TsqueryFactory
     private function splitToTokens($searchText)
     {
         return preg_split(
-            '/[^\w-]+/ui',
+            '/[^\w\/-]+/ui',
             $searchText,
             -1,
             PREG_SPLIT_NO_EMPTY


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| searching for items with slash in its fields results in empty list
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #196 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
