### PR TITLE
[project-base] Missing standards check in CI build process

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,6 +59,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - remove all `depends_on` and `links` from your docker-compose files because they are unnecessary
 - [#538 - phing targets: create-domains-data is now dependent on create-domains-db-functions](https://github.com/shopsys/shopsys/pull/538)
     - modify your `build.xml` and `build-dev.xml` according to this pull request
+- [#558 - Missing standards check in CI build process #558](https://github.com/shopsys/shopsys/pull/558)
+    - the Dockerfile for `php-fpm` has changed for CI stage build, update your `docker/php-fpm/Dockerfile`
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -101,7 +101,7 @@ WORKDIR /source-code
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 
 # clean cache because of recreating valid autloading of vendor after /source-code is copied into /var/www/html
-RUN php phing composer-dev npm dirs-create assets tests-static tests-acceptance-build clean
+RUN php phing composer-dev npm dirs-create assets standards tests-static tests-acceptance-build clean
 
 # switch back to the original workdir
 WORKDIR /var/www/html


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|  After #545 merge, checking of standards vanished from CI build process. The phing target `standards` should be located in the Dockerfile as a part of the image build.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| -
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
