### PR TITLE
Composer: disable installation of broken version of codeception/stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Error reporting functionality was removed as a part of [#313 - Streamed logging](https://github.com/shopsys/shopsys/pull/313)
     - error reporting should be done from the outside of the application (eg. by [Kubernetes](https://kubernetes.io/))
 
+### [shopsys/project-base]
+#### Fixed
+- [#347 - Composer: disable installation of broken version of codeception/stub](https://github.com/shopsys/shopsys/pull/347)
+
 ### [shopsys/shopsys]
 #### Added
 - [#320 - Docs: overview of possible and impossible glassbox customizations](https://github.com/shopsys/shopsys/pull/320)

--- a/composer.json
+++ b/composer.json
@@ -150,6 +150,9 @@
     "phpstan/phpstan": "^0.7",
     "symplify/easy-coding-standard-tester": "^4.4"
   },
+  "conflict": {
+    "codeception/stub": "2.0.2"
+  },
   "scripts": {
     "post-install-cmd": [
       "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -113,6 +113,9 @@
         "shopsys/coding-standards": "dev-master",
         "shopsys/http-smoke-testing": "dev-master"
     },
+    "conflict": {
+        "codeception/stub": "2.0.2"
+    },
     "scripts": {
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| when composer installs `codecption/stub` package in version `2.0.2`, the `tests-acceptance-build` phing target fails without mentioning any reason. There is already released newer version of the package that fixes the issue but in some cases composer can resolve dependencies in a way when the `2.0.2` version is installed after all.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
