### PR TITLE
[shopsys] docs: added missing link to Adding an Icon into a Button cookbook

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@
 * [Adding New Attribute to an Entity](./cookbook/adding-new-attribute-to-an-entity.md)
 * [Adding a New Administration Page](./cookbook/adding-a-new-administration-page.md)
 * [Adding a New Advert Position](./cookbook/adding-a-new-advert-position.md)
+* [Adding an Icon into a Button](./cookbook/adding-an-icon-into-a-button.md)
 * [Modifying a Template in Administration](./cookbook/modifying-a-template-in-administration.md)
 
 ## Microservices


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| there was no link to the cookbook
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes/No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
