### PR TITLE
Fixes of typesystem issues (PHPStan upgrade preparation)

### DIFF
--- a/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
+++ b/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
@@ -27,7 +27,10 @@ class GetCountOfMigrationsToExecuteCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $migrationsConfiguration = $this->getMigrationsConfiguration();
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $migrationsConfiguration);
+
+        /** @var \Symfony\Bundle\FrameworkBundle\Console\Application $application */
+        $application = $this->getApplication();
+        DoctrineCommand::configureMigrations($application->getKernel()->getContainer(), $migrationsConfiguration);
 
         $latestVersion = $migrationsConfiguration->getLatestVersion();
         $migrationsToExecute = $migrationsConfiguration->getMigrationsToExecute(Version::DIRECTION_UP, $latestVersion);

--- a/packages/product-feed-google/src/Model/Product/GoogleProductDomainFacade.php
+++ b/packages/product-feed-google/src/Model/Product/GoogleProductDomainFacade.php
@@ -47,7 +47,7 @@ class GoogleProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      * @param \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData[] $googleProductDomainsData
      */
     public function saveGoogleProductDomainsForProductId($productId, array $googleProductDomainsData)
@@ -84,7 +84,7 @@ class GoogleProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      * @param \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData $googleProductDomainData
      */
     public function saveGoogleProductDomain($productId, GoogleProductDomainData $googleProductDomainData)
@@ -108,7 +108,7 @@ class GoogleProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      */
     public function delete($productId)
     {

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
@@ -51,7 +51,7 @@ class HeurekaCategoryDownloader
     }
 
     /**
-     * @param \SimpleXMLElement[] $categoryDataObjects
+     * @param \SimpleXMLElement[] $xmlCategoryDataObjects
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[]
      */
     private function convertToShopEntities(array $xmlCategoryDataObjects)

--- a/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomainFacade.php
+++ b/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomainFacade.php
@@ -66,7 +66,7 @@ class HeurekaProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      */
     public function delete($productId)
     {
@@ -79,7 +79,7 @@ class HeurekaProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData[] $heurekaProductDomainsData
      */
     public function saveHeurekaProductDomainsForProductId($productId, array $heurekaProductDomainsData)
@@ -94,7 +94,7 @@ class HeurekaProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData $heurekaProductDomainData
      */
     public function saveHeurekaProductDomain($productId, HeurekaProductDomainData $heurekaProductDomainData)

--- a/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomainFacade.php
+++ b/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomainFacade.php
@@ -66,7 +66,7 @@ class ZboziProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      * @param \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData[] $zboziProductDomainsData
      */
     public function saveZboziProductDomainsForProductId($productId, array $zboziProductDomainsData)
@@ -101,7 +101,7 @@ class ZboziProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      * @param \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData $zboziProductDomainData
      */
     public function saveZboziProductDomain($productId, ZboziProductDomainData $zboziProductDomainData)
@@ -125,7 +125,7 @@ class ZboziProductDomainFacade
     }
 
     /**
-     * @param $productId
+     * @param int $productId
      */
     public function delete($productId)
     {

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerController.php
@@ -100,8 +100,8 @@ class CustomerController extends FrontBaseController
             return $this->redirectToRoute('front_login');
         }
 
+        /** @var \Shopsys\FrameworkBundle\Model\Customer\User $user */
         $user = $this->getUser();
