### PR TITLE
[shopsys] phing targets: create-domains-data is now dependent on create-domains-db-functions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -53,6 +53,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 ### [shopsys/project-base]
 - *(optional)* [#428 Removed depends_on and links from docker-compose.yml files](https://github.com/shopsys/shopsys/pull/528) 
     - remove all `depends_on` and `links` from your docker-compose files because they are unnecessary
+- [#538 - phing targets: create-domains-data is now dependent on create-domains-db-functions](https://github.com/shopsys/shopsys/pull/538)
+    - modify your `build.xml` and `build-dev.xml` according to this pull request
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -16,7 +16,7 @@
     <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check" description="Checks coding standards."/>
     <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff" description="Checks coding standards on changed files."/>
 
-    <target name="test-db-demo" depends="clean,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-create-domains-db-functions,test-db-fixtures-demo-singledomain,test-create-domains-data,test-generate-friendly-urls,test-db-fixtures-demo-multidomain,test-load-plugin-demo-data,test-replace-domains-urls" description="Drops all data in test database and creates a new one with demo data."/>
+    <target name="test-db-demo" depends="clean,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-db-fixtures-demo-singledomain,test-create-domains-data,test-generate-friendly-urls,test-db-fixtures-demo-multidomain,test-load-plugin-demo-data,test-replace-domains-urls" description="Drops all data in test database and creates a new one with demo data."/>
     <target name="test-db-performance" depends="test-db-demo,test-db-fixtures-performance" description="Drops all data in test database and creates a new one with performance data."/>
     <target name="tests" depends="test-db-demo,tests-unit,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests on a newly built test database."/>
 
@@ -537,7 +537,7 @@
         </exec>
     </target>
 
-    <target name="test-create-domains-data" description="Creates domains data in tests DB for newly configured domains.">
+    <target name="test-create-domains-data" depends="test-create-domains-db-functions" description="Creates domains data in tests DB for newly configured domains.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
             <arg value="shopsys:domains-data:create" />

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -56,7 +56,7 @@
     <target name="build-deploy-part-2-db-dependent" depends="db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,grunt,error-pages-generate,warmup" description="Second part of application build for production preserving your DB (must be run with maintenance page when containing DB migrations)."/>
     <target name="build-new" depends="wipe,composer,npm,dirs-create,domains-urls-check,assets,db-rebuild,grunt,error-pages-generate,warmup,microservice-product-search-create-structure" description="Builds application for production with clean DB (with base data only)."/>
     <target name="build-demo" depends="wipe,composer,npm,dirs-create,domains-urls-check,assets,db-demo,grunt,error-pages-generate,warmup,microservice-product-search-recreate-structure" description="Builds application for production with clean demo DB."/>
-    <target name="db-demo" depends="db-wipe-public-schema,db-import-basic-structure,db-migrations,create-domains-db-functions,db-fixtures-demo-singledomain,create-domains-data,db-fixtures-demo-multidomain,load-plugin-demo-data,generate-friendly-urls,replace-domains-urls" description="Creates DB and fills it with demo data"/>
+    <target name="db-demo" depends="db-wipe-public-schema,db-import-basic-structure,db-migrations,db-fixtures-demo-singledomain,create-domains-data,db-fixtures-demo-multidomain,load-plugin-demo-data,generate-friendly-urls,replace-domains-urls" description="Creates DB and fills it with demo data"/>
     <target name="db-rebuild" depends="db-wipe-public-schema,db-import-basic-structure,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls" description="Drops all data in database and creates a new one with base data only."/>
     <target name="microservice-product-search-recreate-structure" depends="microservice-product-search-delete-structure,microservice-product-search-create-structure" description="Recreates structure for searching via microservice (deletes existing structure and creates new one)" />
 
@@ -112,7 +112,7 @@
         </exec>
     </target>
 
-    <target name="create-domains-data" description="Creates domains data for newly configured domains.">
+    <target name="create-domains-data" depends="create-domains-db-functions" description="Creates domains data for newly configured domains.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
             <arg value="shopsys:domains-data:create" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This is a fix of https://github.com/shopsys/shopsys/pull/513/commits/36717a3c75180865c30923e5a58232950418ed7f. In the linked commit, creation of db functions was extracted from `create-domains-data` target but new target was not used in all places where the original target was used
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
