### PR TITLE
[framework] Added translation extractor for custom constraint violation messages

### DIFF
--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -81,22 +81,22 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
      */
     public function enterNode(Node $node)
     {
-        $this->setCurrentExecutionContextVariableNamesFromNode($node);
-        if ($node instanceof MethodCall && $this->isAddViolationMethodCall($node)) {
+        if ($node instanceof ClassMethod) {
+            $this->setCurrentExecutionContextVariableNamesFromNode($node);
+        } elseif ($node instanceof MethodCall && $this->isAddViolationMethodCall($node)) {
             $this->extractMessage($node);
         }
     }
 
     /**
-     * @param \PhpParser\Node $node
+     * @param \PhpParser\Node\Stmt\ClassMethod $node
      */
-    private function setCurrentExecutionContextVariableNamesFromNode(Node $node)
+    private function setCurrentExecutionContextVariableNamesFromNode(ClassMethod $node)
     {
-        if ($node instanceof ClassMethod) {
-            foreach ($node->getParams() as $parameter) {
-                if ($this->isParameterExecutionContextInterfaceSubclass($parameter)) {
-                    $this->currentExecutionContextVariableNames[] = $parameter->name;
-                }
+        $this->currentExecutionContextVariableNames = [];
+        foreach ($node->getParams() as $parameter) {
+            if ($this->isParameterExecutionContextInterfaceSubclass($parameter)) {
+                $this->currentExecutionContextVariableNames[] = $parameter->name;
             }
         }
     }

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Component\Translation;
+
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitor\NameResolver;
+use SplFileInfo;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Twig_Node;
+
+class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
+{
+    private const CONSTRAINT_MESSAGE_METHOD_NAME = 'addViolation';
+
+    /**
+     * @var \PhpParser\NodeTraverser
+     */
+    private $traverser;
+
+    /**
+     * @var \JMS\TranslationBundle\Model\MessageCatalogue
+     */
+    private $catalogue;
+
+    /**
+     * @var \SplFileInfo
+     */
+    private $file;
+
+    /**
+     * @var string
+     */
+    private $interfaceInstanceName;
+
+    public function __construct()
+    {
+        $this->traverser = new NodeTraverser();
+        $this->traverser->addVisitor(new NameResolver());
+        $this->traverser->addVisitor($this);
+        $this->interfaceInstanceName = '';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
+    {
+        $this->file = $file;
+        $this->catalogue = $catalogue;
+        $this->traverser->traverse($ast);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof ClassMethod && $this->haveMethodContextInterfaceImplemented($node) === true) {
+            foreach ($node->stmts as $stmt) {
+                $this->recursiveFindMessages($stmt);
+            }
+        }
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\ClassMethod $node
+     * @return bool
+     */
+    private function haveMethodContextInterfaceImplemented(ClassMethod $node)
+    {
+        foreach ($node->getParams() as $param) {
+            if ($this->haveParamExecutionContextInterface($param) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PhpParser\Node\Param $param
+     * @return bool
+     */
+    private function haveParamExecutionContextInterface(Node\Param $param)
+    {
+        if ($param->type instanceof FullyQualified) {
+            $className = implode('\\', $param->type->parts);
+            $interfaceName = ExecutionContextInterface::class;
+            $this->interfaceInstanceName = $param->name;
+
+            return $className === $interfaceName;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PhpParser\Node $node
+     */
+    private function recursiveFindMessages(Node $node)
+    {
+        if ($node instanceof MethodCall &&
+            $node->var instanceof Variable &&
+            $node->var->name === $this->interfaceInstanceName &&
+            $node->name === self::CONSTRAINT_MESSAGE_METHOD_NAME
+        ) {
+            $this->extractMessage($node);
+        }
+
+        $variables = get_object_vars($node);
+        foreach ($variables as $variable) {
+            if (is_object($variable)) {
+                $this->recursiveFindMessages($variable);
+            } elseif (is_array($variable)) {
+                foreach ($variable as $value) {
+                    if (is_object($value)) {
+                        $this->recursiveFindMessages($value);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\MethodCall $methodCall
+     */
+    private function extractMessage(MethodCall $methodCall)
+    {
+        $firstArgumentWithMessage = reset($methodCall->args);
+        if ($firstArgumentWithMessage->value instanceof String_) {
+            $messageId = $firstArgumentWithMessage->value->value; // value with translatable message
+
+            $message = new Message($messageId, ConstraintMessageExtractor::CONSTRAINT_MESSAGE_DOMAIN);
+            $message->addSource(new FileSource($this->file->getFilename(), $firstArgumentWithMessage->getLine()));
+
+            $this->catalogue->add($message);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function leaveNode(Node $node)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function afterTraverse(array $nodes)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $ast)
+    {
+        return null;
+    }
+}

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -19,6 +19,23 @@ use SplFileInfo;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Twig_Node;
 
+/**
+ * Extracts custom message from constraint callback function.
+ *
+ * Examples:
+ *     Working example
+ *     public function workingExample(ExecutionContextInterface $context)
+ *      {
+ *          $context->addViolation('This message will be extracted into "validators" translation domain');
+ *      }
+ *
+ *      non-working example
+ *      public function nonWorkingExample(ExecutionContextInterface $context)
+ *      {
+ *          $message = 'This message will be not extracted into "validators" translation domain';
+ *          $context->addViolation($message);
+ *      }
+ */
 class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
 {
     /**

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -335,6 +335,10 @@ services:
         tags:
             - { name: jms_translation.file_visitor }
 
+    Shopsys\FrameworkBundle\Component\Translation\ConstraintViolationExtractor:
+      tags:
+        - { name: jms_translation.file_visitor }
+
     Shopsys\FrameworkBundle\Component\Translation\PoDumper:
         tags:
             - { name: jms_translation.dumper, format: po }

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -328,6 +328,9 @@ msgstr "Cena musí být větší nebo rovna {{ compared_value }}"
 msgid "Product name cannot be longer than {{ limit }} characters"
 msgstr "Název produktu nesmí být delší než {{ limit }} znaků"
 
+msgid "Promo code with this code already exists"
+msgstr "Slevový kupón s tímto kódem již existuje"
+
 msgid "Quantity must be greater than {{ compared_value }}"
 msgstr "Množství musí být větší než {{ compared_value }}"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -328,6 +328,9 @@ msgstr ""
 msgid "Product name cannot be longer than {{ limit }} characters"
 msgstr ""
 
+msgid "Promo code with this code already exists"
+msgstr ""
+
 msgid "Quantity must be greater than {{ compared_value }}"
 msgstr ""
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.cs.po
@@ -40,6 +40,9 @@ msgstr "Heslo nesmí být stejné jako část e-mailu před zavináčem."
 msgid "Passwords do not match"
 msgstr "Hesla se neshodují"
 
+msgid "Please choose a valid combination of transport and payment"
+msgstr "Prosím vyberte povolenou kombinaci dopravy a platby"
+
 msgid "Please choose country"
 msgstr "Prosím vyberte stát"
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.en.po
@@ -40,6 +40,9 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr ""
 
+msgid "Please choose a valid combination of transport and payment"
+msgstr ""
+
 msgid "Please choose country"
 msgstr ""
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On constraints with callback missing violation text in translation files
|New feature| Yes
|BC breaks| No
|Fixes issues| #369 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

As i promised, i create next constraint extractor, which extracting text from methods `->addViolation()` called to `ExecutionContextInterface`. I will be glad when you check names is okay and please check czech translation, because my czech language in text form is not good 😄
PS: thanks @Miroslav-Stopka for help with docker on windows 10 home (thas was suffering) 😄
