### PR TITLE
Cart migration: call method on null

### DIFF
--- a/packages/framework/src/Model/Cart/CartMigrationFacade.php
+++ b/packages/framework/src/Model/Cart/CartMigrationFacade.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Cart;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Customer\CustomerIdentifierFactory;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -76,12 +77,15 @@ class CartMigrationFacade
     {
         $session = $filterControllerEvent->getRequest()->getSession();
 
-        $previousCartIdentifier = $session->get(self::SESSION_PREVIOUS_CART_IDENTIFIER);
-        if (!empty($previousCartIdentifier) && $previousCartIdentifier !== $session->getId()) {
-            $previousCustomerIdentifier = $this->customerIdentifierFactory->getOnlyWithCartIdentifier($previousCartIdentifier);
-            $cart = $this->cartFactory->get($previousCustomerIdentifier);
-            $this->mergeCurrentCartWithCart($cart);
+        if ($session !== null) {
+            $previousCartIdentifier = $session->get(self::SESSION_PREVIOUS_CART_IDENTIFIER);
+            $previousCartIdentifier = TransformString::emptyToNull($previousCartIdentifier);
+            if ($previousCartIdentifier !== null && $previousCartIdentifier !== $session->getId()) {
+                $previousCustomerIdentifier = $this->customerIdentifierFactory->getOnlyWithCartIdentifier($previousCartIdentifier);
+                $cart = $this->cartFactory->get($previousCustomerIdentifier);
+                $this->mergeCurrentCartWithCart($cart);
+            }
+            $session->set(self::SESSION_PREVIOUS_CART_IDENTIFIER, $session->getId());
         }
-        $session->set(self::SESSION_PREVIOUS_CART_IDENTIFIER, $session->getId());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In cart migration facade is not correct call the method because it's called on null
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

On one SS6 project, this row https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Cart/CartMigrationFacade.php#L79 often throw error because `session` is null

```
[2019-01-25 15:17:21] request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Call to a member function get() on null" at .../src/Shopsys/ShopBundle/Model/Cart/CartMigrationFacade.php line 79 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to a member function get() on null at .../src/Shopsys/ShopBundle/Model/Cart/CartMigrationFacade.php:79)"} []
```
I know that method migrate cart after login (i hope). I did a "fix" but i am not really sure whether is correct. Can you check this "fix" is correct?

Thanks