### PR TITLE
product search: fix wrong variable usage in url to reset filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 #### Fixed
 - [#260 - JS validation: dynamically added form inputs are now validated](https://github.com/shopsys/shopsys/pull/260)
 
+### [shopsys/project-base]
+#### Fixed
+- [#359 - fix wrong variable usage in url to reset product filter](https://github.com/shopsys/shopsys/pull/359)
+
 ## [7.0.0-alpha4] - 2018-08-02
 ### [shopsys/framework]
 #### Added

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/ajaxSearch.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/ajaxSearch.html.twig
@@ -4,7 +4,7 @@
     {{ productFilterForm.filterForm(
         filterForm,
         url('front_product_search'),
-        url('front_product_search', { SEARCH_TEXT_PARAMETER : searchText }),
+        url('front_product_search', { (SEARCH_TEXT_PARAMETER) : searchText }),
         searchText,
         'search',
         productFilterCountData,

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/search.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/search.html.twig
@@ -22,7 +22,7 @@
                 {{ productFilterForm.filterForm(
                     filterForm,
                     url('front_product_search'),
-                    url('front_product_search', { SEARCH_TEXT_PARAMETER : searchText }),
+                    url('front_product_search', { (SEARCH_TEXT_PARAMETER) : searchText }),
                     searchText,
                     'search',
                     productFilterCountData,


### PR DESCRIPTION
-  variable name was used in url instead of variable value

| Q             | A
| ------------- | ------------- 
|Description, reason for the PR| bugfix
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| -
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
