### PR TITLE
[shopsys] fixed kubernetes naming

### DIFF
--- a/docs/kubernetes/continuous-integration-using-kubernetes.md
+++ b/docs/kubernetes/continuous-integration-using-kubernetes.md
@@ -16,7 +16,7 @@ It performs the load of data fixtures, initialization of databases, tests, check
 Selection of the CI is important.
 We currently have really great experience with Jenkins CI.
 Mainly because of its freedom with jobs, where it gives you opportunity to write any shell code you want.
-That means that you can control things like workspaces clean up, or have control over kubernetes namespaces which can be crucial with server resources.
+That means that you can control things like workspaces clean up, or have control over Kubernetes namespaces which can be crucial with server resources.
 
 ### Prepare your CI
 There are couple of prerequisites that need to be installed onto the server running the CI.

--- a/docs/kubernetes/how-to-set-smtp-server-container.md
+++ b/docs/kubernetes/how-to-set-smtp-server-container.md
@@ -1,7 +1,7 @@
 # How to set SMTP Server Container
 
-For sending e-mails from our application we use [SMTP server container](https://hub.docker.com/r/namshi/smtp/) in separate `k8s POD` so we need to set some additional settings as permission to be able to send e-mails from `webserver-php-fpm` POD.
-For this purpose, we have set `RELAY_NETWORKS` ENV variable with all private networks that can be created by docker into `/project-base/kubernetes/deployments/smtp-server.yml` for POD of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
+For sending e-mails from our application we use [SMTP server container](https://hub.docker.com/r/namshi/smtp/) in separate Kubernetes pod so we need to set some additional settings as permission to be able to send e-mails from `webserver-php-fpm` pod.
+For this purpose, we have set `RELAY_NETWORKS` ENV variable with all private networks that can be created by docker into `/project-base/kubernetes/deployments/smtp-server.yml` for pod of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
 for instance:
 ```yaml
 image: namshi/smtp:latest

--- a/docs/kubernetes/logging-on-continuous-integration-server-running-kubernetes.md
+++ b/docs/kubernetes/logging-on-continuous-integration-server-running-kubernetes.md
@@ -2,7 +2,10 @@
 As this [article](/docs/introduction/logging.md) describes, our logs are streamed. Since we want to be able to look at logs on our CI without needing to perform `kubectl` commands on server we need to make simple workaround in order to get logs out of application and containers onto local storage.
 
 ## Problem
-As we do not want to have much instances of application running at once on our servers because of heavy load we delete after each build Kubernetes namespace. Deleting namespace means that all running pods will be deleted with their logs.
+On our CI, every branch is built in its own Kubernetes namespace for isolation.
+As we do not want to have many instances of application running at once on our servers because of heavy load, we delete the whole Kubernetes namespace after each build.
+Deleting the namespace removes all running pods in it along with the logs.
+So, after a failed build we don't have access to the logs to see what went wrong.
 
 ## Our way
 We decided to go the simplest way possible. In order to get logs for developers to see easily, we print the output of `kubectl logs` into files saved in jenkins workspace.

--- a/docs/kubernetes/logging-on-continuous-integration-server-running-kubernetes.md
+++ b/docs/kubernetes/logging-on-continuous-integration-server-running-kubernetes.md
@@ -2,7 +2,7 @@
 As this [article](/docs/introduction/logging.md) describes, our logs are streamed. Since we want to be able to look at logs on our CI without needing to perform `kubectl` commands on server we need to make simple workaround in order to get logs out of application and containers onto local storage.
 
 ## Problem
-As we do not want to have much instances of application running at once on our servers because of heavy load we delete after each build `kubernetes namespace`. Deleting namespace means that all running pods will be deleted with their logs.
+As we do not want to have much instances of application running at once on our servers because of heavy load we delete after each build Kubernetes namespace. Deleting namespace means that all running pods will be deleted with their logs.
 
 ## Our way
 We decided to go the simplest way possible. In order to get logs for developers to see easily, we print the output of `kubectl logs` into files saved in jenkins workspace.

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -8,7 +8,7 @@ There you can find links to upgrade notes for other versions too.
 ## [shopsys/framework]
 ### Infrastructure
 - *(optional)* in your `docker/php-fpm/Dockerfile` change base image to `php:7.3-fpm-stretch` ([#694](https://github.com/shopsys/shopsys/pull/694))
-- add subnet of your **k8s** cluster as ENV variable into the config `/project-base/kubernetes/deployments/smtp-server.yml` for POD of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
+- add subnet of your Kubernetes cluster as ENV variable into the config `/project-base/kubernetes/deployments/smtp-server.yml` for the pod of smtp container ([#777](https://github.com/shopsys/shopsys/pull/777))  
 for instance:
     ```yaml
     image: namshi/smtp:latest


### PR DESCRIPTION
- we don't abbreviate Kuberenetes to k8s (see [Terminology section in Introduction to Kubernetes](https://github.com/shopsys/shopsys/blob/v7.0.0-beta5/docs/kubernetes/introduction-to-kubernetes.md#terminology-of-kubernetes))
- "pod" and "namespace" are just regular words, no need to use code style or capitals
- reworded the *Problem* section in *Logging on Continuous Integration server running Kubernetes* so it makes more sense

| Q             | A
| ------------- | ---
|Description, reason for the PR| in #777, there were introduced some inconsistencies in terminology
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