-        /* @var $user \Shopsys\FrameworkBundle\Model\Customer\User */
 
         $orders = $this->orderFacade->getCustomerOrderList($user);
         return $this->render('@ShopsysShop/Front/Content/Customer/orders.html.twig', [
@@ -139,15 +139,15 @@ class CustomerController extends FrontBaseController
 
             $user = $this->getUser();
             try {
+                /** @var \Shopsys\FrameworkBundle\Model\Order\Order $order */
                 $order = $this->orderFacade->getByOrderNumberAndUser($orderNumber, $user);
-                /* @var $order \Shopsys\FrameworkBundle\Model\Order\Order */
             } catch (\Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException $ex) {
                 $this->getFlashMessageSender()->addErrorFlash(t('Order not found'));
                 return $this->redirectToRoute('front_customer_orders');
             }
         } else {
+            /** @var \Shopsys\FrameworkBundle\Model\Order\Order $order */
             $order = $this->orderFacade->getByUrlHashAndDomain($urlHash, $this->domain->getId());
-            /* @var $order \Shopsys\FrameworkBundle\Model\Order\Order */
         }
 
         $orderItemTotalPricesById = $this->orderItemPriceCalculation->calculateTotalPricesIndexedById($order->getItems());
@@ -167,8 +167,8 @@ class CustomerController extends FrontBaseController
         try {
             $this->loginAsUserFacade->loginAsRememberedUser($request);
         } catch (\Shopsys\FrameworkBundle\Model\Customer\Exception\UserNotFoundException $e) {
+            /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessageSender $adminFlashMessageSender */
             $adminFlashMessageSender = $this->get('shopsys.shop.component.flash_message.sender.admin');
-            /* @var $adminFlashMessageSender \Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessageSender */
             $adminFlashMessageSender->addErrorFlash(t('User not found.'));
 
             return $this->redirectToRoute('admin_customer_list');

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/FlashMessageController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/FlashMessageController.php
@@ -6,8 +6,8 @@ class FlashMessageController extends FrontBaseController
 {
     public function indexAction()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageBag */
         $flashMessageBag = $this->get('shopsys.shop.component.flash_message.bag.front');
-        /* @var $flashMessageBag \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         return $this->render('@ShopsysShop/Front/Inline/FlashMessage/index.html.twig', [
             'errorMessages' => $flashMessageBag->getErrorMessages(),

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -274,7 +274,7 @@ class OrderController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
+     * @param \Shopsys\ShopBundle\Model\Order\OrderData $orderData
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreview $orderPreview
      * @param \Shopsys\FrameworkBundle\Model\Transport\Transport[] $transports
      * @param \Shopsys\FrameworkBundle\Model\Payment\Payment[] $payments

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -149,8 +149,8 @@ class OrderController extends FrontBaseController
 
     public function indexAction()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageBag */
         $flashMessageBag = $this->get('shopsys.shop.component.flash_message.bag.front');
-        /* @var $flashMessageBag \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         $cart = $this->cartFacade->getCartOfCurrentCustomer();
         if ($cart->isEmpty()) {

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php
@@ -175,7 +175,7 @@ class PersonalDataController extends FrontBaseController
     }
 
     /**
-     * @param $hash
+     * @param string $hash
      */
     public function accessExportAction($hash)
     {
@@ -211,7 +211,7 @@ class PersonalDataController extends FrontBaseController
     }
 
     /**
-     * @param $hash
+     * @param string $hash
      */
     public function exportXmlAction($hash)
     {

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/BillingAddressFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/BillingAddressFormType.php
@@ -125,8 +125,8 @@ class BillingAddressFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
+                    /** @var \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $billingAddressData */
                     $billingAddressData = $form->getData();
-                    /* @var $billingAddressData \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData */
 
                     if ($billingAddressData->companyCustomer) {
                         $validationGroups[] = self::VALIDATION_GROUP_COMPANY_CUSTOMER;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/DeliveryAddressFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/DeliveryAddressFormType.php
@@ -150,8 +150,8 @@ class DeliveryAddressFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
+                    /** @var \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData $deliveryAddressData */
                     $deliveryAddressData = $form->getData();
-                    /* @var $customerData \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData */
 
                     if ($deliveryAddressData->addressFilled) {
                         $validationGroups[] = self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
@@ -298,8 +298,8 @@ class PersonalInfoFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
+                    /** @var \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData */
                     $orderData = $form->getData();
-                    /* @var $data \Shopsys\FrameworkBundle\Model\Order\OrderData */
 
                     if ($orderData->companyCustomer) {
                         $validationGroups[] = self::VALIDATION_GROUP_COMPANY_CUSTOMER;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
@@ -298,7 +298,7 @@ class PersonalInfoFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
-                    /** @var \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData */
+                    /** @var \Shopsys\FrameworkBundle\Model\Order\FrontOrderData $orderData */
                     $orderData = $form->getData();
 
                     if ($orderData->companyCustomer) {

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ParameterFilterFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ParameterFilterFormType.php
@@ -23,8 +23,8 @@ class ParameterFilterFormType extends AbstractType implements DataTransformerInt
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig $config */
         $config = $options['product_filter_config'];
-        /* @var $config \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig */
 
         $this->parameterChoicesIndexedByParameterId = [];
         foreach ($config->getParameterChoices() as $parameterChoice) {

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
@@ -24,8 +24,8 @@ class ProductFilterFormType extends AbstractType
     {
         $priceScale = 2;
         $priceTransformer = new MoneyToLocalizedStringTransformer($priceScale, false);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig $config */
         $config = $options['product_filter_config'];
-        /* @var $config \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig */
 
         $builder
             ->add('minimalPrice', MoneyType::class, [

--- a/project-base/src/Shopsys/ShopBundle/Model/Administrator/AdministratorDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Administrator/AdministratorDataFactory.php
@@ -17,7 +17,7 @@ class AdministratorDataFactory extends BaseAdministratorDataFactory
     }
 
     /**
-     * @param \Shopsys\ShopBundle\Model\Administrator\Administrator
+     * @param \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator
      * @return \Shopsys\ShopBundle\Model\Administrator\AdministratorData
      */
     public function createFromAdministrator(BaseAdministrator $administrator): BaseAdministratorData

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
@@ -24,7 +24,7 @@ class Product extends BaseProduct
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface $productCategoryDomainFactory
-     * @param \Shopsys\ShopBundle\Model\Product\ProductData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      */
     public function edit(
         ProductCategoryDomainFactoryInterface $productCategoryDomainFactory,

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/AbstractPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/AbstractPage.php
@@ -8,7 +8,7 @@ use Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver;
 abstract class AbstractPage
 {
     /**
-     * @var \Facebook\WebDriver\WebDriver
+     * @var \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver
      */
     protected $webDriver;
 

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/RegistrationPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/RegistrationPage.php
@@ -43,7 +43,7 @@ class RegistrationPage extends AbstractPage
     }
 
     /**
-     * @param $fieldClass $text
+     * @param string $fieldClass
      * @param string $text
      */
     private function seeErrorForField($fieldClass, $text)

--- a/project-base/tests/ShopBundle/Functional/Component/Doctrine/SortableNullsWalkerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Doctrine/SortableNullsWalkerTest.php
@@ -11,10 +11,10 @@ class SortableNullsWalkerTest extends FunctionalTestCase
 {
     public function testWalkOrderByItemAsc()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
+        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
         $queryBuilder = $em->createQueryBuilder();
-        /* @var $queryBuilder \Doctrine\ORM\QueryBuilder */
 
         $queryBuilder
             ->select('p.id')
@@ -29,10 +29,10 @@ class SortableNullsWalkerTest extends FunctionalTestCase
 
     public function testWalkOrderByItemDesc()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
+        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
         $queryBuilder = $em->createQueryBuilder();
-        /* @var $queryBuilder \Doctrine\ORM\QueryBuilder */
 
         $queryBuilder
             ->select('p.id')
@@ -47,10 +47,10 @@ class SortableNullsWalkerTest extends FunctionalTestCase
 
     public function testWalkOrderByItemWithoutOrdering()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
+        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
         $queryBuilder = $em->createQueryBuilder();
-        /* @var $queryBuilder \Doctrine\ORM\QueryBuilder */
 
         $queryBuilder
             ->select('p.id')

--- a/project-base/tests/ShopBundle/Functional/Component/Domain/Config/DomainsConfigLoaderTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Domain/Config/DomainsConfigLoaderTest.php
@@ -12,8 +12,8 @@ class DomainsConfigLoaderTest extends FunctionalTestCase
     {
         $domainsConfigFilepath = $this->getContainer()->getParameter('shopsys.domain_config_filepath');
         $domainsUrlsConfigFilepath = $this->getContainer()->getParameter('shopsys.domain_urls_config_filepath');
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader $domainsConfigLoader */
         $domainsConfigLoader = $this->getContainer()->get(DomainsConfigLoader::class);
-        /* @var $domainsConfigLoader \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader */
 
         $domainConfigs = $domainsConfigLoader->loadDomainConfigsFromYaml($domainsConfigFilepath, $domainsUrlsConfigFilepath);
 
@@ -26,8 +26,8 @@ class DomainsConfigLoaderTest extends FunctionalTestCase
 
     public function testLoadDomainConfigsFromYamlConfigFileNotFound()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader $domainsConfigLoader */
         $domainsConfigLoader = $this->getContainer()->get(DomainsConfigLoader::class);
-        /* @var $domainsConfigLoader \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader */
         $domainsUrlsConfigFilepath = $this->getContainer()->getParameter('shopsys.domain_urls_config_filepath');
 
         $this->expectException(\Symfony\Component\Filesystem\Exception\FileNotFoundException::class);
@@ -36,8 +36,8 @@ class DomainsConfigLoaderTest extends FunctionalTestCase
 
     public function testLoadDomainConfigsFromYamlUrlsConfigFileNotFound()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader $domainsConfigLoader */
         $domainsConfigLoader = $this->getContainer()->get(DomainsConfigLoader::class);
-        /* @var $domainsConfigLoader \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader */
         $domainsConfigFilepath = $this->getContainer()->getParameter('shopsys.domain_config_filepath');
 
         $this->expectException(\Symfony\Component\Filesystem\Exception\FileNotFoundException::class);
@@ -46,8 +46,8 @@ class DomainsConfigLoaderTest extends FunctionalTestCase
 
     public function testLoadDomainConfigsFromYamlDomainConfigsDoNotMatchException()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader $domainsConfigLoader */
         $domainsConfigLoader = $this->getContainer()->get(DomainsConfigLoader::class);
-        /* @var $domainsConfigLoader \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader */
         $domainsConfigFilepath = __DIR__ . '/test_domains.yml';
         $domainsUrlsConfigFilepath = __DIR__ . '/test_domains_urls.yml';
 

--- a/project-base/tests/ShopBundle/Functional/Component/Domain/Multidomain/MultidomainEntityDataCreatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Domain/Multidomain/MultidomainEntityDataCreatorTest.php
@@ -11,8 +11,8 @@ class MultidomainEntityDataCreatorTest extends TransactionFunctionalTestCase
 {
     public function testCopyAllMultidomainDataForNewDomainCopiesTestRow()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.default_entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $em->getConnection()->executeQuery('
             CREATE TABLE _test_table (
@@ -68,8 +68,8 @@ class MultidomainEntityDataCreatorTest extends TransactionFunctionalTestCase
 
     public function testCopyAllMultidomainDataForNewDomainWithDomainIdDoesNotThrowDriverException()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.default_entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $em->getConnection()->executeQuery('
             CREATE TABLE _test_table (

--- a/project-base/tests/ShopBundle/Functional/Component/FlashMessage/BagTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/FlashMessage/BagTest.php
@@ -8,10 +8,10 @@ class BagTest extends FunctionalTestCase
 {
     public function testAddFrontVsAdmin()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageAdmin */
         $flashMessageAdmin = $this->getContainer()->get('shopsys.shop.component.flash_message.bag.admin');
-        /* @var $flashMessageAdmin \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageFront */
         $flashMessageFront = $this->getContainer()->get('shopsys.shop.component.flash_message.bag.front');
-        /* @var $flashMessageAdmin \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         $errorMessageAdmin = 'Error message admin';
         $errorMessageFront = 'Error message front';
@@ -31,8 +31,8 @@ class BagTest extends FunctionalTestCase
 
     public function testAddArrayOfMessages()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageAdmin */
         $flashMessageAdmin = $this->getContainer()->get('shopsys.shop.component.flash_message.bag.admin');
-        /* @var $flashMessageAdmin \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         $errorMessagesAdmin = ['First error message admin', 'Second error message admin'];
 
@@ -43,8 +43,8 @@ class BagTest extends FunctionalTestCase
 
     public function testGetUniqueMessage()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageAdmin */
         $flashMessageAdmin = $this->getContainer()->get('shopsys.shop.component.flash_message.bag.admin');
-        /* @var $flashMessageAdmin \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         $errorMessageAdmin = 'Error message admin';
 
@@ -56,8 +56,8 @@ class BagTest extends FunctionalTestCase
 
     public function testGetAndClearBag()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageAdmin */
         $flashMessageAdmin = $this->getContainer()->get('shopsys.shop.component.flash_message.bag.admin');
-        /* @var $flashMessageAdmin \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         $errorMessageAdmin = 'Error message admin';
 
@@ -69,8 +69,8 @@ class BagTest extends FunctionalTestCase
 
     public function testIsEmpty()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageAdmin */
         $flashMessageAdmin = $this->getContainer()->get('shopsys.shop.component.flash_message.bag.admin');
-        /* @var $flashMessageAdmin \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         // clearing after previous tests
         $flashMessageAdmin->getErrorMessages();

--- a/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderDataSourceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderDataSourceTest.php
@@ -11,8 +11,8 @@ class QueryBuilderDataSourceTest extends TransactionFunctionalTestCase
 {
     public function testGetOneRow()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')
@@ -28,8 +28,8 @@ class QueryBuilderDataSourceTest extends TransactionFunctionalTestCase
 
     public function testGetTotalRowsCount()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')
@@ -47,8 +47,8 @@ class QueryBuilderDataSourceTest extends TransactionFunctionalTestCase
 
     public function testGetRows()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')
@@ -69,8 +69,8 @@ class QueryBuilderDataSourceTest extends TransactionFunctionalTestCase
 
     public function testGetRowsInAscOrder()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')
@@ -94,8 +94,8 @@ class QueryBuilderDataSourceTest extends TransactionFunctionalTestCase
 
     public function testGetRowsInDescOrder()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')

--- a/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderWithRowManipulatorDataSourceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderWithRowManipulatorDataSourceTest.php
@@ -11,8 +11,8 @@ class QueryBuilderWithRowManipulatorDataSourceTest extends TransactionFunctional
 {
     public function testGetOneRow()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')
@@ -32,8 +32,8 @@ class QueryBuilderWithRowManipulatorDataSourceTest extends TransactionFunctional
 
     public function testGetTotalRowsCount()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')
@@ -54,8 +54,8 @@ class QueryBuilderWithRowManipulatorDataSourceTest extends TransactionFunctional
 
     public function testGetRows()
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
 
         $qb = $em->createQueryBuilder();
         $qb->select('p')

--- a/project-base/tests/ShopBundle/Functional/Component/HttpFoundation/FragmentHandlerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/HttpFoundation/FragmentHandlerTest.php
@@ -11,8 +11,8 @@ class FragmentHandlerTest extends TransactionFunctionalTestCase
 {
     public function testRenderingFragmentDoesNotIgnoreException()
     {
+        /** @var \Symfony\Bridge\Twig\Extension\HttpKernelRuntime $httpKernelRuntime */
         $httpKernelRuntime = $this->getContainer()->get('twig.runtime.httpkernel');
-        /* @var $httpKernelRuntime \Symfony\Bridge\Twig\Extension\HttpKernelRuntime */
 
         // Rendering a fragment can only be done when handling a Request.
         $this->putFakeRequestToRequestStack();
@@ -25,8 +25,8 @@ class FragmentHandlerTest extends TransactionFunctionalTestCase
 
     private function putFakeRequestToRequestStack()
     {
+        /** @var \Symfony\Component\HttpFoundation\RequestStack $requestStack */
         $requestStack = $this->getContainer()->get('request_stack');
-        /* @var $requestStack \Symfony\Component\HttpFoundation\RequestStack */
 
         $request = new Request();
         $session = new Session(new MockArraySessionStorage());

--- a/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Translator/JsTranslatorCompilerPassTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Translator/JsTranslatorCompilerPassTest.php
@@ -10,10 +10,10 @@ class JsTranslatorCompilerPassTest extends FunctionalTestCase
 {
     public function testProcess()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Translation\Translator $translator */
         $translator = $this->getContainer()->get('translator');
-        /* @var $translator \Shopsys\FrameworkBundle\Component\Translation\Translator */
+        /** @var \Shopsys\FrameworkBundle\Component\Javascript\Compiler\Translator\JsTranslatorCompilerPass $jsTranslatorCompilerPass */
         $jsTranslatorCompilerPass = $this->getContainer()->get(JsTranslatorCompilerPass::class);
-        /* @var $jsTranslatorCompilerPass \Shopsys\FrameworkBundle\Component\Javascript\Compiler\Translator\JsTranslatorCompilerPass */
 
         $translator->setLocale('testLocale');
         $translator->getCatalogue()->add([

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
@@ -109,10 +109,10 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
      */
     public function overwriteEntityExtensionMapInServicesInContainer(array $entityExtensionMap): void
     {
+        /** @var \Tests\ShopBundle\Functional\EntityExtension\OverwritableLoadORMMetadataSubscriber $loadORMMetadataSubscriber */
         $loadORMMetadataSubscriber = $this->getContainer()->get('joschi127_doctrine_entity_override.event_subscriber.load_orm_metadata');
-        /* @var $loadORMMetadataSubscriber \Tests\ShopBundle\Functional\EntityExtension\OverwritableLoadORMMetadataSubscriber */
+        /** @var \Tests\ShopBundle\Functional\EntityExtension\OverwritableEntityNameResolver $entityNameResolver */
         $entityNameResolver = $this->getContainer()->get(EntityNameResolver::class);
-        /* @var $entityNameResolver \Tests\ShopBundle\Functional\EntityExtension\OverwritableEntityNameResolver */
 
         $loadORMMetadataSubscriber->overwriteEntityExtensionMap($entityExtensionMap);
         $entityNameResolver->overwriteEntityExtensionMap($entityExtensionMap);

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
@@ -450,7 +450,7 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
 
     /**
      * @param int $id
-     * @return \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory
+     * @return \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedOrderTransport
      */
     private function getOrderTransport(int $id): ExtendedOrderTransport
     {

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryManyToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryManyToManyBidirectionalEntity.php
@@ -20,7 +20,7 @@ class CategoryManyToManyBidirectionalEntity
     protected $id;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
      *
      * @ORM\ManyToMany(targetEntity="ExtendedCategory", mappedBy="manyToManyBidirectionalEntities")
      */

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedCategory.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedCategory.php
@@ -53,14 +53,14 @@ class ExtendedCategory extends Category
     protected $oneToOneSelfReferencingEntity;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\CategoryOneToManyBidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\CategoryOneToManyBidirectionalEntity[]
      *
      * @ORM\OneToMany(targetEntity="CategoryOneToManyBidirectionalEntity", mappedBy="category")
      */
     protected $oneToManyBidirectionalEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
      *
      * @ORM\ManyToMany(targetEntity="UnidirectionalEntity")
      * @ORM\JoinTable(name="categories_oneToManyUnidirectionalWithJoinTableEntity",
@@ -71,14 +71,14 @@ class ExtendedCategory extends Category
     protected $oneToManyUnidirectionalWithJoinTableEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
      *
      * @ORM\OneToMany(targetEntity="ExtendedCategory", mappedBy="oneToManySelfReferencingInverseEntity")
      */
     protected $oneToManySelfReferencingEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory
      *
      * @ORM\ManyToOne(targetEntity="ExtendedCategory", inversedBy="oneToManySelfReferencingEntities")
      * @ORM\JoinColumn(nullable=true, name="oneToManySelfReferencingParent_id", referencedColumnName="id")
@@ -86,7 +86,7 @@ class ExtendedCategory extends Category
     protected $oneToManySelfReferencingInverseEntity;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
      *
      * @ORM\ManyToMany(targetEntity="UnidirectionalEntity")
      * @ORM\JoinTable(name="categories_manyToManyUnidirectionalEntity",
@@ -97,7 +97,7 @@ class ExtendedCategory extends Category
     protected $manyToManyUnidirectionalEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\CategoryManyToManyBidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\CategoryManyToManyBidirectionalEntity[]
      *
      * @ORM\ManyToMany(targetEntity="CategoryManyToManyBidirectionalEntity", inversedBy="categories")
      * @ORM\JoinTable(name="categories_manyToManyBidirectionalEntity")
@@ -105,14 +105,14 @@ class ExtendedCategory extends Category
     protected $manyToManyBidirectionalEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
      *
      * @ORM\ManyToMany(targetEntity="ExtendedCategory", mappedBy="manyToManySelfReferencingInverseEntities")
      */
     protected $manyToManySelfReferencingEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedCategory[]
      *
      * @ORM\ManyToMany(targetEntity="ExtendedCategory", inversedBy="manyToManySelfReferencingEntities")
      * @ORM\JoinTable(name="categories_manyToManySelfReferencing",

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedOrderProduct.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedOrderProduct.php
@@ -40,7 +40,7 @@ class ExtendedOrderProduct extends ExtendedOrderItem
      * @param int $quantity
      * @param string $unitName
      * @param string|null $catnum
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
+     * @param \Shopsys\ShopBundle\Model\Product\Product|null $product
      */
     public function __construct(
         Order $order,

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedOrderTransport.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedOrderTransport.php
@@ -40,7 +40,7 @@ class ExtendedOrderTransport extends ExtendedOrderItem
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $price
      * @param string $vatPercent
      * @param int $quantity
-     * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
+     * @param \Shopsys\ShopBundle\Model\Transport\Transport $transport
      */
     public function __construct(
         Order $order,

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
@@ -53,14 +53,14 @@ class ExtendedProduct extends Product
     protected $oneToOneSelfReferencingEntity;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ProductOneToManyBidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ProductOneToManyBidirectionalEntity[]
      *
      * @ORM\OneToMany(targetEntity="ProductOneToManyBidirectionalEntity", mappedBy="product")
      */
     protected $oneToManyBidirectionalEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
      *
      * @ORM\ManyToMany(targetEntity="UnidirectionalEntity")
      * @ORM\JoinTable(name="products_oneToManyUnidirectionalWithJoinTableEntity",
@@ -71,7 +71,7 @@ class ExtendedProduct extends Product
     protected $oneToManyUnidirectionalWithJoinTableEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
      *
      * @ORM\OneToMany(targetEntity="ExtendedProduct", mappedBy="oneToManySelfReferencingInverseEntity")
      */
@@ -86,7 +86,7 @@ class ExtendedProduct extends Product
     protected $oneToManySelfReferencingInverseEntity;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\UnidirectionalEntity[]
      *
      * @ORM\ManyToMany(targetEntity="UnidirectionalEntity")
      * @ORM\JoinTable(name="products_manyToManyUnidirectionalEntity",
@@ -97,7 +97,7 @@ class ExtendedProduct extends Product
     protected $manyToManyUnidirectionalEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ProductManyToManyBidirectionalEntity[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ProductManyToManyBidirectionalEntity[]
      *
      * @ORM\ManyToMany(targetEntity="ProductManyToManyBidirectionalEntity", inversedBy="products")
      * @ORM\JoinTable(name="products_manyToManyBidirectionalEntity")
@@ -105,14 +105,14 @@ class ExtendedProduct extends Product
     protected $manyToManyBidirectionalEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
      *
      * @ORM\ManyToMany(targetEntity="ExtendedProduct", mappedBy="manyToManySelfReferencingInverseEntities")
      */
     protected $manyToManySelfReferencingEntities;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
      *
      * @ORM\ManyToMany(targetEntity="ExtendedProduct", inversedBy="manyToManySelfReferencingEntities")
      * @ORM\JoinTable(name="products_manyToManySelfReferencing",

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductManyToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductManyToManyBidirectionalEntity.php
@@ -20,7 +20,7 @@ class ProductManyToManyBidirectionalEntity
     protected $id;
 
     /**
-     * @var \Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
+     * @var \Doctrine\Common\Collections\Collection|\Tests\ShopBundle\Functional\EntityExtension\Model\ExtendedProduct[]
      *
      * @ORM\ManyToMany(targetEntity="ExtendedProduct", mappedBy="manyToManyBidirectionalEntities")
      */

--- a/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOperatorTranslationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOperatorTranslationTest.php
@@ -10,13 +10,13 @@ class AdvancedSearchOperatorTranslationTest extends FunctionalTestCase
 {
     public function testTranslateOperator()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig $productAdvancedSearchConfig */
         $productAdvancedSearchConfig = $this->getContainer()->get(ProductAdvancedSearchConfig::class);
-        /* @var $productAdvancedSearchConfig \Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig */
+        /** @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchConfig $orderAdvancedSearchConfig */
         $orderAdvancedSearchConfig = $this->getContainer()->get(ProductAdvancedSearchConfig::class);
-        /* @var $orderAdvancedSearchConfig \Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchConfig */
 
+        /** @var \Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOperatorTranslation $advancedSearchOperatorTranslation */
         $advancedSearchOperatorTranslation = $this->getContainer()->get(AdvancedSearchOperatorTranslation::class);
-        /* @var $advancedSearchOperatorTranslation \Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOperatorTranslation */
 
         $operators = [];
         foreach ($productAdvancedSearchConfig->getAllFilters() as $filter) {

--- a/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOrderFilterTranslationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOrderFilterTranslationTest.php
@@ -10,10 +10,10 @@ class AdvancedSearchOrderFilterTranslationTest extends FunctionalTestCase
 {
     public function testTranslateFilterName()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchConfig $advancedSearchConfig */
         $advancedSearchConfig = $this->getContainer()->get(OrderAdvancedSearchConfig::class);
-        /* @var $advancedSearchConfig \Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchConfig */
+        /** @var \Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOrderFilterTranslation $advancedSearchOrderFilterTranslation */
         $advancedSearchOrderFilterTranslation = $this->getContainer()->get(AdvancedSearchOrderFilterTranslation::class);
-        /* @var $advancedSearchOrderFilterTranslation \Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOrderFilterTranslation */
 
         foreach ($advancedSearchConfig->getAllFilters() as $filter) {
             $this->assertNotEmpty($advancedSearchOrderFilterTranslation->translateFilterName($filter->getName()));

--- a/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchProductFilterTranslationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchProductFilterTranslationTest.php
@@ -10,10 +10,10 @@ class AdvancedSearchProductFilterTranslationTest extends FunctionalTestCase
 {
     public function testTranslateFilterName()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig $advancedSearchConfig */
         $advancedSearchConfig = $this->getContainer()->get(ProductAdvancedSearchConfig::class);
-        /* @var $advancedSearchConfig \Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig */
+        /** @var \Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchProductFilterTranslation $advancedSearchProductFilterTranslation */
         $advancedSearchProductFilterTranslation = $this->getContainer()->get(AdvancedSearchProductFilterTranslation::class);
-        /* @var $advancedSearchProductFilterTranslation \Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchProductFilterTranslation */
 
         foreach ($advancedSearchConfig->getAllFilters() as $filter) {
             $this->assertNotEmpty($advancedSearchProductFilterTranslation->translateFilterName($filter->getName()));

--- a/project-base/tests/ShopBundle/Functional/Form/YesNoTypeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/YesNoTypeTest.php
@@ -44,8 +44,8 @@ class YesNoTypeTest extends FunctionalTestCase
      */
     private function getForm()
     {
+        /** @var \Symfony\Component\Form\FormFactoryInterface $formFactory */
         $formFactory = $this->getContainer()->get('form.factory');
-        /* @var $formFactory \Symfony\Component\Form\FormFactoryInterface */
 
         return $formFactory->create(YesNoType::class);
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Administrator/AdministratorRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Administrator/AdministratorRepositoryTest.php
@@ -14,10 +14,10 @@ class AdministratorRepositoryTest extends TransactionFunctionalTestCase
         $validMultidomainLoginToken = 'validMultidomainLoginToken';
         $multidomainLoginTokenExpiration = new DateTime('+60 seconds');
 
+        /** @var \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
-        /* @var $administrator \Shopsys\ShopBundle\Model\Administrator\Administrator */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository $administratorRepository */
         $administratorRepository = $this->getContainer()->get(AdministratorRepository::class);
-        /* @var $administratorRepository \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository */
 
         $administrator->setMultidomainLoginTokenWithExpiration($validMultidomainLoginToken, $multidomainLoginTokenExpiration);
         $this->getEntityManager()->flush($administrator);
@@ -33,10 +33,10 @@ class AdministratorRepositoryTest extends TransactionFunctionalTestCase
         $invalidMultidomainLoginToken = 'invalidMultidomainLoginToken';
         $multidomainLoginTokenExpiration = new DateTime('+60 seconds');
 
+        /** @var \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
-        /* @var $administrator \Shopsys\ShopBundle\Model\Administrator\Administrator */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository $administratorRepository */
         $administratorRepository = $this->getContainer()->get(AdministratorRepository::class);
-        /* @var $administratorRepository \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository */
 
         $administrator->setMultidomainLoginTokenWithExpiration($validMultidomainLoginToken, $multidomainLoginTokenExpiration);
         $this->getEntityManager()->flush($administrator);
@@ -51,10 +51,10 @@ class AdministratorRepositoryTest extends TransactionFunctionalTestCase
         $validMultidomainLoginToken = 'validMultidomainLoginToken';
         $multidomainLoginTokenExpiration = new DateTime('-60 seconds');
 
+        /** @var \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
-        /* @var $administrator \Shopsys\ShopBundle\Model\Administrator\Administrator */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository $administratorRepository */
         $administratorRepository = $this->getContainer()->get(AdministratorRepository::class);
-        /* @var $administratorRepository \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository */
 
         $administrator->setMultidomainLoginTokenWithExpiration($validMultidomainLoginToken, $multidomainLoginTokenExpiration);
         $this->getEntityManager()->flush($administrator);

--- a/project-base/tests/ShopBundle/Functional/Model/Administrator/Security/AdministratorFrontSecurityFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Administrator/Security/AdministratorFrontSecurityFacadeTest.php
@@ -12,29 +12,29 @@ class AdministratorFrontSecurityFacadeTest extends TransactionFunctionalTestCase
 {
     public function testIsAdministratorLoggedNot()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade */
         $administratorFrontSecurityFacade = $this->getContainer()->get(AdministratorFrontSecurityFacade::class);
-        /* @var $administratorFrontSecurityFacade \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade */
 
         $this->assertFalse($administratorFrontSecurityFacade->isAdministratorLogged());
     }
 
     public function testIsAdministratorLogged()
     {
+        /** @var \Symfony\Component\HttpFoundation\Session\SessionInterface $session */
         $session = $this->getContainer()->get('session');
-        /* @var $session \Symfony\Component\HttpFoundation\Session\SessionInterface */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade */
         $administratorFrontSecurityFacade = $this->getContainer()->get(AdministratorFrontSecurityFacade::class);
-        /* @var $administratorFrontSecurityFacade \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade */
 
+        /** @var \Shopsys\ShopBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
-        /* @var $administrator \Shopsys\ShopBundle\Model\Administrator\Administrator */
         $password = '';
         $roles = $administrator->getRoles();
         $token = new UsernamePasswordToken($administrator, $password, AdministratorFrontSecurityFacade::ADMINISTRATION_CONTEXT, $roles);
 
         $session->set('_security_' . AdministratorFrontSecurityFacade::ADMINISTRATION_CONTEXT, serialize($token));
 
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade $administratorActivityFacade */
         $administratorActivityFacade = $this->getContainer()->get(AdministratorActivityFacade::class);
-        /* @var $administratorActivityFacade \Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade */
         $administratorActivityFacade->create($administrator, '127.0.0.1');
 
         $this->assertTrue($administratorFrontSecurityFacade->isAdministratorLogged());

--- a/project-base/tests/ShopBundle/Functional/Model/Article/ArticleTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Article/ArticleTest.php
@@ -53,6 +53,7 @@ class ArticleTest extends TransactionFunctionalTestCase
 
         $this->em->clear();
 
+        /** @var Article $refreshedArticle */
         $refreshedArticle = $this->em->getRepository(Article::class)->find($articleId);
 
         $this->assertSame('Demonstrative name', $refreshedArticle->getName());

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -78,8 +78,8 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
      */
     private function getProductById($productId)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
 
         return $productFacade->getById($productId);
     }
@@ -89,8 +89,8 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
      */
     private function getCartFacadeForRegisteredCustomer()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade */
         $customerFacade = $this->getContainer()->get(CustomerFacade::class);
-        /* @var $customerFacade \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade */
 
         $user = $customerFacade->getUserById(1);
 

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
@@ -22,6 +22,8 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     {
         $customerIdentifier = new CustomerIdentifier('secretSessionHash');
         $anotherCustomerIdentifier = new CustomerIdentifier('anotherSecretSessionHash');
+
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
         $productId = $product->getId();
         $quantity = 10;
@@ -41,6 +43,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
 
     public function testCannotAddUnsellableProductToCart()
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '6');
         $productId = $product->getId();
         $quantity = 1;
@@ -59,7 +62,9 @@ class CartFacadeTest extends TransactionFunctionalTestCase
 
     public function testCanChangeCartItemsQuantities()
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product1 */
         $product1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product2 */
         $product2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '3');
 
         $customerIdentifier = new CustomerIdentifier('secretSessionHash');
@@ -89,6 +94,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     {
         $customerIdentifier = new CustomerIdentifier('secretSessionHash');
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
         $quantity = 1;
 
@@ -107,13 +113,15 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     {
         // Set currentLocale in TranslatableListener as it done in real request
         // because CartWatcherFacade works with entity translations.
+        /** @var \Shopsys\FrameworkBundle\Model\Localization\TranslatableListener $translatableListener */
         $translatableListener = $this->getContainer()->get(TranslatableListener::class);
-        /* @var $translatableListener \Shopsys\FrameworkBundle\Model\Localization\TranslatableListener */
         $translatableListener->setCurrentLocale('cs');
 
         $customerIdentifier = new CustomerIdentifier('secretSessionHash');
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product1 */
         $product1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product2 */
         $product2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '2');
         $quantity = 1;
 

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherServiceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherServiceTest.php
@@ -37,15 +37,15 @@ class CartWatcherServiceTest extends FunctionalTestCase
         $productData1->priceCalculationType = Product::PRICE_CALCULATION_TYPE_AUTO;
         $productMock = Product::create($productData1);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser $productPriceCalculationForUser */
         $productPriceCalculationForUser = $this->getContainer()->get(ProductPriceCalculationForUser::class);
-        /* @var $productPriceCalculationForUser \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser */
         $productPrice = $productPriceCalculationForUser->calculatePriceForCurrentUser($productMock);
         $cartItem = new CartItem($customerIdentifier, $productMock, 1, $productPrice->getPriceWithVat());
         $cartItems = [$cartItem];
         $cart = new Cart($cartItems);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherService $cartWatcherService */
         $cartWatcherService = $this->getContainer()->get(CartWatcherService::class);
-        /* @var $cartWatcherService \Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherService */
 
         $modifiedItems1 = $cartWatcherService->getModifiedPriceItemsAndUpdatePrices($cart);
         $this->assertEmpty($modifiedItems1);
@@ -83,8 +83,8 @@ class CartWatcherServiceTest extends FunctionalTestCase
         $cartItems = [$cartItemMock];
         $cart = new Cart($cartItems);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherService $cartWatcherService */
         $cartWatcherService = $this->getContainer()->get(CartWatcherService::class);
-        /* @var $cartWatcherService \Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherService */
 
         $notListableItems = $cartWatcherService->getNotListableItems($cart, $currentCustomerMock);
         $this->assertCount(1, $notListableItems);

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
@@ -15,14 +15,14 @@ class CategoryRepositoryTest extends TransactionFunctionalTestCase
 
     public function testDoNotGetCategoriesWithoutVisibleChildren()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade */
         $categoryFacade = $this->getContainer()->get(CategoryFacade::class);
-        /* @var $categoryFacade \Shopsys\FrameworkBundle\Model\Category\CategoryFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Category\CategoryRepository $categoryRepository */
         $categoryRepository = $this->getContainer()->get(CategoryRepository::class);
-        /* @var $categoryRepository \Shopsys\FrameworkBundle\Model\Category\CategoryRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository $categoryVisibilityRepository */
         $categoryVisibilityRepository = $this->getContainer()->get(CategoryVisibilityRepository::class);
-        /* @var $categoryVisibilityRepository \Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository */
+        /** @var \Shopsys\ShopBundle\Model\Category\CategoryDataFactory $categoryDataFactory */
         $categoryDataFactory = $this->getContainer()->get(CategoryDataFactoryInterface::class);
-        /* @var $categoryDataFactory \Shopsys\ShopBundle\Model\Category\CategoryDataFactory */
 
         $categoryData = $categoryDataFactory->create();
         $categoryData->name = ['en' => 'name', 'cs' => 'name'];
@@ -44,14 +44,14 @@ class CategoryRepositoryTest extends TransactionFunctionalTestCase
 
     public function testGetCategoriesWithAtLeastOneVisibleChild()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade */
         $categoryFacade = $this->getContainer()->get(CategoryFacade::class);
-        /* @var $categoryFacade \Shopsys\FrameworkBundle\Model\Category\CategoryFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Category\CategoryRepository $categoryRepository */
         $categoryRepository = $this->getContainer()->get(CategoryRepository::class);
-        /* @var $categoryRepository \Shopsys\FrameworkBundle\Model\Category\CategoryRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository $categoryVisibilityRepository */
         $categoryVisibilityRepository = $this->getContainer()->get(CategoryVisibilityRepository::class);
-        /* @var $categoryVisibilityRepository \Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository */
+        /** @var \Shopsys\ShopBundle\Model\Category\CategoryDataFactory $categoryDataFactory */
         $categoryDataFactory = $this->getContainer()->get(CategoryDataFactoryInterface::class);
-        /* @var $categoryDataFactory \Shopsys\ShopBundle\Model\Category\CategoryDataFactory */
 
         $categoryData = $categoryDataFactory->create();
         $categoryData->name = ['en' => 'name', 'cs' => 'name'];

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
@@ -24,24 +24,24 @@ class OrderFacadeTest extends TransactionFunctionalTestCase
 {
     public function testCreate()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Cart\CartFacade $cartFacade */
         $cartFacade = $this->getContainer()->get(CartFacade::class);
-        /* @var $cartFacade \Shopsys\FrameworkBundle\Model\Cart\CartFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Cart\CartService $cartService */
         $cartService = $this->getContainer()->get(CartService::class);
-        /* @var $cartService \Shopsys\FrameworkBundle\Model\Cart\CartService */
+        /** @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade */
         $orderFacade = $this->getContainer()->get(OrderFacade::class);
-        /* @var $orderFacade \Shopsys\FrameworkBundle\Model\Order\OrderFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory */
         $orderPreviewFactory = $this->getContainer()->get(OrderPreviewFactory::class);
-        /* @var $orderPreviewFactory \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Order\OrderRepository $orderRepository */
         $orderRepository = $this->getContainer()->get(OrderRepository::class);
-        /* @var $orderRepository \Shopsys\FrameworkBundle\Model\Order\OrderRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository */
         $productRepository = $this->getContainer()->get(ProductRepository::class);
-        /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportRepository $transportRepository */
         $transportRepository = $this->getContainer()->get(TransportRepository::class);
-        /* @var $transportRepository \Shopsys\FrameworkBundle\Model\Transport\TransportRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentRepository $paymentRepository */
         $paymentRepository = $this->getContainer()->get(PaymentRepository::class);
-        /* @var $paymentRepository \Shopsys\FrameworkBundle\Model\Payment\PaymentRepository */
+        /** @var \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade */
         $persistentReferenceFacade = $this->getContainer()->get(PersistentReferenceFacade::class);
-        /* @var $persistentReferenceFacade \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade */
 
         $cart = $cartFacade->getCartOfCurrentCustomer();
 
@@ -116,15 +116,15 @@ class OrderFacadeTest extends TransactionFunctionalTestCase
 
     public function testEdit()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade */
         $orderFacade = $this->getContainer()->get(OrderFacade::class);
-        /* @var $orderFacade \Shopsys\FrameworkBundle\Model\Order\OrderFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Order\OrderRepository $orderRepository */
         $orderRepository = $this->getContainer()->get(OrderRepository::class);
-        /* @var $orderRepository \Shopsys\FrameworkBundle\Model\Order\OrderRepository */
+        /** @var \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory */
         $orderDataFactory = $this->getContainer()->get(OrderDataFactoryInterface::class);
-        /* @var $orderDataFactory \Shopsys\ShopBundle\Model\Order\OrderDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
         $order = $this->getReference('order_1');
-        /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
 
         $this->assertCount(4, $order->getItems());
 

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderNumberSequenceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderNumberSequenceRepositoryTest.php
@@ -9,8 +9,8 @@ class OrderNumberSequenceRepositoryTest extends TransactionFunctionalTestCase
 {
     public function testGetNextNumber()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Order\OrderNumberSequenceRepository $orderNumberSequenceRepository */
         $orderNumberSequenceRepository = $this->getContainer()->get(OrderNumberSequenceRepository::class);
-        /* @var $orderNumberSequenceRepository \Shopsys\FrameworkBundle\Model\Order\OrderNumberSequenceRepository */
 
         $numbers = [];
         for ($i = 0; $i < 10; $i++) {

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderTransportAndPaymentTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderTransportAndPaymentTest.php
@@ -35,9 +35,9 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
 //        $em->flush();
 //
 //        $transportFacade = $this->getContainer()->get(TransportFacade::class);
-//        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+//        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
 //        $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-//        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
+//        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
 //
 //        $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 //        $visibleTransports = $transportFacade->getVisibleOnCurrentDomain($visiblePayments);
@@ -64,10 +64,10 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
         $visibleTransports = $transportFacade->getVisibleOnCurrentDomain($visiblePayments);
@@ -99,10 +99,10 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
         $visibleTransports = $transportFacade->getVisibleOnCurrentDomain($visiblePayments);
@@ -125,10 +125,10 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($transport);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
         $visibleTransports = $transportFacade->getVisibleOnCurrentDomain($visiblePayments);
@@ -160,10 +160,10 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
         $visibleTransports = $transportFacade->getVisibleOnCurrentDomain($visiblePayments);
@@ -193,10 +193,10 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
         $visibleTransports = $transportFacade->getVisibleOnCurrentDomain($visiblePayments);
@@ -223,8 +223,8 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 
@@ -250,8 +250,8 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 
@@ -277,8 +277,8 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 
@@ -300,8 +300,8 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 
@@ -330,8 +330,8 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 
@@ -361,8 +361,8 @@ class OrderTransportAndPaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $visiblePayments = $paymentFacade->getVisibleOnCurrentDomain();
 

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
@@ -24,8 +24,8 @@ class OrderPreviewCalculationTest extends FunctionalTestCase
 {
     public function testCalculatePreviewWithTransportAndPayment()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
         $vatData = new VatData();
         $vatData->name = 'vatName';
         $vatData->percent = 20;
@@ -111,8 +111,8 @@ class OrderPreviewCalculationTest extends FunctionalTestCase
 
     public function testCalculatePreviewWithoutTransportAndPayment()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
         $vatData = new VatData();
         $vatData->name = 'vatName';
         $vatData->percent = 20;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Status/OrderStatusFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Status/OrderStatusFacadeTest.php
@@ -15,20 +15,20 @@ class OrderStatusFacadeTest extends TransactionFunctionalTestCase
     public function testDeleteByIdAndReplace()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade $orderStatusFacade */
         $orderStatusFacade = $this->getContainer()->get(OrderStatusFacade::class);
-        /* @var $orderStatusFacade \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade */
         $orderFacade = $this->getContainer()->get(OrderFacade::class);
-        /* @var $orderFacade \Shopsys\FrameworkBundle\Model\Order\OrderFacade */
 
         $orderStatusData = new OrderStatusData();
         $orderStatusData->name = ['cs' => 'name'];
         $orderStatusToDelete = $orderStatusFacade->create($orderStatusData);
+        /** @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus $orderStatusToReplaceWith */
         $orderStatusToReplaceWith = $this->getReference(OrderStatusDataFixture::ORDER_STATUS_NEW);
-        /* @var $orderStatusToReplaceWith \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus */
+        /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
         $order = $this->getReference(OrderDataFixture::ORDER_PREFIX . '1');
-        /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
+        /** @var \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory */
         $orderDataFactory = $this->getContainer()->get(OrderDataFactoryInterface::class);
-        /* @var $orderDataFactory \Shopsys\ShopBundle\Model\Order\OrderDataFactory */
 
         $orderData = $orderDataFactory->createFromOrder($order);
         $orderData->status = $orderStatusToDelete;

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
@@ -29,9 +29,9 @@ class IndependentPaymentVisibilityCalculationTest extends TransactionFunctionalT
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation $independentPaymentVisibilityCalculation */
         $independentPaymentVisibilityCalculation =
             $this->getContainer()->get(IndependentPaymentVisibilityCalculation::class);
-        /* @var $independentPaymentVisibilityCalculation \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation */
 
         $this->assertTrue($independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, self::FIRST_DOMAIN_ID));
     }
@@ -59,9 +59,9 @@ class IndependentPaymentVisibilityCalculationTest extends TransactionFunctionalT
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation $independentPaymentVisibilityCalculation */
         $independentPaymentVisibilityCalculation =
             $this->getContainer()->get(IndependentPaymentVisibilityCalculation::class);
-        /* @var $independentPaymentVisibilityCalculation \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation */
 
         $this->assertFalse($independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, self::FIRST_DOMAIN_ID));
     }
@@ -81,9 +81,9 @@ class IndependentPaymentVisibilityCalculationTest extends TransactionFunctionalT
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation $independentPaymentVisibilityCalculation */
         $independentPaymentVisibilityCalculation =
             $this->getContainer()->get(IndependentPaymentVisibilityCalculation::class);
-        /* @var $independentPaymentVisibilityCalculation \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation */
 
         $this->assertFalse($independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, self::FIRST_DOMAIN_ID));
     }
@@ -103,9 +103,9 @@ class IndependentPaymentVisibilityCalculationTest extends TransactionFunctionalT
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation $independentPaymentVisibilityCalculation */
         $independentPaymentVisibilityCalculation =
             $this->getContainer()->get(IndependentPaymentVisibilityCalculation::class);
-        /* @var $independentPaymentVisibilityCalculation \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation */
 
         $this->assertFalse($independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, self::FIRST_DOMAIN_ID));
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentTest.php
@@ -15,10 +15,10 @@ class PaymentTest extends TransactionFunctionalTestCase
 {
     public function testRemoveTransportFromPaymentAfterDelete()
     {
-        $paymentDataFactory = $this->getContainer()->get(PaymentDataFactoryInterface::class);
         /** @var \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory $paymentDataFactory */
-        $transportDataFactory = $this->getContainer()->get(TransportDataFactoryInterface::class);
+        $paymentDataFactory = $this->getContainer()->get(PaymentDataFactoryInterface::class);
         /** @var \Shopsys\ShopBundle\Model\Transport\TransportDataFactory $transportDataFactory */
+        $transportDataFactory = $this->getContainer()->get(TransportDataFactoryInterface::class);
         $em = $this->getEntityManager();
 
         $vatData = new VatData();
@@ -42,8 +42,8 @@ class PaymentTest extends TransactionFunctionalTestCase
         $em->persist($payment);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
         $transportFacade->deleteById($transport->getId());
 
         $this->assertFalse($payment->getTransports()->contains($transport));

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -19,12 +19,12 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
     public function testCreate()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $prodcu \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade */
         $pricingGroupFacade = $this->getContainer()->get(PricingGroupFacade::class);
-        /* @var $pricingGroupFacade \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
         $pricingGroupData = new PricingGroupData();
         $pricingGroupData->name = 'pricing_group_name';
         $pricingGroupData->coefficient = 1;
@@ -42,14 +42,14 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
     public function testEdit()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $prodcu \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade */
         $pricingGroupFacade = $this->getContainer()->get(PricingGroupFacade::class);
-        /* @var $pricingGroupFacade \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
         $productCalculatedPrice = $em->getRepository(ProductCalculatedPrice::class)->findOneBy([
             'product' => $product,
             'pricingGroup' => $pricingGroup,
@@ -80,24 +80,24 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
     public function testDeleteAndReplace()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade */
         $pricingGroupFacade = $this->getContainer()->get(PricingGroupFacade::class);
-        /* @var $pricingGroupFacade \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade */
         $customerFacade = $this->getContainer()->get(CustomerFacade::class);
-        /* @var $customerFacade \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade */
 
         $domainId = 1;
         $pricingGroupData = new PricingGroupData();
         $pricingGroupData->name = 'name';
         $pricingGroupToDelete = $pricingGroupFacade->create($pricingGroupData, $domainId);
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroupToReplaceWith */
         $pricingGroupToReplaceWith = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        /** @var \Shopsys\ShopBundle\Model\Customer\User $user */
         $user = $customerFacade->getUserById(1);
-        /* @var $user \Shopsys\ShopBundle\Model\Customer\User */
+        /** @var \Shopsys\ShopBundle\Model\Customer\UserDataFactory $userDataFactory */
         $userDataFactory = $this->getContainer()->get(UserDataFactoryInterface::class);
-        /* @var $userDataFactory \Shopsys\ShopBundle\Model\Customer\UserDataFactory */
         $userData = $userDataFactory->createFromUser($user);
+        /** @var \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactory $customerDataFactory */
         $customerDataFactory = $this->getContainer()->get(CustomerDataFactory::class);
-        /* @var $customerDataFactory \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactory */
 
         $userData->pricingGroup = $pricingGroupToDelete;
         $customerData = $customerDataFactory->create();

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php
@@ -26,8 +26,8 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
 {
     public function testOnKernelResponseNoAction()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Setting\Setting $setting */
         $setting = $this->getContainer()->get(Setting::class);
-        /* @var $setting \Shopsys\FrameworkBundle\Component\Setting\Setting */
 
         $inputPriceRecalculatorMock = $this->getMockBuilder(InputPriceRecalculator::class)
             ->setMethods(['__construct', 'recalculateToInputPricesWithoutVat', 'recalculateToInputPricesWithVat'])
@@ -66,10 +66,10 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
         $vatPercent
     ) {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
 
         $vatData = new VatData();
         $vatData->name = 'vat';
@@ -96,18 +96,18 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
     ) {
         $em = $this->getEntityManager();
 
+        /** @var \Shopsys\FrameworkBundle\Component\Setting\Setting $setting */
         $setting = $this->getContainer()->get(Setting::class);
-        /* @var $setting \Shopsys\FrameworkBundle\Component\Setting\Setting */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler $inputPriceRecalculationScheduler */
         $inputPriceRecalculationScheduler = $this->getContainer()->get(InputPriceRecalculationScheduler::class);
-        /* @var $inputPriceRecalculationScheduler \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory $paymentDataFactory */
         $paymentDataFactory = $this->getContainer()->get(PaymentDataFactoryInterface::class);
-        /* @var $paymentDataFactory \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory */
+        /** @var \Shopsys\ShopBundle\Model\Transport\TransportDataFactory $transportDataFactory */
         $transportDataFactory = $this->getContainer()->get(TransportDataFactoryInterface::class);
-        /* @var $transportDataFactory \Shopsys\ShopBundle\Model\Transport\TransportDataFactory */
 
         $setting->set(PricingSetting::INPUT_PRICE_TYPE, PricingSetting::INPUT_PRICE_TYPE_WITH_VAT);
 
@@ -121,7 +121,9 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
         $em->persist($vat);
         $em->persist($availability);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency1 */
         $currency1 = $this->getReference(CurrencyDataFixture::CURRENCY_CZK);
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency2 */
         $currency2 = $this->getReference(CurrencyDataFixture::CURRENCY_EUR);
 
         $product = $this->createProductWithInputPriceAndVatPercentAndAutoCalculationPriceType(
@@ -133,16 +135,16 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
         $paymentData->name = ['cs' => 'name'];
         $paymentData->pricesByCurrencyId = [$currency1->getId() => $inputPriceWithVat, $currency2->getId() => $inputPriceWithVat];
         $paymentData->vat = $vat;
+        /** @var \Shopsys\ShopBundle\Model\Payment\Payment $payment */
         $payment = $paymentFacade->create($paymentData);
-        /* @var $payment \Shopsys\ShopBundle\Model\Payment\Payment */
 
         $transportData = $transportDataFactory->create();
         $transportData->name = ['cs' => 'name'];
         $transportData->description = ['cs' => 'desc'];
         $transportData->pricesByCurrencyId = [$currency1->getId() => $inputPriceWithVat, $currency2->getId() => $inputPriceWithVat];
         $transportData->vat = $vat;
+        /** @var \Shopsys\ShopBundle\Model\Transport\Transport $transport */
         $transport = $transportFacade->create($transportData);
-        /* @var $transport \Shopsys\ShopBundle\Model\Transport\Transport */
         $em->flush();
 
         $filterResponseEventMock = $this->getMockBuilder(FilterResponseEvent::class)
@@ -174,22 +176,24 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
     ) {
         $em = $this->getEntityManager();
 
+        /** @var \Shopsys\FrameworkBundle\Component\Setting\Setting $setting */
         $setting = $this->getContainer()->get(Setting::class);
-        /* @var $setting \Shopsys\FrameworkBundle\Component\Setting\Setting */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler $inputPriceRecalculationScheduler */
         $inputPriceRecalculationScheduler = $this->getContainer()->get(InputPriceRecalculationScheduler::class);
-        /* @var $inputPriceRecalculationScheduler \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory $paymentDataFactory */
         $paymentDataFactory = $this->getContainer()->get(PaymentDataFactoryInterface::class);
-        /* @var $paymentDataFactory \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory */
+        /** @var \Shopsys\ShopBundle\Model\Transport\TransportDataFactory $transportDataFactory */
         $transportDataFactory = $this->getContainer()->get(TransportDataFactoryInterface::class);
-        /* @var $transportDataFactory \Shopsys\ShopBundle\Model\Transport\TransportDataFactory */
 
         $setting->set(PricingSetting::INPUT_PRICE_TYPE, PricingSetting::INPUT_PRICE_TYPE_WITHOUT_VAT);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency1 */
         $currency1 = $this->getReference(CurrencyDataFixture::CURRENCY_CZK);
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency2 */
         $currency2 = $this->getReference(CurrencyDataFixture::CURRENCY_EUR);
 
         $vatData = new VatData();
@@ -211,15 +215,15 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
         $paymentData->name = ['cs' => 'name'];
         $paymentData->pricesByCurrencyId = [$currency1->getId() => $inputPriceWithoutVat, $currency2->getId() => $inputPriceWithoutVat];
         $paymentData->vat = $vat;
+        /** @var \Shopsys\ShopBundle\Model\Payment\Payment $payment */
         $payment = $paymentFacade->create($paymentData);
-        /* @var $payment \Shopsys\ShopBundle\Model\Payment\Payment */
 
         $transportData = $transportDataFactory->create();
         $transportData->name = ['cs' => 'name'];
         $transportData->pricesByCurrencyId = [$currency1->getId() => $inputPriceWithoutVat, $currency2->getId() => $inputPriceWithoutVat];
         $transportData->vat = $vat;
+        /** @var \Shopsys\ShopBundle\Model\Transport\Transport $transport */
         $transport = $transportFacade->create($transportData);
-        /* @var $transport \Shopsys\ShopBundle\Model\Transport\Transport */
 
         $em->flush();
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php
@@ -15,22 +15,22 @@ class AvailabilityFacadeTest extends TransactionFunctionalTestCase
     public function testDeleteByIdAndReplace()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade */
         $availabilityFacade = $this->getContainer()->get(AvailabilityFacade::class);
-        /* @var $availabilityFacade \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
 
         $availabilityData = new AvailabilityData();
         $availabilityData->name = ['cs' => 'name'];
         $availabilityToDelete = $availabilityFacade->create($availabilityData);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability $availabilityToReplaceWith */
         $availabilityToReplaceWith = $this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK);
-        /* @var $availabilityToReplaceWith \Shopsys\FrameworkBundle\Model\Product\Availability\Availability */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $product \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductData $productData */
         $productData = $productDataFactory->createFromProduct($product);
-        /* @var $productData \Shopsys\FrameworkBundle\Model\Product\ProductData */
 
         $productData->availability = $availabilityToDelete;
         $productData->outOfStockAvailability = $availabilityToDelete;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityRecalculatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityRecalculatorTest.php
@@ -14,12 +14,12 @@ class ProductAvailabilityRecalculatorTest extends TransactionFunctionalTestCase
 {
     public function testRecalculateOnProductEditNotUsingStock()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator $productAvailabilityRecalculator */
         $productAvailabilityRecalculator = $this->getContainer()->get(ProductAvailabilityRecalculator::class);
-        /* @var $productAvailabilityRecalculator \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator */
 
         $productId = 1;
 
@@ -41,14 +41,14 @@ class ProductAvailabilityRecalculatorTest extends TransactionFunctionalTestCase
 
     public function testRecalculateOnProductEditUsingStockInStock()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade */
         $availabilityFacade = $this->getContainer()->get(AvailabilityFacade::class);
-        /* @var $availabilityFacade \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator $productAvailabilityRecalculator */
         $productAvailabilityRecalculator = $this->getContainer()->get(ProductAvailabilityRecalculator::class);
-        /* @var $productAvailabilityRecalculator \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator */
 
         $productId = 1;
 
@@ -72,12 +72,12 @@ class ProductAvailabilityRecalculatorTest extends TransactionFunctionalTestCase
 
     public function testRecalculateOnProductEditUsingStockOutOfStock()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator $productAvailabilityRecalculator */
         $productAvailabilityRecalculator = $this->getContainer()->get(ProductAvailabilityRecalculator::class);
-        /* @var $productAvailabilityRecalculator \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator */
 
         $productId = 1;
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductFacadeTest.php
@@ -37,8 +37,8 @@ class ProductFacadeTest extends TransactionFunctionalTestCase
         $productData->vat = $this->getReference(VatDataFixture::VAT_HIGH);
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
 
         $product = $productFacade->create($productData);
 
@@ -106,12 +106,12 @@ class ProductFacadeTest extends TransactionFunctionalTestCase
 
     public function testEditMarkProductForVisibilityRecalculation()
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $product \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
         $reflectionClass = new ReflectionClass(Product::class);
         $reflectionPropertyRecalculateVisibility = $reflectionClass->getProperty('recalculateVisibility');

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -159,8 +159,8 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
      */
     private function createParameterFilterData(array $namesByLocale, array $valuesTextsByLocales)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository $parameterRepository */
         $parameterRepository = $this->getContainer()->get(ParameterRepository::class);
-        /* @var $parameterRepository \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository */
 
         $parameter = $parameterRepository->findParameterByNames($namesByLocale);
         $parameterValues = $this->getParameterValuesByLocalesAndTexts($valuesTextsByLocales);
@@ -178,8 +178,8 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
      */
     private function getParameterValuesByLocalesAndTexts(array $valuesTextsByLocales)
     {
+        /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.default_entity_manager');
-        /* @var $em \Doctrine\ORM\EntityManager */
         $parameterValues = [];
 
         foreach ($valuesTextsByLocales as $valueTextsByLocales) {
@@ -201,8 +201,8 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
      */
     private function getPaginationResultInCategory(ProductFilterData $productFilterData, Category $category)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade $productOnCurrentDomainFacade */
         $productOnCurrentDomainFacade = $this->getContainer()->get(ProductOnCurrentDomainFacade::class);
-        /* @var $productOnCurrentDomainFacade \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade */
         $page = 1;
         $limit = PHP_INT_MAX;
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductRepositoryTest.php
@@ -39,14 +39,15 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
 
     private function getAllListableQueryBuilderTest($productReferenceId, $isExpectedInResult)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository */
         $productRepository = $this->getContainer()->get(ProductRepository::class);
-        /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
 
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productReferenceId);
         $productId = $product->getId();
 
@@ -80,14 +81,15 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
 
     private function getAllSellableQueryBuilderTest($productReferenceId, $isExpectedInResult)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository */
         $productRepository = $this->getContainer()->get(ProductRepository::class);
-        /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
 
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productReferenceId);
         $productId = $product->getId();
 
@@ -121,14 +123,14 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
 
     private function getAllOfferedQueryBuilderTest($productReferenceId, $isExpectedInResult)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository */
         $productRepository = $this->getContainer()->get(ProductRepository::class);
-        /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
 
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
-
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productReferenceId);
         $productId = $product->getId();
 
@@ -142,8 +144,8 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
 
     public function testOrderingByProductPriorityInCategory()
     {
+        /** @var \Shopsys\FrameworkBundle\DataFixtures\Demo\CategoryDataFixture $category */
         $category = $this->getReference(CategoryDataFixture::CATEGORY_FOOD);
-        /* @var $category \Shopsys\FrameworkBundle\DataFixtures\Demo\CategoryDataFixture */
         $product1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . 70);
         $product2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . 71);
 
@@ -186,10 +188,10 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
      */
     private function setProductOrderingPriority(Product $product, $priority)
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
 
         $productData = $productDataFactory->createFromProduct($product);
         $productData->orderingPriority = $priority;
@@ -202,12 +204,12 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
      */
     private function getProductsForSearchOrderedByPriority($searchText)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository */
         $productRepository = $this->getContainer()->get(ProductRepository::class);
-        /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         $paginationResult = $productRepository->getPaginationResultForSearchListable(
             $searchText,
@@ -229,12 +231,12 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
      */
     private function getProductsInCategoryOrderedByPriority(Category $category)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository */
         $productRepository = $this->getContainer()->get(ProductRepository::class);
-        /* @var $productRepository \Shopsys\FrameworkBundle\Model\Product\ProductRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         $paginationResult = $productRepository->getPaginationResultForListableInCategory(
             $category,

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
@@ -13,21 +13,21 @@ class ProductSellingDeniedRecalculatorTest extends TransactionFunctionalTestCase
     public function testCalculateSellingDeniedForProductSellableVariant()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator */
         $productSellingDeniedRecalculator = $this->getContainer()->get(ProductSellingDeniedRecalculator::class);
-        /* @var $productSellingDeniedRecalculator \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant1 */
         $variant1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '53');
-        /* @var $variant1 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant2 */
         $variant2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '54');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant3 */
         $variant3 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '69');
-        /* @var $variant3 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $mainVariant */
         $mainVariant = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148');
-        /* @var $mainVariant \Shopsys\ShopBundle\Model\Product\Product */
 
         $variant1productData = $productDataFactory->createFromProduct($variant1);
         $variant1productData->sellingDenied = true;
@@ -49,21 +49,21 @@ class ProductSellingDeniedRecalculatorTest extends TransactionFunctionalTestCase
     public function testCalculateSellingDeniedForProductNotSellableVariants()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator */
         $productSellingDeniedRecalculator = $this->getContainer()->get(ProductSellingDeniedRecalculator::class);
-        /* @var $productSellingDeniedRecalculator \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant1 */
         $variant1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '53');
-        /* @var $variant1 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant2 */
         $variant2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '54');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant3 */
         $variant3 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '69');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $mainVariant */
         $mainVariant = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
 
         $variant1productData = $productDataFactory->createFromProduct($variant1);
         $variant1productData->sellingDenied = true;
@@ -91,21 +91,21 @@ class ProductSellingDeniedRecalculatorTest extends TransactionFunctionalTestCase
     public function testCalculateSellingDeniedForProductNotSellableMainVariant()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator */
         $productSellingDeniedRecalculator = $this->getContainer()->get(ProductSellingDeniedRecalculator::class);
-        /* @var $productSellingDeniedRecalculator \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant1 */
         $variant1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '53');
-        /* @var $variant1 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant2 */
         $variant2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '54');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant3 */
         $variant3 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '69');
-        /* @var $variant3 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $mainVariant */
         $mainVariant = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148');
-        /* @var $mainVariant \Shopsys\ShopBundle\Model\Product\Product */
 
         $mainVariantproductData = $productDataFactory->createFromProduct($mainVariant);
         $mainVariantproductData->sellingDenied = true;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductServiceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductServiceTest.php
@@ -18,10 +18,10 @@ class ProductServiceTest extends TransactionFunctionalTestCase
 {
     public function testRecalculateInputPriceForNewVatPercentWithInputPriceWithoutVat()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductService $productService */
         $productService = $this->getContainer()->get(ProductService::class);
-        /* @var $productService \Shopsys\FrameworkBundle\Model\Product\ProductService */
+        /** @var \Shopsys\FrameworkBundle\Component\Setting\Setting $setting */
         $setting = $this->getContainer()->get(Setting::class);
-        /* @var $setting \Shopsys\FrameworkBundle\Component\Setting\Setting */
         $producDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
 
         $setting->set(PricingSetting::INPUT_PRICE_TYPE, PricingSetting::INPUT_PRICE_TYPE_WITHOUT_VAT);
@@ -49,10 +49,10 @@ class ProductServiceTest extends TransactionFunctionalTestCase
 
     public function testRecalculateInputPriceForNewVatPercentWithInputPriceWithVat()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductService $productService */
         $productService = $this->getContainer()->get(ProductService::class);
-        /* @var $productService \Shopsys\FrameworkBundle\Model\Product\ProductService */
+        /** @var \Shopsys\FrameworkBundle\Component\Setting\Setting $setting */
         $setting = $this->getContainer()->get(Setting::class);
-        /* @var $setting \Shopsys\FrameworkBundle\Component\Setting\Setting */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
 
         $setting->set(PricingSetting::INPUT_PRICE_TYPE, PricingSetting::INPUT_PRICE_TYPE_WITH_VAT);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
@@ -73,10 +73,13 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility1 */
         $productVisibility1 = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $productAgain,
-            'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
+            'pricingGroup' => $pricingGroup->getId(),
             'domainId' => 1,
         ]);
 
@@ -106,10 +109,13 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility1 */
         $productVisibility1 = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $productAgain->getId(),
-            'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
+            'pricingGroup' => $pricingGroup->getId(),
             'domainId' => 1,
         ]);
 
@@ -258,10 +264,13 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
-            'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
+            'pricingGroup' => $pricingGroup->getId(),
             'domainId' => 1,
         ]);
 
@@ -287,10 +296,13 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
-            'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
+            'pricingGroup' => $pricingGroup->getId(),
             'domainId' => 1,
         ]);
 
@@ -318,10 +330,13 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
-            'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
+            'pricingGroup' => $pricingGroup->getId(),
             'domainId' => 1,
         ]);
 
@@ -347,9 +362,12 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
-            'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
+            'pricingGroup' => $pricingGroup->getId(),
             'domainId' => 1,
         ]);
 
@@ -374,7 +392,9 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
             $productData->manualInputPricesByPricingGroupId[$pricingGroup->getId()] = 10;
         }
 
-        $pricingGroupWithZeroPriceId = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId();
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+        $pricingGroupWithZeroPriceId = $pricingGroup->getId();
 
         $productData->manualInputPricesByPricingGroupId[$pricingGroupWithZeroPriceId] = 0;
 
@@ -415,7 +435,9 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
             $productData->manualInputPricesByPricingGroupId[$pricingGroup->getId()] = 10;
         }
 
-        $pricingGroupWithNullPriceId = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId();
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+        $pricingGroupWithNullPriceId = $pricingGroup->getId();
         $productData->manualInputPricesByPricingGroupId[$pricingGroupWithNullPriceId] = null;
 
         $product = $productFacade->create($productData);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
@@ -35,8 +35,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $vat = new Vat($vatData);
         $em->persist($vat);
 
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
         $productData = $productDataFactory->create();
         $productData->name = ['cs' => 'Name', 'en' => 'Name'];
@@ -54,8 +54,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     {
         $em = $this->getEntityManager();
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $productData = $this->getDefaultProductData();
         $productData->hidden = true;
@@ -66,19 +66,19 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $id = $product->getId();
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
-        /* @var $productAgain \Shopsys\ShopBundle\Model\Product\Product */
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility1 */
         $productVisibility1 = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $productAgain,
             'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
             'domainId' => 1,
         ]);
-        /* @var $productVisibility1 \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertFalse($productAgain->isVisible());
         $this->assertFalse($productVisibility1->isVisible());
@@ -88,8 +88,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     {
         $em = $this->getEntityManager();
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $productData = $this->getDefaultProductData();
         $product = $productFacade->create($productData);
@@ -99,19 +99,19 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $id = $product->getId();
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
-        /* @var $productAgain \Shopsys\ShopBundle\Model\Product\Product */
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility1 */
         $productVisibility1 = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $productAgain->getId(),
             'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
             'domainId' => 1,
         ]);
-        /* @var $productVisibility1 \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertTrue($productAgain->isVisible());
         $this->assertTrue($productVisibility1->isVisible());
@@ -121,8 +121,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     {
         $em = $this->getEntityManager();
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $sellingFrom = new DateTime('now');
         $sellingFrom->modify('+1 day');
@@ -136,12 +136,12 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $id = $product->getId();
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
-        /* @var $productAgain \Shopsys\ShopBundle\Model\Product\Product */
 
         $this->assertFalse($productAgain->isVisible());
     }
@@ -150,8 +150,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     {
         $em = $this->getEntityManager();
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $sellingTo = new DateTime('now');
         $sellingTo->modify('-1 day');
@@ -165,12 +165,12 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $id = $product->getId();
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
-        /* @var $productAgain \Shopsys\ShopBundle\Model\Product\Product */
 
         $this->assertFalse($productAgain->isVisible());
     }
@@ -179,8 +179,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     {
         $em = $this->getEntityManager();
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $sellingFrom = new DateTime('now');
         $sellingFrom->modify('-1 day');
@@ -197,12 +197,12 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $id = $product->getId();
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $productAgain */
         $productAgain = $em->getRepository(Product::class)->find($id);
-        /* @var $productAgain \Shopsys\ShopBundle\Model\Product\Product */
 
         $this->assertTrue($productAgain->isVisible());
     }
@@ -211,8 +211,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     {
         $em = $this->getEntityManager();
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $productData = $this->getDefaultProductData();
         $productData->price = 0;
@@ -226,14 +226,14 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
         $product2Id = $product2->getId();
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product1Again */
         $product1Again = $em->getRepository(Product::class)->find($product1Id);
-        /* @var $product1Again \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product2Again */
         $product2Again = $em->getRepository(Product::class)->find($product2Id);
-        /* @var $product2Again \Shopsys\ShopBundle\Model\Product\Product */
 
         $this->assertFalse($product1Again->isVisible());
         $this->assertFalse($product2Again->isVisible());
@@ -242,10 +242,10 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testIsVisibleWithFilledName()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $productData = $this->getDefaultProductData();
         $productData->name = ['cs' => 'Name', 'en' => 'Name'];
@@ -254,16 +254,16 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
 
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
             'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
             'domainId' => 1,
         ]);
-        /* @var $productVisibility \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertTrue($productVisibility->isVisible());
     }
@@ -271,10 +271,10 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testIsNotVisibleWithEmptyName()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $productData = $this->getDefaultProductData();
         $productData->name = ['cs' => null, 'en' => null];
@@ -283,16 +283,16 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
 
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
             'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
             'domainId' => 1,
         ]);
-        /* @var $productVisibility \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertFalse($productVisibility->isVisible());
     }
@@ -300,10 +300,10 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testIsVisibleInVisibileCategory()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $category = $this->getReference(CategoryDataFixture::CATEGORY_TOYS);
 
@@ -314,16 +314,16 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
 
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
             'pricingGroup' => $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1)->getId(),
             'domainId' => 1,
         ]);
-        /* @var $productVisibility \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertTrue($productVisibility->isVisible());
     }
@@ -331,10 +331,10 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testIsNotVisibleInHiddenCategory()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
 
         $productData = $this->getDefaultProductData();
         $productData->categoriesByDomainId = [];
@@ -343,8 +343,8 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
 
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
@@ -359,12 +359,12 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testIsNotVisibleWhenZeroManualPrice()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade */
         $pricingGroupFacade = $this->getContainer()->get(PricingGroupFacade::class);
-        /* @var $pricingGroupFacade \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade */
 
         $productData = $this->getDefaultProductData();
         $productData->priceCalculationType = Product::PRICE_CALCULATION_TYPE_MANUAL;
@@ -383,16 +383,16 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
 
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
             'pricingGroup' => $pricingGroupWithZeroPriceId,
             'domainId' => 1,
         ]);
-        /* @var $productVisibility \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertFalse($productVisibility->isVisible());
     }
@@ -400,12 +400,12 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testIsNotVisibleWhenNullManualPrice()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator */
         $productPriceRecalculator = $this->getContainer()->get(ProductPriceRecalculator::class);
-        /* @var $productPriceRecalculator \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade */
         $pricingGroupFacade = $this->getContainer()->get(PricingGroupFacade::class);
-        /* @var $pricingGroupFacade \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade */
 
         $productData = $this->getDefaultProductData();
         $productData->priceCalculationType = Product::PRICE_CALCULATION_TYPE_MANUAL;
@@ -423,16 +423,16 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
 
         $em->clear();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
         $productVisibilityRepository->refreshProductsVisibility();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibility $productVisibility */
         $productVisibility = $em->getRepository(ProductVisibility::class)->findOneBy([
             'product' => $product,
             'pricingGroup' => $pricingGroupWithNullPriceId,
             'domainId' => 1,
         ]);
-        /* @var $productVisibility \Shopsys\FrameworkBundle\Model\Product\ProductVisibility */
 
         $this->assertFalse($productVisibility->isVisible());
     }
@@ -440,21 +440,21 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testRefreshProductsVisibilityVisibleVariants()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant1 */
         $variant1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '53');
-        /* @var $variant1 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant2 */
         $variant2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '54');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant3 */
         $variant3 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '69');
-        /* @var $variant3 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $mainVariant */
         $mainVariant = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148');
-        /* @var $mainVariant \Shopsys\ShopBundle\Model\Product\Product */
 
         $variant1productData = $productDataFactory->createFromProduct($variant1);
         $variant1productData->hidden = true;
@@ -476,21 +476,21 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testRefreshProductsVisibilityNotVisibleVariants()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant1 */
         $variant1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '53');
-        /* @var $variant1 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant2 */
         $variant2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '54');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant3 */
         $variant3 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '69');
-        /* @var $variant3 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $mainVariant */
         $mainVariant = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148');
-        /* @var $mainVariant \Shopsys\ShopBundle\Model\Product\Product */
 
         $variant1productData = $productDataFactory->createFromProduct($variant1);
         $variant1productData->hidden = true;
@@ -520,21 +520,21 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     public function testRefreshProductsVisibilityNotVisibleMainVariant()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository */
         $productVisibilityRepository = $this->getContainer()->get(ProductVisibilityRepository::class);
-        /* @var $productVisibilityRepository \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
 
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant1 */
         $variant1 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '53');
-        /* @var $variant1 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant2 */
         $variant2 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '54');
-        /* @var $variant2 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $variant3 */
         $variant3 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '69');
-        /* @var $variant3 \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $mainVariant */
         $mainVariant = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '148');
-        /* @var $mainVariant \Shopsys\ShopBundle\Model\Product\Product */
 
         $mainVariantproductData = $productDataFactory->createFromProduct($mainVariant);
         $mainVariantproductData->hidden = true;

--- a/project-base/tests/ShopBundle/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
@@ -30,9 +30,9 @@ class IndependentTransportVisibilityCalculationTest extends TransactionFunctiona
         $em->persist($transport);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation $independentTransportVisibilityCalculation */
         $independentTransportVisibilityCalculation =
             $this->getContainer()->get(IndependentTransportVisibilityCalculation::class);
-        /* @var $independentTransportVisibilityCalculation \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation */
 
         $this->assertTrue($independentTransportVisibilityCalculation->isIndependentlyVisible($transport, self::FIRST_DOMAIN_ID));
     }
