### PR TITLE
monorepo: tests-packages now include tests of coding-standards package

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -183,6 +183,10 @@
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="${path.microservices}/product-search-export/tests"/>
         </exec>
+        <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/coding-standards/phpunit.xml"/>
+        </exec>
     </target>
 
     <target name="dump-translations" depends="dump-translations-project-base, dump-translations-packages" description="Extracts translatable messages in all packages ." />

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   "autoload-dev": {
     "psr-4": {
       "Tests\\": "project-base/tests/",
+      "Tests\\CodingStandards\\": "packages/coding-standards/tests/",
       "Tests\\FrameworkBundle\\": "packages/framework/tests/",
       "Tests\\HttpSmokeTesting\\": "packages/http-smoke-testing/tests/",
       "Tests\\MigrationBundle\\": "packages/migrations/tests/",


### PR DESCRIPTION
- composer.json of monorepo now sets psr-4 autoload for packages/coding-standards/tests

| Q             | A
| ------------- | ---
|Description, reason for the PR| The phing target `tests-packages` does not include `coding-standards` package at all even though there are tests in the package :frowning_face: 
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
