### PR TITLE
[shopsys] ProductOnCurrentDomainFacade: rename getPaginatedProductDetails* methods

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -36,6 +36,10 @@ There you can find links to upgrade notes for other versions too.
 - *(optional)* display svg icons collection correctly in grunt generated document for all browsers ([#645](https://github.com/shopsys/shopsys/pull/645))
     - add [`src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html`](https://github.com/shopsys/shopsys/pull/645/files#diff-2fa69709c5ba35cd2ad6c5de640d56f9) file from GitHub
     - update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in [pull request #645](https://github.com/shopsys/shopsys/pull/645/files#diff-ff210e4f423be8bd6c88818d2bb2a8cd)
+- change usages of the renamed methods of `ProductOnCurrentDomainFacade` ([#610](https://github.com/shopsys/shopsys/pull/610))
+    - from `getPaginatedProductDetailsInCategory` to `getPaginatedProductsInCategory`
+    - from `getPaginatedProductDetailsForBrand` to `getPaginatedProductsForBrand`
+    - from `getPaginatedProductDetailsForSearch` to `getPaginatedProductsForSearch`
 
 ## [shopsys/migrations]
 - `GenerateMigrationsService` class was renamed to `MigrationsGenerator`, so change it's usage appropriately ([#627](https://github.com/shopsys/shopsys/pull/627))

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -123,7 +123,7 @@ class ProductOnCurrentDomainFacade
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductDetailsInCategory(
+    public function getPaginatedProductsInCategory(
         ProductFilterData $productFilterData,
         $orderingModeId,
         $page,
@@ -151,7 +151,7 @@ class ProductOnCurrentDomainFacade
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductDetailsForBrand(
+    public function getPaginatedProductsForBrand(
         $orderingModeId,
         $page,
         $limit,
@@ -178,7 +178,7 @@ class ProductOnCurrentDomainFacade
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductDetailsForSearch(
+    public function getPaginatedProductsForSearch(
         $searchText,
         ProductFilterData $productFilterData,
         $orderingModeId,

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -159,7 +159,7 @@ class ProductController extends FrontBaseController
         ]);
         $filterForm->handleRequest($request);
 
-        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductDetailsInCategory(
+        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsInCategory(
             $productFilterData,
             $orderingModeId,
             $page,
@@ -209,7 +209,7 @@ class ProductController extends FrontBaseController
             $request
         );
 
-        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductDetailsForBrand(
+        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForBrand(
             $orderingModeId,
             $page,
             self::PRODUCTS_PER_PAGE,
@@ -255,7 +255,7 @@ class ProductController extends FrontBaseController
         ]);
         $filterForm->handleRequest($request);
 
-        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductDetailsForSearch(
+        $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForSearch(
             $searchText,
             $productFilterData,
             $orderingModeId,

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -206,7 +206,7 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
         $page = 1;
         $limit = PHP_INT_MAX;
 
-        return $productOnCurrentDomainFacade->getPaginatedProductDetailsInCategory(
+        return $productOnCurrentDomainFacade->getPaginatedProductsInCategory(
             $productFilterData,
             ProductListOrderingConfig::ORDER_BY_NAME_ASC,
             $page,


### PR DESCRIPTION
Created because of feedback from @Miroslav-Stopka.

I could've kept the original methods annotated with `@deprecated`, triggered an `E_USER_DEPRECATED` error and called the new method. This would avoid the BC break, but I'm not sure if we wanna do that during beta releases.

| Q             | A
| ------------- | ---
|Description, reason for the PR| `ProductDetail` class was removed along with the whole concept of `*Detail` classes during #276, the method names should reflect that for clarity.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
