### PR TITLE
[framework] fixed command "debug:router" by asking for domain

### DIFF
--- a/packages/framework/src/Command/RouterDebugCommandForDomain.php
+++ b/packages/framework/src/Command/RouterDebugCommandForDomain.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler;
+use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class RouterDebugCommandForDomain extends RouterDebugCommand
+{
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'debug:router';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler
+     */
+    private $domainChoiceHelper;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler $domainChoiceHelper
+     * @param \Symfony\Component\Routing\RouterInterface|null $router
+     */
+    public function __construct(DomainChoiceHandler $domainChoiceHelper, $router = null)
+    {
+        $this->domainChoiceHelper = $domainChoiceHelper;
+
+        parent::__construct($router);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int|null
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $this->domainChoiceHelper->chooseDomainAndSwitch($io);
+
+        return parent::execute($input, $output);
+    }
+}

--- a/packages/framework/src/Command/ServerRunForDomainCommand.php
+++ b/packages/framework/src/Command/ServerRunForDomainCommand.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Command;
 
+use Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,16 +18,16 @@ class ServerRunForDomainCommand extends Command
     protected static $defaultName = 'shopsys:server:run';
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     * @var \Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler
      */
-    private $domain;
+    private $domainChoiceHelper;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler $domainChoiceHelper
      */
-    public function __construct(Domain $domain)
+    public function __construct(DomainChoiceHandler $domainChoiceHelper)
     {
-        $this->domain = $domain;
+        $this->domainChoiceHelper = $domainChoiceHelper;
 
         parent::__construct();
     }
@@ -55,43 +55,9 @@ class ServerRunForDomainCommand extends Command
             return 1;
         }
 
-        $domainConfig = $this->chooseDomainConfig($io);
+        $domainConfig = $this->domainChoiceHelper->chooseDomainConfig($io);
 
         return $this->runServerForDomain($domainConfig, $output);
-    }
-
-    /**
-     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
-     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
-     */
-    private function chooseDomainConfig(SymfonyStyle $io)
-    {
-        $domainConfigs = $this->domain->getAll();
-
-        if (count($domainConfigs) === 0) {
-            throw new \Shopsys\FrameworkBundle\Command\Exception\NoDomainSetCommandException();
-        }
-
-        $firstDomainConfig = reset($domainConfigs);
-
-        if (count($domainConfigs) === 1) {
-            return $firstDomainConfig;
-        }
-
-        $domainChoices = [];
-        foreach ($domainConfigs as $domainConfig) {
-            $domainChoices[$domainConfig->getId()] = $domainConfig->getName();
-        }
-        $chosenDomainName = $io->choice(
-            'There are more than one domain. Which domain do you want to use?',
-            $domainChoices,
-            $firstDomainConfig->getName()
-        );
-        foreach ($domainConfigs as $domainConfig) {
-            if ($domainConfig->getName() === $chosenDomainName) {
-                return $domainConfig;
-            }
-        }
     }
 
     /**

--- a/packages/framework/src/Component/Console/DomainChoiceHandler.php
+++ b/packages/framework/src/Component/Console/DomainChoiceHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Console;
+
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DomainChoiceHandler
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    private $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(Domain $domain)
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
+     */
+    public function chooseDomainConfig(SymfonyStyle $io): DomainConfig
+    {
+        $domainConfigs = $this->domain->getAll();
+
+        if (count($domainConfigs) === 0) {
+            throw new \Shopsys\FrameworkBundle\Component\Console\Exception\NoDomainSetException();
+        }
+
+        $firstDomainConfig = reset($domainConfigs);
+
+        if (count($domainConfigs) === 1) {
+            return $firstDomainConfig;
+        }
+
+        $domainChoices = [];
+        foreach ($domainConfigs as $domainConfig) {
+            $domainChoices[$domainConfig->getId()] = $domainConfig->getName();
+        }
+        $chosenDomainName = $io->choice(
+            'There are more than one domain. Which domain do you want to use?',
+            $domainChoices,
+            $firstDomainConfig->getName()
+        );
+        foreach ($domainConfigs as $domainConfig) {
+            if ($domainConfig->getName() === $chosenDomainName) {
+                return $domainConfig;
+            }
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     */
+    public function chooseDomainAndSwitch(SymfonyStyle $io): void
+    {
+        $domainConfig = $this->chooseDomainConfig($io);
+
+        $this->domain->switchDomainById($domainConfig->getId());
+    }
+}

--- a/packages/framework/src/Component/Console/DomainChoiceHandler.php
+++ b/packages/framework/src/Component/Console/DomainChoiceHandler.php
@@ -46,7 +46,7 @@ class DomainChoiceHandler
             $domainChoices[$domainConfig->getId()] = $domainConfig->getName();
         }
         $chosenDomainName = $io->choice(
-            'There are more than one domain. Which domain do you want to use?',
+            'There is more than one domain. Which domain do you want to use?',
             $domainChoices,
             $firstDomainConfig->getName()
         );

--- a/packages/framework/src/Component/Console/Exception/ConsoleException.php
+++ b/packages/framework/src/Component/Console/Exception/ConsoleException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Component\Console\Exception;
+
+use Throwable;
+
+interface ConsoleException extends Throwable
+{
+}

--- a/packages/framework/src/Component/Console/Exception/NoDomainSetException.php
+++ b/packages/framework/src/Component/Console/Exception/NoDomainSetException.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Shopsys\FrameworkBundle\Command\Exception;
+namespace Shopsys\FrameworkBundle\Component\Console\Exception;
 
 use Exception;
 
-class NoDomainSetCommandException extends Exception implements CommandException
+class NoDomainSetException extends Exception implements ConsoleException
 {
     /**
      * @param \Exception|null $previous


### PR DESCRIPTION
- routes are domain-specific in Shopsys Framework but there is no current domain in console environment
- RouterDebugCommandForDomain extends the original Symfony RouterDebugCommand
- the logic of choosing a domain used in ServerRunForDomain extracted into DomainChoiceHandler for reuse
- the debug:router now asks for domain in interactive mode (or chooses the first domain by default)

| Q             | A
| ------------- | ---
|Description, reason for the PR| when trying to dump all routes via `debug:router` command, the execution fails on NoDomainSelectedException
|New feature| Kinda <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| `debug:router` does not fail
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
