### PR TITLE
[shopsys] phpstan updated and resolved dependencies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,6 @@
     <property name="path.packages" value="./packages"/>
     <property name="path.bin-console" value="./project-base/bin/console"/>
     <property name="path.framework" value="${path.packages}/framework"/>
-    <property name="path.phpstan.config" value="./phpstan.neon"/>
 
     <import file="project-base/build-dev.xml" />
     <import file="project-base/build.xml" />
@@ -180,7 +179,7 @@
         <exec executable="${path.phpstan.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="analyze"/>
             <arg value="-c"/>
-            <arg path="${path.phpstan.config}"/>
+            <arg path="./phpstan.neon"/>
             <arg path="${path.packages}/*/src"/>
             <arg path="${path.packages}/*/tests"/>
             <arg path="./utils/*/src"/>

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     "joschi127/doctrine-entity-override-bundle": "^0.5.0",
     "knplabs/knp-menu-bundle": "^2.2.1",
     "league/flysystem": "^1.0",
-    "nikic/php-parser": "^3.1",
+    "nikic/php-parser": "^4.0",
     "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
     "phing/phing": "^2.16.1",
     "phpunit/phpunit": "^7.0",
@@ -141,7 +141,7 @@
     "codeception/codeception": "^2.4.0",
     "codeception/phpunit-wrapper": "^7.0",
     "nette/utils": "^2.5",
