### PR TITLE
Category entity in constructor of CategoryRepository is resolved via EntityNameResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#313 - Streamed logging](https://github.com/shopsys/shopsys/pull/313)
     - monolog logs into streams instead of files (use `docker-compose logs` to access it)
     - see details in the [Logging](/docs/introduction/logging.md) article
+- [#341 - Category entity in constructor of CategoryRepository is resolved via EntityNameResolver](https://github.com/shopsys/shopsys/pull/341)
 
 #### Fixed
 - [#291 - Unnecessary SQL queries on category detail in admin](https://github.com/shopsys/shopsys/pull/304):

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\String\DatabaseSearching;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
@@ -30,13 +31,19 @@ class CategoryRepository extends NestedTreeRepository
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      */
-    public function __construct(EntityManagerInterface $em, ProductRepository $productRepository)
-    {
+    public function __construct(
+        EntityManagerInterface $em,
+        ProductRepository $productRepository,
+        EntityNameResolver $entityNameResolver
+    ) {
         $this->em = $em;
-        $classMetadata = $this->em->getClassMetadata(Category::class);
         $this->productRepository = $productRepository;
+
+        $resolvedClassName = $entityNameResolver->resolve(Category::class);
+        $classMetadata = $this->em->getClassMetadata($resolvedClassName);
         parent::__construct($this->em, $classMetadata);
     }
 


### PR DESCRIPTION
- Category entity is now extendable and extraction of class metadata are loaded from an extended entity if exists

| Q             | A
| ------------- | ---
|Description, reason for the PR| Class metadata for GedmoTree are not available in extended Category entity
|New feature| No
|BC breaks| No 
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
