### PR TITLE
[shopsys] Stale bot for GitHub issues delayed

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 120
 
 # Number of days of inactivity (after marked as Stale) before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 90
+daysUntilClose: 60
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
@@ -24,14 +24,13 @@ staleLabel: Stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-    This issue has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for your contributions.
+    This issue has been automatically marked as stale because there was no acitivity within the last 4 months (and it is quite a long time).
+    It will be closed if no further activity occurs.
+    Thank you for your contributions.
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-    This issue has been automatically closed because it has not had
-    recent activity for a long time.
+    This issue has been automatically closed because there was no acivity within the last half a year.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Stalebot closed issues after short period of time. Time for marked as stale prolonged to 4 months and time to close was reduced to 2 months. Stalebot messages updated.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| 
|Standards and tests pass| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
