### PR TITLE
fix cooperation between AjaxMoreLoader and AjaxFilter

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js
@@ -15,7 +15,6 @@
     };
 
     Shopsys.AjaxMoreLoader = function ($wrapper, options) {
-        var self = this;
         var $loadMoreButton;
         var $currentList;
         var $paginationToItemSpan;
@@ -43,10 +42,6 @@
 
             updateLoadMoreButton();
             $loadMoreButton.on('click', onClickLoadMoreButton);
-        };
-
-        this.reInit = function () {
-            self.init();
         };
 
         var onClickLoadMoreButton = function () {

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.AjaxFilter.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.AjaxFilter.js
@@ -4,7 +4,7 @@
     Shopsys.productList = Shopsys.productList || {};
     Shopsys.productList.AjaxFilter = Shopsys.productList.AjaxFilter || {};
 
-    Shopsys.productList.AjaxFilter = function (ajaxMoreLoader) {
+    Shopsys.productList.AjaxFilter = function () {
         var $productsWithControls = $('.js-product-list-ajax-filter-products-with-controls');
         var $productFilterForm = $('form[name="product_filter_form"]');
         var $showResultsButton = $('.js-product-filter-show-result-button');
@@ -44,7 +44,6 @@
             var $productsHtml = $wrappedData.find('.js-product-list-ajax-filter-products-with-controls');
             $productsWithControls.html($productsHtml.html());
             $productsWithControls.show();
-            ajaxMoreLoader.reInit();
             Shopsys.register.registerNewContent($productsWithControls);
         };
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.js
@@ -3,8 +3,8 @@
     Shopsys = window.Shopsys || {};
     Shopsys.productList = Shopsys.productList || {};
 
-    Shopsys.register.registerCallback(function () {
-        $('.js-product-list-ordering-mode').click(function () {
+    Shopsys.register.registerCallback(function ($container) {
+        $container.filterAllNodes('.js-product-list-ordering-mode').click(function () {
             var cookieName = $(this).data('cookie-name');
             var orderingName = $(this).data('ordering-mode');
 
@@ -13,10 +13,8 @@
 
             return false;
         });
-    });
 
-    $(document).ready(function () {
-        $('.js-product-list-with-paginator').each(function () {
+        $container.filterAllNodes('.js-product-list-with-paginator').each(function () {
             var ajaxMoreLoader = new Shopsys.AjaxMoreLoader($(this), {
                 buttonTextCallback: function (loadNextCount) {
                     return Shopsys.translator.transChoice(
@@ -27,8 +25,12 @@
                 }
             });
             ajaxMoreLoader.init();
+        });
+    });
 
-            var ajaxFilter = new Shopsys.productList.AjaxFilter(ajaxMoreLoader);
+    $(document).ready(function () {
+        $('.js-product-list-with-paginator').each(function () {
+            var ajaxFilter = new Shopsys.productList.AjaxFilter();
             ajaxFilter.init();
         });
     });


### PR DESCRIPTION
- `Shopsys.AjaxMoreLoader` is always initialized using a registered callback (instead of on document-ready)
- this means its manual reinitialization after a filtering is applied is not necessary anymore
- the `reInit` method can be removed as it is never used (which was the only use of the `self` variable)
- this makes `AjaxFilter` independent on the `AjaxMoreLoader` and it doesn't have to provided in a constructor anymore
- the initialization of `Shopsys.productList.AjaxFilter` have been left in the document-ready block, as the instance has to be global (otherwise multiple AJAX calls would be triggered during successive product filtering)
- the callback registered in `productList.js` has a limited scope using `$container`

| Q             | A
| ------------- | ---
|Description, reason for the PR| `AjaxMoreLoader` stopped working when `AjaxFilter` was used due to bad initialization
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #751 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
