### PR TITLE
FileUpload wrong second parameter for UploadFailedException

### DIFF
--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -81,7 +81,7 @@ class FileUpload
     public function upload(UploadedFile $file)
     {
         if ($file->getError()) {
-            throw new \Shopsys\FrameworkBundle\Component\FileUpload\Exception\UploadFailedException($file->getErrorMessage(), $file->getError());
+            throw new \Shopsys\FrameworkBundle\Component\FileUpload\Exception\UploadFailedException($file->getErrorMessage());
         }
 
         $temporaryFilename = $this->getTemporaryFilename($file->getClientOriginalName());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When upload of file contains errors, application will faill. UploadFailedException will not be thrown because wrong second parameter expected instance of Exception or null -  integer given. Method getError() of class UploadedFile returns int only.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
