### PR TITLE
[framework] Manipulation with domains is modified and documented now

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -72,7 +72,9 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - change dependencies:
         - `"doctrine/orm": "dev-doctrine-260-..."` -> `"shopsys/doctrine-orm": "2.6.2"`
         - `"intaro/postgres-search-bundle": "@dev"` -> `"shopsys/postgres-search-bundle": "0.1"`
-
+- [#513 - Manipulation with domains is modified and documented now](https://github.com/shopsys/shopsys/pull/513)
+    - modify your `build.xml` according to this pull request so recalculations will be processed after `create-domains-data` command
+      
 ## [From 7.0.0-alpha6 to 7.0.0-beta1]
 ### [shopsys/framework]
 - *(optional)* [#468 - Setting for docker on mac are now more optimized](https://github.com/shopsys/shopsys/pull/468)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -73,8 +73,12 @@ There is a list of all the repositories maintained by monorepo, changes in log b
         - `"doctrine/orm": "dev-doctrine-260-..."` -> `"shopsys/doctrine-orm": "2.6.2"`
         - `"intaro/postgres-search-bundle": "@dev"` -> `"shopsys/postgres-search-bundle": "0.1"`
 - [#513 - Manipulation with domains is modified and documented now](https://github.com/shopsys/shopsys/pull/513)
-    - modify your `build.xml` according to this pull request so recalculations will be processed after `create-domains-data` command
-      
+    - modify your `build.xml` according to this pull request
+        - recalculations will be processed after `create-domains-data` command
+        - creation of some database functions was moved from `create-domains-data` phing target to a new phing target `create-domains-db-functions`
+    - modify your `build-dev.xml` according to this pull request
+        - creation of some database functions was moved from `test-create-domains-data` phing target to a new phing target `test-create-domains-db-functions`
+  
 ## [From 7.0.0-alpha6 to 7.0.0-beta1]
 ### [shopsys/framework]
 - *(optional)* [#468 - Setting for docker on mac are now more optimized](https://github.com/shopsys/shopsys/pull/468)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@
 * [Product Searching via Elasticsearch](./introduction/product-search-via-elasticsearch.md)
 * [Introduction to Kubernetes](/docs/kubernetes/introduction-to-kubernetes.md)
 * [Continuous Integration Using Kubernetes](/docs/kubernetes/continuous-integration-using-kubernetes.md)
+* [How to Set Up Domains and Locales (Languages)](./introduction/how-to-set-up-domains-and-locales.md)
 
 ## Cookbook
 * [Dumping and Importing the Database](./cookbook/dumping-and-importing-the-database.md)

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -1,0 +1,167 @@
+# How to Set Up Domains and Locales (Languages)
+
+During the development with the Shopsys Framework, it is possible to meet concepts - domain, multidomain, multilanguage.
+This document explains what these terms mean and how to work with them during the development of your project.
+
+## Domain, multidomain, multilanguage
+
+- **Domain** - Domain can be understood as one instance of eshop data.
+For example, just furniture can be bough on the domain shopsys-furniture.com while only electronics can be found on the domain shopsys-electro.com.
+It is still one application with one product catalogue.
+Access to these individual domains is provided through individual url addresses.
+All domains share one common administration.
+
+- **Multidomain attribute** - A distinct value of this attribute can be set for each domain.
+An example of a multidomain attribute is a default pricing group for not logged customer.
+This pricing group can be different for each domain.
+An example of a not multidomain attribute is en ean on the product.
+This attribute is the same for each domain.
+
+- **Multilang attribute** - A distinct value of this attribute can be set for each locale.
+An example of a multilang attribute is a name of the product.
+An example of a not multilang attribute is a price of the product.
+
+- **Difference between multidomain and multilang attribute** - A value of some multilang attribute will be the same for each domain with the same locale.
+For example, when a name of the product is set as *A4tech mouse* for the locale *en* , this name of this product will be the same for each domain with the locale *en*.
+While multidomain attribute can be set to different values for different domains regardless of the locale of the domain.
+
+*Note: Demo data on the Shopsys Framework contains data only in en and cs locales*
+
+## Settings and working with domains
+
+### 1. How to create a single domain application
+
+#### 1.1 Domain configuration
+Modify the configuration of the domain in `app/config/domains.yml`.
+This configuration file contains informations about the domain ID, the domain identifier for the domain tabs in the administration, and the domain locale.
+
+#### 1.2 Set up the url address
+Set the url address for the domain in `app/config/domains_urls.yml`.
+
+#### 1.3 Set up the application as "singledomain" 
+Modify the value of the parameter `is-multidomain` in `build.xml` to `false`.
+This parameter modifies the behaviour of some phing targets - for example, the import of the demo data is modified in such a way, that the application will not try to import demo data for another domain.
+
+#### 1.4 Locale settings
+Set up the locale of the domain according to the instructions in the section [Locale settings](#3-locale-settings)
+
+#### 1.5 Build
+Start the build, for example using a phing target
+```
+php phing build-demo-dev
+```
+After the build is completed, a singledomain application is created.
+
+#### 1.6 Tests
+Some tests are prepared for the configuration with the first domain with `en` locale.
+For example `Tests\ShopBundle\Database\Twig\PriceExtensionTest` is expecting the specific format of displayed currency.
+If you want to use already created tests for your specific configuration, you may need to modify these tests to be able to test your specific configuration of the domain.
+
+### 2. How to add a new domain
+
+#### 2.1 Domain configuration
+Modify the configuration of the domain in `app/config/domains.yml`.
+This configuration file contains pieces of information about the domain ID, the domain identifier for the domain tabs in the administration, and the domain locale.
+
+#### 2.2 Set up the url address
+Set the url address for the domain in `app/config/domains_urls.yml`.
+
+*Note: When you add a domain with the new url address on the MacOS platform, you need to enable this url address also in the network interface, see [Installation Using Docker for MacOS](https://github.com/shopsys/shopsys/blob/master/docs/installation/installation-using-docker-macos.md#11-enable-second-domain-optional)*
+
+#### 2.3 Set up the application as "multidomain" 
+Modify the value of the parameter `is-multidomain` in `build.xml` to `true` (this is the default value).
+This parameter modifies the behaviour of some phing targets - for example, the import of the demo data is modified in such a way, that the application will try to import demo data for another domain if they are available.
+
+#### 2.4 Locale settings
+Set up the locale of the domain according to the instructions in the section [Locale settings](#3-locale-settings)
+
+#### 2.5 Create multidomains data
+There need to be created some multidomain data for the newly added domain.
+Run the phing target
+```
+php phing create-domains-data
+```
+This command performs multiple actions:
+- multidomain attributes from the first domain are copied for this new domain, see `FrameworkBundle/Component/Domain/DomainDataCreator.php`, where the `TEMPLATE_DOMAIN_ID` constant is defined.
+- if a new locale is set for the newly added domain, the empty rows with this new locale will be created for multilang attributes
+- pricing group with the name Default is created for every new domain
+- the last step of this command is the start of automatic recalculations of prices, availabilities, and products visibilities.
+
+#### 2.6 Multilang attributes
+Demo data of Shopsys Framework are prepared only for `en` and `cs` locales.
+This means that if you are using a different locale, these multilang attributes will be empty for this new locale even after the installation of demo data.
+
+#### 2.7 Generate assets for the new domain
+In order to properly display the new domain, assets need to be generated
+```
+php phing grunt
+```
+
+#### 2.8. Create elasticsearch definition for the new domain
+The configuration for elasticsearch must be created for each domain in a separate json file.
+By default, the configurations for the domain 1 and 2 are already parts of a microservice.
+Configuration for elasticsearch can be found in [Definitions of Microservice Product Search Export](https://github.com/shopsys/shopsys/tree/master/microservices/product-search-export/src/Resources/definition).
+If you add a new domain, you need to create an elasticsearch configuration for this new domain.
+As the configuration is part of the microservice, you need to fork the microservice and create this configuration here.
+
+### 3. Locale settings
+Some parts of these instructions are already prepared for the locales en and cs.
+
+#### 3.1 Set up the locale for domain
+Set up the locale of the domain in `app/config/domains.yml`.
+This configuration file contains pieces of information about the domain ID, the domain identifier for the domain tabs in the administration, and the domain locale.
+
+#### 3.2 Frontend routes
+Create a file with the frontend routes for the added locale if this file is not already created for this locale.
+Create this file in the directory `ShopBundle/Resources/config/` with the name `routing_front_xx.yml` where `xx` replace for the code of added locale.
+Import the new routes configuration in `app/config/packages/shopsys_shop.yml`
+
+#### 3.3 Translations and messages
+In order to correctly display the labels like *Registration*, *Cart*, ..., create a file with translations of messages in `ShopBundle/Resources/translations/`.
+Modify the phing target `dump-translations-project-base` in `build-dev.xml` by adding the new locale as `<arg value="xx" />` where `xx` replace for the code of added locale. 
+Then run 
+```
+php phing dump-translations
+```
+There will be created files for translations of messages for the new locale in `ShopBundle/Resources/translations/`.
+
+#### 3.4 Generate database functions for the locale use
+Within the database functions, it is necessary to regenerate the default database functions for the locale use that are already created for the `en` locale as default.
+Regenerate database functions by running a phing target
+```
+php phing create-domains-db-functions
+```
+
+#### 3.5 Multilang attributes
+Demo data of Shopsys Framework are prepared only for `en` and `cs` locales.
+This means that if you are using a different locale, these multilang attributes will be empty for this new locale even after the installation of demo data.
+
+#### 3.6 Locale in administration
+Administration is by default in `en` locale.
+This means that for example product list in administration tries to display translations of product names in `en` locale.
+If you want to switch it to another locale, override the method `getAdminLocale()` of the class `Shopsys\FrameworkBundle\Model\Localization\Localization`.
+
+### 4. Change the url address for an existing domain
+
+#### 4.1 Change the url address
+Change the url address in the configuration of the domain in `app/config/domains.yml`.
+
+*Note: When you add a domain with the new url address on the MacOS platform, you need to enable this url address also in the network interface, see [Installation Using Docker for MacOS](https://github.com/shopsys/shopsys/blob/master/docs/installation/installation-using-docker-macos.md#11-enable-second-domain-optional)*
+
+#### 4.2 Replace the old url address
+Run the phing target
+```
+php phing replace-domains-urls
+```
+Running this command will ensure replacing all occurrences of the old url address in the text attributes in the database with the new url address.
+
+### 5. Change the locale for an existing domain
+This scenario is not supported by default because of the fact, that change of the locale within an already running eshop almost never happens.
+However, there is workaround even for this scenario.
+
+#### Change the locale to the locale that is already used by another domain
+If you need to change the locale of a specific domain to another locale that is already used by another domain, just set the required locale for this domain in the `app/config/domains.yml`.
+
+#### Change the locale to the locale that is not yet used by another domain
+If you need to change the locale of a specific domain to another locale that is not yet already used by another domain, add new temporary domain with this new locale and follow the instructions of [How to add a new domain](#2-how-to-add-a-new-domain).
+The following procedure is the same as in the case with [Change the locale to the locale that is already used by another domain](#change-the-locale-to-the-locale-that-is-already-used-by-another-domain).

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -12,6 +12,7 @@ parameters:
             - '*/src/Model/Product/ProductVisibilityRepository.php'
             - '*/src/Controller/Admin/AdministratorController.php'
             - '*/tests/Unit/Model/Customer/CustomerServiceTest.php'
+            - '*/tests/Unit/Component/Domain/DomainDataCreatorTest.php'
 
         ObjectCalisthenics\Sniffs\Metrics\PropertyPerClassLimitSniff:
             - '*/src/Model/Order/Order.php'

--- a/packages/framework/src/Command/CreateDomainsDataCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDataCommand.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator;
-use Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade;
 use Shopsys\FrameworkBundle\Model\Localization\DbIndexesFacade;
 use Symfony\Component\Console\Command\Command;
@@ -24,11 +23,6 @@ class CreateDomainsDataCommand extends Command
     private $em;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade
-     */
-    private $domainDbFunctionsFacade;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator
      */
     private $domainDataCreator;
@@ -45,20 +39,17 @@ class CreateDomainsDataCommand extends Command
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
-     * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade $domainDbFunctionsFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator $domainDataCreator
      * @param \Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade $multidomainEntityClassFinderFacade
      * @param \Shopsys\FrameworkBundle\Model\Localization\DbIndexesFacade $dbIndexesFacade
      */
     public function __construct(
         EntityManagerInterface $em,
-        DomainDbFunctionsFacade $domainDbFunctionsFacade,
         DomainDataCreator $domainDataCreator,
         MultidomainEntityClassFinderFacade $multidomainEntityClassFinderFacade,
         DbIndexesFacade $dbIndexesFacade
     ) {
         $this->em = $em;
-        $this->domainDbFunctionsFacade = $domainDbFunctionsFacade;
         $this->domainDataCreator = $domainDataCreator;
         $this->multidomainEntityClassFinderFacade = $multidomainEntityClassFinderFacade;
         $this->dbIndexesFacade = $dbIndexesFacade;
@@ -87,7 +78,6 @@ class CreateDomainsDataCommand extends Command
     {
         $output->writeln('Start of creating new domains data.');
 
-        $this->domainDbFunctionsFacade->createDomainDbFunctions();
         $domainsCreated = $this->domainDataCreator->createNewDomainsData();
 
         $output->writeln('<fg=green>New domains created: ' . $domainsCreated . '.</fg=green>');

--- a/packages/framework/src/Command/CreateDomainsDbFunctionsCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDbFunctionsCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateDomainsDbFunctionsCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'shopsys:domains-db-functions:create';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade
+     */
+    private $domainDbFunctionsFacade;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    private $em;
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade $domainDbFunctionsFacade
+     */
+    public function __construct(EntityManagerInterface $em, DomainDbFunctionsFacade $domainDbFunctionsFacade)
+    {
+        $this->em = $em;
+        $this->domainDbFunctionsFacade = $domainDbFunctionsFacade;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Create new domains DB functions');
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->em->transactional(function () use ($output) {
+            $this->doExecute($output);
+        });
+    }
+
+    private function doExecute(OutputInterface $output)
+    {
+        $output->writeln('Start of creating db functions.');
+
+        $this->domainDbFunctionsFacade->createDomainDbFunctions();
+
+        $output->writeln('<fg=green>All db functions created.</fg=green>');
+    }
+}

--- a/packages/framework/src/DataFixtures/Demo/ProductDataFixtureLoader.php
+++ b/packages/framework/src/DataFixtures/Demo/ProductDataFixtureLoader.php
@@ -169,7 +169,7 @@ class ProductDataFixtureLoader
     {
         $domainId = 1;
 
-        $productData->name['en'] = $row[self::COLUMN_NAME_EN];
+        $productData->name[$this->domain->getDomainConfigById($domainId)->getLocale()] = $row[$this->getCsvProductColumnNameByDomainId($domainId)];
         $productData->catnum = $row[self::COLUMN_CATNUM];
         $productData->partno = $row[self::COLUMN_PARTNO];
         $productData->ean = $row[self::COLUMN_EAN];
@@ -346,7 +346,7 @@ class ProductDataFixtureLoader
                 }
 
                 $manualInputPricesFromCsvByPricingGroupId = $productData->manualInputPricesByPricingGroupId;
-                $manualPricesForAllPricingGroups  = $this->addZeroPricesForPricingGroupsThatAreMissingInDemoData($manualInputPricesFromCsvByPricingGroupId);
+                $manualPricesForAllPricingGroups = $this->addZeroPricesForPricingGroupsThatAreMissingInDemoData($manualInputPricesFromCsvByPricingGroupId);
                 $productData->manualInputPricesByPricingGroupId = $manualPricesForAllPricingGroups;
                 break;
             default:
@@ -383,5 +383,21 @@ class ProductDataFixtureLoader
         }
 
         return $demoDataManualPrices;
+    }
+
+    /**
+     * @param int $domainId
+     * @return int
+     */
+    private function getCsvProductColumnNameByDomainId(int $domainId)
+    {
+        switch ($this->domain->getDomainConfigById($domainId)->getLocale()) {
+            case 'cs':
+                return self::COLUMN_NAME_CS;
+            case 'en':
+                return self::COLUMN_NAME_EN;
+            default:
+                throw new \Shopsys\FrameworkBundle\Component\DataFixture\Exception\UnsupportedLocaleException($this->domain->getDomainConfigById($domainId)->getLocale());
+        }
     }
 }

--- a/packages/framework/src/DataFixtures/DemoMultidomain/PricingGroupDataFixture.php
+++ b/packages/framework/src/DataFixtures/DemoMultidomain/PricingGroupDataFixture.php
@@ -37,7 +37,14 @@ class PricingGroupDataFixture extends AbstractReferenceFixture
 
         $pricingGroupData->name = 'Obyčejný zákazník';
         $domainId = 2;
-        $this->createPricingGroup($pricingGroupData, $domainId, self::PRICING_GROUP_ORDINARY_DOMAIN_2);
+
+        $alreadyCreatedDemoPricingGroupsByDomain = $this->pricingGroupFacade->getByDomainId($domainId);
+        if (count($alreadyCreatedDemoPricingGroupsByDomain) > 0) {
+            $pricingGroup = reset($alreadyCreatedDemoPricingGroupsByDomain);
+
+            $this->pricingGroupFacade->edit($pricingGroup->getId(), $pricingGroupData);
+            $this->addReference(self::PRICING_GROUP_ORDINARY_DOMAIN_2, $pricingGroup);
+        }
 
         $pricingGroupData->name = 'VIP zákazník';
         $domainId1 = 2;

--- a/packages/framework/tests/Unit/Component/Domain/DomainDataCreatorTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainDataCreatorTest.php
@@ -10,6 +10,10 @@ use Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityDataCr
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Component\Setting\SettingValueRepository;
 use Shopsys\FrameworkBundle\Component\Translation\TranslatableEntityDataCreator;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactory;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 
 class DomainDataCreatorTest extends TestCase
 {
@@ -31,13 +35,17 @@ class DomainDataCreatorTest extends TestCase
         $settingValueRepositoryMock = $this->createMock(SettingValueRepository::class);
         $multidomainEntityDataCreatorMock = $this->createMock(MultidomainEntityDataCreator::class);
         $translatableEntityDataCreatorMock = $this->createMock(TranslatableEntityDataCreator::class);
+        $pricingGroupDataFactoryMock = $this->createMock(PricingGroupDataFactory::class);
+        $pricingGroupFacadeMock = $this->createMock(PricingGroupFacade::class);
 
         $domainDataCreator = new DomainDataCreator(
             $domain,
             $settingMock,
             $settingValueRepositoryMock,
             $multidomainEntityDataCreatorMock,
-            $translatableEntityDataCreatorMock
+            $translatableEntityDataCreatorMock,
+            $pricingGroupDataFactoryMock,
+            $pricingGroupFacadeMock
         );
         $newDomainsDataCreated = $domainDataCreator->createNewDomainsData();
 
@@ -77,12 +85,30 @@ class DomainDataCreatorTest extends TestCase
 
         $translatableEntityDataCreatorMock = $this->createMock(TranslatableEntityDataCreator::class);
 
+        $pricingGroupData = new PricingGroupData();
+        $pricingGroupData->name = 'Default';
+
+        $pricingGroupDataFactoryMock = $this->createMock(PricingGroupDataFactory::class);
+        $pricingGroupDataFactoryMock
+            ->method('create')
+            ->willReturn($pricingGroupData);
+
+        $pricingGroup = new PricingGroup($pricingGroupData, 2);
+
+        $pricingGroupFacadeMock = $this->createMock(PricingGroupFacade::class);
+        $pricingGroupFacadeMock
+            ->method('create')
+            ->with($pricingGroupData, 2)
+            ->willReturn($pricingGroup);
+
         $domainDataCreator = new DomainDataCreator(
             $domain,
             $settingMock,
             $settingValueRepositoryMock,
             $multidomainEntityDataCreatorMock,
-            $translatableEntityDataCreatorMock
+            $translatableEntityDataCreatorMock,
+            $pricingGroupDataFactoryMock,
+            $pricingGroupFacadeMock
         );
         $newDomainsDataCreated = $domainDataCreator->createNewDomainsData();
 
@@ -131,12 +157,17 @@ class DomainDataCreatorTest extends TestCase
             ->method('copyAllTranslatableDataForNewLocale')
             ->with($domainConfigWithDataCreated->getLocale(), $domainConfigWithNewLocale->getLocale());
 
+        $pricingGroupDataFactoryMock = $this->createMock(PricingGroupDataFactory::class);
+        $pricingGroupFacadeMock = $this->createMock(PricingGroupFacade::class);
+
         $domainDataCreator = new DomainDataCreator(
             $domainMock,
             $settingMock,
             $settingValueRepositoryMock,
             $multidomainEntityDataCreatorMock,
-            $translatableEntityDataCreatorMock
+            $translatableEntityDataCreatorMock,
+            $pricingGroupDataFactoryMock,
+            $pricingGroupFacadeMock
         );
 
         $domainDataCreator->createNewDomainsData();

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -16,7 +16,7 @@
     <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check" description="Checks coding standards."/>
     <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff" description="Checks coding standards on changed files."/>
 
-    <target name="test-db-demo" depends="clean,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-db-fixtures-demo-singledomain,test-create-domains-data,test-generate-friendly-urls,test-db-fixtures-demo-multidomain,test-load-plugin-demo-data,test-replace-domains-urls" description="Drops all data in test database and creates a new one with demo data."/>
+    <target name="test-db-demo" depends="clean,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-create-domains-db-functions,test-db-fixtures-demo-singledomain,test-create-domains-data,test-generate-friendly-urls,test-db-fixtures-demo-multidomain,test-load-plugin-demo-data,test-replace-domains-urls" description="Drops all data in test database and creates a new one with demo data."/>
     <target name="test-db-performance" depends="test-db-demo,test-db-fixtures-performance" description="Drops all data in test database and creates a new one with performance data."/>
     <target name="tests" depends="test-db-demo,tests-unit,tests-db,tests-smoke" description="Runs unit, database and smoke tests on a newly built test database."/>
 
@@ -526,6 +526,14 @@
             <arg value="Unit"/>
             <arg value="--configuration"/>
             <arg value="${path.root}/phpunit.xml"/>
+        </exec>
+    </target>
+
+    <target name="test-create-domains-db-functions" description="Creates new domains DB functions in test database.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="shopsys:domains-db-functions:create" />
+            <arg value="--env=test" />
         </exec>
     </target>
 

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -117,6 +117,10 @@
             <arg value="${path.bin-console}" />
             <arg value="shopsys:domains-data:create" />
         </exec>
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="shopsys:recalculations" />
+        </exec>
     </target>
 
     <target name="microservice-product-search-create-structure" description="Creates structure for searching via microservice.">

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -56,7 +56,7 @@
     <target name="build-deploy-part-2-db-dependent" depends="db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,grunt,error-pages-generate,warmup" description="Second part of application build for production preserving your DB (must be run with maintenance page when containing DB migrations)."/>
     <target name="build-new" depends="wipe,composer,npm,dirs-create,domains-urls-check,assets,db-rebuild,grunt,error-pages-generate,warmup,microservice-product-search-create-structure" description="Builds application for production with clean DB (with base data only)."/>
     <target name="build-demo" depends="wipe,composer,npm,dirs-create,domains-urls-check,assets,db-demo,grunt,error-pages-generate,warmup,microservice-product-search-recreate-structure" description="Builds application for production with clean demo DB."/>
-    <target name="db-demo" depends="db-wipe-public-schema,db-import-basic-structure,db-migrations,db-fixtures-demo-singledomain,create-domains-data,db-fixtures-demo-multidomain,load-plugin-demo-data,generate-friendly-urls,replace-domains-urls" description="Creates DB and fills it with demo data"/>
+    <target name="db-demo" depends="db-wipe-public-schema,db-import-basic-structure,db-migrations,create-domains-db-functions,db-fixtures-demo-singledomain,create-domains-data,db-fixtures-demo-multidomain,load-plugin-demo-data,generate-friendly-urls,replace-domains-urls" description="Creates DB and fills it with demo data"/>
     <target name="db-rebuild" depends="db-wipe-public-schema,db-import-basic-structure,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls" description="Drops all data in database and creates a new one with base data only."/>
     <target name="microservice-product-search-recreate-structure" depends="microservice-product-search-delete-structure,microservice-product-search-create-structure" description="Recreates structure for searching via microservice (deletes existing structure and creates new one)" />
 
@@ -120,6 +120,13 @@
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
             <arg value="shopsys:recalculations" />
+        </exec>
+    </target>
+
+    <target name="create-domains-db-functions" description="Creates new domains DB functions.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="shopsys:domains-db-functions:create" />
         </exec>
     </target>
 

--- a/project-base/tests/ShopBundle/Database/Model/Category/CategoryRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Category/CategoryRepositoryTest.php
@@ -25,7 +25,7 @@ class CategoryRepositoryTest extends DatabaseTestCase
         /* @var $categoryDataFactory \Shopsys\ShopBundle\Model\Category\CategoryDataFactory */
 
         $categoryData = $categoryDataFactory->create();
-        $categoryData->name = ['en' => 'name'];
+        $categoryData->name = ['en' => 'name', 'cs' => 'name'];
         $categoryData->parent = $categoryFacade->getRootCategory();
 
         $parentCategory = $categoryFacade->create($categoryData);
@@ -55,7 +55,7 @@ class CategoryRepositoryTest extends DatabaseTestCase
         /* @var $categoryDataFactory \Shopsys\ShopBundle\Model\Category\CategoryDataFactory */
 
         $categoryData = $categoryDataFactory->create();
-        $categoryData->name = ['en' => 'name'];
+        $categoryData->name = ['en' => 'name', 'cs' => 'name'];
         $categoryData->parent = $categoryFacade->getRootCategory();
 
         $parentCategory = $categoryFacade->create($categoryData);

--- a/project-base/tests/ShopBundle/Database/Model/Category/CategoryRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Category/CategoryRepositoryTest.php
@@ -30,10 +30,9 @@ class CategoryRepositoryTest extends DatabaseTestCase
 
         $parentCategory = $categoryFacade->create($categoryData);
 
-        $categoryData->enabled = [
-            self::FIRST_DOMAIN_ID => false,
-            self::SECOND_DOMAIN_ID => false,
-        ];
+        $categoryData->enabled[self::FIRST_DOMAIN_ID] = false;
+        $categoryData->enabled[self::SECOND_DOMAIN_ID] = false;
+
         $categoryData->parent = $parentCategory;
         $categoryFacade->create($categoryData);
 

--- a/project-base/tests/ShopBundle/Database/Model/Product/ProductRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Database/Model/Product/ProductRepositoryTest.php
@@ -206,11 +206,13 @@ class ProductRepositoryTest extends DatabaseTestCase
         /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
         /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        $domain = $this->getContainer()->get(Domain::class);
+        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         $paginationResult = $productRepository->getPaginationResultForSearchListable(
             $searchText,
             1,
-            'en',
+            $domain->getDomainConfigById(1)->getLocale(),
             new ProductFilterData(),
             ProductListOrderingModeService::ORDER_BY_PRIORITY,
             $pricingGroup,
@@ -231,11 +233,13 @@ class ProductRepositoryTest extends DatabaseTestCase
         /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
         /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        $domain = $this->getContainer()->get(Domain::class);
+        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         $paginationResult = $productRepository->getPaginationResultForListableInCategory(
             $category,
             1,
-            'en',
+            $domain->getDomainConfigById(1)->getLocale(),
             new ProductFilterData(),
             ProductListOrderingModeService::ORDER_BY_PRIORITY,
             $pricingGroup,


### PR DESCRIPTION
- now the CreateDomainsDataCommand creates new default pricing group for every new domain
- for pricing groups that are not filled in demo data, the manual price is set to 0 while importing demo data
- data fixtures of products for single domain are imported in locale according to the domains locale

| Q             | A
| ------------- | ---
|Description, reason for the PR| Testing of phing targets for manipulation with domains to confirm consistency database after some modifications of domains. Documenting manipulation with domains for project developers.
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
