### PR TITLE
cs: keep class spacing consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### [shopsys/coding-standards]
+#### Added
+- [#384 - cs: keep class spacing consistent](https://github.com/shopsys/shopsys/pull/384) [@TomasVotruba]
+    - added new rule (along with fixer `ClassAttributesSeparationFixer`) into `easy-coding-standard.yml`
 
 ## [7.0.0-alpha5] - 2018-08-22
 ### [shopsys/framework]

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -122,6 +122,13 @@ services:
     PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer: ~
     PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
     PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer: ~
+    # keep 1 empty line between constants, properties and methods
+    # keep 0 empty lines after class open bracket {
+    # keep 0 empty lines before class end bracket }
+    PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer:
+        elements:
+        - 'property'
+        - 'method'
 
     # Code Metrics
     ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff:

--- a/packages/framework/src/Command/CheckMicroservicesCommand.php
+++ b/packages/framework/src/Command/CheckMicroservicesCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CheckMicroservicesCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/CheckTimezonesCommand.php
+++ b/packages/framework/src/Command/CheckTimezonesCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CheckTimezonesCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
+++ b/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class CreateApplicationDirectoriesCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/CreateDatabaseCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CreateDatabaseCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/CreateDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseSchemaCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateDatabaseSchemaCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/CreateDomainsDataCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDataCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CreateDomainsDataCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/DropDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/DropDatabaseSchemaCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DropDatabaseSchemaCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/GenerateErrorPagesCommand.php
+++ b/packages/framework/src/Command/GenerateErrorPagesCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateErrorPagesCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/GenerateFriendlyUrlCommand.php
+++ b/packages/framework/src/Command/GenerateFriendlyUrlCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GenerateFriendlyUrlCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/GenerateGruntfileCommand.php
+++ b/packages/framework/src/Command/GenerateGruntfileCommand.php
@@ -11,7 +11,6 @@ use Twig\Environment;
 
 class GenerateGruntfileCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/ImageDemoCommand.php
+++ b/packages/framework/src/Command/ImageDemoCommand.php
@@ -18,7 +18,6 @@ use ZipArchive;
 
 class ImageDemoCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/ImportDefaultDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/ImportDefaultDatabaseSchemaCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ImportDefaultDatabaseSchemaCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/LoadDataFixturesCommand.php
+++ b/packages/framework/src/Command/LoadDataFixturesCommand.php
@@ -24,7 +24,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class LoadDataFixturesCommand extends DoctrineCommand
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Component\DataFixture\FixturesLoader
      */

--- a/packages/framework/src/Command/LoadPluginDataFixturesCommand.php
+++ b/packages/framework/src/Command/LoadPluginDataFixturesCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class LoadPluginDataFixturesCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/PerformanceDataCommand.php
+++ b/packages/framework/src/Command/PerformanceDataCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PerformanceDataCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/RecalculationsCommand.php
+++ b/packages/framework/src/Command/RecalculationsCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RecalculationsCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/ReplaceDomainsUrlsCommand.php
+++ b/packages/framework/src/Command/ReplaceDomainsUrlsCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ReplaceDomainsUrlsCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/ServerRunForDomainCommand.php
+++ b/packages/framework/src/Command/ServerRunForDomainCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ServerRunForDomainCommand extends Command
 {
-
     /**
      * @var string
      */

--- a/packages/framework/src/Component/Cron/CronModuleFactory.php
+++ b/packages/framework/src/Component/Cron/CronModuleFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Cron;
 
 class CronModuleFactory implements CronModuleFactoryInterface
 {
-
     /**
      * @param string $serviceId
      * @return \Shopsys\FrameworkBundle\Component\Cron\CronModule

--- a/packages/framework/src/Component/Cron/CronModuleFactoryInterface.php
+++ b/packages/framework/src/Component/Cron/CronModuleFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Cron;
 
 interface CronModuleFactoryInterface
 {
-
     /**
      * @param string $serviceId
      * @return \Shopsys\FrameworkBundle\Component\Cron\CronModule

--- a/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
+++ b/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Query\ResultSetMapping;
 
 abstract class AbstractNativeFixture extends AbstractFixture
 {
-
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */

--- a/packages/framework/src/Component/DataFixture/FixturesLoader.php
+++ b/packages/framework/src/Component/DataFixture/FixturesLoader.php
@@ -16,7 +16,6 @@ use Doctrine\Common\DataFixtures\Loader;
  */
 class FixturesLoader extends Loader
 {
-
     /**
      * @var \Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader
      */

--- a/packages/framework/src/Component/DataFixture/PersistentReferenceFactory.php
+++ b/packages/framework/src/Component/DataFixture/PersistentReferenceFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\DataFixture;
 
 class PersistentReferenceFactory implements PersistentReferenceFactoryInterface
 {
-
     /**
      * @param string $referenceName
      * @param string $entityName

--- a/packages/framework/src/Component/DataFixture/PersistentReferenceFactoryInterface.php
+++ b/packages/framework/src/Component/DataFixture/PersistentReferenceFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\DataFixture;
 
 interface PersistentReferenceFactoryInterface
 {
-
     /**
      * @param string $referenceName
      * @param string $entityName

--- a/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityClassProviderInterface.php
+++ b/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityClassProviderInterface.php
@@ -12,7 +12,6 @@ namespace Shopsys\FrameworkBundle\Component\Domain\Multidomain;
  */
 interface MultidomainEntityClassProviderInterface
 {
-
     /**
      * Return entities FQNs that have identifier called $domainId but is not multidomain entity.
      *

--- a/packages/framework/src/Component/Grid/InlineEdit/GridInlineEditRegistry.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/GridInlineEditRegistry.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Grid\InlineEdit;
 
 class GridInlineEditRegistry
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface[]
      */

--- a/packages/framework/src/Component/Image/ImageFactory.php
+++ b/packages/framework/src/Component/Image/ImageFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Image;
 
 class ImageFactory implements ImageFactoryInterface
 {
-
     /**
      * @param string $entityName
      * @param int $entityId

--- a/packages/framework/src/Component/Image/ImageFactoryInterface.php
+++ b/packages/framework/src/Component/Image/ImageFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Image;
 
 interface ImageFactoryInterface
 {
-
     /**
      * @param string $entityName
      * @param int $entityId

--- a/packages/framework/src/Component/Paginator/PaginatorInterface.php
+++ b/packages/framework/src/Component/Paginator/PaginatorInterface.php
@@ -5,5 +5,6 @@ namespace Shopsys\FrameworkBundle\Component\Paginator;
 interface PaginatorInterface
 {
     public function getResult($page, $pageSize);
+
     public function getTotalCount();
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
 class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
 {
-
     /**
      * @param string $routeName
      * @param int $entityId

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactoryInterface.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
 interface FriendlyUrlFactoryInterface
 {
-
     /**
      * @param string $routeName
      * @param int $entityId

--- a/packages/framework/src/Component/Setting/SettingValueFactory.php
+++ b/packages/framework/src/Component/Setting/SettingValueFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Setting;
 
 class SettingValueFactory implements SettingValueFactoryInterface
 {
-
     /**
      * @param string $name
      * @param \DateTime|string|int|float|bool|null $value

--- a/packages/framework/src/Component/Setting/SettingValueFactoryInterface.php
+++ b/packages/framework/src/Component/Setting/SettingValueFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Setting;
 
 interface SettingValueFactoryInterface
 {
-
     /**
      * @param string $name
      * @param \DateTime|string|int|float|bool|null $value

--- a/packages/framework/src/Component/UploadedFile/UploadedFileFactory.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\UploadedFile;
 
 class UploadedFileFactory implements UploadedFileFactoryInterface
 {
-
     /**
      * @param string $entityName
      * @param int $entityId

--- a/packages/framework/src/Component/UploadedFile/UploadedFileFactoryInterface.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\UploadedFile;
 
 interface UploadedFileFactoryInterface
 {
-
     /**
      * @param string $entityName
      * @param int $entityId

--- a/packages/framework/src/Controller/Admin/CountryController.php
+++ b/packages/framework/src/Controller/Admin/CountryController.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Country\CountryInlineEdit;
 
 class CountryController extends AdminBaseController
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\CountryInlineEdit
      */

--- a/packages/framework/src/Controller/Admin/MenuController.php
+++ b/packages/framework/src/Controller/Admin/MenuController.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Component\Domain\DomainFacade;
 
 class MenuController extends AdminBaseController
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\DomainFacade
      */

--- a/packages/framework/src/Controller/Admin/SeoController.php
+++ b/packages/framework/src/Controller/Admin/SeoController.php
@@ -10,7 +10,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SeoController extends AdminBaseController
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade
      */

--- a/packages/framework/src/Form/Admin/Customer/UserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/UserFormType.php
@@ -26,7 +26,6 @@ use Symfony\Component\Validator\Constraints;
 
 class UserFormType extends AbstractType
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -22,7 +22,6 @@ use Symfony\Component\Validator\Constraints;
 
 class BrandFormType extends AbstractType
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */

--- a/packages/framework/src/Form/Constraints/Contains.php
+++ b/packages/framework/src/Form/Constraints/Contains.php
@@ -10,6 +10,7 @@ use Symfony\Component\Validator\Constraint;
 class Contains extends Constraint
 {
     public $message = 'Field must contain {{ needle }}.';
+
     public $needle = null;
 
     public function getRequiredOptions()

--- a/packages/framework/src/Form/Constraints/UniqueCollection.php
+++ b/packages/framework/src/Form/Constraints/UniqueCollection.php
@@ -10,6 +10,8 @@ use Symfony\Component\Validator\Constraint;
 class UniqueCollection extends Constraint
 {
     public $message = 'Values are duplicate.';
+
     public $fields = null;
+
     public $allowEmpty = false;
 }

--- a/packages/framework/src/Form/Constraints/UniqueEmail.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmail.php
@@ -7,5 +7,6 @@ use Symfony\Component\Validator\Constraint;
 class UniqueEmail extends Constraint
 {
     public $message = 'Email {{ email }} is already registered';
+
     public $ignoredEmail = null;
 }

--- a/packages/framework/src/Form/Constraints/UniqueSlugsOnDomains.php
+++ b/packages/framework/src/Form/Constraints/UniqueSlugsOnDomains.php
@@ -10,5 +10,6 @@ use Symfony\Component\Validator\Constraint;
 class UniqueSlugsOnDomains extends Constraint
 {
     public $message = 'Address {{ url }} already exists.';
+
     public $messageDuplicate = 'Address {{ url }} can be entered only once.';
 }

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -28,6 +28,7 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
         $view->vars['is_group_container_to_render_as_the_last_one'] = $options['is_group_container_to_render_as_the_last_one'];
         $view->vars['render_form_row'] = $options['render_form_row'];
     }
+
     /**
      * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
      */
@@ -43,6 +44,7 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
             'render_form_row' => true,
         ]);
     }
+
     /**
      * @return string
      */

--- a/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFactory.php
+++ b/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 
 class AdministratorActivityFactory implements AdministratorActivityFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
      * @param string $ipAddress

--- a/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFactoryInterface.php
+++ b/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 
 interface AdministratorActivityFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
      * @param string $ipAddress

--- a/packages/framework/src/Model/Administrator/AdministratorFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 class AdministratorFactory implements AdministratorFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $data
      * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator

--- a/packages/framework/src/Model/Administrator/AdministratorFactoryInterface.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 interface AdministratorFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $data
      * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator

--- a/packages/framework/src/Model/Administrator/AdministratorGridLimitFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorGridLimitFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 class AdministratorGridLimitFactory implements AdministratorGridLimitFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
      * @param string $gridId

--- a/packages/framework/src/Model/Administrator/AdministratorGridLimitFactoryInterface.php
+++ b/packages/framework/src/Model/Administrator/AdministratorGridLimitFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 interface AdministratorGridLimitFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
      * @param string $gridId

--- a/packages/framework/src/Model/Administrator/AdministratorGridService.php
+++ b/packages/framework/src/Model/Administrator/AdministratorGridService.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Component\Grid\Grid;
 
 class AdministratorGridService
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridLimitFactoryInterface
      */

--- a/packages/framework/src/Model/Advert/AdvertFactory.php
+++ b/packages/framework/src/Model/Advert/AdvertFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Advert;
 
 class AdvertFactory implements AdvertFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertData $data
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert

--- a/packages/framework/src/Model/Advert/AdvertFactoryInterface.php
+++ b/packages/framework/src/Model/Advert/AdvertFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Advert;
 
 interface AdvertFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertData $data
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert

--- a/packages/framework/src/Model/Article/ArticleFactory.php
+++ b/packages/framework/src/Model/Article/ArticleFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Article;
 
 class ArticleFactory implements ArticleFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $data
      * @return \Shopsys\FrameworkBundle\Model\Article\Article

--- a/packages/framework/src/Model/Article/ArticleFactoryInterface.php
+++ b/packages/framework/src/Model/Article/ArticleFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Article;
 
 interface ArticleFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $data
      * @return \Shopsys\FrameworkBundle\Model\Article\Article

--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -157,6 +157,7 @@ class CartFacade
     {
         $this->currentPromoCodeFacade->removeEnteredPromoCode();
     }
+
     /**
      * @return \Shopsys\FrameworkBundle\Model\Cart\Cart
      */

--- a/packages/framework/src/Model/Cart/Item/CartItemFactory.php
+++ b/packages/framework/src/Model/Cart/Item/CartItemFactory.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class CartItemFactory implements CartItemFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerIdentifier $customerIdentifier
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product

--- a/packages/framework/src/Model/Cart/Item/CartItemFactoryInterface.php
+++ b/packages/framework/src/Model/Cart/Item/CartItemFactoryInterface.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface CartItemFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerIdentifier $customerIdentifier
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product

--- a/packages/framework/src/Model/Category/CategoryFactory.php
+++ b/packages/framework/src/Model/Category/CategoryFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Category;
 
 class CategoryFactory implements CategoryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryData $data
      * @return \Shopsys\FrameworkBundle\Model\Category\Category

--- a/packages/framework/src/Model/Category/CategoryFactoryInterface.php
+++ b/packages/framework/src/Model/Category/CategoryFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Category;
 
 interface CategoryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryData $data
      * @return \Shopsys\FrameworkBundle\Model\Category\Category

--- a/packages/framework/src/Model/Category/CategoryService.php
+++ b/packages/framework/src/Model/Category/CategoryService.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Category;
 
 class CategoryService
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFactoryInterface
      */

--- a/packages/framework/src/Model/Category/TopCategory/TopCategoryFactory.php
+++ b/packages/framework/src/Model/Category/TopCategory/TopCategoryFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class TopCategoryFactory implements TopCategoryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @param int $domainId

--- a/packages/framework/src/Model/Category/TopCategory/TopCategoryFactoryInterface.php
+++ b/packages/framework/src/Model/Category/TopCategory/TopCategoryFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Category\Category;
 
 interface TopCategoryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @param int $domainId

--- a/packages/framework/src/Model/Country/CountryFactory.php
+++ b/packages/framework/src/Model/Country/CountryFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Country;
 
 class CountryFactory implements CountryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryData $data
      * @param int $domainId

--- a/packages/framework/src/Model/Country/CountryFactoryInterface.php
+++ b/packages/framework/src/Model/Country/CountryFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Country;
 
 interface CountryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryData $data
      * @param int $domainId

--- a/packages/framework/src/Model/Customer/BillingAddressFactory.php
+++ b/packages/framework/src/Model/Customer/BillingAddressFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 class BillingAddressFactory implements BillingAddressFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $data
      * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddress

--- a/packages/framework/src/Model/Customer/BillingAddressFactoryInterface.php
+++ b/packages/framework/src/Model/Customer/BillingAddressFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 interface BillingAddressFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $data
      * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddress

--- a/packages/framework/src/Model/Customer/DeliveryAddressFactory.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddressFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 class DeliveryAddressFactory implements DeliveryAddressFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData $data
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress

--- a/packages/framework/src/Model/Customer/DeliveryAddressFactoryInterface.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddressFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 interface DeliveryAddressFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData $data
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress

--- a/packages/framework/src/Model/Customer/UserFactory.php
+++ b/packages/framework/src/Model/Customer/UserFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 class UserFactory implements UserFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\UserData $userData
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddress $billingAddress

--- a/packages/framework/src/Model/Customer/UserFactoryInterface.php
+++ b/packages/framework/src/Model/Customer/UserFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Customer;
 
 interface UserFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\UserData $userData
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddress $billingAddress

--- a/packages/framework/src/Model/Mail/MailTemplateFactory.php
+++ b/packages/framework/src/Model/Mail/MailTemplateFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Mail;
 
 class MailTemplateFactory implements MailTemplateFactoryInterface
 {
-
     /**
      * @param string $name
      * @param int $domainId

--- a/packages/framework/src/Model/Mail/MailTemplateFactoryInterface.php
+++ b/packages/framework/src/Model/Mail/MailTemplateFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Mail;
 
 interface MailTemplateFactoryInterface
 {
-
     /**
      * @param string $name
      * @param int $domainId

--- a/packages/framework/src/Model/Module/EnabledModuleFactory.php
+++ b/packages/framework/src/Model/Module/EnabledModuleFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Module;
 
 class EnabledModuleFactory implements EnabledModuleFactoryInterface
 {
-
     /**
      * @param string $name
      * @return \Shopsys\FrameworkBundle\Model\Module\EnabledModule

--- a/packages/framework/src/Model/Module/EnabledModuleFactoryInterface.php
+++ b/packages/framework/src/Model/Module/EnabledModuleFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Module;
 
 interface EnabledModuleFactoryInterface
 {
-
     /**
      * @param string $name
      * @return \Shopsys\FrameworkBundle\Model\Module\EnabledModule

--- a/packages/framework/src/Model/Newsletter/NewsletterSubscriberFactory.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterSubscriberFactory.php
@@ -6,7 +6,6 @@ use DateTimeImmutable;
 
 class NewsletterSubscriberFactory implements NewsletterSubscriberFactoryInterface
 {
-
     /**
      * @param string $email
      * @param DateTimeImmutable $createdAt

--- a/packages/framework/src/Model/Newsletter/NewsletterSubscriberFactoryInterface.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterSubscriberFactoryInterface.php
@@ -6,7 +6,6 @@ use DateTimeImmutable;
 
 interface NewsletterSubscriberFactoryInterface
 {
-
     /**
      * @param string $email
      * @param DateTimeImmutable $createdAt

--- a/packages/framework/src/Model/Order/Item/OrderPaymentFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderPaymentFactory.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 
 class OrderPaymentFactory implements OrderPaymentFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Item/OrderPaymentFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderPaymentFactoryInterface.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 
 interface OrderPaymentFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Item/OrderProductFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderProductFactory.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class OrderProductFactory implements OrderProductFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Item/OrderProductFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderProductFactoryInterface.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface OrderProductFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Item/OrderTransportFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderTransportFactory.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
 class OrderTransportFactory implements OrderTransportFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Item/OrderTransportFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderTransportFactoryInterface.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
 interface OrderTransportFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Mail/OrderMailFacade.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMailFacade.php
@@ -49,6 +49,7 @@ class OrderMailFacade
         $messageData->attachmentsFilepaths = $this->mailTemplateFacade->getMailTemplateAttachmentsFilepaths($mailTemplate);
         $this->mailer->send($messageData);
     }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus $orderStatus
      * @param int $domainId

--- a/packages/framework/src/Model/Order/OrderFactory.php
+++ b/packages/framework/src/Model/Order/OrderFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Customer\User;
 
 class OrderFactory implements OrderFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
      * @param string $orderNumber

--- a/packages/framework/src/Model/Order/OrderFactoryInterface.php
+++ b/packages/framework/src/Model/Order/OrderFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Customer\User;
 
 interface OrderFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
      * @param string $orderNumber

--- a/packages/framework/src/Model/Order/OrderNumberSequenceFactory.php
+++ b/packages/framework/src/Model/Order/OrderNumberSequenceFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 
 class OrderNumberSequenceFactory implements OrderNumberSequenceFactoryInterface
 {
-
     /**
      * @param int $id
      * @param string $number

--- a/packages/framework/src/Model/Order/OrderNumberSequenceFactoryInterface.php
+++ b/packages/framework/src/Model/Order/OrderNumberSequenceFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 
 interface OrderNumberSequenceFactoryInterface
 {
-
     /**
      * @param int $id
      * @param string $number

--- a/packages/framework/src/Model/Order/PromoCode/PromoCodeFactory.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCodeFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order\PromoCode;
 
 class PromoCodeFactory implements PromoCodeFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeData $data
      * @return \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode

--- a/packages/framework/src/Model/Order/PromoCode/PromoCodeFactoryInterface.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCodeFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order\PromoCode;
 
 interface PromoCodeFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeData $data
      * @return \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode

--- a/packages/framework/src/Model/Order/Status/OrderStatusFactory.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatusFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order\Status;
 
 class OrderStatusFactory implements OrderStatusFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $data
      * @param int $type

--- a/packages/framework/src/Model/Order/Status/OrderStatusFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatusFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order\Status;
 
 interface OrderStatusFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $data
      * @param int $type

--- a/packages/framework/src/Model/Payment/PaymentFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Payment;
 
 class PaymentFactory implements PaymentFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $data
      * @return \Shopsys\FrameworkBundle\Model\Payment\Payment

--- a/packages/framework/src/Model/Payment/PaymentFactoryInterface.php
+++ b/packages/framework/src/Model/Payment/PaymentFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Payment;
 
 interface PaymentFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $data
      * @return \Shopsys\FrameworkBundle\Model\Payment\Payment

--- a/packages/framework/src/Model/Payment/PaymentPriceFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 class PaymentPriceFactory implements PaymentPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\Payment $payment
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency

--- a/packages/framework/src/Model/Payment/PaymentPriceFactoryInterface.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 interface PaymentPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\Payment $payment
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestData.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestData.php
@@ -6,7 +6,6 @@ use DateTime;
 
 class PersonalDataAccessRequestData
 {
-
     /**
      * @var DateTime|null
      */

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestFactory.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\PersonalData;
 
 class PersonalDataAccessRequestFactory implements PersonalDataAccessRequestFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestData $data
      * @return \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestFactoryInterface.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\PersonalData;
 
 interface PersonalDataAccessRequestFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestData $data
      * @return \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestRepository.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestRepository.php
@@ -7,7 +7,6 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class PersonalDataAccessRequestRepository
 {
-
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Currency;
 
 class CurrencyFactory implements CurrencyFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $data
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyFactoryInterface.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Currency;
 
 interface CurrencyFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $data
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyService.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyService.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 
 class CurrencyService
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFactoryInterface
      */

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupFactory.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
 
 class PricingGroupFactory implements PricingGroupFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $data
      * @param int $domainId

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupFactoryInterface.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
 
 interface PricingGroupFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $data
      * @param int $domainId

--- a/packages/framework/src/Model/Pricing/Vat/VatFactory.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Vat;
 
 class VatFactory implements VatFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $data
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat

--- a/packages/framework/src/Model/Pricing/Vat/VatFactoryInterface.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Vat;
 
 interface VatFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $data
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat

--- a/packages/framework/src/Model/Pricing/Vat/VatService.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatService.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Pricing\Vat;
 
 class VatService
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $defaultVat
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vatToDelete

--- a/packages/framework/src/Model/Product/Accessory/ProductAccessoryFactory.php
+++ b/packages/framework/src/Model/Product/Accessory/ProductAccessoryFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductAccessoryFactory implements ProductAccessoryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $accessory

--- a/packages/framework/src/Model/Product/Accessory/ProductAccessoryFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Accessory/ProductAccessoryFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface ProductAccessoryFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $accessory

--- a/packages/framework/src/Model/Product/Availability/AvailabilityFactory.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Availability;
 
 class AvailabilityFactory implements AvailabilityFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability

--- a/packages/framework/src/Model/Product/Availability/AvailabilityFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Availability;
 
 interface AvailabilityFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability

--- a/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProductFactory.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProductFactory.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ManualBestsellingProductFactory implements ManualBestsellingProductFactoryInterface
 {
-
     /**
      * @param int $domainId
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category

--- a/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProductFactoryInterface.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProductFactoryInterface.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface ManualBestsellingProductFactoryInterface
 {
-
     /**
      * @param int $domainId
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category

--- a/packages/framework/src/Model/Product/Brand/BrandFactory.php
+++ b/packages/framework/src/Model/Product/Brand/BrandFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 
 class BrandFactory implements BrandFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand

--- a/packages/framework/src/Model/Product/Brand/BrandFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Brand/BrandFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 
 interface BrandFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand

--- a/packages/framework/src/Model/Product/Elasticsearch/ElasticsearchExportCronModule.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ElasticsearchExportCronModule.php
@@ -7,7 +7,6 @@ use Symfony\Bridge\Monolog\Logger;
 
 class ElasticsearchExportCronModule implements SimpleCronModuleInterface
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ElasticsearchExportProductFacade
      */

--- a/packages/framework/src/Model/Product/Flag/FlagFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 class FlagFactory implements FlagFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag

--- a/packages/framework/src/Model/Product/Flag/FlagFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Flag/FlagFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 interface FlagFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag

--- a/packages/framework/src/Model/Product/Parameter/ParameterFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 class ParameterFactory implements ParameterFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter

--- a/packages/framework/src/Model/Product/Parameter/ParameterFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 interface ParameterFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter

--- a/packages/framework/src/Model/Product/Parameter/ParameterInlineEdit.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterInlineEdit.php
@@ -34,6 +34,7 @@ class ParameterInlineEdit extends AbstractGridInlineEdit
         $this->formFactory = $formFactory;
         $this->parameterDataFactory = $parameterDataFactory;
     }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $parameterData
      * @return int

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 class ParameterValueFactory implements ParameterValueFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 interface ParameterValueFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductParameterValueFactory implements ProductParameterValueFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface ProductParameterValueFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter

--- a/packages/framework/src/Model/Product/Pricing/ProductCalculatedPriceFactory.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductCalculatedPriceFactory.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductCalculatedPriceFactory implements ProductCalculatedPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/Pricing/ProductCalculatedPriceFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductCalculatedPriceFactoryInterface.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface ProductCalculatedPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFactory.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFactory.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductManualInputPriceFactory implements ProductManualInputPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFactoryInterface.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface ProductManualInputPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceService.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceService.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductManualInputPriceService
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFactoryInterface
      */

--- a/packages/framework/src/Model/Product/ProductCategoryDomainFactory.php
+++ b/packages/framework/src/Model/Product/ProductCategoryDomainFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class ProductCategoryDomainFactory implements ProductCategoryDomainFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category

--- a/packages/framework/src/Model/Product/ProductCategoryDomainFactoryInterface.php
+++ b/packages/framework/src/Model/Product/ProductCategoryDomainFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Category\Category;
 
 interface ProductCategoryDomainFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category

--- a/packages/framework/src/Model/Product/ProductFactory.php
+++ b/packages/framework/src/Model/Product/ProductFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product;
 
 class ProductFactory implements ProductFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Product

--- a/packages/framework/src/Model/Product/ProductFactoryInterface.php
+++ b/packages/framework/src/Model/Product/ProductFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product;
 
 interface ProductFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Product

--- a/packages/framework/src/Model/Product/ProductVisibilityFactory.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 
 class ProductVisibilityFactory implements ProductVisibilityFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/ProductVisibilityFactoryInterface.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 
 interface ProductVisibilityFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/TopProduct/TopProductFactory.php
+++ b/packages/framework/src/Model/Product/TopProduct/TopProductFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class TopProductFactory implements TopProductFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param int $domainId

--- a/packages/framework/src/Model/Product/TopProduct/TopProductFactoryInterface.php
+++ b/packages/framework/src/Model/Product/TopProduct/TopProductFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 interface TopProductFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param int $domainId

--- a/packages/framework/src/Model/Product/Unit/UnitFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Unit;
 
 class UnitFactory implements UnitFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Unit\Unit

--- a/packages/framework/src/Model/Product/Unit/UnitFactoryInterface.php
+++ b/packages/framework/src/Model/Product/Unit/UnitFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Product\Unit;
 
 interface UnitFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Unit\Unit

--- a/packages/framework/src/Model/Script/ScriptFactory.php
+++ b/packages/framework/src/Model/Script/ScriptFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Script;
 
 class ScriptFactory implements ScriptFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Script\ScriptData $data
      * @return \Shopsys\FrameworkBundle\Model\Script\Script

--- a/packages/framework/src/Model/Script/ScriptFactoryInterface.php
+++ b/packages/framework/src/Model/Script/ScriptFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Script;
 
 interface ScriptFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Script\ScriptData $data
      * @return \Shopsys\FrameworkBundle\Model\Script\Script

--- a/packages/framework/src/Model/Slider/SliderItemFactory.php
+++ b/packages/framework/src/Model/Slider/SliderItemFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Slider;
 
 class SliderItemFactory implements SliderItemFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemData $data
      * @return \Shopsys\FrameworkBundle\Model\Slider\SliderItem

--- a/packages/framework/src/Model/Slider/SliderItemFactoryInterface.php
+++ b/packages/framework/src/Model/Slider/SliderItemFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Slider;
 
 interface SliderItemFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemData $data
      * @return \Shopsys\FrameworkBundle\Model\Slider\SliderItem

--- a/packages/framework/src/Model/Transport/TransportFactory.php
+++ b/packages/framework/src/Model/Transport/TransportFactory.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Transport;
 
 class TransportFactory implements TransportFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportData $data
      * @return \Shopsys\FrameworkBundle\Model\Transport\Transport

--- a/packages/framework/src/Model/Transport/TransportFactoryInterface.php
+++ b/packages/framework/src/Model/Transport/TransportFactoryInterface.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Transport;
 
 interface TransportFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportData $data
      * @return \Shopsys\FrameworkBundle\Model\Transport\Transport

--- a/packages/framework/src/Model/Transport/TransportPriceFactory.php
+++ b/packages/framework/src/Model/Transport/TransportPriceFactory.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 class TransportPriceFactory implements TransportPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency

--- a/packages/framework/src/Model/Transport/TransportPriceFactoryInterface.php
+++ b/packages/framework/src/Model/Transport/TransportPriceFactoryInterface.php
@@ -6,7 +6,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 interface TransportPriceFactoryInterface
 {
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency

--- a/packages/framework/src/Twig/FormDetailExtension.php
+++ b/packages/framework/src/Twig/FormDetailExtension.php
@@ -9,7 +9,6 @@ use Twig_SimpleFunction;
 
 class FormDetailExtension extends Twig_Extension
 {
-
     /**
      * @var \Twig_Environment
      */

--- a/packages/framework/src/Twig/JoinNoneEmptyExtension.php
+++ b/packages/framework/src/Twig/JoinNoneEmptyExtension.php
@@ -7,7 +7,6 @@ use Twig_SimpleFilter;
 
 class JoinNoneEmptyExtension extends Twig_Extension
 {
-
     /**
      * @return \Twig_SimpleFilter[]
      */

--- a/packages/framework/src/Twig/LocalizationExtension.php
+++ b/packages/framework/src/Twig/LocalizationExtension.php
@@ -8,7 +8,6 @@ use Twig_SimpleFunction;
 
 class LocalizationExtension extends \Twig_Extension
 {
-
     /**
      * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
      */

--- a/packages/migrations/src/Command/Exception/CheckSchemaCommandException.php
+++ b/packages/migrations/src/Command/Exception/CheckSchemaCommandException.php
@@ -6,7 +6,6 @@ use Exception;
 
 class CheckSchemaCommandException extends Exception
 {
-
     /**
      * @param string $message
      * @param \Exception|null $previous

--- a/packages/migrations/src/Command/Exception/MigrateCommandException.php
+++ b/packages/migrations/src/Command/Exception/MigrateCommandException.php
@@ -6,7 +6,6 @@ use Exception;
 
 class MigrateCommandException extends Exception
 {
-
     /**
      * @param string $message
      * @param \Exception|null $previous

--- a/packages/migrations/src/Component/Doctrine/DatabaseSchemaFacade.php
+++ b/packages/migrations/src/Component/Doctrine/DatabaseSchemaFacade.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\Tools\SchemaTool;
 
 class DatabaseSchemaFacade
 {
-
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */

--- a/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Migrations\AbstractMigration as DoctrineAbstractMigration;
 
 abstract class AbstractMigration extends DoctrineAbstractMigration
 {
-
     /**
      * {@inheritDoc}
      * @deprecated use "sql" method instead

--- a/packages/migrations/src/Component/Doctrine/Migrations/Exception/MethodIsNotAllowedException.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Exception/MethodIsNotAllowedException.php
@@ -6,7 +6,6 @@ use Exception;
 
 class MethodIsNotAllowedException extends Exception
 {
-
     /**
      * @param string $message
      * @param \Exception|null $previous

--- a/packages/migrations/src/Component/Doctrine/SchemaDiffFilter.php
+++ b/packages/migrations/src/Component/Doctrine/SchemaDiffFilter.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Schema\TableDiff;
 
 class SchemaDiffFilter
 {
-
     /**
      * @param \Doctrine\DBAL\Schema\SchemaDiff $schemaDiff
      * @return \Doctrine\DBAL\Schema\SchemaDiff

--- a/packages/migrations/src/Component/Generator/GeneratorResult.php
+++ b/packages/migrations/src/Component/Generator/GeneratorResult.php
@@ -4,7 +4,6 @@ namespace Shopsys\MigrationBundle\Component\Generator;
 
 class GeneratorResult
 {
-
     /**
      * @var string
      */

--- a/packages/migrations/src/DependencyInjection/ShopsysMigrationExtension.php
+++ b/packages/migrations/src/DependencyInjection/ShopsysMigrationExtension.php
@@ -9,7 +9,6 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class ShopsysMigrationExtension extends Extension
 {
-
     /**
      * {@inheritDoc}
      */

--- a/packages/product-feed-google/src/Form/GoogleProductCrudExtension.php
+++ b/packages/product-feed-google/src/Form/GoogleProductCrudExtension.php
@@ -10,7 +10,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class GoogleProductCrudExtension implements PluginCrudExtensionInterface
 {
-
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */

--- a/packages/product-feed-google/src/GoogleFeedInfo.php
+++ b/packages/product-feed-google/src/GoogleFeedInfo.php
@@ -7,7 +7,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class GoogleFeedInfo implements FeedInfoInterface
 {
-
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */

--- a/packages/product-feed-heureka/src/Form/HeurekaProductCrudExtension.php
+++ b/packages/product-feed-heureka/src/Form/HeurekaProductCrudExtension.php
@@ -9,7 +9,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class HeurekaProductCrudExtension implements PluginCrudExtensionInterface
 {
-
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */

--- a/project-base/app/Bootstrap.php
+++ b/project-base/app/Bootstrap.php
@@ -19,6 +19,7 @@ setlocale(LC_CTYPE, 'en_US.utf8');
 class Bootstrap
 {
     private $environment;
+
     private $console;
 
     public function __construct($console = false, $environment = null)

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/PersonalData/PersonalDataFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/PersonalData/PersonalDataFormType.php
@@ -16,7 +16,6 @@ use Symfony\Component\Validator\Constraints\Email;
 
 class PersonalDataFormType extends AbstractType
 {
-
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
      * @param array $options

--- a/project-base/tests/ShopBundle/Database/EntityExtension/EntityExtensionTest.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/EntityExtensionTest.php
@@ -474,6 +474,7 @@ class EntityExtensionTest extends DatabaseTestCase
         $this->assertInstanceOf(ExtendedOrderProduct::class, $orderItem);
         return $orderItem;
     }
+
     /**
      * @param int $id
      * @return \Tests\ShopBundle\Database\EntityExtension\Model\ExtendedOrderItem

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/CategoryManyToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/CategoryManyToManyBidirectionalEntity.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class CategoryManyToManyBidirectionalEntity
 {
-
     /**
      * @var int
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/CategoryOneToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/CategoryOneToManyBidirectionalEntity.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class CategoryOneToManyBidirectionalEntity
 {
-
     /**
      * @var int
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/CategoryOneToOneBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/CategoryOneToOneBidirectionalEntity.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class CategoryOneToOneBidirectionalEntity
 {
-
     /**
      * @var int
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/ExtendedCategory.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/ExtendedCategory.php
@@ -13,7 +13,6 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData;
  */
 class ExtendedCategory extends Category
 {
-
     /**
      * @var string|null
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/ExtendedOrderItem.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/ExtendedOrderItem.php
@@ -18,7 +18,6 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItem;
  */
 abstract class ExtendedOrderItem extends OrderItem
 {
-
     /**
      * @var string|null
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/ExtendedProduct.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/ExtendedProduct.php
@@ -13,7 +13,6 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData;
  */
 class ExtendedProduct extends Product
 {
-
     /**
      * @var string|null
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/ProductManyToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/ProductManyToManyBidirectionalEntity.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class ProductManyToManyBidirectionalEntity
 {
-
     /**
      * @var int
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/ProductOneToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/ProductOneToManyBidirectionalEntity.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class ProductOneToManyBidirectionalEntity
 {
-
     /**
      * @var int
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/ProductOneToOneBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/ProductOneToOneBidirectionalEntity.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class ProductOneToOneBidirectionalEntity
 {
-
     /**
      * @var int
      *

--- a/project-base/tests/ShopBundle/Database/EntityExtension/Model/UnidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Database/EntityExtension/Model/UnidirectionalEntity.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class UnidirectionalEntity
 {
-
     /**
      * @var int
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Empty lines in classes are random at the moment, 0-1 at the beggining, 0-1 at the end, 1-2 between class elements. This PR adds `ClassAttributesSeparationFixer` that makes it consistent and fixes the code to comly with it.
|New feature| No
|BC breaks| No
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

It would make code more consistent and proffesional. People would not have to decide/think about spacing in classes and would be more likely to contribute us.

Found with fixer:

```yaml
# easy-coding-standard.yml
services:
    PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer:
        elements:
            - 'property'
            - 'method'
```

What do you think?

### Todo

- [x] waits on #371
- [x] retarget to `master` after it's merged


