### PR TITLE
[shopsys] markdown formatting fixes in 3rd party copyrights

### DIFF
--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -12,22 +12,22 @@ You can check all the dependencies using the instructions from the section Libra
 
 ### Symfony Framework and Symfony Components
 License: MIT  
-https://symfony.com/doc/3.4/contributing/code/license.html
+https://symfony.com/doc/3.4/contributing/code/license.html  
 Copyright (c) 2004-2018 Fabien Potencier
 
 ### Elasticsearch
 License: Apache License 2.0  
-https://github.com/elastic/elasticsearch-php/blob/master/LICENSE
+https://github.com/elastic/elasticsearch-php/blob/master/LICENSE  
 Copyright 2013-2014 Elasticsearch
 
 ### Grunt: The JavaScript Task Runner
 License: MIT  
-https://github.com/gruntjs/grunt/blob/master/LICENSE
+https://github.com/gruntjs/grunt/blob/master/LICENSE  
 Copyright jQuery Foundation and other contributors, https://jquery.org/
 
 ### Phing
 License: LGPL-3.0-only  
-https://github.com/phingofficial/phing/blob/master/LICENSE
+https://github.com/phingofficial/phing/blob/master/LICENSE  
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 
 ### Nette Foundation tools
@@ -36,17 +36,17 @@ https://nette.org/en/license
 
 ### PHP_CodeSniffer
 License: BSD-3-Clause  
-https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt
+https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt  
 Copyright (c) 2012, Squiz Pty Ltd (ABN 77 084 670 600)
 
 ### PHP Parallel Lint
 License: BSD-2-Clause  
-https://github.com/JakubOnderka/PHP-Parallel-Lint/blob/master/LICENSE
+https://github.com/JakubOnderka/PHP-Parallel-Lint/blob/master/LICENSE  
 Copyright (c) 2012, Jakub Onderka
 
 ### ESLint
 License: MIT  
-https://github.com/eslint/eslint/blob/master/LICENSE
+https://github.com/eslint/eslint/blob/master/LICENSE  
 Copyright JS Foundation and other contributors, https://js.foundation
 
 ### jQuery
@@ -55,12 +55,12 @@ http://jquery.org/license
 
 ### selectize.js
 License: Apache License 2.0  
-https://github.com/selectize/selectize.js/blob/master/LICENSE
+https://github.com/selectize/selectize.js/blob/master/LICENSE  
 Copyright 2013–2015 Brian Reavis
 
 ### slick.js
 License: MIT  
-https://github.com/kenwheeler/slick/blob/master/LICENSE
+https://github.com/kenwheeler/slick/blob/master/LICENSE  
 Copyright (c) 2013-2016
 
 ## Images and libraries installed for a full run of Shopsys Framework on Docker
@@ -89,7 +89,7 @@ https://github.com/erikdubbelboer/phpRedisAdmin/blob/master/README.markdown
 ### Selenium Docker
 Image: `Selenium/standalone-chrome:3.11`  
 License: Apache License 2.0  
-https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md
+https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md  
 Copyright 2018 Software Freedom Conservancy (SFC)
 
 ### Adminer
@@ -100,23 +100,23 @@ https://github.com/vrana/adminer/blob/master/readme.txt
 ### Elasticsearch
 Image: `Docker.elastic.co/elasticsearch/elasticsearch-oss`  
 License: Apache License 2.0  
-https://github.com/elastic/elasticsearch/blob/66b5ed86f7adede8102cd4d979b9f4924e5bd837/LICENSE.txt
+https://github.com/elastic/elasticsearch/blob/66b5ed86f7adede8102cd4d979b9f4924e5bd837/LICENSE.txt  
 Copyright 2009-2018 Elasticsearch
 
 ### Php
 Image: `php:7.2-fpm-stretch`  
 License: The PHP License  
-http://php.net/license/
+http://php.net/license/  
 Copyright (c) 1999 - 2018 The PHP Group. All rights reserved.
 
 ### Composer - Dependency Management for PHP
 License: MIT  
-https://github.com/composer/composer/blob/master/LICENSE
+https://github.com/composer/composer/blob/master/LICENSE  
 Copyright (c) Nils Adermann, Jordi Boggiano
 
 ### wget
 License: GPL  
-https://metadata.ftp-master.debian.org/changelogs/main/w/wget/wget_1.18-5+deb9u2_copyright
+https://metadata.ftp-master.debian.org/changelogs/main/w/wget/wget_1.18-5+deb9u2_copyright  
 Copyright: (C) 2007 Free Software Foundation, Inc.
 
 ### gnupg
@@ -151,22 +151,22 @@ Apt is copyright 1997, 1998, 1999 Jason Gunthorpe and others.
 
 ### grunt-cli
 License: MIT  
-https://github.com/gruntjs/grunt-cli/blob/master/LICENSE-MIT
+https://github.com/gruntjs/grunt-cli/blob/master/LICENSE-MIT  
 Copyright (c) 2016 Tyler Kellen, contributors
 
 ### nodejs-npm
 License: Artistic License 2.0  
-https://www.npmjs.com/policies/npm-license
+https://www.npmjs.com/policies/npm-license  
 Copyright (c) 2000-2006, The Perl Foundation
 
 ### prestissimo (composer plugin)
 License: MIT  
-https://github.com/hirak/prestissimo/blob/master/LICENSE
+https://github.com/hirak/prestissimo/blob/master/LICENSE  
 Copyright (c) 2017 Hiraku NAKANO
 
 ### libicu-dev
 License: ICU License  
-https://metadata.ftp-master.debian.org/changelogs/main/i/icu/icu_57.1-6+deb9u2_copyright
+https://metadata.ftp-master.debian.org/changelogs/main/i/icu/icu_57.1-6+deb9u2_copyright  
 Copyright (c) 1995-2013 International Business Machines Corporation and others
 
 ### libpng-dev
@@ -177,8 +177,9 @@ Copyright: Copyright (c) 1998-2016 Glenn Randers-Pehrson
 ### libpq-dev
 Licens: PostgreSQL  
 https://metadata.ftp-master.debian.org/changelogs/main/p/postgresql-9.6/postgresql-9.6_9.6.10-0+deb9u1_copyright  
-Copyright: Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group,
-           Portions Copyright (c) 1994, The Regents of the University of California
+Copyright:
+Portions Copyright (c) 1996-2016, PostgreSQL Global Development Group,
+Portions Copyright (c) 1994, The Regents of the University of California
 
 ### libzip-dev
 License: GPL  
@@ -192,7 +193,7 @@ Copyright: 1992-1996, 1999-2001, 2003, 2005-2012 Free Software Foundation, Inc.
 
 ### pecl
 License: The PHP License  
-https://pecl.php.net/copyright.php
+https://pecl.php.net/copyright.php  
 Copyright © 2001-2018 The PHP Group. All rights reserved.
 
 ### postgresql-10 and postgresql-client-10
@@ -208,31 +209,31 @@ CSS libraries can be found primarily in the `ShopBundle/Resources/styles/*/libs/
 ### Magnific Popup Repository
 Library: `FrameworkBundle/Resources/scripts/common/plugins/jquery.magnific-popup.js`  
 License: MIT  
-https://github.com/dimsemenov/Magnific-Popup/blob/master/LICENSE
+https://github.com/dimsemenov/Magnific-Popup/blob/master/LICENSE  
 Copyright (c) 2014-2016 Dmitry Semenov, http://dimsemenov.com
 
 ### Bootstrap - front-end framework
 Library: `FrameworkBundle/Resources/scripts/common/bootstrap/`  
 License: MIT  
-https://github.com/twbs/bootstrap/blob/master/LICENSE
+https://github.com/twbs/bootstrap/blob/master/LICENSE  
 Copyright (c) 2011-2018 Twitter, Inc.
 
 ### Chart.js
 Library: `FrameworkBundle/Resources/scripts/admin/plugins/chart.bundle.min.js`  
 License: MIT  
-https://github.com/chartjs/Chart.js/blob/master/LICENSE.md
+https://github.com/chartjs/Chart.js/blob/master/LICENSE.md  
 Copyright (c) 2018 Chart.js Contributors
 
 ### BazingaJsTranslationBundle
 Library: `FrameworkBundle/Resources/scripts/common/plugins/BazingaJsTranslationBundle.translator.js`  
 License: MIT  
-https://github.com/willdurand/BazingaJsTranslationBundle/blob/master/LICENSE
+https://github.com/willdurand/BazingaJsTranslationBundle/blob/master/LICENSE  
 Copyright (c) William Durand <william.durand1@gmail.com>
 
 ### jQuery Ajax File Uploader Widget
 Library: `FrameworkBundle/Resources/scripts/admin/components/jquery.dmuploader.js`  
 License: MIT  
-https://github.com/danielm/uploader/blob/master/LICENSE.txt
+https://github.com/danielm/uploader/blob/master/LICENSE.txt  
 Copyright © Daniel Morales, https://www.danielmg.org
 
 ### jquery.fix.clone
@@ -243,36 +244,36 @@ https://github.com/spencertipping/jquery.fix.clone/blob/master/README
 ### jQuery MiniColors: A tiny color picker built on jQuery
 Library: `FrameworkBundle/Resources/scripts/admin/plugins/jquery.colorpicker.js`  
 License: MIT  
-https://github.com/claviska/jquery-minicolors/blob/master/LICENSE.md
+https://github.com/claviska/jquery-minicolors/blob/master/LICENSE.md  
 Copyright 2017 A Beautiful Site, LLC
 
 ### FastClick
 Library: `FrameworkBundle/Resources/scripts/common/plugins/fastclick.js`  
 License: MIT  
-https://github.com/ftlabs/fastclick/blob/master/LICENSE
+https://github.com/ftlabs/fastclick/blob/master/LICENSE  
 Copyright (c) 2014 The Financial Times Ltd.
 
 ### hoverIntent jQuery Plugin
 Library: `FrameworkBundle/Resources/scripts/admin/plugins/jquery.hoverIntent.js`  
 License: MIT  
-https://github.com/briancherne/jquery-hoverIntent/blob/master/jquery.hoverIntent.js
+https://github.com/briancherne/jquery-hoverIntent/blob/master/jquery.hoverIntent.js  
 Copyright 2007-2017 Brian Cherne
 
 ### nestedSortable jQuery Plugin
 Library: `FrameworkBundle/Resources/scripts/admin/plugins/jquery.mjs.nestedSortable.js`  
 License: MIT  
-https://github.com/ilikenwf/nestedSortable/blob/master/README.md
+https://github.com/ilikenwf/nestedSortable/blob/master/README.md  
 
 ### normalize.css
 Library: `ShopBundle/Resources/styles/front/common/core/reset.less`  
 License: MIT  
-https://github.com/necolas/normalize.css/blob/master/LICENSE.md
+https://github.com/necolas/normalize.css/blob/master/LICENSE.md  
 Copyright © Nicolas Gallagher and Jonathan Neal
 
 ### jQuery UI Touch Punch 0.2.3
 Library: `ShopBundle/Resources/scripts/frontend/plugins/jquery.ui.touch-punch.js`  
 License: MIT or GPL Version 2  
-https://github.com/furf/jquery-ui-touch-punch/blob/master/jquery.ui.touch-punch.js
+https://github.com/furf/jquery-ui-touch-punch/blob/master/jquery.ui.touch-punch.js  
 Copyright 2011–2014, Dave Furfero
 
 ### Modernizr
@@ -283,7 +284,7 @@ https://github.com/Modernizr/Modernizr/blob/master/LICENSE
 ### jquery.cookie
 Library: `ShopBundle/Resources/scripts/frontend/plugins/jquery.cookie.js`  
 License: MIT  
-https://github.com/carhartl/jquery-cookie/blob/master/MIT-LICENSE.txt
+https://github.com/carhartl/jquery-cookie/blob/master/MIT-LICENSE.txt  
 Copyright 2014 Klaus Hartl
 
 ## Libraries dynamically referenced via Composer


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/10008612/52463309-b8ea2a00-2b76-11e9-9520-b33d64a02e4f.png)

**After:**
![image](https://user-images.githubusercontent.com/10008612/52463303-b25bb280-2b76-11e9-922e-ba7fa12415a4.png)


| Q             | A
| ------------- | ---
|Description, reason for the PR| formatting of the 3rd party copyrights (#563) was broken due to missing line breaks
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
