### PR TITLE
[framework] admin menu: fixing visibility of Operator information…

### DIFF
--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -214,12 +214,12 @@ class SideMenuBuilder
         $menu = $this->menuFactory->createItem('settings', ['label' => t('Settings')]);
         $menu->setExtra('icon', 'gear');
 
+        $identificationMenu = $menu->addChild('identification', ['label' => t('E-shop identification')]);
         if ($this->domain->isMultidomain()) {
-            $identificationMenu = $menu->addChild('identification', ['label' => t('E-shop identification')]);
             $domainsMenu = $identificationMenu->addChild('domains', ['route' => 'admin_domain_list', 'label' => t('E-shop identification')]);
             $domainsMenu->addChild('edit', ['route' => 'admin_domain_edit', 'label' => t('Editing domain'), 'display' => false]);
-            $identificationMenu->addChild('shop_info', ['route' => 'admin_shopinfo_setting', 'label' => t('Operator information')]);
         }
+        $identificationMenu->addChild('shop_info', ['route' => 'admin_shopinfo_setting', 'label' => t('Operator information')]);
 
         $legalMenu = $menu->addChild('legal', ['label' => t('Legal conditions')]);
         $legalMenu->addChild('legal_conditions', ['route' => 'admin_legalconditions_setting', 'label' => t('Legal conditions')]);


### PR DESCRIPTION
…on a single-domain project

On single-domain project, the menu now looks like this:
![image](https://user-images.githubusercontent.com/10008612/48605028-e0689680-e97b-11e8-922a-8c6457039287.png)


| Q             | A
| ------------- | ---
|Description, reason for the PR| See https://github.com/shopsys/shopsys/issues/599#issuecomment-439306101 for explanation when was the issue introduced.<br>It was before the menu was reimplemented from `admin_menu.yml` to `SideMenuBuilder` in #335.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #599 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
