### PR TITLE
restart smtp server after crash on production

### DIFF
--- a/project-base/docker/conf/docker-compose.prod.yml.dist
+++ b/project-base/docker/conf/docker-compose.prod.yml.dist
@@ -46,6 +46,7 @@ services:
             - shopsys-network
 
     smtp-server:
+        restart: always
         image: namshi/smtp:latest
         container_name: shopsys-framework-smtp-server
         networks:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| SMTP server should be restarted after crash on production server
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
