### PR TITLE
Improved description where to place GitHub token in installation guide

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -34,8 +34,8 @@ You can find out your UID by running `id -u` and your GID by running `id -g`.
 Shopsys Framework includes a lot of dependencies installed via Composer.
 During `composer install` the GitHub API Rate Limit is reached and it is necessary to provide GitHub OAuth token to overcome this limit.
 This token can be generated on [Github -> Settings -> Developer Settings -> Personal access tokens](https://github.com/settings/tokens/new?scopes=repo&description=Composer+API+token)
-Save your token into the `docker-compose.yml` file.
-Token is located in `services -> php-fpm -> build -> args -> github_oauth_token`.
+Save your token into the `docker-compose.yml` file - 
+token should be placed in `services -> php-fpm -> build -> args -> github_oauth_token`.
 
 ### 5. Compose Docker container
 ```

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -54,8 +54,8 @@ Also you need to insert your UID into `docker-sync.yml` into value `sync_userid`
 Shopsys Framework includes a lot of dependencies installed via Composer.
 During `composer install` the GitHub API Rate Limit is reached and it is necessary to provide GitHub OAuth token to overcome this limit.
 This token can be generated on [Github -> Settings -> Developer Settings -> Personal access tokens](https://github.com/settings/tokens/new?scopes=repo&description=Composer+API+token)
-Save your token into the `docker-compose.yml` file.
-Token is located in `services -> php-fpm -> build -> args -> github_oauth_token`.
+Save your token into the `docker-compose.yml` file - 
+token should be placed in `services -> php-fpm -> build -> args -> github_oauth_token`.
 
 ### 3. Compose Docker container
 On MacOS you need to synchronize folders using docker-sync.

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -35,8 +35,8 @@ copy docker\conf\docker-compose-win.yml.dist docker-compose.yml
 Shopsys Framework includes a lot of dependencies installed via Composer.
 During `composer install` the GitHub API Rate Limit is reached and it is necessary to provide GitHub OAuth token to overcome this limit.
 This token can be generated on [Github -> Settings -> Developer Settings -> Personal access tokens](https://github.com/settings/tokens/new?scopes=repo&description=Composer+API+token)
-Save your token into the `docker-compose.yml` file.
-Token is located in `services -> php-fpm -> build -> args -> github_oauth_token`.
+Save your token into the `docker-compose.yml` file - 
+token should be placed in `services -> php-fpm -> build -> args -> github_oauth_token`.
 
 ### 3. Grant Docker access to your files
 - Right click Docker icon in your system tray and choose `Settings...`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In installation guide is info, that "Token is located in services -> php-fpm -> build -> args -> github_oauth_token". But token is not there yet when you are doing clean install and I spent lot of time looking for it. 
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| 
|Standards and tests pass| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
