### PR TITLE
[project-base] php-fpm image has standard workdir (/var/www/html) in ci stage

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -65,6 +65,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - *(optional)* [#535 added .dockerignore files](https://github.com/shopsys/shopsys/pull/535)
     - to make your Docker image build faster, copy the `.dockerignore` file to the root of you project
     - if you're using Docker-sync, add the directories mentioned in the PR into `sync_exclude` section of your `docker-sync.yml` to make the synchronization faster as well
+- *(optional)* [#557 - php-fpm image has standard workdir (/var/www/html) in ci stage](https://github.com/shopsys/shopsys/pull/557)
+    - update your `docker/php-fpm/Dockerfile` and `kubernetes/deployments/webserver-php-fpm.yml` according to [the pull request](https://github.com/shopsys/shopsys/pull/557) to simplify the CI build
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -93,18 +93,11 @@ RUN php phing composer npm dirs-create assets
 
 FROM base as ci
 
-# copy all files in the context to /source-code and install Composer dependencies
-# the files will be copied inside a mounted volume in /var/www/html so it's available both in php-fpm and nginx container
-# see project-base/kubernetes/deployments/webserver-php-fpm.yml for details
-COPY --chown=www-data:www-data / /source-code
-WORKDIR /source-code
+COPY --chown=www-data:www-data / /var/www/html
+
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 
-# clean cache because of recreating valid autloading of vendor after /source-code is copied into /var/www/html
-RUN php phing composer-dev npm dirs-create test-dirs-create assets standards tests-static tests-acceptance-build clean
-
-# switch back to the original workdir
-WORKDIR /var/www/html
+RUN php phing composer-dev npm dirs-create test-dirs-create assets standards tests-static tests-acceptance-build
 
 ########################################################################################################################
 

--- a/project-base/kubernetes/deployments/webserver-php-fpm.yml
+++ b/project-base/kubernetes/deployments/webserver-php-fpm.yml
@@ -35,12 +35,12 @@ spec:
                         -   key: nginx.conf
                             path: default.conf
             initContainers:
-                -   name: copy-source-codes-to-application-folder
+                -   name: copy-source-codes-to-volume
                     image: $PHP_FPM_IMAGE
-                    command: ["sh", "-c", "cp -r /source-code/. /var/www/html"]
+                    command: ["sh", "-c", "cp -r /var/www/html/. /tmp/source-codes"]
                     volumeMounts:
                     -       name: source-codes
-                            mountPath: /var/www/html
+                            mountPath: /tmp/source-codes
             containers:
             -   image: $PHP_FPM_IMAGE
                 name: php-fpm


### PR DESCRIPTION
- this commit just removes an inconsistency between the stages
- previously, the workdir was set to /source-code, so it can be copied into a mounted volume in an init container in Kubernetes
- this can be also achieved by mounting the volume into different directory of the init container (/tmp/source-codes)
- in the final container, the same volume should be of course mounted to its final destination (/var/www/html)
- because the path is not changed, the autoload cache cleaning should not be necessary

| Q             | A
| ------------- | ---
|Description, reason for the PR| removal of a hacky solution
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes, but only for a CI stage <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
