### PR TITLE
[shopsys] Generate CHANGELOG.md with ChangelogLinker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 | Q             | A
 | ------------- | ---
 |Description, reason for the PR| ...
-|New feature| Yes/No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
+|New feature| Yes/No <!-- Do not forget to update docs/ -->
 |BC breaks| Yes/No <!-- Do not forget to update UPGRADE.md -->
 |Fixes issues| ...
 |Standards and tests pass| Yes/No

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes, that change in some way the behavior of any of our packages that are maintained by monorepo repository.
 
-There is a list of all the repositories maintained by monorepo, changes in log below are ordered as this list:
+There is a list of all the repositories maintained by monorepo:
 
 * [shopsys/framework]
 * [shopsys/project-base]
@@ -24,80 +24,9 @@ Packages are formatted by release version. You can see all the changes done to p
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-### [shopsys/framework]
-#### Changed
-- [#428 - *EditFromTypes removal](https://github.com/shopsys/shopsys/pull/428)
-    - `TransportEditFormType` was removed and it's attributes were moved to `TransportFormType`
-    - `PaymentEditFormType` was removed and it's attributes were moved to `PaymentFormType`
-    - `ProductEditFormType` was removed and it's attributes were moved to `ProductFormType`
-- [#429 - Microservice Product Search Export](https://github.com/shopsys/shopsys/pull/429)
-    - framework doesn't use Elasticsearch directly anymore
-    - feeds Elasticsearch via Product Search Export microservice
-- [#438 - Attribute telephone moved from a billing address to the personal data of a user](https://github.com/shopsys/shopsys/pull/438)
-- [#295 - Javascript compiling: lower memory consumption](https://github.com/shopsys/shopsys/pull/295), thanks to [@pk16011990]
+The changelog is generated during the release process using [ChangelogLinker](https://github.com/symplify/changeloglinker) since `7.0.0-alpha6` release.
 
-#### Fixed
-- [#420 - Order flow fix](https://github.com/shopsys/shopsys/pull/420)
-    - fix fatal error in OrderFlow (issue #419): function call on string, also method getName does not exists since upgrade to Symfony 3 [@jDolba]
-
-### [shopsys/project-base]
-#### Added
-- [#409 - Project-base: framework models extension](https://github.com/shopsys/shopsys/pull/409)
-    - Category is extended
-    - Administrator is extended
-    - Transport is extended
-    - Product is extended
-    - Brand is extended
-    - Payment is extended
-    - User is extended
-    - Order is extended
-- [#438 - Attribute telephone moved from a billing address to the personal data of a user](https://github.com/shopsys/shopsys/pull/438)
-
-#### Changed
-- Docker Compose uses pre-built images of microservices for easier installation (part of [#430 - Microservices are built as Docker images](https://github.com/shopsys/shopsys/pull/430))
-- [#447 - Unable to resolve domain error page](https://github.com/shopsys/shopsys/pull/447)
-- [#449 - Config files are now split into individual package configuration files](https://github.com/shopsys/shopsys/pull/449)
-
-### [shopsys/shopsys]
-#### Added
-- [#429 - Microservice Product Search Export](https://github.com/shopsys/shopsys/pull/429)
-    - added [Microservice Product Search Export](https://github.com/shopsys/microservice-product-search-export), microservice is used for feeding Elasticsearch by products
-- [#409 - Project-base: framework models extension](https://github.com/shopsys/shopsys/pull/409)
-    - factories use EntityNameResolver to create their entities for simplification of extensibility
-- GitHub OAuth token is now passed to Docker images during build to avoid problems with Composer (part of [#430 - Microservices are built as Docker images](https://github.com/shopsys/shopsys/pull/430))
-
-#### Changed
-- [#444 - Improve Postgres configuration to improve performance](https://github.com/shopsys/shopsys/pull/444)
-    - performance improvement on our performance server with 80k products is about 7-8%
-    - introduced configuration of postgres docker image
-#### Fixed
-- [#436 - Symfony >=3.4.15 marked as conflicting in composer.json](https://github.com/shopsys/shopsys/pull/436)
-    - bug https://github.com/symfony/symfony/issues/28296 in Symfony 3.4.15 version causes application build to fail
-#### Changed
-- [#393 - Continuous integration via Kubernetes](https://github.com/shopsys/shopsys/pull/393)
-    - for details, see [Introduction to Kubernetes](/docs/kubernetes/introduction-to-kubernetes.md)
-
-### [shopsys/coding-standards]
-#### Added
-- [#384 - cs: keep class spacing consistent](https://github.com/shopsys/shopsys/pull/384) [@TomasVotruba]
-    - added new rule (along with fixer `ClassAttributesSeparationFixer`) into `easy-coding-standard.yml`
-
-###[shopsys/microservice-product-search]
-#### Changed
-- [#430 - Microservices are built as Docker images](https://github.com/shopsys/shopsys/pull/430)
-    - source codes and all Composer dependencies are part of the Docker image for easier usage
-    - when a container with a microservice is started, it runs its web server automatically
-
-### [shopsys/microservice-product-search-export]
-#### Added
-- [#429 - Microservice Product Search Export](https://github.com/shopsys/shopsys/pull/429)
-    - the repository was added, extracting product search export functionality from the Shopsys Framework
-
-### [shopsys/monorepo-tools]
-#### Fixed
-- [#433 - monorepo-tools: splitting now works correctly on repositories containing files with spaces](https://github.com/shopsys/shopsys/pull/433) [@dominikkaluza]
-
+<!-- changelog-linker -->
 
 ## [7.0.0-alpha5] - 2018-08-22
 ### [shopsys/framework]

--- a/changelog-linker.yml
+++ b/changelog-linker.yml
@@ -1,0 +1,45 @@
+# setup for ChangelogLinker: https://github.com/Symplify/ChangelogLinker
+parameters:
+    authors_to_ignore:
+        - boris-brtan
+        - LukasHeinz
+        - MattCzerner
+        - Miroslav-Stopka
+        - PetrHeinz
+        - simara-svatopluk
+        - TomasLudvik
+        - vitek-rostislav
+    names_to_urls:
+        'shopsys/shopsys': 'https://github.com/shopsys/shopsys'
+        'shopsys/project-base': 'https://github.com/shopsys/project-base'
+        'shopsys/framework': 'https://github.com/shopsys/framework'
+        'shopsys/product-feed-zbozi': 'https://github.com/shopsys/product-feed-zbozi'
+        'shopsys/product-feed-google': 'https://github.com/shopsys/product-feed-google'
+        'shopsys/product-feed-heureka': 'https://github.com/shopsys/product-feed-heureka'
+        'shopsys/product-feed-heureka-delivery': 'https://github.com/shopsys/product-feed-heureka-delivery'
+        'shopsys/product-feed-interface': 'https://github.com/shopsys/product-feed-interface'
+        'shopsys/plugin-interface': 'https://github.com/shopsys/plugin-interface'
+        'shopsys/coding-standards': 'https://github.com/shopsys/coding-standards'
+        'shopsys/http-smoke-testing': 'https://github.com/shopsys/http-smoke-testing'
+        'shopsys/form-types-bundle': 'https://github.com/shopsys/form-types-bundle'
+        'shopsys/migrations': 'https://github.com/shopsys/migrations'
+        'shopsys/monorepo-tools': 'https://github.com/shopsys/monorepo-tools'
+        'shopsys/microservice-product-search': 'https://github.com/shopsys/microservice-product-search'
+        'shopsys/microservice-product-search-export': 'https://github.com/shopsys/microservice-product-search-export'
+    package_aliases:
+        'shopsys': 'shopsys/shopsys'
+        'project-base': 'shopsys/project-base'
+        'framework': 'shopsys/framework'
+        'product-feed-zbozi': 'shopsys/product-feed-zbozi'
+        'product-feed-google': 'shopsys/product-feed-google'
+        'product-feed-heureka': 'shopsys/product-feed-heureka'
+        'product-feed-heureka-delivery': 'shopsys/product-feed-heureka-delivery'
+        'product-feed-interface': 'shopsys/product-feed-interface'
+        'plugin-interface': 'shopsys/plugin-interface'
+        'coding-standards': 'shopsys/coding-standards'
+        'http-smoke-testing': 'shopsys/http-smoke-testing'
+        'form-types-bundle': 'shopsys/form-types-bundle'
+        'migrations': 'shopsys/migrations'
+        'monorepo-tools': 'shopsys/monorepo-tools'
+        'microservice-product-search': 'shopsys/microservice-product-search'
+        'microservice-product-search-export': 'shopsys/microservice-product-search-export'

--- a/composer.json
+++ b/composer.json
@@ -151,7 +151,9 @@
     "codeception/codeception": "^2.4.0",
     "codeception/phpunit-wrapper": "^7.0",
     "phpstan/phpstan": "^0.7",
-    "symplify/easy-coding-standard-tester": "^4.4"
+    "symplify/easy-coding-standard-tester": "^4.4",
+    "symplify/changelog-linker": "dev-master as 4.7",
+    "symplify/package-builder": "dev-master as 4.7"
   },
   "conflict": {
     "codeception/stub": ">=2.0.2",

--- a/docs/contributing/guidelines-for-pull-request.md
+++ b/docs/contributing/guidelines-for-pull-request.md
@@ -26,7 +26,8 @@ git rebase origin/master
 
 * You have to check your change using the command `php phing standards tests tests-acceptance` as it’s mentioned in [contributing](../../project-base/CONTRIBUTING.md).
 * Please make sure you sign form to agree with the [license agreement](https://www.shopsys-framework.com/license-agreement).
-* [Create a PR](https://github.com/shopsys/shopsys/compare?expand=1) with essential information to make our code review easier. 
+* [Create a PR](https://github.com/shopsys/shopsys/compare?expand=1) with essential information to make our code review easier.
+    * you do not have to update `CHANGELOG.md` at all as it is generated automatically using [symplify/changelog-linker](https://github.com/symplify/changeloglinker) during our release process.
 * Now just wait for review of your change.
 
 ## 2. Changes after review


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Automate work with CHANGELOG.md
|New feature| No
|BC breaks| No
|Fixes issues| [US-4575](https://app.yodiz.com/plan/pages/detail.vz?cid=10273#/us-4575)
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Feedback needed**! [ChangelogLinker](https://github.com/symplify/changeloglinker) is quite fresh package and this is its first live testing on humans. 
So please do report *WTFs* you found and what do you expect to happen. It might have some reason, but it might be also easy to resolve it and improve it.  

<br>

### 1. How to Use?

```bash
vendor/bin/changelog-linker dump-merges --in-packages --in-categories --since-id 432 --token XXX --dry-run
```

<br>

### 2. When to Use?

I use it once before release to complete all new features, reorder if needed and delete useless ones. Doing it more often brings extra maintenance, that end user won't appreciate, because it's only the stable (tag) they care about.

<br>

### 3. How Package name and Category (Added/Fixed/Removed/Deprecated) are Detected?

The **merge commit name** (~= a pull-request title) decides, what package or category the merge goes to. 

Basically "[PackageName] (matching 'add(ed)|remove(d)...' regulars)" ([see all regulars](https://github.com/Symplify/Symplify/blob/938384a3d8865368b64ea112d0d0473c97cc12e0/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php#L10-L23)).

E.g. this message:

`[CodingStandards] Add new fixer" with id #9999`

will be generated to `CHANGELOG.md` as:

```markdown
## CodingStandards

### Added

- [#9999] Add new fixer
```

I use such pull-request naming:

![image](https://user-images.githubusercontent.com/924196/45032371-ed9b0800-b051-11e8-8638-94fdfe9bcf50.png)

In 90 % the category is determined right, so it still needs human hands :) but it saves me:

- the packages spliting
- adding categories
- adding "Thanks @vitek-rostislav" messages
- adding `[v4.0.0]` links to diffs to last version
- and [more in README](https://github.com/Symplify/Symplify/blob/master/packages/ChangelogLinker/README.md#usage).

### 4. How it Knows where to Put The Generated Content?

It will add the content to `<!-- changelog-linker -->` section. Put it anywhere in the `CHANGELOG.md`, where you want to dump the merges.

<br>
