### PR TITLE
admin: category translations for ancestor category are loaded in the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### [shopsys/framework]
+#### Fixed
+- [#291 - Unnecessary SQL queries on category detail in admin](https://github.com/shopsys/shopsys/pull/304):
+    - category translations for ancestor category are loaded in the same query as categories
+
 ## [7.0.0-alpha3] - 2018-07-03
 ### [shopsys/framework]
 #### Changed

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -99,9 +99,9 @@ class CategoryFormType extends AbstractType
         }
 
         if ($options['category'] !== null) {
-            $parentChoices = $this->categoryFacade->getAllWithoutBranch($options['category']);
+            $parentChoices = $this->categoryFacade->getTranslatedAllWithoutBranch($options['category'], $this->domain->getCurrentDomainConfig());
         } else {
-            $parentChoices = $this->categoryFacade->getAll();
+            $parentChoices = $this->categoryFacade->getTranslatedAll($this->domain->getCurrentDomainConfig());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -195,11 +195,12 @@ class CategoryFacade
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
-    public function getAll()
+    public function getTranslatedAll(DomainConfig $domainConfig)
     {
-        return $this->categoryRepository->getAll();
+        return $this->categoryRepository->getTranslatedAll($domainConfig);
     }
 
     /**
@@ -303,11 +304,12 @@ class CategoryFacade
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
-    public function getAllWithoutBranch(Category $category)
+    public function getTranslatedAllWithoutBranch(Category $category, DomainConfig $domainConfig)
     {
-        return $this->categoryRepository->getAllWithoutBranch($category);
+        return $this->categoryRepository->getTranslatedAllWithoutBranch($category, $domainConfig);
     }
 
     /**

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -150,12 +150,15 @@ class CategoryRepository extends NestedTreeRepository
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $categoryBranch
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
-    public function getAllWithoutBranch(Category $categoryBranch)
+    public function getTranslatedAllWithoutBranch(Category $categoryBranch, DomainConfig $domainConfig)
     {
-        return $this->getAllQueryBuilder()
-            ->andWhere('c.lft < :branchLft OR c.rgt > :branchRgt')
+        $queryBuilder = $this->getAllQueryBuilder();
+        $this->addTranslation($queryBuilder, $domainConfig->getLocale());
+
+        return $queryBuilder->andWhere('c.lft < :branchLft OR c.rgt > :branchRgt')
             ->setParameter('branchLft', $categoryBranch->getLft())
             ->setParameter('branchRgt', $categoryBranch->getRgt())
             ->getQuery()
@@ -529,5 +532,18 @@ class CategoryRepository extends NestedTreeRepository
             ->setParameter('categories', $categories);
 
         return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * @param  \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     */
+    public function getTranslatedAll(DomainConfig $domainConfig)
+    {
+        $queryBuilder = $this->getAllQueryBuilder();
+        $this->addTranslation($queryBuilder, $domainConfig->getLocale());
+
+        return $queryBuilder->getQuery()
+            ->getResult();
     }
 }


### PR DESCRIPTION
…same query as categories

-  before this change, there was executed the query for every possible ancestor category, which means hundreds of queries for hundreds of categories

| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No 
|BC breaks| No
|Fixes issues| #291
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
