### PR TITLE
[shopsys] add missing upgrade note for #651 when using monorepo

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -64,6 +64,10 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
 
+### [shopsys/shopsys]
+- [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)
+    - either rebuild your Docker images with `docker-compose up -d --build` or add `ELASTIC_SEARCH_INDEX_PREFIX=''` to your `.env` files in the microservice root directories, otherwise all requests to the microservices will throw `EnvNotFoundException` 
+
 ## [From v7.0.0-beta3 to v7.0.0-beta4]
 ### [shopsys/project-base]
 - [#616 - services.yml: automatic registration of classes with suffix "Repository" in namespace ShopBundle\Model\ ](https://github.com/shopsys/shopsys/pull/616)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When using monorepo, it's required to provide the environment variable `ELASTIC_SEARCH_INDEX_PREFIX` in both microservices to upgrade to #651 as it doesn't have any default value (see [docs](https://symfony.com/blog/new-in-symfony-3-2-runtime-environment-variables)), but there were no upgrade notes for that. Remember, that monorepo upgrade requires no action by default (just following notes in `shopsys/shopsys` section, as [written in the UPGRADE.md](https://github.com/shopsys/shopsys/blob/ph-monorepo-upgrade-note/UPGRADE.md#you-are-using-monorepo)).
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
