### PR TITLE
[coding-standards] order of imports and sort algorithm is now explicitly set

### DIFF
--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -107,7 +107,12 @@ services:
     PhpCsFixer\Fixer\Basic\NonPrintableCharacterFixer: ~
     PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer: ~
     PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer: ~
-    PhpCsFixer\Fixer\Import\OrderedImportsFixer: ~
+    PhpCsFixer\Fixer\Import\OrderedImportsFixer:
+        sort_algorithm: alpha
+        imports_order:
+            - class
+            - function
+            - const
     PhpCsFixer\Fixer\Phpdoc\PhpdocAnnotationWithoutDotFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoUselessInheritdocFixer: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Solves issue with coding standards introduced with 2.13.2 release of FriendsOfPHP/PHP-CS-Fixer 
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Following import order is fine and cause no problems with version FriendsOfPHP/PHP-CS-Fixer v2.13.1, but in 2.13.2 (due to FriendsOfPHP/PHP-CS-Fixer#4116) suggest a different sorting (`function` first)

```php
use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpKernel\Controller\ContainerControllerResolver;
use Tests\ShopBundle\Test\FunctionalTestCase;
use function get_class;
```

The solution is to explicitly state, that we want to group by type of import (class, function, const in this order) and then sort alphabetically.