### PR TITLE
added missing typehints in methods of CookiesFacade and OrderMailService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#291 - Dropped triggers before creation](https://github.com/shopsys/shopsys/pull/314)
 - [#263 - CartWatcherFacade: fixed swapped messages](https://github.com/shopsys/shopsys/pull/263)
 - [#339 - Downgrade snc/redis-bundle to 2.1.4 due to Issue in phpredis](https://github.com/shopsys/shopsys/pull/339)
+- [#351 - added missing typehints in methods of CookiesFacade and OrderMailService](https://github.com/shopsys/shopsys/pull/351)
 
 #### Removed
 - Error reporting functionality was removed as a part of [#313 - Streamed logging](https://github.com/shopsys/shopsys/pull/313)

--- a/packages/framework/src/Model/Cookies/CookiesFacade.php
+++ b/packages/framework/src/Model/Cookies/CookiesFacade.php
@@ -63,7 +63,7 @@ class CookiesFacade
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Article\Article|null
      */
-    public function findCookiesArticleByDomainId($domainId)
+    public function findCookiesArticleByDomainId(int $domainId)
     {
         $cookiesArticleId = $this->setting->getForDomain(Setting::COOKIES_ARTICLE_ID, $domainId);
 
@@ -80,7 +80,7 @@ class CookiesFacade
      * @param \Shopsys\FrameworkBundle\Model\Article\Article|null $cookiesArticle
      * @param int $domainId
      */
-    public function setCookiesArticleOnDomain($cookiesArticle, $domainId)
+    public function setCookiesArticleOnDomain(?Article $cookiesArticle, $domainId)
     {
         $cookiesArticleId = null;
         if ($cookiesArticle !== null) {

--- a/packages/framework/src/Model/Order/Mail/OrderMailService.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMailService.php
@@ -256,7 +256,7 @@ class OrderMailService
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getDomainLocaleByOrder($order)
+    private function getDomainLocaleByOrder(Order $order)
     {
         return $this->domain->getDomainConfigById($order->getDomainId())->getLocale();
     }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| Static analyse of our code found out that we have some methods which are not typehinted. This PR solves it
|New feature| No 
|BC breaks| No 
|Fixes issues| (#333)
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
