### PR TITLE
[shopsys] explain minimal version of Docker in docs

### DIFF
--- a/docs/docker/docker-troubleshooting.md
+++ b/docs/docker/docker-troubleshooting.md
@@ -151,3 +151,14 @@ When `composer install` or `composer update` fails on an error with exceeding th
 
 *Note: Since `v7.0.0-beta4` we have set the Composer memory limit to `-1` (which means unlimited) in the php-fpm's `Dockerfile`.*
 *If you still encounter memory issues while using Docker for Windows (or Mac), try increasing the limits in `Docker -> Preferences… -> Advanced`.*
+
+## Starting up the Docker containers fails due to invalid reference format
+Docker images may fail to build during `docker-compose up -d` due to invalid reference format, eg.:
+```
+Building php-fpm
+Step 1/41 : FROM php:7.2-fpm-stretch as base
+ERROR: Service 'php-fpm' failed to build: Error parsing reference: "php:7.2-fpm-stretch as base" is not a valid repository/tag: invalid reference format
+```
+This is because you have a version of Docker which does not support [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).
+
+Upgrade your Docker to version **17.05 or higher** and try running the command again.

--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -9,7 +9,7 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.unix.php)
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
-* [Docker](https://docs.docker.com/engine/installation/)
+* [Docker 17.05 or higher](https://docs.docker.com/engine/installation/)
 * [Docker Compose](https://docs.docker.com/compose/install/)
 
 ## Steps


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| we use multi-stage Docker builds which are supported only in Docker 17.05 or higher, which was not mentioned in our docs (and lead to problems during installation for some people, eg. #761)
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
