### PR TITLE
[project-base] warm up production cache before generating error pages

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -190,8 +190,22 @@ for instance:
     - `ProductSearchExportRepositoryTest` move from `Tests\ShopBundle\Functional\Model\Product\ProductSearchExport` to `Tests\ShopBundle\Functional\Model\Product\Search`
     - in production you will need to run `product-search-recreate-structure` Phing target while next build to create indexes again with new name
         - after that remove previous indexes used for Product search, so they do not consume any memory ([link to Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html))
-- force generating of error pages in production environment ([#816](https://github.com/shopsys/shopsys/pull/816))
-    - update your phing target `error-pages-generate` in `build.xml` to include `<arg value="--env=prod" />`
+- warm up the production cache before generating error pages ([#816](https://github.com/shopsys/shopsys/pull/816))
+    - in `build.xml`, create a new phing target `prod-warmup`:
+    ```xml
+    <target name="prod-warmup" description="Warms up cache for production environment.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="cache:warmup" />
+            <arg value="--env=prod" />
+        </exec>
+    </target>
+    ```
+    - add a dependency on this target to `error-pages-generate`:
+    ```diff
+    - <target name="error-pages-generate" description="...">
+    + <target name="error-pages-generate" depends="prod-warmup" description="...">
+    ```
 
 ## [shopsys/product-feed-heureka]
 - if you have extended class HeurekaCategoryDownloader or HeurekaCategoryCronModule ([#788](https://github.com/shopsys/shopsys/pull/788))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -190,6 +190,8 @@ for instance:
     - `ProductSearchExportRepositoryTest` move from `Tests\ShopBundle\Functional\Model\Product\ProductSearchExport` to `Tests\ShopBundle\Functional\Model\Product\Search`
     - in production you will need to run `product-search-recreate-structure` Phing target while next build to create indexes again with new name
         - after that remove previous indexes used for Product search, so they do not consume any memory ([link to Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html))
+- force generating of error pages in production environment ([#816](https://github.com/shopsys/shopsys/pull/816))
+    - update your phing target `error-pages-generate` in `build.xml` to include `<arg value="--env=prod" />`
 
 ## [shopsys/product-feed-heureka]
 - if you have extended class HeurekaCategoryDownloader or HeurekaCategoryCronModule ([#788](https://github.com/shopsys/shopsys/pull/788))

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -256,6 +256,7 @@
     <target name="error-pages-generate" description="Generates error pages displayed in production environment.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
+            <arg value="--env=prod" />
             <arg value="shopsys:error-page:generate-all" />
         </exec>
     </target>

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -253,10 +253,9 @@
         </exec>
     </target>
 
-    <target name="error-pages-generate" description="Generates error pages displayed in production environment.">
+    <target name="error-pages-generate" depends="prod-warmup" description="Generates error pages displayed in production environment.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
-            <arg value="--env=prod" />
             <arg value="shopsys:error-page:generate-all" />
         </exec>
     </target>
@@ -334,6 +333,14 @@
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
             <arg value="cache:warmup" />
+        </exec>
+    </target>
+
+    <target name="prod-warmup" description="Warms up cache for production environment.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="cache:warmup" />
+            <arg value="--env=prod" />
         </exec>
     </target>
 


### PR DESCRIPTION
- The `ErrorPagesFacade::generateAllErrorPagesForProduction()` method uses production DIC for generating the pages.
- After #788 was merged, generating the cache for production consumes more memory (because protected and public methods of services are inspected using reflection).
- When the production cache was not generated, `./phing error-pages-generate` started to fail on memory usage.
- Phing targets with specified environment are prefixed with the environemnt (see `test-*` targets), that's why the new target is named `prod-warmup`.

| Q             | A
| ------------- | ---
|Description, reason for the PR| Execution of `./phing error-pages-generate` fails on memory limit.
|New feature| No <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes