### PR TITLE
[shopsys] ProductOnCurrentDomainFacade: rename getPaginatedProductDetails* methods

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -58,6 +58,10 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - the last parameter is no longer `bool`, but `integer` - domain ID
 
 ### [shopsys/project-base]
+- change usages of the renamed methods of `ProductOnCurrentDomainFacade`:
+    - from `getPaginatedProductDetailsInCategory` to `getPaginatedProductsInCategory`
+    - from `getPaginatedProductDetailsForBrand` to `getPaginatedProductsForBrand`
+    - from `getPaginatedProductDetailsForSearch` to `getPaginatedProductsForSearch`
 - *(optional)* [#592 phpunit: remove unsupported syntaxCheck attribute](https://github.com/shopsys/shopsys/pull/592)
     - remove unsupported `syntaxCheck` attribute from your `phpunit.xml` configuration file
 - `Shopsys\FrameworkBundle\Model\Product\ProductFacade::create()` and `Shopsys\FrameworkBundle\Model\Product\ProductFactory` were modified

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -124,7 +124,7 @@ class ProductOnCurrentDomainFacade
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductDetailsInCategory(
+    public function getPaginatedProductsInCategory(
         ProductFilterData $productFilterData,
         $orderingModeId,
         $page,
@@ -160,7 +160,7 @@ class ProductOnCurrentDomainFacade
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductDetailsForBrand(
+    public function getPaginatedProductsForBrand(
         $orderingModeId,
         $page,
         $limit,
@@ -195,7 +195,7 @@ class ProductOnCurrentDomainFacade
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductDetailsForSearch(
+    public function getPaginatedProductsForSearch(
         $searchText,
         ProductFilterData $productFilterData,
         $orderingModeId,

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -159,7 +159,7 @@ class ProductController extends FrontBaseController
         ]);
         $filterForm->handleRequest($request);
 
-        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductDetailsInCategory(
+        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsInCategory(
             $productFilterData,
             $orderingModeId,
             $page,
@@ -209,7 +209,7 @@ class ProductController extends FrontBaseController
             $request
         );
 
-        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductDetailsForBrand(
+        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForBrand(
             $orderingModeId,
             $page,
             self::PRODUCTS_PER_PAGE,
@@ -255,7 +255,7 @@ class ProductController extends FrontBaseController
         ]);
         $filterForm->handleRequest($request);
 
-        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductDetailsForSearch(
+        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForSearch(
             $searchText,
             $productFilterData,
             $orderingModeId,

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -206,7 +206,7 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
         $page = 1;
         $limit = PHP_INT_MAX;
 
-        return $productOnCurrentDomainFacade->getPaginatedProductDetailsInCategory(
+        return $productOnCurrentDomainFacade->getPaginatedProductsInCategory(
             $productFilterData,
             ProductListOrderingModeService::ORDER_BY_NAME_ASC,
             $page,


### PR DESCRIPTION
Created because of feedback from @Miroslav-Stopka.

I could've keep the original methods annotated with `@deprecated` and triggering an `E_USER_DEPRECATED` error and calling the new method. This would avoid the BC break, but I'm not sure if we wanna do that during beta releases.

| Q             | A
| ------------- | ---
|Description, reason for the PR| `ProductDetail` class was removed along with the whole concept of `*Detail` classes during #276, the method names should reflect that for clarity.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes/No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
