### PR TITLE
[framework] now it is possible to set administration locale in parameters

### DIFF
--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -67,7 +67,8 @@ See how to install Shopsys Framework in production and how to proceed when deplo
 
 ## How to set up the administration with a different locale/language (e.g. Czech)?
 The administration uses `en` locale by default.
-If you want to switch it to the another locale, override the method `getAdminLocale()` of the class `Shopsys\FrameworkBundle\Model\Localization\Localization`.
+If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `parameters.yml` configuration.
+However, the selected locale has to be one of registered domains locale.
 This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
 
 ## What are the differences between "listable", "sellable", "offered" and "visible" products?

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -124,7 +124,8 @@ This means that if you are using a different locale, these multilang attributes 
 #### 3.6 Locale in administration
 Administration is by default in `en` locale.
 This means that for example product list in administration tries to display translations of product names in `en` locale.
-If you want to switch it to another locale, override the method `getAdminLocale()` of the class `Shopsys\FrameworkBundle\Model\Localization\Localization`.
+If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `parameters.yml` configuration to desired locale.
+However, the selected locale has to be one of registered domains locale.
 
 ### 4. Change the url address for an existing domain
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -157,6 +157,7 @@ for instance:
     - if you have extended `CountryGridFactory`, revise your changes because class changed its namespace
     - if you have extended `CountryFormType`, revise your changes – new fields are available
     - if you have extended `CountryController` revise your changes – `new` and `edit` actions were added
+- if you have extended `Localization` class, you have to add type-hints to extended methods because they were added in the parent class ([#806](https://github.com/shopsys/shopsys/pull/806))
 
 - if you have extended classes from `Shopsys\FrameworkBundle\Model`, `Shopsys\FrameworkBundle\Component` or `Shopsys\FrameworkBundle\DataFixtures\Demo` namespace ([#788](https://github.com/shopsys/shopsys/pull/788))
     - you need to adjust extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -158,6 +158,7 @@ for instance:
     - if you have extended `CountryFormType`, revise your changes – new fields are available
     - if you have extended `CountryController` revise your changes – `new` and `edit` actions were added
 - if you have extended `Localization` class, you have to add type-hints to extended methods because they were added in the parent class ([#806](https://github.com/shopsys/shopsys/pull/806))
+    - if you have extended method `Localization::getAdminLocale()` only to have administration in a different language than english, you can delete it and set parameter `shopsys.admin_locale` in your `parameters.yml` file instead
 
 - if you have extended classes from `Shopsys\FrameworkBundle\Model`, `Shopsys\FrameworkBundle\Component` or `Shopsys\FrameworkBundle\DataFixtures\Demo` namespace ([#788](https://github.com/shopsys/shopsys/pull/788))
     - you need to adjust extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`

--- a/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
+++ b/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Localization\Exception;
+
+use Exception;
+use RuntimeException;
+
+class AdminLocaleNotFoundException extends RuntimeException implements LocalizationException
+{
+    /**
+     * @param string $adminLocale
+     * @param string[] $possibleLocales
+     * @param \Exception|null $previous
+     */
+    public function __construct(string $adminLocale, array $possibleLocales, Exception $previous = null)
+    {
+        $message = sprintf(
+            'You tried to use administration in "%1$s" locale, but you have registered only ["%2$s"].'
+            . ' Either register "%1$s" as a locale with some domain or use one of ["%2$s"] as administration locale.',
+            $adminLocale,
+            implode('","', $possibleLocales)
+        );
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Localization;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -38,7 +40,7 @@ class Localization
     protected $domain;
 
     /**
-     * @var array
+     * @var string[]|null
      */
     protected $allLocales;
 
@@ -53,7 +55,7 @@ class Localization
     /**
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->domain->getLocale();
     }
@@ -61,15 +63,15 @@ class Localization
     /**
      * @return string
      */
-    public function getAdminLocale()
+    public function getAdminLocale(): string
     {
         return 'en';
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getLocalesOfAllDomains()
+    public function getLocalesOfAllDomains(): array
     {
         if ($this->allLocales === null) {
             $this->allLocales = [];
@@ -84,7 +86,7 @@ class Localization
     /**
      * @return string[]
      */
-    public function getAllDefinedCollations()
+    public function getAllDefinedCollations(): array
     {
         return $this->collationsByLocale;
     }
@@ -93,7 +95,7 @@ class Localization
      * @param string $locale
      * @return string
      */
-    public function getLanguageName($locale)
+    public function getLanguageName(string $locale): string
     {
         if (!array_key_exists($locale, $this->languageNamesByLocale)) {
             throw new \Shopsys\FrameworkBundle\Model\Localization\Exception\InvalidLocaleException(
@@ -108,7 +110,7 @@ class Localization
      * @param string $locale
      * @return string
      */
-    public function getCollationByLocale($locale)
+    public function getCollationByLocale(string $locale): string
     {
         if (array_key_exists($locale, $this->collationsByLocale)) {
             return $this->collationsByLocale[$locale];

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Localization;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
 
 class Localization
 {
@@ -45,11 +46,18 @@ class Localization
     protected $allLocales;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @var string
      */
-    public function __construct(Domain $domain)
+    protected $adminLocale;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param string $adminLocale
+     */
+    public function __construct(Domain $domain, string $adminLocale)
     {
         $this->domain = $domain;
+        $this->adminLocale = $adminLocale;
     }
 
     /**
@@ -65,7 +73,13 @@ class Localization
      */
     public function getAdminLocale(): string
     {
-        return 'en';
+        $allLocales = $this->getLocalesOfAllDomains();
+
+        if (!in_array($this->adminLocale, $allLocales, true)) {
+            throw new AdminLocaleNotFoundException($this->adminLocale, $allLocales);
+        }
+
+        return $this->adminLocale;
     }
 
     /**
@@ -76,7 +90,9 @@ class Localization
         if ($this->allLocales === null) {
             $this->allLocales = [];
             foreach ($this->domain->getAll() as $domainConfig) {
-                $this->allLocales[$domainConfig->getLocale()] = $domainConfig->getLocale();
+                $domainLocale = $domainConfig->getLocale();
+
+                $this->allLocales[$domainLocale] = $domainLocale;
             }
         }
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -7,6 +7,7 @@ parameters:
     prezent_doctrine_translatable.listener.class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
     faker.seed: 1234
     shopsys.entity_extension.map: {}
+    shopsys.admin_locale: en
 
 services:
     _defaults:
@@ -481,7 +482,9 @@ services:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }
 
-    Shopsys\FrameworkBundle\Model\Localization\Localization: ~
+    Shopsys\FrameworkBundle\Model\Localization\Localization:
+        arguments:
+            $adminLocale: '%shopsys.admin_locale%'
 
     Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatter:
         factory: ['@Shopsys\FrameworkBundle\Model\Localization\CustomDateTimeFormatterFactory', create]

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -167,8 +167,6 @@ services:
 
     Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Localization\Localization: ~
-
     Shopsys\FrameworkBundle\Model\Product\ProductSearchExport\ProductSearchExportRepository: ~
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Administration locale was possible to change only by inherit Localization class and override method getAdminLocale(). That is too many steps for such an easy change. So now the developer can set parameter `shopsys.admin_locale` to the desired locale. If selected locale is not one of domains registered locales, an exception is thrown because in that case application behaved funny.
|New feature| Yes <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #589 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
