### PR TITLE
classes excluded from ObjectIsCreatedByFactorySniff rule are fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 #### Fixed
 - [#260 - JS validation: dynamically added form inputs are now validated](https://github.com/shopsys/shopsys/pull/260)
+- [#397 - classes excluded from ObjectIsCreatedByFactorySniff rule are fixed](https://github.com/shopsys/shopsys/pull/397)
 
 ### [shopsys/project-base]
 #### Fixed

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -32,18 +32,9 @@ parameters:
 
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:
             - '*/tests/*'
-            - '*/src/DataFixtures/Demo/ArticleDataFixture.php'
-            - '*/src/DataFixtures/Demo/CategoryDataFixture.php'
-            - '*/src/DataFixtures/Demo/PaymentDataFixture.php'
-            - '*/src/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php'
-            - '*/src/DataFixtures/Demo/TransportDataFixture.php'
-            - '*/src/DataFixtures/DemoMultidomain/ArticleDataFixture.php'
-            - '*/src/DataFixtures/Performance/CategoryDataFixture.php'
+            # class that is extended from DomainFactory
             - '*/src/Component/Domain/DomainFactoryOverwritingDomainUrl.php'
-            - '*/src/Controller/Admin/BrandController.php'
-            - '*/src/Model/Customer/CustomerData.php'
-            - '*/src/Model/Feed/FeedCronModule.php'
-            - '*/src/Model/Feed/FeedFacade.php'
+            # class that is used by OrderPreviewFactory to create OrderPreview
             - '*/src/Model/Order/Preview/OrderPreviewCalculation.php'
 
         Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff:

--- a/packages/framework/src/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
@@ -5,8 +5,7 @@ namespace Shopsys\FrameworkBundle\DataFixtures\Demo;
 use Doctrine\Common\Persistence\ObjectManager;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest;
-use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestData;
+use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactory;
 use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade;
 
 class PersonalDataAccessRequestDataFixture extends AbstractReferenceFixture
@@ -14,24 +13,27 @@ class PersonalDataAccessRequestDataFixture extends AbstractReferenceFixture
     const REFERENCE_ACCESS_DISPLAY_REQUEST = 'reference_access_display_request';
     const REFERENCE_ACCESS_EXPORT_REQUEST = 'reference_access_export_request';
 
-    /** @var PersonalDataAccessRequestFacade */
+    /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade */
     private $personalDataFacade;
+
+    /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactory */
+    private $personalDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade $personalDataFacade
      */
-    public function __construct(PersonalDataAccessRequestFacade $personalDataFacade)
+    public function __construct(PersonalDataAccessRequestFacade $personalDataFacade, PersonalDataAccessRequestDataFactory $personalDataFactory)
     {
         $this->personalDataFacade = $personalDataFacade;
+        $this->personalDataFactory = $personalDataFactory;
     }
 
     public function load(ObjectManager $manager)
     {
-        $personalDataAccessRequestData = new PersonalDataAccessRequestData();
+        $personalDataAccessRequestData = $this->personalDataFactory->createForDisplay();
         $personalDataAccessRequestData->domainId = Domain::FIRST_DOMAIN_ID;
         $personalDataAccessRequestData->email = 'no-reply@shopsys.com';
         $personalDataAccessRequestData->hash = 'UrSqiLmCK0cdGfBuwRza';
-        $personalDataAccessRequestData->type = PersonalDataAccessRequest::TYPE_DISPLAY;
 
         $personalDataAccessRequest = $this->personalDataFacade->createPersonalDataAccessRequest(
             $personalDataAccessRequestData,
@@ -40,11 +42,10 @@ class PersonalDataAccessRequestDataFixture extends AbstractReferenceFixture
 
         $this->addReference(self::REFERENCE_ACCESS_DISPLAY_REQUEST, $personalDataAccessRequest);
 
-        $personalDataAccessRequestData = new PersonalDataAccessRequestData();
+        $personalDataAccessRequestData = $this->personalDataFactory->createForExport();
         $personalDataAccessRequestData->domainId = Domain::FIRST_DOMAIN_ID;
         $personalDataAccessRequestData->email = 'no-reply@shopsys.com';
         $personalDataAccessRequestData->hash = 'UrSqiLmCK0cdGfBuwRza';
-        $personalDataAccessRequestData->type = PersonalDataAccessRequest::TYPE_EXPORT;
 
         $personalDataAccessRequest = $this->personalDataFacade->createPersonalDataAccessRequest(
             $personalDataAccessRequestData,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| code in monorepo should apply the rules that are set via coding-standards package
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #252 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
