### PR TITLE
[framework] Stop generating url for unsafe route 'fp_js_form_validator.check_unique_entity'

### DIFF
--- a/packages/framework/src/Form/JsFormValidatorFactory.php
+++ b/packages/framework/src/Form/JsFormValidatorFactory.php
@@ -7,6 +7,7 @@ use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Validator\Constraints;
 
 class JsFormValidatorFactory extends BaseJsFormValidatorFactory
@@ -79,5 +80,19 @@ class JsFormValidatorFactory extends BaseJsFormValidatorFactory
         }
 
         return parent::createJsModel($form);
+    }
+
+    /**
+     * @param string $route
+     * @return string
+     */
+    protected function generateUrl($route)
+    {
+        if ($route === 'fp_js_form_validator.check_unique_entity') {
+            $message = 'Unable to generate a URL for the named route "' . $route . '" as such route was removed as unsafe.';
+            throw new RouteNotFoundException($message);
+        }
+
+        return parent::generateUrl($route);
     }
 }


### PR DESCRIPTION
It is caused by remove unsafe route `fp_js_form_validator.check_unique_entity` to configuration of js validation.

Replaces #298

| Q             | A
| ------------- | ---
|Description, reason for the PR| 
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #298 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes/No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
