### PR TITLE
required version of PHP is mentioned in installation guides

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -10,6 +10,7 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 ## Requirements
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.unix.php)
+    * At least version **7.1 or higher**
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * [Docker](https://docs.docker.com/engine/installation/)
     * At least version **17.05 or higher** so it supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -12,6 +12,7 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for fast two-way syn
 ## Requirements
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.macosx.php)
+    * At least version **7.1 or higher**
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * [Docker for Mac](https://docs.docker.com/engine/installation/)
     * Docker-sync suggests ([in known issue](https://github.com/EugenMayer/docker-sync/issues/517)) to use Docker for Mac in version 17.09.1-ce-mac42 (21090)

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -19,6 +19,7 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for fast two-way syn
 ## Requirements
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.windows.php)
+    * At least version **7.1 or higher**
 * [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
     * Docker for Windows requires at least 4 GB of memory, otherwise, `composer install` can result in `Killed` status (we recommend to set 2 GB RAM, 1 CPU and 2 GB Swap in `Docker -> Preferences… -> Advanced`)
     * Version of Docker Engine should be at least **17.05 or higher** so it supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Composer requires version of PHP 7.1 or newer when creating project
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
