### PR TITLE
[framework] cleaning empty Redis cache doesn't cause an error anymore

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -5,12 +5,17 @@ This guide contains instructions to upgrade from version v7.0.0 to Unreleased.
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+## [shopsys/framework]
+### Application
+- *(low priority)* to add support of functional tests of Redis ([#846](https://github.com/shopsys/shopsys/pull/846))
+    - download [`snc_redis.yml`](https://github.com/shopsys/project-base/blob/master/app/config/packages/test/snc_redis.yml) to `app/config/packages/test/snc_redis.yml`
+    - download [`RedisFacadeTest.php`](https://github.com/shopsys/project-base/tree/master/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php) to your tests directory `tests/ShopBundle/Functional/Component/Redis/`
+
 ## [shopsys/coding-standards]
 - We disallow using [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html) in the Shopsys Framework
   because it causes problems during entity extension. Such problem with `OrderItem` was resolved during [making OrderItem extendable #715](https://github.com/shopsys/shopsys/pull/715)  
   If you want to use Doctrine inheritance mapping anyway, please skip `Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff` ([#848](https://github.com/shopsys/shopsys/pull/848))
 
-[Upgrade from v7.0.0-beta6 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta6...HEAD
-[shopsys/coding-standards]: https://github.com/shopsys/coding-standards
-
 [Upgrade from v7.0.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0...HEAD
+[shopsys/framework]: https://github.com/shopsys/framework
+[shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/packages/framework/src/Component/Redis/RedisFacade.php
+++ b/packages/framework/src/Component/Redis/RedisFacade.php
@@ -26,7 +26,21 @@ class RedisFacade
         foreach ($this->cacheClients as $redis) {
             $prefix = (string)$redis->getOption(Redis::OPT_PREFIX);
             $pattern = $prefix . '*';
+            if (!$this->hasAnyKey($redis, $pattern)) {
+                continue;
+            }
             $redis->eval("return redis.call('del', unpack(redis.call('keys', ARGV[1])))", [$pattern]);
         }
+    }
+
+    /**
+     * @param \Redis $redis
+     * @param string $pattern
+     * @return bool
+     */
+    protected function hasAnyKey(Redis $redis, string $pattern): bool
+    {
+        $keyCount = $redis->eval("return table.getn(redis.call('keys', ARGV[1]))", [$pattern]);
+        return (bool)$keyCount;
     }
 }

--- a/project-base/app/config/packages/test/snc_redis.yml
+++ b/project-base/app/config/packages/test/snc_redis.yml
@@ -1,0 +1,8 @@
+snc_redis:
+    clients:
+        test:
+            type: 'phpredis'
+            alias: 'test'
+            dsn: 'redis://%redis_host%'
+            options:
+                prefix: '%env(REDIS_PREFIX)%test_'

--- a/project-base/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Functional\Component\Redis;
+
+use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Tests\ShopBundle\Test\FunctionalTestCase;
+
+class RedisFacadeTest extends FunctionalTestCase
+{
+    public function testCleanCache(): void
+    {
+        $redisClient = $this->getContainer()->get('snc_redis.test');
+        $redisClient->set('test', 'test');
+        $facade = new RedisFacade([$redisClient]);
+
+        $facade->cleanCache();
+        $this->assertSame(0, $redisClient->exists('test'));
+    }
+
+    public function testCleanCacheNoErrorOnEmpty(): void
+    {
+        $redisClient = $this->getContainer()->get('snc_redis.test');
+        $facade = new RedisFacade([$redisClient]);
+
+        $facade->cleanCache();
+        $lastError = $redisClient->getLastError();
+        $this->assertSame(null, $lastError);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| #767 
|New feature| No
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #767
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
