### PR TITLE
remove symfony/flex from microservices

### DIFF
--- a/microservices/product-search-export/composer.json
+++ b/microservices/product-search-export/composer.json
@@ -8,7 +8,6 @@
         "ext-iconv": "*",
         "elasticsearch/elasticsearch": "^6.0.1",
         "symfony/console": "^4.1",
-        "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^4.1",
         "symfony/lts": "^4@dev",
         "symfony/monolog-bundle": "^3.3",

--- a/microservices/product-search/composer.json
+++ b/microservices/product-search/composer.json
@@ -8,7 +8,6 @@
         "ext-iconv": "*",
         "elasticsearch/elasticsearch": "^6.0.1",
         "symfony/console": "^4.1",
-        "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^4.1",
         "symfony/lts": "^4@dev",
         "symfony/monolog-bundle": "^3.3",


### PR DESCRIPTION
- we are not developing them at the moment so the flex is not needed
- prevents microservices from repeated Flex installation, solves #450

| Q             | A
| ------------- | ---
|Description, reason for the PR| `microservice-product-search-export` - [build on Travis](https://travis-ci.org/shopsys/microservice-product-search-export/jobs/455425565) fails - as a result to missing (gitignored) `/symofny.lock` file, Symfony flex creates `.tests/bootstrap.php` file that does not pass our coding standards. `microservice-product-search` might have the same problem but the package is not added to Travis.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #450 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
