### PR TITLE
MultidomainEntityClassFinderFacade: metadata are checked on class nam…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - see details in the [Logging](/docs/introduction/logging.md) article
 - [#341 - Category entity in constructor of CategoryRepository is resolved via EntityNameResolver](https://github.com/shopsys/shopsys/pull/341)
 - [#364 - Admin: brand form is rendered via BrandFormType](https://github.com/shopsys/shopsys/pull/364)
+- [#370 - MultidomainEntityClassFinderFacade: metadata are checked on class name resolved by EntityNameResolver](https://github.com/shopsys/shopsys/pull/370)
 
 #### Fixed
 - [#291 - Unnecessary SQL queries on category detail in admin](https://github.com/shopsys/shopsys/pull/304):

--- a/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityClassFinderFacade.php
+++ b/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityClassFinderFacade.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle\Component\Domain\Multidomain;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Doctrine\NotNullableColumnsFinder;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 
 class MultidomainEntityClassFinderFacade
 {
@@ -27,16 +28,23 @@ class MultidomainEntityClassFinderFacade
      */
     protected $notNullableColumnsFinder;
 
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
     public function __construct(
         EntityManagerInterface $em,
         MultidomainEntityClassFinder $multidomainEntityClassFinder,
         MultidomainEntityClassProviderInterface $multidomainEntityClassProvider,
-        NotNullableColumnsFinder $notNullableColumnsFinder
+        NotNullableColumnsFinder $notNullableColumnsFinder,
+        EntityNameResolver $entityNameResolver
     ) {
         $this->em = $em;
         $this->multidomainEntityClassFinder = $multidomainEntityClassFinder;
         $this->multidomainEntityClassProvider = $multidomainEntityClassProvider;
         $this->notNullableColumnsFinder = $notNullableColumnsFinder;
+        $this->entityNameResolver = $entityNameResolver;
     }
 
     /**
@@ -58,7 +66,8 @@ class MultidomainEntityClassFinderFacade
     {
         $multidomainClassesMetadata = [];
         foreach ($this->getMultidomainEntitiesNames() as $multidomainEntityName) {
-            $multidomainClassesMetadata[] = $this->em->getMetadataFactory()->getMetadataFor($multidomainEntityName);
+            $resolvedClassName = $this->entityNameResolver->resolve($multidomainEntityName);
+            $multidomainClassesMetadata[] = $this->em->getMetadataFactory()->getMetadataFor($resolvedClassName);
         }
 
         return $this->notNullableColumnsFinder->getAllNotNullableColumnNamesIndexedByTableName($multidomainClassesMetadata);


### PR DESCRIPTION
…e resolved by EntityNameResolver

| Q             | A
| ------------- | ---
|Description, reason for the PR|
During the tests in MultidomainEntityDataCreator some copies of multidomain data are created. This process uses metadata of classes that have multidomain data. In the scenario with already extended multidomain entity, it is necessary to ensure that the extended entity is correctly reflected in this process.
|New feature| No
|BC breaks| No 
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
