### PR TITLE
[shopsys] added warnings about version to installation guides

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -1,5 +1,7 @@
 # Installation Using Docker for Linux
 
+**This guide is for the version which is not released yet. See the [version for `v7.0.0-beta5`](https://github.com/shopsys/shopsys/blob/v7.0.0-beta5/docs/installation/installation-using-docker-linux.md).**
+
 This guide covers building new projects based on Shopsys Framework.
 If you want to contribute to the framework itself,
 you need to install the whole [shopsys/shopsys](https://github.com/shopsys/shopsys) monorepo.

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -1,5 +1,7 @@
 # Installation Using Docker for MacOS
 
+**This guide is for the version which is not released yet. See the [version for `v7.0.0-beta5`](https://github.com/shopsys/shopsys/blob/v7.0.0-beta5/docs/installation/installation-using-docker-macos.md).**
+
 This guide covers building new projects based on Shopsys Framework.
 If you want to contribute to the framework itself,
 you need to install the whole [shopsys/shopsys](https://github.com/shopsys/shopsys) monorepo.

--- a/docs/installation/installation-using-docker-on-production-server.md
+++ b/docs/installation/installation-using-docker-on-production-server.md
@@ -1,5 +1,7 @@
 # Installation Using Docker on Production Server
 
+**This guide is for the version which is not released yet. See the [version for `v7.0.0-beta5`](https://github.com/shopsys/shopsys/blob/v7.0.0-beta5/docs/installation/installation-using-docker-on-production-server.md).**
+
 This guide shows you how to install and configure production server applications needed for your project based on [Shopsys Framework](https://github.com/shopsys/project-base).  
 We do not want to setup each application manually and we want to have separate runtime for each one.
 We use docker containers, built from docker images and php source code from git repository to have everything setup correctly and fast.

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -1,5 +1,7 @@
 # Installation Using Docker for Windows 10 Pro and higher
 
+**This guide is for the version which is not released yet. See the [version for `v7.0.0-beta5`](https://github.com/shopsys/shopsys/blob/v7.0.0-beta5/docs/installation/installation-using-docker-windows-10-pro-higher.md).**
+
 **Expected installation time:** 3 hours.
 
 This guide covers building new projects based on Shopsys Framework.

--- a/utils/releaser/src/FileManipulator/InstallationGuideFileManipulator.php
+++ b/utils/releaser/src/FileManipulator/InstallationGuideFileManipulator.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Shopsys\Releaser\FileManipulator;
+
+use Nette\Utils\Strings;
+use PharIo\Version\Version;
+use Symfony\Component\Finder\SplFileInfo;
+
+class InstallationGuideFileManipulator
+{
+    /**
+     * @var string
+     */
+    private const UNRELEASED_NOTE_REGEX = '#^\*{2}This guide is for the version which is not released yet\. See the \[version for `(.*)`\]\(https:\/\/github\.com\/shopsys\/shopsys\/blob\/(.*)\/docs\/installation\/.*\.md\)\.\*{2}$#m';
+
+    /**
+     * @var string
+     */
+    private const UNRELEASED_NOTE_FORMAT = '**This guide is for the version which is not released yet. See the [version for `%s`](https://github.com/shopsys/shopsys/blob/%s/docs/installation/%s).**';
+
+    /**
+     * @var string
+     */
+    private const RELEASED_VERSION_NOTE_REGEX = '#^\*\*This guide is for version `.*`\. Switch to another tag to see other versions.\*\*$#m';
+
+    /**
+     * @var string
+     */
+    private const RELEASED_VERSION_NOTE_FORMAT = '**This guide is for version `%s`. Switch to another tag to see other versions.**';
+
+    /**
+     * From:
+     * **This guide is for version `v7.0.0-beta5`. Switch to another tag to see other versions.**
+     *
+     * To:
+     * **This guide is for the version which is not released yet. See the [version for `v7.0.0-beta5`](https://github.com/shopsys/shopsys/blob/v7.0.0-beta5/docs/installation/installation-using-docker-linux.md).**
+     *
+     * @param \Symfony\Component\Finder\SplFileInfo $splFileInfo
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function setUnreleasedNote(SplFileInfo $splFileInfo, Version $version)
+    {
+        $newUnreleasedNote = sprintf(
+            self::UNRELEASED_NOTE_FORMAT,
+            $version->getVersionString(),
+            $version->getVersionString(),
+            $splFileInfo->getFilename()
+        );
+
+        return Strings::replace(
+            $splFileInfo->getContents(),
+            self::RELEASED_VERSION_NOTE_REGEX,
+            $newUnreleasedNote
+        );
+    }
+
+    /**
+     * From:
+     * **This guide is for the version which is not released yet. See the [version for `v7.0.0-beta4`](https://github.com/shopsys/shopsys/blob/v7.0.0-beta4/docs/installation/installation-using-docker-linux.md).**
+     *
+     * To:
+     * **This guide is for version `v7.0.0-beta5`. Switch to another tag to see other versions.**
+     *
+     * @param \Symfony\Component\Finder\SplFileInfo $splFileInfo
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function setReleasedVersionNote(SplFileInfo $splFileInfo, Version $version)
+    {
+        return Strings::replace(
+            $splFileInfo->getContents(),
+            self::UNRELEASED_NOTE_REGEX,
+            sprintf(self::RELEASED_VERSION_NOTE_FORMAT, $version->getVersionString())
+        );
+    }
+}

--- a/utils/releaser/src/FilesProvider/InstallationGuideFilesProvider.php
+++ b/utils/releaser/src/FilesProvider/InstallationGuideFilesProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\FilesProvider;
+
+use Symfony\Component\Finder\Finder;
+
+final class InstallationGuideFilesProvider
+{
+    /**
+     * @return \Symfony\Component\Finder\SplFileInfo[]
+     */
+    public function provide(): array
+    {
+        $finder = Finder::create()->files()
+            ->name('installation-using*.md')
+            ->in(getcwd() . '/docs/installation');
+
+        return iterator_to_array($finder->getIterator());
+    }
+}

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/SetUnreleasedNoteInInstallationGuidesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/SetUnreleasedNoteInInstallationGuidesReleaseWorker.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\AfterRelease;
+
+use Nette\Utils\FileSystem;
+use PharIo\Version\Version;
+use Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator;
+use Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+use Symplify\MonorepoBuilder\Release\Message;
+
+final class SetUnreleasedNoteInInstallationGuidesReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @var \Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator
+     */
+    protected $installationGuideFileManipulator;
+
+    /**
+     * @var \Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider
+     */
+    private $installationGuideFilesProvider;
+
+    /**
+     * @param \Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator $installationGuideFileManipulator
+     * @param \Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider $installationGuideFilesProvider
+     */
+    public function __construct(
+        InstallationGuideFileManipulator $installationGuideFileManipulator,
+        InstallationGuideFilesProvider $installationGuideFilesProvider
+    ) {
+        $this->installationGuideFileManipulator = $installationGuideFileManipulator;
+        $this->installationGuideFilesProvider = $installationGuideFilesProvider;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return 'Set unreleased notes in installation guides for Docker on Linux, Mac, and Windows';
+    }
+
+    /**
+     * Higher first
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 150;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $this->symfonyStyle->note('Setting note about the unreleased version in installation guides.');
+        $fileInfos = $this->installationGuideFilesProvider->provide();
+        foreach ($fileInfos as $fileInfo) {
+            $newContent = $this->installationGuideFileManipulator->setUnreleasedNote($fileInfo, $version);
+            FileSystem::write($fileInfo->getPathname(), $newContent);
+        }
+        $this->commit('docker installation guides: updated note about the unreleased version');
+        $this->symfonyStyle->success(Message::SUCCESS);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::AFTER_RELEASE;
+    }
+}

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetReleasedVersionNoteInInstallationGuidesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetReleasedVersionNoteInInstallationGuidesReleaseWorker.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
+
+use Nette\Utils\FileSystem;
+use PharIo\Version\Version;
+use Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator;
+use Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+use Symplify\MonorepoBuilder\Release\Message;
+
+final class SetReleasedVersionNoteInInstallationGuidesReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @var \Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator
+     */
+    protected $installationGuideFileManipulator;
+
+    /**
+     * @var \Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider
+     */
+    private $installationGuideFilesProvider;
+
+    /**
+     * @param \Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator $installationGuideFileManipulator
+     * @param \Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider $installationGuideFilesProvider
+     */
+    public function __construct(
+        InstallationGuideFileManipulator $installationGuideFileManipulator,
+        InstallationGuideFilesProvider $installationGuideFilesProvider
+    ) {
+        $this->installationGuideFileManipulator = $installationGuideFileManipulator;
+        $this->installationGuideFilesProvider = $installationGuideFilesProvider;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return 'Set note about the released version in installation guides for Docker on Linux, Mac, and Windows';
+    }
+
+    /**
+     * Higher first
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 850;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $this->symfonyStyle->note('Setting note about the released version in installation guides.');
+        $fileInfos = $this->installationGuideFilesProvider->provide();
+        foreach ($fileInfos as $fileInfo) {
+            $newContent = $this->installationGuideFileManipulator->setReleasedVersionNote($fileInfo, $version);
+            FileSystem::write($fileInfo->getPathname(), $newContent);
+        }
+        $this->commit('docker installation guides: updated note about the released version');
+        $this->symfonyStyle->success(Message::SUCCESS);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::RELEASE_CANDIDATE;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On Github, the installation guide version is not clear at a first sight
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #794 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
