### PR TITLE
[framework] redirectController is now registered as a public container service

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -524,7 +524,9 @@ services:
 
     # Define RedirectController explicitly to prevent creating it on-the-fly
     # when redirecting (it causes unnecessary container rebuild).
+    # ContainerControllerResolver fetch RedirectController from container, therefore it must be a public service
     Symfony\Bundle\FrameworkBundle\Controller\RedirectController:
+        public: true
         calls:
             - [setContainer, ['@service_container']]
 

--- a/project-base/tests/ShopBundle/Functional/Controller/ContainerControllerResolverTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/ContainerControllerResolverTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ContainerControllerResolver;
+use Tests\ShopBundle\Test\FunctionalTestCase;
+use function get_class;
+
+class ContainerControllerResolverTest extends FunctionalTestCase
+{
+    public function testRedirectControllerObtainableWithResolver(): void
+    {
+        $containerControllerResolver = new ContainerControllerResolver($this->getContainer());
+
+        $request = Request::create('/');
+
+        $request->attributes->set('_controller', 'Symfony\\Bundle\\FrameworkBundle\\Controller\\RedirectController:redirectAction');
+
+        $controller = $containerControllerResolver->getController($request);
+
+        $this->assertEquals(RedirectController::class, get_class($controller[0]));
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Controller;
+
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixture;
+use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory;
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+class ProductRenameRedirectPreviousUrlTest extends TransactionFunctionalTestCase
+{
+    private const TESTED_PRODUCT_ID = 1;
+
+    public function testPreviousUrlRedirect(): void
+    {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
+        $productFacade = $this->getContainer()->get(ProductFacade::class);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactory $productDataFactory */
+        $productDataFactory = $this->getContainer()->get(ProductDataFactory::class);
+
+        $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . self::TESTED_PRODUCT_ID);
+
+        /** @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade */
+        $friendlyUrlFacade = $this->getContainer()->get(FriendlyUrlFacade::class);
+        $previousFriendlyUrlSlug = $friendlyUrlFacade->findMainFriendlyUrl(1, 'front_product_detail', self::TESTED_PRODUCT_ID)->getSlug();
+
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
+        $productData = $productDataFactory->createFromProduct($product);
+        $productData->name['en'] = 'rename';
+
+        $productFacade->edit(self::TESTED_PRODUCT_ID, $productData);
+
+        $client = $this->getClient();
+        $client->request('GET', '/' . $previousFriendlyUrlSlug);
+
+        // Should be 301 (moved permanently), because old product urls should be permanently redirected
+        $this->assertEquals(301, $client->getResponse()->getStatusCode());
+    }
+}


### PR DESCRIPTION
- ContainerControllerResolver fetch controllers from the container, therefore it must be a public service

| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes problem with malfunctioning previous URL after product is renamed.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #677  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes