### PR TITLE
Require global package hirak/prestisimo in docker images

### DIFF
--- a/microservices/product-search-export/docker/Dockerfile
+++ b/microservices/product-search-export/docker/Dockerfile
@@ -38,6 +38,9 @@ USER www-data
 ARG github_oauth_token
 RUN composer config -g github-oauth.github.com $github_oauth_token
 
+# hirak/prestissimo makes the install of Composer dependencies faster by parallel downloading
+RUN composer global require hirak/prestissimo
+
 # install composer dependencies (as www-data user)
 RUN composer install
 

--- a/microservices/product-search/docker/Dockerfile
+++ b/microservices/product-search/docker/Dockerfile
@@ -38,6 +38,9 @@ USER www-data
 ARG github_oauth_token
 RUN composer config -g github-oauth.github.com $github_oauth_token
 
+# hirak/prestissimo makes the install of Composer dependencies faster by parallel downloading
+RUN composer global require hirak/prestissimo
+
 # install composer dependencies (as www-data user)
 RUN composer install
 

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -70,3 +70,6 @@ USER www-data
 # allow configuring the GitHub OAuth token
 ARG github_oauth_token
 RUN if [ -n "$github_oauth_token" ]; then composer config -g github-oauth.github.com $github_oauth_token; fi
+
+# hirak/prestissimo makes the install of Composer dependencies faster by parallel downloading
+RUN composer global require hirak/prestissimo


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Our composer install takes too long because of number of dependencies. hirak/prestisimo package allows paralel installation of dependencies. This cause dramatic improvement of composer install performance
|New feature| No
|BC breaks| No
|Fixes issues| #440
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

I did performance tests of our composer install after few optimalizations.



I tested 4 scenarios and used this process to make sure that installation is clear without any cache:

```
git checkout <branch-name>
docker-compose up -d --build --force-recreate
docker-exec -it shopsys-framework-php-fpm sh
    rm -rf vendor/
    rm composer.lock
    composer clearcache
    composer install
```

Master - using forks
9m12s

Master - using patches (one patch does not apply)
4m 39s

Master with hirak/prestisimo package for paralel installetion of composer dependencies - using forks
7m 31s

Master with hirak/prestisimo package for paralel installetion of composer dependencies - using patches (one patch does not apply)
1m 17s
