### PR TITLE
[shopsys] twig/twig v2.6.1 is now ignored

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -145,7 +145,8 @@
     "symplify/monorepo-builder": "^5.2.17"
   },
   "conflict": {
-    "symfony/dependency-injection": "3.4.15|3.4.16"
+    "symfony/dependency-injection": "3.4.15|3.4.16",
+    "twig/twig": "2.6.1"
   },
   "scripts": {
     "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -95,6 +95,7 @@
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"
     },
     "conflict": {
-        "symfony/dependency-injection": "3.4.15|3.4.16"
+        "symfony/dependency-injection": "3.4.15|3.4.16",
+        "twig/twig": "2.6.1"
     }
 }

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -47,6 +47,7 @@
         "twig/twig": "^2.4.8"
     },
     "conflict": {
-        "symfony/dependency-injection": "3.4.15|3.4.16"
+        "symfony/dependency-injection": "3.4.15|3.4.16",
+        "twig/twig": "2.6.1"
     }
 }

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -46,6 +46,7 @@
         "twig/twig": "^2.4.8"
     },
     "conflict": {
-        "symfony/dependency-injection": "3.4.15|3.4.16"
+        "symfony/dependency-injection": "3.4.15|3.4.16",
+        "twig/twig": "2.6.1"
     }
 }

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -50,6 +50,7 @@
         "twig/twig": "^2.4.8"
     },
     "conflict": {
-        "symfony/dependency-injection": "3.4.15|3.4.16"
+        "symfony/dependency-injection": "3.4.15|3.4.16",
+        "twig/twig": "2.6.1"
     }
 }

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -47,6 +47,7 @@
         "twig/twig": "^2.4.8"
     },
     "conflict": {
-        "symfony/dependency-injection": "3.4.15|3.4.16"
+        "symfony/dependency-injection": "3.4.15|3.4.16",
+        "twig/twig": "2.6.1"
     }
 }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -99,7 +99,8 @@
         "shopsys/http-smoke-testing": "dev-master"
     },
     "conflict": {
-        "symfony/dependency-injection": "3.4.15|3.4.16"
+        "symfony/dependency-injection": "3.4.15|3.4.16",
+        "twig/twig": "2.6.1"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| due to https://github.com/twigphp/Twig/issues/2810 we have to ignore version 2.6.1 of twig/twig package
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes