### PR TITLE
Docker-compose-mac.yml.dist: fix a missing sync external volume

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -143,3 +143,6 @@ volumes:
 
     shopsys-framework-elasticsearch-data-sync:
         external: true
+
+    shopsys-framework-microservice-product-search-export-sync
+        external: true

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -138,11 +138,11 @@ volumes:
     shopsys-framework-microservice-product-search-sync:
         external: true
 
+    shopsys-framework-microservice-product-search-export-sync
+        external: true
+
     shopsys-framework-postgres-data-sync:
         external: true
 
     shopsys-framework-elasticsearch-data-sync:
-        external: true
-
-    shopsys-framework-microservice-product-search-export-sync
         external: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| 
docker-compose-mac.yml.dist: added a missing shopsys-framework-microservice-product-search-export-sync
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes