### PR TITLE
[coding-standards] ObjectIsCreatedByFactorySniff: allow using descendant factories

### DIFF
--- a/packages/coding-standards/src/Sniffs/ObjectIsCreatedByFactorySniff.php
+++ b/packages/coding-standards/src/Sniffs/ObjectIsCreatedByFactorySniff.php
@@ -48,8 +48,9 @@ final class ObjectIsCreatedByFactorySniff implements Sniff
 
         $instantiatedClassName = $this->naming->getClassName($file, $instantiatedClassNamePosition);
         $factoryClassName = $instantiatedClassName . 'Factory';
+        $currentClassName = $this->getFirstClassNameInFile($file);
 
-        if ($factoryClassName === $this->getFirstClassNameInFile($file) || !class_exists($factoryClassName)) {
+        if (!class_exists($factoryClassName) || is_a($currentClassName, $factoryClassName, true)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Shopsys Framework customization is mostly based on class inheritance, it makes sense to allow using classes that extend the original factories for object instantiation
|New feature| Kinda? <!-- Do not forget to update docs/ -->
|BC breaks| No (the rule is loosened) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #795 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
