### PR TITLE
[framework] added missing dependency on composer/composer

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -37,6 +37,7 @@
         "bmatzner/jquery-bundle": "^2.2.2",
         "bmatzner/jquery-ui-bundle": "^1.10.3",
         "commerceguys/intl": "0.7.4",
+        "composer/composer": "^1.6.0",
         "craue/formflow-bundle": "^3.0.3",
         "doctrine/common": "^2.8.1",
         "doctrine/annotations": "^1.6",


### PR DESCRIPTION
- the package provides Composer\Script\Event that is used in ComposerScriptHandler

| Q             | A
| ------------- | ---
|Description, reason for the PR| In #540, new `ComposerScriptHandler` was added in the framework, but the packge is not dependent on `composer/composer` (the dependency is defined in monorepo but not in the `framework` package)
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
