### PR TITLE
[shopsys] change forms in popup so they work with js validation

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -172,6 +172,44 @@ for instance:
     - if you have extended `CountryController` revise your changes – `new` and `edit` actions were added
 - if you have extended `Localization` class, you have to add type-hints to extended methods because they were added in the parent class ([#806](https://github.com/shopsys/shopsys/pull/806))
     - if you have extended method `Localization::getAdminLocale()` only to have administration in a different language than english, you can delete it and set parameter `shopsys.admin_locale` in your `parameters.yml` file instead
+- fixed JS validation of forms in popup windows ([#782](https://github.com/shopsys/shopsys/pull/782))
+    - login form in popup is now loaded via AJAX
+    - in `window.js` add options `textHeading = ''` and `cssClassHeading: ''` to `var defaults` like this:
+        ```diff
+            var defaults = {
+                content: '',
+                buttonClose: true,
+                buttonCancel: false,
+                buttonContinue: false,
+                textContinue: Shopsys.translator.trans('Yes'),
+                textCancel: Shopsys.translator.trans('No'),
+        +       textHeading: '',
+                urlContinue: '#',
+                cssClass: 'window-popup--standard',
+                cssClassContinue: '',
+                cssClassCancel: '',
+        +       cssClassHeading: '',
+                closeOnBgClick: true,
+                eventClose: function () {},
+                eventContinue: function () {},
+                eventCancel: function () {},
+                eventOnLoad: function () {}
+            };
+        ```
+        - then add the heading to `$windowContent` and add div with `js-validation-errors` class to every popup.:
+        ```diff
+        -   var $windowContent = $('<div class="js-window-content window-popup__in"></div>').html(options.content);
+        +   var $windowContent = $('<div class="js-window-content window-popup__in"></div>');
+        +   if (options.textHeading !== '') {
+        +       $windowContent.append('<h2 class="' + options.cssClassHeading + '">' + options.textHeading + '</h2>');
+        +   }
+        +   $windowContent.append(
+        +       '<div class="display-none in-message in-message--alert js-window-validation-errors"></div>'
+        +       + options.content
+        +   );
+        ```
+    - *(optional)* change login form so it is loaded by AJAX and works with JS validation and change `Login/windowForm.html.twig`, `Login/loginForm.html.twig` and `header.html.twig` templates
+        - you can change it as it was done in this [commit](https://github.com/shopsys/shopsys/pull/782/commits/0e7cf1e615563e804657d7b96ef335617461236c)
 
 - if you have extended classes from `Shopsys\FrameworkBundle\Model`, `Shopsys\FrameworkBundle\Component` or `Shopsys\FrameworkBundle\DataFixtures\Demo` namespace ([#788](https://github.com/shopsys/shopsys/pull/788))
     - you need to adjust extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`

--- a/packages/framework/src/Resources/scripts/common/validation/customizeBundle.js
+++ b/packages/framework/src/Resources/scripts/common/validation/customizeBundle.js
@@ -153,6 +153,7 @@
     //   there can be loaded callbacks from last form submit which can cause duplicated form error windows
     // (the rest is copy&pasted from original method; eg. ajax validation)
     FpJsFormValidator.customizeMethods.submitForm = function (event) {
+        $('.js-window-validation-errors').addClass('display-none');
         var $form = $(this);
         if (!$form.hasClass('js-no-validate')) {
             FpJsFormValidator.each(this, function (item) {
@@ -441,14 +442,24 @@
 
     Shopsys.validation.showFormErrorsWindow = function (container) {
         var $formattedFormErrors = Shopsys.validation.getFormattedFormErrors(container);
+        var $window = $('#js-window');
 
-        Shopsys.window({
-            content:
-                '<div class="text-left">'
-                + Shopsys.translator.trans('Please check the entered values.<br><br>')
-                + $formattedFormErrors[0].outerHTML
-                + '</div>'
-        });
+        var $errorListHtml = '<div class="text-left">'
+            + Shopsys.translator.trans('Please check the entered values.<br>')
+            + $formattedFormErrors[0].outerHTML
+            + '</div>';
+
+        if ($window.length === 0) {
+            Shopsys.window({
+                content: $errorListHtml
+
+            });
+        } else {
+            $window.filterAllNodes('.js-window-validation-errors')
+                .html($errorListHtml)
+                .removeClass('display-none');
+        }
+
     };
 
     Shopsys.validation.getFormattedFormErrors = function (container) {

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1579,8 +1579,8 @@ msgstr "Prosím překontrolujte následující informace:"
 msgid "Please check the correctness of all data filled."
 msgstr "Prosím zkontrolujte si správnost vyplnění všech údajů"
 
-msgid "Please check the entered values.<br><br>"
-msgstr "Překontrolujte prosím zadané hodnoty.<br><br>"
+msgid "Please check the entered values.<br>"
+msgstr "Překontrolujte prosím zadané hodnoty.<br>"
 
 msgid "Please fill all default values before creating a product"
 msgstr "Prosím vyplňte všechny výchozí hodnoty před vytvořením produktu"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Please check the correctness of all data filled."
 msgstr ""
 
-msgid "Please check the entered values.<br><br>"
+msgid "Please check the entered values.<br>"
 msgstr ""
 
 msgid "Please fill all default values before creating a product"

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/LoginController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/LoginController.php
@@ -37,7 +37,7 @@ class LoginController extends FrontBaseController
         try {
             $this->authenticator->checkLoginProcess($request);
         } catch (\Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException $e) {
-            $form->addError(new FormError(t('Invalid login')));
+            $form->addError(new FormError(t('This account doesn\'t exist or password is incorrect')));
         }
 
         return $this->render('@ShopsysShop/Front/Content/Login/loginForm.html.twig', [

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/routing_front.yml
@@ -141,3 +141,8 @@ front_registration_exists_email:
 front_export_personal_data:
     path: /personal-overview-export/xml/{hash}
     defaults: { _controller: ShopsysShopBundle:Front\PersonalData:exportXml }
+
+front_login_window_form:
+    path: /login/form
+    defaults: { _controller: ShopsysShopBundle:Front\Login:windowForm }
+    methods: [POST]

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/login.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/login.js
@@ -3,9 +3,29 @@
     Shopsys = window.Shopsys || {};
     Shopsys.login = Shopsys.login || {};
 
-    Shopsys.login.init = function () {
-        $('body').on('submit', '.js-front-login-window', function () {
-            $('.js-front-login-window-message').empty();
+    Shopsys.login.Login = function () {
+
+        this.init = function ($loginButton) {
+            $loginButton.click(showWindow);
+        };
+
+        function showWindow (event) {
+            Shopsys.ajax({
+                url: $(this).data('url'),
+                type: 'POST',
+                success: function (data) {
+                    var $window = Shopsys.window({
+                        content: data
+                    });
+
+                    $window.on('submit', '.js-front-login-window', onSubmit);
+                }
+            });
+
+            event.preventDefault();
+        }
+
+        function onSubmit () {
             Shopsys.ajax({
                 loaderElement: '.js-front-login-window',
                 type: 'POST',
@@ -18,21 +38,26 @@
 
                         document.location = data.urlToRedirect;
                     } else {
-                        $('.js-front-login-window-message')
-                            .text(Shopsys.translator.trans('Invalid login'))
-                            .show();
+                        var $validationErrors = $('.js-window-validation-errors');
+                        if ($validationErrors.hasClass('display-none')) {
+                            $validationErrors
+                                .text(Shopsys.translator.trans('This account doesn\'t exist or password is incorrect'))
+                                .show();
+                        }
+
                     }
                 }
             });
             return false;
-        });
-        $('body').on('focus', '.js-front-login-window', function () {
-            $('.js-front-login-window-message').empty().hide();
-        });
+        }
+
     };
 
-    $(document).ready(function () {
-        Shopsys.login.init();
+    Shopsys.register.registerCallback(function ($container) {
+        $container.filterAllNodes('.js-login-button').each(function () {
+            var $login = new Shopsys.login.Login();
+            $login.init($(this));
+        });
     });
 
 })(jQuery);

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/login.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/login.js
@@ -15,7 +15,8 @@
                 type: 'POST',
                 success: function (data) {
                     var $window = Shopsys.window({
-                        content: data
+                        content: data,
+                        textHeading: Shopsys.translator.trans('Login')
                     });
 
                     $window.on('submit', '.js-front-login-window', onSubmit);

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/window.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/window.js
@@ -66,10 +66,12 @@
             buttonContinue: false,
             textContinue: Shopsys.translator.trans('Yes'),
             textCancel: Shopsys.translator.trans('No'),
+            textHeading: '',
             urlContinue: '#',
             cssClass: 'window-popup--standard',
             cssClassContinue: '',
             cssClassCancel: '',
+            cssClassHeading: '',
             closeOnBgClick: true,
             eventClose: function () {},
             eventContinue: function () {},
@@ -87,7 +89,13 @@
             $window.addClass(options.cssClass);
         }
 
-        var $windowContent = $('<div class="js-window-content window-popup__in"></div>').html(
+        var $windowContent = $('<div class="js-window-content window-popup__in"></div>');
+
+        if (options.textHeading !== '') {
+            $windowContent.append('<h2 class="' + options.cssClassHeading + '">' + options.textHeading + '</h2>');
+        }
+
+        $windowContent.append(
             '<div class="display-none in-message in-message--alert js-window-validation-errors"></div>'
             + options.content
         );

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/window.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/window.js
@@ -87,7 +87,10 @@
             $window.addClass(options.cssClass);
         }
 
-        var $windowContent = $('<div class="js-window-content window-popup__in"></div>').html(options.content);
+        var $windowContent = $('<div class="js-window-content window-popup__in"></div>').html(
+            '<div class="display-none in-message in-message--alert js-window-validation-errors"></div>'
+            + options.content
+        );
 
         $activeWindow = $window;
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/login.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/login.less
@@ -5,6 +5,7 @@
 
     &__item {
         margin-bottom: 5px;
+        margin-right: @margin-gap;
 
         &--checkbox {
             margin-top: 10px;

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
@@ -244,9 +244,6 @@ msgstr "Chci se přihlásit k odběru newsletteru"
 msgid "Image"
 msgstr "Obrázek"
 
-msgid "Invalid login"
-msgstr "Byly zadány neplatné přihlašovací údaje"
-
 msgid "Items"
 msgstr "Položky"
 
@@ -549,6 +546,9 @@ msgstr "V průběhu objednávkového procesu byla změněna cena platby {{ payme
 
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."
 msgstr "V průběhu objednávkového procesu byla změněna cena dopravy {{ transportName }}. Prosím, překontrolujte si objednávku."
+
+msgid "This account doesn't exist or password is incorrect"
+msgstr "Zadali jste špatné uživatelské jméno nebo heslo"
 
 msgid "This category contains no products."
 msgstr "Tato kategorie neobsahuje žádné produkty"

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
@@ -244,9 +244,6 @@ msgstr ""
 msgid "Image"
 msgstr ""
 
-msgid "Invalid login"
-msgstr ""
-
 msgid "Items"
 msgstr ""
 
@@ -548,6 +545,9 @@ msgid "The price of payment {{ paymentName }} changed during ordering process. C
 msgstr ""
 
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."
+msgstr ""
+
+msgid "This account doesn't exist or password is incorrect"
 msgstr ""
 
 msgid "This category contains no products."

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Login/loginForm.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Login/loginForm.html.twig
@@ -9,15 +9,30 @@
 {% endblock %}
 
 {% block main_content %}
-    {{ form_errors(form) }}
 
     {{ form_start(form, {attr: {'multipleForm': true}}) }}
+    {{ form_errors(form, {errors_attr: { class: 'in-message--alert' }}) }}
 
         <h1>{{ 'Login'|trans }}</h1>
 
-        {{ form_row(form.email, {label: 'E-mail'|trans} ) }}
 
-        {{ form_row(form.password, {label: 'Password'|trans} ) }}
+        <dl class="form-line">
+            <dt>
+                {{ form_label(form.email) }}
+            </dt>
+            <dd>
+                {{ form_widget(form.email) }}
+            </dd>
+        </dl>
+
+        <dl class="form-line">
+            <dt>
+                {{ form_label(form.password) }}
+            </dt>
+            <dd>
+                {{ form_widget(form.password) }}
+            </dd>
+        </dl>
 
         <dl class="form-line">
             <dt></dt>
@@ -41,7 +56,7 @@
         <dl class="form-line">
             <dt></dt>
             <dd>
-                {{ form_row(form.login, {label: 'Log in'|trans}) }}
+                {{ form_widget(form.login, {label: 'Log in'|trans}) }}
             </dd>
         </dl>
         <dl class="form-line">

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Login/windowForm.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Login/windowForm.html.twig
@@ -1,19 +1,14 @@
-{{ form_start(form, {attr: {class: 'js-front-login-window', 'multipleForm': true}}) }}
+{{ init_js_validation(null, false) }}
+{{ form_start(form, {attr: {class: 'js-front-login-window'}}) }}
     {{ form_errors(form) }}
 
     <div class="box-login">
-        <h3 class="box-login__title">{{ 'Login'|trans }}</h3>
-
-        <div class="js-front-login-window-message in-message in-message--alert display-none"></div>
-
         <div class="box-login__item">
-            {{ form_widget(form.email, {attr: {placeholder: 'E-mail'|trans}}) }}
-            {{ form_errors(form.email) }}
+            {{ form_row(form.email, { label: 'E-mail'|trans, rowClass: 'form-line-block', errors_attr: { class: 'form-error--line-block' } }) }}
         </div>
 
         <div class="box-login__item">
-            {{ form_errors(form.password) }}
-            {{ form_widget(form.password, {attr: {placeholder: 'Password'|trans}}) }}
+            {{ form_row(form.password, { label: 'Password'|trans, rowClass: 'form-line-block', errors_attr: { class: 'form-error--line-block' } }) }}
         </div>
 
         <div class="box-login__item box-login__item--checkbox">

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Layout/header.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Layout/header.html.twig
@@ -69,8 +69,7 @@
                             {{ 'Log out'|trans }}
                         </a>
                     {% else %}
-                        <a href="{{ url('front_login') }}"
-                            onclick="Shopsys.window({ content: '{{ render(controller('ShopsysShopBundle:Front/Login:windowForm'))|escape('js') }}' }); return false;">
+                        <a class="js-login-button" href="{{ url('front_login') }}" data-url="{{ url('front_login_window_form') }}">
                             {{ 'Log in'|trans }}
                         </a>
                         <a href="{{ url('front_registration_register') }}">
@@ -120,8 +119,8 @@
                         <li class="menu-iconic__item">
                             <a
                                 href="{{ url('front_login') }}"
-                                onclick="Shopsys.window({ content: '{{ render(controller('ShopsysShopBundle:Front/Login:windowForm'))|escape('js') }}' }); return false;"
-                                class="js-login-link-desktop menu-iconic__item__link"
+                                data-url="{{ url('front_login_window_form') }}"
+                                class="js-login-link-desktop js-login-button menu-iconic__item__link"
                             >
                                 <i class="svg svg-user"></i>
                                 <span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| JS validation doesn't work with forms in popups, because it closes the original popup to show errors
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #361  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


When solving #361 I found out that there are 3 problems, that should be solved.

1. We don't have any form in popup with working JS validation
Solution: I changed login form in popup so it is loaded by AJAX and therefore works with JS validation

2. JS validation opens popup with error messages that closes popup with form
Solution: I Added hidden div to popup and changed `showFormErrorsWindow` function in a way that it show errors in the hidden div if popup is open

3. The errors in popup should be under the heading
Solution: I added heading option to window.js so you can have heading at the top of the popup, then you have error messages and then you have the content of the popup
