### PR TITLE
Clarification of Stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,7 +3,7 @@
 # Number of days of inactivity before an Issue or Pull Request becomes stale
 daysUntilStale: 60
 
-# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Number of days of inactivity (after marked as Stale) before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: 90
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is not clear how works setting of Stale bot - if we set to mark issue as Stale after 60 days and close after 90, it means that issue will be closed after 90 or 150 days after last activity form users?
|New feature| No
|BC breaks| No
|Fixes issues| #415 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
