### PR TITLE
Dropped triggers before creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - redis extension enabled in configuration for travis
 - [#316 - Admin: feed items on feeds generation page contain clickable link and datetime](https://github.com/shopsys/shopsys/pull/316)
     - checks for existing file and for modified time of file use abstract filesystem methods
+- [#291 - Dropped triggers before creation](https://github.com/shopsys/shopsys/pull/314)
 
 ### [shopsys/shopsys]
 #### Changed

--- a/packages/framework/src/Migrations/Version20180603135340.php
+++ b/packages/framework/src/Migrations/Version20180603135340.php
@@ -106,6 +106,7 @@ class Version20180603135340 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
 
+        $this->sql('DROP TRIGGER IF EXISTS recalc_catnum_tsvector ON products');
         $this->sql('
             CREATE TRIGGER recalc_catnum_tsvector
             BEFORE INSERT OR UPDATE OF catnum
@@ -126,6 +127,7 @@ class Version20180603135340 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
 
+        $this->sql('DROP TRIGGER IF EXISTS recalc_partno_tsvector ON products');
         $this->sql('
             CREATE TRIGGER recalc_partno_tsvector
             BEFORE INSERT OR UPDATE OF partno
@@ -146,6 +148,7 @@ class Version20180603135340 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
 
+        $this->sql('DROP TRIGGER IF EXISTS recalc_name_tsvector ON product_translations');
         $this->sql('
             CREATE TRIGGER recalc_name_tsvector
             BEFORE INSERT OR UPDATE OF name
@@ -166,6 +169,7 @@ class Version20180603135340 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
 
+        $this->sql('DROP TRIGGER IF EXISTS recalc_description_tsvector ON product_domains');
         $this->sql('
             CREATE TRIGGER recalc_description_tsvector
             BEFORE INSERT OR UPDATE OF description
@@ -202,6 +206,7 @@ class Version20180603135340 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
 
+        $this->sql('DROP TRIGGER IF EXISTS recalc_product_domain_fulltext_tsvector ON products');
         $this->sql('
             CREATE TRIGGER recalc_product_domain_fulltext_tsvector
             AFTER INSERT OR UPDATE OF catnum, partno
@@ -238,6 +243,7 @@ class Version20180603135340 extends AbstractMigration
             $$ LANGUAGE plpgsql;
         ');
 
+        $this->sql('DROP TRIGGER IF EXISTS recalc_product_domain_fulltext_tsvector ON product_translations');
         $this->sql('
             CREATE TRIGGER recalc_product_domain_fulltext_tsvector
             AFTER INSERT OR UPDATE OF name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| (#310) - Creating triggers on already existing database caused migrations to fail, this PR makes sure that triggers get deleted before created
|New feature| No
|BC breaks| No
|Fixes issues| (#310) 
|Standards and tests pass| Yes
