### PR TITLE
Use of AccessDeniedHttpException replaced by use of AccessDeniedExcep…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - product search uses Elasticsearch
     - docs: added [article](./docs/introduction/product-search-via-elasticsearch.md) with Elasticsearch overview
 
+#### Changed
+- [#385 - AccessDeniedHttpException replaced by AccessDeniedException](https://github.com/shopsys/shopsys/pull/385)
+
 #### Fixed
 - [#260 - JS validation: dynamically added form inputs are now validated](https://github.com/shopsys/shopsys/pull/260)
 

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterfac
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
 use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class AdministratorController extends AdminBaseController
 {
@@ -94,7 +95,7 @@ class AdministratorController extends AdminBaseController
 
         $loggedUser = $this->getUser();
         if (!$loggedUser instanceof Administrator) {
-            throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException(sprintf(
+            throw new AccessDeniedException(sprintf(
                 'Logged user is not instance of "%s". That should not happen due to security.yml configuration.',
                 Administrator::class
             ));
@@ -102,7 +103,7 @@ class AdministratorController extends AdminBaseController
 
         if ($administrator->isSuperadmin() && !$loggedUser->isSuperadmin()) {
             $message = 'Superadmin can only be edited by superadmin.';
-            throw new \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException($message);
+            throw new AccessDeniedException($message);
         }
 
         $administratorData = $this->administratorDataFactory->createFromAdministrator($administrator);


### PR DESCRIPTION
…tion

- AccessDeniedHttpException should be used when the request is rejected
- AccessDeniedException is used when user has not enough credentials

| Q             | A
| ------------- | ---
|Description, reason for the PR| #327 
|New feature| No
|BC breaks| No
|Fixes issues| #327
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
