### PR TITLE
[framework] remove redundant PaginationResult instantiation

### DIFF
--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
 use Shopsys\FrameworkBundle\Model\Category\CategoryRepository;
 use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository;

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -133,7 +133,7 @@ class ProductOnCurrentDomainFacade
     ) {
         $category = $this->categoryRepository->getById($categoryId);
 
-        $paginationResult = $this->productRepository->getPaginationResultForListableInCategory(
+        return $this->productRepository->getPaginationResultForListableInCategory(
             $category,
             $this->domain->getId(),
             $this->domain->getLocale(),
@@ -142,14 +142,6 @@ class ProductOnCurrentDomainFacade
             $this->currentCustomer->getPricingGroup(),
             $page,
             $limit
-        );
-        $products = $paginationResult->getResults();
-
-        return new PaginationResult(
-            $paginationResult->getPage(),
-            $paginationResult->getPageSize(),
-            $paginationResult->getTotalCount(),
-            $products
         );
     }
 
@@ -168,7 +160,7 @@ class ProductOnCurrentDomainFacade
     ) {
         $brand = $this->brandRepository->getById($brandId);
 
-        $paginationResult = $this->productRepository->getPaginationResultForListableForBrand(
+        return $this->productRepository->getPaginationResultForListableForBrand(
             $brand,
             $this->domain->getId(),
             $this->domain->getLocale(),
@@ -176,14 +168,6 @@ class ProductOnCurrentDomainFacade
             $this->currentCustomer->getPricingGroup(),
             $page,
             $limit
-        );
-        $products = $paginationResult->getResults();
-
-        return new PaginationResult(
-            $paginationResult->getPage(),
-            $paginationResult->getPageSize(),
-            $paginationResult->getTotalCount(),
-            $products
         );
     }
 
@@ -202,7 +186,7 @@ class ProductOnCurrentDomainFacade
         $page,
         $limit
     ) {
-        $paginationResult = $this->productRepository->getPaginationResultForSearchListable(
+        return $this->productRepository->getPaginationResultForSearchListable(
             $searchText,
             $this->domain->getId(),
             $this->domain->getLocale(),
@@ -211,14 +195,6 @@ class ProductOnCurrentDomainFacade
             $this->currentCustomer->getPricingGroup(),
             $page,
             $limit
-        );
-        $products = $paginationResult->getResults();
-
-        return new PaginationResult(
-            $paginationResult->getPage(),
-            $paginationResult->getPageSize(),
-            $paginationResult->getTotalCount(),
-            $products
         );
     }
 


### PR DESCRIPTION
Created because of feedback from @Miroslav-Stopka.

Created as a separate PR from #610 as this change is backward compatible.

| Q             | A
| ------------- | ---
|Description, reason for the PR| Historically, the reinstantiation was used to convert instances of `Product` to `ProductDetails`, but the concept of `*Detail` classes was removed in #276 (more specifically in 88972833fb0c9e87db14267fcbf29c185b3e0093). There is no need for this and and it just confuses people.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
