### PR TITLE
Admin: feed items on feeds generation page contain clickable link and datetime  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#317 - Travis build is failing for shopsys/framework](https://github.com/shopsys/shopsys/pull/317):
     - framework package requires redis bundle and redis extension
     - redis extension enabled in configuration for travis
+- [#316 - Admin: feed items on feeds generation page contain clickable link and datetime](https://github.com/shopsys/shopsys/pull/316)
+    - checks for existing file and for modified time of file use abstract filesystem methods
 
 ### [shopsys/shopsys]
 #### Changed

--- a/packages/framework/src/Controller/Admin/FeedController.php
+++ b/packages/framework/src/Controller/Admin/FeedController.php
@@ -77,13 +77,13 @@ class FeedController extends AdminBaseController
         $feedsInfo = $this->feedFacade->getFeedsInfo();
         foreach ($feedsInfo as $feedInfo) {
             foreach ($this->domain->getAll() as $domainConfig) {
-                $filepath = $this->feedFacade->getFeedFilepath($feedInfo, $domainConfig);
+                $feedTimestamp = $this->feedFacade->getFeedTimestamp($feedInfo, $domainConfig);
                 $feedsData[] = [
                     'feedLabel' => $feedInfo->getLabel(),
                     'feedName' => $feedInfo->getName(),
                     'domainConfig' => $domainConfig,
                     'url' => $this->feedFacade->getFeedUrl($feedInfo, $domainConfig),
-                    'created' => file_exists($filepath) ? new DateTime('@' . filemtime($filepath)) : null,
+                    'created' => $feedTimestamp === null ? null : (new DateTime())->setTimestamp($feedTimestamp),
                     'actions' => null,
                     'additionalInformation' => $feedInfo->getAdditionalInformation(),
                 ];

--- a/packages/framework/src/Model/Feed/FeedFacade.php
+++ b/packages/framework/src/Model/Feed/FeedFacade.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Model\Feed;
 
+use League\Flysystem\FilesystemInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 
@@ -30,16 +31,23 @@ class FeedFacade
      */
     protected $feedPathProvider;
 
+    /**
+     * @var \League\Flysystem\FilesystemInterface
+     */
+    protected $filesystem;
+
     public function __construct(
         FeedRegistry $feedRegistry,
         ProductVisibilityFacade $productVisibilityFacade,
         FeedExportFactory $feedExportFactory,
-        FeedPathProvider $feedPathProvider
+        FeedPathProvider $feedPathProvider,
+        FilesystemInterface $filesystem
     ) {
         $this->feedRegistry = $feedRegistry;
         $this->productVisibilityFacade = $productVisibilityFacade;
         $this->feedExportFactory = $feedExportFactory;
         $this->feedPathProvider = $feedPathProvider;
+        $this->filesystem = $filesystem;
     }
 
     /**
@@ -123,5 +131,21 @@ class FeedFacade
     public function getFeedFilepath(FeedInfoInterface $feedInfo, DomainConfig $domainConfig): string
     {
         return $this->feedPathProvider->getFeedFilepath($feedInfo, $domainConfig);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface $feedInfo
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @return int|null
+     */
+    public function getFeedTimestamp(FeedInfoInterface $feedInfo, DomainConfig $domainConfig): ?int
+    {
+        $filePath = $this->feedPathProvider->getFeedFilepath($feedInfo, $domainConfig);
+
+        try {
+            return $this->filesystem->getTimestamp($filePath);
+        } catch (\League\Flysystem\FileNotFoundException $fileNotFundException) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| administrator needs to see time of last generation of feed and click on link to it
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #307
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
