### PR TITLE
[framework] refactored checking duplicated e-mail to User constructor

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -33,6 +33,8 @@ There you can find links to upgrade notes for other versions too.
 - fix wrong variable name in flash message ([#685](https://github.com/shopsys/shopsys/pull/685))
     - in `Front/OrderController::checkTransportAndPaymentChanges()`, fix the variable name in the flash message in `$transportAndPaymentCheckResult->isPaymentPriceChanged()` condition
     - dump translations using `php phing dump-translations` and fill in your translations for the new message ID
+- Change `User` constructor in `PersonalDataExportXmlTest::createUser` to `__construct(UserData $userData, BillingAddress $billingAddress, ?DeliveryAddress $deliveryAddress, ?self $userByEmail)` ([#690](https://github.com/shopsys/shopsys/pull/690))
+    - If you extend `User`, change your `User` entity constructor accordingly as well
 - *(optional)* display svg icons collection correctly in grunt generated document for all browsers ([#645](https://github.com/shopsys/shopsys/pull/645))
     - add [`src/Shopsys/ShopBundle/Resources/views/Grunt/htmlDocumentTemplate.html`](https://github.com/shopsys/shopsys/pull/645/files#diff-2fa69709c5ba35cd2ad6c5de640d56f9) file from GitHub
     - update `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig` based on changes in [pull request #645](https://github.com/shopsys/shopsys/pull/645/files#diff-ff210e4f423be8bd6c88818d2bb2a8cd)

--- a/packages/framework/src/Form/Admin/Customer/UserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/UserFormType.php
@@ -132,7 +132,10 @@ class UserFormType extends AbstractType
                         'maxMessage' => 'Email cannot be longer then {{ limit }} characters',
                     ]),
                     new Email(['message' => 'Please enter valid e-mail']),
-                    new UniqueEmail(['ignoredEmail' => $user !== null ? $user->getEmail() : null]),
+                    new UniqueEmail([
+                        'ignoredEmail' => $user !== null ? $user->getEmail() : null,
+                        'domainId' => $options['domain_id'],
+                    ]),
                 ],
                 'label' => t('E-mail'),
             ])

--- a/packages/framework/src/Form/Constraints/UniqueEmail.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmail.php
@@ -9,4 +9,6 @@ class UniqueEmail extends Constraint
     public $message = 'Email {{ email }} is already registered';
 
     public $ignoredEmail = null;
+
+    public $domainId = null;
 }

--- a/packages/framework/src/Form/Constraints/UniqueEmailValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmailValidator.php
@@ -42,7 +42,8 @@ class UniqueEmailValidator extends ConstraintValidator
         }
 
         $email = (string)$value;
-        $domainId = $this->domain->getId();
+
+        $domainId = $constraint->domainId ?? $this->domain->getId();
 
         if ($constraint->ignoredEmail != $value && $this->customerFacade->findUserByEmailAndDomain($email, $domainId) !== null) {
             $this->context->addViolation(

--- a/packages/framework/src/Model/Customer/UserFactory.php
+++ b/packages/framework/src/Model/Customer/UserFactory.php
@@ -40,17 +40,9 @@ class UserFactory implements UserFactoryInterface
         ?DeliveryAddress $deliveryAddress,
         ?User $userByEmail
     ): User {
-        if ($userByEmail instanceof User) {
-            $isSameEmail = (mb_strtolower($userByEmail->getEmail()) === mb_strtolower($userData->email));
-            $isSameDomain = ($userByEmail->getDomainId() === $userData->domainId);
-            if ($isSameEmail && $isSameDomain) {
-                throw new \Shopsys\FrameworkBundle\Model\Customer\Exception\DuplicateEmailException($userData->email);
-            }
-        }
-
         $classData = $this->entityNameResolver->resolve(User::class);
 
-        $user = new $classData($userData, $billingAddress, $deliveryAddress);
+        $user = new $classData($userData, $billingAddress, $deliveryAddress, $userByEmail);
 
         $user->changePassword($this->encoderFactory, $userData->password);
 

--- a/packages/framework/tests/Unit/Model/Customer/CurrentCustomerTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CurrentCustomerTest.php
@@ -72,9 +72,10 @@ class CurrentCustomerTest extends TestCase
     {
         $billingAddress = $this->createMock(BillingAddress::class);
         $userData = new UserData();
+        $userData->email = 'no-reply@shopsys.com';
         $userData->pricingGroup = $pricingGroup;
 
-        return new User($userData, $billingAddress, null);
+        return new User($userData, $billingAddress, null, null);
     }
 
     /**

--- a/packages/framework/tests/Unit/Model/Customer/CustomerDataFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerDataFactoryTest.php
@@ -39,6 +39,7 @@ class CustomerDataFactoryTest extends TestCase
         $userData->lastName = 'lastName';
         $userData->createdAt = new DateTime();
         $userData->telephone = 'telephone';
+        $userData->email = 'no-reply@shopsys.com';
 
         $billingCountryData = new CountryData();
         $billingCountryData->name = 'Česká republika';
@@ -69,7 +70,7 @@ class CustomerDataFactoryTest extends TestCase
 
         $billingAddress = $this->createBillingAddress($billingAddressData);
         $deliveryAddress = $this->createDeliveryAddress($deliveryAddressData);
-        $user = new User($userData, $billingAddress, $deliveryAddress);
+        $user = new User($userData, $billingAddress, $deliveryAddress, null);
 
         $transportData = new TransportData();
         $transportData->name = ['cs' => 'transportName'];
@@ -135,10 +136,11 @@ class CustomerDataFactoryTest extends TestCase
         $userData = new UserData();
         $userData->firstName = 'firstName';
         $userData->lastName = 'lastName';
+        $userData->email = 'no-reply@shopsys.com';
         $userData->createdAt = new DateTime();
 
         $billingAddress = $this->createBillingAddress();
-        $user = new User($userData, $billingAddress, null);
+        $user = new User($userData, $billingAddress, null, null);
 
         $transportData = new TransportData();
         $transportData->name = ['cs' => 'transportName'];

--- a/packages/framework/tests/Unit/Model/Customer/UserFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/UserFactoryTest.php
@@ -39,118 +39,6 @@ class UserFactoryTest extends TestCase
         $this->assertInstanceOf(User::class, $user);
     }
 
-    public function testCreateNotDuplicateEmail()
-    {
-        $customerService = $this->getUserFactory();
-
-        $billingAddress1 = $this->createBillingAddress();
-        $deliveryAddress1 = $this->createDeliveryAddress();
-        $userByEmail = null;
-        $userData1 = new UserData();
-        $userData1->firstName = 'firstName1';
-        $userData1->lastName = 'lastName1';
-        $userData1->email = 'no-reply@shopsys.com';
-        $userData1->password = 'pa55w0rd';
-
-        $user1 = $customerService->create(
-            $userData1,
-            $billingAddress1,
-            $deliveryAddress1,
-            $userByEmail
-        );
-        $this->assertInstanceOf(User::class, $user1);
-
-        $billingAddress2 = $this->createBillingAddress();
-        $deliveryAddress2 = $this->createDeliveryAddress();
-        $userData2 = new UserData();
-        $userData2->firstName = 'firstName2';
-        $userData2->lastName = 'lastName2';
-        $userData2->email = 'no-reply2@shopsys.com';
-        $userData2->password = 'pa55w0rd';
-
-        $user2 = $customerService->create(
-            $userData2,
-            $billingAddress2,
-            $deliveryAddress2,
-            $user1
-        );
-        $this->assertInstanceOf(User::class, $user2);
-    }
-
-    public function testCreateDuplicateEmail()
-    {
-        $customerService = $this->getUserFactory();
-
-        $billingAddress1 = $this->createBillingAddress();
-        $deliveryAddress1 = $this->createDeliveryAddress();
-        $userByEmail = null;
-        $userData1 = new UserData();
-        $userData1->firstName = 'firstName1';
-        $userData1->lastName = 'lastName1';
-        $userData1->email = 'no-reply@shopsys.com';
-        $userData1->password = 'pa55w0rd';
-
-        $user1 = $customerService->create(
-            $userData1,
-            $billingAddress1,
-            $deliveryAddress1,
-            $userByEmail
-        );
-
-        $billingAddress2 = $this->createBillingAddress();
-        $deliveryAddress2 = $this->createDeliveryAddress();
-        $userData2 = new UserData();
-        $userData2->firstName = 'firstName2';
-        $userData2->lastName = 'lastName2';
-        $userData2->email = 'no-reply@shopsys.com';
-        $userData2->password = 'pa55w0rd';
-
-        $this->expectException(\Shopsys\FrameworkBundle\Model\Customer\Exception\DuplicateEmailException::class);
-        $customerService->create(
-            $userData2,
-            $billingAddress2,
-            $deliveryAddress2,
-            $user1
-        );
-    }
-
-    public function testCreateDuplicateEmailCaseInsentitive()
-    {
-        $customerService = $this->getUserFactory();
-
-        $billingAddress1 = $this->createBillingAddress();
-        $deliveryAddress1 = $this->createDeliveryAddress();
-        $userByEmail = null;
-        $userData1 = new UserData();
-        $userData1->firstName = 'firstName1';
-        $userData1->lastName = 'lastName1';
-        $userData1->email = 'no-reply@shopsys.com';
-        $userData1->password = 'pa55w0rd';
-
-        $user1 = $customerService->create(
-            $userData1,
-            $billingAddress1,
-            $deliveryAddress1,
-            $userByEmail
-        );
-
-        $billingAddress2 = $this->createBillingAddress();
-        $deliveryAddress2 = $this->createDeliveryAddress();
-        $userData2 = new UserData();
-        $userData2->firstName = 'firstName2';
-        $userData2->lastName = 'lastName2';
-        $userData2->email = 'NO-reply@shopsys.com';
-        $userData2->password = 'pa55w0rd';
-
-        $this->expectException(\Shopsys\FrameworkBundle\Model\Customer\Exception\DuplicateEmailException::class);
-        $customerService->create(
-            $userData2,
-            $billingAddress2,
-            $deliveryAddress2,
-            $user1
-        );
-    }
-
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\UserFactory
      */
@@ -172,20 +60,18 @@ class UserFactoryTest extends TestCase
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData|null $billingAddressData
      * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddress
      */
-    private function createBillingAddress(BillingAddressData $billingAddressData = null)
+    private function createBillingAddress()
     {
-        return new BillingAddress($billingAddressData ?? new BillingAddressData());
+        return new BillingAddress(new BillingAddressData());
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData|null $deliveryAddressData
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress
      */
-    private function createDeliveryAddress(DeliveryAddressData $deliveryAddressData = null)
+    private function createDeliveryAddress()
     {
-        return new DeliveryAddress($deliveryAddressData ?? new DeliveryAddressData());
+        return new DeliveryAddress(new DeliveryAddressData());
     }
 }

--- a/packages/framework/tests/Unit/Model/Customer/UserTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/UserTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Shopsys\FrameworkBundle\Model\Customer\BillingAddress;
 use Shopsys\FrameworkBundle\Model\Customer\BillingAddressData;
+use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress;
+use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData;
 use Shopsys\FrameworkBundle\Model\Customer\User;
 use Shopsys\FrameworkBundle\Model\Customer\UserData;
 
@@ -17,9 +19,9 @@ class UserTest extends TestCase
         $userData = new UserData();
         $userData->firstName = 'Firstname';
         $userData->lastName = 'Lastname';
-        $billingAddressData = new BillingAddressData();
-        $billingAddress = new BillingAddress($billingAddressData);
-        $user = new User($userData, $billingAddress);
+        $userData->email = 'no-reply@shopsys.com';
+        $billingAddress = $this->createBillingAddress();
+        $user = new User($userData, $billingAddress, null, null);
 
         $this->assertSame('Lastname Firstname', $user->getFullName());
     }
@@ -29,11 +31,12 @@ class UserTest extends TestCase
         $userData = new UserData();
         $userData->firstName = 'Firstname';
         $userData->lastName = 'Lastname';
+        $userData->email = 'no-reply@shopsys.com';
         $billingAddressData = new BillingAddressData();
         $billingAddressData->companyCustomer = true;
         $billingAddressData->companyName = 'CompanyName';
         $billingAddress = new BillingAddress($billingAddressData);
-        $user = new User($userData, $billingAddress);
+        $user = new User($userData, $billingAddress, null, null);
 
         $this->assertSame('CompanyName', $user->getFullName());
     }
@@ -88,9 +91,10 @@ class UserTest extends TestCase
         $isExpectedValid
     ) {
         $userData = new UserData();
+        $userData->email = 'no-reply@shopsys.com';
         $billingAddressData = new BillingAddressData();
         $billingAddress = new BillingAddress($billingAddressData);
-        $user = new User($userData, $billingAddress);
+        $user = new User($userData, $billingAddress, null, null);
 
         $this->setProperty($user, 'resetPasswordHash', $resetPasswordHash);
         $this->setProperty($user, 'resetPasswordHashValidThrough', $resetPasswordHashValidThrough);
@@ -111,5 +115,145 @@ class UserTest extends TestCase
         $property = $reflection->getProperty($propertyName);
         $property->setAccessible(true);
         $property->setValue($user, $value);
+    }
+
+    public function testChangeEmailToExistingEmailButDifferentDomainDoNotThrowException()
+    {
+        $userData1 = new UserData();
+        $userData1->domainId = 1;
+        $userData1->email = 'no-reply@shopsys.com';
+        $user1 = new User($userData1, $this->createBillingAddress(), null, null);
+
+        $userData2 = new UserData();
+        $userData2->domainId = 2;
+        $userData2->email = 'no-reply2@shopsys.com';
+        $billingAddress = $this->createBillingAddress();
+        $user2 = new User($userData2, $billingAddress, null, $user1);
+
+        $user2->changeEmail('no-reply@shopsys.com', $user1);
+
+        $this->assertSame('no-reply@shopsys.com', $user2->getEmail());
+    }
+
+    public function testCreateNotDuplicateEmail()
+    {
+        $billingAddress1 = $this->createBillingAddress();
+        $deliveryAddress1 = $this->createDeliveryAddress();
+        $userByEmail = null;
+        $userData1 = new UserData();
+        $userData1->firstName = 'firstName1';
+        $userData1->lastName = 'lastName1';
+        $userData1->email = 'no-reply@shopsys.com';
+        $userData1->password = 'pa55w0rd';
+
+        $user1 = new User(
+            $userData1,
+            $billingAddress1,
+            $deliveryAddress1,
+            $userByEmail
+        );
+
+        $billingAddress2 = $this->createBillingAddress();
+        $deliveryAddress2 = $this->createDeliveryAddress();
+        $userData2 = new UserData();
+        $userData2->firstName = 'firstName2';
+        $userData2->lastName = 'lastName2';
+        $userData2->email = 'no-reply2@shopsys.com';
+        $userData2->password = 'pa55w0rd';
+
+        $user2 = new User(
+            $userData2,
+            $billingAddress2,
+            $deliveryAddress2,
+            $user1
+        );
+
+        $this->assertInstanceOf(User::class, $user2);
+    }
+
+    public function testCreateDuplicateEmail()
+    {
+        $billingAddress1 = $this->createBillingAddress();
+        $deliveryAddress1 = $this->createDeliveryAddress();
+        $userByEmail = null;
+        $userData1 = new UserData();
+        $userData1->firstName = 'firstName1';
+        $userData1->lastName = 'lastName1';
+        $userData1->email = 'no-reply@shopsys.com';
+        $userData1->password = 'pa55w0rd';
+
+        $user1 = new User(
+            $userData1,
+            $billingAddress1,
+            $deliveryAddress1,
+            $userByEmail
+        );
+
+        $billingAddress2 = $this->createBillingAddress();
+        $deliveryAddress2 = $this->createDeliveryAddress();
+        $userData2 = new UserData();
+        $userData2->firstName = 'firstName2';
+        $userData2->lastName = 'lastName2';
+        $userData2->email = 'no-reply@shopsys.com';
+        $userData2->password = 'pa55w0rd';
+
+        $this->expectException(\Shopsys\FrameworkBundle\Model\Customer\Exception\DuplicateEmailException::class);
+        new User(
+            $userData2,
+            $billingAddress2,
+            $deliveryAddress2,
+            $user1
+        );
+    }
+
+    public function testCreateDuplicateEmailCaseInsentitive()
+    {
+        $billingAddress1 = $this->createBillingAddress();
+        $deliveryAddress1 = $this->createDeliveryAddress();
+        $userByEmail = null;
+        $userData1 = new UserData();
+        $userData1->firstName = 'firstName1';
+        $userData1->lastName = 'lastName1';
+        $userData1->email = 'no-reply@shopsys.com';
+        $userData1->password = 'pa55w0rd';
+
+        $user1 = new User(
+            $userData1,
+            $billingAddress1,
+            $deliveryAddress1,
+            $userByEmail
+        );
+
+        $billingAddress2 = $this->createBillingAddress();
+        $deliveryAddress2 = $this->createDeliveryAddress();
+        $userData2 = new UserData();
+        $userData2->firstName = 'firstName2';
+        $userData2->lastName = 'lastName2';
+        $userData2->email = 'NO-reply@shopsys.com';
+        $userData2->password = 'pa55w0rd';
+
+        $this->expectException(\Shopsys\FrameworkBundle\Model\Customer\Exception\DuplicateEmailException::class);
+        new User(
+            $userData2,
+            $billingAddress2,
+            $deliveryAddress2,
+            $user1
+        );
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddress
+     */
+    private function createBillingAddress()
+    {
+        return new BillingAddress(new BillingAddressData());
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress
+     */
+    private function createDeliveryAddress()
+    {
+        return new DeliveryAddress(new DeliveryAddressData());
     }
 }

--- a/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationForUserTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationForUserTest.php
@@ -28,7 +28,8 @@ class ProductPriceCalculationForUserTest extends TestCase
         $billingAddress = $this->createMock(BillingAddress::class);
         $userData = new UserData();
         $userData->pricingGroup = $pricingGroup;
-        $user = new User($userData, $billingAddress, null);
+        $userData->email = 'no-reply@shopsys.com';
+        $user = new User($userData, $billingAddress, null, null);
         $expectedProductPrice = new ProductPrice(new Price(1, 1), false);
 
         $currentCustomerMock = $this->createMock(CurrentCustomer::class);

--- a/project-base/src/Shopsys/ShopBundle/Model/Customer/User.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Customer/User.php
@@ -27,13 +27,15 @@ class User extends BaseUser
      * @param \Shopsys\ShopBundle\Model\Customer\UserData $userData
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddress $billingAddress
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress|null $deliveryAddress
+     * @param \Shopsys\ShopBundle\Model\Customer\User|null $userByEmail
      */
     public function __construct(
         BaseUserData $userData,
         BillingAddress $billingAddress,
-        DeliveryAddress $deliveryAddress = null
+        ?DeliveryAddress $deliveryAddress,
+        ?BaseUser $userByEmail
     ) {
-        parent::__construct($userData, $billingAddress, $deliveryAddress);
+        parent::__construct($userData, $billingAddress, $deliveryAddress, $userByEmail);
     }
 
     /**

--- a/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
+++ b/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
@@ -129,7 +129,7 @@ class PersonalDataExportXmlTest extends TransactionFunctionalTestCase
         $userData->email = 'no-reply@shopsys.com';
         $userData->telephone = '+420987654321';
 
-        $user = new User($userData, $billingAddress, $deliveryAddress);
+        $user = new User($userData, $billingAddress, $deliveryAddress, null);
 
         return $user;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| checking for duplicated e-mail was in two places - UserFactory and User entity, now it is only in entity. Fixed UniqueEmail validator in administration.
|New feature| No
|BC breaks| Yes
|Fixes issues| ... closes #661
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
