### PR TITLE
[coding-standards] fix whitespace before method argument

### DIFF
--- a/packages/coding-standards/src/CsFixer/OrmJoinColumnRequireNullableFixer.php
+++ b/packages/coding-standards/src/CsFixer/OrmJoinColumnRequireNullableFixer.php
@@ -25,7 +25,7 @@ final class OrmJoinColumnRequireNullableFixer implements FixerInterface, Defined
         return new FixerDefinition(
             'Annotations @ORM\ManyToOne and @ORM\OneToOne must have defined nullable option in @ORM\JoinColumn',
             [new CodeSample(
-<<<'SAMPLE'
+                <<<'SAMPLE'
 /**
  * @var \StdObject
  * @ORM\ManyToOne(targetEntity="StdObject")
@@ -33,7 +33,7 @@ final class OrmJoinColumnRequireNullableFixer implements FixerInterface, Defined
 private $foo;
 SAMPLE
             ), new CodeSample(
-<<<'SAMPLE'
+                <<<'SAMPLE'
 /**
  * @var \StdObject
  * @ORM\OneToOne(targetEntity="StdObject")


### PR DESCRIPTION
- according to our Coding Standards (change done via `./phing standards-fix`)
- the violation started to trigger an error after upgrade of "friendsofphp/php-cs-fixer" from 2.14.0 to 2.14.1
- only the closing identifier of heredoc syntax must be on the beginning of a line (see [heredoc docs](http://php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc))

| Q             | A
| ------------- | ---
|Description, reason for the PR| CS check of coding-standards repository failed
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
