### PR TITLE
monorepo-tools: Handle rewriting of empty commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#260 - JS validation: dynamically added form inputs are now validated](https://github.com/shopsys/shopsys/pull/260)
 - [#397 - classes excluded from ObjectIsCreatedByFactorySniff rule are fixed](https://github.com/shopsys/shopsys/pull/397)
 
+### [shopsys/monorepo-tools]
+#### Fixed
+- [#399 - monorepo-tools: Handle rewriting of empty commits](https://github.com/shopsys/shopsys/pull/399) [@drekbour]
+
 ### [shopsys/project-base]
 #### Fixed
 - [#359 - fix wrong variable usage in url to reset product filter](https://github.com/shopsys/shopsys/pull/359)
@@ -1393,3 +1397,4 @@ That's why is this section formatted differently.
 [@DavidKuna]: https://github.com/DavidKuna
 [@lukaso]: https://github.com/lukaso
 [@TomasVotruba]: https://github.com/TomasVotruba
+[@drekbour]: https://github.com/drekbour

--- a/packages/monorepo-tools/rewrite_history_into.sh
+++ b/packages/monorepo-tools/rewrite_history_into.sh
@@ -17,6 +17,6 @@ echo "Rewriting history into a subdirectory '$SUBDIRECTORY'"
 # The tags are rewritten as well as commits (the "cat" command will use original name without any change)
 SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
     --index-filter '
-    git ls-files -s | sed "s-$TAB\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv $GIT_INDEX_FILE.new $GIT_INDEX_FILE' \
+    git ls-files -s | sed "s-$TAB\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && if [ -f "$GIT_INDEX_FILE.new" ]; then mv "$GIT_INDEX_FILE.new" "$GIT_INDEX_FILE"; fi' \
     --tag-name-filter 'cat' \
     -- $REV_LIST_PARAMS


### PR DESCRIPTION
Repos created via 'git svn' always start with an empty commit that generates no rewritten index file and fails with `mv: cannot stat  .... index.new`. This is commonly reported issue on SO with a simple fix.

| Q             | A
| ------------- | ---
|Description, reason for the PR| monorepo_build/add doesn't work for reasonably common enterprise scenario of upgrading many trunks from a single svn repo into a git monorepo
|New feature| No
|BC breaks| No
|Fixes issues| 
|Standards and tests pass| N/A
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
