### PR TITLE
[framework] now it is possible to run multiple cron commands

### DIFF
--- a/docs/cookbook/working-with-multiple-cron-instances.md
+++ b/docs/cookbook/working-with-multiple-cron-instances.md
@@ -66,7 +66,7 @@ And because we have several cron instances registered, job asks what cron instan
 
 # Running cron jobs automatically
 To be able to run cron instances automatically, we first have to create new Phing targets in `build.xml` configuration file.
-These targets have to be able to run without asking any interactive questions (`--instance-name` argument do the trick).
+These targets have to be able to run without asking any interactive questions (`--instance-name` argument does the trick).
 
 New targets would look like
 

--- a/docs/cookbook/working-with-multiple-cron-instances.md
+++ b/docs/cookbook/working-with-multiple-cron-instances.md
@@ -1,0 +1,95 @@
+# Working with Multiple Cron Instances
+This cookbook will help you to set up independent processing of [cron jobs](/docs/introduction/cron.md).
+We learn, how to work with multiple cron instances, how to register a new instance for modules and how to run them.
+
+Let's presume, we want to run import of products, created for [Basic Data Import](./basic-data-import.md).
+But this import takes some time and we do not want to block processing of the other cron modules.
+
+## Configuration
+When you register cron job in your configuration with tags mandatory for cron module, you can add the optional tag `instanceName`,
+effectively creating a new instance of cron just by tagging the service.  
+You do not have to register the instance anywhere else.
+
+We just edit earlier created configuration to place our `ImportProductsCronModule` to different cron instance.
+```diff
+# src/Shopsys/ShopBundle/Resources/config/cron.yml
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Shopsys\ShopBundle\Model\Product\ImportProductsCronModule:
+        class: Shopsys\ShopBundle\Model\Product\ImportProductsCronModule
+        tags:
+-            - { name: shopsys.cron, hours: '*/3', minutes: '0' }
++            - { name: shopsys.cron, hours: '*/3', minutes: '0', instanceName: products}
+```
+
+*Note: If you do not set `instanceName`, a job will be placed into cron instance named `default`.*
+
+## Listing available modules
+Now by running `php phing cron-list` in a console, we can see a list of all available cron modules, grouped into cron instances.
+`ImportProductsCronModule` is properly placed into cron instance named "products".
+
+```
+products
+--------
+
+ php bin/console shopsys:cron --module="Shopsys\ShopBundle\Model\Product\ImportProductsCronModule" --instance-name=products
+
+default
+-------
+
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Component\Error\ErrorPageCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Cart\Item\DeleteOldCartsCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Feed\DailyFeedCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Feed\HourlyFeedCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Product\ProductVisibilityImmediateCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Product\ProductVisibilityMidnightCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Model\Sitemap\SitemapCronModule" --instance-name=default
+ php bin/console shopsys:cron --module="Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryCronModule" --instance-name=default
+```
+
+# Running cron jobs manually
+We now can run any cron jobs manually by running `php phing cron`.
+And because we have several cron instances registered, job asks what cron instance should be run.
+
+*Note: If only one instance is registered, no question is asked and this instance will run immediately.*
+
+# Running cron jobs automatically
+To be able to run cron instances automatically, we first have to create new Phing targets.
+These targets have to be able to run without asking any interactive questions (`--instance-name` argument do the trick).
+
+New targets would look like
+
+```xml
+<target name="cron-default" description="Runs default background jobs. Should be executed periodically by system Cron every 5 minutes.">
+    <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+        <arg value="${path.bin-console}" />
+        <arg value="shopsys:cron" />
+        <arg value="--instance-name=default" />
+    </exec>
+</target>
+
+<target name="cron-products" description="Runs background jobs for import of products. Should be executed periodically by system Cron every 5 minutes.">
+    <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+        <arg value="${path.bin-console}" />
+        <arg value="shopsys:cron" />
+        <arg value="--instance-name=products" />
+    </exec>
+</target>
+```
+
+and these targets only have to be registered in system crontab.
+
+*Note: Do not delete default `cron` target. It may come in handy.*
+
+## Pitfalls
+- If you tag cron module with another instance without changes in Phing targets, your jobs will not be executed automatically, because command will hold on instance choice question.
+- You can easily set your system to run too much cron jobs at once, resulting in server response time slowdown.

