### PR TITLE
[shopsys] Part of the application build is now contained in the build of the image

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -111,6 +111,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - rebuild image by running `docker-compose up -d --build`
     - files `build.xml` and `build-dev.xml` were updated to speed up deployment process of built docker images of php-fpm
     - installation guide for production via Docker was updated, now there is no need for the first part of the build phing target
+    - file `docker/php-fpm/docker-php-entrypoint` was changed, update it according to [`project-base/docker/php-fpm/docker-php-entrypoint`](./project-base/docker/php-fpm/docker-php-entrypoint)
 
 ## [From 7.0.0-beta1 to 7.0.0-beta2]
 ### [shopsys/project-base]

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -106,6 +106,11 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - [#530 - Update of installation for production via docker](https://github.com/shopsys/shopsys/pull/530)
     - update `docker-compose.yml` on production server with the new configuration from updated [`docker-compose.prod.yml`](./project-base/docker/conf/docker-compose.prod.yml.dist) file
     - update `nginx.conf` with configuration from updated [`nginx.conf`](./project-base/docker/nginx/nginx.conf)
+- [#545 - Part of the application build is now contained in the build of the image](https://github.com/shopsys/shopsys/pull/545)
+    - the Dockerfile for `php-fpm` has changed, update your `docker/php-fpm/Dockerfile`
+    - rebuild image by running `docker-compose up -d --build`
+    - files `build.xml` and `build-dev.xml` were updated to speed up deployment process of built docker images of php-fpm
+    - installation guide for production via Docker was updated, now there is no need for the first part of the build phing target
 
 ## [From 7.0.0-beta1 to 7.0.0-beta2]
 ### [shopsys/project-base]

--- a/build.xml
+++ b/build.xml
@@ -155,7 +155,7 @@
         </exec>
     </target>
 
-    <target name="tests" depends="test-db-demo,tests-unit,tests-functional,tests-smoke,tests-packages" description="Runs unit, functional and smoke tests on a newly built test database and runs tests of all packages."/>
+    <target name="tests-static" depends="tests-unit,tests-packages" description="Runs unit tests and tests of all packages."/>
 
     <target name="tests-packages" description="Runs tests of packages.">
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">

--- a/docs/installation/installation-using-docker-on-production-server.md
+++ b/docs/installation/installation-using-docker-on-production-server.md
@@ -221,7 +221,7 @@ We remove `.git` folder so the built image doesn't have additional data.
 ```
 rm -rf .git
 ```
-After the project is setup correctly, we launch the build of php-fpm container by docker build command.
+After the project is setup correctly, we launch the build of php-fpm container by docker build command that will build image with composer, npm packages and created assets.
 ```
 docker build \
     -f ./docker/php-fpm/Dockerfile \
@@ -292,9 +292,7 @@ Now we go to `/admin/dashboard/` and fulfill all requests that are demanding for
 We have running production shop project and we want to update it with some changes that were made in the project git repository.
 We need to follow some steps that will change old version of the shop for the new one.
  
-To preserve created data we need to use phing targets for building application environment of `php-fpm` container.
-* `build-deploy-part-1-db-independent` no maintenance page is needed during execution of this command 
-* `build-deploy-part-2-db-dependent` maintenance page is needed if there exist unapplied database migrations  
+To preserve created data we need to use phing target `build-deploy-part-2-db-dependent` for building application environment of `php-fpm` container, maintenance page is needed if there exist unapplied database migrations. 
 
 With each update of master branch in our repository we need to rebuild image based on [Docker Image Building](./installation-using-docker-on-production-server.md#docker-image-building) section.
 
@@ -312,9 +310,6 @@ docker run --detach --name build-php-fpm-container \
     --network production_shopsys-network \
     production-php-fpm \
     docker-php-entrypoint php-fpm
-
-# launch build part1 that doesn't have impact on actual running production container
-docker exec build-php-fpm-container php phing build-deploy-part-1-db-independent
 
 # turn on maintenance page on actual running production container
 docker exec production-php-fpm php phing maintenance-on

--- a/packages/framework/src/DependencyInjection/Compiler/LazyRedisCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/LazyRedisCompilerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
+
+use Doctrine\Common\Cache\RedisCache;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Set Redis-related services as lazy because it might not even be connected (e.g during Docker image build)
+ */
+class LazyRedisCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $container->getDefinition('session')
+            ->setLazy(true);
+
+        foreach ($container->getDefinitions() as $definition) {
+            if ($definition->getClass() === RedisCache::class) {
+                $definition->setLazy(true);
+            }
+        }
+    }
+}

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle;
 
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\CompilerPass\RegisterFriendlyUrlDataProviderCompilerPass;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\LazyRedisCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterCronModulesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExtensionsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
@@ -21,5 +22,6 @@ class ShopsysFrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterPluginCrudExtensionsCompilerPass());
         $container->addCompilerPass(new RegisterPluginDataFixturesCompilerPass());
         $container->addCompilerPass(new RegisterProductFeedConfigsCompilerPass());
+        $container->addCompilerPass(new LazyRedisCompilerPass());
     }
 }

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -5,20 +5,21 @@
     <target name="build-dev-quick" depends="clean,composer-dev,npm,dirs-create,assets,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,grunt,tests-acceptance-build" description="Builds application for development preserving your DB while skipping nonessential steps."/>
     <target name="build-demo-dev" depends="wipe-excluding-logs,composer-dev,npm,timezones-check,microservices-check,dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-diff" description="Builds application for development with clean demo DB and runs checks on changed files."/>
     <target name="build-demo-dev-quick" depends="wipe-excluding-logs,composer-dev,npm,dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,tests-acceptance-build" description="Builds application for development with clean demo DB while skipping nonessential steps."/>
-    <target name="build-demo-ci" depends="wipe-excluding-logs,composer-dev,npm,timezones-check,microservices-check,dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-ci" description="Builds application for development with clean demo DB and runs CI checks."/>
-    <target name="build-demo-ci-diff" depends="wipe-excluding-logs,composer-dev,npm,timezones-check,microservices-check,dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-ci-diff" description="Builds application for development with clean demo DB and runs CI checks on changed files."/>
+    <target name="build-demo-ci" depends="wipe-excluding-logs,timezones-check,microservices-check,dirs-create,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,checks-ci" description="Builds application for development with clean demo DB and runs CI checks."/>
+    <target name="build-demo-ci-diff" depends="wipe-excluding-logs,timezones-check,microservices-check,dirs-create,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,checks-ci-diff" description="Builds application for development with clean demo DB and runs CI checks on changed files."/>
 
     <target name="checks" depends="db-check-mapping,standards,tests" description="Checks ORM mapping, coding standards and runs unit, DB and smoke tests."/>
     <target name="checks-diff" depends="db-check-mapping,standards-diff,tests" description="Checks ORM mapping, coding standards on changed files and runs unit, DB and smoke tests."/>
-    <target name="checks-ci" depends="db-check-mapping,standards,tests,tests-acceptance" description="Checks ORM mapping, coding standards and runs unit, DB, smoke and acceptance tests."/>
-    <target name="checks-ci-diff" depends="db-check-mapping,standards-diff,tests,tests-acceptance" description="Checks ORM mapping, coding standards on changed files and runs unit, DB, smoke and acceptance tests."/>
+    <target name="checks-ci" depends="db-check-mapping,test-db-demo,tests-functional,tests-smoke,tests-acceptance" description="Checks ORM mapping and runs DB, smoke and acceptance tests."/>
+    <target name="checks-ci-diff" depends="db-check-mapping,test-db-demo,tests-functional,tests-smoke,tests-acceptance" description="Checks ORM mapping and runs DB, smoke and acceptance tests."/>
 
     <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check" description="Checks coding standards."/>
     <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff" description="Checks coding standards on changed files."/>
 
     <target name="test-db-demo" depends="clean,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-db-fixtures-demo-singledomain,test-create-domains-data,test-generate-friendly-urls,test-db-fixtures-demo-multidomain,test-load-plugin-demo-data,test-replace-domains-urls" description="Drops all data in test database and creates a new one with demo data."/>
     <target name="test-db-performance" depends="test-db-demo,test-db-fixtures-performance" description="Drops all data in test database and creates a new one with performance data."/>
-    <target name="tests" depends="test-db-demo,tests-unit,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests on a newly built test database."/>
+    <target name="tests-static" depends="tests-unit" description="Runs unit tests."/>
+    <target name="tests" depends="test-db-demo,tests-static,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests on a newly built test database."/>
 
     <target name="tests-performance-run" depends="clean,test-db-performance,tests-performance-warmup,tests-performance" description="Runs performance tests on a newly built test database with performance data."/>
 

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -87,6 +87,8 @@ RUN touch /var/www/html/PRODUCTION
 
 RUN composer install --optimize-autoloader --no-interaction --no-progress --no-dev
 
+RUN php phing composer npm dirs-create assets
+
 ########################################################################################################################
 
 FROM base as ci
@@ -97,6 +99,9 @@ FROM base as ci
 COPY --chown=www-data:www-data / /source-code
 WORKDIR /source-code
 RUN composer install --optimize-autoloader --no-interaction --no-progress
+
+# clean cache because of recreating valid autloading of vendor after /source-code is copied into /var/www/html
+RUN php phing composer-dev npm dirs-create assets tests-static tests-acceptance-build clean
 
 # switch back to the original workdir
 WORKDIR /var/www/html

--- a/project-base/docker/php-fpm/docker-php-entrypoint
+++ b/project-base/docker/php-fpm/docker-php-entrypoint
@@ -6,11 +6,11 @@ set -e
 
 # reading from a named pipe and writing to stdout via "tail -f"
 # this workaround prevents logs from being output to console during console commands
+# multistage build uses different UIDs and logpipe is transformed into something else than pipe so best way is to recreate it
 PIPE=/tmp/log-pipe
-if ! [ -p $PIPE ]; then
-    mkfifo $PIPE
-    chmod 660 $PIPE
-fi
+rm -rf $PIPE
+mkfifo $PIPE
+chmod 666 $PIPE
 tail -f $PIPE &
 
 # first arg is `-f` or `--some-option`


### PR DESCRIPTION
- phing build targets are added for ci and production targets
- session handler for framework is temporarily overriden during execution of phing targets

| Q             | A
| ------------- | ---
|Description, reason for the PR| to have faster deployment on CI and Production we can move some of the phing build targets into the Dockerfile that builds php-fpm image 
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| -
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
