### PR TITLE
fix and enhance configuration of docker-compose and docker-sync for windows development

### DIFF
--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -41,7 +41,7 @@ services:
         volumes:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
-            - shopsys-framework-web-sync:/var/www/html/web
+            - shopsys-framework-web-sync:/var/www/html/project-base/web
             - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         ports:
             - "35729:35729"

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -42,6 +42,8 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/project-base/web
+            - shopsys-framework-microservice-product-search-sync:/var/www/html/microservices/product-search
+            - shopsys-framework-microservice-product-search-export-sync:/var/www/html/microservices/product-search-export
             - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         ports:
             - "35729:35729"
@@ -55,7 +57,7 @@ services:
                 <<: *common_build_args
         container_name: shopsys-framework-microservice-product-search
         volumes:
-            - ./microservices/product-search:/var/www/html
+            - shopsys-framework-microservice-product-search-sync:/var/www/html
 
     microservice-product-search-export:
         build:
@@ -66,7 +68,7 @@ services:
                 <<: *common_build_args
         container_name: shopsys-framework-microservice-product-search-export
         volumes:
-            - ./microservices/product-search-export:/var/www/html
+            - shopsys-framework-microservice-product-search-export-sync:/var/www/html
 
     redis:
         image: redis:4.0-alpine
@@ -123,4 +125,8 @@ volumes:
     shopsys-framework-vendor-sync:
         external: true
     shopsys-framework-web-sync:
+        external: true
+    shopsys-framework-microservice-product-search-sync:
+        external: true
+    shopsys-framework-microservice-product-search-export-sync:
         external: true

--- a/docker/conf/docker-sync-win.yml.dist
+++ b/docker/conf/docker-sync-win.yml.dist
@@ -13,6 +13,7 @@ syncs:
             '.docker-sync',
             '.DS_Store',
             'docker',
+            'microservices',
             'nbproject',
             'project-base/docker',
             'project-base/docs',

--- a/docker/conf/docker-sync-win.yml.dist
+++ b/docker/conf/docker-sync-win.yml.dist
@@ -1,4 +1,6 @@
 version: '2'
+options:
+    max_attempt: 15
 syncs:
     shopsys-framework-sync:
         sync_userid: 1000

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -23,6 +23,7 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for fast two-way syn
 
 ### Installation of Docker-sync for Windows
 
+***Note:** be aware of using custom firewalls or protection tools other than default `Windows Defender`, we experienced that some of them make synchronization malfunctioning because of blocking synchronization ports. To speed up the synchronization and developing faster, you can exclude folder from indexing and search path of `Windows Defender`.*
 * In settings of Windows docker check `Expose daemon on localhost:2375` in `General` tab and check drive option in `Shared Drives` tab, where the project will be installed, you will be prompted for your Windows credentials.
 * Enable WSL - Open the `Windows Control Panel`, `Programs and Features`, click on the left on `Turn Windows features on or off` and check `Windows Subsystem for Linux` near the bottom, restart of Windows is required.
 * Install `Debian` app form `Microsoft Store` and launch it, so console window is opened.

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -23,7 +23,7 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for fast two-way syn
 
 ### Installation of Docker-sync for Windows
 
-* In settings of Windows docker check `Expose daemon on localhost:2375` and check drive option in `Shared Drives` tab, where the project will be installed, you will be prompted for your Windows credentials.
+* In settings of Windows docker check `Expose daemon on localhost:2375` in `General` tab and check drive option in `Shared Drives` tab, where the project will be installed, you will be prompted for your Windows credentials.
 * Enable WSL - Open the `Windows Control Panel`, `Programs and Features`, click on the left on `Turn Windows features on or off` and check `Windows Subsystem for Linux` near the bottom, restart of Windows is required.
 * Install `Debian` app form `Microsoft Store` and launch it, so console window is opened.
 * Execute following commands in console window.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| seems that web volume is mounted the same way as in project-base so it needs to be corrected and docker-sync volumes for microservices could be used in php-fpm container 
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| - <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
