### PR TITLE
remove unnecessary configuration from php.ini files

### DIFF
--- a/microservices/product-search-export/docker/php-ini-overrides.ini
+++ b/microservices/product-search-export/docker/php-ini-overrides.ini
@@ -12,9 +12,6 @@ error_reporting = E_ALL
 ; disable sending PHP version in response headers (X-Powered-By) for security reasons
 expose_php = Off
 
-; consistent behaviour of $HTTP_RAW_POST_DATA on PHP 5.6 and PHP 7 (needed only on PHP 5.6)
-always_populate_raw_post_data = -1
-
 ; size-up realpath cache (otherwise Symfony can be slow)
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
@@ -29,7 +26,7 @@ opcache.fast_shutdown = true
 opcache.interned_strings_buffer = 24
 
 ; Optimizations for Symfony, as documented on http://symfony.com/doc/current/performance.html
-opcache.max_accelerated_files = 60000
+opcache.max_accelerated_files = 20000
 
 ; The size of the shared memory storage used by OPcache, in megabytes
 opcache.memory_consumption = 256
@@ -43,7 +40,3 @@ opcache.revalidate_freq = 0
 
 ; use absolute paths, so that there are not collision for files with same names
 opcache.use_cwd=1
-
-; nescessary for file uploads
-upload_max_filesize = 32M
-post_max_size = 32M

--- a/microservices/product-search/docker/php-ini-overrides.ini
+++ b/microservices/product-search/docker/php-ini-overrides.ini
@@ -12,9 +12,6 @@ error_reporting = E_ALL
 ; disable sending PHP version in response headers (X-Powered-By) for security reasons
 expose_php = Off
 
-; consistent behaviour of $HTTP_RAW_POST_DATA on PHP 5.6 and PHP 7 (needed only on PHP 5.6)
-always_populate_raw_post_data = -1
-
 ; size-up realpath cache (otherwise Symfony can be slow)
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
@@ -29,7 +26,7 @@ opcache.fast_shutdown = true
 opcache.interned_strings_buffer = 24
 
 ; Optimizations for Symfony, as documented on http://symfony.com/doc/current/performance.html
-opcache.max_accelerated_files = 60000
+opcache.max_accelerated_files = 20000
 
 ; The size of the shared memory storage used by OPcache, in megabytes
 opcache.memory_consumption = 256
@@ -43,7 +40,3 @@ opcache.revalidate_freq = 0
 
 ; use absolute paths, so that there are not collision for files with same names
 opcache.use_cwd=1
-
-; nescessary for file uploads
-upload_max_filesize = 32M
-post_max_size = 32M

--- a/project-base/docker/php-fpm/php-ini-overrides.ini
+++ b/project-base/docker/php-fpm/php-ini-overrides.ini
@@ -12,9 +12,6 @@ error_reporting = E_ALL
 ; disable sending PHP version in response headers (X-Powered-By) for security reasons
 expose_php = Off
 
-; consistent behaviour of $HTTP_RAW_POST_DATA on PHP 5.6 and PHP 7 (needed only on PHP 5.6)
-always_populate_raw_post_data = -1
-
 ; size-up realpath cache (otherwise Symfony can be slow)
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600


### PR DESCRIPTION
- "always_populate_raw_post_data = -1" can be removed as we do not support PHP 5.6 anymore
- "upload_max_filesize" and "post_max_size" can be removed from microservices as they do not use file uploads
- "opcache.max_accelerated_files" can be lowered to 20k in microservices as it's the exact value recommended in Symfony docs
  - see https://symfony.com/doc/4.1/performance.html
  - the value was increased in the main app of Shopsys Framework as the application is rather big

| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| having PHP 5.6 mentioned in our recommended php.ini config cast a rather unpleasant light on us :smirk: 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
