### PR TITLE
[framework] JsFormValidatorFactory: make sure prototype's parent is set in CollectionType

### DIFF
--- a/packages/framework/src/Form/JsFormValidatorFactory.php
+++ b/packages/framework/src/Form/JsFormValidatorFactory.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Form;
 use Fp\JsFormValidatorBundle\Factory\JsFormValidatorFactory as BaseJsFormValidatorFactory;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Validator\Constraints;
 
@@ -63,5 +64,20 @@ class JsFormValidatorFactory extends BaseJsFormValidatorFactory
         }
 
         return $viewTransformers;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\Form $form
+     * @return \Fp\JsFormValidatorBundle\Model\JsFormElement|null
+     */
+    public function createJsModel(Form $form)
+    {
+        /** @var \Symfony\Component\Form\Form|null $prototype */
+        $prototype = $form->getConfig()->getAttribute('prototype');
+        if ($prototype !== null && $prototype->getParent() === null) {
+            $prototype->setParent($form);
+        }
+
+        return parent::createJsModel($form);
     }
 }

--- a/packages/framework/src/Resources/scripts/common/validation/customizeBundle.js
+++ b/packages/framework/src/Resources/scripts/common/validation/customizeBundle.js
@@ -5,7 +5,9 @@
 
     Shopsys.validation.addNewItemToCollection = function (collectionSelector, itemIndex) {
         $($(collectionSelector)).jsFormValidator('addPrototype', itemIndex);
-        Shopsys.formChangeInfo.showInfo();
+        if (Shopsys.formChangeInfo !== undefined) {
+            Shopsys.formChangeInfo.showInfo();
+        }
     };
 
     Shopsys.validation.removeItemFromCollection = function (collectionSelector, itemIndex) {
@@ -16,7 +18,9 @@
         $($collection).jsFormValidator('delPrototype', itemIndex);
         Shopsys.validation.highlightSubmitButtons($collection.closest('form'));
         $collection.jsFormValidator('validate');
-        Shopsys.formChangeInfo.showInfo();
+        if (Shopsys.formChangeInfo !== undefined) {
+            Shopsys.formChangeInfo.showInfo();
+        }
     };
 
     Shopsys.validation.isFormValid = function (form) {


### PR DESCRIPTION
- thanks to @pk16011990 for this fix
- the parent was missing in collections with `allow_add=true` inside `FormFlow`, causing error in the JS validation of newly added fields
- `FormFlow` creates more form instances (eg. because of multiple calls to `Form::submit()` for restoring form data from session in `OrderFlow`)
- `CollectionType` sets parent to prototype in `buildView()` (`buildForm()` creates the prototype, but parent is unknown yet as there is no instance of `Form`, which is the reason for setting it during `buildView()`)
- JS validation in `JsFormValidatorFactory` collects metadata about all forms and fields during request, but multiple instances of `FormFlow` (eg. `OrderFlow`) call `buildView()` only on one instance (in `OrderController`) and `JsFormValidatorFactory` override built form with another instance without built view

| Q             | A
| ------------- | ---
|Description, reason for the PR| JS validation is not working for dynamically added fields to collections inside FormFlows
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| probably fixes #232, **but it requires testing** (this fix was motivated specifically by JS validation in `OrderFlow`, but from the issue description it seems that the root cause is the same) <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
