### PR TITLE
docs: product-search-via-elasticsearch.md fixed to use proper classname

### DIFF
--- a/docs/introduction/product-search-via-elasticsearch.md
+++ b/docs/introduction/product-search-via-elasticsearch.md
@@ -67,7 +67,7 @@ When using docker installation, Elasticsearch API is available on the address [h
 If you wish to reconfigure the indexes setting, simply change the `%shopsys.framework.elasticsearch_sources_dir%` parameter
 to your custom directory and put your own JSON configurations in it using the same naming pattern (`<domain_id>.json`).
 
-If you need to change the data that are exported into Elasticsearch, overwrite appropriate methods in `ElasticsearchProductRepository` and `ElasticsearchProductTranslator` classes.
+If you need to change the data that are exported into Elasticsearch, overwrite appropriate methods in `ElasticsearchProductRepository` and `ElasticsearchProductDataConverter` classes.
 
 You can also change the searching behavior by overwriting `ElasticsearchSearchClient` class.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `ElasticsearchProductTranslator` class does not exist anymore, it was renamed to `ElasticsearchProductDataConverter` during the code review but the former name of the class was kept in the docs by mistake
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
