### PR TITLE
[shopsys] form-extension.md: fix formatting of headings (nbsp issue)

### DIFF
--- a/docs/wip_glassbox/form-extension.md
+++ b/docs/wip_glassbox/form-extension.md
@@ -39,7 +39,7 @@ If there is no customer set, `unregistered customer` text will be displayed inst
 Sometimes form needs to only display information but does not need to change and persist this data, for this usages
 there is `DisplayOnlyType` which does not map property onto `entity` and let you to display your own data.
 
-### [DisplayOnlyUrlType](../../packages/framework/src/Form/DisplayOnlyUrlType.php)
+### [DisplayOnlyUrlType](../../packages/framework/src/Form/DisplayOnlyUrlType.php)
 For displaying custom URL based on routing system, there can be used `DisplayOnlyUrlType`.
 
 ### [LocalizedFullWidthType](../../packages/framework/src/Form/LocalizedFullWidthType.php)
@@ -48,7 +48,7 @@ For displaying localized field in vertical order of full-width label and inputs,
 ### [OrderItemsType](../../packages/framework/src/Form/OrderItemsType.php)
 Displays editable table of OrderItems from provided Order.
 
-### [WarningMessageType](../../packages/framework/src/Form/WarningMessageType.php)
+### [WarningMessageType](../../packages/framework/src/Form/WarningMessageType.php)
 Sometimes the form needs to contain some information that is important for viewer, for this usage there is  `WarningMessageType`
 that shows highlighted message with warning icon.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| non-breakable spaces (0xc2a0) were used instead of regular spaces (0x20) thus breaking the formatting<br>*(introduced in 4f3ed87fd4a78a74ce2298cb74bb6da195393c37 and b7b3fd874c9c69753ba1712460721fee48d0c1d7)*
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Before:**
![image](https://user-images.githubusercontent.com/10008612/48886574-c2dc7680-ee2c-11e8-9292-5b24b23ba20c.png)

---

**After:**
![image](https://user-images.githubusercontent.com/10008612/48886667-16e75b00-ee2d-11e8-9aac-9709448d2843.png)

---

*Check the question [How to disable non-breaking space with altgr+space](https://stackoverflow.com/questions/31383074/how-to-disable-non-breaking-space-with-altgrspace) on StackOverflow to see how to stop introducing 0xc2a0 to the repo by accident.*