### PR TITLE
docs: native-installation.md: removed information about platform specific sorting from troubleshooting section

### DIFF
--- a/docs/installation/native-installation.md
+++ b/docs/installation/native-installation.md
@@ -197,14 +197,5 @@ Timezone for PHP can be set in your `php.ini` (usually located in `/etc/php.ini`
 date.timezone = "UTC"
 ```
 
-### Sorting is different on different platforms
-This is known PostgreSQL issue, PostgreSQL uses the collation implementation from the OS.
-As a result, sorting can be different on different platforms.
-For example, results sorted by name can begin with a product starting with “A” (Apple iPhone 5S) on iOS and with “1” (100 Czech crowns) on Linux.
-
-This problem only occurs if the installation is native and it should be solved in PostgreSQL v10, when the sorting will be solved by the independent ICU library. 
-
-Installation using docker provides a unified environment for all platforms as a result of which the sorting is the same.
-
 ### Still struggling with installation?
 If you encountered any other problem during the installation please [file an issue](https://github.com/shopsys/shopsys/issues/new) and we will help you.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The problem is solved by upgrade to Postgres 10 so the information is now obsolete.
|New feature| Yes <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

#### todo:
- [x] test the sorting locally on mac with demo data - the first product on `admin/product/list/` must be "100 Czech crowns ticket", not the "Apple iPhone 5S 64GB, gold" - @Miroslav-Stopka 
