### PR TITLE
[shopsys] Removed depends_on and links from docker-compose.yml files

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -50,6 +50,9 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 * [shopsys/microservice-product-search-export]
 
 ## [From 7.0.0-beta2 to Unreleased]
+### [shopsys/project-base]
+- *(optional)* [#428 Removed depends_on and links from docker-compose.yml files](https://github.com/shopsys/shopsys/pull/528) 
+    - remove all `depends_on` and `links` from your docker-compose files because they are unnecessary
 - [#533 main php-fpm container now uses multi-stage build feature](https://github.com/shopsys/shopsys/pull/533)
     - the Dockerfile for `php-fpm` has changed, update your `docker-compose.yml` and `docker/php-fpm/Dockerfile` accordingly
         - copy [`docker/php-fpm/Dockerfile`](https://github.com/shopsys/shopsys/blob/master/project-base/docker/php-fpm/Dockerfile) from GitHub

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -27,9 +27,6 @@ services:
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:delegated
         ports:
             - "8000:8080"
-        links:
-            - php-fpm
-            - smtp-server
 
     php-fpm:
         build:
@@ -44,16 +41,8 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/project-base/web
-        links:
-            - microservice-product-search
-            - microservice-product-search-export
-            - postgres
-            - redis
         ports:
             - "35729:35729"
-        depends_on:
-            - postgres
-            - redis
 
     microservice-product-search:
         build:
@@ -65,10 +54,6 @@ services:
         container_name: shopsys-framework-microservice-product-search
         volumes:
             - shopsys-framework-microservice-product-search-sync:/var/www/html
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     microservice-product-search-export:
         build:
@@ -80,10 +65,6 @@ services:
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
             - shopsys-framework-microservice-product-search-export-sync:/var/www/html
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     redis:
         image: redis:4.0-alpine
@@ -94,10 +75,6 @@ services:
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
-        links:
-            - redis
-        depends_on:
-            - redis
         ports:
             - "1600:80"
 
@@ -109,18 +86,12 @@ services:
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
             - HUB_PORT_4444_TCP_PORT=4444
-        links:
-            - webserver
 
     adminer:
         image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
-        links:
-            - postgres
-        depends_on:
-            - postgres
 
     smtp-server:
         image: namshi/smtp:latest

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -27,9 +27,6 @@ services:
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
         ports:
             - "8000:8080"
-        links:
-            - php-fpm
-            - smtp-server
 
     php-fpm:
         build:
@@ -45,16 +42,8 @@ services:
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/web
             - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
-        links:
-            - microservice-product-search
-            - microservice-product-search-export
-            - postgres
-            - redis
         ports:
             - "35729:35729"
-        depends_on:
-            - postgres
-            - redis
 
     microservice-product-search:
         build:
@@ -66,10 +55,6 @@ services:
         container_name: shopsys-framework-microservice-product-search
         volumes:
             - ./microservices/product-search:/var/www/html
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     microservice-product-search-export:
         build:
@@ -81,10 +66,6 @@ services:
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
             - ./microservices/product-search-export:/var/www/html
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     redis:
         image: redis:4.0-alpine
@@ -95,10 +76,6 @@ services:
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
-        links:
-            - redis
-        depends_on:
-            - redis
         ports:
             - "1600:80"
 
@@ -110,18 +87,12 @@ services:
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
             - HUB_PORT_4444_TCP_PORT=4444
-        links:
-            - webserver
 
     adminer:
         image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
-        links:
-            - postgres
-        depends_on:
-            - postgres
 
     smtp-server:
         image: namshi/smtp:latest

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -27,8 +27,6 @@ services:
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
         ports:
             - "8000:8080"
-        links:
-            - php-fpm
 
     php-fpm:
         build:
@@ -41,16 +39,8 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-        links:
-            - microservice-product-search
-            - microservice-product-search-export
-            - postgres
-            - redis
         ports:
             - "35729:35729"
-        depends_on:
-            - postgres
-            - redis
 
     microservice-product-search:
         build:
@@ -62,10 +52,6 @@ services:
         container_name: shopsys-framework-microservice-product-search
         volumes:
             - ./microservices/product-search:/var/www/html
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     microservice-product-search-export:
         build:
@@ -77,10 +63,6 @@ services:
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
             - ./microservices/product-search-export:/var/www/html
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     redis:
         image: redis:4.0-alpine
@@ -91,10 +73,6 @@ services:
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
-        links:
-            - redis
-        depends_on:
-            - redis
         ports:
             - "1600:80"
 
@@ -106,18 +84,12 @@ services:
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
             - HUB_PORT_4444_TCP_PORT=4444
-        links:
-            - webserver
 
     adminer:
         image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
-        links:
-            - postgres
-        depends_on:
-            - postgres
 
     smtp-server:
         image: namshi/smtp:latest

--- a/docs/introduction/shopsys-framework-on-docker.md
+++ b/docs/introduction/shopsys-framework-on-docker.md
@@ -48,9 +48,6 @@ The definition of container consists of some options:
 * **volumes**: location of data storage in which the data will remain even after the container is removed (see [Volumes official docs.](https://docs.docker.com/engine/admin/volumes/volumes/))
 * **ports**: ports mapping, in default configuration is port 8000 mapped on port 8080 inside container
 * **environment**: environment variables, after setting they can be used throughout the container
-* **links**: settings with which containers can the actual container communicate. If nothing is set,
-an actual container can communicate with all containers
-* **depends_on**: definition of dependency on another running container
 
 ##### Volumes
 The definition of volumes, example:

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -20,9 +20,6 @@ services:
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:delegated
         ports:
             - "8000:8080"
-        links:
-            - php-fpm
-            - smtp-server
 
     php-fpm:
         build:
@@ -38,14 +35,8 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/web
-        links:
-            - postgres
-            - redis
         ports:
             - "35729:35729"
-        depends_on:
-            - postgres
-            - redis
 
     redis:
         image: redis:4.0-alpine
@@ -56,10 +47,6 @@ services:
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
-        links:
-            - redis
-        depends_on:
-            - redis
         ports:
             - "1600:80"
 
@@ -71,18 +58,12 @@ services:
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
             - HUB_PORT_4444_TCP_PORT=4444
-        links:
-            - webserver
 
     adminer:
         image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
-        links:
-            - postgres
-        depends_on:
-            - postgres
 
     smtp-server:
         image: namshi/smtp:latest
@@ -106,18 +87,10 @@ services:
     microservice-product-search:
         image: shopsys/microservice-product-search:latest
         container_name: shopsys-framework-microservice-product-search
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     microservice-product-search-export:
         image: shopsys/microservice-product-search-export:latest
         container_name: shopsys-framework-microservice-product-search-export
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
 volumes:
     shopsys-framework-sync:

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -20,9 +20,6 @@ services:
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
         ports:
             - "8000:8080"
-        links:
-            - php-fpm
-            - smtp-server
 
     php-fpm:
         build:
@@ -39,14 +36,8 @@ services:
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/web
             - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
-        links:
-            - postgres
-            - redis
         ports:
             - "35729:35729"
-        depends_on:
-            - postgres
-            - redis
 
     redis:
         image: redis:4.0-alpine
@@ -57,10 +48,6 @@ services:
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
-        links:
-            - redis
-        depends_on:
-            - redis
         ports:
             - "1600:80"
 
@@ -72,18 +59,12 @@ services:
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
             - HUB_PORT_4444_TCP_PORT=4444
-        links:
-            - webserver
 
     adminer:
         image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
-        links:
-            - postgres
-        depends_on:
-            - postgres
 
     smtp-server:
         image: namshi/smtp:latest
@@ -106,18 +87,10 @@ services:
     microservice-product-search:
         image: shopsys/microservice-product-search:latest
         container_name: shopsys-framework-microservice-product-search
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     microservice-product-search-export:
         image: shopsys/microservice-product-search-export:latest
         container_name: shopsys-framework-microservice-product-search-export
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
 volumes:
     pgdata:

--- a/project-base/docker/conf/docker-compose.prod.yml.dist
+++ b/project-base/docker/conf/docker-compose.prod.yml.dist
@@ -10,8 +10,6 @@ services:
             - nginx-conf:/etc/nginx/conf.d/
         ports:
             - 8000:8080
-        links:
-            - php-fpm
         networks:
             - shopsys-network
 

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -20,9 +20,6 @@ services:
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
         ports:
             - "8000:8080"
-        links:
-            - php-fpm
-            - smtp-server
 
     php-fpm:
         build:
@@ -36,14 +33,8 @@ services:
         container_name: shopsys-framework-php-fpm
         volumes:
             - .:/var/www/html
-        links:
-            - postgres
-            - redis
         ports:
             - "35729:35729"
-        depends_on:
-            - postgres
-            - redis
 
     redis:
         image: redis:4.0-alpine
@@ -54,10 +45,6 @@ services:
         container_name: shopsys-framework-redis-admin
         environment:
             - REDIS_1_HOST=redis
-        links:
-            - redis
-        depends_on:
-            - redis
         ports:
             - "1600:80"
 
@@ -69,18 +56,12 @@ services:
         environment:
             - HUB_PORT_4444_TCP_ADDR=hub
             - HUB_PORT_4444_TCP_PORT=4444
-        links:
-            - webserver
 
     adminer:
         image: adminer:4.6
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
-        links:
-            - postgres
-        depends_on:
-            - postgres
 
     smtp-server:
         image: namshi/smtp:latest
@@ -103,18 +84,10 @@ services:
     microservice-product-search:
         image: shopsys/microservice-product-search:latest
         container_name: shopsys-framework-microservice-product-search
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
     microservice-product-search-export:
         image: shopsys/microservice-product-search-export:latest
         container_name: shopsys-framework-microservice-product-search-export
-        links:
-            - elasticsearch
-        depends_on:
-            - elasticsearch
 
 volumes:
     elasticsearch-data:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Links are deprecated in docker and depends_on is not necessary. To keep docker-compose files simple and consistent, deleted `links` and `depends_on` from docker-compose files
|New feature| No
|BC breaks| No
|Fixes issues| resolves #505 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
