### PR TITLE
naming of promo code and discount code is unified

### DIFF
--- a/docs/introduction/translations.md
+++ b/docs/introduction/translations.md
@@ -124,7 +124,7 @@ _Note: The message is not escaped, so if there is malicious code in `*.po` files
 ### JavaScript
 
 ```js
-Shopsys.translator.trans('Please enter discount code.');
+Shopsys.translator.trans('Please enter promo code.');
 
 Shopsys.translator.transChoice('{1}Load next item|]1,Inf[Load next items', loadNextCount);
 ```

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -7,7 +7,7 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 ### Application
-- naming of promo code and discount code was unified ([#844](https://github.com/shopsys/shopsys/pull/844)) 
+- naming of promo code and discount code was unified ([#844](https://github.com/shopsys/shopsys/pull/844))
     - rename occurrences of `discount code` into `promo code` based on the changes from pull request in following files
         - `src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php`
         - `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -7,8 +7,12 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 ### Application
-
-- naming of promo code and discount code was unified, please rename occurrences of `discount code` into `promo code` based on the pull request ([#844](https://github.com/shopsys/shopsys/pull/844))
+- naming of promo code and discount code was unified ([#844](https://github.com/shopsys/shopsys/pull/844)) 
+    - dump translations using `php phing dump-translations` and fill in the translations based on the changes from pull request
+    - rename occurrences of `discount code` into `promo code` based on the changes from pull request in following files
+        - `src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php`
+        - `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js`
+        - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/PromoCode/index.html.twig`
 
 ### Tools
 - *(low priority)* add `product-search-export-products` as a dependency of `build-demo` phing target in your `build.xml`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -6,6 +6,10 @@ This guide contains instructions to upgrade from version v7.0.0-beta6 to Unrelea
 There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
+### Application
+
+- naming of promo code and discount code was unified, please rename occurrences of `discount code` into `promo code` based on the pull request ([#844](https://github.com/shopsys/shopsys/pull/844))
+
 ### Tools
 - *(low priority)* add `product-search-export-products` as a dependency of `build-demo` phing target in your `build.xml`
 if you want to have products data exported to Elasticsearch after `build-demo` target is run ([#824](https://github.com/shopsys/shopsys/pull/824/files))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -8,11 +8,11 @@ There you can find links to upgrade notes for other versions too.
 ## [shopsys/framework]
 ### Application
 - naming of promo code and discount code was unified ([#844](https://github.com/shopsys/shopsys/pull/844)) 
-    - dump translations using `php phing dump-translations` and fill in the translations based on the changes from pull request
     - rename occurrences of `discount code` into `promo code` based on the changes from pull request in following files
         - `src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php`
         - `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js`
         - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/PromoCode/index.html.twig`
+    - dump translations using `php phing dump-translations` and fill in the translations based on the changes from pull request
 
 ### Tools
 - *(low priority)* add `product-search-export-products` as a dependency of `build-demo` phing target in your `build.xml`

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -506,7 +506,7 @@ msgid "Create pricing group"
 msgstr "Vytvořit cenovou skupinu"
 
 msgid "Create promo code"
-msgstr "Vytvořit slevový kód"
+msgstr "Vytvořit slevový kupón"
 
 msgid "Create record"
 msgstr "Vytvořit záznam"
@@ -722,7 +722,7 @@ msgid "Do you really want to remove this product?"
 msgstr "Opravdu chcete odstranit toto zboží?"
 
 msgid "Do you really want to remove this promo code?"
-msgstr "Opravdu chcete odstranit tento slevový kód?"
+msgstr "Opravdu chcete odstranit tento slevový kupón?"
 
 msgid "Do you really want to remove this script?"
 msgstr "Opravdu chcete odstranit tento skript?"
@@ -1388,7 +1388,7 @@ msgid "No product found."
 msgstr "Nebylo nalezeno žádné zboží."
 
 msgid "No promo codes found. You have to create some first."
-msgstr "Nebyly nalezeny žádné slevové kódy. Nejprve musíte nějaký vytvořit."
+msgstr "Nebyly nalezeny žádné slevové kupóny. Nejprve musíte nějaký vytvořit."
 
 msgid "No records found."
 msgstr "Nebyly nalezeny žádné záznamy."
@@ -1706,13 +1706,13 @@ msgid "Products overview"
 msgstr "Přehled zboží"
 
 msgid "Promo code"
-msgstr "Slevový kód"
+msgstr "Slevový kupón"
 
 msgid "Promo code <strong>{{ code }}</strong> deleted."
-msgstr "Slevový kód <strong>{{ code }}</strong> byl smazán"
+msgstr "Slevový kupón <strong>{{ code }}</strong> byl smazán"
 
 msgid "Promo codes"
-msgstr "Slevové kódy"
+msgstr "Slevové kupóny"
 
 msgid "Published data"
 msgstr "Zveřejněné údaje"
@@ -1868,7 +1868,7 @@ msgid "Selected product doesn't exist."
 msgstr "Zvolený produkt neexistuje."
 
 msgid "Selected promo code doesn't exist."
-msgstr "Zvolený slevový kód neexistuje."
+msgstr "Zvolený slevový kupón neexistuje."
 
 msgid "Selected script doesn't exist."
 msgstr "Zvolený skript neexistuje"
@@ -2216,7 +2216,7 @@ msgid "Value"
 msgstr "Hodnota"
 
 msgid "Value of bought products with VAT after application of all discounts and promo codes without price of shipping and payment"
-msgstr "Jde o hodnotu nakoupeného zboží s DPH po uplatnění všech slev a slevových kódú bez hodnoty dopravy a platby"
+msgstr "Jde o hodnotu nakoupeného zboží s DPH po uplatnění všech slev a slevových kupónů bez hodnoty dopravy a platby"
 
 msgid "Variant"
 msgstr "Varianta"
@@ -2411,7 +2411,7 @@ msgid "products"
 msgstr "zboží"
 
 msgid "promo codes"
-msgstr "slevové kódy"
+msgstr "slevové kupóny"
 
 msgid "records"
 msgstr "záznamů"

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -506,7 +506,7 @@ msgid "Create pricing group"
 msgstr "Vytvořit cenovou skupinu"
 
 msgid "Create promo code"
-msgstr "Vytvořit slevový kupón"
+msgstr "Vytvořit slevový kód"
 
 msgid "Create record"
 msgstr "Vytvořit záznam"
@@ -722,7 +722,7 @@ msgid "Do you really want to remove this product?"
 msgstr "Opravdu chcete odstranit toto zboží?"
 
 msgid "Do you really want to remove this promo code?"
-msgstr "Opravdu chcete odstranit tento slevový kupón?"
+msgstr "Opravdu chcete odstranit tento slevový kód?"
 
 msgid "Do you really want to remove this script?"
 msgstr "Opravdu chcete odstranit tento skript?"
@@ -1388,7 +1388,7 @@ msgid "No product found."
 msgstr "Nebylo nalezeno žádné zboží."
 
 msgid "No promo codes found. You have to create some first."
-msgstr "Nebyly nalezeny žádné slevové kupóny. Nejprve musíte nějaký vytvořit."
+msgstr "Nebyly nalezeny žádné slevové kódy. Nejprve musíte nějaký vytvořit."
 
 msgid "No records found."
 msgstr "Nebyly nalezeny žádné záznamy."
@@ -1706,13 +1706,13 @@ msgid "Products overview"
 msgstr "Přehled zboží"
 
 msgid "Promo code"
-msgstr "Slevový kupón"
+msgstr "Slevový kód"
 
 msgid "Promo code <strong>{{ code }}</strong> deleted."
-msgstr "Slevový kupón <strong>{{ code }}</strong> byl smazán"
+msgstr "Slevový kód <strong>{{ code }}</strong> byl smazán"
 
 msgid "Promo codes"
-msgstr "Slevové kupóny"
+msgstr "Slevové kódy"
 
 msgid "Published data"
 msgstr "Zveřejněné údaje"
@@ -1868,7 +1868,7 @@ msgid "Selected product doesn't exist."
 msgstr "Zvolený produkt neexistuje."
 
 msgid "Selected promo code doesn't exist."
-msgstr "Zvolený slevový kupón neexistuje."
+msgstr "Zvolený slevový kód neexistuje."
 
 msgid "Selected script doesn't exist."
 msgstr "Zvolený skript neexistuje"
@@ -2216,7 +2216,7 @@ msgid "Value"
 msgstr "Hodnota"
 
 msgid "Value of bought products with VAT after application of all discounts and promo codes without price of shipping and payment"
-msgstr "Jde o hodnotu nakoupeného zboží s DPH po uplatnění všech slev a kupónů bez hodnoty dopravy a platby"
+msgstr "Jde o hodnotu nakoupeného zboží s DPH po uplatnění všech slev a slevových kódú bez hodnoty dopravy a platby"
 
 msgid "Variant"
 msgstr "Varianta"
@@ -2411,7 +2411,7 @@ msgid "products"
 msgstr "zboží"
 
 msgid "promo codes"
-msgstr "slevové kupóny"
+msgstr "slevové kódy"
 
 msgid "records"
 msgstr "záznamů"

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -347,7 +347,7 @@ msgid "Product parameters are duplicate."
 msgstr "Parametry produktů jsou duplicitní."
 
 msgid "Promo code with this code already exists"
-msgstr "Slevový kód s touhle hodnotou již existuje"
+msgstr "Slevový kupón s tímto kódem již existuje"
 
 msgid "Quantity must be greater than {{ compared_value }}"
 msgstr "Množství musí být větší než {{ compared_value }}"

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -347,7 +347,7 @@ msgid "Product parameters are duplicate."
 msgstr "Parametry produktů jsou duplicitní."
 
 msgid "Promo code with this code already exists"
-msgstr "Slevový kupón s tímto kódem již existuje"
+msgstr "Slevový kód s touhle hodnotou již existuje"
 
 msgid "Quantity must be greater than {{ compared_value }}"
 msgstr "Množství musí být větší než {{ compared_value }}"

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php
@@ -42,10 +42,10 @@ class PromoCodeController extends FrontBaseController
         } catch (\Shopsys\FrameworkBundle\Model\Order\PromoCode\Exception\InvalidPromoCodeException $ex) {
             return new JsonResponse([
                 'result' => false,
-                'message' => t('Discount code invalid. Check it, please.'),
+                'message' => t('Promo code invalid. Check it, please.'),
             ]);
         }
-        $this->getFlashMessageSender()->addSuccessFlash(t('Discount code added to order'));
+        $this->getFlashMessageSender()->addSuccessFlash(t('Promo code added to order'));
 
         return new JsonResponse(['result' => true]);
     }
@@ -53,7 +53,7 @@ class PromoCodeController extends FrontBaseController
     public function removeAction()
     {
         $this->currentPromoCodeFacade->removeEnteredPromoCode();
-        $this->getFlashMessageSender()->addSuccessFlash(t('Discount code removed from order'));
+        $this->getFlashMessageSender()->addSuccessFlash(t('Promo code removed from order'));
 
         return $this->redirectToRoute('front_cart');
     }

--- a/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js
+++ b/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js
@@ -32,7 +32,7 @@
                 });
             } else {
                 Shopsys.window({
-                    content: Shopsys.translator.trans('Please enter discount code.')
+                    content: Shopsys.translator.trans('Please enter promo code.')
                 });
             }
         };

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
@@ -383,7 +383,7 @@ msgid "Please check the correctness of all data filled."
 msgstr "Prosím zkontrolujte si správnost vyplnění všech údajů"
 
 msgid "Please enter promo code."
-msgstr "Zadejte, prosím, slevový kód."
+msgstr "Zadejte, prosím, slevový kupón."
 
 msgid "Please enter valid quantity you want to add to cart."
 msgstr "Zadejte prosím platné množství, které chcete vložit do košíku."
@@ -437,16 +437,16 @@ msgid "Products in stock only"
 msgstr "Jen zboží skladem"
 
 msgid "Promo code"
-msgstr "Slevový kód"
+msgstr "Slevový kupón"
 
 msgid "Promo code added to order"
-msgstr "Slevový kód byl přidán do objednávky."
+msgstr "Slevový kupón byl přidán do objednávky."
 
 msgid "Promo code invalid. Check it, please."
-msgstr "Slevový kód není platný. Prosím, zkontrolujte ho."
+msgstr "Slevový kupón není platný. Prosím, zkontrolujte ho."
 
 msgid "Promo code removed from order"
-msgstr "Slevový kód byl odebrán z objednávky."
+msgstr "Slevový kupón byl odebrán z objednávky."
 
 msgid "Register"
 msgstr "Registrovat"

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
@@ -139,18 +139,6 @@ msgstr "Detail"
 msgid "Discount"
 msgstr "Sleva"
 
-msgid "Discount code"
-msgstr "Slevový kód"
-
-msgid "Discount code added to order"
-msgstr "Slevový kód byl přidán do objednávky."
-
-msgid "Discount code invalid. Check it, please."
-msgstr "Slevový kód není platný. Prosím, zkontrolujte ho."
-
-msgid "Discount code removed from order"
-msgstr "Slevový kód byl odebrán z objednávky."
-
 msgid "Displaying"
 msgstr "Zobrazuji"
 
@@ -394,7 +382,7 @@ msgstr "Přehled osobních údajů"
 msgid "Please check the correctness of all data filled."
 msgstr "Prosím zkontrolujte si správnost vyplnění všech údajů"
 
-msgid "Please enter discount code."
+msgid "Please enter promo code."
 msgstr "Zadejte, prosím, slevový kód."
 
 msgid "Please enter valid quantity you want to add to cart."
@@ -449,7 +437,16 @@ msgid "Products in stock only"
 msgstr "Jen zboží skladem"
 
 msgid "Promo code"
-msgstr "Slevový kupón"
+msgstr "Slevový kód"
+
+msgid "Promo code added to order"
+msgstr "Slevový kód byl přidán do objednávky."
+
+msgid "Promo code invalid. Check it, please."
+msgstr "Slevový kód není platný. Prosím, zkontrolujte ho."
+
+msgid "Promo code removed from order"
+msgstr "Slevový kód byl odebrán z objednávky."
 
 msgid "Register"
 msgstr "Registrovat"

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
@@ -139,18 +139,6 @@ msgstr ""
 msgid "Discount"
 msgstr ""
 
-msgid "Discount code"
-msgstr ""
-
-msgid "Discount code added to order"
-msgstr ""
-
-msgid "Discount code invalid. Check it, please."
-msgstr ""
-
-msgid "Discount code removed from order"
-msgstr ""
-
 msgid "Displaying"
 msgstr ""
 
@@ -394,7 +382,7 @@ msgstr ""
 msgid "Please check the correctness of all data filled."
 msgstr ""
 
-msgid "Please enter discount code."
+msgid "Please enter promo code."
 msgstr ""
 
 msgid "Please enter valid quantity you want to add to cart."
@@ -449,6 +437,15 @@ msgid "Products in stock only"
 msgstr ""
 
 msgid "Promo code"
+msgstr ""
+
+msgid "Promo code added to order"
+msgstr ""
+
+msgid "Promo code invalid. Check it, please."
+msgstr ""
+
+msgid "Promo code removed from order"
 msgstr ""
 
 msgid "Register"

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/PromoCode/index.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/PromoCode/index.html.twig
@@ -1,7 +1,7 @@
 <div class="box-promo-code">
     {% if validEnteredPromoCode is null %}
         <label class="box-promo-code__input">
-            {{ 'Discount code'|trans }}:
+            {{ 'Promo code'|trans }}:
             <input type="text" value="" id="js-promo-code-input" class="input" data-apply-code-url="{{ url('front_promo_code_apply') }}"/>
         </label>
         <button type="button" id="js-promo-code-submit-button" class="btn box-promo-code__btn">{{ 'Apply'|trans }}</button>


### PR DESCRIPTION
- discount code keywords were renamed into promo code
- translations were fixed
- documentation was fixed

| Q             | A
| ------------- | ---
|Description, reason for the PR| project should contain unified naming of the entities and their usages
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #786 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
