### PR TITLE
[shopsys] Use shopsys packages instead of hacking composer.json to speed up installation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,6 +62,16 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - [#502 - fixed acceptance tests (loading DB dump)](https://github.com/shopsys/shopsys/pull/502)
     - when you upgrade `codeception/codeception` to version `2.5.0`, you have to change parameter `populate` to `true`
       in `tests/ShopBundle/Acceptance/acceptance.suite.yml`
+- make changes in `composer.json`:
+    - remove repositories:
+        - `https://github.com/shopsys/doctrine2.git`
+        - `https://github.com/shopsys/jparser.git`
+        - `https://github.com/molaux/PostgreSearchBundle.git`
+    - remove dependencies:
+        - `"timwhitlock/jparser": "@dev"`
+    - change dependencies:
+        - `"doctrine/orm": "dev-doctrine-260-..."` -> `"shopsys/doctrine-orm": "2.6.2"`
+        - `"intaro/postgres-search-bundle": "@dev"` -> `"shopsys/postgres-search-bundle": "0.1"`
 
 ## [From 7.0.0-alpha6 to 7.0.0-beta1]
 ### [shopsys/framework]

--- a/composer.json
+++ b/composer.json
@@ -44,20 +44,6 @@
       "Shopsys\\MicroserviceProductSearchExport\\": "microservices/product-search-export/src/"
     }
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/molaux/PostgreSearchBundle.git"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/shopsys/doctrine2.git"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/shopsys/jparser.git"
-    }
-  ],
   "require": {
     "php": "^7.1",
     "ext-bcmath": "*",
@@ -94,7 +80,6 @@
     "doctrine/doctrine-fixtures-bundle": "^3.0.2",
     "doctrine/doctrine-migrations-bundle": "^1.3.0",
     "doctrine/migrations": "^1.6.0",
-    "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
     "egeloen/ckeditor-bundle": "^4.0.6",
     "elasticsearch/elasticsearch": "^6.0.1",
     "friendsofphp/php-cs-fixer": "^2.11.1",
@@ -105,7 +90,6 @@
     "helios-ag/fm-elfinder-bundle": "^8.0",
     "heureka/overeno-zakazniky": "^2.0.6",
     "incenteev/composer-parameter-handler": "^2.1.3",
-    "intaro/postgres-search-bundle": "dev-master#06625bdc1d",
     "intervention/image": "^2.3.14",
     "jakub-onderka/php-parallel-lint": "^0.9",
     "jdorn/sql-formatter": "^1.2",
@@ -126,6 +110,9 @@
     "sensio/distribution-bundle": "^5.0.21",
     "sensio/framework-extra-bundle": "^3.0.29",
     "sensio/generator-bundle": "^3.1.7",
+    "shopsys/doctrine-orm": "2.6.2",
+    "shopsys/jparser": "0.1",
+    "shopsys/postgres-search-bundle": "0.1",
     "slevomat/coding-standard": "^4.6.0",
     "snc/redis-bundle": "2.1.4",
     "squizlabs/php_codesniffer": "^3.2.0",
@@ -139,7 +126,6 @@
     "symfony/monolog-bundle": "^3.1.2",
     "symfony/swiftmailer-bundle": "^3.2.2",
     "symfony/symfony": "^3.4.8",
-    "timwhitlock/jparser": "dev-get-rid-of-import#c37f4c6",
     "tracy/tracy": "^2.4.13",
     "twig/extensions": "^1.5.1",
     "twig/twig": "^2.4.8",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -17,20 +17,6 @@
             "Tests\\FrameworkBundle\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/molaux/PostgreSearchBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/doctrine2.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/jparser.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "ext-bcmath": "*",
@@ -60,7 +46,6 @@
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
-        "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
         "egeloen/ckeditor-bundle": "^4.0.6",
         "fp/jsformvalidator-bundle": "^1.5.1",
         "fzaninotto/faker": "^1.7.1",
@@ -68,7 +53,6 @@
         "guzzlehttp/guzzle": "^6.3",
         "helios-ag/fm-elfinder-bundle": "^6.2.1",
         "heureka/overeno-zakazniky": "^2.0.6",
-        "intaro/postgres-search-bundle": "dev-master#06625bdc1d",
         "intervention/image": "^2.3.14",
         "jms/metadata": "^1.6",
         "jms/translation-bundle": "^1.4.1",
@@ -83,6 +67,9 @@
         "psr/log": "^1.0",
         "sensio/distribution-bundle": "^5.0.21",
         "sensio/framework-extra-bundle": "^3.0.29",
+        "shopsys/doctrine-orm": "2.6.2",
+        "shopsys/jparser": "0.1",
+        "shopsys/postgres-search-bundle": "0.1",
         "shopsys/migrations": "dev-master",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/plugin-interface": "dev-master",
@@ -95,7 +82,6 @@
         "symfony/symfony": "^3.4.8",
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
-        "timwhitlock/jparser": "dev-get-rid-of-import#c37f4c6",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.4.8"
     },

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -20,34 +20,18 @@
             "Tests\\ProductFeed\\GoogleBundle\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/molaux/PostgreSearchBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/doctrine2.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/jparser.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "ext-pdo": "*",
         "ext-json": "*",
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
-        "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
-        "intaro/postgres-search-bundle": "@dev",
+        "shopsys/doctrine-orm": "2.6.2",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/framework": "dev-master",
         "shopsys/migrations": "dev-master",
         "shopsys/plugin-interface": "dev-master",
-        "symfony/symfony": "^3.4.8",
-        "timwhitlock/jparser": "@dev"
+        "symfony/symfony": "^3.4.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -20,24 +20,9 @@
             "Tests\\ProductFeed\\HeurekaDeliveryBundle\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/molaux/PostgreSearchBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/doctrine2.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/jparser.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
-        "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
-        "intaro/postgres-search-bundle": "@dev",
+        "shopsys/doctrine-orm": "2.6.2",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/framework": "dev-master",
         "shopsys/migrations": "dev-master",
@@ -45,8 +30,7 @@
         "symfony/config": "^3.4",
         "symfony/dependency-injection": "^3.4",
         "symfony/framework-bundle": "^3.4",
-        "symfony/http-kernel": "^3.4",
-        "timwhitlock/jparser": "@dev"
+        "symfony/http-kernel": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -20,20 +20,6 @@
             "Tests\\ProductFeed\\HeurekaBundle\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/molaux/PostgreSearchBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/doctrine2.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/jparser.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "ext-simplexml": "*",
@@ -43,14 +29,12 @@
         "doctrine/collections": "^1.5",
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
-        "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
-        "intaro/postgres-search-bundle": "@dev",
+        "shopsys/doctrine-orm": "2.6.2",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/framework": "dev-master",
         "shopsys/migrations": "dev-master",
         "shopsys/plugin-interface": "dev-master",
-        "symfony/symfony": "^3.4.8",
-        "timwhitlock/jparser": "@dev"
+        "symfony/symfony": "^3.4.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -20,34 +20,18 @@
             "Tests\\ProductFeed\\ZboziBundle\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/molaux/PostgreSearchBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/doctrine2.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/jparser.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "ext-pdo": "*",
         "ext-json": "*",
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
-        "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
-        "intaro/postgres-search-bundle": "@dev",
+        "shopsys/doctrine-orm": "2.6.2",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/framework": "dev-master",
         "shopsys/migrations": "dev-master",
         "shopsys/plugin-interface": "dev-master",
-        "symfony/symfony": "^3.4.8",
-        "timwhitlock/jparser": "@dev"
+        "symfony/symfony": "^3.4.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -22,20 +22,6 @@
             "Tests\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/molaux/PostgreSearchBundle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/doctrine2.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/shopsys/jparser.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "ext-bcmath": "*",
@@ -63,14 +49,12 @@
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/doctrine-migrations-bundle": "^1.3.0",
-        "doctrine/orm": "dev-doctrine-260-with-ddc1960-hotfix-and-ddc4005-hotfix as 2.6.0",
         "egeloen/ckeditor-bundle": "^4.0.6",
         "fp/jsformvalidator-bundle": "^1.5.1",
         "fzaninotto/faker": "^1.7.1",
         "helios-ag/fm-elfinder-bundle": "^6.2.1",
         "heureka/overeno-zakazniky": "^2.0.6",
         "incenteev/composer-parameter-handler": "^2.1.3",
-        "intaro/postgres-search-bundle": "@dev",
         "intervention/image": "^2.3.14",
         "jms/translation-bundle": "^1.4.1",
         "joschi127/doctrine-entity-override-bundle": "^0.5.0",
@@ -82,6 +66,8 @@
         "sensio/distribution-bundle": "^5.0.21",
         "sensio/framework-extra-bundle": "^3.0.29",
         "sensio/generator-bundle": "^3.1.7",
+        "shopsys/doctrine-orm": "2.6.2",
+        "shopsys/postgres-search-bundle": "0.1",
         "shopsys/migrations": "dev-master",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/framework": "dev-master",
@@ -98,7 +84,6 @@
         "symfony/symfony": "^3.4.8",
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
-        "timwhitlock/jparser": "@dev",
         "tracy/tracy": "^2.4.13",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.4.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Use shopsys packages instead of hacking composer.json to speed up installation
|New feature| No
|BC breaks| No
|Fixes issues| #421
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
