### PR TITLE
[shopsys] added scripts for monorepo maintenance into /.ci directory

### DIFF
--- a/.ci/monorepo_force_split_branch.sh
+++ b/.ci/monorepo_force_split_branch.sh
@@ -44,10 +44,10 @@ for PACKAGE in $(get_all_packages); do
     cd $WORKSPACE
     git clone --bare .git $WORKSPACE/split/$PACKAGE
     cd $WORKSPACE/split/$PACKAGE
-    
+
     printf "${BLUE}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY'...${NC}\n"
     printf "The progress will be logged into '$LOG_FILE'.\n\n"
-    
+
     # Running the splitting processes in parallel
     $WORKSPACE/packages/monorepo-tools/rewrite_history_from.sh $SUBDIRECTORY $SPLIT_BRANCH > $LOG_FILE 2>&1 &&
         printf "${GREEN}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY' finished!${NC}\n" ||
@@ -62,9 +62,9 @@ printf "\n${BLUE}$(date +%T) > Splitting of all packages finished. Checking the 
 for PACKAGE in $(get_all_packages); do
     cd $WORKSPACE/split/$PACKAGE
     REMOTE=$(get_package_remote "$PACKAGE")
-    
+
     git push $REMOTE $SPLIT_BRANCH --dry-run --force
-    
+
     if [[ $? -eq 0 ]]; then
         printf "${GREEN}The split package '$PACKAGE' can be pushed into '$REMOTE'!${NC}\n"
     else

--- a/.ci/monorepo_force_split_branch.sh
+++ b/.ci/monorepo_force_split_branch.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Split specified branches of all packages of the monorepo in parallel and force push it to corresponding repositories.
+#
+# Logs of history rewriting can be found in $WORKSPACE/split/ along with the individual bare repositories.
+#
+# Usage: monorepo_force_split_branch.sh <branch>
+#
+# Example: monorepo_force_split_branch.sh my-feature-branch
+
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+NC="\e[0m"
+
+SPLIT_BRANCH=$1
+WORKSPACE=${WORKSPACE:-.}
+
+if [[ "$SPLIT_BRANCH" == "" ]]; then
+    printf "${RED}$(date +%T) > You must provide branch name to remove!${NC}\n\n"
+    exit 1
+elif [[ "$SPLIT_BRANCH" == "master" ]]; then
+    printf "${RED}$(date +%T) > You cannot force split master branch!${NC}\n\n"
+    exit 1
+else
+    printf "${BLUE}$(date +%T) > Force splitting branch '$SPLIT_BRANCH'...${NC}\n\n"
+fi
+
+# Relatively new version of git must be installed
+printf "\n${BLUE}Using $(git --version). The package shopsys/monorepo-tools was tested on 2.16.1.${NC}\n\n"
+
+# Import functions
+. $(dirname "$0")/monorepo_functions.sh
+
+for PACKAGE in $(get_all_packages); do
+    # Preparing the variables to be used for splitting
+    LOG_FILE="$WORKSPACE/split/$PACKAGE.log"
+    SUBDIRECTORY=$(get_package_subdirectory "$PACKAGE")
+    
+    # Cloning the repository as bare into separate directory, so it can be split in a parallel process
+    cd $WORKSPACE
+    git clone --bare .git $WORKSPACE/split/$PACKAGE
+    cd $WORKSPACE/split/$PACKAGE
+    
+    printf "${BLUE}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY'...${NC}\n"
+    printf "The progress will be logged into '$LOG_FILE'.\n\n"
+    
+    # Running the splitting processes in parallel
+    $WORKSPACE/packages/monorepo-tools/rewrite_history_from.sh $SUBDIRECTORY $SPLIT_BRANCH > $LOG_FILE 2>&1 &&
+        printf "${GREEN}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY' finished!${NC}\n" ||
+        printf "${RED}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY' failed!${NC}\n" &
+done
+
+wait
+
+# Checking the status of the split repositories
+EXIT_STATUS=0
+printf "\n${BLUE}$(date +%T) > Splitting of all packages finished. Checking the ability to push the split repositories...${NC}\n\n"
+for PACKAGE in $(get_all_packages); do
+    cd $WORKSPACE/split/$PACKAGE
+    REMOTE="git@github.com:shopsys/$PACKAGE.git"
+    
+    git push $REMOTE $SPLIT_BRANCH --dry-run --force
+    
+    if [[ $? -eq 0 ]]; then
+        printf "${GREEN}The split package '$PACKAGE' can be pushed into '$REMOTE'!${NC}\n"
+    else
+        printf "${RED}The split package '$PACKAGE' cannot be pushed into '$REMOTE'!${NC}\n"
+        EXIT_STATUS=1
+    fi
+done
+
+# Pushing all repositories at once if they are OK so they are released at one moment
+if [[ $EXIT_STATUS -eq 0 ]]; then
+    printf "\n${GREEN}$(date +%T) > All repositories can be pushed! Pushing them into their remotes now...${NC}\n\n"
+    for PACKAGE in $(get_all_packages); do
+        cd $WORKSPACE/split/$PACKAGE
+        git push git@github.com:shopsys/$PACKAGE.git $SPLIT_BRANCH --force
+    done
+else
+    printf "\n${RED}$(date +%T) > Repositories were not pushed into their remotes due to an error.${NC}\n\n"
+fi
+
+exit $EXIT_STATUS

