### PR TITLE
[coding-standards] sniff that forbids Doctrine Inheritance mapping

### DIFF
--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -87,5 +87,3 @@ Besides the rules that are checked by automatic tools, we have few rules for whi
     }
     ```
 - Entities have to be created by factories. Only allowed exception are `*Translation` entities that are created by their owner entity.
-- Framework entities must not use [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html)
-  because it causes problems during entity extension. Such problem with `OrderItem` was resolved during [making OrderItem extendable #715](https://github.com/shopsys/shopsys/pull/715).

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -5,4 +5,12 @@ This guide contains instructions to upgrade from version v7.0.0 to Unreleased.
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+## [shopsys/coding-standards]
+- We disallow using [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html) in the Shopsys Framework
+  because it causes problems during entity extension. Such problem with `OrderItem` was resolved during [making OrderItem extendable #715](https://github.com/shopsys/shopsys/pull/715)  
+  If you want to use Doctrine inheritance mapping anyway, please skip `Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff` ([#848](https://github.com/shopsys/shopsys/pull/848))
+
+[Upgrade from v7.0.0-beta6 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta6...HEAD
+[shopsys/coding-standards]: https://github.com/shopsys/coding-standards
+
 [Upgrade from v7.0.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0...HEAD

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -26,6 +26,7 @@ services:
     Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff: ~
     Shopsys\CodingStandards\Sniffs\ForbiddenExitSniff: ~
     Shopsys\CodingStandards\Sniffs\ForbiddenSuperGlobalSniff: ~
+    Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff: ~
     # method arguments and variables should be $camelCase
     Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff: ~
     # add all @param, @return and @var annotations, in FQN
@@ -162,7 +163,9 @@ services:
 parameters:
     exclude_files:
         - '*/tests/Unit/**/wrong/*'
+        - '*/tests/Unit/**/Wrong/*'
         - '*/tests/Unit/**/correct/*'
+        - '*/tests/Unit/**/Correct/*'
         - '*/tests/Unit/**/fixed/*'
     skip:
         SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff:

--- a/packages/coding-standards/src/Sniffs/ForbiddenDoctrineInheritanceSniff.php
+++ b/packages/coding-standards/src/Sniffs/ForbiddenDoctrineInheritanceSniff.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+class ForbiddenDoctrineInheritanceSniff implements Sniff
+{
+    /**
+     * @return int[]
+     */
+    public function register()
+    {
+        return [T_CLASS];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $classPosition
+     */
+    public function process(File $file, $classPosition)
+    {
+        $phpDocStartPosition = $file->findPrevious(T_DOC_COMMENT_OPEN_TAG, $classPosition);
+        if ($phpDocStartPosition === false) {
+            return;
+        }
+
+        $phpDocTags = $this->findPhpDocTags($file, $classPosition, $phpDocStartPosition);
+        foreach ($phpDocTags as $position => $token) {
+            if ($this->isDoctrineInheritanceAnnotation($token)) {
+                $message = 'It is forbidden to use Doctrine inheritance mapping because it causes problems during entity extension. Such problem with `OrderItem` was resolved during making OrderItem extendable #715.';
+                $file->addError(
+                    $message,
+                    $position,
+                    self::class
+                );
+            }
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $classPosition
+     * @param int $phpDocStartPosition
+     * @return array
+     */
+    private function findPhpDocTags(File $file, int $classPosition, int $phpDocStartPosition): array
+    {
+        $phpDocEndPosition = $file->findPrevious(T_DOC_COMMENT_CLOSE_TAG, $classPosition);
+
+        $result = [];
+        $tokens = $file->getTokens();
+        for ($i = $phpDocStartPosition; $i < $phpDocEndPosition; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG) {
+                $result[$i] = $tokens[$i];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $token
+     */
+    private function isDoctrineInheritanceAnnotation(array $token)
+    {
+        $content = $token['content'];
+        return preg_match('~^.*ORM.*InheritanceType~', $content) === 1;
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Correct/ClassWithoutComment.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Correct/ClassWithoutComment.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\ForbiddenDoctrineInheritanceSniff\Correct;
+
+class ClassWithoutComment
+{
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Correct/EntityWithoutInheritanceMapping.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Correct/EntityWithoutInheritanceMapping.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\ForbiddenDoctrineInheritanceSniff\Correct;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * Doctrine\ORM\Mapping\InheritanceType
+ */
+class EntityWithoutInheritanceMapping
+{
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Correct/fileWithoutClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Correct/fileWithoutClass.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+echo 'ok';

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/ForbiddenDoctrineInheritanceSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/ForbiddenDoctrineInheritanceSniffTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForbiddenExitSniff;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class ForbiddenDoctrineInheritanceSniffTest extends AbstractCheckerTestCase
+{
+    public function testWrong(): void
+    {
+        $this->doTestWrongFile(__DIR__ . '/Wrong/ClassWithFullNamespaceInheritanceMapping.php');
+        $this->doTestWrongFile(__DIR__ . '/Wrong/EntityWithOrmInheritanceMapping.php');
+    }
+
+    public function testCorrect(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/Correct/fileWithoutClass.php');
+        $this->doTestCorrectFile(__DIR__ . '/Correct/EntityWithoutInheritanceMapping.php');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Wrong/ClassWithFullNamespaceInheritanceMapping.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Wrong/ClassWithFullNamespaceInheritanceMapping.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\ForbiddenDoctrineInheritanceSniff\Wrong;
+
+/**
+ * @Doctrine\ORM\Mapping\InheritanceType("SINGLE_TABLE")
+ */
+class ClassWithFullNamespaceInheritanceMapping
+{
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Wrong/EntityWithOrmInheritanceMapping.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/Wrong/EntityWithOrmInheritanceMapping.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\Sniffs\ForbiddenDoctrineInheritanceSniff\Wrong;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType
+ */
+class EntityWithOrmInheritanceMapping
+{
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/config.yml
@@ -1,0 +1,2 @@
+services:
+    Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff:

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -34,3 +34,7 @@ parameters:
 
         Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff:
             - '*/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php'
+
+        Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff:
+            - '*/src/Shopsys/ShopBundle/*'
+            - '*/tests/ShopBundle/*'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We have a rule that forbids Doctrine inheritance and now we have a sniff that checks it
|New feature| Yes
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes