### PR TITLE
[shopsys] added new coding standard: forbidden private visibility in namespace

### DIFF
--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -87,12 +87,5 @@ Besides the rules that are checked by automatic tools, we have few rules for whi
     }
     ```
 - Entities have to be created by factories. Only allowed exception are `*Translation` entities that are created by their owner entity.
-- Visibility of all properties, methods and constants of following classes must be protected or public to enable extensibility.
-  This is valid for packages in which we plan extensibility - Framework, ProductFeed\*
-    - Entities
-    - Factories
-    - Controllers
-    - Facades
-    - Repositories
 - Framework entities must not use [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html)
   because it causes problems during entity extension. Such problem with `OrderItem` was resolved during [making OrderItem extendable #715](https://github.com/shopsys/shopsys/pull/715).

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -155,6 +155,10 @@ for instance:
     - if you have extended `CountryFormType`, revise your changes – new fields are available
     - if you have extended `CountryController` revise your changes – `new` and `edit` actions were added
 
+- if you have extended classes from `Shopsys\FrameworkBundle\Model`, `Shopsys\FrameworkBundle\Component` or `Shopsys\FrameworkBundle\DataFixtures\Demo` namespace ([#788](https://github.com/shopsys/shopsys/pull/788))
+    - you need to adjust extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`
+    - you can delete methods that you just copied due to inability to inherit
+
 [Upgrade from v7.0.0-beta5 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta5...HEAD
 [shopsys/shopsys]: https://github.com/shopsys/shopsys
 [shopsys/project-base]: https://github.com/shopsys/project-base

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -159,6 +159,11 @@ for instance:
     - you need to adjust extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`
     - you can delete methods that you just copied due to inability to inherit
 
+## [shopsys/product-feed-heureka]
+- if you have extended class HeurekaCategoryDownloader or HeurekaCategoryCronModule ([#788](https://github.com/shopsys/shopsys/pull/788))
+    - you need to adjust already extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`
+    - you can delete methods that you just copied due to inability to inherit
+
 [Upgrade from v7.0.0-beta5 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta5...HEAD
 [shopsys/shopsys]: https://github.com/shopsys/shopsys
 [shopsys/project-base]: https://github.com/shopsys/project-base

--- a/packages/coding-standards/src/CsFixer/ForbiddenPrivateVisibilityFixer.php
+++ b/packages/coding-standards/src/CsFixer/ForbiddenPrivateVisibilityFixer.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer;
+
+use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use Shopsys\CodingStandards\Exception\NamespaceNotFoundException;
+use SplFileInfo;
+
+final class ForbiddenPrivateVisibilityFixer implements DefinedFixerInterface, ConfigurableFixerInterface
+{
+    private const OPTION_ANALYZED_NAMESPACE = 'analyzed_namespaces';
+
+    private $analyzedNamespaces = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(array $configuration = null): void
+    {
+        if ($configuration !== null) {
+            $this->analyzedNamespaces = $this->extractNamespaces($configuration);
+        }
+    }
+
+    /**
+     * @param array $configuration
+     * @return array
+     */
+    private function extractNamespaces(array $configuration): array
+    {
+        if (!array_key_exists(self::OPTION_ANALYZED_NAMESPACE, $configuration)) {
+            return [];
+        }
+
+        if (!is_array($configuration[self::OPTION_ANALYZED_NAMESPACE])) {
+            throw new InvalidFixerConfigurationException($this->getName(), 'Namespace configuration has to be an array');
+        }
+
+        return $configuration[self::OPTION_ANALYZED_NAMESPACE];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Properties and methods should be public or protected in defined namespace',
+            [
+                new CodeSample(
+                    '<?php
+namespace Some\Namespace;
+class SomeClass
+{
+private $property;
+}'
+                ),
+                new CodeSample(
+                    '<?php
+namespace Some\Namespace;
+class SomeClass
+{
+private function method()
+{
+    ...
+}
+}'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAllTokenKindsFound([T_PRIVATE]) && $this->checkNamespace($tokens);
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return bool
+     */
+    private function checkNamespace(Tokens $tokens): bool
+    {
+        try {
+            $namespace = $this->getNamespace($tokens);
+        } catch (NamespaceNotFoundException $e) {
+            return false;
+        }
+
+        foreach ($this->analyzedNamespaces as $analyzedNamespace) {
+            if ($this->namespaceStartsWith($namespace, $analyzedNamespace)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @throws \Shopsys\CodingStandards\Exception\NamespaceNotFoundException
+     * @return string
+     */
+    private function getNamespace(Tokens $tokens): string
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(T_NAMESPACE)) {
+                continue;
+            }
+
+            $namespaceStartIndex = $tokens->getNextMeaningfulToken($index);
+            $namespaceEndIndex = $tokens->getPrevMeaningfulToken($tokens->getNextTokenOfKind($index, [';']));
+
+            return $tokens->generatePartialCode($namespaceStartIndex, $namespaceEndIndex);
+        }
+
+        throw new NamespaceNotFoundException('No namespace found');
+    }
+
+    /**
+     * @param string $fullNamespace
+     * @param string $namespacePrefix
+     * @return bool
+     */
+    private function namespaceStartsWith(string $fullNamespace, string $namespacePrefix): bool
+    {
+        return strncmp($fullNamespace, $namespacePrefix, strlen($namespacePrefix)) === 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens->findGivenKind(T_PRIVATE) as $index => $privateToken) {
+            $tokens[$index] = new Token([T_PROTECTED, 'protected']);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Shopsys/forbidden_private_visibility';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/src/Exception/NamespaceNotFoundException.php
+++ b/packages/coding-standards/src/Exception/NamespaceNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Exception;
+
+use RuntimeException;
+
+class NamespaceNotFoundException extends RuntimeException
+{
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/ForbiddenPrivateVisibilityFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/ForbiddenPrivateVisibilityFixerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\CsFixer\ForbiddenDumpFixer;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class ForbiddenPrivateVisibilityFixerTest extends AbstractCheckerTestCase
+{
+    public function testFix(): void
+    {
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/wrong.php', __DIR__ . '/fixed/fixed.php');
+    }
+
+    public function testCorrect(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/correct/correct.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/ignored-namespace.php');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/config.yml
@@ -1,0 +1,4 @@
+services:
+    Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer:
+        analyzed_namespaces:
+            - TestNamespace

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/correct/correct.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/correct/correct.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TestNamespace\TestSubNamespace;
+
+class SomeClass
+{
+    /**
+     * @var int
+     */
+    public $field;
+
+    /**
+     * @return bool
+     */
+    protected function method()
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/correct/ignored-namespace.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/correct/ignored-namespace.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OtherNamespace\TestSubNamespace;
+
+class SomeClass
+{
+    /**
+     * @var int
+     */
+    private $field;
+
+    /**
+     * @return bool
+     */
+    private function method()
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/fixed/fixed.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/fixed/fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TestNamespace\TestSubNamespace;
+
+class SomeClass
+{
+    /**
+     * @var int
+     */
+    protected $field;
+
+    /**
+     * @return bool
+     */
+    protected function method()
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/wrong/wrong.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/wrong/wrong.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TestNamespace\TestSubNamespace;
+
+class SomeClass
+{
+    /**
+     * @var int
+     */
+    private $field;
+
+    /**
+     * @return bool
+     */
+    private function method()
+    {
+        return true;
+    }
+}

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -1,6 +1,19 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in these namespaces
+    forbidden_private_visibility_fixer.framework:
+        class: Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer
+        calls:
+            - method: configure
+              arguments:
+                - analyzed_namespaces:
+                    - Shopsys\FrameworkBundle\Model
+                    - Shopsys\FrameworkBundle\Component
+                    - Shopsys\FrameworkBundle\Controller
+                    - Shopsys\FrameworkBundle\DataFixtures\Demo
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/framework/src/Component/Breadcrumb/BreadcrumbItem.php
+++ b/packages/framework/src/Component/Breadcrumb/BreadcrumbItem.php
@@ -7,17 +7,17 @@ class BreadcrumbItem
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string|null
      */
-    private $routeName;
+    protected $routeName;
 
     /**
      * @var array
      */
-    private $routeParameters;
+    protected $routeParameters;
 
     /**
      * @param string $name

--- a/packages/framework/src/Component/Breadcrumb/BreadcrumbResolver.php
+++ b/packages/framework/src/Component/Breadcrumb/BreadcrumbResolver.php
@@ -7,7 +7,7 @@ class BreadcrumbResolver
     /**
      * @var \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface[]
      */
-    private $breadcrumbGeneratorsByRouteName;
+    protected $breadcrumbGeneratorsByRouteName;
 
     public function __construct()
     {

--- a/packages/framework/src/Component/Console/DomainChoiceHandler.php
+++ b/packages/framework/src/Component/Console/DomainChoiceHandler.php
@@ -13,7 +13,7 @@ class DomainChoiceHandler
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Component/Cron/Config/CronConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronConfig.php
@@ -12,12 +12,12 @@ class CronConfig
     /**
      * @var \Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver
      */
-    private $cronTimeResolver;
+    protected $cronTimeResolver;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig[]
      */
-    private $cronModuleConfigs;
+    protected $cronModuleConfigs;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver $cronTimeResolver

--- a/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
@@ -9,22 +9,22 @@ class CronModuleConfig implements CronTimeInterface
     /**
      * @var \Shopsys\Plugin\Cron\SimpleCronModuleInterface
      */
-    private $service;
+    protected $service;
 
     /**
      * @var string
      */
-    private $serviceId;
+    protected $serviceId;
 
     /**
      * @var string
      */
-    private $timeMinutes;
+    protected $timeMinutes;
 
     /**
      * @var string
      */
-    private $timeHours;
+    protected $timeHours;
 
     /**
      * @param \Shopsys\Plugin\Cron\SimpleCronModuleInterface|\Shopsys\Plugin\Cron\IteratedCronModuleInterface $service

--- a/packages/framework/src/Component/Cron/CronModuleExecutor.php
+++ b/packages/framework/src/Component/Cron/CronModuleExecutor.php
@@ -15,7 +15,7 @@ class CronModuleExecutor
     /**
      * @var \DateTimeImmutable|null
      */
-    private $canRunTo;
+    protected $canRunTo;
 
     /**
      * @param int $secondsTimeout

--- a/packages/framework/src/Component/Cron/CronTimeResolver.php
+++ b/packages/framework/src/Component/Cron/CronTimeResolver.php
@@ -25,7 +25,7 @@ class CronTimeResolver
      * @param string $timeString
      * @return bool
      */
-    private function isMatchWithTimeString($value, $timeString)
+    protected function isMatchWithTimeString($value, $timeString)
     {
         $timeValues = explode(',', $timeString);
         $matches = null;

--- a/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
+++ b/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
@@ -11,7 +11,7 @@ abstract class AbstractNativeFixture extends AbstractFixture
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $entityManager;
+    protected $entityManager;
 
     /**
      * @required

--- a/packages/framework/src/Component/DataFixture/AbstractReferenceFixture.php
+++ b/packages/framework/src/Component/DataFixture/AbstractReferenceFixture.php
@@ -11,7 +11,7 @@ abstract class AbstractReferenceFixture implements FixtureInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade
      */
-    private $persistentReferenceFacade;
+    protected $persistentReferenceFacade;
 
     /**
      * @required

--- a/packages/framework/src/Component/Doctrine/CollateFunction.php
+++ b/packages/framework/src/Component/Doctrine/CollateFunction.php
@@ -12,12 +12,12 @@ class CollateFunction extends FunctionNode
     /**
      * @var \Doctrine\ORM\Query\AST\Node
      */
-    private $inputStringExpression;
+    protected $inputStringExpression;
 
     /**
      * @var string
      */
-    private $collation;
+    protected $collation;
 
     /**
      * @param \Doctrine\ORM\Query\Parser $parser

--- a/packages/framework/src/Component/Doctrine/FieldFunction.php
+++ b/packages/framework/src/Component/Doctrine/FieldFunction.php
@@ -13,12 +13,12 @@ class FieldFunction extends FunctionNode
     /**
      * @var \Doctrine\ORM\Query\AST\Node
      */
-    private $firstArgumentExpression;
+    protected $firstArgumentExpression;
 
     /**
      * @var \Doctrine\ORM\Query\AST\Node[]
      */
-    private $nextArgumentExpressions;
+    protected $nextArgumentExpressions;
 
     /**
      * @param \Doctrine\ORM\Query\Parser $parser

--- a/packages/framework/src/Component/Doctrine/GroupedScalarHydrator.php
+++ b/packages/framework/src/Component/Doctrine/GroupedScalarHydrator.php
@@ -38,7 +38,7 @@ class GroupedScalarHydrator extends AbstractHydrator
      * @param array $data
      * @return array
      */
-    private function gatherGroupedScalarRowData(&$data)
+    protected function gatherGroupedScalarRowData(&$data)
     {
         $rowData = [];
 

--- a/packages/framework/src/Component/Doctrine/NotNullableColumnsFinder.php
+++ b/packages/framework/src/Component/Doctrine/NotNullableColumnsFinder.php
@@ -32,7 +32,7 @@ class NotNullableColumnsFinder
      * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadataInfo
      * @return string[]
      */
-    private function getNotNullableFieldColumnNames(ClassMetadataInfo $classMetadataInfo)
+    protected function getNotNullableFieldColumnNames(ClassMetadataInfo $classMetadataInfo)
     {
         $notNullableFieldNames = [];
         foreach ($classMetadataInfo->getFieldNames() as $fieldName) {
@@ -48,7 +48,7 @@ class NotNullableColumnsFinder
      * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadataInfo
      * @return string[]
      */
-    private function getNotNullableAssociationColumnNames(ClassMetadataInfo $classMetadataInfo)
+    protected function getNotNullableAssociationColumnNames(ClassMetadataInfo $classMetadataInfo)
     {
         $notNullableAssociationNames = [];
         foreach ($classMetadataInfo->getAssociationMappings() as $associationMapping) {

--- a/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
+++ b/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
@@ -48,7 +48,7 @@ class QueryBuilderExtender
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
      * @return string
      */
-    private function getRootAlias(QueryBuilder $queryBuilder)
+    protected function getRootAlias(QueryBuilder $queryBuilder)
     {
         $rootAliases = $queryBuilder->getRootAliases();
         if (count($rootAliases) !== self::REQUIRED_ALIASES_COUNT) {

--- a/packages/framework/src/Component/Doctrine/SqlQuoter.php
+++ b/packages/framework/src/Component/Doctrine/SqlQuoter.php
@@ -9,7 +9,7 @@ class SqlQuoter
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Component/Doctrine/StringColumnsFinder.php
+++ b/packages/framework/src/Component/Doctrine/StringColumnsFinder.php
@@ -31,7 +31,7 @@ class StringColumnsFinder
      * @param \Doctrine\ORM\Mapping\ClassMetadataInfo $classMetadataInfo
      * @return string[]
      */
-    private function getStringColumnNames(ClassMetadataInfo $classMetadataInfo)
+    protected function getStringColumnNames(ClassMetadataInfo $classMetadataInfo)
     {
         $stringColumnNames = [];
         foreach ($classMetadataInfo->getFieldNames() as $fieldName) {
@@ -46,7 +46,7 @@ class StringColumnsFinder
     /**
      * @return string[]
      */
-    private function getDoctrineStringTypes()
+    protected function getDoctrineStringTypes()
     {
         return [
             'text',

--- a/packages/framework/src/Component/Domain/Config/DomainConfig.php
+++ b/packages/framework/src/Component/Domain/Config/DomainConfig.php
@@ -9,27 +9,27 @@ class DomainConfig
     /**
      * @var int
      */
-    private $id;
+    protected $id;
 
     /**
      * @var string
      */
-    private $url;
+    protected $url;
 
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var string
      */
-    private $locale;
+    protected $locale;
 
     /**
      * @var string
      */
-    private $stylesDirectory;
+    protected $stylesDirectory;
 
     /**
      * @param int $id

--- a/packages/framework/src/Component/Domain/Config/DomainsConfigLoader.php
+++ b/packages/framework/src/Component/Domain/Config/DomainsConfigLoader.php
@@ -12,7 +12,7 @@ class DomainsConfigLoader
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
@@ -50,7 +50,7 @@ class DomainsConfigLoader
      * @param array $processedConfigsByDomainId
      * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
      */
-    private function loadDomainConfigsFromArray($processedConfigsByDomainId)
+    protected function loadDomainConfigsFromArray($processedConfigsByDomainId)
     {
         $domainConfigs = [];
 
@@ -65,7 +65,7 @@ class DomainsConfigLoader
      * @param array $domainConfig
      * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
      */
-    private function processDomainConfigArray(array $domainConfig)
+    protected function processDomainConfigArray(array $domainConfig)
     {
         return new DomainConfig(
             $domainConfig[DomainsConfigDefinition::CONFIG_ID],
@@ -81,7 +81,7 @@ class DomainsConfigLoader
      * @param array $domainUrlsConfigsByDomainId
      * @return array
      */
-    private function addUrlsToProcessedConfig($domainConfigsByDomainId, $domainUrlsConfigsByDomainId)
+    protected function addUrlsToProcessedConfig($domainConfigsByDomainId, $domainUrlsConfigsByDomainId)
     {
         foreach ($domainConfigsByDomainId as $domainId => $domainConfigArray) {
             $domainConfigArray[DomainsUrlsConfigDefinition::CONFIG_URL] =
@@ -97,7 +97,7 @@ class DomainsConfigLoader
      * @param \Symfony\Component\Config\Definition\ConfigurationInterface $configDefinition
      * @return array
      */
-    private function getProcessedConfig($filepath, ConfigurationInterface $configDefinition)
+    protected function getProcessedConfig($filepath, ConfigurationInterface $configDefinition)
     {
         $yamlParser = new Parser();
         $processor = new Processor();
@@ -118,7 +118,7 @@ class DomainsConfigLoader
      * @param array $domainUrlsConfigsByDomainId
      * @return bool
      */
-    private function isConfigMatchingUrlsConfig($domainConfigsByDomainId, $domainUrlsConfigsByDomainId)
+    protected function isConfigMatchingUrlsConfig($domainConfigsByDomainId, $domainUrlsConfigsByDomainId)
     {
         foreach (array_keys($domainConfigsByDomainId) as $domainId) {
             if (!array_key_exists($domainId, $domainUrlsConfigsByDomainId)) {

--- a/packages/framework/src/Component/Domain/Domain.php
+++ b/packages/framework/src/Component/Domain/Domain.php
@@ -14,17 +14,17 @@ class Domain implements DomainIdsProviderInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig|null
      */
-    private $currentDomainConfig;
+    protected $currentDomainConfig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
      */
-    private $domainConfigs;
+    protected $domainConfigs;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[] $domainConfigs

--- a/packages/framework/src/Component/Domain/DomainAwareSecurityHeadersSetter.php
+++ b/packages/framework/src/Component/Domain/DomainAwareSecurityHeadersSetter.php
@@ -9,7 +9,7 @@ class DomainAwareSecurityHeadersSetter
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Component/Domain/DomainDataCreator.php
+++ b/packages/framework/src/Component/Domain/DomainDataCreator.php
@@ -16,37 +16,37 @@ class DomainDataCreator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\SettingValueRepository
      */
-    private $settingValueRepository;
+    protected $settingValueRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityDataCreator
      */
-    private $multidomainEntityDataCreator;
+    protected $multidomainEntityDataCreator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\TranslatableEntityDataCreator
      */
-    private $translatableEntityDataCreator;
+    protected $translatableEntityDataCreator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactory
      */
-    private $pricingGroupDataFactory;
+    protected $pricingGroupDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */
-    private $pricingGroupFacade;
+    protected $pricingGroupFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -112,7 +112,7 @@ class DomainDataCreator
      * @param string $locale
      * @return bool
      */
-    private function isNewLocale($locale)
+    protected function isNewLocale($locale)
     {
         foreach ($this->domain->getAll() as $domainConfig) {
             if ($domainConfig->getLocale() === $locale) {
@@ -126,7 +126,7 @@ class DomainDataCreator
     /**
      * @return string
      */
-    private function getTemplateLocale()
+    protected function getTemplateLocale()
     {
         return $this->domain->getDomainConfigById(self::TEMPLATE_DOMAIN_ID)->getLocale();
     }
@@ -134,7 +134,7 @@ class DomainDataCreator
     /**
      * @param int $domainId
      */
-    private function processDefaultPricingGroupForNewDomain(int $domainId)
+    protected function processDefaultPricingGroupForNewDomain(int $domainId)
     {
         $pricingGroup = $this->createDefaultPricingGroupForNewDomain($domainId);
         $this->setting->setForDomain(Setting::DEFAULT_PRICING_GROUP, $pricingGroup->getId(), $domainId);
@@ -144,7 +144,7 @@ class DomainDataCreator
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup
      */
-    private function createDefaultPricingGroupForNewDomain(int $domainId)
+    protected function createDefaultPricingGroupForNewDomain(int $domainId)
     {
         $pricingGroupData = $this->pricingGroupDataFactory->create();
         $pricingGroupData->name = 'Default';

--- a/packages/framework/src/Component/Domain/DomainIconResizer.php
+++ b/packages/framework/src/Component/Domain/DomainIconResizer.php
@@ -15,17 +15,17 @@ class DomainIconResizer
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor
      */
-    private $imageProcessor;
+    protected $imageProcessor;
 
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @param \Symfony\Bridge\Monolog\Logger $logger

--- a/packages/framework/src/Component/Domain/DomainSubscriber.php
+++ b/packages/framework/src/Component/Domain/DomainSubscriber.php
@@ -11,7 +11,7 @@ class DomainSubscriber implements EventSubscriberInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Component/Domain/DomainUrlReplacer.php
+++ b/packages/framework/src/Component/Domain/DomainUrlReplacer.php
@@ -12,17 +12,17 @@ class DomainUrlReplacer
     /**
      * @var \Shopsys\FrameworkBundle\Component\Doctrine\StringColumnsFinder
      */
-    private $stringColumnsFinder;
+    protected $stringColumnsFinder;
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Doctrine\SqlQuoter
      */
-    private $sqlQuoter;
+    protected $sqlQuoter;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\StringColumnsFinder $stringColumnsFinder
@@ -56,7 +56,7 @@ class DomainUrlReplacer
     /**
      * @return string[][]
      */
-    private function getAllStringColumnNamesIndexedByTableName()
+    protected function getAllStringColumnNamesIndexedByTableName()
     {
         $classesMetadata = $this->em->getMetadataFactory()->getAllMetadata();
 
@@ -70,7 +70,7 @@ class DomainUrlReplacer
      * @param string $domainConfigUrl
      * @return string
      */
-    private function getUrlReplacementSql($tableName, array $columnNames, $domainSettingUrl, $domainConfigUrl)
+    protected function getUrlReplacementSql($tableName, array $columnNames, $domainSettingUrl, $domainConfigUrl)
     {
         $sqlParts = [];
         $quotedTableName = $this->sqlQuoter->quoteIdentifier($tableName);

--- a/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityClassFinder.php
+++ b/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityClassFinder.php
@@ -36,7 +36,7 @@ class MultidomainEntityClassFinder
      * @param \Doctrine\ORM\Mapping\ClassMetadata $classMetadata
      * @return bool
      */
-    private function isMultidomainEntity(ClassMetadata $classMetadata)
+    protected function isMultidomainEntity(ClassMetadata $classMetadata)
     {
         $identifierFieldNames = $classMetadata->getIdentifierFieldNames();
 

--- a/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityDataCreator.php
+++ b/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityDataCreator.php
@@ -11,17 +11,17 @@ class MultidomainEntityDataCreator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade
      */
-    private $multidomainEntityClassFinderFacade;
+    protected $multidomainEntityClassFinderFacade;
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Doctrine\SqlQuoter
      */
-    private $sqlQuoter;
+    protected $sqlQuoter;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade $multidomainEntityClassFinderFacade
@@ -66,7 +66,7 @@ class MultidomainEntityDataCreator
      * @param string $tableName
      * @param string[] $columnNames
      */
-    private function copyMultidomainDataForNewDomain($templateDomainId, $newDomainId, $tableName, array $columnNames)
+    protected function copyMultidomainDataForNewDomain($templateDomainId, $newDomainId, $tableName, array $columnNames)
     {
         $quotedColumnNames = $this->sqlQuoter->quoteIdentifiers($columnNames);
         $quotedColumnNamesSql = implode(', ', $quotedColumnNames);

--- a/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
+++ b/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
@@ -11,12 +11,12 @@ class EntityManagerDecorator extends BaseEntityManagerDecorator
     /**
      * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
      */
-    private $entityNameResolver;
+    protected $entityNameResolver;
 
     /**
      * @var \Doctrine\ORM\Repository\RepositoryFactory
      */
-    private $repositoryFactory;
+    protected $repositoryFactory;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Component/EntityExtension/EntityNameResolver.php
+++ b/packages/framework/src/Component/EntityExtension/EntityNameResolver.php
@@ -49,7 +49,7 @@ class EntityNameResolver
      * @param string $string
      * @return string
      */
-    private function resolveInString(string $string): string
+    protected function resolveInString(string $string): string
     {
         foreach ($this->entityExtensionMap as $originalEntityName => $extendedEntityName) {
             $pattern = '~\b' . preg_quote($originalEntityName, '~') . '\b(?!\\\\)~u';
@@ -63,7 +63,7 @@ class EntityNameResolver
      * @param array $array
      * @return array
      */
-    private function resolveInArray(array $array): array
+    protected function resolveInArray(array $array): array
     {
         return array_map([$this, 'resolveIn'], $array);
     }
@@ -73,7 +73,7 @@ class EntityNameResolver
      *
      * @param object $object
      */
-    private function resolveInObjectProperties($object): void
+    protected function resolveInObjectProperties($object): void
     {
         $reflection = new \ReflectionObject($object);
         foreach ($reflection->getProperties() as $property) {

--- a/packages/framework/src/Component/EntityExtension/QueryBuilder.php
+++ b/packages/framework/src/Component/EntityExtension/QueryBuilder.php
@@ -10,7 +10,7 @@ class QueryBuilder extends BaseQueryBuilder
     /**
      * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
      */
-    private $entityNameResolver;
+    protected $entityNameResolver;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
+++ b/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
@@ -16,7 +16,7 @@ class EnvironmentFileSetting
     /**
      * @var string
      */
-    private $environmentFileDirectory;
+    protected $environmentFileDirectory;
 
     /**
      * @param string $environmentFileDirectory

--- a/packages/framework/src/Component/Error/ErrorPageCronModule.php
+++ b/packages/framework/src/Component/Error/ErrorPageCronModule.php
@@ -10,7 +10,7 @@ class ErrorPageCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade
      */
-    private $errorPagesFacade;
+    protected $errorPagesFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade

--- a/packages/framework/src/Component/Error/ExceptionListener.php
+++ b/packages/framework/src/Component/Error/ExceptionListener.php
@@ -9,7 +9,7 @@ class ExceptionListener
     /**
      * @var \Exception|null
      */
-    private $lastException;
+    protected $lastException;
 
     /**
      * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event

--- a/packages/framework/src/Component/FileUpload/DoctrineListener.php
+++ b/packages/framework/src/Component/FileUpload/DoctrineListener.php
@@ -10,7 +10,7 @@ class DoctrineListener
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
      */
-    private $fileUpload;
+    protected $fileUpload;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload

--- a/packages/framework/src/Component/FileUpload/FileForUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileForUpload.php
@@ -7,27 +7,27 @@ class FileForUpload
     /**
      * @var string
      */
-    private $temporaryFilename;
+    protected $temporaryFilename;
 
     /**
      * @var bool
      */
-    private $isImage;
+    protected $isImage;
 
     /**
      * @var string
      */
-    private $category;
+    protected $category;
 
     /**
      * @var string|null
      */
-    private $targetDirectory;
+    protected $targetDirectory;
 
     /**
      * @var int
      */
-    private $nameConventionType;
+    protected $nameConventionType;
 
     /**
      * @param string $temporaryFilename

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -15,37 +15,37 @@ class FileUpload
     /**
      * @var string
      */
-    private $temporaryDir;
+    protected $temporaryDir;
 
     /**
      * @var string
      */
-    private $uploadedFileDir;
+    protected $uploadedFileDir;
 
     /**
      * @var string
      */
-    private $imageDir;
+    protected $imageDir;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileNamingConvention
      */
-    private $fileNamingConvention;
+    protected $fileNamingConvention;
 
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $localFilesystem;
+    protected $localFilesystem;
 
     /**
      * @var \League\Flysystem\MountManager
      */
-    private $mountManager;
+    protected $mountManager;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @param string $temporaryDir
@@ -111,7 +111,7 @@ class FileUpload
      * @param string $filename
      * @return string
      */
-    private function getTemporaryFilename($filename)
+    protected function getTemporaryFilename($filename)
     {
         return TransformString::safeFilename(uniqid('', true) . '__' . $filename);
     }
@@ -153,7 +153,7 @@ class FileUpload
      * @param string|null $targetDirectory
      * @return string
      */
-    private function getTargetFilepath($filename, $isImage, $category, $targetDirectory)
+    protected function getTargetFilepath($filename, $isImage, $category, $targetDirectory)
     {
         return $this->getUploadDirectory($isImage, $category, $targetDirectory) . '/' . $filename;
     }

--- a/packages/framework/src/Component/Filesystem/FilepathComparator.php
+++ b/packages/framework/src/Component/Filesystem/FilepathComparator.php
@@ -26,7 +26,7 @@ class FilepathComparator
      * @param string $directoryRealpath
      * @return bool
      */
-    private function isPathWithinDirectoryRealpathRecursive($path, $directoryRealpath)
+    protected function isPathWithinDirectoryRealpathRecursive($path, $directoryRealpath)
     {
         if (realpath($path) === $directoryRealpath) {
             return true;
@@ -43,7 +43,7 @@ class FilepathComparator
      * @param string $path
      * @return bool
      */
-    private function hasAncestorPath($path)
+    protected function hasAncestorPath($path)
     {
         return dirname($path) !== $path;
     }

--- a/packages/framework/src/Component/Filesystem/MainFilesystemFactory.php
+++ b/packages/framework/src/Component/Filesystem/MainFilesystemFactory.php
@@ -11,7 +11,7 @@ class MainFilesystemFactory implements FilesystemFactoryInterface
     /**
      * @var string
      */
-    private $projectDir;
+    protected $projectDir;
 
     /**
      * @param string $projectDir

--- a/packages/framework/src/Component/FlashMessage/Bag.php
+++ b/packages/framework/src/Component/FlashMessage/Bag.php
@@ -20,7 +20,7 @@ class Bag
     /**
      * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
-    private $session;
+    protected $session;
 
     /**
      * @param string $bagName
@@ -104,7 +104,7 @@ class Bag
      * @param string $key
      * @return string
      */
-    private function getFullbagName($key)
+    protected function getFullbagName($key)
     {
         return self::MAIN_KEY . '__' . $this->bagName . '__' . $key;
     }
@@ -113,7 +113,7 @@ class Bag
      * @param string $key
      * @return array
      */
-    private function getMessages($key)
+    protected function getMessages($key)
     {
         $flashBag = $this->session->getFlashBag();
         $messages = $flashBag->get($this->getFullbagName($key));
@@ -125,7 +125,7 @@ class Bag
      * @param bool $escape
      * @param string $key
      */
-    private function addMessage($message, $escape, $key)
+    protected function addMessage($message, $escape, $key)
     {
         if (is_array($message)) {
             foreach ($message as $item) {

--- a/packages/framework/src/Component/FlashMessage/FlashMessageSender.php
+++ b/packages/framework/src/Component/FlashMessage/FlashMessageSender.php
@@ -9,12 +9,12 @@ class FlashMessageSender
     /**
      * @var \Shopsys\FrameworkBundle\Component\FlashMessage\Bag
      */
-    private $flashMessageBag;
+    protected $flashMessageBag;
 
     /**
      * @var \Twig_Environment
      */
-    private $twigEnvironment;
+    protected $twigEnvironment;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\FlashMessage\Bag $flashMessageBag
@@ -63,7 +63,7 @@ class FlashMessageSender
      * @param array $parameters
      * @return string
      */
-    private function renderStringTwigTemplate($template, array $parameters)
+    protected function renderStringTwigTemplate($template, array $parameters)
     {
         $twigTemplate = $this->twigEnvironment->createTemplate($template);
 

--- a/packages/framework/src/Component/Form/FormTimeProvider.php
+++ b/packages/framework/src/Component/Form/FormTimeProvider.php
@@ -10,7 +10,7 @@ class FormTimeProvider
     /**
      * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
-    private $session;
+    protected $session;
 
     /**
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session

--- a/packages/framework/src/Component/Form/MultipleFormSetting.php
+++ b/packages/framework/src/Component/Form/MultipleFormSetting.php
@@ -9,7 +9,7 @@ class MultipleFormSetting
     /**
      * @var bool
      */
-    private $isCurrentFormMultiple = self::DEFAULT_MULTIPLE;
+    protected $isCurrentFormMultiple = self::DEFAULT_MULTIPLE;
 
     public function currentFormIsMultiple()
     {

--- a/packages/framework/src/Component/Form/ResizeFormListener.php
+++ b/packages/framework/src/Component/Form/ResizeFormListener.php
@@ -17,27 +17,27 @@ class ResizeFormListener implements EventSubscriberInterface
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @var array
      */
-    private $options;
+    protected $options;
 
     /**
      * @var bool
      */
-    private $allowAdd;
+    protected $allowAdd;
 
     /**
      * @var bool
      */
-    private $allowDelete;
+    protected $allowDelete;
 
     /**
      * @var bool
      */
-    private $deleteEmpty;
+    protected $deleteEmpty;
 
     /**
      * @param string|null $type
@@ -233,7 +233,7 @@ class ResizeFormListener implements EventSubscriberInterface
      * @param mixed $previousViewData
      * @return mixed
      */
-    private function removeEmptyChildrenFromFormAndData(FormInterface $form, $viewData, $previousViewData)
+    protected function removeEmptyChildrenFromFormAndData(FormInterface $form, $viewData, $previousViewData)
     {
         foreach ($form as $name => $child) {
             $isNew = !isset($previousViewData[$name]);
@@ -254,7 +254,7 @@ class ResizeFormListener implements EventSubscriberInterface
      * @param \Symfony\Component\Form\FormInterface $form
      * @return mixed
      */
-    private function removeDataItemsNotPresentInForm($viewData, FormInterface $form)
+    protected function removeDataItemsNotPresentInForm($viewData, FormInterface $form)
     {
         $toDelete = [];
 
@@ -278,7 +278,7 @@ class ResizeFormListener implements EventSubscriberInterface
      * @param mixed $value
      * @return mixed
      */
-    private function normToView(FormInterface $form, $value)
+    protected function normToView(FormInterface $form, $value)
     {
         // Scalar values should  be converted to strings to
         // facilitate differentiation between empty ("") and zero (0).
@@ -303,7 +303,7 @@ class ResizeFormListener implements EventSubscriberInterface
      * @param string $value
      * @return mixed
      */
-    private function viewToNorm(FormInterface $form, $value)
+    protected function viewToNorm(FormInterface $form, $value)
     {
         $transformers = $form->getConfig()->getViewTransformers();
 

--- a/packages/framework/src/Component/Form/TimedFormTypeExtension.php
+++ b/packages/framework/src/Component/Form/TimedFormTypeExtension.php
@@ -18,7 +18,7 @@ class TimedFormTypeExtension extends AbstractTypeExtension
     /**
      * @var \Shopsys\FrameworkBundle\Component\Form\FormTimeProvider
      */
-    private $formTimeProvider;
+    protected $formTimeProvider;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Form\FormTimeProvider $formTimeProvider

--- a/packages/framework/src/Component/Form/TimedSpamValidationListener.php
+++ b/packages/framework/src/Component/Form/TimedSpamValidationListener.php
@@ -12,12 +12,12 @@ class TimedSpamValidationListener implements EventSubscriberInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Form\FormTimeProvider
      */
-    private $formTimeProvider;
+    protected $formTimeProvider;
 
     /**
      * @var string[]
      */
-    private $options;
+    protected $options;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Form\FormTimeProvider $formTimeProvider

--- a/packages/framework/src/Component/Grid/ActionColumn.php
+++ b/packages/framework/src/Component/Grid/ActionColumn.php
@@ -14,52 +14,52 @@ class ActionColumn
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector
      */
-    private $routeCsrfProtector;
+    protected $routeCsrfProtector;
 
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @var string
      */
-    private $title;
+    protected $title;
 
     /**
      * @var string
      */
-    private $route;
+    protected $route;
 
     /**
      * @var array
      */
-    private $bindingRouteParams;
+    protected $bindingRouteParams;
 
     /**
      * @var array
      */
-    private $additionalRouteParams;
+    protected $additionalRouteParams;
 
     /**
      * @var string|null
      */
-    private $classAttribute;
+    protected $classAttribute;
 
     /**
      * @var string|null
      */
-    private $confirmMessage;
+    protected $confirmMessage;
 
     /**
      * @var bool
      */
-    private $isAjaxConfirm;
+    protected $isAjaxConfirm;
 
     /**
      * @param \Symfony\Component\Routing\RouterInterface $router

--- a/packages/framework/src/Component/Grid/ArrayDataSource.php
+++ b/packages/framework/src/Component/Grid/ArrayDataSource.php
@@ -9,12 +9,12 @@ class ArrayDataSource implements DataSourceInterface
     /**
      * @var array
      */
-    private $data;
+    protected $data;
 
     /**
      * @var string
      */
-    private $rowIdSourceColumnName;
+    protected $rowIdSourceColumnName;
 
     /**
      * @param array $data

--- a/packages/framework/src/Component/Grid/Column.php
+++ b/packages/framework/src/Component/Grid/Column.php
@@ -7,32 +7,32 @@ class Column
     /**
      * @var string
      */
-    private $id;
+    protected $id;
 
     /**
      * @var string
      */
-    private $sourceColumnName;
+    protected $sourceColumnName;
 
     /**
      * @var string
      */
-    private $title;
+    protected $title;
 
     /**
      * @var bool
      */
-    private $sortable;
+    protected $sortable;
 
     /**
      * @var string
      */
-    private $classAttribute;
+    protected $classAttribute;
 
     /**
      * @var string
      */
-    private $orderSourceColumnName;
+    protected $orderSourceColumnName;
 
     /**
      * @param string $id

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -17,142 +17,142 @@ class Grid
     /**
      * @var string
      */
-    private $id;
+    protected $id;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\Column[]
      */
-    private $columnsById = [];
+    protected $columnsById = [];
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\ActionColumn[]
      */
-    private $actionColumns = [];
+    protected $actionColumns = [];
 
     /**
      * @var bool
      */
-    private $enablePaging = false;
+    protected $enablePaging = false;
 
     /**
      * @var bool
      */
-    private $enableSelecting = false;
+    protected $enableSelecting = false;
 
     /**
      * @var array
      */
-    private $allowedLimits = [30, 100, 200, 500];
+    protected $allowedLimits = [30, 100, 200, 500];
 
     /**
      * @var int
      */
-    private $limit;
+    protected $limit;
 
     /**
      * @var bool
      */
-    private $isLimitFromRequest = false;
+    protected $isLimitFromRequest = false;
 
     /**
      * @var int
      */
-    private $page = 1;
+    protected $page = 1;
 
     /**
      * @var int|null
      */
-    private $totalCount;
+    protected $totalCount;
 
     /**
      * @var int|null
      */
-    private $pageCount;
+    protected $pageCount;
 
     /**
      * @var string|null
      */
-    private $orderSourceColumnName;
+    protected $orderSourceColumnName;
 
     /**
      * @var string|null
      */
-    private $orderDirection;
+    protected $orderDirection;
 
     /**
      * @var bool
      */
-    private $isOrderFromRequest = false;
+    protected $isOrderFromRequest = false;
 
     /**
      * @var array
      */
-    private $rows = [];
+    protected $rows = [];
 
     /**
      * @var \Symfony\Component\HttpFoundation\RequestStack
      */
-    private $requestStack;
+    protected $requestStack;
 
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector
      */
-    private $routeCsrfProtector;
+    protected $routeCsrfProtector;
 
     /**
      * @var \Twig_Environment
      */
-    private $twig;
+    protected $twig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\DataSourceInterface
      */
-    private $dataSource;
+    protected $dataSource;
 
     /**
      * @var string
      */
-    private $actionColumnClassAttribute = '';
+    protected $actionColumnClassAttribute = '';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface|null
      */
-    private $inlineEditService;
+    protected $inlineEditService;
 
     /**
      * @var string|null
      */
-    private $orderingEntityClass;
+    protected $orderingEntityClass;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    private $paginationResults;
+    protected $paginationResults;
 
     /**
      * @var string|string[]|null
      */
-    private $viewTheme;
+    protected $viewTheme;
 
     /**
      * @var array
      */
-    private $viewTemplateParameters;
+    protected $viewTemplateParameters;
 
     /**
      * @var array
      */
-    private $selectedRowIds;
+    protected $selectedRowIds;
 
     /**
      * @var bool
      */
-    private $multipleDragAndDrop;
+    protected $multipleDragAndDrop;
 
     /**
      * @param string $id
@@ -477,7 +477,7 @@ class Grid
     /**
      * @param int $limit
      */
-    private function setLimit($limit)
+    protected function setLimit($limit)
     {
         if (in_array($limit, $this->allowedLimits, true)) {
             $this->limit = $limit;
@@ -564,7 +564,7 @@ class Grid
     /**
      * @param string $orderString
      */
-    private function setOrderingByOrderString($orderString)
+    protected function setOrderingByOrderString($orderString)
     {
         if (substr($orderString, 0, 1) === '-') {
             $this->orderDirection = DataSourceInterface::ORDER_DESC;
@@ -574,7 +574,7 @@ class Grid
         $this->orderSourceColumnName = trim($orderString, '-');
     }
 
-    private function loadFromRequest()
+    protected function loadFromRequest()
     {
         $queryData = $this->requestStack->getMasterRequest()->query->get(self::GET_PARAMETER, []);
         if (array_key_exists($this->id, $queryData)) {
@@ -655,7 +655,7 @@ class Grid
         );
     }
 
-    private function loadRows()
+    protected function loadRows()
     {
         if (array_key_exists($this->orderSourceColumnName, $this->columnsById)
             && $this->columnsById[$this->orderSourceColumnName]->isSortable()
@@ -685,12 +685,12 @@ class Grid
     /**
      * @param int $rowId
      */
-    private function loadRowsWithOneRow($rowId)
+    protected function loadRowsWithOneRow($rowId)
     {
         $this->rows = [$this->dataSource->getOneRow($rowId)];
     }
 
-    private function executeTotalQuery()
+    protected function executeTotalQuery()
     {
         $this->totalCount = $this->dataSource->getTotalRowsCount();
         $this->pageCount = max(ceil($this->totalCount / $this->limit), 1);

--- a/packages/framework/src/Component/Grid/GridView.php
+++ b/packages/framework/src/Component/Grid/GridView.php
@@ -13,37 +13,37 @@ class GridView
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    private $grid;
+    protected $grid;
 
     /**
      * @var array
      */
-    private $templateParameters;
+    protected $templateParameters;
 
     /**
      * @var \Twig_TemplateWrapper[]
      */
-    private $templates;
+    protected $templates;
 
     /**
      * @var string|string[]|null
      */
-    private $theme;
+    protected $theme;
 
     /**
      * @var \Symfony\Component\HttpFoundation\RequestStack
      */
-    private $requestStack;
+    protected $requestStack;
 
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @var \Twig_Environment
      */
-    private $twig;
+    protected $twig;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Grid\Grid $grid
@@ -215,7 +215,7 @@ class GridView
      * @param string $name
      * @return bool
      */
-    private function blockExists($name)
+    protected function blockExists($name)
     {
         foreach ($this->getTemplates() as $template) {
             if ($template->hasBlock($name)) {
@@ -238,7 +238,7 @@ class GridView
      * @param string|string[] $theme
      * @param array $parameters
      */
-    private function setTheme($theme, array $parameters = [])
+    protected function setTheme($theme, array $parameters = [])
     {
         $this->theme = $theme;
         $this->templateParameters = $parameters;
@@ -247,7 +247,7 @@ class GridView
     /**
      * @return \Twig_TemplateWrapper[]
      */
-    private function getTemplates()
+    protected function getTemplates()
     {
         if (empty($this->templates)) {
             $this->templates = [];
@@ -267,7 +267,7 @@ class GridView
      * @param string $theme
      * @return \Twig_TemplateWrapper
      */
-    private function getTemplateFromString($theme)
+    protected function getTemplateFromString($theme)
     {
         return $this->twig->load($theme);
     }
@@ -277,7 +277,7 @@ class GridView
      * @param array $row
      * @return mixed
      */
-    private function getCellValue(Column $column, $row)
+    protected function getCellValue(Column $column, $row)
     {
         return Grid::getValueFromRowBySourceColumnName($row, $column->getSourceColumnName());
     }
@@ -286,7 +286,7 @@ class GridView
      * @param mixed $variable
      * @return string
      */
-    private function getVariableType($variable)
+    protected function getVariableType($variable)
     {
         switch (gettype($variable)) {
             case 'boolean':

--- a/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
@@ -10,7 +10,7 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface
      */
-    private $gridFactory;
+    protected $gridFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Grid\GridFactoryInterface $gridFactory

--- a/packages/framework/src/Component/Grid/InlineEdit/Exception/InvalidFormDataException.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/Exception/InvalidFormDataException.php
@@ -9,7 +9,7 @@ class InvalidFormDataException extends Exception implements InlineEditException
     /**
      * @var array
      */
-    private $formErrors;
+    protected $formErrors;
 
     /**
      * @param array $formErrors

--- a/packages/framework/src/Component/Grid/InlineEdit/GridInlineEditRegistry.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/GridInlineEditRegistry.php
@@ -7,7 +7,7 @@ class GridInlineEditRegistry
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface[]
      */
-    private $gridInlineEdits;
+    protected $gridInlineEdits;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface[] $gridInlineEdits

--- a/packages/framework/src/Component/Grid/InlineEdit/InlineEditFacade.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/InlineEditFacade.php
@@ -11,7 +11,7 @@ class InlineEditFacade
     /**
      * @var \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditRegistry
      */
-    private $gridInlineEditRegistry;
+    protected $gridInlineEditRegistry;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditRegistry $gridInlineEditRegistry
@@ -73,7 +73,7 @@ class InlineEditFacade
      * @param \Symfony\Component\Form\Form $form
      * @return string
      */
-    private function renderFormAsRow(GridInlineEditInterface $gridInlineEditService, $rowId, Form $form)
+    protected function renderFormAsRow(GridInlineEditInterface $gridInlineEditService, $rowId, Form $form)
     {
         $grid = $gridInlineEditService->getGrid();
         if ($rowId === null) {
@@ -90,7 +90,7 @@ class InlineEditFacade
      * @param \Symfony\Component\Form\Form $form
      * @return array
      */
-    private function getFormRowTemplateParameters(Grid $grid, Form $form)
+    protected function getFormRowTemplateParameters(Grid $grid, Form $form)
     {
         $formView = $form->createView();
         $rows = $grid->getRows();

--- a/packages/framework/src/Component/Grid/QueryBuilderDataSource.php
+++ b/packages/framework/src/Component/Grid/QueryBuilderDataSource.php
@@ -11,12 +11,12 @@ class QueryBuilderDataSource implements DataSourceInterface
     /**
      * @var \Doctrine\ORM\QueryBuilder
      */
-    private $queryBuilder;
+    protected $queryBuilder;
 
     /**
      * @var string
      */
-    private $rowIdSourceColumnName;
+    protected $rowIdSourceColumnName;
 
     /**
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
@@ -80,7 +80,7 @@ class QueryBuilderDataSource implements DataSourceInterface
      * @param string $orderSourceColumnName
      * @param string $orderDirection
      */
-    private function addQueryOrder(QueryBuilder $queryBuilder, $orderSourceColumnName, $orderDirection)
+    protected function addQueryOrder(QueryBuilder $queryBuilder, $orderSourceColumnName, $orderDirection)
     {
         $queryBuilder->orderBy($orderSourceColumnName, $orderDirection);
     }
@@ -89,7 +89,7 @@ class QueryBuilderDataSource implements DataSourceInterface
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
      * @param int $rowId
      */
-    private function prepareQueryWithOneRow(QueryBuilder $queryBuilder, $rowId)
+    protected function prepareQueryWithOneRow(QueryBuilder $queryBuilder, $rowId)
     {
         $queryBuilder
             ->andWhere($this->rowIdSourceColumnName . ' = :rowId')

--- a/packages/framework/src/Component/Grid/QueryBuilderWithRowManipulatorDataSource.php
+++ b/packages/framework/src/Component/Grid/QueryBuilderWithRowManipulatorDataSource.php
@@ -11,7 +11,7 @@ class QueryBuilderWithRowManipulatorDataSource extends QueryBuilderDataSource
     /**
      * @var callable
      */
-    private $manipulateRowCallback;
+    protected $manipulateRowCallback;
 
     /**
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder

--- a/packages/framework/src/Component/HttpFoundation/SubRequestListener.php
+++ b/packages/framework/src/Component/HttpFoundation/SubRequestListener.php
@@ -12,12 +12,12 @@ class SubRequestListener
     /**
      * @var \Symfony\Component\HttpFoundation\RedirectResponse
      */
-    private $redirectResponse;
+    protected $redirectResponse;
 
     /**
      * @var \Symfony\Component\HttpFoundation\Request
      */
-    private $masterRequest;
+    protected $masterRequest;
 
     /**
      * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
@@ -34,7 +34,7 @@ class SubRequestListener
     /**
      * @param \Symfony\Component\HttpFoundation\Request $subRequest
      */
-    private function fillSubRequestFromMasterRequest(Request $subRequest)
+    protected function fillSubRequestFromMasterRequest(Request $subRequest)
     {
         $subRequest->setMethod($this->masterRequest->getMethod());
         $subRequest->request = $this->masterRequest->request;
@@ -62,7 +62,7 @@ class SubRequestListener
     /**
      * @param \Symfony\Component\HttpFoundation\Response $subResponse
      */
-    private function processSubResponse(Response $subResponse)
+    protected function processSubResponse(Response $subResponse)
     {
         if ($subResponse->isRedirection()) {
             if ($this->redirectResponse === null) {

--- a/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
+++ b/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
@@ -12,12 +12,12 @@ class TransactionalMasterRequestListener
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var bool
      */
-    private $inTransaction;
+    protected $inTransaction;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateEntityNameException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateEntityNameException.php
@@ -9,7 +9,7 @@ class DuplicateEntityNameException extends Exception implements ImageConfigExcep
     /**
      * @var string
      */
-    private $entityName;
+    protected $entityName;
 
     /**
      * @param string $entityName

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateSizeNameException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateSizeNameException.php
@@ -9,7 +9,7 @@ class DuplicateSizeNameException extends Exception implements ImageConfigExcepti
     /**
      * @var string|null
      */
-    private $sizeName;
+    protected $sizeName;
 
     /**
      * @param string|null $sizeName

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateTypeNameException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateTypeNameException.php
@@ -9,7 +9,7 @@ class DuplicateTypeNameException extends Exception implements ImageConfigExcepti
     /**
      * @var string|null
      */
-    private $typeName;
+    protected $typeName;
 
     /**
      * @param string|null $typeName

--- a/packages/framework/src/Component/Image/Config/Exception/EntityParseException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/EntityParseException.php
@@ -9,7 +9,7 @@ class EntityParseException extends Exception implements ImageConfigException
     /**
      * @var string
      */
-    private $entityClass;
+    protected $entityClass;
 
     /**
      * @param string $entityClass

--- a/packages/framework/src/Component/Image/Config/Exception/ImageEntityConfigNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageEntityConfigNotFoundException.php
@@ -9,7 +9,7 @@ class ImageEntityConfigNotFoundException extends Exception implements ImageConfi
     /**
      * @var string
      */
-    private $entityClassOrName;
+    protected $entityClassOrName;
 
     /**
      * @param string $entityClassOrName

--- a/packages/framework/src/Component/Image/Config/Exception/ImageSizeNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageSizeNotFoundException.php
@@ -9,12 +9,12 @@ class ImageSizeNotFoundException extends Exception implements ImageConfigExcepti
     /**
      * @var string
      */
-    private $entityClass;
+    protected $entityClass;
 
     /**
      * @var string
      */
-    private $sizeName;
+    protected $sizeName;
 
     /**
      * @param string $entityClass

--- a/packages/framework/src/Component/Image/Config/Exception/ImageTypeNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageTypeNotFoundException.php
@@ -9,12 +9,12 @@ class ImageTypeNotFoundException extends Exception implements ImageConfigExcepti
     /**
      * @var string
      */
-    private $entityClass;
+    protected $entityClass;
 
     /**
      * @var string
      */
-    private $imageType;
+    protected $imageType;
 
     /**
      * @param string $entityClass

--- a/packages/framework/src/Component/Image/Config/ImageAdditionalSizeConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageAdditionalSizeConfig.php
@@ -7,17 +7,17 @@ class ImageAdditionalSizeConfig
     /**
      * @var int|null
      */
-    private $width;
+    protected $width;
 
     /**
      * @var int|null
      */
-    private $height;
+    protected $height;
 
     /**
      * @var string
      */
-    private $media;
+    protected $media;
 
     /**
      * @param int|null $width

--- a/packages/framework/src/Component/Image/Config/ImageConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfig.php
@@ -12,7 +12,7 @@ class ImageConfig
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[]
      */
-    private $imageEntityConfigsByClass;
+    protected $imageEntityConfigsByClass;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[] $imageEntityConfigsByClass

--- a/packages/framework/src/Component/Image/Config/ImageConfigDefinition.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigDefinition.php
@@ -39,7 +39,7 @@ class ImageConfigDefinition implements ConfigurationInterface
      * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
      * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
      */
-    private function buildItemsNode(ArrayNodeDefinition $node)
+    protected function buildItemsNode(ArrayNodeDefinition $node)
     {
         return $node
             ->addDefaultsIfNotSet()

--- a/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
@@ -14,17 +14,17 @@ class ImageConfigLoader
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[]
      */
-    private $foundEntityConfigs;
+    protected $foundEntityConfigs;
 
     /**
      * @var array
      */
-    private $foundEntityNames;
+    protected $foundEntityNames;
 
     /**
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
@@ -85,7 +85,7 @@ class ImageConfigLoader
     /**
      * @param array $entityConfig
      */
-    private function processEntityConfig($entityConfig)
+    protected function processEntityConfig($entityConfig)
     {
         $entityClass = $entityConfig[ImageConfigDefinition::CONFIG_CLASS];
         $entityName = $entityConfig[ImageConfigDefinition::CONFIG_ENTITY_NAME];
@@ -109,7 +109,7 @@ class ImageConfigLoader
      * @param array $sizesConfig
      * @return \Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig[]
      */
-    private function prepareSizes($sizesConfig)
+    protected function prepareSizes($sizesConfig)
     {
         $result = [];
         foreach ($sizesConfig as $sizeConfig) {
@@ -141,7 +141,7 @@ class ImageConfigLoader
      * @param array $additionalSizesConfig
      * @return \Shopsys\FrameworkBundle\Component\Image\Config\ImageAdditionalSizeConfig[]
      */
-    private function prepareAdditionalSizes(string $sizeName, array $additionalSizesConfig): array
+    protected function prepareAdditionalSizes(string $sizeName, array $additionalSizesConfig): array
     {
         $usedMedia = [];
         $result = [];
@@ -170,7 +170,7 @@ class ImageConfigLoader
      * @param array $typesConfig
      * @return array
      */
-    private function prepareTypes($typesConfig)
+    protected function prepareTypes($typesConfig)
     {
         $result = [];
         foreach ($typesConfig as $typeConfig) {
@@ -189,7 +189,7 @@ class ImageConfigLoader
      * @param array $entityConfig
      * @return array
      */
-    private function getMultipleByType(array $entityConfig)
+    protected function getMultipleByType(array $entityConfig)
     {
         $multipleByType = [];
         $multipleByType[ImageEntityConfig::WITHOUT_NAME_KEY] = $entityConfig[ImageConfigDefinition::CONFIG_MULTIPLE];

--- a/packages/framework/src/Component/Image/Config/ImageEntityConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageEntityConfig.php
@@ -11,27 +11,27 @@ class ImageEntityConfig
     /**
      * @var string
      */
-    private $entityName;
+    protected $entityName;
 
     /**
      * @var string
      */
-    private $entityClass;
+    protected $entityClass;
 
     /**
      * @var array
      */
-    private $sizeConfigsByType;
+    protected $sizeConfigsByType;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig[]
      */
-    private $sizeConfigs;
+    protected $sizeConfigs;
 
     /**
      * @var array
      */
-    private $multipleByType;
+    protected $multipleByType;
 
     /**
      * @param string $entityName
@@ -145,7 +145,7 @@ class ImageEntityConfig
      * @param string $sizeName
      * @return \Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig
      */
-    private function getSizeConfigFromSizeConfigs($sizes, $sizeName)
+    protected function getSizeConfigFromSizeConfigs($sizes, $sizeName)
     {
         $key = Utils::ifNull($sizeName, self::WITHOUT_NAME_KEY);
         if (array_key_exists($key, $sizes)) {

--- a/packages/framework/src/Component/Image/Config/ImageSizeConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageSizeConfig.php
@@ -9,32 +9,32 @@ class ImageSizeConfig
     /**
      * @var string|null
      */
-    private $name;
+    protected $name;
 
     /**
      * @var int
      */
-    private $width;
+    protected $width;
 
     /**
      * @var int
      */
-    private $height;
+    protected $height;
 
     /**
      * @var bool
      */
-    private $crop;
+    protected $crop;
 
     /**
      * @var string|null
      */
-    private $occurrence;
+    protected $occurrence;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageAdditionalSizeConfig[]
      */
-    private $additionalSizes;
+    protected $additionalSizes;
 
     /**
      * @param string|null $name

--- a/packages/framework/src/Component/Image/DirectoryStructureCreator.php
+++ b/packages/framework/src/Component/Image/DirectoryStructureCreator.php
@@ -10,27 +10,27 @@ class DirectoryStructureCreator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig
      */
-    private $imageConfig;
+    protected $imageConfig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageLocator
      */
-    private $imageLocator;
+    protected $imageLocator;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @var string
      */
-    private $imageDir;
+    protected $imageDir;
 
     /**
      * @var string
      */
-    private $domainImageDir;
+    protected $domainImageDir;
 
     /**
      * @param string $imageDir
@@ -90,7 +90,7 @@ class DirectoryStructureCreator
      * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig[] $sizeConfigs
      * @return string[]
      */
-    private function getTargetDirectoriesFromSizeConfigs($entityName, $type, array $sizeConfigs)
+    protected function getTargetDirectoriesFromSizeConfigs($entityName, $type, array $sizeConfigs)
     {
         $directories = [];
         foreach ($sizeConfigs as $sizeConfig) {

--- a/packages/framework/src/Component/Image/ImageDeleteDoctrineListener.php
+++ b/packages/framework/src/Component/Image/ImageDeleteDoctrineListener.php
@@ -11,12 +11,12 @@ class ImageDeleteDoctrineListener
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig
      */
-    private $imageConfig;
+    protected $imageConfig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
      */
-    private $imageFacade;
+    protected $imageFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig $imageConfig
@@ -35,7 +35,7 @@ class ImageDeleteDoctrineListener
      *
      * @return \Shopsys\FrameworkBundle\Component\Image\ImageFacade
      */
-    private function getImageFacade()
+    protected function getImageFacade()
     {
         return $this->imageFacade;
     }
@@ -58,7 +58,7 @@ class ImageDeleteDoctrineListener
      * @param object $entity
      * @param \Doctrine\ORM\EntityManagerInterface $em
      */
-    private function deleteEntityImages($entity, EntityManagerInterface $em)
+    protected function deleteEntityImages($entity, EntityManagerInterface $em)
     {
         $images = $this->getImageFacade()->getAllImagesByEntity($entity);
         foreach ($images as $image) {

--- a/packages/framework/src/Component/Image/ImageLocator.php
+++ b/packages/framework/src/Component/Image/ImageLocator.php
@@ -7,22 +7,22 @@ use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 
 class ImageLocator
 {
-    private const ADDITIONAL_IMAGE_MASK = 'additional_{index}_{filename}';
+    protected const ADDITIONAL_IMAGE_MASK = 'additional_{index}_{filename}';
 
     /**
      * @var string
      */
-    private $imageDir;
+    protected $imageDir;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig
      */
-    private $imageConfig;
+    protected $imageConfig;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @param mixed $imageDir

--- a/packages/framework/src/Component/Image/Processing/ImageGenerator.php
+++ b/packages/framework/src/Component/Image/Processing/ImageGenerator.php
@@ -13,22 +13,22 @@ class ImageGenerator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor
      */
-    private $imageProcessor;
+    protected $imageProcessor;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageLocator
      */
-    private $imageLocator;
+    protected $imageLocator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig
      */
-    private $imageConfig;
+    protected $imageConfig;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor $imageProcessor

--- a/packages/framework/src/Component/Image/Processing/ImageProcessor.php
+++ b/packages/framework/src/Component/Image/Processing/ImageProcessor.php
@@ -20,22 +20,22 @@ class ImageProcessor
     /**
      * @var string[]
      */
-    private $supportedImageExtensions;
+    protected $supportedImageExtensions;
 
     /**
      * @var \Intervention\Image\ImageManager
      */
-    private $imageManager;
+    protected $imageManager;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $localFilesystem;
+    protected $localFilesystem;
 
     /**
      * @param \Intervention\Image\ImageManager $imageManager
@@ -167,7 +167,7 @@ class ImageProcessor
      * @param string $filepath
      * @param string $newFilepath
      */
-    private function removeFileIfRenamed($filepath, $newFilepath)
+    protected function removeFileIfRenamed($filepath, $newFilepath)
     {
         if ($this->filesystem->has($filepath) && $filepath !== $newFilepath) {
             $this->filesystem->delete($filepath);

--- a/packages/framework/src/Component/Javascript/Compiler/Constant/JsConstantCompilerPass.php
+++ b/packages/framework/src/Component/Javascript/Compiler/Constant/JsConstantCompilerPass.php
@@ -11,7 +11,7 @@ class JsConstantCompilerPass implements JsCompilerPassInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\Constant\JsConstantCallParser
      */
-    private $jsConstantCallParser;
+    protected $jsConstantCallParser;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Parser\Constant\JsConstantCallParser $jsConstantCallParser
@@ -50,7 +50,7 @@ class JsConstantCompilerPass implements JsCompilerPassInterface
      * @param string $constantName
      * @return mixed
      */
-    private function getConstantValue($constantName)
+    protected function getConstantValue($constantName)
     {
         // Normal defined constant (either class or global)
         if (defined($constantName)) {

--- a/packages/framework/src/Component/Javascript/Compiler/JsCompiler.php
+++ b/packages/framework/src/Component/Javascript/Compiler/JsCompiler.php
@@ -10,7 +10,7 @@ class JsCompiler
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Compiler\JsCompilerPassInterface[]
      */
-    private $compilerPasses;
+    protected $compilerPasses;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Compiler\JsCompilerPassInterface[] $compilerPasses

--- a/packages/framework/src/Component/Javascript/Compiler/Translator/JsTranslatorCompilerPass.php
+++ b/packages/framework/src/Component/Javascript/Compiler/Translator/JsTranslatorCompilerPass.php
@@ -13,12 +13,12 @@ class JsTranslatorCompilerPass implements JsCompilerPassInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\Translator\JsTranslatorCallParser
      */
-    private $jsTranslatorCallParser;
+    protected $jsTranslatorCallParser;
 
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
-    private $translator;
+    protected $translator;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Parser\Translator\JsTranslatorCallParser $jsTranslatorCallParser
@@ -58,7 +58,7 @@ class JsTranslatorCompilerPass implements JsCompilerPassInterface
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Parser\Translator\JsTranslatorCall $jsTranslatorsCall
      * @return string
      */
-    private function translate($jsTranslatorsCall)
+    protected function translate($jsTranslatorsCall)
     {
         $locale = $this->translator->getLocale();
         $catalogue = $this->translator->getCatalogue($locale);

--- a/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCall.php
+++ b/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCall.php
@@ -9,12 +9,12 @@ class JsConstantCall
     /**
      * @var \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode
      */
-    private $callExprNode;
+    protected $callExprNode;
 
     /**
      * @var string
      */
-    private $constantName;
+    protected $constantName;
 
     /**
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode

--- a/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCallParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCallParser.php
@@ -17,12 +17,12 @@ class JsConstantCallParser
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsFunctionCallParser
      */
-    private $jsFunctionCallParser;
+    protected $jsFunctionCallParser;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsStringParser
      */
-    private $jsStringParser;
+    protected $jsStringParser;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsFunctionCallParser $jsFunctionCallParser
@@ -65,7 +65,7 @@ class JsConstantCallParser
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode
      * @return bool
      */
-    private function isConstantFunctionCall(JCallExprNode $callExprNode)
+    protected function isConstantFunctionCall(JCallExprNode $callExprNode)
     {
         $functionName = $this->jsFunctionCallParser->getFunctionName($callExprNode);
 
@@ -76,7 +76,7 @@ class JsConstantCallParser
      * @param \PLUG\JavaScript\JNodes\JNodeBase $constantNameArgumentNode
      * @return string
      */
-    private function getConstantName(JNodeBase $constantNameArgumentNode)
+    protected function getConstantName(JNodeBase $constantNameArgumentNode)
     {
         try {
             $constantName = $this->jsStringParser->getConcatenatedString($constantNameArgumentNode);
@@ -96,7 +96,7 @@ class JsConstantCallParser
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode
      * @return \PLUG\JavaScript\JNodes\JNodeBase
      */
-    private function getConstantNameArgumentNode(JCallExprNode $callExprNode)
+    protected function getConstantNameArgumentNode(JCallExprNode $callExprNode)
     {
         $argumentNodes = $this->jsFunctionCallParser->getArgumentNodes($callExprNode);
         if (!isset($argumentNodes[self::NAME_ARGUMENT_INDEX])) {

--- a/packages/framework/src/Component/Javascript/Parser/JsStringParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/JsStringParser.php
@@ -43,7 +43,7 @@ class JsStringParser
      * @param string $stringLiteral
      * @return string
      */
-    private function parseStringLiteral($stringLiteral)
+    protected function parseStringLiteral($stringLiteral)
     {
         return json_decode($this->normalizeStringLiteral($stringLiteral));
     }
@@ -52,7 +52,7 @@ class JsStringParser
      * @param string $stringLiteral
      * @return string
      */
-    private function normalizeStringLiteral($stringLiteral)
+    protected function normalizeStringLiteral($stringLiteral)
     {
         $matches = [];
         if (preg_match('/^"(.*)"$/', $stringLiteral, $matches)) {

--- a/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCall.php
+++ b/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCall.php
@@ -10,27 +10,27 @@ class JsTranslatorCall
     /**
      * @var \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode
      */
-    private $callExprNode;
+    protected $callExprNode;
 
     /**
      * @var \PLUG\JavaScript\JNodes\JNodeBase
      */
-    private $messageIdArgumentNode;
+    protected $messageIdArgumentNode;
 
     /**
      * @var string
      */
-    private $messageId;
+    protected $messageId;
 
     /**
      * @var string
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var string
      */
-    private $functionName;
+    protected $functionName;
 
     /**
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode

--- a/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParser.php
@@ -16,17 +16,17 @@ class JsTranslatorCallParser
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsFunctionCallParser
      */
-    private $jsFunctionCallParser;
+    protected $jsFunctionCallParser;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsStringParser
      */
-    private $jsStringParser;
+    protected $jsStringParser;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\TransMethodSpecification[]
      */
-    private $transMethodSpecifications;
+    protected $transMethodSpecifications;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsFunctionCallParser $jsFunctionCallParser
@@ -79,7 +79,7 @@ class JsTranslatorCallParser
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode
      * @return bool
      */
-    private function isTransFunctionCall(JCallExprNode $callExprNode)
+    protected function isTransFunctionCall(JCallExprNode $callExprNode)
     {
         $functionName = $this->jsFunctionCallParser->getFunctionName($callExprNode);
 
@@ -96,7 +96,7 @@ class JsTranslatorCallParser
      * @param \PLUG\JavaScript\JNodes\JNodeBase $messageIdArgumentNode
      * @return string
      */
-    private function getMessageId(JNodeBase $messageIdArgumentNode)
+    protected function getMessageId(JNodeBase $messageIdArgumentNode)
     {
         try {
             $messageId = $this->jsStringParser->getConcatenatedString($messageIdArgumentNode);
@@ -116,7 +116,7 @@ class JsTranslatorCallParser
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode
      * @return string
      */
-    private function getDomain(JCallExprNode $callExprNode)
+    protected function getDomain(JCallExprNode $callExprNode)
     {
         $functionName = $this->jsFunctionCallParser->getFunctionName($callExprNode);
         $domainArgumentIndex = $this->transMethodSpecifications[$functionName]->getDomainArgumentIndex();
@@ -144,7 +144,7 @@ class JsTranslatorCallParser
      * @param \PLUG\JavaScript\JNodes\nonterminal\JCallExprNode $callExprNode
      * @return \PLUG\JavaScript\JNodes\JNodeBase
      */
-    private function getMessageIdArgumentNode(JCallExprNode $callExprNode)
+    protected function getMessageIdArgumentNode(JCallExprNode $callExprNode)
     {
         $functionName = $this->jsFunctionCallParser->getFunctionName($callExprNode);
         $messageIdArgumentIndex = $this->transMethodSpecifications[$functionName]->getMessageIdArgumentIndex();

--- a/packages/framework/src/Component/Localization/DateTimeFormatPattern.php
+++ b/packages/framework/src/Component/Localization/DateTimeFormatPattern.php
@@ -7,24 +7,24 @@ class DateTimeFormatPattern
     /**
      * @var string
      */
-    private $pattern;
+    protected $pattern;
 
     /**
      * @var string
      */
-    private $locale;
+    protected $locale;
 
     /**
      * @link http://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
      * @var int|null
      */
-    private $dateType;
+    protected $dateType;
 
     /**
      * @link http://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
      * @var int|null
      */
-    private $timeType;
+    protected $timeType;
 
     /**
      * @param string $pattern

--- a/packages/framework/src/Component/Localization/DateTimeFormatter.php
+++ b/packages/framework/src/Component/Localization/DateTimeFormatter.php
@@ -10,7 +10,7 @@ class DateTimeFormatter
     /**
      * @var \Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatPatternRepository
      */
-    private $customDateTimeFormatPatternRepository;
+    protected $customDateTimeFormatPatternRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatPatternRepository $customDateTimeFormatPatternRepository
@@ -47,7 +47,7 @@ class DateTimeFormatter
      * @param int|null $timeType
      * @return string|null
      */
-    private function getCustomPattern($locale, $dateType, $timeType)
+    protected function getCustomPattern($locale, $dateType, $timeType)
     {
         $dateTimePattern = $this->customDateTimeFormatPatternRepository->findDateTimePattern($locale, $dateType, $timeType);
         if ($dateTimePattern !== null) {

--- a/packages/framework/src/Component/Microservice/MicroserviceClient.php
+++ b/packages/framework/src/Component/Microservice/MicroserviceClient.php
@@ -10,7 +10,7 @@ class MicroserviceClient
     /**
      * @var \GuzzleHttp\Client
      */
-    private $guzzleClient;
+    protected $guzzleClient;
 
     /**
      * @param \GuzzleHttp\Client $guzzleClient

--- a/packages/framework/src/Component/Paginator/PaginationResult.php
+++ b/packages/framework/src/Component/Paginator/PaginationResult.php
@@ -7,37 +7,37 @@ class PaginationResult
     /**
      * @var int
      */
-    private $page;
+    protected $page;
 
     /**
      * @var int
      */
-    private $pageSize;
+    protected $pageSize;
 
     /**
      * @var int
      */
-    private $totalCount;
+    protected $totalCount;
 
     /**
      * @var array
      */
-    private $results;
+    protected $results;
 
     /**
      * @var int
      */
-    private $pageCount;
+    protected $pageCount;
 
     /**
      * @var int
      */
-    private $fromItem;
+    protected $fromItem;
 
     /**
      * @var int
      */
-    private $toItem;
+    protected $toItem;
 
     /**
      * @param int $page

--- a/packages/framework/src/Component/Paginator/QueryPaginator.php
+++ b/packages/framework/src/Component/Paginator/QueryPaginator.php
@@ -13,12 +13,12 @@ class QueryPaginator implements PaginatorInterface
     /**
      * @var \Doctrine\ORM\QueryBuilder
      */
-    private $queryBuilder;
+    protected $queryBuilder;
 
     /**
      * @var string|null
      */
-    private $hydrationMode;
+    protected $hydrationMode;
 
     /**
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
@@ -82,7 +82,7 @@ class QueryPaginator implements PaginatorInterface
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
      * @return \Doctrine\ORM\NativeQuery
      */
-    private function getTotalNativeQuery(QueryBuilder $queryBuilder)
+    protected function getTotalNativeQuery(QueryBuilder $queryBuilder)
     {
         $em = $queryBuilder->getEntityManager();
 

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionRegistry.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionRegistry.php
@@ -17,7 +17,7 @@ class PluginCrudExtensionRegistry
     /**
      * @var \Shopsys\Plugin\PluginCrudExtensionInterface[][]
      */
-    private $crudExtensionsByTypeAndServiceId = [];
+    protected $crudExtensionsByTypeAndServiceId = [];
 
     /**
      * @param \Shopsys\Plugin\PluginCrudExtensionInterface $crudExtension

--- a/packages/framework/src/Component/Plugin/PluginDataFixtureRegistry.php
+++ b/packages/framework/src/Component/Plugin/PluginDataFixtureRegistry.php
@@ -9,7 +9,7 @@ class PluginDataFixtureRegistry
     /**
      * @var \Shopsys\Plugin\PluginDataFixtureInterface[]
      */
-    private $pluginDataFixtures = [];
+    protected $pluginDataFixtures = [];
 
     /**
      * @param \Shopsys\Plugin\PluginDataFixtureInterface $pluginDataFixture

--- a/packages/framework/src/Component/Router/CurrentDomainRouter.php
+++ b/packages/framework/src/Component/Router/CurrentDomainRouter.php
@@ -11,17 +11,17 @@ class CurrentDomainRouter implements RouterInterface
     /**
      * @var \Symfony\Component\Routing\RequestContext
      */
-    private $context;
+    protected $context;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -80,7 +80,7 @@ class CurrentDomainRouter implements RouterInterface
     /**
      * @return \Shopsys\FrameworkBundle\Component\Router\DomainRouter
      */
-    private function getDomainRouter()
+    protected function getDomainRouter()
     {
         return $this->domainRouterFactory->getRouter($this->domain->getId());
     }

--- a/packages/framework/src/Component/Router/DomainRouter.php
+++ b/packages/framework/src/Component/Router/DomainRouter.php
@@ -14,12 +14,12 @@ class DomainRouter extends ChainRouter
     /**
      * @var bool
      */
-    private $freeze = false;
+    protected $freeze = false;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouter
      */
-    private $friendlyUrlRouter;
+    protected $friendlyUrlRouter;
 
     /**
      * @param \Symfony\Component\Routing\RequestContext $context

--- a/packages/framework/src/Component/Router/FriendlyUrl/CompilerPass/FriendlyUrlDataProviderRegistry.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/CompilerPass/FriendlyUrlDataProviderRegistry.php
@@ -9,7 +9,7 @@ class FriendlyUrlDataProviderRegistry
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\CompilerPass\FriendlyUrlDataProviderInterface[]
      */
-    private $friendlyUrlDataProviders;
+    protected $friendlyUrlDataProviders;
 
     public function __construct()
     {

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
@@ -14,7 +14,7 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository
      */
-    private $friendlyUrlRepository;
+    protected $friendlyUrlRepository;
 
     /**
      * @param \Symfony\Component\Routing\RequestContext $context

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlMatcher.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlMatcher.php
@@ -10,7 +10,7 @@ class FriendlyUrlMatcher
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository
      */
-    private $friendlyUrlRepository;
+    protected $friendlyUrlRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRouter.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRouter.php
@@ -12,37 +12,37 @@ class FriendlyUrlRouter implements RouterInterface
     /**
      * @var \Symfony\Component\Routing\RequestContext
      */
-    private $context;
+    protected $context;
 
     /**
      * @var \Symfony\Component\Config\Loader\LoaderInterface
      */
-    private $configLoader;
+    protected $configLoader;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlGenerator
      */
-    private $friendlyUrlGenerator;
+    protected $friendlyUrlGenerator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlMatcher
      */
-    private $friendlyUrlMatcher;
+    protected $friendlyUrlMatcher;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
      */
-    private $domainConfig;
+    protected $domainConfig;
 
     /**
      * @var string
      */
-    private $friendlyUrlRouterResourceFilepath;
+    protected $friendlyUrlRouterResourceFilepath;
 
     /**
      * @var \Symfony\Component\Routing\RouteCollection
      */
-    private $collection;
+    protected $collection;
 
     /**
      * @param \Symfony\Component\Routing\RequestContext $context

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlUniqueResult.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlUniqueResult.php
@@ -7,12 +7,12 @@ class FriendlyUrlUniqueResult
     /**
      * @var bool
      */
-    private $unique;
+    protected $unique;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl
      */
-    private $friendlyUrlForPersist;
+    protected $friendlyUrlForPersist;
 
     /**
      * @param bool $unique

--- a/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
+++ b/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
@@ -19,12 +19,12 @@ class RouteCsrfProtector implements EventSubscriberInterface
     /**
      * @var \Doctrine\Common\Annotations\Reader
      */
-    private $annotationReader;
+    protected $annotationReader;
 
     /**
      * @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface
      */
-    private $tokenManager;
+    protected $tokenManager;
 
     /**
      * @param \Doctrine\Common\Annotations\Reader $annotationReader
@@ -85,7 +85,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
      * @param string $csrfToken
      * @return bool
      */
-    private function isCsrfTokenValid($routeName, $csrfToken)
+    protected function isCsrfTokenValid($routeName, $csrfToken)
     {
         $token = new CsrfToken($this->getCsrfTokenId($routeName), $csrfToken);
 
@@ -96,7 +96,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
      * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
      * @return bool
      */
-    private function isProtected(FilterControllerEvent $event)
+    protected function isProtected(FilterControllerEvent $event)
     {
         if (!$event->isMasterRequest()) {
             return false;

--- a/packages/framework/src/Component/Setting/ClearSettingsCacheDoctrineSubscriber.php
+++ b/packages/framework/src/Component/Setting/ClearSettingsCacheDoctrineSubscriber.php
@@ -11,7 +11,7 @@ class ClearSettingsCacheDoctrineSubscriber implements EventSubscriber
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting

--- a/packages/framework/src/Component/Setting/Setting.php
+++ b/packages/framework/src/Component/Setting/Setting.php
@@ -25,17 +25,17 @@ class Setting
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\SettingValueRepository
      */
-    private $settingValueRepository;
+    protected $settingValueRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\SettingValue[][]
      */
-    private $values;
+    protected $values;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
@@ -127,7 +127,7 @@ class Setting
     /**
      * @param int $domainId
      */
-    private function loadDomainValues($domainId)
+    protected function loadDomainValues($domainId)
     {
         if ($domainId === null) {
             $message = 'Cannot load setting value for null domain ID';

--- a/packages/framework/src/Component/String/EncodingConverter.php
+++ b/packages/framework/src/Component/String/EncodingConverter.php
@@ -8,7 +8,7 @@ class EncodingConverter
      * @param string $stringCp1250
      * @return string
      */
-    private static function stringCp1250ToUtf8($stringCp1250)
+    protected static function stringCp1250ToUtf8($stringCp1250)
     {
         return iconv('CP1250', 'UTF-8//TRANSLIT', $stringCp1250);
     }
@@ -17,7 +17,7 @@ class EncodingConverter
      * @param array $array
      * @return array
      */
-    private static function arrayCp1250ToUtf8(array $array)
+    protected static function arrayCp1250ToUtf8(array $array)
     {
         foreach ($array as $key => $value) {
             if (is_array($value)) {

--- a/packages/framework/src/Component/String/HashGenerator.php
+++ b/packages/framework/src/Component/String/HashGenerator.php
@@ -4,7 +4,7 @@ namespace Shopsys\FrameworkBundle\Component\String;
 
 class HashGenerator
 {
-    private $characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz';
+    protected $characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz';
 
     /**
      * @param int $length

--- a/packages/framework/src/Component/String/TransformString.php
+++ b/packages/framework/src/Component/String/TransformString.php
@@ -78,7 +78,7 @@ class TransformString
      * @param string $string
      * @return string
      */
-    private static function toAscii($string)
+    protected static function toAscii($string)
     {
         return iconv('utf-8', 'us-ascii//TRANSLIT//IGNORE', $string);
     }

--- a/packages/framework/src/Component/System/PostgresqlLocaleMapper.php
+++ b/packages/framework/src/Component/System/PostgresqlLocaleMapper.php
@@ -17,7 +17,7 @@ class PostgresqlLocaleMapper
     /**
      * @var string[]
      */
-    private static $windowsLocalesIndexedByCollation = [
+    protected static $windowsLocalesIndexedByCollation = [
         'af_ZA' => 'Afrikaans_South Africa',
         'am_ET' => 'Amharic_Ethiopia',
         'ar_AE' => 'Arabic_United Arab Emirates',

--- a/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
@@ -38,17 +38,17 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @var \PhpParser\NodeTraverser
      */
-    private $traverser;
+    protected $traverser;
 
     /**
      * @var \JMS\TranslationBundle\Model\MessageCatalogue
      */
-    private $catalogue;
+    protected $catalogue;
 
     /**
      * @var \SplFileInfo
      */
-    private $file;
+    protected $file;
 
     public function __construct()
     {
@@ -83,7 +83,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return bool
      */
-    private function isConstraintClass(Node $node)
+    protected function isConstraintClass(Node $node)
     {
         return $node instanceof FullyQualified && is_subclass_of((string)$node, Constraint::class);
     }
@@ -91,7 +91,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @param \PhpParser\Node $optionsNode
      */
-    private function extractMessagesFromOptions(Node $optionsNode)
+    protected function extractMessagesFromOptions(Node $optionsNode)
     {
         if ($optionsNode instanceof Array_) {
             foreach ($optionsNode->items as $optionItemNode) {
@@ -111,7 +111,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node\Expr\ArrayItem $node
      * @return bool
      */
-    private function isMessageOptionItem(ArrayItem $node)
+    protected function isMessageOptionItem(ArrayItem $node)
     {
         return $node->key instanceof String_ && strtolower(substr($node->key->value, -7)) === 'message';
     }

--- a/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
@@ -35,22 +35,22 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     /**
      * @var \PhpParser\NodeTraverser
      */
-    private $traverser;
+    protected $traverser;
 
     /**
      * @var \JMS\TranslationBundle\Model\MessageCatalogue
      */
-    private $catalogue;
+    protected $catalogue;
 
     /**
      * @var \SplFileInfo
      */
-    private $file;
+    protected $file;
 
     /**
      * @var bool
      */
-    private $isInsideConstraintClass = null;
+    protected $isInsideConstraintClass = null;
 
     public function __construct()
     {
@@ -97,7 +97,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
      * @param \PhpParser\Node\Stmt\Class_ $node
      * @return bool
      */
-    private function isConstraintClass(Class_ $node)
+    protected function isConstraintClass(Class_ $node)
     {
         return is_subclass_of((string)$node->namespacedName, Constraint::class);
     }
@@ -105,7 +105,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     /**
      * @param \PhpParser\Node\Stmt\Property $node
      */
-    private function extractMessagesFromProperty(Property $node)
+    protected function extractMessagesFromProperty(Property $node)
     {
         foreach ($node->props as $propertyProperty) {
             if ($this->isMessagePropertyProperty($propertyProperty)) {
@@ -123,7 +123,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
      * @param \PhpParser\Node\Stmt\PropertyProperty $node
      * @return bool
      */
-    private function isMessagePropertyProperty(PropertyProperty $node)
+    protected function isMessagePropertyProperty(PropertyProperty $node)
     {
         return strtolower(substr($node->name, -7)) === 'message';
     }

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -41,22 +41,22 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @var \PhpParser\NodeTraverser
      */
-    private $traverser;
+    protected $traverser;
 
     /**
      * @var \JMS\TranslationBundle\Model\MessageCatalogue
      */
-    private $catalogue;
+    protected $catalogue;
 
     /**
      * @var \SplFileInfo
      */
-    private $file;
+    protected $file;
 
     /**
      * @var string[]
      */
-    private $currentExecutionContextVariableNames;
+    protected $currentExecutionContextVariableNames;
 
     public function __construct()
     {
@@ -91,7 +91,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @param \PhpParser\Node\Stmt\ClassMethod $node
      */
-    private function setCurrentExecutionContextVariableNamesFromNode(ClassMethod $node)
+    protected function setCurrentExecutionContextVariableNamesFromNode(ClassMethod $node)
     {
         $this->currentExecutionContextVariableNames = [];
         foreach ($node->getParams() as $parameter) {
@@ -105,7 +105,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node\Param $parameter
      * @return string
      */
-    private function isParameterExecutionContextInterfaceSubclass(Node\Param $parameter)
+    protected function isParameterExecutionContextInterfaceSubclass(Node\Param $parameter)
     {
         if ($parameter->type instanceof FullyQualified) {
             $fullyQualifiedName = implode('\\', $parameter->type->parts);
@@ -121,7 +121,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return bool
      */
-    private function isAddViolationMethodCall(Node $node): bool
+    protected function isAddViolationMethodCall(Node $node): bool
     {
         return $node->var instanceof Variable
             && in_array($node->var->name, $this->currentExecutionContextVariableNames, true)
@@ -131,7 +131,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @param \PhpParser\Node\Expr\MethodCall $methodCall
      */
-    private function extractMessage(MethodCall $methodCall)
+    protected function extractMessage(MethodCall $methodCall)
     {
         $firstArgumentWithMessage = reset($methodCall->args);
         if ($firstArgumentWithMessage->value instanceof String_) {

--- a/packages/framework/src/Component/Translation/CustomTransFiltersVisitor.php
+++ b/packages/framework/src/Component/Translation/CustomTransFiltersVisitor.php
@@ -43,7 +43,7 @@ class CustomTransFiltersVisitor extends Twig_BaseNodeVisitor
      * @param \Twig_Node_Expression_Filter $filterExpressionNode
      * @param string $newFilterName
      */
-    private function replaceCustomFilterName(Twig_Node_Expression_Filter $filterExpressionNode, $newFilterName)
+    protected function replaceCustomFilterName(Twig_Node_Expression_Filter $filterExpressionNode, $newFilterName)
     {
         $filterNameConstantNode = $filterExpressionNode->getNode('filter');
         $filterNameConstantNode->setAttribute('value', $newFilterName);

--- a/packages/framework/src/Component/Translation/JsFileExtractor.php
+++ b/packages/framework/src/Component/Translation/JsFileExtractor.php
@@ -17,17 +17,17 @@ class JsFileExtractor implements FileVisitorInterface
     /**
      * @var \SplFileInfo
      */
-    private $file;
+    protected $file;
 
     /**
      * @var \JMS\TranslationBundle\Model\MessageCatalogue
      */
-    private $catalogue;
+    protected $catalogue;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\Translator\JsTranslatorCallParser
      */
-    private $jsTranslatorCallParser;
+    protected $jsTranslatorCallParser;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Javascript\Parser\Translator\JsTranslatorCallParser $jsTranslatorCallParser
@@ -87,7 +87,7 @@ class JsFileExtractor implements FileVisitorInterface
     /**
      * @param string $contents
      */
-    private function parseFile($contents)
+    protected function parseFile($contents)
     {
         $node = JParser::parse_string($contents, true, JParser::class, JTokenizer::class);
 

--- a/packages/framework/src/Component/Translation/MessageIdNormalizer.php
+++ b/packages/framework/src/Component/Translation/MessageIdNormalizer.php
@@ -40,7 +40,7 @@ class MessageIdNormalizer
      * @param string $domain
      * @return \JMS\TranslationBundle\Model\Message
      */
-    private function getNormalizedMessage(Message $message, $domain)
+    protected function getNormalizedMessage(Message $message, $domain)
     {
         $normalizedMessageId = $this->normalizeMessageId($message->getId());
 

--- a/packages/framework/src/Component/Translation/NormalizingExtractorManager.php
+++ b/packages/framework/src/Component/Translation/NormalizingExtractorManager.php
@@ -11,7 +11,7 @@ class NormalizingExtractorManager extends ExtractorManager
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\MessageIdNormalizer
      */
-    private $messageIdNormalizer;
+    protected $messageIdNormalizer;
 
     /**
      * @param \JMS\TranslationBundle\Translation\Extractor\FileExtractor $extractor

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -24,32 +24,32 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @var \PhpParser\NodeTraverser
      */
-    private $traverser;
+    protected $traverser;
 
     /**
      * @var \Doctrine\Common\Annotations\DocParser
      */
-    private $docParser;
+    protected $docParser;
 
     /**
      * @var \JMS\TranslationBundle\Model\MessageCatalogue
      */
-    private $catalogue;
+    protected $catalogue;
 
     /**
      * @var \SplFileInfo
      */
-    private $file;
+    protected $file;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\TransMethodSpecification[]
      */
-    private $transMethodSpecifications;
+    protected $transMethodSpecifications;
 
     /**
      * @var \PhpParser\Node|null
      */
-    private $previousNode;
+    protected $previousNode;
 
     /**
      * @param \Doctrine\Common\Annotations\DocParser $docParser
@@ -105,7 +105,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\FuncCall $node
      * @return string
      */
-    private function getMessageId($node)
+    protected function getMessageId($node)
     {
         $methodName = $this->getNormalizedMethodName($this->getNodeName($node));
         $messageIdArgumentIndex = $this->transMethodSpecifications[$methodName]->getMessageIdArgumentIndex();
@@ -121,7 +121,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\FuncCall $node
      * @return string
      */
-    private function getDomain($node)
+    protected function getDomain($node)
     {
         $methodName = $this->getNormalizedMethodName($this->getNodeName($node));
         $domainArgumentIndex = $this->transMethodSpecifications[$methodName]->getDomainArgumentIndex();
@@ -137,7 +137,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return bool
      */
-    private function isTransMethodOrFuncCall(Node $node)
+    protected function isTransMethodOrFuncCall(Node $node)
     {
         if ($node instanceof MethodCall || $node instanceof FuncCall) {
             try {
@@ -158,7 +158,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return bool
      */
-    private function isIgnored(Node $node)
+    protected function isIgnored(Node $node)
     {
         foreach ($this->getAnnotations($node) as $annotation) {
             if ($annotation instanceof Ignore) {
@@ -173,7 +173,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return \Doctrine\Common\Annotations\Annotation[]
      */
-    private function getAnnotations(Node $node)
+    protected function getAnnotations(Node $node)
     {
         $docComment = $this->getDocComment($node);
 
@@ -188,7 +188,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return \PhpParser\Comment\Doc|null
      */
-    private function getDocComment(Node $node)
+    protected function getDocComment(Node $node)
     {
         $docComment = $node->getDocComment();
 
@@ -205,7 +205,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param string $methodName
      * @return string
      */
-    private function getNormalizedMethodName($methodName)
+    protected function getNormalizedMethodName($methodName)
     {
         return mb_strtolower($methodName);
     }
@@ -214,7 +214,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
      * @param \PhpParser\Node $node
      * @return string
      */
-    private function getNodeName(Node $node)
+    protected function getNodeName(Node $node)
     {
         if ($node instanceof MethodCall) {
             return $node->name;

--- a/packages/framework/src/Component/Translation/PoDumper.php
+++ b/packages/framework/src/Component/Translation/PoDumper.php
@@ -43,7 +43,7 @@ class PoDumper implements DumperInterface
      * @param string $str
      * @return string
      */
-    private function escape($str)
+    protected function escape($str)
     {
         return addcslashes($str, "\0..\37\42\134");
     }
@@ -52,7 +52,7 @@ class PoDumper implements DumperInterface
      * @param \JMS\TranslationBundle\Model\Message[] $messages
      * @return \JMS\TranslationBundle\Model\Message[]
      */
-    private function sortMessagesByMessageId(array $messages)
+    protected function sortMessagesByMessageId(array $messages)
     {
         usort($messages, function (Message $messageA, Message $messageB) {
             return strcmp($messageA->getId(), $messageB->getId());

--- a/packages/framework/src/Component/Translation/TransMethodSpecification.php
+++ b/packages/framework/src/Component/Translation/TransMethodSpecification.php
@@ -7,17 +7,17 @@ class TransMethodSpecification
     /**
      * @var string
      */
-    private $methodName;
+    protected $methodName;
 
     /**
      * @var int
      */
-    private $messageIdArgumentIndex;
+    protected $messageIdArgumentIndex;
 
     /**
      * @var int|null
      */
-    private $domainArgumentIndex;
+    protected $domainArgumentIndex;
 
     /**
      * @param string $methodName

--- a/packages/framework/src/Component/Translation/TranslatableEntityDataCreator.php
+++ b/packages/framework/src/Component/Translation/TranslatableEntityDataCreator.php
@@ -13,17 +13,17 @@ class TranslatableEntityDataCreator
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Doctrine\NotNullableColumnsFinder
      */
-    private $notNullableColumnsFinder;
+    protected $notNullableColumnsFinder;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Doctrine\SqlQuoter
      */
-    private $sqlQuoter;
+    protected $sqlQuoter;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
@@ -61,7 +61,7 @@ class TranslatableEntityDataCreator
     /**
      * @return \Doctrine\ORM\Mapping\ClassMetadata[]
      */
-    private function getAllTranslatableEntitiesMetadata()
+    protected function getAllTranslatableEntitiesMetadata()
     {
         $translatableEntitiesMetadata = [];
         $allClassesMetadata = $this->em->getMetadataFactory()->getAllMetadata();
@@ -81,7 +81,7 @@ class TranslatableEntityDataCreator
      * @param string $tableName
      * @param string[] $columnNames
      */
-    private function copyTranslatableDataForNewLocale($templateLocale, $newLocale, $tableName, array $columnNames)
+    protected function copyTranslatableDataForNewLocale($templateLocale, $newLocale, $tableName, array $columnNames)
     {
         $quotedColumnNames = $this->sqlQuoter->quoteIdentifiers($columnNames);
         $quotedColumnNamesSql = implode(', ', $quotedColumnNames);

--- a/packages/framework/src/Component/Translation/TranslationSourceReplacement.php
+++ b/packages/framework/src/Component/Translation/TranslationSourceReplacement.php
@@ -7,22 +7,22 @@ class TranslationSourceReplacement
     /**
      * @var string
      */
-    private $oldSource;
+    protected $oldSource;
 
     /**
      * @var string
      */
-    private $newSource;
+    protected $newSource;
 
     /**
      * @var string
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var string[]
      */
-    private $sourceFileReferences;
+    protected $sourceFileReferences;
 
     /**
      * @param string $oldSource
@@ -113,7 +113,7 @@ class TranslationSourceReplacement
      * @param string $sourceFileReference
      * @return string
      */
-    private function extractSourceFilePathFromReference($sourceFileReference)
+    protected function extractSourceFilePathFromReference($sourceFileReference)
     {
         return explode(':', $sourceFileReference)[0];
     }
@@ -122,7 +122,7 @@ class TranslationSourceReplacement
      * @param string $sourceFileReference
      * @return int|null
      */
-    private function extractSourceFileLineFromReference($sourceFileReference)
+    protected function extractSourceFileLineFromReference($sourceFileReference)
     {
         $parts = explode(':', $sourceFileReference);
 

--- a/packages/framework/src/Component/Translation/Translator.php
+++ b/packages/framework/src/Component/Translation/Translator.php
@@ -13,27 +13,27 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\Translator|null
      */
-    private static $self;
+    protected static $self;
 
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
-    private $originalTranslator;
+    protected $originalTranslator;
 
     /**
      * @var \Symfony\Component\Translation\TranslatorBagInterface
      */
-    private $originalTranslatorBag;
+    protected $originalTranslatorBag;
 
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
-    private $identityTranslator;
+    protected $identityTranslator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\MessageIdNormalizer
      */
-    private $messageIdNormalizer;
+    protected $messageIdNormalizer;
 
     /**
      * @param \Symfony\Component\Translation\TranslatorInterface $originalTranslator
@@ -107,7 +107,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      * @param string|null $locale
      * @return string|null
      */
-    private function resolveLocale($locale)
+    protected function resolveLocale($locale)
     {
         if ($locale === null) {
             return $this->getLocale();
@@ -120,7 +120,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
      * @param string|null $domain
      * @return string
      */
-    private function resolveDomain($domain)
+    protected function resolveDomain($domain)
     {
         if ($domain === null) {
             return self::DEFAULT_DOMAIN;

--- a/packages/framework/src/Component/Translation/TwigFileExtractor.php
+++ b/packages/framework/src/Component/Translation/TwigFileExtractor.php
@@ -12,7 +12,7 @@ class TwigFileExtractor implements FileVisitorInterface
     /**
      * @var \JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor
      */
-    private $originalTwigFileExtractor;
+    protected $originalTwigFileExtractor;
 
     /**
      * @param \JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor $originalTwigFileExtractor
@@ -29,7 +29,7 @@ class TwigFileExtractor implements FileVisitorInterface
      * but original \JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor is not open for that type of extension
      * so we need to inject our \Shopsys\FrameworkBundle\Component\Translation\CustomTransFiltersVisitor using ReflectionObject
      */
-    private function injectCustomVisitor()
+    protected function injectCustomVisitor()
     {
         $reflectionObject = new ReflectionObject($this->originalTwigFileExtractor);
         $traverserReflectionProperty = $reflectionObject->getProperty('traverser');

--- a/packages/framework/src/Component/UploadedFile/Config/Exception/DuplicateEntityNameException.php
+++ b/packages/framework/src/Component/UploadedFile/Config/Exception/DuplicateEntityNameException.php
@@ -9,7 +9,7 @@ class DuplicateEntityNameException extends Exception implements UploadedFileConf
     /**
      * @var string
      */
-    private $entityName;
+    protected $entityName;
 
     /**
      * @param string $entityName

--- a/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileConfigurationParseException.php
+++ b/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileConfigurationParseException.php
@@ -9,7 +9,7 @@ class UploadedFileConfigurationParseException extends Exception implements Uploa
     /**
      * @var string
      */
-    private $entityClass;
+    protected $entityClass;
 
     /**
      * @param string $entityClass

--- a/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileEntityConfigNotFoundException.php
+++ b/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileEntityConfigNotFoundException.php
@@ -9,7 +9,7 @@ class UploadedFileEntityConfigNotFoundException extends Exception implements Upl
     /**
      * @var string
      */
-    private $entityClassOrName;
+    protected $entityClassOrName;
 
     /**
      * @param string $entityClassOrName

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfig.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfig.php
@@ -7,7 +7,7 @@ class UploadedFileConfig
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig[]
      */
-    private $uploadedFileEntityConfigsByClass;
+    protected $uploadedFileEntityConfigsByClass;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig[] $uploadedFileEntityConfigsByClass

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigDefinition.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigDefinition.php
@@ -28,7 +28,7 @@ class UploadedFileConfigDefinition implements ConfigurationInterface
      * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
      * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
      */
-    private function buildItemsNode(ArrayNodeDefinition $node)
+    protected function buildItemsNode(ArrayNodeDefinition $node)
     {
         return $node
             ->addDefaultsIfNotSet()

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigLoader.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigLoader.php
@@ -11,17 +11,17 @@ class UploadedFileConfigLoader
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig[]
      */
-    private $uploadedFileEntityConfigsByClass;
+    protected $uploadedFileEntityConfigsByClass;
 
     /**
      * @var string[]
      */
-    private $entityNamesByEntityNames;
+    protected $entityNamesByEntityNames;
 
     /**
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
@@ -58,7 +58,7 @@ class UploadedFileConfigLoader
     /**
      * @param array $outputConfig
      */
-    private function loadFileEntityConfigsFromArray($outputConfig)
+    protected function loadFileEntityConfigsFromArray($outputConfig)
     {
         $this->uploadedFileEntityConfigsByClass = [];
         $this->entityNamesByEntityNames = [];
@@ -81,7 +81,7 @@ class UploadedFileConfigLoader
      * @param array $entityConfig
      * @return \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileEntityConfig
      */
-    private function processEntityConfig($entityConfig)
+    protected function processEntityConfig($entityConfig)
     {
         $entityClass = $entityConfig[UploadedFileConfigDefinition::CONFIG_CLASS];
         $entityName = $entityConfig[UploadedFileConfigDefinition::CONFIG_ENTITY_NAME];

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileEntityConfig.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileEntityConfig.php
@@ -7,12 +7,12 @@ class UploadedFileEntityConfig
     /**
      * @var string
      */
-    private $entityName;
+    protected $entityName;
 
     /**
      * @var string
      */
-    private $entityClass;
+    protected $entityClass;
 
     /**
      * @param string $entityName

--- a/packages/framework/src/Component/UploadedFile/DirectoryStructureCreator.php
+++ b/packages/framework/src/Component/UploadedFile/DirectoryStructureCreator.php
@@ -10,17 +10,17 @@ class DirectoryStructureCreator
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileConfig
      */
-    private $uploadedFileConfig;
+    protected $uploadedFileConfig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileLocator
      */
-    private $uploadedFileLocator;
+    protected $uploadedFileLocator;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesysytem;
+    protected $filesysytem;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileConfig $uploadedFileConfig

--- a/packages/framework/src/Component/UploadedFile/UploadedFileDeleteDoctrineListener.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileDeleteDoctrineListener.php
@@ -10,12 +10,12 @@ class UploadedFileDeleteDoctrineListener
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileConfig
      */
-    private $uploadedFileConfig;
+    protected $uploadedFileConfig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade
      */
-    private $uploadedFileFacade;
+    protected $uploadedFileFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\Config\UploadedFileConfig $uploadedFileConfig

--- a/packages/framework/src/Component/UploadedFile/UploadedFileLocator.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileLocator.php
@@ -10,17 +10,17 @@ class UploadedFileLocator
     /**
      * @var string
      */
-    private $uploadedFileDir;
+    protected $uploadedFileDir;
 
     /**
      * @var string
      */
-    private $uploadedFileUrlPrefix;
+    protected $uploadedFileUrlPrefix;
 
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @param string $uploadedFileDir
@@ -83,7 +83,7 @@ class UploadedFileLocator
      * @param string $entityName
      * @return string
      */
-    private function getRelativeFilePath($entityName)
+    protected function getRelativeFilePath($entityName)
     {
         return $entityName;
     }

--- a/packages/framework/src/DataFixtures/Demo/AdministratorDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/AdministratorDataFixture.php
@@ -14,7 +14,7 @@ class AdministratorDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade
      */
-    private $administratorFacade;
+    protected $administratorFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade
@@ -40,7 +40,7 @@ class AdministratorDataFixture extends AbstractReferenceFixture
      * @param string $referenceName
      * @see \Shopsys\FrameworkBundle\Migrations\Version20180702111015
      */
-    private function createAdministratorReference(int $administratorId, string $referenceName)
+    protected function createAdministratorReference(int $administratorId, string $referenceName)
     {
         $administrator = $this->administratorFacade->getById($administratorId);
         $this->addReference($referenceName, $administrator);

--- a/packages/framework/src/DataFixtures/Demo/AdvertDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/AdvertDataFixture.php
@@ -13,12 +13,12 @@ class AdvertDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Advert\AdvertFacade
      */
-    private $advertFacade;
+    protected $advertFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactoryInterface
      */
-    private $advertDataFactory;
+    protected $advertDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertFacade $advertFacade

--- a/packages/framework/src/DataFixtures/Demo/ArticleDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/ArticleDataFixture.php
@@ -19,12 +19,12 @@ class ArticleDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade
      */
-    private $articleFacade;
+    protected $articleFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface
      */
-    private $articleDataFactory;
+    protected $articleDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
@@ -80,7 +80,7 @@ class ArticleDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
      * @param string|null $referenceName
      */
-    private function createArticle(ArticleData $articleData, $referenceName = null)
+    protected function createArticle(ArticleData $articleData, $referenceName = null)
     {
         $article = $this->articleFacade->create($articleData);
         if ($referenceName !== null) {

--- a/packages/framework/src/DataFixtures/Demo/AvailabilityDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/AvailabilityDataFixture.php
@@ -19,17 +19,17 @@ class AvailabilityDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade
      */
-    private $availabilityFacade;
+    protected $availabilityFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface
      */
-    private $availabilityDataFactory;
+    protected $availabilityDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade
@@ -75,7 +75,7 @@ class AvailabilityDataFixture extends AbstractReferenceFixture
      * @param string|null $referenceName
      * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
      */
-    private function createAvailability(AvailabilityData $availabilityData, $referenceName = null)
+    protected function createAvailability(AvailabilityData $availabilityData, $referenceName = null)
     {
         $availability = $this->availabilityFacade->create($availabilityData);
         if ($referenceName !== null) {

--- a/packages/framework/src/DataFixtures/Demo/BestsellingProductDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/BestsellingProductDataFixture.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingPr
 class BestsellingProductDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
     /** @var \Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade */
-    private $manualBestsellingProductFacade;
+    protected $manualBestsellingProductFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade $manualBestsellingProductFacade

--- a/packages/framework/src/DataFixtures/Demo/BrandDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/BrandDataFixture.php
@@ -35,10 +35,10 @@ class BrandDataFixture extends AbstractReferenceFixture
     const BRAND_NIKON = 'brand_nikon';
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade */
-    private $brandFacade;
+    protected $brandFacade;
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface */
-    private $brandDataFactory;
+    protected $brandDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
@@ -72,7 +72,7 @@ class BrandDataFixture extends AbstractReferenceFixture
     /**
      * @return string[]
      */
-    private function getBrandNamesIndexedByBrandConstants()
+    protected function getBrandNamesIndexedByBrandConstants()
     {
         return [
             self::BRAND_APPLE => 'Apple',

--- a/packages/framework/src/DataFixtures/Demo/CategoryDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/CategoryDataFixture.php
@@ -26,17 +26,17 @@ class CategoryDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
-    private $categoryFacade;
+    protected $categoryFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface
      */
-    private $categoryDataFactory;
+    protected $categoryDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
@@ -229,7 +229,7 @@ class CategoryDataFixture extends AbstractReferenceFixture
     /**
      * @return null[]
      */
-    private function createDomainKeyedArray(): array
+    protected function createDomainKeyedArray(): array
     {
         return array_fill_keys($this->domain->getAllIds(), null);
     }
@@ -239,7 +239,7 @@ class CategoryDataFixture extends AbstractReferenceFixture
      * @param string|null $referenceName
      * @return \Shopsys\FrameworkBundle\Model\Category\Category
      */
-    private function createCategory(CategoryData $categoryData, $referenceName = null)
+    protected function createCategory(CategoryData $categoryData, $referenceName = null)
     {
         $category = $this->categoryFacade->create($categoryData);
         if ($referenceName !== null) {

--- a/packages/framework/src/DataFixtures/Demo/CountryDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/CountryDataFixture.php
@@ -16,12 +16,12 @@ class CountryDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\CountryFacade
      */
-    private $countryFacade;
+    protected $countryFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\CountryDataFactoryInterface
      */
-    private $countryDataFactory;
+    protected $countryDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade
@@ -60,7 +60,7 @@ class CountryDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryData $countryData
      * @param string $referenceName
      */
-    private function createCountry(CountryData $countryData, $referenceName): void
+    protected function createCountry(CountryData $countryData, $referenceName): void
     {
         $country = $this->countryFacade->create($countryData);
         $this->addReference($referenceName, $country);

--- a/packages/framework/src/DataFixtures/Demo/CurrencyDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/CurrencyDataFixture.php
@@ -16,12 +16,12 @@ class CurrencyDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade
      */
-    private $currencyFacade;
+    protected $currencyFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactoryInterface
      */
-    private $currencyDataFactory;
+    protected $currencyDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade

--- a/packages/framework/src/DataFixtures/Demo/FlagDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/FlagDataFixture.php
@@ -17,12 +17,12 @@ class FlagDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade
      */
-    private $flagFacade;
+    protected $flagFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagDataFactoryInterface
      */
-    private $flagDataFactory;
+    protected $flagDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade
@@ -63,7 +63,7 @@ class FlagDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData $flagData
      * @param string|null $referenceName
      */
-    private function createFlag(FlagData $flagData, $referenceName = null)
+    protected function createFlag(FlagData $flagData, $referenceName = null)
     {
         $flag = $this->flagFacade->create($flagData);
         if ($referenceName !== null) {

--- a/packages/framework/src/DataFixtures/Demo/ImageDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/ImageDataFixture.php
@@ -21,37 +21,37 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
     /**
      * @var string
      */
-    private $dataFixturesImagesDirectory;
+    protected $dataFixturesImagesDirectory;
 
     /**
      * @var string
      */
-    private $targetDomainImagesDirectory;
+    protected $targetDomainImagesDirectory;
 
     /**
      * @var string
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @var string
      */
-    private $targetImagesDirectory;
+    protected $targetImagesDirectory;
 
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $localFilesystem;
+    protected $localFilesystem;
 
     /**
      * @var \League\Flysystem\MountManager
      */
-    private $mountManager;
+    protected $mountManager;
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @param mixed $dataFixturesImagesDirectory
@@ -94,7 +94,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function processDbImagesChanges()
+    protected function processDbImagesChanges()
     {
         $this->processBrandsImages();
         $this->processCategoriesImages();
@@ -105,7 +105,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         $this->restartImagesIdsDbSequence();
     }
 
-    private function processBrandsImages()
+    protected function processBrandsImages()
     {
         $brandsImagesData = [
             79 => BrandDataFixture::BRAND_APPLE,
@@ -142,7 +142,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function processCategoriesImages()
+    protected function processCategoriesImages()
     {
         $categoriesImagesData = [
             68 => CategoryDataFixture::CATEGORY_ELECTRONICS,
@@ -166,7 +166,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function processPaymentsImages()
+    protected function processPaymentsImages()
     {
         $paymentsImagesData = [
             53 => PaymentDataFixture::PAYMENT_CARD,
@@ -182,7 +182,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function processTransportsImages()
+    protected function processTransportsImages()
     {
         $transportsImagesData = [
             56 => TransportDataFixture::TRANSPORT_CZECH_POST,
@@ -198,7 +198,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function processProductsImages()
+    protected function processProductsImages()
     {
         $productsIdsWithImageIdSameAsProductId = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
@@ -223,7 +223,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function processSliderItemsImages()
+    protected function processSliderItemsImages()
     {
         $imagesIdsIndexedBySliderItemsIds = [
             1 => 59,
@@ -241,7 +241,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
      * @param string $entityName
      * @param int $imageId
      */
-    private function saveImageIntoDb(int $entityId, string $entityName, int $imageId)
+    protected function saveImageIntoDb(int $entityId, string $entityName, int $imageId)
     {
         $query = $this->em->createNativeQuery(
             'INSERT INTO images (id, entity_name, entity_id, type, extension, position, modified_at)
@@ -264,7 +264,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
      * @param string $origin
      * @param string $target
      */
-    private function moveFilesFromLocalFilesystemToFilesystem(string $origin, string $target)
+    protected function moveFilesFromLocalFilesystemToFilesystem(string $origin, string $target)
     {
         $finder = new Finder();
         $finder->files()->in($origin);
@@ -282,12 +282,12 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         }
     }
 
-    private function truncateImagesFromDb()
+    protected function truncateImagesFromDb()
     {
         $this->em->createNativeQuery('TRUNCATE TABLE ' . self::IMAGES_TABLE_NAME, new ResultSetMapping())->execute();
     }
 
-    private function restartImagesIdsDbSequence()
+    protected function restartImagesIdsDbSequence()
     {
         $this->em->createNativeQuery('ALTER SEQUENCE images_id_seq RESTART WITH 103', new ResultSetMapping())->execute();
     }

--- a/packages/framework/src/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -129,7 +129,7 @@ team of {domain}
      * @param mixed $name
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData $mailTemplateData
      */
-    private function createMailTemplate(
+    protected function createMailTemplate(
         ObjectManager $manager,
         $name,
         MailTemplateData $mailTemplateData

--- a/packages/framework/src/DataFixtures/Demo/MultidomainArticleDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainArticleDataFixture.php
@@ -22,17 +22,17 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade
      */
-    private $articleFacade;
+    protected $articleFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface
      */
-    private $articleDataFactory;
+    protected $articleDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
@@ -62,7 +62,7 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $articleData = $this->articleDataFactory->create();
 
@@ -102,7 +102,7 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
      * @param string|null $referenceName
      */
-    private function createArticle(ArticleData $articleData, string $referenceName = null)
+    protected function createArticle(ArticleData $articleData, string $referenceName = null)
     {
         $article = $this->articleFacade->create($articleData);
         if ($referenceName !== null) {

--- a/packages/framework/src/DataFixtures/Demo/MultidomainBestsellingProductDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainBestsellingProductDataFixture.php
@@ -17,12 +17,12 @@ class MultidomainBestsellingProductDataFixture extends AbstractReferenceFixture 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade
      */
-    private $manualBestsellingProductFacade;
+    protected $manualBestsellingProductFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade $manualBestsellingProductFacade
@@ -47,7 +47,7 @@ class MultidomainBestsellingProductDataFixture extends AbstractReferenceFixture 
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $this->manualBestsellingProductFacade->edit(
             $this->getReference(DemoCategoryDataFixture::CATEGORY_PHOTO),

--- a/packages/framework/src/DataFixtures/Demo/MultidomainCategoryDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainCategoryDataFixture.php
@@ -17,17 +17,17 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
-    private $categoryFacade;
+    protected $categoryFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface
      */
-    private $categoryDataFacade;
+    protected $categoryDataFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
@@ -57,7 +57,7 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $this->editCategoryOnDomain(
             DemoCategoryDataFixture::CATEGORY_ELECTRONICS,
@@ -158,7 +158,7 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
      * @param int $domainId
      * @param string $description
      */
-    private function editCategoryOnDomain(string $referenceName, int $domainId, string $description)
+    protected function editCategoryOnDomain(string $referenceName, int $domainId, string $description)
     {
         $category = $this->getReference($referenceName);
         /* @var $category \Shopsys\FrameworkBundle\Model\Category\Category */

--- a/packages/framework/src/DataFixtures/Demo/MultidomainMailTemplateDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainMailTemplateDataFixture.php
@@ -18,17 +18,17 @@ class MultidomainMailTemplateDataFixture extends AbstractReferenceFixture implem
     /**
      * @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade
      */
-    private $mailTemplateFacade;
+    protected $mailTemplateFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateDataFactoryInterface
      */
-    private $mailTemplateDataFactory;
+    protected $mailTemplateDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade $mailTemplateFacade
@@ -58,7 +58,7 @@ class MultidomainMailTemplateDataFixture extends AbstractReferenceFixture implem
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $mailTemplateData = $this->mailTemplateDataFactory->create();
         $mailTemplateData->name = 'order_status_1';
@@ -167,7 +167,7 @@ class MultidomainMailTemplateDataFixture extends AbstractReferenceFixture implem
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData $mailTemplateData
      * @param int $domainId
      */
-    private function updateMailTemplate(MailTemplateData $mailTemplateData, int $domainId)
+    protected function updateMailTemplate(MailTemplateData $mailTemplateData, int $domainId)
     {
         $this->mailTemplateFacade->saveMailTemplatesData([$mailTemplateData], $domainId);
     }

--- a/packages/framework/src/DataFixtures/Demo/MultidomainNewsletterSubscriberDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainNewsletterSubscriberDataFixture.php
@@ -15,12 +15,12 @@ class MultidomainNewsletterSubscriberDataFixture extends AbstractReferenceFixtur
     /**
      * @var \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade
      */
-    private $newsletterFacade;
+    protected $newsletterFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade $newsletterFacade
@@ -47,7 +47,7 @@ class MultidomainNewsletterSubscriberDataFixture extends AbstractReferenceFixtur
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $newsletterSubscribersData = $this->getEmailData();
 
@@ -59,7 +59,7 @@ class MultidomainNewsletterSubscriberDataFixture extends AbstractReferenceFixtur
     /**
      * @return string[]
      */
-    private function getEmailData()
+    protected function getEmailData()
     {
         return [
             'anna.anina@no-reply.com',

--- a/packages/framework/src/DataFixtures/Demo/MultidomainOrderDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainOrderDataFixture.php
@@ -25,32 +25,32 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\UserRepository
      */
-    private $userRepository;
+    protected $userRepository;
 
     /**
      * @var \Faker\Generator
      */
-    private $faker;
+    protected $faker;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
      */
-    private $orderFacade;
+    protected $orderFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory
      */
-    private $orderPreviewFactory;
+    protected $orderPreviewFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
      */
-    private $orderDataFactory;
+    protected $orderDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\UserRepository $userRepository
@@ -89,7 +89,7 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $orderData = $this->orderDataFactory->create();
         $orderData->transport = $this->getReference(DemoTransportDataFixture::TRANSPORT_CZECH_POST);
@@ -207,7 +207,7 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
      * @param array $products
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      */
-    private function createOrder(
+    protected function createOrder(
         OrderData $orderData,
         array $products,
         User $user = null

--- a/packages/framework/src/DataFixtures/Demo/MultidomainPricingGroupDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainPricingGroupDataFixture.php
@@ -20,17 +20,17 @@ class MultidomainPricingGroupDataFixture extends AbstractReferenceFixture implem
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */
-    private $pricingGroupFacade;
+    protected $pricingGroupFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactoryInterface
      */
-    private $pricingGroupDataFactory;
+    protected $pricingGroupDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
@@ -60,7 +60,7 @@ class MultidomainPricingGroupDataFixture extends AbstractReferenceFixture implem
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $pricingGroupData = $this->pricingGroupDataFactory->create();
 
@@ -83,7 +83,7 @@ class MultidomainPricingGroupDataFixture extends AbstractReferenceFixture implem
      * @param int $domainId
      * @param string $referenceName
      */
-    private function createPricingGroup(
+    protected function createPricingGroup(
         PricingGroupData $pricingGroupData,
         $domainId,
         $referenceName

--- a/packages/framework/src/DataFixtures/Demo/MultidomainProductDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainProductDataFixture.php
@@ -19,37 +19,37 @@ class MultidomainProductDataFixture extends AbstractReferenceFixture implements 
     /**
      * @var \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixtureLoader
      */
-    private $productDataFixtureLoader;
+    protected $productDataFixtureLoader;
 
     /**
      * @var \Shopsys\FrameworkBundle\DataFixtures\ProductDataFixtureReferenceInjector
      */
-    private $referenceInjector;
+    protected $referenceInjector;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade
      */
-    private $persistentReferenceFacade;
+    protected $persistentReferenceFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixtureCsvReader
      */
-    private $productDataFixtureCsvReader;
+    protected $productDataFixtureCsvReader;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
      */
-    private $productFacade;
+    protected $productFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface
      */
-    private $productDataFactory;
+    protected $productDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixtureLoader $productDataFixtureLoader
@@ -91,7 +91,7 @@ class MultidomainProductDataFixture extends AbstractReferenceFixture implements 
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $this->referenceInjector->loadReferences($this->productDataFixtureLoader, $this->persistentReferenceFacade, $domainId);
 
@@ -111,7 +111,7 @@ class MultidomainProductDataFixture extends AbstractReferenceFixture implements 
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param array $row
      */
-    private function editProduct(Product $product, array $row)
+    protected function editProduct(Product $product, array $row)
     {
         $productData = $this->productDataFactory->createFromProduct($product);
         $this->productDataFixtureLoader->updateProductDataFromCsvRowForSecondDomain($productData, $row);

--- a/packages/framework/src/DataFixtures/Demo/MultidomainSettingValueDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainSettingValueDataFixture.php
@@ -17,12 +17,12 @@ class MultidomainSettingValueDataFixture extends AbstractReferenceFixture implem
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
@@ -47,7 +47,7 @@ class MultidomainSettingValueDataFixture extends AbstractReferenceFixture implem
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $termsAndConditionsDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_TERMS_AND_CONDITIONS, $domainId);
         /* @var $termsAndConditionsDomain \Shopsys\FrameworkBundle\Model\Article\Article */

--- a/packages/framework/src/DataFixtures/Demo/MultidomainSettingValueShopInfoDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainSettingValueShopInfoDataFixture.php
@@ -22,12 +22,12 @@ class MultidomainSettingValueShopInfoDataFixture extends AbstractReferenceFixtur
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
@@ -52,7 +52,7 @@ class MultidomainSettingValueShopInfoDataFixture extends AbstractReferenceFixtur
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         foreach (self::SETTING_VALUES as $key => $value) {
             $this->setting->setForDomain($key, $value, $domainId);

--- a/packages/framework/src/DataFixtures/Demo/MultidomainTopProductDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainTopProductDataFixture.php
@@ -16,12 +16,12 @@ class MultidomainTopProductDataFixture extends AbstractReferenceFixture implemen
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade
      */
-    private $topProductFacade;
+    protected $topProductFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade $topProductFacade
@@ -46,7 +46,7 @@ class MultidomainTopProductDataFixture extends AbstractReferenceFixture implemen
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $topProductReferenceNamesOnDomain = [
             DemoProductDataFixture::PRODUCT_PREFIX . '14',

--- a/packages/framework/src/DataFixtures/Demo/MultidomainUserDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/MultidomainUserDataFixture.php
@@ -16,22 +16,22 @@ class MultidomainUserDataFixture extends AbstractReferenceFixture implements Dep
     /**
      * @var \Shopsys\FrameworkBundle\DataFixtures\Demo\UserDataFixtureLoader
      */
-    private $loaderService;
+    protected $loaderService;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade
      */
-    private $customerFacade;
+    protected $customerFacade;
 
     /**
      * @var \Faker\Generator
      */
-    private $faker;
+    protected $faker;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\DataFixtures\Demo\UserDataFixtureLoader $loaderService
@@ -64,7 +64,7 @@ class MultidomainUserDataFixture extends AbstractReferenceFixture implements Dep
     /**
      * @param int $domainId
      */
-    private function loadForDomain(int $domainId)
+    protected function loadForDomain(int $domainId)
     {
         $countries = [
             $this->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC),

--- a/packages/framework/src/DataFixtures/Demo/NewsletterSubscriberDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/NewsletterSubscriberDataFixture.php
@@ -11,7 +11,7 @@ class NewsletterSubscriberDataFixture extends AbstractReferenceFixture
     const FIRST_DOMAIN_ID = 1;
 
     /** @var \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade */
-    private $newsletterFacade;
+    protected $newsletterFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade $newsletterFacade
@@ -36,7 +36,7 @@ class NewsletterSubscriberDataFixture extends AbstractReferenceFixture
     /**
      * @return string[]
      */
-    private function getEmailData()
+    protected function getEmailData()
     {
         return [
             'james.black@no-reply.com',

--- a/packages/framework/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/OrderDataFixture.php
@@ -22,27 +22,27 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\UserRepository
      */
-    private $userRepository;
+    protected $userRepository;
 
     /**
      * @var \Faker\Generator
      */
-    private $faker;
+    protected $faker;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
      */
-    private $orderFacade;
+    protected $orderFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory
      */
-    private $orderPreviewFactory;
+    protected $orderPreviewFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
      */
-    private $orderDataFactory;
+    protected $orderDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\UserRepository $userRepository
@@ -567,7 +567,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
      * @param array $products
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      */
-    private function createOrder(
+    protected function createOrder(
         OrderData $orderData,
         array $products,
         User $user = null

--- a/packages/framework/src/DataFixtures/Demo/OrderStatusDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/OrderStatusDataFixture.php
@@ -16,7 +16,7 @@ class OrderStatusDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade
      */
-    private $orderStatusFacade;
+    protected $orderStatusFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade $orderStatusFacade
@@ -44,7 +44,7 @@ class OrderStatusDataFixture extends AbstractReferenceFixture
      * @param string $referenceName
      * @see \Shopsys\FrameworkBundle\Migrations\Version20180603135341
      */
-    private function createOrderStatusReference(
+    protected function createOrderStatusReference(
         $orderStatusId,
         $referenceName
     ) {

--- a/packages/framework/src/DataFixtures/Demo/PaymentDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/PaymentDataFixture.php
@@ -16,12 +16,12 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
     const PAYMENT_CASH = 'payment_cash';
 
     /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
-    private $paymentFacade;
+    protected $paymentFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface
      */
-    private $paymentDataFactory;
+    protected $paymentDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
@@ -94,7 +94,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $paymentData
      * @param array $transportsReferenceNames
      */
-    private function createPayment(
+    protected function createPayment(
         $referenceName,
         PaymentData $paymentData,
         array $transportsReferenceNames

--- a/packages/framework/src/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
@@ -14,10 +14,10 @@ class PersonalDataAccessRequestDataFixture extends AbstractReferenceFixture
     const REFERENCE_ACCESS_EXPORT_REQUEST = 'reference_access_export_request';
 
     /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade */
-    private $personalDataFacade;
+    protected $personalDataFacade;
 
     /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactory */
-    private $personalDataFactory;
+    protected $personalDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade $personalDataFacade

--- a/packages/framework/src/DataFixtures/Demo/PricingGroupDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/PricingGroupDataFixture.php
@@ -18,12 +18,12 @@ class PricingGroupDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */
-    private $pricingGroupFacade;
+    protected $pricingGroupFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactoryInterface
      */
-    private $pricingGroupDataFactory;
+    protected $pricingGroupDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
@@ -62,7 +62,7 @@ class PricingGroupDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $pricingGroupData
      * @param string $referenceName
      */
-    private function createPricingGroup(
+    protected function createPricingGroup(
         PricingGroupData $pricingGroupData,
         $referenceName
     ) {

--- a/packages/framework/src/DataFixtures/Demo/ProductAccessoriesDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/ProductAccessoriesDataFixture.php
@@ -11,10 +11,10 @@ use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 class ProductAccessoriesDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
     /** @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface */
-    private $productDataFactory;
+    protected $productDataFactory;
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
-    private $productFacade;
+    protected $productFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface $productDataFactory

--- a/packages/framework/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/ProductDataFixture.php
@@ -17,22 +17,22 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
     const PRODUCT_PREFIX = 'product_';
 
     /** @var \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixtureLoader */
-    private $productDataFixtureLoader;
+    protected $productDataFixtureLoader;
 
     /** @var \Shopsys\FrameworkBundle\DataFixtures\ProductDataFixtureReferenceInjector */
-    private $referenceInjector;
+    protected $referenceInjector;
 
     /** @var \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade */
-    private $persistentReferenceFacade;
+    protected $persistentReferenceFacade;
 
     /** @var \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixtureCsvReader */
-    private $productDataFixtureCsvReader;
+    protected $productDataFixtureCsvReader;
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
-    private $productFacade;
+    protected $productFacade;
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade */
-    private $productVariantFacade;
+    protected $productVariantFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixtureLoader $productDataFixtureLoader
@@ -86,7 +86,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
      * @return \Shopsys\FrameworkBundle\Model\Product\Product
      */
-    private function createProduct($referenceName, ProductData $productData)
+    protected function createProduct($referenceName, ProductData $productData)
     {
         $product = $this->productFacade->create($productData);
 
@@ -99,7 +99,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $productsByCatnum
      * @param int $productNo
      */
-    private function createVariants(array $productsByCatnum, $productNo)
+    protected function createVariants(array $productsByCatnum, $productNo)
     {
         $csvRows = $this->productDataFixtureCsvReader->getProductDataFixtureCsvRows();
         $variantCatnumsByMainVariantCatnum = $this->productDataFixtureLoader->getVariantCatnumsIndexedByMainVariantCatnum($csvRows);

--- a/packages/framework/src/DataFixtures/Demo/ProductDataFixtureCsvReader.php
+++ b/packages/framework/src/DataFixtures/Demo/ProductDataFixtureCsvReader.php
@@ -11,12 +11,12 @@ class ProductDataFixtureCsvReader
     /**
      * @var string
      */
-    private $path;
+    protected $path;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Csv\CsvReader
      */
-    private $csvReader;
+    protected $csvReader;
 
     /**
      * @param string $path
@@ -48,7 +48,7 @@ class ProductDataFixtureCsvReader
      * @param array $rawRow
      * @return array mixed
      */
-    private function prepareRawRow($rawRow)
+    protected function prepareRawRow($rawRow)
     {
         $row = array_map([TransformString::class, 'emptyToNull'], $rawRow);
 

--- a/packages/framework/src/DataFixtures/Demo/ProductDataFixtureLoader.php
+++ b/packages/framework/src/DataFixtures/Demo/ProductDataFixtureLoader.php
@@ -39,57 +39,57 @@ class ProductDataFixtureLoader
     /**
      * @var \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductParametersFixtureLoader
      */
-    private $productParametersFixtureLoader;
+    protected $productParametersFixtureLoader;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat[]
      */
-    private $vats;
+    protected $vats;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability[]
      */
-    private $availabilities;
+    protected $availabilities;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
-    private $categories;
+    protected $categories;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
      */
-    private $flags;
+    protected $flags;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
      */
-    private $brands;
+    protected $brands;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit[]
      */
-    private $units;
+    protected $units;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup[]
      */
-    private $pricingGroups;
+    protected $pricingGroups;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface
      */
-    private $productDataFactory;
+    protected $productDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */
-    private $pricingGroupFacade;
+    protected $pricingGroupFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\DataFixtures\Demo\ProductParametersFixtureLoader $productParametersFixtureLoader
@@ -169,7 +169,7 @@ class ProductDataFixtureLoader
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
      * @param array $row
      */
-    private function updateProductDataFromCsvRowForFirstDomain(ProductData $productData, array $row)
+    protected function updateProductDataFromCsvRowForFirstDomain(ProductData $productData, array $row)
     {
         $domainId = 1;
 
@@ -260,7 +260,7 @@ class ProductDataFixtureLoader
      * @param int $domainId
      * @return int
      */
-    private function getShortDescriptionColumnForDomain($domainId)
+    protected function getShortDescriptionColumnForDomain($domainId)
     {
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
 
@@ -278,7 +278,7 @@ class ProductDataFixtureLoader
      * @param int $domainId
      * @return int
      */
-    private function getDescriptionColumnForDomain($domainId)
+    protected function getDescriptionColumnForDomain($domainId)
     {
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
 
@@ -296,7 +296,7 @@ class ProductDataFixtureLoader
      * @param string $string
      * @return string[]
      */
-    private function getProductManualPricesIndexedByPricingGroupFromString($string)
+    protected function getProductManualPricesIndexedByPricingGroupFromString($string)
     {
         $productManualPricesByPricingGroup = [];
         $rowData = explode(';', $string);
@@ -313,7 +313,7 @@ class ProductDataFixtureLoader
      * @param array $valuesByKey
      * @return string[]
      */
-    private function getValuesByKeyString($keyString, array $valuesByKey)
+    protected function getValuesByKeyString($keyString, array $valuesByKey)
     {
         $values = [];
         if (!empty($keyString)) {
@@ -331,7 +331,7 @@ class ProductDataFixtureLoader
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
      * @param int $domainId
      */
-    private function setProductDataPricesFromCsv(array $row, ProductData $productData, $domainId)
+    protected function setProductDataPricesFromCsv(array $row, ProductData $productData, $domainId)
     {
         if ($domainId === 1) {
             $manualPricesColumn = $row[self::COLUMN_MANUAL_PRICES_DOMAIN_1];
@@ -353,7 +353,7 @@ class ProductDataFixtureLoader
      * @param string[] $demoDataManualPrices
      * @return string[]
      */
-    private function addZeroPricesForPricingGroupsThatAreMissingInDemoData($demoDataManualPrices)
+    protected function addZeroPricesForPricingGroupsThatAreMissingInDemoData($demoDataManualPrices)
     {
         $allPricingGroups = $this->pricingGroupFacade->getAll();
 
@@ -370,7 +370,7 @@ class ProductDataFixtureLoader
      * @param int $domainId
      * @return int
      */
-    private function getCsvProductColumnNameByDomainId(int $domainId)
+    protected function getCsvProductColumnNameByDomainId(int $domainId)
     {
         switch ($this->domain->getDomainConfigById($domainId)->getLocale()) {
             case 'cs':

--- a/packages/framework/src/DataFixtures/Demo/ProductParametersFixtureLoader.php
+++ b/packages/framework/src/DataFixtures/Demo/ProductParametersFixtureLoader.php
@@ -13,27 +13,27 @@ class ProductParametersFixtureLoader
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade
      */
-    private $parameterFacade;
+    protected $parameterFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter[]
      */
-    private $parameters;
+    protected $parameters;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactoryInterface
      */
-    private $productParameterValueDataFactory;
+    protected $productParameterValueDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueDataFactoryInterface
      */
-    private $parameterValueDataFactory;
+    protected $parameterValueDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterDataFactoryInterface
      */
-    private $parameterDataFactory;
+    protected $parameterDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade $parameterFacade
@@ -89,7 +89,7 @@ class ProductParametersFixtureLoader
      * @param string $serializedParameterNames
      * @param string $serializedValueTexts
      */
-    private function addProductParameterValuesDataToCollection(
+    protected function addProductParameterValuesDataToCollection(
         ArrayCollection $productParameterValuesDataCollection,
         $serializedParameterNames,
         $serializedValueTexts
@@ -115,7 +115,7 @@ class ProductParametersFixtureLoader
      * @param string $serializedString
      * @return string[]
      */
-    private function getDeserializedValuesIndexedByLocale($serializedString)
+    protected function getDeserializedValuesIndexedByLocale($serializedString)
     {
         $values = [];
         $items = explode(',', $serializedString);
@@ -131,7 +131,7 @@ class ProductParametersFixtureLoader
      * @param string[] $parameterNamesByLocale
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter
      */
-    private function findParameterByNamesOrCreateNew(array $parameterNamesByLocale)
+    protected function findParameterByNamesOrCreateNew(array $parameterNamesByLocale)
     {
         $cacheId = json_encode($parameterNamesByLocale);
 

--- a/packages/framework/src/DataFixtures/Demo/PromoCodeDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/PromoCodeDataFixture.php
@@ -12,12 +12,12 @@ class PromoCodeDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade
      */
-    private $promoCodeFacade;
+    protected $promoCodeFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface
      */
-    private $promoCodeDataFactory;
+    protected $promoCodeDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade $promoCodeFacade

--- a/packages/framework/src/DataFixtures/Demo/ScriptDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/ScriptDataFixture.php
@@ -13,12 +13,12 @@ class ScriptDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Script\ScriptFacade
      */
-    private $scriptFacade;
+    protected $scriptFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Script\ScriptDataFactoryInterface
      */
-    private $scriptDataFactory;
+    protected $scriptDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Script\ScriptFacade $scriptFacade

--- a/packages/framework/src/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/SettingValueDataFixture.php
@@ -13,7 +13,7 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting

--- a/packages/framework/src/DataFixtures/Demo/SettingValueShopInfoDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/SettingValueShopInfoDataFixture.php
@@ -13,7 +13,7 @@ class SettingValueShopInfoDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     const SETTING_VALUES = [
         ShopInfoSettingFacade::SHOP_INFO_PHONE_NUMBER => '+1-234-567-8989',

--- a/packages/framework/src/DataFixtures/Demo/SliderItemDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/SliderItemDataFixture.php
@@ -13,12 +13,12 @@ class SliderItemDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Slider\SliderItemFacade
      */
-    private $sliderItemFacade;
+    protected $sliderItemFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactoryInterface
      */
-    private $sliderItemDataFactory;
+    protected $sliderItemDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemFacade $sliderItemFacade

--- a/packages/framework/src/DataFixtures/Demo/TopCategoryDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/TopCategoryDataFixture.php
@@ -13,12 +13,12 @@ class TopCategoryDataFixture extends AbstractReferenceFixture implements Depende
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\TopCategory\TopCategoryFacade
      */
-    private $topCategoryFacade;
+    protected $topCategoryFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\TopCategory\TopCategoryFacade $topCategoryFacade

--- a/packages/framework/src/DataFixtures/Demo/TopProductDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/TopProductDataFixture.php
@@ -13,7 +13,7 @@ class TopProductDataFixture extends AbstractReferenceFixture implements Dependen
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade
      */
-    private $topProductFacade;
+    protected $topProductFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade $topProductFacade
@@ -40,7 +40,7 @@ class TopProductDataFixture extends AbstractReferenceFixture implements Dependen
     /**
      * @param string[] $productReferenceNames
      */
-    private function createTopProducts(array $productReferenceNames)
+    protected function createTopProducts(array $productReferenceNames)
     {
         $products = [];
         foreach ($productReferenceNames as $productReferenceName) {

--- a/packages/framework/src/DataFixtures/Demo/TransportDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/TransportDataFixture.php
@@ -16,12 +16,12 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
     const TRANSPORT_PERSONAL = 'transport_personal';
 
     /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
-    private $transportFacade;
+    protected $transportFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface
      */
-    private $transportDataFactory;
+    protected $transportDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
@@ -89,7 +89,7 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
      * @param string $referenceName
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportData $transportData
      */
-    private function createTransport($referenceName, TransportData $transportData)
+    protected function createTransport($referenceName, TransportData $transportData)
     {
         $transport = $this->transportFacade->create($transportData);
         $this->addReference($referenceName, $transport);

--- a/packages/framework/src/DataFixtures/Demo/UnitDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/UnitDataFixture.php
@@ -17,17 +17,17 @@ class UnitDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade
      */
-    private $unitFacade;
+    protected $unitFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactoryInterface
      */
-    private $unitDataFactory;
+    protected $unitDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
@@ -64,7 +64,7 @@ class UnitDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $unitData
      * @param string|null $referenceName
      */
-    private function createUnit(UnitData $unitData, $referenceName = null)
+    protected function createUnit(UnitData $unitData, $referenceName = null)
     {
         $unit = $this->unitFacade->create($unitData);
         if ($referenceName !== null) {
@@ -72,7 +72,7 @@ class UnitDataFixture extends AbstractReferenceFixture
         }
     }
 
-    private function setPiecesAsDefaultUnit(): void
+    protected function setPiecesAsDefaultUnit(): void
     {
         $defaultUnit = $this->getReference(self::UNIT_PIECES);
         /** @var $defaultUnit \Shopsys\FrameworkBundle\Model\Product\Unit\Unit */

--- a/packages/framework/src/DataFixtures/Demo/UserDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/UserDataFixture.php
@@ -17,19 +17,19 @@ class UserDataFixture extends AbstractReferenceFixture implements DependentFixtu
     const USER_WITH_RESET_PASSWORD_HASH = 'user_with_reset_password_hash';
 
     /** @var \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade */
-    private $customerFacade;
+    protected $customerFacade;
 
     /** @var \Shopsys\FrameworkBundle\DataFixtures\Demo\UserDataFixtureLoader */
-    private $loaderService;
+    protected $loaderService;
 
     /** @var \Faker\Generator */
-    private $faker;
+    protected $faker;
 
     /** @var \Doctrine\ORM\EntityManagerInterface */
-    private $em;
+    protected $em;
 
     /** @var \Shopsys\FrameworkBundle\Component\String\HashGenerator */
-    private $hashGenerator;
+    protected $hashGenerator;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade
@@ -90,7 +90,7 @@ class UserDataFixture extends AbstractReferenceFixture implements DependentFixtu
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $customer
      */
-    private function resetPassword(User $customer)
+    protected function resetPassword(User $customer)
     {
         $customer->resetPassword($this->hashGenerator);
         $this->em->flush($customer);

--- a/packages/framework/src/DataFixtures/Demo/UserDataFixtureLoader.php
+++ b/packages/framework/src/DataFixtures/Demo/UserDataFixtureLoader.php
@@ -41,42 +41,42 @@ class UserDataFixtureLoader
     /**
      * @var \Shopsys\FrameworkBundle\Component\Csv\CsvReader
      */
-    private $csvReader;
+    protected $csvReader;
 
     /**
      * @var string
      */
-    private $path;
+    protected $path;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface
      */
-    private $userDataFactory;
+    protected $userDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\Country[]
      */
-    private $countries;
+    protected $countries;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface
      */
-    private $customerDataFactory;
+    protected $customerDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\BillingAddressDataFactoryInterface
      */
-    private $billingAddressDataFactory;
+    protected $billingAddressDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactoryInterface
      */
-    private $deliveryAddressDataFactory;
+    protected $deliveryAddressDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param string $path
@@ -137,7 +137,7 @@ class UserDataFixtureLoader
      * @param int $domainId
      * @return array
      */
-    private function filterRowsByDomainId(array $rows, $domainId)
+    protected function filterRowsByDomainId(array $rows, $domainId)
     {
         $filteredRows = [];
         $rowId = 0;
@@ -163,7 +163,7 @@ class UserDataFixtureLoader
      * @param array $row
      * @return \Shopsys\FrameworkBundle\Model\Customer\CustomerData
      */
-    private function getCustomerDataFromCsvRow(array $row)
+    protected function getCustomerDataFromCsvRow(array $row)
     {
         $customerData = $this->customerDataFactory->create();
         $domainId = (int)$row[self::COLUMN_DOMAIN_ID];
@@ -212,7 +212,7 @@ class UserDataFixtureLoader
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Country\Country
      */
-    private function getCountryByNameAndDomain(string $countryName, int $domainId): Country
+    protected function getCountryByNameAndDomain(string $countryName, int $domainId): Country
     {
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
 

--- a/packages/framework/src/DataFixtures/Demo/VatDataFixture.php
+++ b/packages/framework/src/DataFixtures/Demo/VatDataFixture.php
@@ -20,17 +20,17 @@ class VatDataFixture extends AbstractReferenceFixture
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade
      */
-    private $vatFacade;
+    protected $vatFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactoryInterface
      */
-    private $vatDataFactory;
+    protected $vatDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
@@ -81,7 +81,7 @@ class VatDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $vatData
      * @param string|null $referenceName
      */
-    private function createVat(VatData $vatData, $referenceName = null)
+    protected function createVat(VatData $vatData, $referenceName = null)
     {
         $vat = $this->vatFacade->create($vatData);
         if ($referenceName !== null) {
@@ -89,7 +89,7 @@ class VatDataFixture extends AbstractReferenceFixture
         }
     }
 
-    private function setHighVatAsDefault()
+    protected function setHighVatAsDefault()
     {
         $defaultVat = $this->getReference(self::VAT_HIGH);
         /** @var $defaultVat \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat */

--- a/packages/framework/src/Model/AdminNavigation/ConfigureMenuEvent.php
+++ b/packages/framework/src/Model/AdminNavigation/ConfigureMenuEvent.php
@@ -21,12 +21,12 @@ class ConfigureMenuEvent extends Event
     /**
      * @var \Knp\Menu\FactoryInterface
      */
-    private $menuFactory;
+    protected $menuFactory;
 
     /**
      * @var \Knp\Menu\ItemInterface
      */
-    private $menu;
+    protected $menu;
 
     /**
      * @param \Knp\Menu\FactoryInterface $menuFactory

--- a/packages/framework/src/Model/Administrator/Exception/InvalidGridLimitValueException.php
+++ b/packages/framework/src/Model/Administrator/Exception/InvalidGridLimitValueException.php
@@ -10,7 +10,7 @@ class InvalidGridLimitValueException extends Exception implements AdministratorE
     /**
      * @var mixed
      */
-    private $limit;
+    protected $limit;
 
     /**
      * @param mixed $limit

--- a/packages/framework/src/Model/Administrator/Exception/RememberGridLimitException.php
+++ b/packages/framework/src/Model/Administrator/Exception/RememberGridLimitException.php
@@ -9,7 +9,7 @@ class RememberGridLimitException extends Exception implements AdministratorExcep
     /**
      * @var string
      */
-    private $gridId;
+    protected $gridId;
 
     /**
      * @param string $gridId

--- a/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
@@ -16,12 +16,12 @@ class AdministratorUserProvider implements UserProviderInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository
      */
-    private $administratorRepository;
+    protected $administratorRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade
      */
-    private $administratorActivityFacade;
+    protected $administratorActivityFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository $administratorRepository

--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchConfig.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchConfig.php
@@ -7,7 +7,7 @@ class AdvancedSearchConfig
     /**
      * @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface[]
      */
-    private $filters;
+    protected $filters;
 
     public function __construct()
     {

--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchQueryBuilderExtender.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchQueryBuilderExtender.php
@@ -11,7 +11,7 @@ class AdvancedSearchQueryBuilderExtender
     /**
      * @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchConfig
      */
-    private $advancedSearchConfig;
+    protected $advancedSearchConfig;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchConfig $advancedSearchConfig

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductAvailabilityFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductAvailabilityFilter.php
@@ -16,7 +16,7 @@ class ProductAvailabilityFilter implements AdvancedSearchFilterInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade
      */
-    private $availabilityFacade;
+    protected $availabilityFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductBrandFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductBrandFilter.php
@@ -16,7 +16,7 @@ class ProductBrandFilter implements AdvancedSearchFilterInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade
      */
-    private $brandFacade;
+    protected $brandFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCatnumFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCatnumFilter.php
@@ -74,7 +74,7 @@ class ProductCatnumFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductFlagFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductFlagFilter.php
@@ -16,7 +16,7 @@ class ProductFlagFilter implements AdvancedSearchFilterInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade
      */
-    private $flagFacade;
+    protected $flagFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductNameFilter.php
@@ -68,7 +68,7 @@ class ProductNameFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getDqlOperator($operator)
+    protected function getDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductPartnoFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductPartnoFilter.php
@@ -74,7 +74,7 @@ class ProductPartnoFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
@@ -68,7 +68,7 @@ class OrderCityFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderDomainFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderDomainFilter.php
@@ -64,7 +64,7 @@ class OrderDomainFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_IS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
@@ -65,7 +65,7 @@ class OrderEmailFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
@@ -68,7 +68,7 @@ class OrderLastNameFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
@@ -68,7 +68,7 @@ class OrderNameFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNumberFilter.php
@@ -71,7 +71,7 @@ class OrderNumberFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
@@ -68,7 +68,7 @@ class OrderPhoneNumberFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPriceFilterWithVatFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPriceFilterWithVatFilter.php
@@ -69,7 +69,7 @@ class OrderPriceFilterWithVatFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_GT:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderProductFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderProductFilter.php
@@ -72,7 +72,7 @@ class OrderProductFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStatusFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStatusFilter.php
@@ -14,7 +14,7 @@ class OrderStatusFilter implements AdvancedSearchFilterInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade
      */
-    private $orderStatusFacade;
+    protected $orderStatusFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade $orderStatusFacade
@@ -83,7 +83,7 @@ class OrderStatusFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_IS:

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
@@ -68,7 +68,7 @@ class OrderStreetFilter implements AdvancedSearchFilterInterface
      * @param string $operator
      * @return string
      */
-    private function getContainsDqlOperator($operator)
+    protected function getContainsDqlOperator($operator)
     {
         switch ($operator) {
             case self::OPERATOR_CONTAINS:

--- a/packages/framework/src/Model/Article/ArticleBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Article/ArticleBreadcrumbGenerator.php
@@ -10,7 +10,7 @@ class ArticleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleRepository
      */
-    private $articleRepository;
+    protected $articleRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleRepository $articleRepository

--- a/packages/framework/src/Model/Article/ArticleDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Article/ArticleDetailFriendlyUrlDataProvider.php
@@ -11,17 +11,17 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryI
 
 class ArticleDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInterface
 {
-    private const ROUTE_NAME = 'front_article_detail';
+    protected const ROUTE_NAME = 'front_article_detail';
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryInterface
      */
-    private $friendlyUrlDataFactory;
+    protected $friendlyUrlDataFactory;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Model/Breadcrumb/SimpleBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Breadcrumb/SimpleBreadcrumbGenerator.php
@@ -10,7 +10,7 @@ class SimpleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @var string[]|null
      */
-    private $routeNameMap;
+    protected $routeNameMap;
 
     /**
      * @param string $routeName
@@ -37,7 +37,7 @@ class SimpleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @return string[]
      */
-    private function getRouteNameMap()
+    protected function getRouteNameMap()
     {
         if ($this->routeNameMap === null) {
             // Caching in order to translate breadcrumb item names only once

--- a/packages/framework/src/Model/Cart/AddProductResult.php
+++ b/packages/framework/src/Model/Cart/AddProductResult.php
@@ -9,17 +9,17 @@ class AddProductResult
     /**
      * @var \Shopsys\FrameworkBundle\Model\Cart\Item\CartItem
      */
-    private $cartItem;
+    protected $cartItem;
 
     /**
      * @var bool
      */
-    private $isNew;
+    protected $isNew;
 
     /**
      * @var int
      */
-    private $addedQuantity;
+    protected $addedQuantity;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Cart\Item\CartItem $cartItem

--- a/packages/framework/src/Model/Cart/Exception/InvalidQuantityException.php
+++ b/packages/framework/src/Model/Cart/Exception/InvalidQuantityException.php
@@ -9,7 +9,7 @@ class InvalidQuantityException extends Exception implements CartException
     /**
      * @var mixed
      */
-    private $invalidValue;
+    protected $invalidValue;
 
     /**
      * @param mixed $invalidValue

--- a/packages/framework/src/Model/Cart/Item/DeleteOldCartsCronModule.php
+++ b/packages/framework/src/Model/Cart/Item/DeleteOldCartsCronModule.php
@@ -11,7 +11,7 @@ class DeleteOldCartsCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Cart\CartFacade
      */
-    private $cartFacade;
+    protected $cartFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Cart\CartFacade $cartFacade

--- a/packages/framework/src/Model/Cart/Watcher/CartWatcher.php
+++ b/packages/framework/src/Model/Cart/Watcher/CartWatcher.php
@@ -13,17 +13,17 @@ class CartWatcher
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser
      */
-    private $productPriceCalculationForUser;
+    protected $productPriceCalculationForUser;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository
      */
-    private $productVisibilityRepository;
+    protected $productVisibilityRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser $productPriceCalculationForUser

--- a/packages/framework/src/Model/Category/CategoryBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Category/CategoryBreadcrumbGenerator.php
@@ -11,12 +11,12 @@ class CategoryBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryRepository
      */
-    private $categoryRepository;
+    protected $categoryRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryRepository $categoryRepository

--- a/packages/framework/src/Model/Category/CategoryVisibilityRecalculationScheduler.php
+++ b/packages/framework/src/Model/Category/CategoryVisibilityRecalculationScheduler.php
@@ -9,12 +9,12 @@ class CategoryVisibilityRecalculationScheduler
     /**
      * @var bool
      */
-    private $recalculate = false;
+    protected $recalculate = false;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade
      */
-    private $productVisibilityFacade;
+    protected $productVisibilityFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade $productVisibilityFacade

--- a/packages/framework/src/Model/Category/CategoryWithLazyLoadedVisibleChildren.php
+++ b/packages/framework/src/Model/Category/CategoryWithLazyLoadedVisibleChildren.php
@@ -15,22 +15,22 @@ class CategoryWithLazyLoadedVisibleChildren
     /**
      * @var \Closure
      */
-    private $lazyLoadChildrenCallback;
+    protected $lazyLoadChildrenCallback;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\Category
      */
-    private $category;
+    protected $category;
 
     /**
      * @var bool
      */
-    private $hasChildren;
+    protected $hasChildren;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryWithLazyLoadedVisibleChildren[]|null
      */
-    private $children;
+    protected $children;
 
     /**
      * @param \Closure $lazyLoadChildrenCallback

--- a/packages/framework/src/Model/Category/CategoryWithPreloadedChildren.php
+++ b/packages/framework/src/Model/Category/CategoryWithPreloadedChildren.php
@@ -14,12 +14,12 @@ class CategoryWithPreloadedChildren
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\Category
      */
-    private $category;
+    protected $category;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryWithPreloadedChildren[]
      */
-    private $children;
+    protected $children;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category

--- a/packages/framework/src/Model/Customer/CurrentCustomer.php
+++ b/packages/framework/src/Model/Customer/CurrentCustomer.php
@@ -10,12 +10,12 @@ class CurrentCustomer
     /**
      * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
      */
-    private $tokenStorage;
+    protected $tokenStorage;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade
      */
-    private $pricingGroupSettingFacade;
+    protected $pricingGroupSettingFacade;
 
     /**
      * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage

--- a/packages/framework/src/Model/Customer/CustomerIdentifier.php
+++ b/packages/framework/src/Model/Customer/CustomerIdentifier.php
@@ -7,12 +7,12 @@ class CustomerIdentifier
     /**
      * @var string
      */
-    private $cartIdentifier = '';
+    protected $cartIdentifier = '';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\User|null
      */
-    private $user;
+    protected $user;
 
     /**
      * @param string $cartIdentifier

--- a/packages/framework/src/Model/Customer/Exception/DuplicateEmailException.php
+++ b/packages/framework/src/Model/Customer/Exception/DuplicateEmailException.php
@@ -9,7 +9,7 @@ class DuplicateEmailException extends Exception implements CustomerException
     /**
      * @var string
      */
-    private $email;
+    protected $email;
 
     /**
      * @param string $email

--- a/packages/framework/src/Model/Customer/Exception/UserNotFoundByEmailAndDomainException.php
+++ b/packages/framework/src/Model/Customer/Exception/UserNotFoundByEmailAndDomainException.php
@@ -9,12 +9,12 @@ class UserNotFoundByEmailAndDomainException extends UserNotFoundException
     /**
      * @var string
      */
-    private $email;
+    protected $email;
 
     /**
      * @var int
      */
-    private $domainId;
+    protected $domainId;
 
     /**
      * @param string $email

--- a/packages/framework/src/Model/Customer/FrontendUserProvider.php
+++ b/packages/framework/src/Model/Customer/FrontendUserProvider.php
@@ -14,12 +14,12 @@ class FrontendUserProvider implements UserProviderInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\UserRepository
      */
-    private $userRepository;
+    protected $userRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\UserRepository $userRepository

--- a/packages/framework/src/Model/Customer/Mail/RegistrationMail.php
+++ b/packages/framework/src/Model/Customer/Mail/RegistrationMail.php
@@ -22,12 +22,12 @@ class RegistrationMail implements MessageFactoryInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
@@ -61,7 +61,7 @@ class RegistrationMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      * @return array
      */
-    private function getVariablesReplacements(User $user)
+    protected function getVariablesReplacements(User $user)
     {
         $router = $this->domainRouterFactory->getRouter($user->getDomainId());
 

--- a/packages/framework/src/Model/Customer/Mail/ResetPasswordMail.php
+++ b/packages/framework/src/Model/Customer/Mail/ResetPasswordMail.php
@@ -20,12 +20,12 @@ class ResetPasswordMail implements MailTypeInterface, MessageFactoryInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
@@ -99,7 +99,7 @@ class ResetPasswordMail implements MailTypeInterface, MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      * @return string[]
      */
-    private function getBodyValuesIndexedByVariableName(User $user)
+    protected function getBodyValuesIndexedByVariableName(User $user)
     {
         return [
             self::VARIABLE_EMAIL => $user->getEmail(),
@@ -111,7 +111,7 @@ class ResetPasswordMail implements MailTypeInterface, MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      * @return string
      */
-    private function getVariableNewPasswordUrl(User $user)
+    protected function getVariableNewPasswordUrl(User $user)
     {
         $router = $this->domainRouterFactory->getRouter($user->getDomainId());
 
@@ -131,7 +131,7 @@ class ResetPasswordMail implements MailTypeInterface, MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      * @return string[]
      */
-    private function getSubjectValuesIndexedByVariableName(User $user)
+    protected function getSubjectValuesIndexedByVariableName(User $user)
     {
         return $this->getBodyValuesIndexedByVariableName($user);
     }

--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -12,32 +12,32 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Feed\FeedFacade
      */
-    private $feedFacade;
+    protected $feedFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Feed\FeedExportCreationDataQueue
      */
-    private $feedExportCreationDataQueue;
+    protected $feedExportCreationDataQueue;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Feed\FeedExport|null
      */
-    private $currentFeedExport;
+    protected $currentFeedExport;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Feed\FeedFacade $feedFacade
@@ -151,7 +151,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
      * @param int|null $lastSeekId
      * @return \Shopsys\FrameworkBundle\Model\Feed\FeedExport
      */
-    private function createCurrentFeedExport(int $lastSeekId = null): FeedExport
+    protected function createCurrentFeedExport(int $lastSeekId = null): FeedExport
     {
         return $this->feedFacade->createFeedExport(
             $this->feedExportCreationDataQueue->getCurrentFeedName(),

--- a/packages/framework/src/Model/Feed/FeedExportCreationDataQueue.php
+++ b/packages/framework/src/Model/Feed/FeedExportCreationDataQueue.php
@@ -16,7 +16,7 @@ class FeedExportCreationDataQueue
     /**
      * @var array
      */
-    private $dataInQueue = [];
+    protected $dataInQueue = [];
 
     /**
      * @param string[] $feedNames

--- a/packages/framework/src/Model/Feed/FeedPathProvider.php
+++ b/packages/framework/src/Model/Feed/FeedPathProvider.php
@@ -25,7 +25,7 @@ class FeedPathProvider
     /**
      * @var string
      */
-    private $projectDir;
+    protected $projectDir;
 
     /**
      * @param string $feedUrlPrefix

--- a/packages/framework/src/Model/Feed/FeedRegistry.php
+++ b/packages/framework/src/Model/Feed/FeedRegistry.php
@@ -9,22 +9,22 @@ class FeedRegistry
     /**
      * @var \Shopsys\FrameworkBundle\Model\Feed\FeedInterface[][]
      */
-    private $feedsByType = [];
+    protected $feedsByType = [];
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Feed\FeedInterface[]
      */
-    private $feedsByName = [];
+    protected $feedsByName = [];
 
     /**
      * @var string[]
      */
-    private $knownTypes;
+    protected $knownTypes;
 
     /**
      * @var string
      */
-    private $defaultType;
+    protected $defaultType;
 
     /**
      * @param string[] $knownTypes
@@ -90,7 +90,7 @@ class FeedRegistry
     /**
      * @param string $type
      */
-    private function assertTypeIsKnown(string $type): void
+    protected function assertTypeIsKnown(string $type): void
     {
         if (!in_array($type, $this->knownTypes, true)) {
             throw new \Shopsys\FrameworkBundle\Model\Feed\Exception\UnknownFeedTypeException($type, $this->knownTypes);
@@ -100,7 +100,7 @@ class FeedRegistry
     /**
      * @param string $name
      */
-    private function assertNameIsUnique(string $name): void
+    protected function assertNameIsUnique(string $name): void
     {
         if (array_key_exists($name, $this->feedsByName)) {
             throw new \Shopsys\FrameworkBundle\Model\Feed\Exception\FeedNameNotUniqueException($name);

--- a/packages/framework/src/Model/Feed/FeedRenderer.php
+++ b/packages/framework/src/Model/Feed/FeedRenderer.php
@@ -11,12 +11,12 @@ class FeedRenderer
     /**
      * @var \Twig_Environment
      */
-    private $twig;
+    protected $twig;
 
     /**
      * @var \Twig_TemplateWrapper
      */
-    private $template;
+    protected $template;
 
     /**
      * @param \Twig_Environment $twig
@@ -61,7 +61,7 @@ class FeedRenderer
      * @param array $parameters
      * @return string
      */
-    private function getRenderedBlock(string $name, array $parameters): string
+    protected function getRenderedBlock(string $name, array $parameters): string
     {
         if (!$this->template->hasBlock($name)) {
             throw new \Shopsys\FrameworkBundle\Model\Feed\Exception\TemplateBlockNotFoundException($name, $this->template->getTemplateName());

--- a/packages/framework/src/Model/Feed/HourlyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/HourlyFeedCronModule.php
@@ -11,17 +11,17 @@ class HourlyFeedCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Feed\FeedFacade
      */
-    private $feedFacade;
+    protected $feedFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Feed\FeedFacade $feedFacade

--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -12,7 +12,7 @@ class HeurekaSetting
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -11,7 +11,7 @@ class Localization
     /**
      * @var string[]
      */
-    private $languageNamesByLocale = [
+    protected $languageNamesByLocale = [
         'cs' => 'Čeština',
         'de' => 'Deutsch',
         'en' => 'English',
@@ -23,7 +23,7 @@ class Localization
     /**
      * @var string[]
      */
-    private $collationsByLocale = [
+    protected $collationsByLocale = [
         'cs' => 'cs_CZ',
         'de' => 'de_DE',
         'en' => 'en_US',
@@ -35,12 +35,12 @@ class Localization
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var array
      */
-    private $allLocales;
+    protected $allLocales;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Model/Localization/LocalizationListener.php
+++ b/packages/framework/src/Model/Localization/LocalizationListener.php
@@ -13,12 +13,12 @@ class LocalizationListener implements EventSubscriberInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
      */
-    private $localization;
+    protected $localization;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -52,7 +52,7 @@ class LocalizationListener implements EventSubscriberInterface
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @return bool
      */
-    private function isAdminRequest(Request $request)
+    protected function isAdminRequest(Request $request)
     {
         return preg_match('/^admin_/', $request->attributes->get('_route')) === 1;
     }

--- a/packages/framework/src/Model/Mail/Exception/SendMailFailedException.php
+++ b/packages/framework/src/Model/Mail/Exception/SendMailFailedException.php
@@ -10,7 +10,7 @@ class SendMailFailedException extends Exception implements MailException
     /**
      * @var array
      */
-    private $failedRecipients;
+    protected $failedRecipients;
 
     /**
      * @param array $failedRecipients

--- a/packages/framework/src/Model/Mail/Mailer.php
+++ b/packages/framework/src/Model/Mail/Mailer.php
@@ -11,7 +11,7 @@ class Mailer
     /**
      * @var \Swift_Mailer
      */
-    private $swiftMailer;
+    protected $swiftMailer;
 
     /**
      * @param \Swift_Mailer $swiftMailer
@@ -43,7 +43,7 @@ class Mailer
      * @param \Shopsys\FrameworkBundle\Model\Mail\MessageData $messageData
      * @return \Swift_Message
      */
-    private function getMessageWithReplacedVariables(MessageData $messageData)
+    protected function getMessageWithReplacedVariables(MessageData $messageData)
     {
         $toEmail = $messageData->toEmail;
         $body = $this->replaceVariables(
@@ -82,7 +82,7 @@ class Mailer
      * @param array $variablesKeysAndValues
      * @return string
      */
-    private function replaceVariables($string, $variablesKeysAndValues)
+    protected function replaceVariables($string, $variablesKeysAndValues)
     {
         return strtr($string, $variablesKeysAndValues);
     }

--- a/packages/framework/src/Model/Module/ModuleList.php
+++ b/packages/framework/src/Model/Module/ModuleList.php
@@ -33,7 +33,7 @@ class ModuleList
     /**
      * @return string[]
      */
-    private function getLabelsIndexedByName()
+    protected function getLabelsIndexedByName()
     {
         return [
             self::ACCESSORIES_ON_BUY => t('Accessories in purchase confirmation box'),

--- a/packages/framework/src/Model/Order/Item/OrderItemPriceCalculation.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemPriceCalculation.php
@@ -12,7 +12,7 @@ class OrderItemPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation
      */
-    private $priceCalculation;
+    protected $priceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFactoryInterface
@@ -22,7 +22,7 @@ class OrderItemPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactoryInterface
      */
-    private $vatDataFactory;
+    protected $vatDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation $priceCalculation

--- a/packages/framework/src/Model/Order/Item/QuantifiedItemPrice.php
+++ b/packages/framework/src/Model/Order/Item/QuantifiedItemPrice.php
@@ -10,17 +10,17 @@ class QuantifiedItemPrice
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private $unitPrice;
+    protected $unitPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private $totalPrice;
+    protected $totalPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat
      */
-    private $vat;
+    protected $vat;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $unitPrice

--- a/packages/framework/src/Model/Order/Item/QuantifiedProduct.php
+++ b/packages/framework/src/Model/Order/Item/QuantifiedProduct.php
@@ -9,12 +9,12 @@ class QuantifiedProduct
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product
      */
-    private $product;
+    protected $product;
 
     /**
      * @var int
      */
-    private $quantity;
+    protected $quantity;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product

--- a/packages/framework/src/Model/Order/Mail/OrderMail.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMail.php
@@ -38,42 +38,42 @@ class OrderMail implements MessageFactoryInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @var \Twig_Environment
      */
-    private $twig;
+    protected $twig;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation
      */
-    private $orderItemPriceCalculation;
+    protected $orderItemPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Twig\PriceExtension
      */
-    private $priceExtension;
+    protected $priceExtension;
 
     /**
      * @var \Shopsys\FrameworkBundle\Twig\DateTimeFormatterExtension
      */
-    private $dateTimeFormatterExtension;
+    protected $dateTimeFormatterExtension;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderUrlGenerator
      */
-    private $orderUrlGenerator;
+    protected $orderUrlGenerator;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
@@ -153,7 +153,7 @@ class OrderMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return array
      */
-    private function getVariablesReplacementsForBody(Order $order)
+    protected function getVariablesReplacementsForBody(Order $order)
     {
         $router = $this->domainRouterFactory->getRouter($order->getDomainId());
         $orderDomainConfig = $this->domain->getDomainConfigById($order->getDomainId());
@@ -185,7 +185,7 @@ class OrderMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return array
      */
-    private function getVariablesReplacementsForSubject(Order $order)
+    protected function getVariablesReplacementsForSubject(Order $order)
     {
         return [
             self::VARIABLE_NUMBER => $order->getNumber(),
@@ -219,7 +219,7 @@ class OrderMail implements MessageFactoryInterface
      * @param  \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getFormattedPrice(Order $order)
+    protected function getFormattedPrice(Order $order)
     {
         return $this->priceExtension->priceTextWithCurrencyByCurrencyIdAndLocaleFilter(
             $order->getTotalPriceWithVat(),
@@ -232,7 +232,7 @@ class OrderMail implements MessageFactoryInterface
      * @param  \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getFormattedDateTime(Order $order)
+    protected function getFormattedDateTime(Order $order)
     {
         return $this->dateTimeFormatterExtension->formatDateTime(
             $order->getCreatedAt(),
@@ -244,7 +244,7 @@ class OrderMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getBillingAddressHtmlTable(Order $order)
+    protected function getBillingAddressHtmlTable(Order $order)
     {
         return $this->twig->render('@ShopsysFramework/Mail/Order/billingAddress.html.twig', [
             'order' => $order,
@@ -256,7 +256,7 @@ class OrderMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getDeliveryAddressHtmlTable(Order $order)
+    protected function getDeliveryAddressHtmlTable(Order $order)
     {
         return $this->twig->render('@ShopsysFramework/Mail/Order/deliveryAddress.html.twig', [
             'order' => $order,
@@ -268,7 +268,7 @@ class OrderMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getProductsHtmlTable(Order $order)
+    protected function getProductsHtmlTable(Order $order)
     {
         $orderItemTotalPricesById = $this->orderItemPriceCalculation->calculateTotalPricesIndexedById($order->getItems());
 
@@ -283,7 +283,7 @@ class OrderMail implements MessageFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @return string
      */
-    private function getDomainLocaleByOrder(Order $order)
+    protected function getDomainLocaleByOrder(Order $order)
     {
         return $this->domain->getDomainConfigById($order->getDomainId())->getLocale();
     }

--- a/packages/framework/src/Model/Order/OrderDataMapper.php
+++ b/packages/framework/src/Model/Order/OrderDataMapper.php
@@ -7,7 +7,7 @@ class OrderDataMapper
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
      */
-    private $orderDataFactory;
+    protected $orderDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface $orderDataFactory

--- a/packages/framework/src/Model/Order/OrderEditResult.php
+++ b/packages/framework/src/Model/Order/OrderEditResult.php
@@ -7,7 +7,7 @@ class OrderEditResult
     /**
      * @var bool
      */
-    private $statusChanged;
+    protected $statusChanged;
 
     /**
      * @param bool $statusChanged

--- a/packages/framework/src/Model/Order/OrderPriceCalculation.php
+++ b/packages/framework/src/Model/Order/OrderPriceCalculation.php
@@ -13,12 +13,12 @@ class OrderPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation
      */
-    private $orderItemPriceCalculation;
+    protected $orderItemPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Rounding
      */
-    private $rounding;
+    protected $rounding;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation $orderItemPriceCalculation

--- a/packages/framework/src/Model/Order/OrderTotalPrice.php
+++ b/packages/framework/src/Model/Order/OrderTotalPrice.php
@@ -7,17 +7,17 @@ class OrderTotalPrice
     /**
      * @var string
      */
-    private $priceWithVat;
+    protected $priceWithVat;
 
     /**
      * @var string
      */
-    private $priceWithoutVat;
+    protected $priceWithoutVat;
 
     /**
      * @var string
      */
-    private $productPriceWithVat;
+    protected $productPriceWithVat;
 
     /**
      * @param string $priceWithVat

--- a/packages/framework/src/Model/Order/Preview/OrderPreview.php
+++ b/packages/framework/src/Model/Order/Preview/OrderPreview.php
@@ -11,57 +11,57 @@ class OrderPreview
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct[]
      */
-    private $quantifiedProductsByIndex;
+    protected $quantifiedProductsByIndex;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice[]
      */
-    private $quantifiedItemsPricesByIndex;
+    protected $quantifiedItemsPricesByIndex;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price[]
      */
-    private $quantifiedItemsDiscountsByIndex;
+    protected $quantifiedItemsDiscountsByIndex;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\Transport|null
      */
-    private $transport;
+    protected $transport;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
-    private $transportPrice;
+    protected $transportPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\Payment|null
      */
-    private $payment;
+    protected $payment;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
-    private $paymentPrice;
+    protected $paymentPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private $totalPrice;
+    protected $totalPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private $productsPrice;
+    protected $productsPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
-    private $roundingPrice;
+    protected $roundingPrice;
 
     /**
      * @var float|null
      */
-    private $promoCodeDiscountPercent;
+    protected $promoCodeDiscountPercent;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct[] $quantifiedProductsByIndex

--- a/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php
+++ b/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php
@@ -18,27 +18,27 @@ class OrderPreviewCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\QuantifiedProductPriceCalculation
      */
-    private $quantifiedProductPriceCalculation;
+    protected $quantifiedProductPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\QuantifiedProductDiscountCalculation
      */
-    private $quantifiedProductDiscountCalculation;
+    protected $quantifiedProductDiscountCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation
      */
-    private $transportPriceCalculation;
+    protected $transportPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation
      */
-    private $paymentPriceCalculation;
+    protected $paymentPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation
      */
-    private $orderPriceCalculation;
+    protected $orderPriceCalculation;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\QuantifiedProductPriceCalculation $quantifiedProductPriceCalculation
@@ -152,7 +152,7 @@ class OrderPreviewCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price|null $paymentPrice
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
-    private function calculateRoundingPrice(
+    protected function calculateRoundingPrice(
         Payment $payment,
         Currency $currency,
         Price $productsPrice,
@@ -176,7 +176,7 @@ class OrderPreviewCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price|null $roundingPrice
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private function calculateTotalPrice(
+    protected function calculateTotalPrice(
         Price $productsPrice,
         Price $transportPrice = null,
         Price $paymentPrice = null,
@@ -206,7 +206,7 @@ class OrderPreviewCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price[] $quantifiedItemsDiscounts
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private function getProductsPrice(array $quantifiedItemsPrices, array $quantifiedItemsDiscounts)
+    protected function getProductsPrice(array $quantifiedItemsPrices, array $quantifiedItemsDiscounts)
     {
         $finalPrice = new Price(0, 0);
 

--- a/packages/framework/src/Model/Order/PromoCode/Grid/PromoCodeInlineEdit.php
+++ b/packages/framework/src/Model/Order/PromoCode/Grid/PromoCodeInlineEdit.php
@@ -13,17 +13,17 @@ class PromoCodeInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade
      */
-    private $promoCodeFacade;
+    protected $promoCodeFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface
      */
-    private $promoCodeDataFactory;
+    protected $promoCodeDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\Grid\PromoCodeGridFactory $promoCodeGridFactory

--- a/packages/framework/src/Model/Order/Status/Exception/InvalidOrderStatusTypeException.php
+++ b/packages/framework/src/Model/Order/Status/Exception/InvalidOrderStatusTypeException.php
@@ -9,7 +9,7 @@ class InvalidOrderStatusTypeException extends Exception implements OrderStatusEx
     /**
      * @var int
      */
-    private $orderStatusType;
+    protected $orderStatusType;
 
     /**
      * @param int $orderStatusType

--- a/packages/framework/src/Model/Order/Status/Exception/OrderStatusDeletionForbiddenException.php
+++ b/packages/framework/src/Model/Order/Status/Exception/OrderStatusDeletionForbiddenException.php
@@ -10,7 +10,7 @@ class OrderStatusDeletionForbiddenException extends Exception implements OrderSt
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus
      */
-    private $orderStatus;
+    protected $orderStatus;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus $orderStatus

--- a/packages/framework/src/Model/Order/Status/Grid/OrderStatusInlineEdit.php
+++ b/packages/framework/src/Model/Order/Status/Grid/OrderStatusInlineEdit.php
@@ -14,17 +14,17 @@ class OrderStatusInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade
      */
-    private $orderStatusFacade;
+    protected $orderStatusFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactoryInterface
      */
-    private $orderStatusDataFactory;
+    protected $orderStatusDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\Grid\OrderStatusGridFactory $orderStatusGridFactory

--- a/packages/framework/src/Model/Order/Watcher/TransportAndPaymentCheckResult.php
+++ b/packages/framework/src/Model/Order/Watcher/TransportAndPaymentCheckResult.php
@@ -7,12 +7,12 @@ class TransportAndPaymentCheckResult
     /**
      * @var bool
      */
-    private $transportPriceChanged;
+    protected $transportPriceChanged;
 
     /**
      * @var bool
      */
-    private $paymentPriceChanged;
+    protected $paymentPriceChanged;
 
     /**
      * @param bool $transportPriceChanged

--- a/packages/framework/src/Model/Order/Watcher/TransportAndPaymentWatcher.php
+++ b/packages/framework/src/Model/Order/Watcher/TransportAndPaymentWatcher.php
@@ -20,17 +20,17 @@ class TransportAndPaymentWatcher
     /**
      * @var \Symfony\Component\HttpFoundation\Session\SessionInterface
      */
-    private $session;
+    protected $session;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation
      */
-    private $paymentPriceCalculation;
+    protected $paymentPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation
      */
-    private $transportPriceCalculation;
+    protected $transportPriceCalculation;
 
     /**
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session
@@ -97,7 +97,7 @@ class TransportAndPaymentWatcher
      * @param int $domainId
      * @return bool
      */
-    private function checkTransportPrice(
+    protected function checkTransportPrice(
         Transport $transport,
         Currency $currency,
         OrderPreview $orderPreview,
@@ -129,7 +129,7 @@ class TransportAndPaymentWatcher
      * @param int $domainId
      * @return bool
      */
-    private function checkPaymentPrice(
+    protected function checkPaymentPrice(
         Payment $payment,
         Currency $currency,
         OrderPreview $orderPreview,
@@ -161,7 +161,7 @@ class TransportAndPaymentWatcher
      * @param int $domainId
      * @return array
      */
-    private function getTransportPrices(
+    protected function getTransportPrices(
         $transports,
         Currency $currency,
         OrderPreview $orderPreview,
@@ -188,7 +188,7 @@ class TransportAndPaymentWatcher
      * @param int $domainId
      * @return array
      */
-    private function getPaymentPrices(
+    protected function getPaymentPrices(
         $payments,
         Currency $currency,
         OrderPreview $orderPreview,
@@ -215,7 +215,7 @@ class TransportAndPaymentWatcher
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreview $orderPreview
      * @param int $domainId
      */
-    private function rememberTransportAndPayment(
+    protected function rememberTransportAndPayment(
         array $transports,
         array $payments,
         Currency $currency,
@@ -241,7 +241,7 @@ class TransportAndPaymentWatcher
     /**
      * @return array
      */
-    private function getRememberedTransportAndPayment()
+    protected function getRememberedTransportAndPayment()
     {
         return $this->session->get(self::SESSION_ROOT, [
             self::SESSION_TRANSPORT_PRICES => [],
@@ -252,7 +252,7 @@ class TransportAndPaymentWatcher
     /**
      * @return array
      */
-    private function getRememberedTransportPrices()
+    protected function getRememberedTransportPrices()
     {
         return $this->getRememberedTransportAndPayment()[self::SESSION_TRANSPORT_PRICES];
     }
@@ -260,7 +260,7 @@ class TransportAndPaymentWatcher
     /**
      * @return array
      */
-    private function getRememberedPaymentPrices()
+    protected function getRememberedPaymentPrices()
     {
         return $this->getRememberedTransportAndPayment()[self::SESSION_PAYMENT_PRICES];
     }

--- a/packages/framework/src/Model/Payment/IndependentPaymentVisibilityCalculation.php
+++ b/packages/framework/src/Model/Payment/IndependentPaymentVisibilityCalculation.php
@@ -9,7 +9,7 @@ class IndependentPaymentVisibilityCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
@@ -12,12 +12,12 @@ class PaymentPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation
      */
-    private $basePriceCalculation;
+    protected $basePriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting
      */
-    private $pricingSetting;
+    protected $pricingSetting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation $basePriceCalculation
@@ -72,7 +72,7 @@ class PaymentPriceCalculation
      * @param int $domainId
      * @return bool
      */
-    private function isFree(Price $productsPrice, $domainId)
+    protected function isFree(Price $productsPrice, $domainId)
     {
         $freeTransportAndPaymentPriceLimit = $this->pricingSetting->getFreeTransportAndPaymentPriceLimit($domainId);
 

--- a/packages/framework/src/Model/Payment/PaymentVisibilityCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentVisibilityCalculation.php
@@ -9,12 +9,12 @@ class PaymentVisibilityCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation
      */
-    private $independentPaymentVisibilityCalculation;
+    protected $independentPaymentVisibilityCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation
      */
-    private $independentTransportVisibilityCalculation;
+    protected $independentTransportVisibilityCalculation;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation $independentPaymentVisibilityCalculation
@@ -50,7 +50,7 @@ class PaymentVisibilityCalculation
      * @param int $domainId
      * @return bool
      */
-    private function isVisible(Payment $payment, $domainId)
+    protected function isVisible(Payment $payment, $domainId)
     {
         if (!$this->independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, $domainId)) {
             return false;
@@ -64,7 +64,7 @@ class PaymentVisibilityCalculation
      * @param int $domainId
      * @return bool
      */
-    private function hasIndependentlyVisibleTransport(Payment $payment, $domainId)
+    protected function hasIndependentlyVisibleTransport(Payment $payment, $domainId)
     {
         foreach ($payment->getTransports() as $transport) {
             /* @var $transport \Shopsys\FrameworkBundle\Model\Transport\Transport */

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMail.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMail.php
@@ -21,17 +21,17 @@ class PersonalDataAccessMail implements MailTypeInterface, MessageFactoryInterfa
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -117,7 +117,7 @@ class PersonalDataAccessMail implements MailTypeInterface, MessageFactoryInterfa
      * @param string $domainName
      * @return array
      */
-    private function getBodyValuesIndexedByVariableName($url, $email, $domainName)
+    protected function getBodyValuesIndexedByVariableName($url, $email, $domainName)
     {
         return [
             self::VARIABLE_URL => $url,
@@ -130,7 +130,7 @@ class PersonalDataAccessMail implements MailTypeInterface, MessageFactoryInterfa
      * @param string $domainName
      * @return array
      */
-    private function getSubjectValuesIndexedByVariableName($domainName)
+    protected function getSubjectValuesIndexedByVariableName($domainName)
     {
         return [
             self::VARIABLE_DOMAIN => $domainName,
@@ -141,7 +141,7 @@ class PersonalDataAccessMail implements MailTypeInterface, MessageFactoryInterfa
      * @param string $hash
      * @return string
      */
-    private function getVariablePersonalDataAccessUrl($hash)
+    protected function getVariablePersonalDataAccessUrl($hash)
     {
         $router = $this->domainRouterFactory->getRouter($this->domain->getId());
 

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataExportMail.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataExportMail.php
@@ -21,17 +21,17 @@ class PersonalDataExportMail implements MailTypeInterface, MessageFactoryInterfa
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -117,7 +117,7 @@ class PersonalDataExportMail implements MailTypeInterface, MessageFactoryInterfa
      * @param string $domainName
      * @return array
      */
-    private function getBodyValuesIndexedByVariableName($url, $email, $domainName)
+    protected function getBodyValuesIndexedByVariableName($url, $email, $domainName)
     {
         return [
             self::VARIABLE_URL => $url,
@@ -130,7 +130,7 @@ class PersonalDataExportMail implements MailTypeInterface, MessageFactoryInterfa
      * @param string $domainName
      * @return array
      */
-    private function getSubjectValuesIndexedByVariableName($domainName)
+    protected function getSubjectValuesIndexedByVariableName($domainName)
     {
         return [
             self::VARIABLE_DOMAIN => $domainName,
@@ -141,7 +141,7 @@ class PersonalDataExportMail implements MailTypeInterface, MessageFactoryInterfa
      * @param string $hash
      * @return string
      */
-    private function getVariablePersonalDataAccessUrl($hash)
+    protected function getVariablePersonalDataAccessUrl($hash)
     {
         $router = $this->domainRouterFactory->getRouter($this->domain->getId());
 

--- a/packages/framework/src/Model/PersonalData/PersonalDataBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataBreadcrumbGenerator.php
@@ -37,7 +37,7 @@ class PersonalDataBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @return array
      */
-    private function getPersonalDataRouteNames()
+    protected function getPersonalDataRouteNames()
     {
         return [
             'front_personal_data',

--- a/packages/framework/src/Model/Pricing/BasePriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/BasePriceCalculation.php
@@ -9,12 +9,12 @@ class BasePriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation
      */
-    private $priceCalculation;
+    protected $priceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Rounding
      */
-    private $rounding;
+    protected $rounding;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation $priceCalculation
@@ -66,7 +66,7 @@ class BasePriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
      * @return string
      */
-    private function getBasePriceWithVat($inputPrice, $inputPriceType, Vat $vat)
+    protected function getBasePriceWithVat($inputPrice, $inputPriceType, Vat $vat)
     {
         switch ($inputPriceType) {
             case PricingSetting::INPUT_PRICE_TYPE_WITH_VAT:

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyInlineEdit.php
@@ -13,17 +13,17 @@ class CurrencyInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade
      */
-    private $currencyFacade;
+    protected $currencyFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactoryInterface
      */
-    private $currencyDataFactory;
+    protected $currencyDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Grid\CurrencyGridFactory $currencyGridFactory

--- a/packages/framework/src/Model/Pricing/DelayedPricingSetting.php
+++ b/packages/framework/src/Model/Pricing/DelayedPricingSetting.php
@@ -7,12 +7,12 @@ class DelayedPricingSetting
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting
      */
-    private $pricingSetting;
+    protected $pricingSetting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler
      */
-    private $inputPriceRecalculationScheduler;
+    protected $inputPriceRecalculationScheduler;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting

--- a/packages/framework/src/Model/Pricing/Group/Grid/PricingGroupInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Group/Grid/PricingGroupInlineEdit.php
@@ -14,22 +14,22 @@ class PricingGroupInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */
-    private $pricingGroupFacade;
+    protected $pricingGroupFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade
      */
-    private $adminDomainTabsFacade;
+    protected $adminDomainTabsFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactoryInterface
      */
-    private $pricingGroupDataFactory;
+    protected $pricingGroupDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\Grid\PricingGroupGridFactory $pricingGroupGridFactory

--- a/packages/framework/src/Model/Pricing/InputPriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/InputPriceCalculation.php
@@ -33,7 +33,7 @@ class InputPriceCalculation
      * @param string $vatPercent
      * @return string
      */
-    private function getInputPriceWithoutVat($basePriceWithVat, $vatPercent)
+    protected function getInputPriceWithoutVat($basePriceWithVat, $vatPercent)
     {
         return 100 * $basePriceWithVat / (100 + $vatPercent);
     }

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculationScheduler.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculationScheduler.php
@@ -10,22 +10,22 @@ class InputPriceRecalculationScheduler
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculator
      */
-    private $inputPriceRecalculator;
+    protected $inputPriceRecalculator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var bool
      */
-    private $recalculateInputPricesWithoutVat;
+    protected $recalculateInputPricesWithoutVat;
 
     /**
      * @var bool
      */
-    private $recalculateInputPricesWithVat;
+    protected $recalculateInputPricesWithVat;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculator $inputPriceRecalculator

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
@@ -17,22 +17,22 @@ class InputPriceRecalculator
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\InputPriceCalculation
      */
-    private $inputPriceCalculation;
+    protected $inputPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation
      */
-    private $paymentPriceCalculation;
+    protected $paymentPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation
      */
-    private $transportPriceCalculation;
+    protected $transportPriceCalculation;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
@@ -65,7 +65,7 @@ class InputPriceRecalculator
     /**
      * @param string $newInputPriceType
      */
-    private function recalculateInputPriceForNewType($newInputPriceType)
+    protected function recalculateInputPriceForNewType($newInputPriceType)
     {
         $this->recalculateTransportsInputPriceForNewType($newInputPriceType);
         $this->recalculatePaymentsInputPriceForNewType($newInputPriceType);
@@ -74,7 +74,7 @@ class InputPriceRecalculator
     /**
      * @param string $toInputPriceType
      */
-    private function recalculatePaymentsInputPriceForNewType($toInputPriceType)
+    protected function recalculatePaymentsInputPriceForNewType($toInputPriceType)
     {
         $query = $this->em->createQueryBuilder()
             ->select('p')
@@ -102,7 +102,7 @@ class InputPriceRecalculator
     /**
      * @param string $toInputPriceType
      */
-    private function recalculateTransportsInputPriceForNewType($toInputPriceType)
+    protected function recalculateTransportsInputPriceForNewType($toInputPriceType)
     {
         $query = $this->em->createQueryBuilder()
             ->select('t')
@@ -131,7 +131,7 @@ class InputPriceRecalculator
      * @param \Doctrine\ORM\Query $query
      * @param \Closure $callback
      */
-    private function batchProcessQuery(Query $query, Closure $callback)
+    protected function batchProcessQuery(Query $query, Closure $callback)
     {
         $iteration = 0;
 

--- a/packages/framework/src/Model/Pricing/Price.php
+++ b/packages/framework/src/Model/Pricing/Price.php
@@ -7,17 +7,17 @@ class Price
     /**
      * @var string
      */
-    private $priceWithoutVat;
+    protected $priceWithoutVat;
 
     /**
      * @var string
      */
-    private $priceWithVat;
+    protected $priceWithVat;
 
     /**
      * @var string
      */
-    private $vatAmount;
+    protected $vatAmount;
 
     /**
      * @param string $priceWithoutVat

--- a/packages/framework/src/Model/Pricing/PriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/PriceCalculation.php
@@ -9,7 +9,7 @@ class PriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Rounding
      */
-    private $rounding;
+    protected $rounding;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Rounding $rounding

--- a/packages/framework/src/Model/Pricing/PricingSetting.php
+++ b/packages/framework/src/Model/Pricing/PricingSetting.php
@@ -24,12 +24,12 @@ class PricingSetting
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting
      */
-    private $setting;
+    protected $setting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler
      */
-    private $productPriceRecalculationScheduler;
+    protected $productPriceRecalculationScheduler;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting

--- a/packages/framework/src/Model/Pricing/Rounding.php
+++ b/packages/framework/src/Model/Pricing/Rounding.php
@@ -7,7 +7,7 @@ class Rounding
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting
      */
-    private $pricingSetting;
+    protected $pricingSetting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting

--- a/packages/framework/src/Model/Pricing/Vat/VatDeletionCronModule.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatDeletionCronModule.php
@@ -11,17 +11,17 @@ class VatDeletionCronModule implements IteratedCronModuleInterface
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade
      */
-    private $vatFacade;
+    protected $vatFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductInputPriceFacade
      */
-    private $productInputPriceFacade;
+    protected $productInputPriceFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade

--- a/packages/framework/src/Model/Pricing/Vat/VatInlineEdit.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatInlineEdit.php
@@ -11,17 +11,17 @@ class VatInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade
      */
-    private $vatFacade;
+    protected $vatFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactoryInterface
      */
-    private $vatDataFactory;
+    protected $vatDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatGridFactory $vatGridFactory

--- a/packages/framework/src/Model/Product/Availability/AvailabilityInlineEdit.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityInlineEdit.php
@@ -11,17 +11,17 @@ class AvailabilityInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade
      */
-    private $availabilityFacade;
+    protected $availabilityFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface
      */
-    private $availabilityDataFactory;
+    protected $availabilityDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityGridFactory $availabilityGridFactory

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -13,27 +13,27 @@ class ProductAvailabilityCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade
      */
-    private $availabilityFacade;
+    protected $availabilityFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator
      */
-    private $productSellingDeniedRecalculator;
+    protected $productSellingDeniedRecalculator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade
      */
-    private $productVisibilityFacade;
+    protected $productVisibilityFacade;
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade
@@ -82,7 +82,7 @@ class ProductAvailabilityCalculation
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $mainVariant
      * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
      */
-    private function calculateMainVariantAvailability(Product $mainVariant)
+    protected function calculateMainVariantAvailability(Product $mainVariant)
     {
         $atLeastSomewhereSellableVariants = $this->getAtLeastSomewhereSellableVariantsByMainVariant($mainVariant);
         if (count($atLeastSomewhereSellableVariants) === 0) {
@@ -107,7 +107,7 @@ class ProductAvailabilityCalculation
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $mainVariant
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private function getAtLeastSomewhereSellableVariantsByMainVariant(Product $mainVariant)
+    protected function getAtLeastSomewhereSellableVariantsByMainVariant(Product $mainVariant)
     {
         $allVariants = $mainVariant->getVariants();
         foreach ($allVariants as $variant) {

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCronModule.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCronModule.php
@@ -10,12 +10,12 @@ class ProductAvailabilityCronModule implements IteratedCronModuleInterface
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator
      */
-    private $productAvailabilityRecalculator;
+    protected $productAvailabilityRecalculator;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator $productAvailabilityRecalculator

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculationScheduler.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculationScheduler.php
@@ -10,12 +10,12 @@ class ProductAvailabilityRecalculationScheduler
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private $products = [];
+    protected $products = [];
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
@@ -13,22 +13,22 @@ class ProductAvailabilityRecalculator
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculationScheduler
      */
-    private $productAvailabilityRecalculationScheduler;
+    protected $productAvailabilityRecalculationScheduler;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityCalculation
      */
-    private $productAvailabilityCalculation;
+    protected $productAvailabilityCalculation;
 
     /**
      * @var \Doctrine\ORM\Internal\Hydration\IterableResult|\Shopsys\FrameworkBundle\Model\Product\Product[][]|null
      */
-    private $productRowsIterator;
+    protected $productRowsIterator;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
@@ -88,7 +88,7 @@ class ProductAvailabilityRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      */
-    private function recalculateProductAvailability(Product $product)
+    protected function recalculateProductAvailability(Product $product)
     {
         $calculatedAvailability = $this->productAvailabilityCalculation->calculateAvailability($product);
         $product->setCalculatedAvailability($calculatedAvailability);

--- a/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductCombinator.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductCombinator.php
@@ -32,7 +32,7 @@ class BestsellingProductCombinator
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $manualProducts
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private function getAutomaticProductsExcludingManual(
+    protected function getAutomaticProductsExcludingManual(
         array $automaticProducts,
         array $manualProducts
     ) {
@@ -52,7 +52,7 @@ class BestsellingProductCombinator
      * @param int $maxResults
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private function getCombinedProducts(
+    protected function getCombinedProducts(
         array $manualProductsIndexedByPosition,
         array $automaticProductsExcludingManual,
         $maxResults

--- a/packages/framework/src/Model/Product/Brand/BrandBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Product/Brand/BrandBreadcrumbGenerator.php
@@ -10,7 +10,7 @@ class BrandBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandRepository
      */
-    private $brandRepository;
+    protected $brandRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandRepository $brandRepository

--- a/packages/framework/src/Model/Product/Brand/BrandDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDetailFriendlyUrlDataProvider.php
@@ -16,12 +16,12 @@ class BrandDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInter
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryInterface
      */
-    private $friendlyUrlDataFactory;
+    protected $friendlyUrlDataFactory;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Model/Product/Filter/ParameterFilterChoice.php
+++ b/packages/framework/src/Model/Product/Filter/ParameterFilterChoice.php
@@ -9,12 +9,12 @@ class ParameterFilterChoice
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter
      */
-    private $parameter;
+    protected $parameter;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue[]
      */
-    private $values;
+    protected $values;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter

--- a/packages/framework/src/Model/Product/Filter/PriceRange.php
+++ b/packages/framework/src/Model/Product/Filter/PriceRange.php
@@ -7,12 +7,12 @@ class PriceRange
     /**
      * @var string
      */
-    private $minimalPrice;
+    protected $minimalPrice;
 
     /**
      * @var string
      */
-    private $maximalPrice;
+    protected $maximalPrice;
 
     /**
      * @param string|null $minimalPrice

--- a/packages/framework/src/Model/Product/Filter/ProductFilterConfig.php
+++ b/packages/framework/src/Model/Product/Filter/ProductFilterConfig.php
@@ -7,22 +7,22 @@ class ProductFilterConfig
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice[]
      */
-    private $parameterChoices;
+    protected $parameterChoices;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
      */
-    private $flagChoices;
+    protected $flagChoices;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
      */
-    private $brandChoices;
+    protected $brandChoices;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Filter\PriceRange
      */
-    private $priceRange;
+    protected $priceRange;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice[] $parameterChoices

--- a/packages/framework/src/Model/Product/Flag/FlagInlineEdit.php
+++ b/packages/framework/src/Model/Product/Flag/FlagInlineEdit.php
@@ -11,17 +11,17 @@ class FlagInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade
      */
-    private $flagFacade;
+    protected $flagFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagDataFactoryInterface
      */
-    private $flagDataFactory;
+    protected $flagDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagGridFactory $flagGridFactory

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingConfig.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingConfig.php
@@ -14,17 +14,17 @@ class ProductListOrderingConfig
     /**
      * @var string[]
      */
-    private $supportedOrderingModesNamesById;
+    protected $supportedOrderingModesNamesById;
 
     /**
      * @var string
      */
-    private $defaultOrderingModeId;
+    protected $defaultOrderingModeId;
 
     /**
      * @var string
      */
-    private $cookieName;
+    protected $cookieName;
 
     /**
      * @param string[] $supportedOrderingModesNamesById

--- a/packages/framework/src/Model/Product/Parameter/ParameterInlineEdit.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterInlineEdit.php
@@ -11,17 +11,17 @@ class ParameterInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade
      */
-    private $parameterFacade;
+    protected $parameterFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterDataFactoryInterface
      */
-    private $parameterDataFactory;
+    protected $parameterDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGridFactory $parameterGridFactory

--- a/packages/framework/src/Model/Product/Pricing/ProductPrice.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPrice.php
@@ -9,7 +9,7 @@ class ProductPrice extends Price
     /**
      * @var bool
      */
-    private $priceFrom;
+    protected $priceFrom;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $price

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCalculation.php
@@ -13,22 +13,22 @@ class ProductPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation
      */
-    private $basePriceCalculation;
+    protected $basePriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting
      */
-    private $pricingSetting;
+    protected $pricingSetting;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceRepository
      */
-    private $productManualInputPriceRepository;
+    protected $productManualInputPriceRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation $basePriceCalculation
@@ -69,7 +69,7 @@ class ProductPriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice
      */
-    private function calculateMainVariantPrice(Product $mainVariant, $domainId, PricingGroup $pricingGroup)
+    protected function calculateMainVariantPrice(Product $mainVariant, $domainId, PricingGroup $pricingGroup)
     {
         $variants = $this->productRepository->getAllSellableVariantsByMainVariant(
             $mainVariant,
@@ -97,7 +97,7 @@ class ProductPriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice
      */
-    private function calculateProductPriceForPricingGroup(Product $product, PricingGroup $pricingGroup)
+    protected function calculateProductPriceForPricingGroup(Product $product, PricingGroup $pricingGroup)
     {
         $manualInputPrice = $this->productManualInputPriceRepository->findByProductAndPricingGroup($product, $pricingGroup);
         if ($manualInputPrice !== null) {

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCalculationForUser.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCalculationForUser.php
@@ -13,22 +13,22 @@ class ProductPriceCalculationForUser
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation
      */
-    private $productPriceCalculation;
+    protected $productPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer
      */
-    private $currentCustomer;
+    protected $currentCustomer;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade
      */
-    private $pricingGroupSettingFacade;
+    protected $pricingGroupSettingFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation $productPriceCalculation

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCronModule.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCronModule.php
@@ -10,12 +10,12 @@ class ProductPriceCronModule implements IteratedCronModuleInterface
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator
      */
-    private $productPriceRecalculator;
+    protected $productPriceRecalculator;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator $productPriceRecalculator

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculationScheduler.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculationScheduler.php
@@ -10,12 +10,12 @@ class ProductPriceRecalculationScheduler
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private $products = [];
+    protected $products = [];
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
@@ -14,37 +14,37 @@ class ProductPriceRecalculator
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation
      */
-    private $productPriceCalculation;
+    protected $productPriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductCalculatedPriceRepository
      */
-    private $productCalculatedPriceRepository;
+    protected $productCalculatedPriceRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler
      */
-    private $productPriceRecalculationScheduler;
+    protected $productPriceRecalculationScheduler;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade
      */
-    private $pricingGroupFacade;
+    protected $pricingGroupFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup[]|null
      */
-    private $allPricingGroups;
+    protected $allPricingGroups;
 
     /**
      * @var \Doctrine\ORM\Internal\Hydration\IterableResult|\Shopsys\FrameworkBundle\Model\Product\Product[][]|null
      */
-    private $productRowsIterator;
+    protected $productRowsIterator;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
@@ -111,7 +111,7 @@ class ProductPriceRecalculator
         $this->clearCache();
     }
 
-    private function clearCache()
+    protected function clearCache()
     {
         $this->allPricingGroups = null;
     }
@@ -119,7 +119,7 @@ class ProductPriceRecalculator
     /**
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup[]
      */
-    private function getAllPricingGroups()
+    protected function getAllPricingGroups()
     {
         if ($this->allPricingGroups === null) {
             $this->allPricingGroups = $this->pricingGroupFacade->getAll();
@@ -131,7 +131,7 @@ class ProductPriceRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      */
-    private function recalculateProductPrices(Product $product)
+    protected function recalculateProductPrices(Product $product)
     {
         foreach ($this->getAllPricingGroups() as $pricingGroup) {
             try {

--- a/packages/framework/src/Model/Product/Pricing/ProductSellingPrice.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductSellingPrice.php
@@ -10,12 +10,12 @@ class ProductSellingPrice
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup
      */
-    private $pricingGroup;
+    protected $pricingGroup;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private $sellingPrice;
+    protected $sellingPrice;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup

--- a/packages/framework/src/Model/Product/Pricing/QuantifiedProductDiscountCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/QuantifiedProductDiscountCalculation.php
@@ -12,12 +12,12 @@ class QuantifiedProductDiscountCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation
      */
-    private $priceCalculation;
+    protected $priceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Rounding
      */
-    private $rounding;
+    protected $rounding;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation $priceCalculation
@@ -36,7 +36,7 @@ class QuantifiedProductDiscountCalculation
      * @param float $discountPercent
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private function calculateDiscount(QuantifiedItemPrice $quantifiedItemPrice, $discountPercent)
+    protected function calculateDiscount(QuantifiedItemPrice $quantifiedItemPrice, $discountPercent)
     {
         $vat = $quantifiedItemPrice->getVat();
         $priceWithVat = $this->rounding->roundPriceWithVat(

--- a/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
@@ -15,32 +15,32 @@ class QuantifiedProductPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser
      */
-    private $productPriceCalculationForUser;
+    protected $productPriceCalculationForUser;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Rounding
      */
-    private $rounding;
+    protected $rounding;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct
      */
-    private $quantifiedProduct;
+    protected $quantifiedProduct;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product
      */
-    private $product;
+    protected $product;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
-    private $productPrice;
+    protected $productPrice;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation
      */
-    private $priceCalculation;
+    protected $priceCalculation;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser $productPriceCalculationForUser
@@ -94,7 +94,7 @@ class QuantifiedProductPriceCalculation
     /**
      * @return string
      */
-    private function getTotalPriceWithoutVat()
+    protected function getTotalPriceWithoutVat()
     {
         return $this->getTotalPriceWithVat() - $this->getTotalPriceVatAmount();
     }
@@ -102,7 +102,7 @@ class QuantifiedProductPriceCalculation
     /**
      * @return string
      */
-    private function getTotalPriceWithVat()
+    protected function getTotalPriceWithVat()
     {
         return $this->productPrice->getPriceWithVat() * $this->quantifiedProduct->getQuantity();
     }
@@ -110,7 +110,7 @@ class QuantifiedProductPriceCalculation
     /**
      * @return string
      */
-    private function getTotalPriceVatAmount()
+    protected function getTotalPriceVatAmount()
     {
         $vatPercent = $this->product->getVat()->getPercent();
 

--- a/packages/framework/src/Model/Product/ProductBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Product/ProductBreadcrumbGenerator.php
@@ -13,17 +13,17 @@ class ProductBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
-    private $categoryFacade;
+    protected $categoryFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
@@ -65,7 +65,7 @@ class ProductBreadcrumbGenerator implements BreadcrumbGeneratorInterface
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @return \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbItem[]
      */
-    private function getCategoryBreadcrumbItems(Category $category)
+    protected function getCategoryBreadcrumbItems(Category $category)
     {
         $categoriesInPath = $this->categoryFacade->getVisibleCategoriesInPathFromRootOnDomain(
             $category,

--- a/packages/framework/src/Model/Product/ProductDeleteResult.php
+++ b/packages/framework/src/Model/Product/ProductDeleteResult.php
@@ -7,7 +7,7 @@ class ProductDeleteResult
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private $productsForRecalculations;
+    protected $productsForRecalculations;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $productsForRecalculations

--- a/packages/framework/src/Model/Product/ProductDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/ProductDetailFriendlyUrlDataProvider.php
@@ -16,12 +16,12 @@ class ProductDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInt
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryInterface
      */
-    private $friendlyUrlDataFactory;
+    protected $friendlyUrlDataFactory;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -129,7 +129,7 @@ class ProductFacade
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation
      */
-    private $productPriceCalculation;
+    protected $productPriceCalculation;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Model/Product/ProductFactory.php
+++ b/packages/framework/src/Model/Product/ProductFactory.php
@@ -20,7 +20,7 @@ class ProductFactory implements ProductFactoryInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface
      */
-    private $productCategoryDomainFactory;
+    protected $productCategoryDomainFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver

--- a/packages/framework/src/Model/Product/ProductHiddenRecalculator.php
+++ b/packages/framework/src/Model/Product/ProductHiddenRecalculator.php
@@ -9,7 +9,7 @@ class ProductHiddenRecalculator
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
@@ -36,7 +36,7 @@ class ProductHiddenRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
      */
-    private function executeQuery(Product $product = null)
+    protected function executeQuery(Product $product = null)
     {
         $qb = $this->em->createQueryBuilder()
             ->update(Product::class, 'p')

--- a/packages/framework/src/Model/Product/ProductListFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/ProductListFriendlyUrlDataProvider.php
@@ -17,12 +17,12 @@ class ProductListFriendlyUrlDataProvider implements FriendlyUrlDataProviderInter
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryInterface
      */
-    private $friendlyUrlDataFactory;
+    protected $friendlyUrlDataFactory;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Model/Product/ProductSearchExport/ProductSearchExportCronModule.php
+++ b/packages/framework/src/Model/Product/ProductSearchExport/ProductSearchExportCronModule.php
@@ -10,7 +10,7 @@ class ProductSearchExportCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductSearchExport\ProductSearchExportFacade
      */
-    private $productSearchExportFacade;
+    protected $productSearchExportFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductSearchExport\ProductSearchExportFacade $productSearchExportFacade

--- a/packages/framework/src/Model/Product/ProductSellingDeniedRecalculator.php
+++ b/packages/framework/src/Model/Product/ProductSellingDeniedRecalculator.php
@@ -9,7 +9,7 @@ class ProductSellingDeniedRecalculator
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
@@ -37,7 +37,7 @@ class ProductSellingDeniedRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
      */
-    private function calculate(array $products = [])
+    protected function calculate(array $products = [])
     {
         $this->calculateIndependent($products);
         $this->propagateMainVariantSellingDeniedToVariants($products);
@@ -48,7 +48,7 @@ class ProductSellingDeniedRecalculator
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    private function getProductsForCalculations(Product $product)
+    protected function getProductsForCalculations(Product $product)
     {
         $products = [$product];
         if ($product->isMainVariant()) {
@@ -63,7 +63,7 @@ class ProductSellingDeniedRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
      */
-    private function calculateIndependent(array $products)
+    protected function calculateIndependent(array $products)
     {
         $qb = $this->em->createQueryBuilder()
             ->update(Product::class, 'p')
@@ -87,7 +87,7 @@ class ProductSellingDeniedRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
      */
-    private function propagateMainVariantSellingDeniedToVariants(array $products)
+    protected function propagateMainVariantSellingDeniedToVariants(array $products)
     {
         $qb = $this->em->createQueryBuilder()
             ->update(Product::class, 'p')
@@ -113,7 +113,7 @@ class ProductSellingDeniedRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
      */
-    private function propagateVariantsSellingDeniedToMainVariant(array $products)
+    protected function propagateVariantsSellingDeniedToMainVariant(array $products)
     {
         $qb = $this->em->createQueryBuilder()
             ->update(Product::class, 'p')

--- a/packages/framework/src/Model/Product/ProductVisibilityImmediateCronModule.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityImmediateCronModule.php
@@ -10,7 +10,7 @@ class ProductVisibilityImmediateCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade
      */
-    private $productVisibilityFacade;
+    protected $productVisibilityFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade $productVisibilityFacade

--- a/packages/framework/src/Model/Product/ProductVisibilityMidnightCronModule.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityMidnightCronModule.php
@@ -10,7 +10,7 @@ class ProductVisibilityMidnightCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade
      */
-    private $productVisibilityFacade;
+    protected $productVisibilityFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade $productVisibilityFacade

--- a/packages/framework/src/Model/Product/Unit/UnitInlineEdit.php
+++ b/packages/framework/src/Model/Product/Unit/UnitInlineEdit.php
@@ -11,17 +11,17 @@ class UnitInlineEdit extends AbstractGridInlineEdit
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade
      */
-    private $unitFacade;
+    protected $unitFacade;
 
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface
      */
-    private $formFactory;
+    protected $formFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactoryInterface
      */
-    private $unitDataFactory;
+    protected $unitDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitGridFactory $unitGridFactory

--- a/packages/framework/src/Model/Security/AdminLogoutHandler.php
+++ b/packages/framework/src/Model/Security/AdminLogoutHandler.php
@@ -12,12 +12,12 @@ class AdminLogoutHandler implements LogoutSuccessHandlerInterface
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Security\AdministratorLoginFacade
      */
-    private $administratorLoginFacade;
+    protected $administratorLoginFacade;
 
     /**
      * @param \Symfony\Component\Routing\RouterInterface $router

--- a/packages/framework/src/Model/Security/Authenticator.php
+++ b/packages/framework/src/Model/Security/Authenticator.php
@@ -16,12 +16,12 @@ class Authenticator
     /**
      * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage
      */
-    private $tokenStorage;
+    protected $tokenStorage;
 
     /**
      * @var \Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher
      */
-    private $traceableEventDispatcher;
+    protected $traceableEventDispatcher;
 
     /**
      * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage $tokenStorage

--- a/packages/framework/src/Model/Security/CustomerLoginHandler.php
+++ b/packages/framework/src/Model/Security/CustomerLoginHandler.php
@@ -17,7 +17,7 @@ class CustomerLoginHandler implements AuthenticationSuccessHandlerInterface, Aut
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\CurrentDomainRouter $router

--- a/packages/framework/src/Model/Security/Filesystem/FilemanagerAccess.php
+++ b/packages/framework/src/Model/Security/Filesystem/FilemanagerAccess.php
@@ -10,22 +10,22 @@ class FilemanagerAccess
     /**
      * @var \Shopsys\FrameworkBundle\Model\Security\Filesystem\FilemanagerAccess|null
      */
-    private static $self;
+    protected static $self;
 
     /**
      * @var string
      */
-    private $filemanagerUploadDir;
+    protected $filemanagerUploadDir;
 
     /**
      * @var \FM\ElfinderBundle\Configuration\ElFinderConfigurationReader
      */
-    private $elFinderConfigurationReader;
+    protected $elFinderConfigurationReader;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Filesystem\FilepathComparator
      */
-    private $filepathComparator;
+    protected $filepathComparator;
 
     /**
      * @param mixed $filamanagerUploadDir

--- a/packages/framework/src/Model/Security/FrontLogoutHandler.php
+++ b/packages/framework/src/Model/Security/FrontLogoutHandler.php
@@ -13,12 +13,12 @@ class FrontLogoutHandler implements LogoutSuccessHandlerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderFlowFacade
      */
-    private $orderFlowFacade;
+    protected $orderFlowFacade;
 
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    protected $router;
 
     /**
      * @param \Symfony\Component\Routing\RouterInterface $router

--- a/packages/framework/src/Model/Security/LoginListener.php
+++ b/packages/framework/src/Model/Security/LoginListener.php
@@ -15,17 +15,17 @@ class LoginListener
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
-    private $em;
+    protected $em;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderFlowFacade
      */
-    private $orderFlowFacade;
+    protected $orderFlowFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade
      */
-    private $administratorActivityFacade;
+    protected $administratorActivityFacade;
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Model/Sitemap/SitemapCronModule.php
+++ b/packages/framework/src/Model/Sitemap/SitemapCronModule.php
@@ -10,7 +10,7 @@ class SitemapCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFacade
      */
-    private $sitemapFacade;
+    protected $sitemapFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFacade $sitemapFacade

--- a/packages/framework/src/Model/Sitemap/SitemapDumper.php
+++ b/packages/framework/src/Model/Sitemap/SitemapDumper.php
@@ -15,12 +15,12 @@ class SitemapDumper extends Dumper
     /**
      * @var \League\Flysystem\FilesystemInterface
      */
-    private $abstractFilesystem;
+    protected $abstractFilesystem;
 
     /**
      * @var \League\Flysystem\MountManager
      */
-    private $mountManager;
+    protected $mountManager;
 
     /**
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -21,17 +21,17 @@ class SitemapListener implements EventSubscriberInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFacade
      */
-    private $sitemapFacade;
+    protected $sitemapFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFacade $sitemapFacade
@@ -88,7 +88,7 @@ class SitemapListener implements EventSubscriberInterface
      * @param string $section
      * @param int $elementPriority
      */
-    private function addUrlsBySitemapItems(
+    protected function addUrlsBySitemapItems(
         array $sitemapItems,
         AbstractGenerator $generator,
         DomainConfig $domainConfig,
@@ -108,7 +108,7 @@ class SitemapListener implements EventSubscriberInterface
      * @param string $section
      * @param int $elementPriority
      */
-    private function addHomepageUrl(
+    protected function addHomepageUrl(
         AbstractGenerator $generator,
         DomainConfig $domainConfig,
         $section,
@@ -125,7 +125,7 @@ class SitemapListener implements EventSubscriberInterface
      * @param string $slug
      * @return string
      */
-    private function getAbsoluteUrlByDomainConfigAndSlug(DomainConfig $domainConfig, $slug)
+    protected function getAbsoluteUrlByDomainConfigAndSlug(DomainConfig $domainConfig, $slug)
     {
         return $domainConfig->getUrl() . '/' . $slug;
     }

--- a/packages/framework/src/Model/Statistics/ValueByDateTimeDataPoint.php
+++ b/packages/framework/src/Model/Statistics/ValueByDateTimeDataPoint.php
@@ -9,12 +9,12 @@ class ValueByDateTimeDataPoint
     /**
      * @var int
      */
-    private $value;
+    protected $value;
 
     /**
      * @var \DateTime
      */
-    private $dateTime;
+    protected $dateTime;
 
     /**
      * @param mixed $count

--- a/packages/framework/src/Model/Statistics/ValueByDateTimeDataPointFormatter.php
+++ b/packages/framework/src/Model/Statistics/ValueByDateTimeDataPointFormatter.php
@@ -11,7 +11,7 @@ class ValueByDateTimeDataPointFormatter
     /**
      * @var \Shopsys\FrameworkBundle\Twig\DateTimeFormatterExtension
      */
-    private $dateTimeFormatterExtension;
+    protected $dateTimeFormatterExtension;
 
     /**
      * @param \Shopsys\FrameworkBundle\Twig\DateTimeFormatterExtension $dateTimeFormatterExtension
@@ -72,7 +72,7 @@ class ValueByDateTimeDataPointFormatter
      * @param \Shopsys\FrameworkBundle\Model\Statistics\ValueByDateTimeDataPoint[] $valueByDateTimeDataPoints
      * @return \DateTime[]
      */
-    private function getDateTimes(array $valueByDateTimeDataPoints)
+    protected function getDateTimes(array $valueByDateTimeDataPoints)
     {
         $returnData = [];
         foreach ($valueByDateTimeDataPoints as $key => $valueByDateTimeDataPoint) {

--- a/packages/framework/src/Model/Transport/IndependentTransportVisibilityCalculation.php
+++ b/packages/framework/src/Model/Transport/IndependentTransportVisibilityCalculation.php
@@ -9,7 +9,7 @@ class IndependentTransportVisibilityCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Model/Transport/TransportPriceCalculation.php
+++ b/packages/framework/src/Model/Transport/TransportPriceCalculation.php
@@ -12,12 +12,12 @@ class TransportPriceCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation
      */
-    private $basePriceCalculation;
+    protected $basePriceCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting
      */
-    private $pricingSetting;
+    protected $pricingSetting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation $basePriceCalculation
@@ -72,7 +72,7 @@ class TransportPriceCalculation
      * @param int $domainId
      * @return bool
      */
-    private function isFree(Price $productsPrice, $domainId)
+    protected function isFree(Price $productsPrice, $domainId)
     {
         $freeTransportAndPaymentPriceLimit = $this->pricingSetting->getFreeTransportAndPaymentPriceLimit($domainId);
 

--- a/packages/framework/src/Model/Transport/TransportVisibilityCalculation.php
+++ b/packages/framework/src/Model/Transport/TransportVisibilityCalculation.php
@@ -9,12 +9,12 @@ class TransportVisibilityCalculation
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation
      */
-    private $independentTransportVisibilityCalculation;
+    protected $independentTransportVisibilityCalculation;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation
      */
-    private $independentPaymentVisibilityCalculation;
+    protected $independentPaymentVisibilityCalculation;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation $independentTransportVisibilityCalculation
@@ -49,7 +49,7 @@ class TransportVisibilityCalculation
      * @param int $domainId
      * @return bool
      */
-    private function existsIndependentlyVisiblePaymentWithTransport(array $payments, Transport $transport, $domainId)
+    protected function existsIndependentlyVisiblePaymentWithTransport(array $payments, Transport $transport, $domainId)
     {
         foreach ($payments as $payment) {
             if ($this->independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, $domainId)) {

--- a/packages/product-feed-google/easy-coding-standard.yml
+++ b/packages/product-feed-google/easy-coding-standard.yml
@@ -1,6 +1,16 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    forbidden_private_visibility_fixer.product_feed_google:
+        class: Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer
+        calls:
+            - method: configure
+              arguments:
+                  - analyzed_namespaces:
+                        - Shopsys\ProductFeed\GoogleBundle\Model
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-heureka-delivery/easy-coding-standard.yml
+++ b/packages/product-feed-heureka-delivery/easy-coding-standard.yml
@@ -1,6 +1,16 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    forbidden_private_visibility_fixer.product_feed_heureka_delivery:
+        class: Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer
+        calls:
+            - method: configure
+              arguments:
+                  - analyzed_namespaces:
+                        - Shopsys\ProductFeed\HeurekaDeliveryBundle\Model
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -1,6 +1,16 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    forbidden_private_visibility_fixer.product_feed_heureka:
+        class: Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer
+        calls:
+            - method: configure
+              arguments:
+                  - analyzed_namespaces:
+                        - Shopsys\ProductFeed\HeurekaBundle\Model
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
@@ -10,17 +10,17 @@ class HeurekaCategoryCronModule implements SimpleCronModuleInterface
     /**
      * @var \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader
      */
-    private $heurekaCategoryDownloader;
+    protected $heurekaCategoryDownloader;
 
     /**
      * @var \Symfony\Bridge\Monolog\Logger
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacade
      */
-    private $heurekaCategoryFacade;
+    protected $heurekaCategoryFacade;
 
     /**
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDownloader $heurekaCategoryDownloader

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
@@ -9,12 +9,12 @@ class HeurekaCategoryDownloader
     /**
      * @var string
      */
-    private $heurekaCategoryFeedUrl;
+    protected $heurekaCategoryFeedUrl;
 
     /**
      * @var \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryDataFactoryInterface
      */
-    private $heurekaCategoryDataFactory;
+    protected $heurekaCategoryDataFactory;
 
     /**
      * @param string $heurekaCategoryFeedUrl
@@ -41,7 +41,7 @@ class HeurekaCategoryDownloader
     /**
      * @return \SimpleXMLElement
      */
-    private function loadXml()
+    protected function loadXml()
     {
         try {
             return new SimpleXMLElement($this->heurekaCategoryFeedUrl, LIBXML_NOERROR | LIBXML_NOWARNING, true);
@@ -54,7 +54,7 @@ class HeurekaCategoryDownloader
      * @param \SimpleXMLElement[] $xmlCategoryDataObjects
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[]
      */
-    private function convertToShopEntities(array $xmlCategoryDataObjects)
+    protected function convertToShopEntities(array $xmlCategoryDataObjects)
     {
         $heurekaCategoriesData = [];
 

--- a/packages/product-feed-zbozi/easy-coding-standard.yml
+++ b/packages/product-feed-zbozi/easy-coding-standard.yml
@@ -1,6 +1,16 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    forbidden_private_visibility_fixer.product_feed_zbozi:
+        class: Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer
+        calls:
+            - method: configure
+              arguments:
+                  - analyzed_namespaces:
+                        - Shopsys\ProductFeed\ZboziBundle\Model
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Enabled and forces not having any private fields and methods in certain namespaces.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #726, closes #664 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

According to our coding standards, there should be only public or protected functions, properties, and constants in Entities, Factories, Controllers, Facades, and Repositories in framework package and plugins.

Following namespaces are checked:
- `Shopsys\FrameworkBundle\Model`
- `Shopsys\FrameworkBundle\Component`
- `Shopsys\FrameworkBundle\Controller`
- `Shopsys\FrameworkBundle\DataFixtures\Demo`
- `Shopsys\ProductFeed\GoogleBundle\Model`
- `Shopsys\ProductFeed\HeurekaBundle\Model`
- `Shopsys\ProductFeed\HeurekaDeliveryBundle\Model`
- `Shopsys\ProductFeed\ZboziBundle\Model`