### PR TITLE
Route logout/ without csrf token returns not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ It was only important with [the original open-box architecture](https://blog.sho
     - creation of entity data objects moved to factories to allow extensibility
 - [#271 - Complete refactoring of feeds functionality](https://github.com/shopsys/shopsys/pull/271)
     - for details see section shopsys/framework
+    
+### [shopsys/project-base]
+#### Fixed
+- [#315 - Route logout/ without csrf token returns not found](https://github.com/shopsys/shopsys/pull/315)
+    - route logout/ must to be called with token in every case because LogoutListener from Symfony throws exception if token generator is set in configuration of firewall but the route logout is used without csrf token parameter
 
 ## [7.0.0-alpha3] - 2018-07-03
 ### [shopsys/framework]

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front_cs.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front_cs.yml
@@ -23,7 +23,7 @@ front_login:
   defaults: { _controller: ShopsysShopBundle:Front\Login:login }
 
 front_logout:
-  path: /odhlasit/
+  path: /odhlasit/{_csrf_token}
   # controller's action is unnecessary, because firewall processes whole request
 
 front_order_index:

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front_en.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front_en.yml
@@ -23,7 +23,7 @@ front_login:
   defaults: { _controller: ShopsysShopBundle:Front\Login:login }
 
 front_logout:
-  path: /logout/
+  path: /logout/{_csrf_token}
   # controller's action is unnecessary, because firewall processes whole request
 
 front_order_index:


### PR DESCRIPTION
- route logout/ must to be called with token in every case because LogoutListener from Symfony throws exception if token generator is set in configuration of firewall but the route logout is used without csrf token parameter

| Q             | A
| ------------- | ---
|Description, reason for the PR| #195
|New feature| No 
|BC breaks| No 
|Fixes issues| #195
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
