### PR TITLE
[project-base] kubernetes uses relay setting for sending mails

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@
 * [Logging on Continuous Integration server running Kubernetes](/docs/kubernetes/logging-on-continuous-integration-server-running-kubernetes.md)
 * [How to deploy SSFW to Google Cloud platform](/docs/kubernetes/how-to-deploy-ssfw-to-google-cloud-platform.md)
 * [Deploy Your Application to Google Cloud on your CI/CD](/docs/kubernetes/deploy-your-application-to-google-cloud-on-your-ci-cd.md)
+* [How to set SMTP Server Container](/docs/kubernetes/how-to-set-smtp-server-container.md)
 
 ## Microservices
 One of the explored ideas of Shopsys Framework is the idea of a product, that some of its parts are designed as the microservices.

--- a/docs/kubernetes/how-to-set-smtp-server-container.md
+++ b/docs/kubernetes/how-to-set-smtp-server-container.md
@@ -1,0 +1,11 @@
+# How to set SMTP Server Container
+
+For sending e-mails from our application we use [SMTP server container](https://hub.docker.com/r/namshi/smtp/) in separate `k8s POD` so we need to set some additional settings as permission to be able to send e-mails from `webserver-php-fpm` POD.
+For this purpose we have set `RELAY_NETWORKS` ENV variable with all private network that can be created by docker into `/project-base/kubernetes/deployments/smtp-server.yml` for POD of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
+for instance:
+```yaml
+image: namshi/smtp:latest
+env:
+-   name: RELAY_NETWORKS
+    value: :192.168.0.0/16:10.0.0.0/8:172.16.0.0/12
+```

--- a/docs/kubernetes/how-to-set-smtp-server-container.md
+++ b/docs/kubernetes/how-to-set-smtp-server-container.md
@@ -1,7 +1,7 @@
 # How to set SMTP Server Container
 
 For sending e-mails from our application we use [SMTP server container](https://hub.docker.com/r/namshi/smtp/) in separate `k8s POD` so we need to set some additional settings as permission to be able to send e-mails from `webserver-php-fpm` POD.
-For this purpose we have set `RELAY_NETWORKS` ENV variable with all private network that can be created by docker into `/project-base/kubernetes/deployments/smtp-server.yml` for POD of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
+For this purpose, we have set `RELAY_NETWORKS` ENV variable with all private networks that can be created by docker into `/project-base/kubernetes/deployments/smtp-server.yml` for POD of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
 for instance:
 ```yaml
 image: namshi/smtp:latest

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -8,6 +8,14 @@ There you can find links to upgrade notes for other versions too.
 ## [shopsys/framework]
 ### Infrastructure
 - *(optional)* in your `docker/php-fpm/Dockerfile` change base image to `php:7.3-fpm-stretch` ([#694](https://github.com/shopsys/shopsys/pull/694))
+- add subnet of your **k8s** cluster as ENV variable into the config `/project-base/kubernetes/deployments/smtp-server.yml` for POD of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
+for instance:
+    ```yaml
+    image: namshi/smtp:latest
+    env:
+    -   name: RELAY_NETWORKS
+        value: :192.168.0.0/16:10.0.0.0/8:172.16.0.0/12
+    ```
 
 ### Tools
 - *(optional)* add a new phing target `clean-redis` to your `build.xml` and `build-dev.xml` and use it where you need to clean Redis cache.

--- a/project-base/kubernetes/deployments/smtp-server.yml
+++ b/project-base/kubernetes/deployments/smtp-server.yml
@@ -12,6 +12,9 @@ spec:
             containers:
             -   name: smtp-server
                 image: namshi/smtp:latest
+                env:
+                -   name: RELAY_NETWORKS
+                    value: :192.168.0.0/16:10.0.0.0/8:172.16.0.0/12
                 ports:
                 -   name: smtp
                     containerPort: 25


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| k8s deploy doesn't want to send mails via smtp container because of relay permissions and sending mail for shop is very important thing
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #537 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
