### PR TITLE
[project-base] Set development docker build target before production and CI targets

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -116,6 +116,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
       as command `shopsys:fixtures:load` doesn't exist anymore and remove `--fixtures` argument
     - rename `db-fixtures-demo-singledomain` to `db-fixtures-demo`
     - rename `test-db-fixtures-demo-singledomain` to `test-db-fixtures-demo`
+- *(optional)* [#566 - Set development docker build target before production and CI targets](https://github.com/shopsys/shopsys/pull/566)
+    - move `development` stage build before `production` stage in `docker/php-fpm/Dockerfile` to make your dev build faster
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -118,6 +118,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - rename `test-db-fixtures-demo-singledomain` to `test-db-fixtures-demo`
 - *(optional)* [#566 - Set development docker build target before production and CI targets](https://github.com/shopsys/shopsys/pull/566)
     - move `development` stage build before `production` stage in `docker/php-fpm/Dockerfile` to make your dev build faster
+    - make the `www_data_uid` and `www_data_gid` arguments optional using an if condition (for building ci and production stage)
 
 ### [shopsys/shopsys]
 - *(MacOS only)* [#503 updated docker-sync configuration](https://github.com/shopsys/shopsys/pull/503/)

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -79,6 +79,23 @@ RUN composer global require hirak/prestissimo
 
 ########################################################################################################################
 
+FROM base as development
+
+USER root
+
+# allow overwriting UID and GID o the user "www-data" to help solve issues with permissions in mounted volumes
+# if the GID is already in use, we will assign GID 82 instead (82 is the standard uid/gid for "www-data" in Alpine)
+ARG www_data_uid
+ARG www_data_gid
+RUN deluser www-data && (addgroup -g $www_data_gid www-data || addgroup -g 82 www-data) && adduser -u $www_data_uid -D -S -G www-data www-data
+
+# as the UID and GID might have changed, change the ownership of the home directory workdir again
+RUN chown www-data:www-data -R /home/www-data && chown www-data:www-data /var/www/html
+
+USER www-data
+
+########################################################################################################################
+
 FROM base as production
 
 COPY --chown=www-data:www-data / /var/www/html
@@ -98,20 +115,3 @@ COPY --chown=www-data:www-data / /var/www/html
 RUN composer install --optimize-autoloader --no-interaction --no-progress
 
 RUN php phing composer-dev npm dirs-create test-dirs-create assets standards tests-static tests-acceptance-build
-
-########################################################################################################################
-
-FROM base as development
-
-USER root
-
-# allow overwriting UID and GID o the user "www-data" to help solve issues with permissions in mounted volumes
-# if the GID is already in use, we will assign GID 82 instead (82 is the standard uid/gid for "www-data" in Alpine)
-ARG www_data_uid
-ARG www_data_gid
-RUN deluser www-data && (addgroup -g $www_data_gid www-data || addgroup -g 82 www-data) && adduser -u $www_data_uid -D -S -G www-data www-data
-
-# as the UID and GID might have changed, change the ownership of the home directory workdir again
-RUN chown www-data:www-data -R /home/www-data && chown www-data:www-data /var/www/html
-
-USER www-data

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -87,7 +87,7 @@ USER root
 # if the GID is already in use, we will assign GID 82 instead (82 is the standard uid/gid for "www-data" in Alpine)
 ARG www_data_uid
 ARG www_data_gid
-RUN deluser www-data && (addgroup -g $www_data_gid www-data || addgroup -g 82 www-data) && adduser -u $www_data_uid -D -S -G www-data www-data
+RUN if [ -n "$www_data_uid" ]; then deluser www-data && (addgroup -g $www_data_gid www-data || addgroup -g 82 www-data) && adduser -u $www_data_uid -D -S -G www-data www-data; fi;
 
 # as the UID and GID might have changed, change the ownership of the home directory workdir again
 RUN chown www-data:www-data -R /home/www-data && chown www-data:www-data /var/www/html

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -90,7 +90,7 @@ ARG www_data_gid
 RUN if [ -n "$www_data_uid" ]; then deluser www-data && (addgroup -g $www_data_gid www-data || addgroup -g 82 www-data) && adduser -u $www_data_uid -D -S -G www-data www-data; fi;
 
 # as the UID and GID might have changed, change the ownership of the home directory workdir again
-RUN chown www-data:www-data -R /home/www-data && chown www-data:www-data /var/www/html
+RUN chown -R www-data:www-data /home/www-data /var/www/html
 
 USER www-data
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| current stable version of docker doesn't allow building targeted stage but it builds stages from top to bottom until targeted stage occurs, so we can speed up build for development target because development target do not need to build images with the source code because all the code is mounted as a volume.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| -
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