@@ -60,9 +60,9 @@ class IndependentTransportVisibilityCalculationTest extends TransactionFunctiona
         $em->persist($transport);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation $independentTransportVisibilityCalculation */
         $independentTransportVisibilityCalculation =
             $this->getContainer()->get(IndependentTransportVisibilityCalculation::class);
-        /* @var $independentTransportVisibilityCalculation \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation */
 
         $this->assertFalse($independentTransportVisibilityCalculation->isIndependentlyVisible($transport, self::FIRST_DOMAIN_ID));
     }
@@ -83,9 +83,9 @@ class IndependentTransportVisibilityCalculationTest extends TransactionFunctiona
         $em->persist($transport);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation $independentTransportVisibilityCalculation */
         $independentTransportVisibilityCalculation =
             $this->getContainer()->get(IndependentTransportVisibilityCalculation::class);
-        /* @var $independentTransportVisibilityCalculation \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation */
 
         $this->assertFalse($independentTransportVisibilityCalculation->isIndependentlyVisible($transport, self::FIRST_DOMAIN_ID));
     }
@@ -106,9 +106,9 @@ class IndependentTransportVisibilityCalculationTest extends TransactionFunctiona
         $em->persist($transport);
         $em->flush();
 
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation $independentTransportVisibilityCalculation */
         $independentTransportVisibilityCalculation =
             $this->getContainer()->get(IndependentTransportVisibilityCalculation::class);
