### PR TITLE
[shopsys] monorepo force splitting using a RAM-disk

### DIFF
--- a/.ci/monorepo_force_split_branch.sh
+++ b/.ci/monorepo_force_split_branch.sh
@@ -37,7 +37,7 @@ printf "\n${BLUE}Using $(git --version). The package shopsys/monorepo-tools was 
 
 # Try to mount the splitting directory as a RAM-disk
 mkdir "$WORKSPACE/split"
-sudo mount -t tmpfs -o size=256M tmpfs "$WORKSPACE/split"
+sudo mount -t tmpfs -o size=2G tmpfs "$WORKSPACE/split"
 MOUNT_EXIT_STATUS=$?
 
 for PACKAGE in $(get_all_packages); do


### PR DESCRIPTION
- requires permission to sudo "mount" and "umount" commands (set in "/etc/sudoers")
- if the permission is not provided, RAM-disk will not be mounted
- at the end of the script it will back-up the data and unmount the volume (this will not be done if the script is interrupted; signal handling using "trap" would need to be implemented)

| Q             | A
| ------------- | ---
|Description, reason for the PR| using a tmpfs mount should increase performance and decrease disk usage; this is just a prototype (considering only `monorepo_force_split_branch.sh`)
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
