### PR TITLE
[framework] FormGroup: unused option "is_group_container_to_render_as_the_last_one" removed

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -50,6 +50,10 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 * [shopsys/microservice-product-search-export]
 
 ## [From v7.0.0-beta4 to Unreleased]
+### [shopsys/framework]
+- stop providing the option `is_group_container_to_render_as_the_last_one` to the `FormGroup` in your forms, the option was removed
+    - the separators are rendered automatically since [PR #619](https://github.com/shopsys/shopsys/pull/619) was merged and the option hasn't been used anymore
+
 ### [shopsys/project-base]
 - *(optional)* [#596 Trusted proxies are now configurable in parameters.yml file](https://github.com/shopsys/shopsys/pull/596)
     - for easier deployment to production, make the trusted proxies in `Shopsys\Boostrap` class loaded from DIC parameter `trusted_proxies` instead of being hard-coded

--- a/docs/wip_glassbox/form-extension.md
+++ b/docs/wip_glassbox/form-extension.md
@@ -27,10 +27,6 @@ styled `div` wrap.
 Label is used for displaying heading of section for example in `CustomerFormType` all user data like name, last name or
 email address are all in section with label 'Personal Data'
 
-#### `is_group_container_to_render_as_the_last_one`
-Right now we need to tell form type which GroupType is the last one to render form correctly, just remember to add this
-option if it is last group of fields.
-
 ### [DisplayOnlyCustomerType](../../packages/framework/src/Form/DisplayOnlyCustomerType.php)
 Displays name of a registered customer along with a link to his/her detail.
 If there is no customer set, `unregistered customer` text will be displayed instead.

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
@@ -37,7 +37,6 @@ class PluginCrudExtensionFacade
         foreach ($crudExtensions as $key => $crudExtension) {
             $builderExtensionGroup = $builder->create($key . 'Group', GroupType::class, [
                 'label' => $crudExtension->getFormLabel(),
-                'is_group_container_to_render_as_the_last_one' => end($crudExtensions) === $crudExtension,
             ]);
 
             $builderExtensionGroup->add($key, $crudExtension->getFormTypeClass(), [

--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -110,7 +110,6 @@ class ArticleFormType extends AbstractType
 
         $builderSeoData = $builder->create('seo', GroupType::class, [
             'label' => t('SEO'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
 
         $builderSeoData

--- a/packages/framework/src/Form/Admin/CustomerCommunication/CustomerCommunicationFormType.php
+++ b/packages/framework/src/Form/Admin/CustomerCommunication/CustomerCommunicationFormType.php
@@ -18,7 +18,6 @@ class CustomerCommunicationFormType extends AbstractType
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
             'label' => t('Settings'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
 
         $builderSettingsGroup

--- a/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
+++ b/packages/framework/src/Form/Admin/Heureka/HeurekaShopCertificationFormType.php
@@ -21,7 +21,6 @@ class HeurekaShopCertificationFormType extends AbstractType
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
             'label' => t('Settings'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
 
         $builderSettingsGroup

--- a/packages/framework/src/Form/Admin/LegalConditions/LegalConditionsSettingFormType.php
+++ b/packages/framework/src/Form/Admin/LegalConditions/LegalConditionsSettingFormType.php
@@ -35,7 +35,6 @@ class LegalConditionsSettingFormType extends AbstractType
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
             'label' => t('Settings'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
 
         $builderSettingsGroup

--- a/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
@@ -22,7 +22,6 @@ class MailSettingFormType extends AbstractType
     {
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
             'label' => t('Settings'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
 
         $builderSettingsGroup

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -167,7 +167,6 @@ class PaymentFormType extends AbstractType
 
         $builderPriceGroup = $builder->create('prices', GroupType::class, [
             'label' => t('Prices'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
         $builderPriceGroup
             ->add('pricesByCurrencyId', PriceTableType::class, [

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -149,7 +149,6 @@ class BrandFormType extends AbstractType
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
             'label' => t('Image'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
         $builderImageGroup
             ->add('image', ImageUploadType::class, [

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -511,7 +511,6 @@ class ProductFormType extends AbstractType
         $builderStockGroup = $builder->create('stockGroup', FormType::class, [
             'render_form_row' => false,
             'inherit_data' => true,
-            'is_group_container_to_render_as_the_last_one' => false,
             'attr' => [
                 'class' => 'js-product-using-stock form-line__js',
             ],
@@ -835,7 +834,6 @@ class ProductFormType extends AbstractType
     {
         $builderParametersGroup = $builder->create('parametersGroup', GroupType::class, [
             'label' => t('Parameters'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
 
         $builderParametersGroup

--- a/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Seo/SeoSettingFormType.php
@@ -56,7 +56,6 @@ class SeoSettingFormType extends AbstractType
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [
             'required' => false,
-            'is_group_container_to_render_as_the_last_one' => true,
             'label' => t('Settings'),
         ]);
 

--- a/packages/framework/src/Form/Admin/ShopInfo/ShopInfoSettingFormType.php
+++ b/packages/framework/src/Form/Admin/ShopInfo/ShopInfoSettingFormType.php
@@ -18,7 +18,6 @@ class ShopInfoSettingFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builderPublishedDataGroup = $builder->create('publishedData', GroupType::class, [
-            'is_group_container_to_render_as_the_last_one' => true,
             'label' => t('Published data'),
         ]);
 

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -89,7 +89,6 @@ class SliderItemFormType extends AbstractType
             ]);
 
         $builderImageGroup = $builder->create('image', GroupType::class, [
-            'is_group_container_to_render_as_the_last_one' => true,
             'label' => t('Image'),
         ]);
 

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -164,7 +164,6 @@ class TransportFormType extends AbstractType
 
         $builderPricesGroup = $builder->create('prices', GroupType::class, [
             'label' => t('Prices'),
-            'is_group_container_to_render_as_the_last_one' => true,
         ]);
         $builderPricesGroup
             ->add('pricesByCurrencyId', PriceTableType::class, [

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -25,7 +25,6 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
         $view->vars['display_format'] = $options['display_format'];
         $view->vars['js_container'] = $options['js_container'];
         $view->vars['is_plugin_data_group'] = $options['is_plugin_data_group'];
-        $view->vars['is_group_container_to_render_as_the_last_one'] = $options['is_group_container_to_render_as_the_last_one'];
         $view->vars['render_form_row'] = $options['render_form_row'];
     }
 
@@ -40,7 +39,6 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
             'display_format' => null,
             'js_container' => null,
             'is_plugin_data_group' => false,
-            'is_group_container_to_render_as_the_last_one' => false,
             'render_form_row' => true,
         ]);
     }

--- a/packages/framework/src/Form/GroupType.php
+++ b/packages/framework/src/Form/GroupType.php
@@ -16,7 +16,6 @@ class GroupType extends AbstractType
             ->setAllowedTypes('label', 'string')
             ->setDefaults([
                 'inherit_data' => true,
-                'is_group_container_to_render_as_the_last_one' => false,
             ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the separators are rendered automatically since #619 was merged and the option hasn't been used anymore
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes, but simple to upgrade <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