-        /* @var $independentTransportVisibilityCalculation \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation */
 
         $this->assertFalse($independentTransportVisibilityCalculation->isIndependentlyVisible($transport, self::FIRST_DOMAIN_ID));
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Unit/UnitFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Unit/UnitFacadeTest.php
@@ -15,22 +15,22 @@ class UnitFacadeTest extends TransactionFunctionalTestCase
     public function testDeleteByIdAndReplace()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade */
         $unitFacade = $this->getContainer()->get(UnitFacade::class);
-        /* @var $unitFacade \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /* @var $productDataFactory \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
-        /* @var $productFacade \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
 
         $unitData = new UnitData();
         $unitData->name = ['cs' => 'name'];
         $unitToDelete = $unitFacade->create($unitData);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $unitToReplaceWith */
         $unitToReplaceWith = $this->getReference(UnitDataFixture::UNIT_PIECES);
-        /* @var $newUnit \Shopsys\FrameworkBundle\Model\Product\Unit\Unit */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $product \Shopsys\ShopBundle\Model\Product\Product */
+        /** @var \Shopsys\ShopBundle\Model\Product\ProductData $productData */
         $productData = $productDataFactory->createFromProduct($product);
-        /* @var $productData \Shopsys\ShopBundle\Model\Product\ProductData */
 
         $productData->unit = $unitToDelete;
         $productFacade->edit($product->getId(), $productData);

