### PR TITLE
[framework] feeds generation now works with performance data

### DIFF
--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -99,6 +99,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
      */
     public function sleep(): void
     {
+        $this->currentFeedExport->sleep();
         $currentFeedName = $this->feedExportCreationDataQueue->getCurrentFeedName();
         $currentDomain = $this->feedExportCreationDataQueue->getCurrentDomain();
         $lastSeekId = $this->currentFeedExport !== null ? $this->currentFeedExport->getLastSeekId() : null;
@@ -131,6 +132,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
 
         $lastSeekId = $this->setting->get(Setting::FEED_ITEM_ID_TO_CONTINUE);
         $this->currentFeedExport = $this->createCurrentFeedExport($lastSeekId);
+        $this->currentFeedExport->wakeUp();
 
         $this->logger->addDebug(sprintf(
             'Waking up... Continuing with feed "%s" on "%s", processing from ID %d.',

--- a/packages/framework/src/Model/Feed/FeedExportFactory.php
+++ b/packages/framework/src/Model/Feed/FeedExportFactory.php
@@ -4,7 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Feed;
 
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemInterface;
+use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Symfony\Component\Filesystem\Filesystem;
 
 class FeedExportFactory
 {
@@ -31,16 +33,30 @@ class FeedExportFactory
      */
     protected $feedPathProvider;
 
+    /**
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    private $localFilesystem;
+
+    /**
+     * @var \League\Flysystem\MountManager
+     */
+    private $mountManager;
+
     public function __construct(
         FeedRendererFactory $feedRendererFactory,
         FilesystemInterface $filesystem,
         EntityManagerInterface $em,
-        FeedPathProvider $feedPathProvider
+        FeedPathProvider $feedPathProvider,
+        Filesystem $localFilesystem,
+        MountManager $mountManager
     ) {
         $this->feedRendererFactory = $feedRendererFactory;
         $this->filesystem = $filesystem;
         $this->em = $em;
         $this->feedPathProvider = $feedPathProvider;
+        $this->localFilesystem = $localFilesystem;
+        $this->mountManager = $mountManager;
     }
 
     /**
@@ -53,7 +69,19 @@ class FeedExportFactory
     {
         $feedRenderer = $this->feedRendererFactory->create($feed);
         $feedFilepath = $this->feedPathProvider->getFeedFilepath($feed->getInfo(), $domainConfig);
+        $feedLocalFilepath = $this->feedPathProvider->getFeedLocalFilepath($feed->getInfo(), $domainConfig);
 
-        return new FeedExport($feed, $domainConfig, $feedRenderer, $this->filesystem, $this->em, $feedFilepath, $lastSeekId);
+        return new FeedExport(
+            $feed,
+            $domainConfig,
+            $feedRenderer,
+            $this->filesystem,
+            $this->localFilesystem,
+            $this->mountManager,
+            $this->em,
+            $feedFilepath,
+            $feedLocalFilepath,
+            $lastSeekId
+        );
     }
 }

--- a/packages/framework/src/Model/Feed/FeedPathProvider.php
+++ b/packages/framework/src/Model/Feed/FeedPathProvider.php
@@ -22,11 +22,17 @@ class FeedPathProvider
      */
     protected $setting;
 
-    public function __construct(string $feedUrlPrefix, string $feedDir, Setting $setting)
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    public function __construct(string $feedUrlPrefix, string $feedDir, string $projectDir, Setting $setting)
     {
         $this->feedUrlPrefix = $feedUrlPrefix;
         $this->feedDir = $feedDir;
         $this->setting = $setting;
+        $this->projectDir = $projectDir;
     }
 
     /**
@@ -47,6 +53,16 @@ class FeedPathProvider
     public function getFeedFilepath(FeedInfoInterface $feedInfo, DomainConfig $domainConfig)
     {
         return $this->feedDir . $this->getFeedFilename($feedInfo, $domainConfig);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface $feedInfo
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @return string
+     */
+    public function getFeedLocalFilepath(FeedInfoInterface $feedInfo, DomainConfig $domainConfig)
+    {
+        return $this->projectDir . $this->feedDir . $this->getFeedFilename($feedInfo, $domainConfig);
     }
 
     /**

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -440,6 +440,7 @@ services:
         arguments:
             $feedUrlPrefix: '%shopsys.feed_url_prefix%'
             $feedDir: '%shopsys.feed_dir%'
+            $projectDir: '%kernel.project_dir%'
 
     Shopsys\FrameworkBundle\Model\Feed\FeedRegistry:
         arguments:


### PR DESCRIPTION
- feeds are now generated on local filesystem and moved to abstract filesystem after generation is complete
- feeds files are moved also to the abstract filesystem in case that generation of feed is put to sleep and moved back on feed wakeup

| Q             | A
| ------------- | ---
|Description, reason for the PR| Generating of feeds was problematic around 50k+ products
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
