### PR TITLE
[shopsys] Phing: PHPStan analysis of packages is separated into another target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,6 +7,7 @@
     <property name="path.microservices" value="./microservices"/>
     <property name="path.bin-console" value="./project-base/bin/console"/>
     <property name="path.framework" value="${path.packages}/framework"/>
+    <property name="path.phpstan.config" value="./phpstan.neon"/>
 
     <import file="project-base/build-dev.xml" />
     <import file="project-base/build.xml" />
@@ -34,8 +35,8 @@
         <phingcall target="composer-check" />
     </target>
 
-    <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check,standards-packages,standards-utils" description="Checks coding standards in the project-base, packages, microservices and utils folder."/>
-    <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff,standards-packages, standards-utils" description="Checks coding standards on changed files in the project-base, packages, microservices and utils folder."/>
+    <target name="standards" depends="phplint,ecs,phpstan-packages,twig-lint,yaml-lint,eslint-check,standards-packages,standards-utils" description="Checks coding standards in the project-base, packages, microservices and utils folder."/>
+    <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan-packages,twig-lint-diff,yaml-lint,eslint-check-diff,standards-packages, standards-utils" description="Checks coding standards on changed files in the project-base, packages, microservices and utils folder."/>
 
     <target name="clean" description="Cleans up directories with cache and scripts which are generated on demand.">
         <delete failonerror="false" includeemptydirs="true">
@@ -187,21 +188,17 @@
         </exec>
     </target>
 
-    <target name="phpstan" depends="tests-acceptance-build" description="Performs static analysis of PHP files using PHPStan on all packages.">
-        <exec executable="${path.php.executable}" logoutput="true" passthru="true" checkreturn="true">
-            <arg value="-d" />
-            <arg value="memory_limit=-1" />
-            <arg value="${path.phpstan.executable}"/>
+    <target name="phpstan-packages" depends="phpstan" description="Performs static analysis of PHP files using PHPStan on all packages.">
+        <exec executable="${path.phpstan.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="analyze"/>
             <arg value="-c"/>
-            <arg path="./phpstan.neon"/>
-            <arg path="${path.src}"/>
-            <arg path="${path.tests}"/>
-            <arg path="./packages/*/src"/>
-            <arg path="./packages/*/tests"/>
+            <arg path="${path.phpstan.config}"/>
+            <arg path="${path.packages}/*/src"/>
+            <arg path="${path.packages}/*/tests"/>
             <arg path="./utils/*/src"/>
             <arg path="./utils/*/tests"/>
             <arg value="--level=0"/>
+            <arg value="-vvv"/>
         </exec>
     </target>
 

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -327,6 +327,7 @@
             <arg path="${path.tests}"/>
 
             <arg value="--level=0"/>
+            <arg value="-vvv"/>
         </exec>
     </target>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In monorepo PHPStan now checks packages and src as a separate targets to prevent memory exhaustion.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #704 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
