### PR TITLE
[project-base] Dockerignore no longer excludes docker/nginx folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,8 @@ project-base/kubernetes
 
 # ignore docker configs for other images than php-fpm, and the php-fpm's Dockerfile itself
 docker
+!docker/nginx
 project-base/docker
 !project-base/docker/php-fpm
+!project-base/docker/nginx
 project-base/docker/php-fpm/Dockerfile

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,7 +67,7 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
 - [#674 - Dockerignore needs to accept nginx configuration for porduction on docker](https://github.com/shopsys/shopsys/pull/674)
-    - add `!docker/nginx` line into `.dockerignore` file so during production deployment nginx configuration can be exported from `php-fpm` image for use of `webserver` container
+    - add `!docker/nginx` line into `.dockerignore` file so during production deployment nginx configuration can be exported from `php-fpm` image for use in `webserver` container
 
 ### [shopsys/shopsys]
 - [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -68,7 +68,6 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
 - [#674 - Dockerignore needs to accept nginx configuration for production on docker](https://github.com/shopsys/shopsys/pull/674)
     - add `!docker/nginx` line into `.dockerignore` file so `docker/nginx` directory is not excluded during building `php-fpm` image
-        - its content is exported to `webserver` container during deploy to production
 
 ### [shopsys/shopsys]
 - [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,6 +66,8 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - new macro `loadMoreButton` is integrated into `@ShopsysShop/Front/Inline/Paginator/paginator.html.twig`, update files based on commit from [`ajaxMoreLoader is updated and generalized`](https://github.com/shopsys/shopsys/pull/579/files)
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
+- [#674 - Dockerignore needs to accept nginx configuration for porduction on docker](https://github.com/shopsys/shopsys/pull/674)
+    - add `!docker/nginx` line into `.dockerignore` file so during production deployment nginx configuration can be exported from `php-fpm` image for use of `webserver` container
 
 ### [shopsys/shopsys]
 - [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -66,8 +66,9 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - new macro `loadMoreButton` is integrated into `@ShopsysShop/Front/Inline/Paginator/paginator.html.twig`, update files based on commit from [`ajaxMoreLoader is updated and generalized`](https://github.com/shopsys/shopsys/pull/579/files)
 - *(optional)* [#645 SVG icons in generated document](https://github.com/shopsys/shopsys/pull/645)
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
-- [#674 - Dockerignore needs to accept nginx configuration for porduction on docker](https://github.com/shopsys/shopsys/pull/674)
-    - add `!docker/nginx` line into `.dockerignore` file so during production deployment nginx configuration can be exported from `php-fpm` image for use in `webserver` container
+- [#674 - Dockerignore needs to accept nginx configuration for production on docker](https://github.com/shopsys/shopsys/pull/674)
+    - add `!docker/nginx` line into `.dockerignore` file so `docker/nginx` directory is not excluded during building `php-fpm` image
+        - its content is exported to `webserver` container during deploy to production
 
 ### [shopsys/shopsys]
 - [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)

--- a/project-base/.dockerignore
+++ b/project-base/.dockerignore
@@ -20,5 +20,6 @@ kubernetes
 
 # ignore docker configs for other images than php-fpm, and the php-fpm's Dockerfile itself
 docker
+!docker/nginx
 !docker/php-fpm
 docker/php-fpm/Dockerfile


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are trying to create production using Shopsys Framework documentation and nginx configuration files needs to be part of the production image
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
