### PR TITLE
[shopsys] docs for Docker installation on Linux: add Docker Compose

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -5,6 +5,7 @@
 * [PHP](http://php.net/manual/en/install.unix.php)
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * [Docker](https://docs.docker.com/engine/installation/)
+* [Docker Compose](https://docs.docker.com/compose/install/)
 
 ## Steps
 ### 1. Create new project from Shopsys Framework sources


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Docker Compose is not included in "raw" Docker installation. This PR adds Docker Compose installation link to Docker installation guide for Linux. So beginning developers will not get OS's note e.g. "docker-compose: command not found".
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| -
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
