### PR TITLE
[project-base] fixed acceptance tests (loading DB dump)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -24,6 +24,9 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - url addresses to microservices have changed, you need to upgrade url address provided in `app/config/parameters.yml`  
         - update parameter `microservice_product_search_url` from `microservice-product-search:8000` to `microservice-product-search`
         - update parameter `microservice_product_search_export_url`, from `microservice-product-search-export:8000` to `microservice-product-search-export`
+- [#502 - fixed acceptance tests (loading DB dump)](https://github.com/shopsys/shopsys/pull/502)
+    - when you upgrade `codeception/codeception` to version `2.5.0`, you have to change parameter `populate` to `true`
+      in `tests/ShopBundle/Acceptance/acceptance.suite.yml`
 
 ## [From 7.0.0-alpha6 to 7.0.0-beta1]
 ### [shopsys/framework]

--- a/project-base/tests/ShopBundle/Acceptance/acceptance.suite.yml
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance.suite.yml
@@ -27,7 +27,7 @@ modules:
             user: ~
             password: ~
             dump: ../var/cache/test-db-dump.sql
-            populate: false
+            populate: true
             cleanup: true
         Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver:
             host: "%selenium_server_host%"


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| since codeception v 2.5.0 `populate` option is checked also during `_loadDump` ([see the code](https://github.com/Codeception/Codeception/blame/2.5.0/src/Codeception/Module/Db.php#L603-L605), [see Populator docs](https://codeception.com/docs/modules/Db#Populator))
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
