### PR TITLE
[shopsys] generate error pages in restart_kubernetes.sh

### DIFF
--- a/.ci/restart_kubernetes.sh
+++ b/.ci/restart_kubernetes.sh
@@ -25,4 +25,4 @@ kubectl rollout status --namespace=${JOB_NAME} deployment/microservice-product-s
 PHP_FPM_POD=$(kubectl get pods -n ${JOB_NAME} -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
 
 # Run phing build in the pod
-kubectl exec --namespace=${JOB_NAME} ${PHP_FPM_POD} ./phing db-create test-db-create build-demo-dev-quick
+kubectl exec --namespace=${JOB_NAME} ${PHP_FPM_POD} ./phing db-create test-db-create error-pages-generate build-demo-dev-quick

--- a/.ci/restart_kubernetes.sh
+++ b/.ci/restart_kubernetes.sh
@@ -25,4 +25,4 @@ kubectl rollout status --namespace=${JOB_NAME} deployment/microservice-product-s
 PHP_FPM_POD=$(kubectl get pods -n ${JOB_NAME} -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
 
 # Run phing build in the pod
-kubectl exec --namespace=${JOB_NAME} ${PHP_FPM_POD} ./phing db-create test-db-create error-pages-generate build-demo-dev-quick
+kubectl exec --namespace=${JOB_NAME} ${PHP_FPM_POD} ./phing db-create test-db-create build-demo-dev-quick error-pages-generate 


### PR DESCRIPTION
- the error pages are not a part of neither the built Docker images nor build-demo-dev-quick target
- generation takes just 2-4 s so it doesn't delay the task

| Q             | A
| ------------- | ---
|Description, reason for the PR| Application does not handle errors correctly when restarted on CI using .ci/restart_kubernetes.sh
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
