### PR TITLE
phing target "phpstan" now depends on "tests-acceptance-build"

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -133,7 +133,7 @@
         </exec>
     </target>
 
-    <target name="phpstan" description="Performs static analysis of PHP files using PHPStan on all packages.">
+    <target name="phpstan" depends="tests-acceptance-build" description="Performs static analysis of PHP files using PHPStan on all packages.">
         <exec executable="${path.phpstan.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="analyze"/>
             <arg value="-c"/>

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -307,7 +307,7 @@
         </if>
     </target>
 
-    <target name="phpstan" description="Performs static analysis of PHP files using PHPStan.">
+    <target name="phpstan" depends="tests-acceptance-build" description="Performs static analysis of PHP files using PHPStan.">
         <exec
             executable="${path.phpstan.executable}"
             logoutput="true"


### PR DESCRIPTION
- missing the generated trait AcceptanceTesterActions would cause PHPStan check to fail
- this may happen if phing target "standards" is called immediately after "composer install"
- other coding standards checks are ignoring this file
- thanks to @ondrejmirtes for coming up with this solution

I haven't updated the changelog as I don't see this particular change noteworthy.

| Q             | A
| ------------- | ---
|Description, reason for the PR| phing Coding Standard check fails on phpstan run when run right after the composer install
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #382 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
