### PR TITLE
[framework] selectboxes rollout problem for dev env

### DIFF
--- a/packages/framework/src/Resources/scripts/admin/components/autocompleteSelectbox.js
+++ b/packages/framework/src/Resources/scripts/admin/components/autocompleteSelectbox.js
@@ -6,7 +6,7 @@
     Selectize.prototype.positionDropdown = function () {
         var $control = this.$control;
         var offset = this.settings.dropdownParent === 'body' ? $control.offset() : $control.position();
-        var bottomOffset = $('.js-window-fixed-bar').height() || 0;
+        var bottomOffset = Shopsys.view.getBottomOffset();
         offset.top += $control.outerHeight(true);
 
         var css = {

--- a/packages/framework/src/Resources/scripts/admin/components/view.js
+++ b/packages/framework/src/Resources/scripts/admin/components/view.js
@@ -1,0 +1,13 @@
+(function ($) {
+
+    Shopsys = Shopsys || {};
+    Shopsys.view = Shopsys.view || {};
+
+    Shopsys.view.getBottomOffset = function () {
+        var windowFixedBarHeight = $('.js-window-fixed-bar').height() || 0;
+        var symfonyBarHeight = $('.sf-toolbar').height() || 0;
+
+        return windowFixedBarHeight + symfonyBarHeight;
+    };
+
+})(jQuery);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in some cases in admin forms when dev env is enabled selectboxes are scrolled under bottom box and last option is hidden for user.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolve #604 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
