### PR TITLE
[framework] Product creation: calculated availability is set additionally if necessary

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -51,6 +51,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 
 ## [From 7.0.0-beta2 to Unreleased]
 ### [shopsys/project-base]
+- `Shopsys\FrameworkBundle\Model\Product\ProductFacade::create()` and `Shopsys\FrameworkBundle\Model\Product\ProductFactory` were modified
+    - if you extended the classes in your project, please check out the changes in the framework ones (and the reasons for the changes) in [the pull request](https://github.com/shopsys/shopsys/pull/581/files)
 - *(optional)* [#540 domains URLs are auto-configured during "composer install"](https://github.com/shopsys/shopsys/pull/540)
     - to simplify installation, add `"Shopsys\\FrameworkBundle\\Command\\ComposerScriptHandler::postInstall"` to `post-install-cmd` and `"Shopsys\\FrameworkBundle\\Command\\ComposerScriptHandler::postUpdate"` to  `post-update-cmd` scripts in your `composer.json`
     - you will not have to copy the `domains_urls.yml.dist` during the installation anymore

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -226,12 +226,6 @@ class ProductFacade
     {
         $product = $this->productFactory->create($productData);
 
-        if ($product->isUsingStock()) {
-            $defaultInStockAvailability = $this->availabilityFacade->getDefaultInStockAvailability();
-            $product->setCalculatedAvailability($defaultInStockAvailability);
-            $product->markForAvailabilityRecalculation();
-        }
-
         $this->em->persist($product);
         $this->em->flush($product);
         $this->setAdditionalDataAfterCreate($product, $productData);


### PR DESCRIPTION
- `ProductFactory` is now responsible for setting calculated availability to the new product (if necessary)

| Q             | A
| ------------- | ---
|Description, reason for the PR| When a developer is trying to create the main variant from a product that has nullable availability, the null value is then propagated to `$calculatedAvailability` attribute of the new product. This is a problem as the property is not nullable - therefore application fails when trying to persist the new product. It was already (hot)fixed in `ProductFacade::create()` but not in `ProductVariantFacade::createVariant()`
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #189
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
