### PR TITLE
[project-base] fix wrong variable name in flash message

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -68,6 +68,9 @@ There is a list of all the repositories maintained by monorepo, changes in log b
     - to display svg icons collection correctly in grunt generated document for all browsers please add `src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html` file and update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in this pull request
 - [#674 - Dockerignore needs to accept nginx configuration for production on docker](https://github.com/shopsys/shopsys/pull/674)
     - add `!docker/nginx` line into `.dockerignore` file so `docker/nginx` directory is not excluded during building `php-fpm` image
+- [#685 - fix wrong variable name in flash message](https://github.com/shopsys/shopsys/pull/685)
+    - in `Front/OrderController::checkTransportAndPaymentChanges()`, fix the variable name in the flash message in `$transportAndPaymentCheckResult->isPaymentPriceChanged()` condition 
+    - dump translations using `php phing dump-translations` and fill in your translations for the new message ID 
 
 ### [shopsys/shopsys]
 - [#651 It's possible to add index prefix to elastic search](https://github.com/shopsys/shopsys/pull/651)

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -320,7 +320,7 @@ class OrderController extends FrontBaseController
         }
         if ($transportAndPaymentCheckResult->isPaymentPriceChanged()) {
             $this->getFlashMessageSender()->addInfoFlashTwig(
-                t('The price of payment {{ transportName }} changed during ordering process. Check your order, please.'),
+                t('The price of payment {{ paymentName }} changed during ordering process. Check your order, please.'),
                 [
                     'paymentName' => $orderData->payment->getName(),
                 ]

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
@@ -544,7 +544,7 @@ msgstr "Děkujeme, váš vzkaz byl odeslán."
 msgid "The link to change your password expired."
 msgstr "Platnost odkazu pro změnu hesla vypršela."
 
-msgid "The price of payment {{ transportName }} changed during ordering process. Check your order, please."
+msgid "The price of payment {{ paymentName }} changed during ordering process. Check your order, please."
 msgstr "V průběhu objednávkového procesu byla změněna cena platby {{ paymentName }}. Prosím, překontrolujte si objednávku."
 
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
@@ -544,7 +544,7 @@ msgstr ""
 msgid "The link to change your password expired."
 msgstr ""
 
-msgid "The price of payment {{ transportName }} changed during ordering process. Check your order, please."
+msgid "The price of payment {{ paymentName }} changed during ordering process. Check your order, please."
 msgstr ""
 
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When a price of a payment is changed during the ordering process, flash message should be shown, however, there was an undefined variable `transportName` in the message that caused 500 error is such a situation.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes - translatable message ID has changed <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
