### PR TITLE
[microservice-product-search-export] fixed search in EAN, partno, catnum

### DIFF
--- a/docs/introduction/product-search-via-elasticsearch.md
+++ b/docs/introduction/product-search-via-elasticsearch.md
@@ -53,9 +53,9 @@ But if we simplify, we can say that the search term is searched in attributes an
 * partno - exact match
 * name - match in first couple of letters of any word
 * name - match in first couple of letters of any word ignoring diacritics
-* ean - match in first couple of letters
-* catnum - match in first couple of letters
-* partno - match in first couple of letters
+* ean - exact match in first characters
+* catnum - exact match in first characters
+* partno - exact match in first characters
 * short description - match anywhere
 * description - match anywhere
 

--- a/microservices/product-search-export/src/Resources/definition/1.json
+++ b/microservices/product-search-export/src/Resources/definition/1.json
@@ -113,7 +113,8 @@
           "fields": {
             "edge_ngram": {
               "type": "text",
-              "analyzer": "edge_ngram_unanalyzed"
+              "analyzer": "edge_ngram_unanalyzed",
+              "search_analyzer": "keyword"
             }
           }
         },
@@ -123,7 +124,8 @@
           "fields": {
             "edge_ngram": {
               "type": "text",
-              "analyzer": "edge_ngram_unanalyzed"
+              "analyzer": "edge_ngram_unanalyzed",
+              "search_analyzer": "keyword"
             }
           }
         },
@@ -133,7 +135,8 @@
           "fields": {
             "edge_ngram": {
               "type": "text",
-              "analyzer": "edge_ngram_unanalyzed"
+              "analyzer": "edge_ngram_unanalyzed",
+              "search_analyzer": "keyword"
             }
           }
         },

--- a/microservices/product-search-export/src/Resources/definition/2.json
+++ b/microservices/product-search-export/src/Resources/definition/2.json
@@ -113,7 +113,8 @@
           "fields": {
             "edge_ngram": {
               "type": "text",
-              "analyzer": "edge_ngram_unanalyzed"
+              "analyzer": "edge_ngram_unanalyzed",
+              "search_analyzer": "keyword"
             }
           }
         },
@@ -123,7 +124,8 @@
           "fields": {
             "edge_ngram": {
               "type": "text",
-              "analyzer": "edge_ngram_unanalyzed"
+              "analyzer": "edge_ngram_unanalyzed",
+              "search_analyzer": "keyword"
             }
           }
         },
@@ -133,7 +135,8 @@
           "fields": {
             "edge_ngram": {
               "type": "text",
-              "analyzer": "edge_ngram_unanalyzed"
+              "analyzer": "edge_ngram_unanalyzed",
+              "search_analyzer": "keyword"
             }
           }
         },


### PR DESCRIPTION
You'll need to recreate the structure in Elasticsearch and export the products for the change to take place in production environment (otherwise the issue described in #398 will still occur):
```sh
# execute it in the php-fpm container when using Docker
php phing microservice-product-search-recreate-structure \
          microservice-product-search-export-products
```

| Q             | A
| ------------- | ---
|Description, reason for the PR| #398
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #398
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
