### PR TITLE
[project-base] content-test directory is used instead of content during the tests

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,7 +20,7 @@ Follow instructions in the section `shopsys/shopsys`.
     * Repeat
 * typical upgrade sequence should be:
     * `docker-compose down`
-    * follow upgrade notes for `docker-compose.yml`, `Dockerfile`, docker containers
+    * follow upgrade notes for `docker-compose.yml`, `Dockerfile`, docker containers, `nginx.conf`, `php.ini`
     * `docker-compose up -d`
     * update shopsys framework dependencies in `composer.json` to version you are upgrading to
         eg. `"shopsys/framework": "v7.0.0-beta1"`
@@ -115,6 +115,12 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - files `build.xml` and `build-dev.xml` were updated to speed up deployment process of built docker images of php-fpm
     - installation guide for production via Docker was updated, now there is no need for the first part of the build phing target
     - file `docker/php-fpm/docker-php-entrypoint` was changed, update it according to [`project-base/docker/php-fpm/docker-php-entrypoint`](./project-base/docker/php-fpm/docker-php-entrypoint)
+- [#547 - content-test directory is used instead of content during the tests](https://github.com/shopsys/shopsys/pull/547)
+    - modify your `parameters_test.yml.dist`, `parameters_test.yml`, `paths.yml` according to this pull request so there will be used different directory for feeds, images, etc., during the tests
+    - modify your `build-dev.xml`, add a new phing target `test-dirs-create` and add it as a dependency after each `dirs-create` in this file
+    - modify your `build.xml`, phing target `wipe-excluding-logs`  according to this pull request so the directory `content-test` will be truncated too
+    - modify your `nginx.conf`, change location for images from `^/content/images/` to `^/content(-test)?/images/`
+    - modify your `routing_front.yml`, change configuration for routes `front_image`, `front_image_without_type` - replace `/content/` by `/%shopsys.content_dir_name%/`
 
 ## [From 7.0.0-beta1 to 7.0.0-beta2]
 ### [shopsys/project-base]

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -37,7 +37,7 @@ server {
             try_files $uri @app;
         }
 
-        location ~ ^/content/images/ {
+        location ~ ^/content(-test)?/images/ {
             # Newly uploaded images get new ID (different URL) so they could be cached forever.
             # But change of resolution in images.yml does not induce a change of URL
             # so it is safer to cache generated images only for few days.

--- a/docs/installation/native-installation.md
+++ b/docs/installation/native-installation.md
@@ -146,6 +146,7 @@ Composer will then prompt you to set parameters for testing environment (`app/co
 | `test_mailer_host`                | ...                                                                           | ...           |
 | `test_mailer_user`                | ...                                                                           | ...           |
 | `test_mailer_password`            | ...                                                                           | ...           |
+| `shopsys.content_dir_name`        | web/content-test/ directory is used instead of web/content/ during the tests  | content-test  |
 
 #### Choose environment type
 For development choose `n` when asked `Build in production environment? (Y/n)`.

--- a/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
+++ b/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
@@ -43,7 +43,13 @@ class CreateApplicationDirectoriesCommand extends Command
     private $projectDir;
 
     /**
+     * @var string
+     */
+    private $webContentDirName;
+
+    /**
      * @param string $projectDir
+     * @param string $webContentDirName
      * @param \League\Flysystem\FilesystemInterface $filesystem
      * @param \Symfony\Component\Filesystem\Filesystem $localFilesystem
      * @param \Shopsys\FrameworkBundle\Component\Image\DirectoryStructureCreator $imageDirectoryStructureCreator
@@ -51,6 +57,7 @@ class CreateApplicationDirectoriesCommand extends Command
      */
     public function __construct(
         string $projectDir,
+        string $webContentDirName,
         FilesystemInterface $filesystem,
         Filesystem $localFilesystem,
         ImageDirectoryStructureCreator $imageDirectoryStructureCreator,
@@ -63,6 +70,7 @@ class CreateApplicationDirectoriesCommand extends Command
 
         parent::__construct();
         $this->projectDir = $projectDir;
+        $this->webContentDirName = $webContentDirName;
     }
 
     protected function configure()
@@ -85,9 +93,9 @@ class CreateApplicationDirectoriesCommand extends Command
     private function createMiscellaneousDirectories(OutputInterface $output)
     {
         $directories = [
-            '/web/content/feeds',
-            '/web/content/sitemaps',
-            '/web/content/wysiwyg',
+            '/web/' . $this->webContentDirName . '/feeds',
+            '/web/' . $this->webContentDirName . '/sitemaps',
+            '/web/' . $this->webContentDirName . '/wysiwyg',
         ];
 
         $localDirectories = [

--- a/packages/framework/src/Resources/config/services/commands.yml
+++ b/packages/framework/src/Resources/config/services/commands.yml
@@ -24,6 +24,7 @@ services:
     Shopsys\FrameworkBundle\Command\CreateApplicationDirectoriesCommand:
         arguments:
             - '%kernel.project_dir%'
+            - '%shopsys.content_dir_name%'
 
     Shopsys\FrameworkBundle\Command\GenerateGruntfileCommand:
         arguments:

--- a/project-base/app/config/parameters_test.yml.dist
+++ b/project-base/app/config/parameters_test.yml.dist
@@ -12,3 +12,5 @@ parameters:
     test_mailer_host: smtp-server
     test_mailer_user: ~
     test_mailer_password: ~
+
+    shopsys.content_dir_name: 'content-test'

--- a/project-base/app/config/paths.yml
+++ b/project-base/app/config/paths.yml
@@ -1,4 +1,5 @@
 parameters:
+    shopsys.content_dir_name: 'content'
     shopsys.css_version_filepath: '%shopsys.web_dir%/assets/cssVersion'
     shopsys.data_fixtures.resource_customers_filepath: '%shopsys.data_fixtures.resources_dir%/demo-data-customers.csv'
     shopsys.data_fixtures.resource_products_filepath: '%shopsys.data_fixtures.resources_dir%/demo-data-products.csv'
@@ -6,28 +7,28 @@ parameters:
     shopsys.default_db_schema_filepath: '%shopsys.framework.resources_dir%/database/schema.sql'
     shopsys.domain_config_filepath: '%kernel.root_dir%/config/domains.yml'
     shopsys.domain_images_dir: '/web%shopsys.domain_images_url_prefix%'
-    shopsys.domain_images_url_prefix: /content/admin/images/domain
+    shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
     shopsys.domain_urls_config_filepath: '%kernel.root_dir%/config/domains_urls.yml'
     shopsys.error_pages_dir: '%shopsys.root_dir%/var/errorPages/'
     shopsys.feed_dir: '/web%shopsys.feed_url_prefix%'
-    shopsys.feed_url_prefix: /content/feeds/
+    shopsys.feed_url_prefix: '/%shopsys.content_dir_name%/feeds/'
     shopsys.filemanager_upload_dir: '%shopsys.web_dir%/%shopsys.filemanager_upload_web_dir%'
-    shopsys.filemanager_upload_web_dir: content/wysiwyg
+    shopsys.filemanager_upload_web_dir: '%shopsys.content_dir_name%/wysiwyg'
     shopsys.framework.root_dir: '%shopsys.root_dir%/vendor/shopsys/framework'
     shopsys.front_design_image_url_prefix: /assets/frontend/images/
     shopsys.image_config_filepath: '%shopsys.root_dir%/src/Shopsys/ShopBundle/Resources/config/images.yml'
     shopsys.image_dir: '/web%shopsys.image_url_prefix%'
-    shopsys.image_url_prefix: /content/images/
+    shopsys.image_url_prefix: '/%shopsys.content_dir_name%/images/'
     shopsys.javascript_sources_dir: '%shopsys.resources_dir%/scripts'
     shopsys.javascript_url_prefix: /assets/scripts/
     shopsys.log_stream: /tmp/log-pipe
     shopsys.resources_dir: '%shopsys.root_dir%/src/Shopsys/ShopBundle/Resources'
     shopsys.root_dir: '%kernel.root_dir%/..'
     shopsys.sitemaps_dir: '/web%shopsys.sitemaps_url_prefix%'
-    shopsys.sitemaps_url_prefix: /content/sitemaps
+    shopsys.sitemaps_url_prefix: '/%shopsys.content_dir_name%/sitemaps'
     shopsys.uploaded_file_config_filepath: '%shopsys.root_dir%/src/Shopsys/ShopBundle/Resources/config/uploaded_files.yml'
     shopsys.uploaded_file_dir: '/web%shopsys.uploaded_file_url_prefix%'
-    shopsys.uploaded_file_url_prefix: /content/uploadedFiles/
+    shopsys.uploaded_file_url_prefix: '/%shopsys.content_dir_name%/uploadedFiles/'
     shopsys.web_dir: '%shopsys.root_dir%/web'
     shopsys.vendor_dir: '%kernel.root_dir%/../vendor'
     shopsys.js_form_validator_output_vendor_dir: '../vendor'

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Shopsys Framework (dev)" default="build-demo-ci">
 
-    <target name="build-dev" depends="clean,composer-dev,npm,timezones-check,microservices-check,dirs-create,assets,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-diff" description="Builds application for development preserving your DB and runs checks on changed files."/>
-    <target name="build-dev-quick" depends="clean,composer-dev,npm,dirs-create,assets,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,grunt,tests-acceptance-build" description="Builds application for development preserving your DB while skipping nonessential steps."/>
-    <target name="build-demo-dev" depends="wipe-excluding-logs,composer-dev,npm,timezones-check,microservices-check,dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-diff" description="Builds application for development with clean demo DB and runs checks on changed files."/>
-    <target name="build-demo-dev-quick" depends="wipe-excluding-logs,composer-dev,npm,dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,tests-acceptance-build" description="Builds application for development with clean demo DB while skipping nonessential steps."/>
-    <target name="build-demo-ci" depends="wipe-excluding-logs,timezones-check,microservices-check,dirs-create,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,checks-ci" description="Builds application for development with clean demo DB and runs CI checks."/>
-    <target name="build-demo-ci-diff" depends="wipe-excluding-logs,timezones-check,microservices-check,dirs-create,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,checks-ci-diff" description="Builds application for development with clean demo DB and runs CI checks on changed files."/>
+    <target name="build-dev" depends="clean,composer-dev,npm,timezones-check,microservices-check,dirs-create,test-dirs-create,assets,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-diff" description="Builds application for development preserving your DB and runs checks on changed files."/>
+    <target name="build-dev-quick" depends="clean,composer-dev,npm,dirs-create,test-dirs-create,assets,db-migrations,create-domains-data,generate-friendly-urls,replace-domains-urls,grunt,tests-acceptance-build" description="Builds application for development preserving your DB while skipping nonessential steps."/>
+    <target name="build-demo-dev" depends="wipe-excluding-logs,composer-dev,npm,timezones-check,microservices-check,dirs-create,test-dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,checks-diff" description="Builds application for development with clean demo DB and runs checks on changed files."/>
+    <target name="build-demo-dev-quick" depends="wipe-excluding-logs,composer-dev,npm,dirs-create,test-dirs-create,assets,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,tests-acceptance-build" description="Builds application for development with clean demo DB while skipping nonessential steps."/>
+    <target name="build-demo-ci" depends="wipe-excluding-logs,timezones-check,microservices-check,dirs-create,test-dirs-create,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,checks-ci" description="Builds application for development with clean demo DB and runs CI checks."/>
+    <target name="build-demo-ci-diff" depends="wipe-excluding-logs,timezones-check,microservices-check,dirs-create,test-dirs-create,db-demo,microservice-product-search-recreate-structure,microservice-product-search-export-products,grunt,error-pages-generate,checks-ci-diff" description="Builds application for development with clean demo DB and runs CI checks on changed files."/>
 
     <target name="checks" depends="db-check-mapping,standards,tests" description="Checks ORM mapping, coding standards and runs unit, DB and smoke tests."/>
     <target name="checks-diff" depends="db-check-mapping,standards-diff,tests" description="Checks ORM mapping, coding standards on changed files and runs unit, DB and smoke tests."/>
@@ -660,6 +660,14 @@
             <arg value="${path.bin-console}" />
             <arg value="--env=test" />
             <arg value="shopsys:schema:create" />
+        </exec>
+    </target>
+
+    <target name="test-dirs-create" description="Creates application directories for content, images, uploaded files, etc. for test environment">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="--env=test" />
+            <arg value="shopsys:create-directories" />
         </exec>
     </target>
 

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -378,6 +378,9 @@
             <fileset dir="${path.web}/content/">
                 <exclude name="/" />
             </fileset>
+            <fileset dir="${path.web}/content-test/">
+                <exclude name="/" />
+            </fileset>
         </delete>
     </target>
 

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -37,7 +37,7 @@ server {
             try_files $uri @app;
         }
 
-        location ~ ^/content/images/ {
+        location ~ ^/content(-test)?/images/ {
             # Newly uploaded images get new ID (different URL) so they could be cached forever.
             # But change of resolution in images.yml does not induce a change of URL
             # so it is safer to cache generated images only for few days.

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -101,7 +101,7 @@ WORKDIR /source-code
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 
 # clean cache because of recreating valid autloading of vendor after /source-code is copied into /var/www/html
-RUN php phing composer-dev npm dirs-create assets standards tests-static tests-acceptance-build clean
+RUN php phing composer-dev npm dirs-create test-dirs-create assets standards tests-static tests-acceptance-build clean
 
 # switch back to the original workdir
 WORKDIR /var/www/html

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front.yml
@@ -57,13 +57,13 @@ front_homepage:
     defaults: { _controller: ShopsysShopBundle:Front\Homepage:index }
 
 front_image:
-    path: /content/images/{entityName}/{type}/{sizeName}/{imageId}.{extension}
+    path: /%shopsys.content_dir_name%/images/{entityName}/{type}/{sizeName}/{imageId}.{extension}
     defaults: { _controller: ShopsysShopBundle:Front\Image:getImage }
     requirements:
         imageId: \d+
 
 front_image_without_type:
-    path: /content/images/{entityName}/{sizeName}/{imageId}.{extension}
+    path: /%shopsys.content_dir_name%/images/{entityName}/{sizeName}/{imageId}.{extension}
     defaults:
         _controller: ShopsysShopBundle:Front\Image:getImage
         type: ~

--- a/project-base/web/.gitignore
+++ b/project-base/web/.gitignore
@@ -1,4 +1,5 @@
 /bundles
 /assetic
 /content
+/content-test
 /components


### PR DESCRIPTION
web/content-test/ directory is used instead of web/content/ during the tests

| Q             | A
| ------------- | ---
|Description, reason for the PR| We observed some strange behavior of the images after smoke tests are finished. Problem was caused because of overriding of content images during the tests or in test environment. This is solved with modification when web/content-test/ directory is used instead of web/content/ during the tests. Similar principle is used for database when shopsys-test database is used in test environment instead of shopsys database
|New feature| No
|BC breaks| No
|Fixes issues| #488 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