--- a/docs/cookbook/working-with-multiple-cron-instances.md
+++ b/docs/cookbook/working-with-multiple-cron-instances.md
@@ -1,9 +1,9 @@
 # Working with Multiple Cron Instances
 This cookbook will help you to set up independent processing of [cron jobs](/docs/introduction/cron.md).
-We learn, how to work with multiple cron instances, how to register a new instance for modules and how to run them.
+We will learn, how to work with multiple cron instances, how to register a new instance for modules and how to run them.
 
 Let's presume, we want to run import of products, created for [Basic Data Import](./basic-data-import.md).
-But this import takes some time and we do not want to block processing of the other cron modules.
+But this import might take some time and we do not want to block processing of the other cron modules.
 
 ## Configuration
 When you register cron job in your configuration with tags mandatory for cron module, you can add the optional tag `instanceName`,
@@ -56,6 +56,8 @@ default
  php bin/console shopsys:cron --module="Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryCronModule" --instance-name=default
 ```
 
+*Note: More information about what Phing targets are and how they work can be found in [Console Commands for Application Management (Phing Targets)](/docs/introduction/console-commands-for-application-management-phing-targets.md)*
+
 # Running cron jobs manually
 We now can run any cron jobs manually by running `php phing cron`.
 And because we have several cron instances registered, job asks what cron instance should be run.
@@ -63,7 +65,7 @@ And because we have several cron instances registered, job asks what cron instan
 *Note: If only one instance is registered, no question is asked and this instance will run immediately.*
 
 # Running cron jobs automatically
-To be able to run cron instances automatically, we first have to create new Phing targets.
+To be able to run cron instances automatically, we first have to create new Phing targets in `build.xml` configuration file.
 These targets have to be able to run without asking any interactive questions (`--instance-name` argument do the trick).
 
 New targets would look like

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,11 @@
 * [How to Work with Products](./introduction/how-to-work-with-products.md)
 * [Translations](./introduction/translations.md)
 * [Directories](./introduction/directories.md)
+<!--- TODO
+Add:
+
+* [Cron](./introduction/cron.md)
+-->
 
 ## Cookbook
 * [Dumping and Importing the Database](./cookbook/dumping-and-importing-the-database.md)
@@ -40,6 +45,11 @@
 * [Adding Ajax Load More Button into Pagination](./cookbook/adding-ajax-load-more-button-into-pagination.md)
 * [Implementing a basic data import](./cookbook/basic-data-import.md)
 * [Creating a Multidomain Design](./cookbook/creating-a-multidomain-design.md)
+<!--- TODO
+Add:
+
+* [Working with Multiple Cron Instances](./cookbook/working-with-multiple-cron-instances.md)
+-->
 
 ## Functional documentation
 * [Behavior of Product Variants](./functional/behavior-of-product-variants.md)

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -166,8 +166,33 @@ Runs background jobs. Should be executed periodically by system Cron every 5 min
 
 Essential for the production environment. Periodically executed Cron modules recalculate visibility, generate XML feeds and sitemaps, provide error reporting etc.
 
+If you want to have more cron instances registered, you need to create new targets with instance specified.  
+For example:
+```xml
+<target name="cron-default" description="Runs background jobs. Should be executed periodically by system Cron every 5 minutes.">
+    <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+        <arg value="${path.bin-console}" />
+        <arg value="shopsys:cron" />
+        <arg value="--instance-name=default" />
+    </exec>
+</target>
+
+<target name="cron-import" description="Runs background jobs for import. Should be executed periodically by system Cron every 5 minutes.">
+    <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+        <arg value="${path.bin-console}" />
+        <arg value="shopsys:cron" />
+        <arg value="--instance-name=import" />
+    </exec>
+</target>
+```
+
+You can read more about cron instances in [the separate article](/docs/introduction/multiple-cron.md).
+
 #### cron-list
 Lists all available background jobs.
+
+If there is more than one cron instance registered, jobs are grouped by instance.
+You can read more about cron instances in [the separate article](/docs/introduction/multiple-cron.md).
 
 #### grunt
 Builds CSS from LESS via Grunt.

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -186,13 +186,12 @@ For example:
 </target>
 ```
 
