### PR TITLE
Static call of FreeTransportAndPaymentPriceLimitsFormType is replaced…

### DIFF
--- a/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
+++ b/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
@@ -55,8 +55,8 @@ class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
                     'validation_groups' => function (FormInterface $form) {
                         $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
                         $formData = $form->getData();
-                        if ($formData[FreeTransportAndPaymentPriceLimitsFormType::FIELD_ENABLED]) {
-                            $validationGroups[] = FreeTransportAndPaymentPriceLimitsFormType::VALIDATION_GROUP_PRICE_LIMIT_ENABLED;
+                        if ($formData[self::FIELD_ENABLED]) {
+                            $validationGroups[] = self::VALIDATION_GROUP_PRICE_LIMIT_ENABLED;
                         }
 
                         return $validationGroups;


### PR DESCRIPTION
… by self in FreeTransportAndPaymentPriceLimitsFormType class

| Q             | A
| ------------- | ---
|Description, reason for the PR| Standards checks fails on usage of static FreeTransportAndPaymentPriceLimitsFormType. Fixed with PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
