### PR TITLE
[shopsys] webserver container starts after php-fpm is started

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -82,10 +82,14 @@ There is a list of all the repositories maintained by monorepo, changes in log b
 - *(optional)* [#673 added support for custom prefixing in redis](https://github.com/shopsys/shopsys/pull/673)
     - add default value (e.g. empty string) for `REDIS_PREFIX` env variable to your `app/config/parameters.yml.dist`, `app/config/parameters.yml` (if you already have your parameters file), and to your `docker/php-fpm/Dockerfile`
     - modify your Redis configuration (`app/config/packages/snc_redis.yml`) by prefixing all the prefix values with the value of the env variable (`%env(REDIS_PREFIX)%`)
+- [#679 webserver container starts after php-fpm is started](https://github.com/shopsys/shopsys/pull/679)
+    - add `depends_on: php-fpm` into `webserver` service of your `docker-compose.yml` file so webserver will not fail on error `host not found in upstream php-fpm:9000`
 
 ### [shopsys/shopsys]
 - [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)
     - either rebuild your Docker images with `docker-compose up -d --build` or add `ELASTIC_SEARCH_INDEX_PREFIX=''` to your `.env` files in the microservice root directories, otherwise all requests to the microservices will throw `EnvNotFoundException` 
+- [#679 webserver container starts after php-fpm is started](https://github.com/shopsys/shopsys/pull/679)
+    - add `depends_on: php-fpm` into `webserver` service of your `docker-compose.yml` file so webserver will not fail on error `host not found in upstream php-fpm:9000`
 
 ### [shopsys/migrations]
  - [#627 model service layer removal](https://github.com/shopsys/shopsys/pull/627)

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -21,6 +21,8 @@ services:
     webserver:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - shopsys-framework-web-sync:/var/www/html/project-base/web
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:delegated

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -21,6 +21,8 @@ services:
     webserver:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - shopsys-framework-web-sync:/var/www/html/project-base/web
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -21,6 +21,8 @@ services:
     webserver:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - .:/var/www/html
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -15,6 +15,8 @@ services:
     webserver:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - shopsys-framework-web-sync:/var/www/html/web
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:delegated

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -15,6 +15,8 @@ services:
     webserver:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - shopsys-framework-web-sync:/var/www/html/web
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -15,6 +15,8 @@ services:
     webserver:
         image: nginx:1.13-alpine
         container_name: shopsys-framework-webserver
+        depends_on:
+            - php-fpm
         volumes:
             - .:/var/www/html
             - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- all docker-compose files are fixed with depends_on attribute for webserver
- webserver doesn't fail on "host not found in upstream php-fpm:9000"

| Q             | A
| ------------- | ---
|Description, reason for the PR| during testing of special jobs there emerged error once per 30 minutes on 32 core CPU and 130GB server that webserver didn't start on error nginx: host not found in upstream php-fpm:9000
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| - <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