-You can read more about cron instances in [the separate article](/docs/introduction/multiple-cron.md).
+For more information, see [Working with Multiple Cron Instances](/docs/cookbook/working-with-multiple-cron-instances.md) cookbook or you can read about [Cron in general](/docs/introduction/cron.md).
 
 #### cron-list
-Lists all available background jobs.
+Lists all available background jobs. If there is more than one cron instance registered, jobs are grouped by instance.
 
-If there is more than one cron instance registered, jobs are grouped by instance.
-You can read more about cron instances in [the separate article](/docs/introduction/multiple-cron.md).
+For more information, see [Working with Multiple Cron Instances](/docs/cookbook/working-with-multiple-cron-instances.md) cookbook or you can read about [Cron in general](/docs/introduction/cron.md).
 
 #### grunt
 Builds CSS from LESS via Grunt.

--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -1,0 +1,20 @@
+# Cron
+
+## Basics
+Cron is a tool to run background jobs and is essential for the production environment.
+Periodically executed Cron modules recalculate visibility, generate XML feeds and sitemaps, provide error reporting etc.
+
+## Default Cron Commands
+There is some prepared configuration for Shopsys Framework in a file `src/Resources/config/services/cron.yml` in `FrameworkBundle`.
+
+## Running Cron Jobs
+Do not forget to set up a cron on your server to execute [`php phing cron`](/docs/introduction/console-commands-for-application-management-phing-targets.md#cron) every 5 minutes.
+
+## Multiple Cron Instances
+By default, all cron jobs are run as part of one, default, instance.
+However, you may want to have several instances to be able to run, for example, lots of transfers from/into ERP systems and these transfers could block other cron processes.
+Separating the cron jobs into two (or more) cron instances allows you to run some jobs in parallel.
+
+The instance of cron is actually a named group of cron jobs.
+
+You can learn how to set up multiple cron instances in [Working with Multiple Cron Instances](/docs/cookbook/working-with-multiple-cron-instances.md) cookbook.

--- a/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
@@ -6,6 +6,8 @@ use Shopsys\FrameworkBundle\Component\Cron\CronTimeInterface;
 
 class CronModuleConfig implements CronTimeInterface
 {
+    public const DEFAULT_INSTANCE_NAME = 'default';
+
     /**
      * @var \Shopsys\Plugin\Cron\SimpleCronModuleInterface
      */
@@ -27,6 +29,11 @@ class CronModuleConfig implements CronTimeInterface
     protected $timeHours;
 
     /**
+     * @var string
+     */
+    protected $instanceName;
+
+    /**
      * @param \Shopsys\Plugin\Cron\SimpleCronModuleInterface|\Shopsys\Plugin\Cron\IteratedCronModuleInterface $service
      * @param string $serviceId
      * @param string $timeHours
@@ -38,6 +45,7 @@ class CronModuleConfig implements CronTimeInterface
         $this->serviceId = $serviceId;
         $this->timeHours = $timeHours;
         $this->timeMinutes = $timeMinutes;
+        $this->assignToInstance(self::DEFAULT_INSTANCE_NAME);
     }
 
     /**
@@ -70,5 +78,21 @@ class CronModuleConfig implements CronTimeInterface
     public function getTimeHours()
     {
         return $this->timeHours;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInstanceName(): string
+    {
+        return $this->instanceName;
+    }
+
+    /**
+     * @param string $instanceName
+     */
+    public function assignToInstance(string $instanceName): void
+    {
+        $this->instanceName = $instanceName;
     }
 }

--- a/packages/framework/src/Component/Cron/MutexFactory.php
+++ b/packages/framework/src/Component/Cron/MutexFactory.php
@@ -30,13 +30,32 @@ class MutexFactory
 
     /**
      * @return \NinjaMutex\Mutex
+     * @deprecated Use `getPrefixedCronMutex` instead
      */
     public function getCronMutex()
     {
-        if (!array_key_exists(self::MUTEX_CRON_NAME, $this->mutexesByName)) {
-            $this->mutexesByName[self::MUTEX_CRON_NAME] = new Mutex(self::MUTEX_CRON_NAME, $this->lock);
+        return $this->getMutexByName(self::MUTEX_CRON_NAME);
+    }
+
+    /**
+     * @param string $prefix
+     * @return \NinjaMutex\Mutex
+     */
+    public function getPrefixedCronMutex(string $prefix): Mutex
+    {
+        return $this->getMutexByName($prefix . '-' . self::MUTEX_CRON_NAME);
+    }
+
+    /**
+     * @param string $mutexName
+     * @return \NinjaMutex\Mutex
+     */
+    protected function getMutexByName(string $mutexName): Mutex
+    {
+        if (!array_key_exists($mutexName, $this->mutexesByName)) {
+            $this->mutexesByName[$mutexName] = new Mutex($mutexName, $this->lock);
         }
 
-        return $this->mutexesByName[self::MUTEX_CRON_NAME];
+        return $this->mutexesByName[$mutexName];
     }
 }

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
 
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
+use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -20,12 +21,13 @@ class RegisterCronModulesCompilerPass implements CompilerPassInterface
         foreach ($taggedServiceIds as $serviceId => $tags) {
             foreach ($tags as $tag) {
                 $cronConfigDefinition->addMethodCall(
-                    'registerCronModule',
+                    'registerCronModuleInstance',
                     [
                         new Reference($serviceId),
                         $serviceId,
                         $tag['hours'],
                         $tag['minutes'],
+                        $tag['instanceName'] ?? CronModuleConfig::DEFAULT_INSTANCE_NAME,
                     ]
                 );
             }

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -102,7 +102,7 @@ class CronFacadeTest extends TestCase
             });
         $this->expectMethodCallWithCronModuleConfig($cronModuleFacadeMock, 'unscheduleModule', $scheduledServiceId);
 
-        $this->createCronFacade($cronConfig, $cronModuleFacadeMock)->runScheduledModules();
+        $this->createCronFacade($cronConfig, $cronModuleFacadeMock)->runScheduledModulesForInstance(CronModuleConfig::DEFAULT_INSTANCE_NAME);
     }
 
     /**
@@ -148,7 +148,7 @@ class CronFacadeTest extends TestCase
         $cronTimeResolver = $cronTimeResolverMock !== null ? $cronTimeResolverMock : new CronTimeResolver();
         $cronConfig = new CronConfig($cronTimeResolver);
         foreach ($servicesIndexedById as $serviceId => $service) {
-            $cronConfig->registerCronModule($service, $serviceId, '*', '*');
+            $cronConfig->registerCronModuleInstance($service, $serviceId, '*', '*', CronModuleConfig::DEFAULT_INSTANCE_NAME);
         }
 
         return $cronConfig;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Cron services now can be tagged with `instanceName` tag and then a cron command runner can run only cron with specific instanceName. This is a way how to run, for example, lots of transfers from/into ERP systems and do not block other quicker cron jobs from running.
|New feature| Yes <!-- Do not forget to update docs/ -->
|BC breaks| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #356 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes