### PR TITLE
[shopsys] docs: use "sh" instead of "bash" in docker exec commands

### DIFF
--- a/docs/docker/docker-troubleshooting.md
+++ b/docs/docker/docker-troubleshooting.md
@@ -84,8 +84,9 @@ Remember that after changing these you need to do few things differently.
 * You changed `container_name` of php-fpm which means that in order to get inside the php-fpm container you must now use this name.
   for instance, if your new container name is `my-new-project-name-php-fpm` you need to execute
 
+<!--- TODO exhchange "sh" with "bash" when releasing a new version -->
 ```
-docker exec -it my-new-project-name-php-fpm bash
+docker exec -it my-new-project-name-php-fpm sh
 ```
 
 ## Update of Dockerfile is not Reflected

--- a/docs/installation/installation-using-docker-application-setup.md
+++ b/docs/installation/installation-using-docker-application-setup.md
@@ -7,8 +7,9 @@ If you haven't already done that check the [Installation Using Docker](installat
 Now that the Docker environment is prepared we can setup the application itself.
 
 ### 1.1. Connect into terminal of the Docker container
+<!--- TODO exhchange "sh" with "bash" when releasing a new version -->
 ```
-docker exec -it shopsys-framework-php-fpm bash
+docker exec -it shopsys-framework-php-fpm sh
 ```
 
 ### 1.2. Install dependencies and configure parameters


### PR DESCRIPTION
- Debian version with bash is not released yet
- added TODOs for the next release

| Q             | A
| ------------- | ---
|Description, reason for the PR| When someone tries to install project-base by the current installation guide, he will encounter an error - `OCI runtime exec failed: exec failed: container_linux.go:344: starting container process caused "exec: \"bash\": executable file not found in $PATH": unknown`
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
