### PR TITLE
[framework] fixed rendering of product visibilities box

### DIFF
--- a/packages/framework/src/Twig/ProductVisibilityExtension.php
+++ b/packages/framework/src/Twig/ProductVisibilityExtension.php
@@ -70,7 +70,11 @@ class ProductVisibilityExtension extends \Twig_Extension
     public function isVisibleForDefaultPricingGroupOnDomain(Product $product, $domainId)
     {
         $pricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($domainId);
-        $productVisibility = $this->productVisibilityRepository->getProductVisibility($product, $pricingGroup, $domainId);
+        try {
+            $productVisibility = $this->productVisibilityRepository->getProductVisibility($product, $pricingGroup, $domainId);
+        } catch (\Shopsys\FrameworkBundle\Model\Product\Exception\ProductVisibilityNotFoundException $ex) {
+            return false;
+        }
 
         return $productVisibility->isVisible();
     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| Rendering of product visibilities box in admin ends up with an error when the entry is not found in `product_visibilities` DB table
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #516 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