--- a/.ci/monorepo_force_split_branch.sh
+++ b/.ci/monorepo_force_split_branch.sh
@@ -39,7 +39,7 @@ for PACKAGE in $(get_all_packages); do
     # Preparing the variables to be used for splitting
     LOG_FILE="$WORKSPACE/split/$PACKAGE.log"
     SUBDIRECTORY=$(get_package_subdirectory "$PACKAGE")
-    
+
     # Cloning the repository as bare into separate directory, so it can be split in a parallel process
     cd $WORKSPACE
     git clone --bare .git $WORKSPACE/split/$PACKAGE
@@ -61,7 +61,7 @@ EXIT_STATUS=0
 printf "\n${BLUE}$(date +%T) > Splitting of all packages finished. Checking the ability to push the split repositories...${NC}\n\n"
 for PACKAGE in $(get_all_packages); do
     cd $WORKSPACE/split/$PACKAGE
-    REMOTE="git@github.com:shopsys/$PACKAGE.git"
+    REMOTE=$(get_package_remote "$PACKAGE")
     
     git push $REMOTE $SPLIT_BRANCH --dry-run --force
     
@@ -78,7 +78,7 @@ if [[ $EXIT_STATUS -eq 0 ]]; then
     printf "\n${GREEN}$(date +%T) > All repositories can be pushed! Pushing them into their remotes now...${NC}\n\n"
     for PACKAGE in $(get_all_packages); do
         cd $WORKSPACE/split/$PACKAGE
-        git push git@github.com:shopsys/$PACKAGE.git $SPLIT_BRANCH --force
+        git push $(get_package_remote "$PACKAGE") $SPLIT_BRANCH --force
     done
 else
     printf "\n${RED}$(date +%T) > Repositories were not pushed into their remotes due to an error.${NC}\n\n"

--- a/.ci/monorepo_force_split_branch.sh
+++ b/.ci/monorepo_force_split_branch.sh
@@ -15,7 +15,9 @@ BLUE="\e[34m"
 NC="\e[0m"
 
 SPLIT_BRANCH=$1
-WORKSPACE=${WORKSPACE:-.}
+
+# Default value for WORKSPACE is the current working directory
+WORKSPACE=${WORKSPACE:-$PWD}
 
 if [[ "$SPLIT_BRANCH" == "" ]]; then
     printf "${RED}$(date +%T) > You must provide branch name to remove!${NC}\n\n"

--- a/.ci/monorepo_functions.sh
+++ b/.ci/monorepo_functions.sh
@@ -30,3 +30,10 @@ get_package_subdirectory() {
         echo "packages/$PACKAGE"
     fi
 }
+
+# Gets a remote into which a package should be pushed
+get_package_remote() {
+    PACKAGE=$1
+
+    echo "git@github.com:shopsys/$PACKAGE.git"
+}

--- a/.ci/monorepo_functions.sh
+++ b/.ci/monorepo_functions.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Lists packages that should be split
+get_all_packages() {
+    echo "framework \
+        product-feed-zbozi \
+        product-feed-google \
+        product-feed-heureka \
+        product-feed-heureka-delivery \
+        plugin-interface \
+        coding-standards \
+        http-smoke-testing \
+        form-types-bundle \
+        migrations \
+        monorepo-tools \
+        project-base \
+        microservice-product-search \
+        microservice-product-search-export"
+}
+
+# Gets a subdirectory in which a package is located
+get_package_subdirectory() {
+    PACKAGE=$1
+
+    if [[ "$PACKAGE" == "project-base" ]]; then
+        echo $PACKAGE
+    elif [[ "${PACKAGE:0:13}" == "microservice-" ]]; then
+        echo "microservices/${PACKAGE:13}"
+    else
+        echo "packages/$PACKAGE"
+    fi
+}

--- a/.ci/monorepo_remove_branch.sh
+++ b/.ci/monorepo_remove_branch.sh
@@ -30,7 +30,7 @@ fi
 # Remove the branch from all repositories
 EXIT_STATUS=0
 for PACKAGE in $(get_all_packages); do
-    git push --delete git@github.com:shopsys/$PACKAGE.git $SPLIT_BRANCH
+    git push --delete $(get_package_remote "$PACKAGE") $SPLIT_BRANCH
 
     if [[ $? -eq 0 ]]; then
         printf "${GREEN}Branch '$SPLIT_BRANCH' was removed from the package '$PACKAGE'!${NC}\n"

--- a/.ci/monorepo_remove_branch.sh
+++ b/.ci/monorepo_remove_branch.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Removes specified previously split branches from all repositories
+#
+# Usage: monorepo_remove_branch.sh <branch>
+#
+# Example: monorepo_remove_branch.sh my-feature-branch
+
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+NC="\e[0m"
+
+SPLIT_BRANCH=$1
+
+if [[ "$SPLIT_BRANCH" == "" ]]; then
+    printf "${RED}$(date +%T) > You must provide branch name to remove!${NC}\n\n"
+    exit 1
+elif [[ "$SPLIT_BRANCH" == "master" ]]; then
+    printf "${RED}$(date +%T) > You cannot remove master branch!${NC}\n\n"
+    exit 1
+else
+    printf "${BLUE}$(date +%T) > Removing branch '$SPLIT_BRANCH'...${NC}\n\n"
+fi
+
+# Import functions
+. $(dirname "$0")/monorepo_functions.sh
+
+# Remove the branch from all repositories
+EXIT_STATUS=0
+for PACKAGE in $(get_all_packages); do
+    git push --delete git@github.com:shopsys/$PACKAGE.git $SPLIT_BRANCH
+
+    if [[ $? -eq 0 ]]; then
+        printf "${GREEN}Branch '$SPLIT_BRANCH' was removed from the package '$PACKAGE'!${NC}\n"
+    else
+        printf "${RED}Branch '$SPLIT_BRANCH' could not be removed from the package '$PACKAGE'!${NC}\n"
+        EXIT_STATUS=1
+    fi
+done
+
+if [[ $EXIT_STATUS -eq 0 ]]; then
+    printf "\n${GREEN}$(date +%T) > Branches from all repositories were removed!${NC}\n\n"
+else
+    printf "\n${RED}$(date +%T) > Some branches were not removed from their remotes due to an error.${NC}\n\n"
+fi
+
+exit $EXIT_STATUS

--- a/.ci/monorepo_split.sh
+++ b/.ci/monorepo_split.sh
@@ -47,7 +47,7 @@ EXIT_STATUS=0
 printf "\n${BLUE}$(date +%T) > Splitting of all packages finished. Checking the ability to push the split repositories...${NC}\n\n"
 for PACKAGE in $(get_all_packages); do
     cd $WORKSPACE/split/$PACKAGE
-    REMOTE="git@github.com:shopsys/$PACKAGE.git"
+    REMOTE=$(get_package_remote "$PACKAGE")
 
     git push --tags $REMOTE master --dry-run
 
@@ -64,7 +64,7 @@ if [[ $EXIT_STATUS -eq 0 ]]; then
     printf "\n${GREEN}$(date +%T) > All repositories can be pushed! Pushing them into their remotes now...${NC}\n\n"
     for PACKAGE in $(get_all_packages); do
         cd $WORKSPACE/split/$PACKAGE
-        git push --tags git@github.com:shopsys/$PACKAGE.git master
+        git push --tags $(get_package_remote "$PACKAGE") master
     done
 else
     printf "\n${RED}$(date +%T) > Repositories were not pushed into their remotes due to an error.${NC}\n\n"

--- a/.ci/monorepo_split.sh
+++ b/.ci/monorepo_split.sh
@@ -12,7 +12,8 @@ GREEN="\e[32m"
 BLUE="\e[34m"
 NC="\e[0m"
 
-WORKSPACE=${WORKSPACE:-.}
+# Default value for WORKSPACE is the current working directory
+WORKSPACE=${WORKSPACE:-$PWD}
 
 # Relatively new version of git must be installed
 printf "\n${BLUE}Using $(git --version). The package shopsys/monorepo-tools was tested on 2.16.1.${NC}\n\n"