--- a/project-base/tests/ShopBundle/Functional/Model/Vat/VatFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Vat/VatFacadeTest.php
@@ -18,28 +18,28 @@ class VatFacadeTest extends TransactionFunctionalTestCase
     public function testDeleteByIdAndReplace()
     {
         $em = $this->getEntityManager();
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade */
         $vatFacade = $this->getContainer()->get(VatFacade::class);
-        /* @var $vatFacade \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade */
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade */
         $transportFacade = $this->getContainer()->get(TransportFacade::class);
-        /* @var $transportFacade \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
+        /** @var \Shopsys\ShopBundle\Model\Transport\TransportDataFactory $transportDataFactory */
         $transportDataFactory = $this->getContainer()->get(TransportDataFactoryInterface::class);
-        /* @var $transportDataFactory \Shopsys\ShopBundle\Model\Transport\TransportDataFactory */
+        /** @var \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory $paymentDataFactory */
         $paymentDataFactory = $this->getContainer()->get(PaymentDataFactoryInterface::class);
-        /* @var $paymentDataFactory \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory */
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade */
         $paymentFacade = $this->getContainer()->get(PaymentFacade::class);
-        /* @var $paymentFacade \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
 
         $vatData = new VatData();
         $vatData->name = 'name';
         $vatData->percent = 10;
         $vatToDelete = $vatFacade->create($vatData);
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vatToReplaceWith */
         $vatToReplaceWith = $this->getReference(VatDataFixture::VAT_HIGH);
-        /* @var $vatToReplaceWith \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat */
+        /** @var \Shopsys\ShopBundle\Model\Transport\Transport $transport */
         $transport = $this->getReference(TransportDataFixture::TRANSPORT_PERSONAL);
-        /* @var $transport \Shopsys\ShopBundle\Model\Transport\Transport */
         $transportData = $transportDataFactory->createFromTransport($transport);
+        /** @var \Shopsys\ShopBundle\Model\Payment\Payment $payment */
         $payment = $this->getReference(PaymentDataFixture::PAYMENT_CASH);
-        /* @var $payment \Shopsys\ShopBundle\Model\Payment\Payment */
         $paymentData = $paymentDataFactory->createFromPayment($payment);
 
         $transportData->vat = $vatToDelete;

--- a/project-base/tests/ShopBundle/Functional/Twig/DateTimeFormatterExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/DateTimeFormatterExtensionTest.php
@@ -33,9 +33,8 @@ class DateTimeFormatterExtensionTest extends FunctionalTestCase
         $localizationMock->expects($this->any())->method('getLocale')
             ->willReturn($locale);
 
+        /** @var \Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatter $dateTimeFormatter */
         $dateTimeFormatter = $this->getContainer()->get(DateTimeFormatter::class);
-        /* @var $dateTimeFormatter \Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatter */
-
         $dateTimeFormatterExtension = new DateTimeFormatterExtension($dateTimeFormatter, $localizationMock);
 
         $this->assertSame($result, $dateTimeFormatterExtension->formatDate($input));

--- a/project-base/tests/ShopBundle/Functional/Twig/NumberFormatterExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/NumberFormatterExtensionTest.php
@@ -44,8 +44,8 @@ class NumberFormatterExtensionTest extends FunctionalTestCase
         $localizationMock->expects($this->any())->method('getLocale')
             ->willReturn($locale);
 
+        /** @var \CommerceGuys\Intl\NumberFormat\NumberFormatRepository $numberFormatRepository */
         $numberFormatRepository = $this->getContainer()->get(NumberFormatRepository::class);
-        /* @var $numberFormatRepository \CommerceGuys\Intl\NumberFormat\NumberFormatRepository */
 
         $numberFormatterExtension = new NumberFormatterExtension($localizationMock, $numberFormatRepository);
 

--- a/project-base/tests/ShopBundle/Performance/Feed/AllFeedsTest.php
+++ b/project-base/tests/ShopBundle/Performance/Feed/AllFeedsTest.php
@@ -62,9 +62,12 @@ class AllFeedsTest extends KernelTestCase
         $performanceTestSamples = [];
         $allFeedGenerationData = $this->getAllFeedGenerationData();
         foreach ($allFeedGenerationData as $feedGenerationData) {
-            list($feedInfo, $domainConfig, $maxDuration) = $feedGenerationData;
-            /* @var $feedInfo \Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface */
-            /* @var $domainConfig \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig */
+            /** @var \Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface $feedInfo */
+            $feedInfo = $feedGenerationData[0];
+            /** @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig */
+            $domainConfig = $feedGenerationData[1];
+            /** @var int $maxDuration */
+            $maxDuration = $feedGenerationData[2];
 
             $consoleOutput->writeln(
                 sprintf(
@@ -109,11 +112,10 @@ class AllFeedsTest extends KernelTestCase
      */
     public function getAllFeedGenerationData()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Feed\FeedRegistry $feedRegistry */
         $feedRegistry = self::$kernel->getContainer()->get(FeedRegistry::class);
-        /* @var $feedRegistry \Shopsys\FrameworkBundle\Model\Feed\FeedRegistry */
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = self::$kernel->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
-
         $dailyFeedGenerationData = $this->getFeedGenerationData(
             $feedRegistry->getFeeds('daily'),
             $domain->getAll(),
@@ -179,8 +181,8 @@ class AllFeedsTest extends KernelTestCase
     {
         $this->setUp();
 
+        /** @var \Symfony\Component\Routing\RouterInterface $router */
         $router = self::$kernel->getContainer()->get('router');
-        /* @var $router \Symfony\Component\Routing\RouterInterface */
 
         $uri = $router->generate(
             self::ROUTE_NAME_GENERATE_FEED,
@@ -193,8 +195,8 @@ class AllFeedsTest extends KernelTestCase
         $auth = new BasicHttpAuth(self::ADMIN_USERNAME, self::ADMIN_PASSWORD);
         $auth->authenticateRequest($request);
 
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
         $entityManager = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $entityManager \Doctrine\ORM\EntityManager */
 
         $startTime = microtime(true);
         $entityManager->beginTransaction();

--- a/project-base/tests/ShopBundle/Performance/Feed/PerformanceTestSample.php
+++ b/project-base/tests/ShopBundle/Performance/Feed/PerformanceTestSample.php
@@ -45,9 +45,9 @@ class PerformanceTestSample
     /**
      * @param \Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface $feedInfo
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
-     * @param $generationUri
-     * @param $duration
-     * @param $statusCode
+     * @param string $generationUri
+     * @param float $duration
+     * @param int $statusCode
      */
     public function __construct(
         FeedInfoInterface $feedInfo,

--- a/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
+++ b/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
@@ -182,8 +182,8 @@ class AllPagesTest extends KernelTestCase
         $request = Request::create($uri);
         $requestDataSet->getAuth()->authenticateRequest($request);
 
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
         $entityManager = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $entityManager \Doctrine\ORM\EntityManager */
 
         $startTime = microtime(true);
         $entityManager->beginTransaction();

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSamplesAggregator.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSamplesAggregator.php
@@ -55,7 +55,7 @@ class PerformanceTestSamplesAggregator
     }
 
     /**
-     * @param \Tests\ShopBundle\Performance\Page\PerformanceTestSample[][] $performanceTestSamples
+     * @param \Tests\ShopBundle\Performance\Page\PerformanceTestSample[] $performanceTestSamples
      */
     private function getPerformanceTestSamplesGroupedByUrl(array $performanceTestSamples)
     {

--- a/project-base/tests/ShopBundle/Smoke/Http/HttpSmokeTest.php
+++ b/project-base/tests/ShopBundle/Smoke/Http/HttpSmokeTest.php
@@ -32,8 +32,8 @@ class HttpSmokeTest extends HttpSmokeTestCase
      */
     protected function handleRequest(Request $request)
     {
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
         $entityManager = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $entityManager \Doctrine\ORM\EntityManager */
 
         $entityManager->beginTransaction();
         ob_start();

--- a/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
@@ -123,10 +123,10 @@ class RouteConfigCustomization
                         . '(Routes are protected by RouteCsrfProtector.)';
                     $config->changeDefaultRequestDataSet($debugNote)
                         ->addCallDuringTestExecution(function (RequestDataSet $requestDataSet, ContainerInterface $container) {
+                            /** @var \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector $routeCsrfProtector */
                             $routeCsrfProtector = $container->get(RouteCsrfProtector::class);
-                            /* @var $routeCsrfProtector \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector */
+                            /** @var \Symfony\Component\Security\Csrf\CsrfTokenManager $csrfTokenManager */
                             $csrfTokenManager = $container->get('security.csrf.token_manager');
-                            /* @var $csrfTokenManager \Symfony\Component\Security\Csrf\CsrfTokenManager */
 
                             $tokenId = $routeCsrfProtector->getCsrfTokenId($requestDataSet->getRouteName());
                             $token = $csrfTokenManager->getToken($tokenId);
@@ -199,8 +199,8 @@ class RouteConfigCustomization
                     ->setParameter('categoryId', 2);
             })
             ->customizeByRouteName('admin_pricinggroup_delete', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
                 $pricingGroup = $this->getPersistentReference(PricingGroupDataFixture::PRICING_GROUP_PARTNER_DOMAIN_1);
-                /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
 
                 $debugNote = sprintf('Delete pricing group "%s".', $pricingGroup->getName());
                 $config->changeDefaultRequestDataSet($debugNote)
@@ -213,10 +213,10 @@ class RouteConfigCustomization
                     ->setParameter('id', 75);
             })
             ->customizeByRouteName('admin_unit_delete', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $unit */
                 $unit = $this->getPersistentReference(UnitDataFixture::UNIT_PIECES);
-                /* @var $unit \Shopsys\FrameworkBundle\Model\Product\Unit\Unit */
+                /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $newUnit */
                 $newUnit = $this->getPersistentReference(UnitDataFixture::UNIT_CUBIC_METERS);
-                /* @var $newUnit \Shopsys\FrameworkBundle\Model\Product\Unit\Unit */
 
                 $debugNote = sprintf('Delete unit "%s" and replace it by "%s".', $unit->getName('en'), $newUnit->getName('en'));
                 $config->changeDefaultRequestDataSet($debugNote)
@@ -224,10 +224,10 @@ class RouteConfigCustomization
                     ->setParameter('newId', $newUnit->getId());
             })
             ->customizeByRouteName('admin_vat_delete', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat */
                 $vat = $this->getPersistentReference(VatDataFixture::VAT_SECOND_LOW);
-                /* @var $vat \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat */
+                /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $newVat */
                 $newVat = $this->getPersistentReference(VatDataFixture::VAT_LOW);
-                /* @var $newVat \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat */
 
                 $debugNote = sprintf('Delete VAT "%s" and replace it by "%s".', $vat->getName(), $newVat->getName());
                 $config->changeDefaultRequestDataSet($debugNote)
@@ -260,8 +260,8 @@ class RouteConfigCustomization
                 $debugNote = 'Add CSRF token for logout action (configured in app/security.yml) during test execution.';
                 $config->changeDefaultRequestDataSet($debugNote)
                     ->addCallDuringTestExecution(function (RequestDataSet $requestDataSet, ContainerInterface $container) {
+                        /** @var \Symfony\Component\Security\Csrf\CsrfTokenManager $csrfTokenManager */
                         $csrfTokenManager = $container->get('security.csrf.token_manager');
-                        /* @var $csrfTokenManager \Symfony\Component\Security\Csrf\CsrfTokenManager */
 
                         $token = $csrfTokenManager->getToken('frontend_logout');
 
@@ -279,16 +279,16 @@ class RouteConfigCustomization
                     ->setParameter('id', 1);
             })
             ->customizeByRouteName('front_customer_order_detail_unregistered', function (RouteConfig $config) {
+                /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
                 $order = $this->getPersistentReference(OrderDataFixture::ORDER_PREFIX . '1');
-                /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
 
                 $debugNote = sprintf('Use hash of order n. %s for unregistered access.', $order->getNumber());
                 $config->changeDefaultRequestDataSet($debugNote)
                     ->setParameter('urlHash', $order->getUrlHash());
             })
             ->customizeByRouteName('front_customer_order_detail_registered', function (RouteConfig $config) {
+                /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
                 $order = $this->getPersistentReference(OrderDataFixture::ORDER_PREFIX . '1');
-                /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
 
                 $debugNote = sprintf('Log as demo user "Jaromír Jágr" on front-end to access order n. %s.', $order->getNumber());
                 $config->changeDefaultRequestDataSet($debugNote)
@@ -344,8 +344,8 @@ class RouteConfigCustomization
                     ]);
             })
             ->customizeByRouteName('front_registration_set_new_password', function (RouteConfig $config) {
+                /** @var \Shopsys\ShopBundle\Model\Customer\User $customer */
                 $customer = $this->getPersistentReference(UserDataFixture::USER_WITH_RESET_PASSWORD_HASH);
-                /* @var $customer \Shopsys\ShopBundle\Model\Customer\User */
 
                 $config->changeDefaultRequestDataSet('See new password page for customer with reset password hash.')
                     ->setParameter('email', $customer->getEmail())
@@ -355,8 +355,8 @@ class RouteConfigCustomization
                     ->setExpectedStatusCode(302);
             })
             ->customizeByRouteName('front_personal_data_access', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest $personalDataAccessRequest */
                 $personalDataAccessRequest = $this->getPersistentReference(PersonalDataAccessRequestDataFixture::REFERENCE_ACCESS_DISPLAY_REQUEST);
-                /* @var $personalDataAccessRequest \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest */
 
                 $config->changeDefaultRequestDataSet('Check personal data site with wrong hash')
                     ->setParameter('hash', 'invalidHash')
@@ -366,8 +366,8 @@ class RouteConfigCustomization
                     ->setExpectedStatusCode(200);
             })
             ->customizeByRouteName('front_personal_data_access_export', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest $personalDataAccessRequest */
                 $personalDataAccessRequest = $this->getPersistentReference(PersonalDataAccessRequestDataFixture::REFERENCE_ACCESS_EXPORT_REQUEST);
-                /* @var $personalDataAccessRequest \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest */
 
                 $config->changeDefaultRequestDataSet('Check personal data export site with wrong hash')
                     ->setParameter('hash', 'invalidHash')
@@ -377,8 +377,8 @@ class RouteConfigCustomization
                     ->setExpectedStatusCode(200);
             })
             ->customizeByRouteName('front_export_personal_data', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest $personalDataAccessRequest */
                 $personalDataAccessRequest = $this->getPersistentReference(PersonalDataAccessRequestDataFixture::REFERENCE_ACCESS_EXPORT_REQUEST);
-                /* @var $personalDataAccessRequest \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest */
 
                 $config->changeDefaultRequestDataSet('Check personal data XML export with wrong hash')
                     ->setParameter('hash', 'invalidHash')
@@ -395,9 +395,9 @@ class RouteConfigCustomization
      */
     private function getPersistentReference($name)
     {
+        /** @var \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade */
         $persistentReferenceFacade = $this->container
             ->get(PersistentReferenceFacade::class);
-        /* @var $persistentReferenceFacade \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade */
 
         return $persistentReferenceFacade->getReference($name);
     }
@@ -407,8 +407,8 @@ class RouteConfigCustomization
      */
     private function isSingleDomain()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->container->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         return count($domain->getAll()) === 1;
     }

--- a/project-base/tests/ShopBundle/Smoke/LocalizationListenerTest.php
+++ b/project-base/tests/ShopBundle/Smoke/LocalizationListenerTest.php
@@ -12,8 +12,8 @@ class LocalizationListenerTest extends TransactionFunctionalTestCase
 {
     public function testProductDetailOnFirstDomainHasEnglishLocale()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Router\CurrentDomainRouter $router */
         $router = $this->getContainer()->get(CurrentDomainRouter::class);
-        /* @var $router \Shopsys\FrameworkBundle\Component\Router\CurrentDomainRouter */
         $productUrl = $router->generate('front_product_detail', ['id' => 3], UrlGeneratorInterface::ABSOLUTE_URL);
 
         $crawler = $this->getClient()->request('GET', $productUrl);
@@ -30,13 +30,13 @@ class LocalizationListenerTest extends TransactionFunctionalTestCase
      */
     public function testProductDetailOnSecondDomainHasCzechLocale()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         $domain->switchDomainById(2);
 
+        /** @var \Symfony\Component\Routing\RouterInterface $router */
         $router = $this->getContainer()->get(DomainRouterFactory::class)->getRouter(2);
-        /* @var $router \Symfony\Component\Routing\RouterInterface */
         $productUrl = $router->generate('front_product_detail', ['id' => 3], UrlGeneratorInterface::ABSOLUTE_URL);
         $crawler = $this->getClient()->request('GET', $productUrl);
 

--- a/project-base/tests/ShopBundle/Smoke/NewProductTest.php
+++ b/project-base/tests/ShopBundle/Smoke/NewProductTest.php
@@ -56,6 +56,15 @@ class NewProductTest extends FunctionalTestCase
      */
     private function fillForm(Form $form)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat */
+        $vat = $this->getReference(VatDataFixture::VAT_ZERO);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $unit */
+        $unit = $this->getReference(UnitDataFixture::UNIT_CUBIC_METERS);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability $availability */
+        $availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK);
+
         /** @var \Symfony\Component\DomCrawler\Field\InputFormField[] $nameForms */
         $nameForms = $form->get('product_form[name]');
         foreach ($nameForms as $nameForm) {
@@ -66,12 +75,12 @@ class NewProductTest extends FunctionalTestCase
         $form['product_form[basicInformationGroup][ean]'] = '123456';
         $form['product_form[descriptionsGroup][descriptions][1]'] = 'test description';
         $form['product_form[pricesGroup][productCalculatedPricesGroup][price]'] = '10000';
-        $form['product_form[pricesGroup][vat]']->select($this->getReference(VatDataFixture::VAT_ZERO)->getId());
+        $form['product_form[pricesGroup][vat]']->select($vat->getId());
         $form['product_form[displayAvailabilityGroup][sellingFrom]'] = '1.1.1990';
         $form['product_form[displayAvailabilityGroup][sellingTo]'] = '1.1.2000';
         $form['product_form[displayAvailabilityGroup][stockGroup][stockQuantity]'] = '10';
-        $form['product_form[displayAvailabilityGroup][unit]']->select($this->getReference(UnitDataFixture::UNIT_CUBIC_METERS)->getId());
-        $form['product_form[displayAvailabilityGroup][availability]']->select($this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK)->getId());
+        $form['product_form[displayAvailabilityGroup][unit]']->select($unit->getId());
+        $form['product_form[displayAvailabilityGroup][availability]']->select($availability->getId());
     }
 
     /**

--- a/project-base/tests/ShopBundle/Smoke/NewProductTest.php
+++ b/project-base/tests/ShopBundle/Smoke/NewProductTest.php
@@ -29,13 +29,13 @@ class NewProductTest extends FunctionalTestCase
         $this->fillForm($form);
 
         $client2 = $this->getClient(true, 'admin', 'admin123');
+        /** @var \Doctrine\ORM\EntityManager $em2 */
         $em2 = $client2->getContainer()->get('doctrine.orm.entity_manager');
-        /* @var $em2 \Doctrine\ORM\EntityManager */
 
         $em2->beginTransaction();
 
+        /** @var \Symfony\Component\Security\Csrf\CsrfTokenManager $tokenManager */
         $tokenManager = $client2->getContainer()->get('security.csrf.token_manager');
-        /* @var $tokenManager \Symfony\Component\Security\Csrf\CsrfTokenManager */
         $token = $tokenManager->getToken(ProductFormType::CSRF_TOKEN_ID);
         $this->setFormCsrfToken($form, $token);
 
@@ -43,8 +43,8 @@ class NewProductTest extends FunctionalTestCase
 
         $em2->rollback();
 
+        /** @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageBag */
         $flashMessageBag = $client2->getContainer()->get('shopsys.shop.component.flash_message.bag.admin');
-        /* @var $flashMessageBag \Shopsys\FrameworkBundle\Component\FlashMessage\Bag */
 
         $this->assertSame(302, $client2->getResponse()->getStatusCode());
         $this->assertNotEmpty($flashMessageBag->getSuccessMessages());
@@ -56,8 +56,8 @@ class NewProductTest extends FunctionalTestCase
      */
     private function fillForm(Form $form)
     {
+        /** @var \Symfony\Component\DomCrawler\Field\InputFormField[] $nameForms */
         $nameForms = $form->get('product_form[name]');
-        /* @var $nameForms \Symfony\Component\DomCrawler\Field\InputFormField[] */
         foreach ($nameForms as $nameForm) {
             $nameForm->setValue('testProduct');
         }

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
@@ -15,8 +15,8 @@ class CloseNewlyOpenedWindowsHelper extends Module
      */
     public function _after(TestInterface $test)
     {
+        /** @var \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver $webDriver */
         $webDriver = $this->getModule(StrictWebDriver::class);
-        /* @var $webDriver \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver */
 
         if ($webDriver->webDriver === null) {
             // Workaround: When Codeception fails to connect to Selenium WebDriver,

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
@@ -29,7 +29,7 @@ class CloseNewlyOpenedWindowsHelper extends Module
     }
 
     /**
-     * @param \RemoteWebDriver $webDriver
+     * @param \Facebook\WebDriver\Remote\RemoteWebDriver $webDriver
      */
     private function closeNewlyOpenedWindows(RemoteWebDriver $webDriver)
     {

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/DatabaseHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/DatabaseHelper.php
@@ -13,12 +13,12 @@ class DatabaseHelper extends Module
      */
     public function _initialize()
     {
+        /** @var \Tests\ShopBundle\Test\Codeception\Module\Db $dbModule */
         $dbModule = $this->getModule(Db::class);
-        /* @var $dbModule \Tests\ShopBundle\Test\Codeception\Module\Db */
+        /** @var \Tests\ShopBundle\Test\Codeception\Helper\SymfonyHelper $symfonyHelper */
         $symfonyHelper = $this->getModule(SymfonyHelper::class);
-        /* @var $symfonyHelper \Tests\ShopBundle\Test\Codeception\Helper\SymfonyHelper */
+        /** @var \Doctrine\DBAL\Connection $connection */
         $connection = $symfonyHelper->grabServiceFromContainer('doctrine.dbal.default_connection');
-        /* @var $connection \Doctrine\DBAL\Connection */
 
         $dbModule->_reconfigure([
             'dsn' => $this->getConnectionDsn($connection),

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/DomainHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/DomainHelper.php
@@ -14,12 +14,12 @@ class DomainHelper extends Module
      */
     public function _before(TestInterface $test)
     {
+        /** @var \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver $webDriver */
         $webDriver = $this->getModule(StrictWebDriver::class);
-        /* @var $webDriver \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver */
+        /** @var \Tests\ShopBundle\Test\Codeception\Helper\SymfonyHelper $symfonyHelper */
         $symfonyHelper = $this->getModule(SymfonyHelper::class);
-        /* @var $symfonyHelper \Tests\ShopBundle\Test\Codeception\Helper\SymfonyHelper */
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $symfonyHelper->grabServiceFromContainer(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
 
         $domainConfig = $domain->getDomainConfigById(1);
 

--- a/project-base/tests/ShopBundle/Test/Codeception/Module/Db.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Module/Db.php
@@ -19,10 +19,10 @@ class Db extends BaseDb
 
     public function cleanup()
     {
+        /** @var \Tests\ShopBundle\Test\Codeception\Helper\SymfonyHelper $symfonyHelper */
         $symfonyHelper = $this->getModule(SymfonyHelper::class);
-        /* @var $symfonyHelper \Tests\ShopBundle\Test\Codeception\Helper\SymfonyHelper */
+        /** @var \Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade $databaseSchemaFacade */
         $databaseSchemaFacade = $symfonyHelper->grabServiceFromContainer(DatabaseSchemaFacade::class);
-        /* @var $databaseSchemaFacade \Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade */
         $databaseSchemaFacade->dropSchemaIfExists('public');
         $databaseSchemaFacade->createSchema('public');
     }

--- a/project-base/tests/ShopBundle/Test/FunctionalTestCase.php
+++ b/project-base/tests/ShopBundle/Test/FunctionalTestCase.php
@@ -16,8 +16,8 @@ abstract class FunctionalTestCase extends WebTestCase
 
     protected function setUpDomain()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $this->getContainer()->get(Domain::class);
-        /* @var $domain \Shopsys\FrameworkBundle\Component\Domain\Domain */
         $domain->switchDomainById(1);
     }
 
@@ -78,9 +78,9 @@ abstract class FunctionalTestCase extends WebTestCase
      */
     protected function getReference($referenceName)
     {
+        /** @var \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade */
         $persistentReferenceFacade = $this->getContainer()
             ->get(PersistentReferenceFacade::class);
-        /* @var $persistentReferenceFacade \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade */
 
         return $persistentReferenceFacade->getReference($referenceName);
     }

--- a/project-base/tests/ShopBundle/Test/TransactionFunctionalTestCase.php
+++ b/project-base/tests/ShopBundle/Test/TransactionFunctionalTestCase.php
@@ -5,7 +5,7 @@ namespace Tests\ShopBundle\Test;
 abstract class TransactionFunctionalTestCase extends FunctionalTestCase
 {
     /**
-     * @return \Doctrine\ORM\EntityManagerInterface
+     * @return \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator
      */
     protected function getEntityManager()
     {

--- a/project-base/tests/ShopBundle/Unit/Form/Front/Order/PersonalInfoFormTypeTest.php
+++ b/project-base/tests/ShopBundle/Unit/Form/Front/Order/PersonalInfoFormTypeTest.php
@@ -43,7 +43,7 @@ class PersonalInfoFormTypeTest extends TypeTestCase
 
     /**
      * @param array $personalInfoFormData
-     * @param $isExpectedValid
+     * @param bool $isExpectedValid
      * @dataProvider getTermsAndConditionsAgreementIsMandatoryData
      */
     public function testTermsAndConditionsAgreementIsMandatory(array $personalInfoFormData, $isExpectedValid)


### PR DESCRIPTION
cc @PetrHeinz 

| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes of issues for static analysis by PhpStan (mostly changes in annotations), a follow-up from our discussion on [Shopsys Roadshow 2018 Prague](https://www.shopsys.com/shopsys-roadshow).
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| No *(note: you can run `php phing standards-fix` in the `php-fpm` container to fix those violations automatically)*
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
