### PR TITLE
[framework] Records of SettingValues table need to be valid with application

### DIFF
--- a/packages/framework/src/Component/Setting/Exception/SettingValueTypeNotMatchValueException.php
+++ b/packages/framework/src/Component/Setting/Exception/SettingValueTypeNotMatchValueException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Component\Setting\Exception;
+
+use Exception;
+
+class SettingValueTypeNotMatchValueException extends Exception implements SettingException
+{
+    /**
+     * @param string $message
+     * @param \Exception|null $previous
+     */
+    public function __construct($message = '', Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Component/Setting/SettingValue.php
+++ b/packages/framework/src/Component/Setting/SettingValue.php
@@ -89,6 +89,11 @@ class SettingValue
      */
     public function getValue()
     {
+        if ($this->value === null && $this->type !== self::TYPE_NULL) {
+            $message = 'Setting value type "' . $this->type . '" does not allow null value.';
+            throw new \Shopsys\FrameworkBundle\Component\Setting\Exception\SettingValueTypeNotMatchValueException($message);
+        }
+
         switch ($this->type) {
             case self::TYPE_INTEGER:
                 return (int)$this->value;
@@ -97,10 +102,6 @@ class SettingValue
             case self::TYPE_BOOLEAN:
                 return $this->value === self::BOOLEAN_TRUE;
             case self::TYPE_DATETIME:
-                if ($this->value === null) {
-                    return null;
-                }
-
                 return DateTimeHelper::createFromFormat(self::DATETIME_STORED_FORMAT, $this->value);
             default:
                 return $this->value;

--- a/packages/framework/src/Migrations/Version20181008000001.php
+++ b/packages/framework/src/Migrations/Version20181008000001.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20181008000001 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->sql('UPDATE setting_values SET value = 0 WHERE value IS NULL AND type = \'integer\' AND  name = \'' . Setting::DEFAULT_AVAILABILITY_IN_STOCK . '\'');
+        $this->sql('UPDATE setting_values SET value = 0 WHERE value IS NULL AND type = \'integer\' AND  name = \'' . Setting::DEFAULT_UNIT . '\'');
+        $this->sql('UPDATE setting_values SET type = \'none\' where value IS NULL');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| if the shop is created with build-new phing target, which should be state when there are basic data needed to create new shop, there are some pages that don't work because of inconsistency with the records of SettingsValue table when null value is converted into number 0.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #508 [Demoshop_17](https://github.com/shopsys/demoshop/issues/17)
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
