### PR TITLE
[project-base] Bootstrap: do not prematurely boot Kernel when running in console

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,7 +59,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 ### [shopsys/project-base]
 - *(optional)* [#596 Trusted proxies are now configurable in parameters.yml file](https://github.com/shopsys/shopsys/pull/596)
     - for easier deployment to production, make the trusted proxies in `Shopsys\Boostrap` class loaded from DIC parameter `trusted_proxies` instead of being hard-coded
-    - in your `Shopsys\Boostrap`, move the `Request::setTrustedProxies(...)` call along with `Kernel::boot()` so it's not run in console environment, like in [the PR #660 diff](https://github.com/shopsys/shopsys/pull/660/files), otherwise console commands will trigger excessive logging
+    - in your `Shopsys\Boostrap`, move the `Request::setTrustedProxies(...)` call along with `Kernel::boot()` so it's not run in console environment, like in [the PR #660](https://github.com/shopsys/shopsys/pull/660/files), otherwise console commands will trigger excessive logging
 - [#579 - ajaxMoreLoader is generalized](https://github.com/shopsys/shopsys/pull/579)
     - new macro `loadMoreButton` is integrated into `@ShopsysShop/Front/Inline/Paginator/paginator.html.twig`, update files based on commit from [`ajaxMoreLoader is updated and generalized`](https://github.com/shopsys/shopsys/pull/579/files)
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -63,6 +63,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - new macro `loadMoreButton` is integrated into `@ShopsysShop/Front/Inline/Paginator/paginator.html.twig`, update files based on commit from [`ajaxMoreLoader is updated and generalized`](https://github.com/shopsys/shopsys/pull/579/files)
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
+- [#660 - Bootstrap: do not prematurely boot Kernel when running in console](https://github.com/shopsys/shopsys/pull/660)
+    - in your `app/Bootstrap.php`, move the `Request::setTrustedProxies(...)` call along with `Kernel::boot()` so it's not run in console environment, like in [the PR's diff](https://github.com/shopsys/shopsys/pull/660/files), to stop excessive logging during console commands
 
 ## [From v7.0.0-beta3 to v7.0.0-beta4]
 ### [shopsys/project-base]

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -59,12 +59,11 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 ### [shopsys/project-base]
 - *(optional)* [#596 Trusted proxies are now configurable in parameters.yml file](https://github.com/shopsys/shopsys/pull/596)
     - for easier deployment to production, make the trusted proxies in `Shopsys\Boostrap` class loaded from DIC parameter `trusted_proxies` instead of being hard-coded
+    - in your `Shopsys\Boostrap`, move the `Request::setTrustedProxies(...)` call along with `Kernel::boot()` so it's not run in console environment, like in [the PR #660 diff](https://github.com/shopsys/shopsys/pull/660/files), otherwise console commands will trigger excessive logging
 - [#579 - ajaxMoreLoader is generalized](https://github.com/shopsys/shopsys/pull/579)
     - new macro `loadMoreButton` is integrated into `@ShopsysShop/Front/Inline/Paginator/paginator.html.twig`, update files based on commit from [`ajaxMoreLoader is updated and generalized`](https://github.com/shopsys/shopsys/pull/579/files)
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
-- [#660 - Bootstrap: do not prematurely boot Kernel when running in console](https://github.com/shopsys/shopsys/pull/660)
-    - in your `app/Bootstrap.php`, move the `Request::setTrustedProxies(...)` call along with `Kernel::boot()` so it's not run in console environment, like in [the PR's diff](https://github.com/shopsys/shopsys/pull/660/files), to stop excessive logging during console commands
 
 ## [From v7.0.0-beta3 to v7.0.0-beta4]
 ### [shopsys/project-base]

--- a/project-base/app/Bootstrap.php
+++ b/project-base/app/Bootstrap.php
@@ -54,9 +54,6 @@ class Bootstrap
 
         $kernel = new AppKernel($this->environment, EnvironmentType::isDebug($this->environment));
 
-        $kernel->boot();
-        $trustedProxies = $kernel->getContainer()->getParameter('trusted_proxies');
-        Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_ALL);
         if ($this->console) {
             $input = new ArgvInput();
             $output = new ConsoleOutput();
@@ -66,6 +63,10 @@ class Bootstrap
             $application->run($input, $output);
         } else {
             $this->initDoctrine();
+
+            $kernel->boot();
+            $trustedProxies = $kernel->getContainer()->getParameter('trusted_proxies');
+            Request::setTrustedProxies($trustedProxies, Request::HEADER_X_FORWARDED_ALL);
 
             $request = Request::createFromGlobals();
             $response = $kernel->handle($request);


### PR DESCRIPTION
- the Kernel boot was done to build DIC so `%trusted_proxies%` parameter is available
- setting trusted proxies is not required when running in console, as there are no Requests involved
- this stops excessive logging in console environment

| Q             | A
| ------------- | ---
|Description, reason for the PR| console commands output excessive log messages after #596 was merged
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No, but it's a project-base change, so users will have to replicate it <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #658  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes/No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
