### PR TITLE
[shopsys] MicroserviceClient: timeout limits are now less strict

### DIFF
--- a/packages/framework/src/Component/Microservice/MicroserviceClient.php
+++ b/packages/framework/src/Component/Microservice/MicroserviceClient.php
@@ -82,8 +82,8 @@ class MicroserviceClient
     protected function createDefaultOptions(): array
     {
         return [
-            RequestOptions::CONNECT_TIMEOUT => 0.1,
-            RequestOptions::TIMEOUT => 1.0,
+            RequestOptions::CONNECT_TIMEOUT => 15,
+            RequestOptions::TIMEOUT => 15,
             RequestOptions::HEADERS => ['Accept' => 'application/json'],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the low limits were causing failures of build process as export of products data into elasticsearch can take a while
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
