### PR TITLE
OrderInterface is created for extensibility of OrderItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### [shopsys/framework]
+#### Changed
+- [#387 - OrderInterface is created for extensibility of OrderItem](https://github.com/shopsys/shopsys/pull/387)
+    - OrderItem target entity is now OrderInterface
+
 #### Fixed
 - [#260 - JS validation: dynamically added form inputs are now validated](https://github.com/shopsys/shopsys/pull/260)
+
+### [shopsys/project-base]
+#### Added
+- [#387 - OrderInterface is created for extensibility of OrderItem](https://github.com/shopsys/shopsys/pull/387)
+    - mapping for OrderInterface to Order target entity is added into doctrine.orm.resolve_target_rentities section
 
 ## [7.0.0-alpha4] - 2018-08-02
 ### [shopsys/framework]

--- a/docs/wip_glassbox/entity-extension.md
+++ b/docs/wip_glassbox/entity-extension.md
@@ -76,6 +76,11 @@ It replaces the parent entity name by the extended entity name in strings, array
 
 The various capabilities of this resolver are best described in its unit test `\Tests\FrameworkBundle\Unit\Component\EntityExtension\EntityNameResolverTest`.
 
+### Resolve Target Entities
+
+Parent entities that are included in the association types of ORM annotation as target entities need to be resolved into 
+their extended forms. For that purpose we use doctrine [resolve_target_entity](https://symfony.com/doc/current/doctrine/resolve_target_entity.html).
+
 ### Factories
 
 Entities are created by factories. If any part of framework creates an entity, it uses a factory.

--- a/packages/framework/src/Model/Order/Item/OrderItem.php
+++ b/packages/framework/src/Model/Order/Item/OrderItem.php
@@ -31,7 +31,7 @@ abstract class OrderItem
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Order
      *
-     * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Order\Order", inversedBy="items")
+     * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Order\OrderInterface", inversedBy="items")
      * @ORM\JoinColumn(name="order_id", referencedColumnName="id", nullable=false)
      */
     protected $order;

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -17,7 +17,7 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
  * @ORM\Table(name="orders")
  * @ORM\Entity
  */
-class Order
+class Order implements OrderInterface
 {
     /**
      * @var int

--- a/packages/framework/src/Model/Order/OrderInterface.php
+++ b/packages/framework/src/Model/Order/OrderInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Model\Order;
+
+interface OrderInterface
+{
+}

--- a/project-base/app/config/config.yml
+++ b/project-base/app/config/config.yml
@@ -65,6 +65,8 @@ doctrine:
         is_bundle: false
     hydrators:
       GroupedScalarHydrator: \Shopsys\FrameworkBundle\Component\Doctrine\GroupedScalarHydrator
+    resolve_target_entities:
+      Shopsys\FrameworkBundle\Model\Order\OrderInterface: Shopsys\FrameworkBundle\Model\Order\Order
 
 doctrine_migrations:
     table_name: migrations


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| after Order entity is extended, all entities that have targetEntity set onto OrderEntity needs to be remapped on the extended one.
|New feature| Yes <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
