### PR TITLE
[project-base] adding php.ini to image is now done only in dockerfiles

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -19,9 +19,6 @@ yq write --inplace project-base/kubernetes/deployments/webserver-php-fpm.yml spe
 
 # Create configmaps for configuration files used by pods
 kubectl create configmap nginx-configuration --from-file docker/nginx/nginx.conf --dry-run --output=yaml > project-base/kubernetes/nginx-configuration.yml
-kubectl create configmap php-configuration --from-file project-base/docker/php-fpm/php-ini-overrides.ini --dry-run --output=yaml > project-base/kubernetes/php-configuration.yml
-kubectl create configmap product-search-php-configuration --from-file microservices/product-search/docker/php-ini-overrides.ini --dry-run --output=yaml > project-base/kubernetes/product-search-php-configuration.yml
-kubectl create configmap product-search-export-php-configuration --from-file microservices/product-search-export/docker/php-ini-overrides.ini --dry-run --output=yaml > project-base/kubernetes/product-search-export-php-configuration.yml
 kubectl create configmap postgres-configuration --from-file project-base/docker/postgres/postgres.conf --dry-run --output=yaml > project-base/kubernetes/postgres-configuration.yml
 
 # Set parameters.yml file and domains_urls

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,9 +20,9 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 ## [From 7.0.0-beta1 to Unreleased]
 ### [shopsys/shopsys]
 - [#497 adding php.ini to image is now done only in dockerfiles](https://github.com/shopsys/shopsys/pull/497)
-    - deleted mounting of `php.ini` in `docker-compose.yml` [files](/docker/conf) because it would not load changes instantly and there was need to restart php process
-    - loading of `php.ini` is now done during dockerimage build
-    - delete the mounting of `php.ini` files in your `docker-compose.yml`
+    - deleted mounting of `php-ini-overrides.ini` in `docker-compose.yml` [files](/docker/conf) because it would not load changes instantly and there was need to restart php process
+    - loading of `php-ini-overrides.ini` is now done during dockerimage build so any change in `php-ini-overrides.ini` is now only loaded by rebuilding the image
+    - delete the mounting of `php-ini-overrides.ini` files in your `docker-compose.yml`
 
 ### [shopsys/project-base]
 - [#494 Microservices webserver using nginx + php-fpm](https://github.com/shopsys/shopsys/pull/494)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,12 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 * [shopsys/microservice-product-search-export]
 
 ## [From 7.0.0-beta1 to Unreleased]
+### [shopsys/shopsys]
+- [#497 adding php.ini to image is now done only in dockerfiles](https://github.com/shopsys/shopsys/pull/497)
+    - deleted mounting of `php.ini` in `docker-compose.yml` [files](/docker/conf) because it would not load changes instantly and there was need to restart php process
+    - loading of `php.ini` is now done during dockerimage build
+    - delete the mounting of `php.ini` files in your `docker-compose.yml`
+
 ### [shopsys/project-base]
 - [#494 Microservices webserver using nginx + php-fpm](https://github.com/shopsys/shopsys/pull/494)
     - execute `docker-compose pull` to pull new microservice images and `docker-compose up -d` to start newly pulled microservices

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,13 +18,10 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 * [shopsys/microservice-product-search-export]
 
 ## [From 7.0.0-beta1 to Unreleased]
-### [shopsys/shopsys]
-- [#497 adding php.ini to image is now done only in dockerfiles](https://github.com/shopsys/shopsys/pull/497)
-    - deleted mounting of `php-ini-overrides.ini` in `docker-compose.yml` [files](/docker/conf) because it would not load changes instantly and there was need to restart php process
-    - loading of `php-ini-overrides.ini` is now done during dockerimage build so any change in `php-ini-overrides.ini` is now only loaded by rebuilding the image
-    - delete the mounting of `php-ini-overrides.ini` files in your `docker-compose.yml`
-
 ### [shopsys/project-base]
+- [#497 adding php.ini to image is now done only in dockerfiles](https://github.com/shopsys/shopsys/pull/497)
+    - you should make the same changes in your repository for the php.ini configuration files to be added to your Docker images
+    - from now on, you will have to rebuild your Docker images (`docker-compose up -d --build`) for the changes in the php.ini file to apply
 - [#494 Microservices webserver using nginx + php-fpm](https://github.com/shopsys/shopsys/pull/494)
     - execute `docker-compose pull` to pull new microservice images and `docker-compose up -d` to start newly pulled microservices
     - url addresses to microservices have changed, you need to upgrade url address provided in `app/config/parameters.yml`  

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -36,7 +36,6 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/project-base/web
-            - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini:delegated
         links:
             - microservice-product-search
             - microservice-product-search-export
@@ -57,7 +56,6 @@ services:
         container_name: shopsys-framework-microservice-product-search
         volumes:
             - shopsys-framework-microservice-product-search-sync:/var/www/html
-            - ./microservices/product-search/docker/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - elasticsearch
         depends_on:
@@ -72,7 +70,6 @@ services:
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
             - shopsys-framework-microservice-product-search-export-sync:/var/www/html
-            - ./microservices/product-search-export/docker/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - elasticsearch
         depends_on:

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -34,7 +34,6 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-            - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - microservice-product-search
             - microservice-product-search-export
@@ -55,7 +54,6 @@ services:
         container_name: shopsys-framework-microservice-product-search
         volumes:
             - ./microservices/product-search:/var/www/html
-            - ./microservices/product-search/docker/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - elasticsearch
         depends_on:
@@ -70,7 +68,6 @@ services:
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
             - ./microservices/product-search-export:/var/www/html
-            - ./microservices/product-search-export/docker/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - elasticsearch
         depends_on:

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -33,7 +33,6 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-            - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - microservice-product-search
             - microservice-product-search-export
@@ -54,7 +53,6 @@ services:
         container_name: shopsys-framework-microservice-product-search
         volumes:
             - ./microservices/product-search:/var/www/html
-            - ./microservices/product-search/docker/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - elasticsearch
         depends_on:
@@ -69,7 +67,6 @@ services:
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
             - ./microservices/product-search-export:/var/www/html
-            - ./microservices/product-search-export/docker/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - elasticsearch
         depends_on:

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -36,7 +36,6 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/web
-            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini:delegated
         links:
             - postgres
             - redis

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -34,7 +34,6 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - postgres
             - redis

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -34,7 +34,6 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         links:
             - postgres
             - redis

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -60,6 +60,9 @@ ENV LC_ALL=en_US.utf8 LANG=en_US.utf8 LANGUAGE=en_US.utf8
 # overwrite the original entry-point from the PHP Docker image with our own
 COPY docker-php-entrypoint /usr/local/bin/
 
+# copy php.ini configuration
+COPY php-ini-overrides.ini /usr/local/etc/php/php.ini
+
 # allow overwriting UID and GID o the user "www-data" to help solve issues with permissions in mounted volumes
 # if the GID is already in use, we will assign GID 82 instead (82 is the standard uid/gid for "www-data" in Alpine)
 ARG www_data_uid

--- a/project-base/docker/php-fpm/ci/Dockerfile
+++ b/project-base/docker/php-fpm/ci/Dockerfile
@@ -63,6 +63,9 @@ ENV LC_ALL=en_US.utf8 LANG=en_US.utf8 LANGUAGE=en_US.utf8
 # overwrite the original entry-point from the PHP Docker image with our own
 COPY project-base/docker/php-fpm/docker-php-entrypoint /usr/local/bin/
 
+# copy php.ini configuration
+COPY project-base/docker/php-fpm/php-ini-overrides.ini /usr/local/etc/php/php.ini
+
 # allow configuring the GitHub OAuth token
 ARG github_oauth_token
 RUN composer config -g github-oauth.github.com $github_oauth_token

--- a/project-base/kubernetes/deployments/microservice-product-search-export.yml
+++ b/project-base/kubernetes/deployments/microservice-product-search-export.yml
@@ -19,17 +19,6 @@ spec:
             labels:
                 app: microservice-product-search-export
         spec:
-            volumes:
-            -   name: product-search-export-php-configuration
-                configMap:
-                    name: product-search-export-php-configuration
-                    items:
-                    -   key: php-ini-overrides.ini
-                        path: php.ini
             containers:
             -   image: $MICROSERVICE_PRODUCT_SEARCH_EXPORT_PHP_FPM_IMAGE
                 name: microservice-product-search-export
-                volumeMounts:
-                -   name: product-search-export-php-configuration
-                    mountPath: /usr/local/etc/php/php.ini
-                    subPath: php.ini

--- a/project-base/kubernetes/deployments/microservice-product-search.yml
+++ b/project-base/kubernetes/deployments/microservice-product-search.yml
@@ -19,17 +19,6 @@ spec:
             labels:
                 app: microservice-product-search
         spec:
-            volumes:
-            -   name: product-search-php-configuration
-                configMap:
-                    name: product-search-php-configuration
-                    items:
-                    -   key: php-ini-overrides.ini
-                        path: php.ini
             containers:
             -   image: $MICROSERVICE_PRODUCT_SEARCH_PHP_FPM_IMAGE
                 name: microservice-product-search
-                volumeMounts:
-                -   name: product-search-php-configuration
-                    mountPath: /usr/local/etc/php/php.ini
-                    subPath: php.ini

--- a/project-base/kubernetes/deployments/webserver-php-fpm.yml
+++ b/project-base/kubernetes/deployments/webserver-php-fpm.yml
@@ -34,12 +34,6 @@ spec:
                         items:
                         -   key: nginx.conf
                             path: default.conf
-                -   name: php-configuration
-                    configMap:
-                        name: php-configuration
-                        items:
-                        -   key: php-ini-overrides.ini
-                            path: php.ini
             initContainers:
                 -   name: copy-source-codes-to-application-folder
                     image: $PHP_FPM_IMAGE
@@ -54,9 +48,6 @@ spec:
                         runAsUser: 82
                 workingDir: /var/www/html
                 volumeMounts:
-                    -   name: php-configuration
-                        mountPath: /usr/local/etc/php/php.ini
-                        subPath: php.ini
                     -   name: source-codes
                         mountPath: /var/www/html
             -   image: nginx:1.13.10-alpine


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Mounting of php.ini using volumes does not apply the changes without manually restarting the php-fpm process. Because of that, the mounting is not used anymore and instead it is added using COPY during Docker image build. That way, if anything changes in php.ini, it is added to the image during build and loaded when the container starts.
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
