### PR TITLE
added missing shopsys/google-cloud-bundle into monorepo split package list

### DIFF
--- a/.ci/monorepo_functions.sh
+++ b/.ci/monorepo_functions.sh
@@ -3,6 +3,7 @@
 # Lists packages that should be split
 get_all_packages() {
     echo "framework \
+        google-cloud-bundle \
         product-feed-zbozi \
         product-feed-google \
         product-feed-heureka \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This should be added with #730, so with split of monorepo, our new package google-cloud-bundle will be split too
|New feature| No
|BC breaks| No
|Fixes issues| ... 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
