### PR TITLE
[framework] fixed link to our Twitter account @ShopsysFW in demo data

### DIFF
--- a/packages/framework/src/DataFixtures/Demo/SliderItemDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/SliderItemDataFixture.php
@@ -47,7 +47,7 @@ class SliderItemDataFixture extends AbstractReferenceFixture
         $this->sliderItemFacade->create($sliderItemData);
 
         $sliderItemData->name = 'Twitter';
-        $sliderItemData->link = 'https://twitter.com/shopsys';
+        $sliderItemData->link = 'https://twitter.com/ShopsysFW';
 
         $this->sliderItemFacade->create($sliderItemData);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Twitter link in our demo data was pointing to the account of Mike Spreeman by mistake (Twitter handle `@shopsys`, unrelated to Shopsys company), instead of https://twitter.com/ShopsysFW. Thanks @PatrikBajer for noticing!<br>(introduced in https://github.com/shopsys/shopsys/commit/94dd01d29ef976c185659718b441642562f27160#diff-0ab370d2228934110df950452854beca)
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
