### PR TITLE
[project-base] Removed blank space when popup is active

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -48,6 +48,14 @@ There you can find links to upgrade notes for other versions too.
     - from `getPaginatedProductDetailsInCategory` to `getPaginatedProductsInCategory`
     - from `getPaginatedProductDetailsForBrand` to `getPaginatedProductsForBrand`
     - from `getPaginatedProductDetailsForSearch` to `getPaginatedProductsForSearch`
+- (optional) in order to remove white space of webpage after popup window shows up, change file located in [`project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/layout.less`](https://github.com/shopsys/shopsys/pull/710/files#diff-b6f30401eed85fcb59b3b1761855493b) by following instructions.
+    - add new CSS attribute `width: 100%` to CSS class `.web`
+    - add following code snippet to CSS class `.web--window-activated`
+    ```
+    @media @query-vl {
+        overflow: unset;
+    }
+    ```
 
 ## [shopsys/migrations]
 - `GenerateMigrationsService` class was renamed to `MigrationsGenerator`, so change it's usage appropriately ([#627](https://github.com/shopsys/shopsys/pull/627))

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/layout.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/layout.less
@@ -9,6 +9,7 @@ img {
 .web {
     display: flex;
     flex-direction: column;
+    width: 100%;
     min-height: 100%;
 
     .is-no-flex &, .is-safari & {
@@ -17,7 +18,10 @@ img {
 
     &--window-activated {
         overflow: hidden;
-        margin-right: @web-scrollbar-size;
+
+        @media @query-vl {
+            overflow: unset;
+        }
     }
 
     &__in {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR remove blank space at right side of the page when the popup is active. 
|New feature| No
|BC breaks| No
|Fixes issues| closes #695 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
