### PR TITLE
Composer.json: require Shopsys packages in the current version (dev-master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [7.0.0-alpha3] - 2018-08-02
+## [7.0.0-alpha4] - 2018-08-02
 ### [shopsys/framework]
 #### Added
 - [#335 - Possibility to add a new administration page](https://github.com/shopsys/shopsys/pull/335)

--- a/packages/form-types-bundle/composer.json
+++ b/packages/form-types-bundle/composer.json
@@ -26,6 +26,6 @@
         "symfony/translation": "^3.4"
     },
     "require-dev": {
-        "shopsys/coding-standards": "7.0.0-alpha4"
+        "shopsys/coding-standards": "dev-master"
     }
 }

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -83,9 +83,9 @@
         "psr/log": "^1.0",
         "sensio/distribution-bundle": "^5.0.21",
         "sensio/framework-extra-bundle": "^3.0.29",
-        "shopsys/migrations": "7.0.0-alpha4",
-        "shopsys/form-types-bundle": "7.0.0-alpha4",
-        "shopsys/plugin-interface": "7.0.0-alpha4",
+        "shopsys/migrations": "dev-master",
+        "shopsys/form-types-bundle": "dev-master",
+        "shopsys/plugin-interface": "dev-master",
         "snc/redis-bundle": "2.1.4",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "swiftmailer/swiftmailer": "^6.0",
@@ -102,7 +102,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.7",
         "phpunit/phpunit": "^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4"
+        "shopsys/coding-standards": "dev-master"
     },
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command",

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -37,6 +37,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.0|^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4"
+        "shopsys/coding-standards": "dev-master"
     }
 }

--- a/packages/plugin-interface/composer.json
+++ b/packages/plugin-interface/composer.json
@@ -20,6 +20,6 @@
         "symfony/monolog-bridge": "^3.0.0"
     },
     "require-dev": {
-        "shopsys/coding-standards": "7.0.0-alpha4"
+        "shopsys/coding-standards": "dev-master"
     }
 }

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -42,16 +42,16 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
         "intaro/postgres-search-bundle": "@dev",
-        "shopsys/form-types-bundle": "7.0.0-alpha4",
-        "shopsys/framework": "7.0.0-alpha4",
-        "shopsys/migrations": "7.0.0-alpha4",
-        "shopsys/plugin-interface": "7.0.0-alpha4",
+        "shopsys/form-types-bundle": "dev-master",
+        "shopsys/framework": "dev-master",
+        "shopsys/migrations": "dev-master",
+        "shopsys/plugin-interface": "dev-master",
         "symfony/symfony": "^3.4.8",
         "timwhitlock/jparser": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4",
+        "shopsys/coding-standards": "dev-master",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.4.8"
     }

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -38,10 +38,10 @@
         "php": "^7.1",
         "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
         "intaro/postgres-search-bundle": "@dev",
-        "shopsys/form-types-bundle": "7.0.0-alpha4",
-        "shopsys/framework": "7.0.0-alpha4",
-        "shopsys/migrations": "7.0.0-alpha4",
-        "shopsys/plugin-interface": "7.0.0-alpha4",
+        "shopsys/form-types-bundle": "dev-master",
+        "shopsys/framework": "dev-master",
+        "shopsys/migrations": "dev-master",
+        "shopsys/plugin-interface": "dev-master",
         "symfony/config": "^3.4",
         "symfony/dependency-injection": "^3.4",
         "symfony/framework-bundle": "^3.4",
@@ -50,7 +50,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4",
+        "shopsys/coding-standards": "dev-master",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.4.8"
     }

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -45,16 +45,16 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
         "intaro/postgres-search-bundle": "@dev",
-        "shopsys/form-types-bundle": "7.0.0-alpha4",
-        "shopsys/framework": "7.0.0-alpha4",
-        "shopsys/migrations": "7.0.0-alpha4",
-        "shopsys/plugin-interface": "7.0.0-alpha4",
+        "shopsys/form-types-bundle": "dev-master",
+        "shopsys/framework": "dev-master",
+        "shopsys/migrations": "dev-master",
+        "shopsys/plugin-interface": "dev-master",
         "symfony/symfony": "^3.4.8",
         "timwhitlock/jparser": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4",
+        "shopsys/coding-standards": "dev-master",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.4.8"
     }

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -42,16 +42,16 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
         "intaro/postgres-search-bundle": "@dev",
-        "shopsys/form-types-bundle": "7.0.0-alpha4",
-        "shopsys/framework": "7.0.0-alpha4",
-        "shopsys/migrations": "7.0.0-alpha4",
-        "shopsys/plugin-interface": "7.0.0-alpha4",
+        "shopsys/form-types-bundle": "dev-master",
+        "shopsys/framework": "dev-master",
+        "shopsys/migrations": "dev-master",
+        "shopsys/plugin-interface": "dev-master",
         "symfony/symfony": "^3.4.8",
         "timwhitlock/jparser": "@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4",
+        "shopsys/coding-standards": "dev-master",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.4.8"
     }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -82,14 +82,14 @@
         "sensio/distribution-bundle": "^5.0.21",
         "sensio/framework-extra-bundle": "^3.0.29",
         "sensio/generator-bundle": "^3.1.7",
-        "shopsys/migrations": "7.0.0-alpha4",
-        "shopsys/form-types-bundle": "7.0.0-alpha4",
-        "shopsys/framework": "7.0.0-alpha4",
-        "shopsys/plugin-interface": "7.0.0-alpha4",
-        "shopsys/product-feed-heureka": "7.0.0-alpha4",
-        "shopsys/product-feed-heureka-delivery": "7.0.0-alpha4",
-        "shopsys/product-feed-zbozi": "7.0.0-alpha4",
-        "shopsys/product-feed-google": "7.0.0-alpha4",
+        "shopsys/migrations": "dev-master",
+        "shopsys/form-types-bundle": "dev-master",
+        "shopsys/framework": "dev-master",
+        "shopsys/plugin-interface": "dev-master",
+        "shopsys/product-feed-heureka": "dev-master",
+        "shopsys/product-feed-heureka-delivery": "dev-master",
+        "shopsys/product-feed-zbozi": "dev-master",
+        "shopsys/product-feed-google": "dev-master",
         "snc/redis-bundle": "2.1.4",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/assetic-bundle": "^2.8.2",
@@ -110,8 +110,8 @@
         "codeception/codeception": "^2.4.0",
         "phpstan/phpstan": "^0.7",
         "phpunit/phpunit": "^7.0",
-        "shopsys/coding-standards": "7.0.0-alpha4",
-        "shopsys/http-smoke-testing": "7.0.0-alpha4"
+        "shopsys/coding-standards": "dev-master",
+        "shopsys/http-smoke-testing": "dev-master"
     },
     "conflict": {
         "codeception/stub": ">=2.0.2"


### PR DESCRIPTION
Composer.json: require Shopsys packages in the current version (dev-master)

- revert of commit ca81a09c9bf259e91607a5dd0601ee9a5cfefcaf after release

| Q             | A
| ------------- | ---
|Description, reason for the PR| Rever of dependecies from v7.0.0-alpha4 back to dev-master after release
|New feature| No
|BC breaks| No
|Fixes issues| No
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