--- a/.ci/monorepo_split.sh
+++ b/.ci/monorepo_split.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Split master branches of all packages of the monorepo in parallel and push it into master branches in corresponding repositories.
+#
+# Logs of history rewriting can be found in $WORKSPACE/split/ along with the individual bare repositories.
+#
+# Usage: monorepo_split.sh
+
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+BLUE="\e[34m"
+NC="\e[0m"
+
+WORKSPACE=${WORKSPACE:-.}
+
+# Relatively new version of git must be installed
+printf "\n${BLUE}Using $(git --version). The package shopsys/monorepo-tools was tested on 2.16.1.${NC}\n\n"
+
+# Import functions
+. $(dirname "$0")/monorepo_functions.sh
+
+for PACKAGE in $(get_all_packages); do
+    # Preparing the variables to be used for splitting
+    LOG_FILE="$WORKSPACE/split/$PACKAGE.log"
+    SUBDIRECTORY=$(get_package_subdirectory "$PACKAGE")
+
+    # Cloning the repository as bare into separate directory, so it can be split in a parallel process
+    cd $WORKSPACE
+    git clone --bare .git $WORKSPACE/split/$PACKAGE
+    cd $WORKSPACE/split/$PACKAGE
+
+    printf "${BLUE}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY'...${NC}\n"
+    printf "The progress will be logged into '$LOG_FILE'.\n\n"
+
+    # Running the splitting processes in parallel
+    $WORKSPACE/packages/monorepo-tools/rewrite_history_from.sh $SUBDIRECTORY master $(git tag) > $LOG_FILE 2>&1 &&
+        printf "${GREEN}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY' finished!${NC}\n" ||
+        printf "${RED}$(date +%T) > Splitting package '$PACKAGE' from directory '$SUBDIRECTORY' failed!${NC}\n" &
+done
+
+wait
+
+# Checking the status of the split repositories
+EXIT_STATUS=0
+printf "\n${BLUE}$(date +%T) > Splitting of all packages finished. Checking the ability to push the split repositories...${NC}\n\n"
+for PACKAGE in $(get_all_packages); do
+    cd $WORKSPACE/split/$PACKAGE
+    REMOTE="git@github.com:shopsys/$PACKAGE.git"
+
+    git push --tags $REMOTE master --dry-run
+
+    if [[ $? -eq 0 ]]; then
+        printf "${GREEN}The split package '$PACKAGE' can be pushed into '$REMOTE'!${NC}\n"
+    else
+        printf "${RED}The split package '$PACKAGE' cannot be pushed into '$REMOTE'!${NC}\n"
+        EXIT_STATUS=1
+    fi
+done
+
+# Pushing all repositories at once if they are OK so they are released at one moment
+if [[ $EXIT_STATUS -eq 0 ]]; then
+    printf "\n${GREEN}$(date +%T) > All repositories can be pushed! Pushing them into their remotes now...${NC}\n\n"
+    for PACKAGE in $(get_all_packages); do
+        cd $WORKSPACE/split/$PACKAGE
+        git push --tags git@github.com:shopsys/$PACKAGE.git master
+    done
+else
+    printf "\n${RED}$(date +%T) > Repositories were not pushed into their remotes due to an error.${NC}\n\n"
+fi
+
+exit $EXIT_STATUS

--- a/docs/introduction/monorepo.md
+++ b/docs/introduction/monorepo.md
@@ -43,6 +43,9 @@ If you are interested, you can read more about the monorepo approach here - http
 * [shopsys/microservice-product-search](https://github.com/shopsys/microservice-product-search)
 * [shopsys/microservice-product-search-export](https://github.com/shopsys/microservice-product-search-export)
 
+*Note: The list of these packages is maintained in the function `get_all_packages` in [`.ci/monorepo_functions.sh`](/.ci/monorepo_functions.sh).
+It is used for automated splitting of the monorepo and needs to be updated when a package is added or removed.*
+
 ## Infrastructure
 Monorepo can be installed and used as standard application. This requires some additional infrastructure:
 


### PR DESCRIPTION
- basically copy-pasted from our Jenkins configuration so we can change it with the codebase (eg. add a package inside a PR as a modification of `get_all_packages()` in `monorepo_functions.sh` and let it be split automatically after the PR is merged)
- `monorepo_split.sh` splits master into all subrepositories
  - should be executed automatically after `master` is successfully built
- `monorepo_force_split_branch.sh` splits and force pushes selected branch into all subrepositories
  - should be executed manually as a parameterized build
- `monorepo_remove_branch.sh` removes selected branch from all subrepositories
  - should be executed manually as a parameterized build
  - cleans up after `monorepo_force_split_branch.sh`
- `monorepo_functions.sh` contains reusable functions
- related to #698 and #408
- allows us to simplify our Jenkins configuration for monorepo maintenance to something like:
![image](https://user-images.githubusercontent.com/10008612/51036960-0478da80-15af-11e9-82cf-0df0beb28e01.png)

| Q             | A
| ------------- | ---
|Description, reason for the PR| adding a package requires changes to Jenkins configuration for it to be split (or stop being split for package removal)
|New feature| Yes <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
