### PR TITLE
[project-base] be more descriptive about UnableToResolveDomainResponse

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -60,6 +60,9 @@ There you can find links to upgrade notes for other versions too.
                 hidden: true
     ```
     - read the section about proxying the URL content subpaths via webserver domain [`docs/introduction/abstract-filesystem.md`](https://github.com/shopsys/shopsys/blob/master/docs/introduction/abstract-filesystem.md)
+- to be more descriptive about error caused by active TEST environment ([#701](https://github.com/shopsys/shopsys/pull/701))
+    - modify `ErrorController::createUnableToResolveDomainResponse()` by these [changes](https://github.com/shopsys/shopsys/pull/701/files#diff-0b1aecbf82624ce474ca3cb8bd75811c).
+
 
 ### Configuration
  - use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -3,8 +3,10 @@
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Exception;
+use Shopsys\Environment;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\UnableToResolveDomainException;
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade;
 use Shopsys\FrameworkBundle\Component\Error\ExceptionController;
 use Shopsys\FrameworkBundle\Component\Error\ExceptionListener;
@@ -182,7 +184,12 @@ class ErrorController extends FrontBaseController
     private function createUnableToResolveDomainResponse(Request $request): Response
     {
         $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
-        $content = sprintf("You are trying to access an unknown domain '%s'", $url);
+        $content = sprintf("You are trying to access an unknown domain '%s'.", $url);
+
+        if (EnvironmentType::TEST === Environment::getEnvironment(false)) {
+            $overwriteDomainUrl = $this->getParameter('overwrite_domain_url');
+            $content .= sprintf(" TEST environment is active, current domain url is '%s'.", $overwriteDomainUrl);
+        }
 
         return new Response($content, Response::HTTP_INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
error now tells you about active TEST environment which overwrites
domain url

| Q             | A
| ------------- | ---
|Description, reason for the PR| Having active TEST environment is not obvious when having `UnableToResolveDomainResponse`
|New feature| No
|BC breaks| No
|Fixes issues|
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
