### PR TITLE
[project-base] fix folder sharing for production docker-compose

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,6 +57,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - you can also remove the now redundant Phing target `domains-urls-check` from your `build.xml` and `build-dev.xml`
 - *(optional)* [#428 Removed depends_on and links from docker-compose.yml files](https://github.com/shopsys/shopsys/pull/528)
     - remove all `depends_on` and `links` from your docker-compose files because they are unnecessary
+    - the only exception is the `webserver` container that should depend on `php-fpm` in the production configuration `docker-compose.prod.yml.dist`, otherwise a volume will not mount properly (see [PR #598](https://github.com/shopsys/shopsys/pull/598))
 - [#538 - phing targets: create-domains-data is now dependent on create-domains-db-functions](https://github.com/shopsys/shopsys/pull/538)
     - in your `build.xml`, make your `create-domains-data` task dependent on `create-domains-db-functions` task
     - in your `build-dev.xml`, make your `test-create-domains-data` task dependent on `test-create-domains-db-functions` task

--- a/project-base/docker/conf/docker-compose.prod.yml.dist
+++ b/project-base/docker/conf/docker-compose.prod.yml.dist
@@ -4,6 +4,8 @@ services:
         restart: always
         image: nginx:1.13-alpine
         container_name: production-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - /var/www/production-content:/var/www/html/web/content
             - web-volume:/var/www/html/web


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Volumes on production are not shared well. Webserver container mounts empty folders, but we need data from php-fpm container.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
