### PR TITLE
Downgrade snc/redis-bundle to 2.1.4 due to Issue in phpredis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - checks for existing file and for modified time of file use abstract filesystem methods
 - [#291 - Dropped triggers before creation](https://github.com/shopsys/shopsys/pull/314)
 - [#263 - CartWatcherFacade: fixed swapped messages](https://github.com/shopsys/shopsys/pull/263)
+- [#339 - Downgrade snc/redis-bundle to 2.1.4 due to Issue in phpredis](https://github.com/shopsys/shopsys/pull/339)
 
 ### [shopsys/shopsys]
 #### Added
@@ -135,6 +136,7 @@ It was only important with [the original open-box architecture](https://blog.sho
 #### Fixed
 - [#315 - Route logout/ without csrf token returns not found](https://github.com/shopsys/shopsys/pull/315)
     - route logout/ must to be called with token in every case because LogoutListener from Symfony throws exception if token generator is set in configuration of firewall but the route logout is used without csrf token parameter
+- [#339 - Downgrade snc/redis-bundle to 2.1.4 due to Issue in phpredis](https://github.com/shopsys/shopsys/pull/339)
 
 ## [7.0.0-alpha3] - 2018-07-03
 ### [shopsys/framework]

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
     "sensio/framework-extra-bundle": "^3.0.29",
     "sensio/generator-bundle": "^3.1.7",
     "slevomat/coding-standard": "^4.6.0",
-    "snc/redis-bundle": "^2.1.0",
+    "snc/redis-bundle": "2.1.4",
     "squizlabs/php_codesniffer": "^3.2.0",
     "stof/doctrine-extensions-bundle": "^1.3.0",
     "symplify/easy-coding-standard": "^4.3.0",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -85,7 +85,7 @@
         "shopsys/migrations": "dev-master",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/plugin-interface": "dev-master",
-        "snc/redis-bundle": "^2.1.0",
+        "snc/redis-bundle": "2.1.4",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/assetic-bundle": "^2.8.2",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -90,7 +90,7 @@
         "shopsys/product-feed-heureka-delivery": "dev-master",
         "shopsys/product-feed-zbozi": "dev-master",
         "shopsys/product-feed-google": "dev-master",
-        "snc/redis-bundle": "^2.1.0",
+        "snc/redis-bundle": "2.1.4",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/assetic-bundle": "^2.8.2",
         "symfony/monolog-bundle": "^3.1.2",


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| downgrade snc/redis-bundle to 2.1.4 (from 2.1.5) due to issue in phpredis extension,  issue - https://github.com/snc/SncRedisBundle/issues/442
|New feature| No
|BC breaks| Yes
|Fixes issues| 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
