### PR TITLE
[framework] Directories created during shopsys:create-directories command are configurable in yml configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,11 @@
 * [Shopsys Framework Development Workflow](introduction/shopsys-framework-development-workflow.md)
 * [How to Work with Products](./introduction/how-to-work-with-products.md)
 * [Translations](./introduction/translations.md)
+<!--- TODO
+Add:
 
+* [Directories](./introduction/directories.md)
+-->
 ## Cookbook
 * [Dumping and Importing the Database](./cookbook/dumping-and-importing-the-database.md)
 * [Configuring Jenkins for Continuous Integration](./cookbook/jenkins-configuration.md)

--- a/docs/introduction/directories.md
+++ b/docs/introduction/directories.md
@@ -1,0 +1,45 @@
+
+# Directories
+This article describes how to work with directories and how to create your own directories.
+
+## Config
+Default directories that need to be created in order to app to be able to run properly are defined in framework's [`/Resources/config/directories.yml`](/packages/framework/src/Resources/config/directories.yml) and are created by symfony command `shopsys:create-directories`.
+
+## Directories type
+There are 2 types of directories that are created.
+
+### Internal directories
+Directories that are used by application and do not need to be public, typically cache or logs.
+
+These directories are grouped under `internal_directores` in `app/config/directories.yml` file and their definition is an absolute path.
+
+For example:
+```
+internal_directories:
+    - '%kernel.project_dir%/var/logs'
+```
+
+### Public directories
+Directories that needs to be available for public usage, for example feeds or sitemaps.
+
+These directories are grouped under `public_directores` in `app/config/directories.yml` file and their definition is relative path to the root directory of a project.
+
+For example:
+```
+public_directories:
+    - '/web/content/images'
+```
+
+## Adding a new directory
+In case you need to create your own directories, you can simply add them into  `app/config/directories.yml` under suitable type as an array element.
+
+For example:
+
+```
+// app/config/directories.yml
+
+parameters:
+    public_directories:
++   - '/my/new/folder'
+    internal_directories:
+```

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -39,6 +39,9 @@ for instance:
     - [`Version20190121094400`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Migrations/Version20190121094400.php <!--- TODO: change to released version instead of master -->
 
 ### Application
+- use configuration file to define directories that needs to be created during build of the application ([#781](https://github.com/shopsys/shopsys/pull/781))
+    - create new configuration file `app/config/directories.yml` with 2 types of directories `public_directories` and `internal_directories` and add this file into `$configs` array in `AppKernel::getConfigs()`.
+    - if you had implemented your individual directories in `CreateApplicationDirectoriesCommand`, delete your extension of a class and add the directories into `app/config/directories.yml` and fill them into sections, you can read more about sections [here](https://github.com/shopsys/shopsys/blob/master/docs/intruduction/directories.yml) <!--- TODO: change to released version instead of master -->
 - if you were using `oneup/flysystembundle` for using different adapter than the local one, you must now implement `FilesystemFactoryInterface` and init the adapter by yourself.
 - *(optional)* delete dependency on `oneup/flysystembundle` from your `composer.json`
 - remove usages of inherited `OrderItem` classes ([#715](https://github.com/shopsys/shopsys/pull/715))

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -17,6 +17,7 @@ class ShopsysFrameworkExtension extends Extension
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('directories.yml');
         $loader->load('services.yml');
         $loader->load('paths.yml');
 

--- a/packages/framework/src/Resources/config/directories.yml
+++ b/packages/framework/src/Resources/config/directories.yml
@@ -1,0 +1,15 @@
+parameters:
+    shopsys.framework.default_public_directories:
+    - '/web/%shopsys.content_dir_name%/feeds'
+    - '/web/%shopsys.content_dir_name%/sitemaps'
+    - '/web/%shopsys.content_dir_name%/wysiwyg'
+    shopsys.framework.default_internal_directories:
+    - '%kernel.project_dir%/build/stats'
+    - '%kernel.project_dir%/docs/generated'
+    - '%kernel.project_dir%/var/cache'
+    - '%kernel.project_dir%/var/lock'
+    - '%kernel.project_dir%/var/logs'
+    - '%kernel.project_dir%/var/errorPages'
+    - '%shopsys.web_dir%/assets/admin/styles'
+    - '%shopsys.web_dir%/assets/frontend/styles'
+    - '%shopsys.web_dir%/assets/scripts'

--- a/packages/framework/src/Resources/config/services/commands.yml
+++ b/packages/framework/src/Resources/config/services/commands.yml
@@ -23,8 +23,10 @@ services:
 
     Shopsys\FrameworkBundle\Command\CreateApplicationDirectoriesCommand:
         arguments:
-            - '%kernel.project_dir%'
-            - '%shopsys.content_dir_name%'
+            $defaultInternalDirectories: '%shopsys.framework.default_internal_directories%'
+            $defaultPublicDirectories: '%shopsys.framework.default_public_directories%'
+            $internalDirectories: '%internal_directories%'
+            $publicDirectories: '%public_directories%'
 
     Shopsys\FrameworkBundle\Command\GenerateGruntfileCommand:
         arguments:

--- a/project-base/app/AppKernel.php
+++ b/project-base/app/AppKernel.php
@@ -78,6 +78,7 @@ class AppKernel extends Kernel
     private function getConfigs()
     {
         $configs = [
+            __DIR__ . '/config/directories.yml',
             __DIR__ . '/config/parameters_common.yml',
             __DIR__ . '/config/parameters.yml',
             __DIR__ . '/config/paths.yml',

--- a/project-base/app/config/directories.yml
+++ b/project-base/app/config/directories.yml
@@ -1,0 +1,3 @@
+parameters:
+    public_directories:
+    internal_directories:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Adding a new directory to be created during `shopsys:create-directories` was only able to add by extending `CreateApplicationDirectoriesCommand::CreateMiscellaneousDirectories()`. Because of that there was created `directories.yml` that defines directories and can be easily extended.
|New feature| Yes
|BC breaks| Yes
|Fixes issues| #349
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