-    "phpstan/phpstan": "^0.7",
+    "phpstan/phpstan": "^0.11",
     "symplify/easy-coding-standard-tester": "^5.2.17",
     "symplify/changelog-linker": "^5.2.17",
     "symplify/monorepo-builder": "^5.2.17"

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -47,6 +47,10 @@ for instance:
               </exec>
           </target>
         ```
+- update PHPStan to the 0.11 version ([#826](https://github.com/shopsys/shopsys/pull/826))
+    - change version of phpstan/phpstan to ^0.11 in your composer.json and update dependencies with `composer update`
+    - add `- '#Undefined variable: \$undefined#'` as ignored error to `phpstan.neon` configuration file
+    - you may need to change `StdClass` to `stdClass` in `tests/ShopBundle/Functional/Component/Grid/Ordering/GridOrderingFacadeTest.php` to pass PHPStan check
 
 ### Database migrations
 - after running database migrations, all your countries across domains will be merged together and original names will be added as translations

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -61,7 +61,7 @@
         "joschi127/doctrine-entity-override-bundle": "^0.5.0",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "league/flysystem": "^1.0",
-        "nikic/php-parser": "^3.1",
+        "nikic/php-parser": "^4.0",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable": "^1.2",
         "prezent/doctrine-translatable-bundle": "^1.0.3",
@@ -88,7 +88,7 @@
         "twig/twig": "^2.4.8"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.7",
+        "phpstan/phpstan": "^0.11",
         "phpunit/phpunit": "^7.0",
         "shopsys/coding-standards": "dev-master"
     },

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -96,7 +96,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
         $this->currentExecutionContextVariableNames = [];
         foreach ($node->getParams() as $parameter) {
             if ($this->isParameterExecutionContextInterfaceSubclass($parameter)) {
-                $this->currentExecutionContextVariableNames[] = $parameter->name;
+                $this->currentExecutionContextVariableNames[] = $parameter->var->name;
             }
         }
     }
@@ -123,9 +123,10 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
      */
     protected function isAddViolationMethodCall(Node $node): bool
     {
+        /** @var \PhpParser\Node\Expr\MethodCall $node */
         return $node->var instanceof Variable
             && in_array($node->var->name, $this->currentExecutionContextVariableNames, true)
-            && $node->name === 'addViolation';
+            && $node->name->name === 'addViolation';
     }
 
     /**

--- a/packages/framework/src/Twig/Exception/HoneyPotRenderedBeforePasswordException.php
+++ b/packages/framework/src/Twig/Exception/HoneyPotRenderedBeforePasswordException.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Twig\Exception;
 
 use Exception;
 use Shopsys\FrameworkBundle\Form\HoneyPotType;
-use Shopsys\FrameworkBundle\Twig\HoneyPotExtension;
 use Twig_Error;
 
 class HoneyPotRenderedBeforePasswordException extends Twig_Error implements TwigException
@@ -18,8 +17,7 @@ class HoneyPotRenderedBeforePasswordException extends Twig_Error implements Twig
             '%s was rendered before password field.'
             . ' Render honeypot after password field to overcome issues when Firefox prefills input'
             . ' before password with saved username.',
-            HoneyPotType::class,
-            HoneyPotExtension::PASSWORD_FIELD_NAME
+            HoneyPotType::class
         );
 
         // let the parent exception guess lineno and filename

--- a/packages/framework/tests/Unit/Component/Translation/ConstraintViolationExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConstraintViolationExtractorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Translation;
+
+use JMS\TranslationBundle\Model\FileSource;
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Translation\ConstraintViolationExtractor;
+use SplFileInfo;
+
+class ConstraintViolationExtractorTest extends TestCase
+{
+    public function testMessagesAreExtractedFromConstraintViolationClass(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/ConstraintViolationClass.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $expectedCatalogue = new MessageCatalogue();
+
+        $message = new Message('This message will be extracted into "validators" translation domain', 'validators');
+        $message->addSource(new FileSource($file->getFilename(), 16));
+        $expectedCatalogue->add($message);
+
+        $this->assertEquals($expectedCatalogue, $actualCatalogue);
+    }
+
+    public function testNothingIsExtractedFromNonConstraintClass(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/NonConstraintClass.php');
+
+        $actualCatalogue = $this->extract($file);
+
+        $expectedCatalogue = new MessageCatalogue();
+
+        $this->assertEquals($expectedCatalogue, $actualCatalogue);
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @return \JMS\TranslationBundle\Model\MessageCatalogue
+     */
+    private function extract(SplFileInfo $file): MessageCatalogue
+    {
+        $extractor = new ConstraintViolationExtractor();
+
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->create(ParserFactory::ONLY_PHP7);
+        $ast = $parser->parse(file_get_contents($file->getPathname()));
+
+        $catalogue = new MessageCatalogue();
+        $extractor->visitPhpFile($file, $catalogue, $ast);
+
+        return $catalogue;
+    }
+}

--- a/packages/framework/tests/Unit/Component/Translation/Resources/ConstraintViolationClass.php
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/ConstraintViolationClass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Translation\Resources;
+
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class ConstraintViolationClass
+{
+    /**
+     * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
+     */
+    public function workingExample(ExecutionContextInterface $context): void
+    {
+        $context->addViolation('This message will be extracted into "validators" translation domain');
+    }
+}

--- a/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
+++ b/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
@@ -4,7 +4,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Security;
 
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Model\Security\Authenticator;
-use StdClass;
+use stdClass;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
@@ -20,7 +20,7 @@ class AuthenticatorTest extends TestCase
 
         $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
         $requestMock->attributes->expects($this->once())->method('has')->will($this->returnValue(true));
-        $requestMock->attributes->expects($this->once())->method('get')->will($this->returnValue(new StdClass()));
+        $requestMock->attributes->expects($this->once())->method('get')->will($this->returnValue(new stdClass()));
 
         $this->expectException('Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException');
         $authenticator->checkLoginProcess($requestMock);
@@ -31,7 +31,7 @@ class AuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator();
 
         $sessionMock = $this->createMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
-        $sessionMock->expects($this->atLeastOnce())->method('get')->will($this->returnValue(new StdClass()));
+        $sessionMock->expects($this->atLeastOnce())->method('get')->will($this->returnValue(new stdClass()));
         $sessionMock->expects($this->atLeastOnce())->method('remove');
 
         $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -93,7 +93,7 @@
         "ext-pgsql": "*",
         "ext-zip": "*",
         "codeception/codeception": "^2.4.0",
-        "phpstan/phpstan": "^0.7",
+        "phpstan/phpstan": "^0.11",
         "phpunit/phpunit": "^7.0",
         "shopsys/coding-standards": "dev-master",
         "shopsys/http-smoke-testing": "dev-master"

--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -2,4 +2,5 @@ parameters:
     ignoreErrors:
         # Add ignored errors here as regular expressions, e.g.:
         # - '#PHPUnit_Framework_MockObject_MockObject(.*) given#'
+        - '#Undefined variable: \$undefined#'
 

--- a/project-base/tests/ShopBundle/Functional/Component/Grid/Ordering/GridOrderingFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Grid/Ordering/GridOrderingFacadeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\ShopBundle\Functional\Component\Grid\Ordering;
 
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\GridOrderingFacade;
+use stdClass;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class GridOrderingFacadeTest extends TransactionFunctionalTestCase
@@ -12,7 +13,7 @@ class GridOrderingFacadeTest extends TransactionFunctionalTestCase
         /** @var \Doctrine\ORM\EntityManager $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
         $gridOrderingFacade = new GridOrderingFacade($em);
-        $entity = new \StdClass();
+        $entity = new stdClass();
         $this->expectException(\Shopsys\FrameworkBundle\Component\Grid\Ordering\Exception\EntityIsNotOrderableException::class);
         $gridOrderingFacade->saveOrdering($entity, []);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Updated PHPStan due to old version and persistent travis build fails.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

This PR contains 5 almost independent commits, but they all changes needs to be applied before update of PHPStan is even possible and creating separate pull requests only raise the difficulty of update.

- new version of PHPStan reveal incorrect letter case in stdClass
- new version of PHPStan reveal different placeholders and values count
- due to update of nikic/php-parser I added test for ConstraintViolationExtractorClass (to be sure it's safe to update)

I need to add ignored error for project-base phpstan because in ErrorHandlerController is intentionally `undefined` error. 
And because we have phing target for phpstan for project-base and for packages separated, I had to change configuration file for phpstan project-base.
PHPStan in project-base is now run with ./project-base/phpstan.neon configuration even when you're working in monorepo.