### PR TITLE
[project-base] the environment setting during "composer install" is not interactive

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -166,6 +166,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - remove the lines mentioning `github_oauth_token` from your `docker/php-fpm/Dockerfile` and `docker-compose.yml`
     - rebuild `php-fpm` container
 - *(optional)* you can change your `Shopsys\Environment` class for consistent env setting during `composer install` ([see diff](https://github.com/shopsys/shopsys/pull/543/files#diff-02efa1bf1cc55b01e582e2b8bff3f2f7))
+    - you should add a command to change the environment to the `ci` stage in `docker/php-fpm/Dockerfile` to keep it building in `prod` environment, otherwise it will be built in `dev` ([see diff](https://github.com/shopsys/shopsys/pull/543/files#diff-50a0e02c146dc64c2a172b42022589fa))
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -165,6 +165,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - *(optional)* [#551 - github token erase](https://github.com/shopsys/shopsys/pull/551)
     - remove the lines mentioning `github_oauth_token` from your `docker/php-fpm/Dockerfile` and `docker-compose.yml`
     - rebuild `php-fpm` container
+- *(optional)* you can change your `Shopsys\Environment` class for consistent env setting during `composer install` ([see diff](https://github.com/shopsys/shopsys/pull/543/files#diff-02efa1bf1cc55b01e582e2b8bff3f2f7))
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/docs/installation/installation-using-docker-application-setup.md
+++ b/docs/installation/installation-using-docker-application-setup.md
@@ -28,6 +28,8 @@ The default parameters suggested by composer are currently set for application r
 Only exception is the `secret` parameter - you should input a random string to be used for security purposes.
 It is not necessary for development though.
 
+<!--- TODO Remove the following paragraphs as the environment is set depending on whether it's installed by "composer install" or "composer install --no-dev"  -->
+
 For development choose `n` when asked `Build in production environment? (Y/n)`.
 
 It will set the environment in your application to `dev` (this will, for example, show Symfony Web Debug Toolbar).

--- a/docs/installation/native-installation.md
+++ b/docs/installation/native-installation.md
@@ -153,6 +153,8 @@ For development choose `n` when asked `Build in production environment? (Y/n)`.
 
 It will set the environment in your application to `dev` (this will, for example, show Symfony Web Debug Toolbar).
 
+<!--- TODO Remove this section as the environment is set depending on whether it's installed by "composer install" or "composer install --no-dev"  -->
+
 ### 4. Configure domains
 Create `domains_urls.yml` from `domains_urls.yml.dist`.
 

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -78,7 +78,9 @@ See more about calculated attributes in the article [How to Work with Products](
 
 ## How do I change the environment (PRODUCTION/DEVELOPMENT/TEST)?
 The environment is determined by the existence of the files `PRODUCTION`, `DEVELOPMENT`, `TEST` in the root of your project.
-This file is created automatically during the run of a command `composer install` (it will prompt you to decide, default option is `DEVELOPMENT`).
+This file is created automatically during the run of a command `composer install`.
+If the command `composer install` is executed, the file `DEVELOPMENT` is created.
+If the command `composer install --no-dev` is executed, the file `PRODUCTION` is created.
 
 You can change the environment manually by using the command `php bin/console shopsys:environment:change`.
 

--- a/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
+++ b/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
@@ -79,7 +79,7 @@ class EnvironmentFileSetting
      * @param string $environment
      * @return string
      */
-    private function getEnvironmentFilePath(string $environment): string
+    public function getEnvironmentFilePath(string $environment): string
     {
         return $this->environmentFileDirectory . '/' . self::FILE_NAMES_BY_ENVIRONMENT[$environment];
     }

--- a/project-base/app/Environment.php
+++ b/project-base/app/Environment.php
@@ -22,12 +22,11 @@ class Environment
         $io = $event->getIO();
         /* @var $io \Composer\IO\IOInterface */
         $environmentFileSetting = self::getEnvironmentFileSetting();
-        if ($io->isInteractive() && !$environmentFileSetting->isAnyEnvironmentSet()) {
-            if ($io->askConfirmation('Build in production environment? (Y/n): ', true)) {
-                $environmentFileSetting->createFileForEnvironment(EnvironmentType::PRODUCTION);
-            } else {
-                $environmentFileSetting->createFileForEnvironment(EnvironmentType::DEVELOPMENT);
-            }
+        if (!$environmentFileSetting->isAnyEnvironmentSet()) {
+            $environment = $event->isDevMode() ? EnvironmentType::DEVELOPMENT : EnvironmentType::PRODUCTION;
+            $environmentFileSetting->createFileForEnvironment($environment);
+            $environmentFilePath = $environmentFileSetting->getEnvironmentFilePath($environment);
+            $io->write(sprintf('Created a file "%s" to set the application environment!', $environmentFilePath));
         }
         self::printEnvironmentInfo($io);
     }

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -109,3 +109,5 @@ COPY --chown=www-data:www-data / /var/www/html
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 
 RUN php phing composer-dev npm dirs-create test-dirs-create assets standards tests-static tests-acceptance-build
+
+RUN ./bin/console shopsys:environment:change prod

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -96,8 +96,6 @@ FROM base as production
 
 COPY --chown=www-data:www-data / /var/www/html
 
-RUN touch /var/www/html/PRODUCTION
-
 RUN composer install --optimize-autoloader --no-interaction --no-progress --no-dev
 
 RUN php phing composer npm dirs-create assets


### PR DESCRIPTION
- "composer install" previously created `PRODUCTION`/`DEVELOPMENT` file only in interactive mode, based on user's input
- now the file is created even in non-interactive mode, base on whether `composer install` or `composer install --no-dev` was called
- the file is still created only if there is no environment file yet

| Q             | A
| ------------- | ---
|Description, reason for the PR| current behavior needs user interaction, even when unnecessary (user already used either dev build or production build), also it leads to unspecified environment when installed non-interactively (`prod` is used by default)
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| default non-interactive installation changed from `prod` to `dev` <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
