### PR TITLE
[framework] eased adding JS to admin

### DIFF
--- a/docs/introduction/framework-extensibility.md
+++ b/docs/introduction/framework-extensibility.md
@@ -22,6 +22,8 @@ as well as a list of customizations that are not (and will not be) possible at a
 * open-box modifications in `project-base`
     * e.g. adding new entities, changing the FE design, customization of FE javascripts, adding new FE pages (routes and controllers), ...
 * [Hiding the existing features and functionality](https://github.com/shopsys/demoshop/pull/13)
+* adding a new javascript into admin
+    * add the new javascript files into the directory `src/Shopsys/ShopBundle/Resources/scripts/custom_admin` and they will be loaded automatically
 
 ## What is achievable with additional effort
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -578,6 +578,7 @@ services:
             - '%shopsys.web_dir%'
             - ['%shopsys.javascript_sources_dir%', '%shopsys.framework.javascript_sources_dir%']
             - '%shopsys.javascript_url_prefix%'
+            - ['admin/', 'common/', 'custom_admin/', 'frontend/']
 
     translation.loader.po:
         class: Shopsys\FrameworkBundle\Component\Translation\PoFileLoader

--- a/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
@@ -49,6 +49,7 @@
             'admin/validation/*.js',
             'admin/components/*.js',
             'admin/*.js',
+            'custom_admin/*.js',
         ]) }}
         {{ js_validator_config() }}
         {{ init_js_validation() }}

--- a/packages/framework/src/Twig/Javascript/JavascriptCompilerService.php
+++ b/packages/framework/src/Twig/Javascript/JavascriptCompilerService.php
@@ -24,6 +24,11 @@ class JavascriptCompilerService
     /**
      * @var string[]
      */
+    private $allowedDirectories;
+
+    /**
+     * @var string[]
+     */
     private $jsSourcePaths;
 
     /**
@@ -55,6 +60,7 @@ class JavascriptCompilerService
         string $webPath,
         array $jsSourcePaths,
         string $jsUrlPrefix,
+        array $allowedDirectories,
         Filesystem $filesystem,
         Domain $domain,
         JsCompiler $jsCompiler,
@@ -63,6 +69,7 @@ class JavascriptCompilerService
         $this->webPath = $webPath;
         $this->jsSourcePaths = $jsSourcePaths;
         $this->jsUrlPrefix = $jsUrlPrefix;
+        $this->allowedDirectories = $allowedDirectories;
         $this->filesystem = $filesystem;
         $this->domain = $domain;
         $this->jsCompiler = $jsCompiler;
@@ -148,7 +155,7 @@ class JavascriptCompilerService
     private function getRelativeTargetPath($javascript)
     {
         $relativeTargetPath = null;
-        if (strpos($javascript, 'admin/') === 0 || strpos($javascript, 'frontend/') === 0 || strpos($javascript, 'common/') === 0) {
+        if ($this->isDirectoryAllowed($javascript)) {
             $relativeTargetPath = substr($this->jsUrlPrefix, 1) . $javascript;
             if (strpos($relativeTargetPath, '/') === 0) {
                 $relativeTargetPath = substr($relativeTargetPath, 1);
@@ -158,6 +165,20 @@ class JavascriptCompilerService
         }
 
         return $relativeTargetPath;
+    }
+
+    /**
+     * @param string $javascript
+     * @return bool
+     */
+    private function isDirectoryAllowed(string $javascript): bool
+    {
+        foreach ($this->allowedDirectories as $allowedDirectory) {
+            if (strpos($javascript, $allowedDirectory) === 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| it used to be difficult to add JS to admin instead of rewriting all admin JS
|New feature| Yes
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
