### PR TITLE
admin: category editation: main URL is not recreated from the category name anymore

### DIFF
--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -140,7 +140,6 @@ class CategoryFacade
         $category = $this->categoryService->edit($category, $categoryData, $rootCategory);
         $this->em->flush();
         $this->friendlyUrlFacade->saveUrlListFormData('front_product_list', $category->getId(), $categoryData->urls);
-        $this->friendlyUrlFacade->createFriendlyUrls('front_product_list', $category->getId(), $category->getNames());
         $this->imageFacade->uploadImage($category, $categoryData->image->uploadedFiles, null);
 
         $this->pluginCrudExtensionFacade->saveAllData('category', $category->getId(), $categoryData->pluginData);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Problem with URL recreation described in #668. If the solution is accepted, the same approach should be used for products as there is a similar problem when editing a product.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #668 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
