### PR TITLE
monorepo-tools: add note about splitting signed commits

### DIFF
--- a/packages/monorepo-tools/README.md
+++ b/packages/monorepo-tools/README.md
@@ -76,6 +76,14 @@ Other branches are not pushed.
 
 It may again take a while, depending on the size of your monorepo.
 
+***Note:***  
+*The commits in the split repositories should be identical to those from the original repo, keeping the git history intact.*
+*Thus, if you have checked out the original `master` previously, you should be able to fast-forward to the new version after splitting.*  
+*The only known exception is a signed commit (note that GitHub signs commits made via its web UI by default).*
+*If you have signed commits in your original repository, the split commits will NOT be signed.*
+*This will prevent `monorepo_split.sh` from pushing the unsigned commits to the remote.*  
+*To overcome this you can add [the `--force` flag](https://git-scm.com/docs/git-push#git-push--f) to the `git push` calls in the script, but it may cause unforeseen consequences if you're not sure what you're doing.*
+
 ### Add a new package into the monorepo
 
 When you have the monorepo, you may find a reason for adding a new package after some time you already use the monorepo.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We should be more explicit about the behavior of monorepo-tools in respect to keeping the history intact. GitHub signs all commits made via its web UI (even the init commit during repository creation) by default, so it's likely that people will run into issues at this step. It would be nice to explore the possibility of re-signing the commits (see #435), but until then we should document the current state and the commonly used workaround.
|New feature| No <!-- Do not forget to update CHANGELOG.md and possibly docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #445 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
