### PR TITLE
[migrations] migration count command is now fixed and initialized with correct configuration

### DIFF
--- a/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
+++ b/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\MigrationBundle\Command;
 
+use Doctrine\Bundle\MigrationsBundle\Command\DoctrineCommand;
 use Doctrine\DBAL\Migrations\Version;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -26,6 +27,7 @@ class GetCountOfMigrationsToExecuteCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $migrationsConfiguration = $this->getMigrationsConfiguration();
+        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $migrationsConfiguration);
 
         $latestVersion = $migrationsConfiguration->getLatestVersion();
         $migrationsToExecute = $migrationsConfiguration->getMigrationsToExecute(Version::DIRECTION_UP, $latestVersion);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| migration command shopsys:migrations:count is not initialized with migration configuration and some of the methods that depends on validate() method are failing.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #469 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
