### PR TITLE
[project-base] Reload page after promocode is set

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -137,7 +137,7 @@ for instance:
     - remove all npm packages by removing folder `project-base/node_modules` and `project-base/package-lock.json`
     - run command `php phing npm`
     - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint. 
-        - there could be error about `no-self-assign` for `document.location` in `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js` and it could be solved by replacing `document.location = document.location` with `windows.location.reload()` ([#809](https://github.com/shopsys/shopsys/pull/809))
+        - there could be error about `no-self-assign` for `document.location` in `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js` and it could be solved by replacing `document.location = document.location` with `document.location.reload()` ([#809](https://github.com/shopsys/shopsys/pull/809))
 - unify countries across domains with translations and domain dependency ([#762](https://github.com/shopsys/shopsys/pull/762))
     - fix new entity `Country` creation (either using factory or directly) as it changed its constructor and `CountryFactory::create` method signature (removed argument `domainId`)
         - do not forget to fix `PersonalDataExportXmlTest`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -136,7 +136,7 @@ for instance:
 - *(optional)* upgrade npm packages to the latest version ([#755](https://github.com/shopsys/shopsys/pull/755))
     - remove all npm packages by removing folder `project-base/node_modules` and `project-base/package-lock.json`
     - run command `php phing npm`
-    - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint.
+    - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint. There could be error about `no-self-assign` for `window.location` in `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js` and it could be solved by replacing `window.location = window.location` into `windows.location.reload()` ([#809](https://github.com/shopsys/shopsys/pull/809))
 - unify countries across domains with translations and domain dependency ([#762](https://github.com/shopsys/shopsys/pull/762))
     - fix new entity `Country` creation (either using factory or directly) as it changed its constructor and `CountryFactory::create` method signature (removed argument `domainId`)
         - do not forget to fix `PersonalDataExportXmlTest`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -136,7 +136,8 @@ for instance:
 - *(optional)* upgrade npm packages to the latest version ([#755](https://github.com/shopsys/shopsys/pull/755))
     - remove all npm packages by removing folder `project-base/node_modules` and `project-base/package-lock.json`
     - run command `php phing npm`
-    - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint. There could be error about `no-self-assign` for `window.location` in `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js` and it could be solved by replacing `window.location = window.location` into `windows.location.reload()` ([#809](https://github.com/shopsys/shopsys/pull/809))
+    - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint. 
+        - there could be error about `no-self-assign` for `document.location` in `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js` and it could be solved by replacing `document.location = document.location` with `windows.location.reload()` ([#809](https://github.com/shopsys/shopsys/pull/809))
 - unify countries across domains with translations and domain dependency ([#762](https://github.com/shopsys/shopsys/pull/762))
     - fix new entity `Country` creation (either using factory or directly) as it changed its constructor and `CountryFactory::create` method signature (removed argument `domainId`)
         - do not forget to fix `PersonalDataExportXmlTest`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -136,7 +136,7 @@ for instance:
 - *(optional)* upgrade npm packages to the latest version ([#755](https://github.com/shopsys/shopsys/pull/755))
     - remove all npm packages by removing folder `project-base/node_modules` and `project-base/package-lock.json`
     - run command `php phing npm`
-    - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint. 
+    - in order to pass standards tests you also need to run `php phing eslint-fix` to let ESlint npm package update your JavaScript files. After that your syntax should be updated to latest JavaScript standards checked by ESLint.
         - there could be error about `no-self-assign` for `document.location` in `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js` and it could be solved by replacing `document.location = document.location` with `document.location.reload()` ([#809](https://github.com/shopsys/shopsys/pull/809))
 - unify countries across domains with translations and domain dependency ([#762](https://github.com/shopsys/shopsys/pull/762))
     - fix new entity `Country` creation (either using factory or directly) as it changed its constructor and `CountryFactory::create` method signature (removed argument `domainId`)

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js
@@ -39,7 +39,7 @@
 
         var onApplyPromoCode = function (response) {
             if (response.result === true) {
-                window.location.reload();
+                document.location.reload();
             } else {
                 Shopsys.window({
                     content: response.message

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js
@@ -38,7 +38,9 @@
         };
 
         var onApplyPromoCode = function (response) {
-            if (response.result !== true) {
+            if (response.result === true) {
+                window.location.reload();
+            } else {
                 Shopsys.window({
                     content: response.message
                 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Implemented reload function after the promo code is set as a fix of npm upgrade implementation in #755 
|New feature| No
|BC breaks| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
