### PR TITLE
[shopsys] fixed project-base install conflict due to snc/redis-bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
     "shopsys/jparser": "0.1",
     "shopsys/postgres-search-bundle": "0.1",
     "slevomat/coding-standard": "^4.6.0",
-    "snc/redis-bundle": "2.1.8",
+    "snc/redis-bundle": "^2.1.8",
     "squizlabs/php_codesniffer": "^3.2.0",
     "stof/doctrine-extensions-bundle": "^1.3.0",
     "superbalist/flysystem-google-storage": "^7.1",

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -32,6 +32,7 @@ for instance:
     - this script serves as a fast way to install demo instance of Shopsys Framework.
     - also this script can be used if you change the configuration of docker or app, script will apply all the changes done in these files and rebuild images.
 - add a way to check if Redis is running [#815](https://github.com/shopsys/shopsys/pull/815)
+    - change version of snc/redis-bundle to ^2.1.8 in your composer.json and update dependencies with `composer update`
     - upgrade redis extension version in your `DockerFile` to version `4.1.1`
     ```diff
     -       RUN pecl install redis-4.0.2 && \

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -74,7 +74,7 @@
         "shopsys/migrations": "dev-master",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/plugin-interface": "dev-master",
-        "snc/redis-bundle": "2.1.8",
+        "snc/redis-bundle": "^2.1.8",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/assetic-bundle": "^2.8.2",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -76,7 +76,7 @@
         "shopsys/product-feed-heureka-delivery": "dev-master",
         "shopsys/product-feed-zbozi": "dev-master",
         "shopsys/product-feed-google": "dev-master",
-        "snc/redis-bundle": "2.1.4",
+        "snc/redis-bundle": "^2.1.8",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/assetic-bundle": "^2.8.2",
         "symfony/monolog-bundle": "^3.1.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When installing project-base there was version conflict in snc/redis-bundle introduced in #815. #549 was resolved also as there should not be reason not to have ^ version constraint.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #549 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes