### PR TITLE
[framework] formatNumber filter supplied with missing orderLocale variable

### DIFF
--- a/packages/framework/src/Resources/views/Mail/Order/products.html.twig
+++ b/packages/framework/src/Resources/views/Mail/Order/products.html.twig
@@ -8,7 +8,7 @@
     {% for item in order.items %}
         <tr>
             <td style="font-weight: bold;">{{ item.name }}</td>
-            <td style="text-align: right;">{{ item.quantity|formatNumber }} {{ item.unitName }}</td>
+            <td style="text-align: right;">{{ item.quantity|formatNumber(orderLocale) }} {{ item.unitName }}</td>
             <td style="text-align: right;">{{ item.priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale) }}</td>
             <td style="text-align: right;">{{ orderItemTotalPricesById[item.id].priceWithVat|priceTextWithCurrencyByCurrencyIdAndLocale(order.currency.id, orderLocale) }}</td>
         </tr>


### PR DESCRIPTION
In my point of view, in Mail/Order/products.html.twig is missing orderLocale variable in formatNumber filter, that formats item.quantity. 

This variable is supplied to all other filters in this template.

Moreover, if you try to submit this email from CLI task, it throws exception due to getCurrentDomainConfig method call.

| Q | A
| -| -
|New feature| No
|BC breaks| No 
|Standards and tests pass| No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
