### PR TITLE
composer.json: mark codeception/stub as conflicting from 2.0.2 onwards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,7 +151,7 @@
     "symplify/easy-coding-standard-tester": "^4.4"
   },
   "conflict": {
-    "codeception/stub": "2.0.2"
+    "codeception/stub": ">=2.0.2"
   },
   "scripts": {
     "post-install-cmd": [

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -114,7 +114,7 @@
         "shopsys/http-smoke-testing": "dev-master"
     },
     "conflict": {
-        "codeception/stub": "2.0.2"
+        "codeception/stub": ">=2.0.2"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
- PHPUnit 7.2 and Conception 2.4 are incompatible, see https://github.com/Codeception/Codeception/issues/5092
- codeception/stub added compatibility with the newer version in their composer.json in 2.0.2
- with codeception/stub 2.0.2, phing target tests-acceptance-build silently fails, breaking our build (see #347)
- codeception/stub 2.0.3 reverted this change as the mainteiners saw the incompatibility issue
- codeception/stub 2.0.4 reverted the revert
- the package is marked as conflicting in version >=2.0.2 until the issue is fixed (I've added a bullet to our internal release checklist)

| Q             | A
| ------------- | ---
|Description, reason for the PR| target tests-acceptance-build fails
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes