### PR TITLE
Fixing heading sizes in frontend

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/core/base.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/core/base.less
@@ -69,17 +69,40 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
     margin: 0 0 10px 0;
 
-    font-size: 20px;
+    font-size: 24px;
     font-weight: normal;
 
     @media @query-md {
-        font-size: 24px;
+        font-size: 28px;
     }
 
     @media @query-lg {
         margin-bottom: 15px;
 
-        font-size: 28px;
+        font-size: 32px;
+    }
+
+    @media @query-vl {
+        margin-bottom: 20px;
+
+        font-size: 36px;
+    }
+}
+
+h2 {
+    margin: 0 0 10px 0;
+
+    font-size: 23px;
+    font-weight: normal;
+
+    @media @query-md {
+        font-size: 25px;
+    }
+
+    @media @query-lg {
+        margin-bottom: 15px;
+
+        font-size: 27px;
     }
 
     @media @query-vl {
@@ -89,104 +112,93 @@ h1 {
     }
 }
 
-h2 {
+h3 {
     margin: 0 0 10px 0;
 
     font-size: 16px;
     font-weight: normal;
 
     @media @query-md {
-        font-size: 18px;
+        font-size: 19px;
     }
 
     @media @query-lg {
         margin-bottom: 15px;
 
-        font-size: 20px;
+        font-size: 21px;
     }
 
     @media @query-vl {
         margin-bottom: 20px;
 
-        font-size: 22px;
-    }
-}
-
-h3 {
-    margin: 0 0 10px 0;
-
-    font-size: 14px;
-    font-weight: normal;
-
-    @media @query-md {
-        font-size: 15px;
-    }
-
-    @media @query-lg {
-        margin-bottom: 15px;
-
-        font-size: 16px;
-    }
-
-    @media @query-vl {
-        margin-bottom: 20px;
-
-        font-size: 18px;
+        font-size: 24px;
     }
 }
 
 h4 {
     margin: 0 0 10px 0;
 
-    font-size: 10px;
+    font-size: 15px;
     font-weight: bold;
 
     @media @query-md {
-        font-size: 11px;
+        font-size: 17px;
     }
 
     @media @query-lg {
         margin-bottom: 15px;
 
-        font-size: 12px;
+        font-size: 18px;
     }
 
     @media @query-vl {
         margin-bottom: 20px;
 
-        font-size: 14px;
+        font-size: 21px;
     }
 }
 
 h5 {
     margin: 0 0 10px 0;
 
-    font-size: 9px;
+    font-size: 11px;
     text-transform: uppercase;
     font-weight: bold;
 
     @media @query-md {
-        font-size: 10px;
+        font-size: 12px;
     }
 
     @media @query-lg {
         margin-bottom: 15px;
 
-        font-size: 11px;
+        font-size: 14px;
     }
 
     @media @query-vl {
         margin-bottom: 20px;
 
-        font-size: 12px;
+        font-size: 16px;
     }
 }
 
 h6 {
     margin: 0 0 10px 0;
 
-    font-size: 12px;
+    font-size: @font-size-mobile-xs;
     font-weight: bold;
+
+    @media @query-md {
+        font-size: @font-size-mobile;
+    }
+
+    @media @query-lg {
+        font-size: @font-size-tablet;
+    }
+
+    @media @query-vl {
+        font-size: @font-size;
+    }
 }
 
 a {

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/core/variables.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/core/variables.less
@@ -10,7 +10,9 @@
 @font: @font-base;
 
 @font-size: 14px;
-@font-size-mobile: 12px;
+@font-size-tablet: 12px;
+@font-size-mobile: 11px;
+@font-size-mobile-xs: 10px;
 
 // Layout
 @web-width: 1200px;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| Title headings of heading level 4 - 6 (h5 - h6 HTML element) are has title sizes smaller than regular text (p HTML element) size. This pull request is fixing that.
|New feature| No
|BC breaks| No
|Fixes issues| closes #148 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
