### PR TITLE
flysystem for ImageFacade::copyImages and FileUpload::postFlushEntity is unified

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -13,6 +13,8 @@ There you can find links to upgrade notes for other versions too.
         - `src/Shopsys/ShopBundle/Resources/scripts/frontend/promoCode.js`
         - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Order/PromoCode/index.html.twig`
     - dump translations using `php phing dump-translations` and fill in the translations based on the changes from pull request
+- check whether you extended class or method `ImageFacade::copyImages` or used it in your project and make sure it works like you intended ([#851](https://github.com/shopsys/shopsys/pull/851))
+    - *(low priority)* remove `/var/www/html/var/cache` folder from your `@main_filesystem` filesystem storage if exists, set as local filesystem storage in path `%kernel.project_dir%` by default
 
 ### Tools
 - *(low priority)* add `product-search-export-products` as a dependency of `build-demo` phing target in your `build.xml`

--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle\Component\Image;
 
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemInterface;
+use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
@@ -29,6 +30,11 @@ class ImageFacade
      * @var \League\Flysystem\FilesystemInterface
      */
     protected $filesystem;
+
+    /**
+     * @var \League\Flysystem\MountManager
+     */
+    protected $mountManager;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
@@ -59,6 +65,8 @@ class ImageFacade
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageLocator $imageLocator
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFactoryInterface $imageFactory
+     * @param \League\Flysystem\MountManager $mountManager
+     * @param \League\Flysystem\MountManager;
      */
     public function __construct(
         $imageUrlPrefix,
@@ -68,7 +76,8 @@ class ImageFacade
         FilesystemInterface $filesystem,
         FileUpload $fileUpload,
         ImageLocator $imageLocator,
-        ImageFactoryInterface $imageFactory
+        ImageFactoryInterface $imageFactory,
+        MountManager $mountManager
     ) {
         $this->imageUrlPrefix = $imageUrlPrefix;
         $this->em = $em;
@@ -78,6 +87,7 @@ class ImageFacade
         $this->fileUpload = $fileUpload;
         $this->imageLocator = $imageLocator;
         $this->imageFactory = $imageFactory;
+        $this->mountManager = $mountManager;
     }
 
     /**
@@ -329,9 +339,9 @@ class ImageFacade
         $sourceImages = $this->getAllImagesByEntity($sourceEntity);
         $targetImages = [];
         foreach ($sourceImages as $sourceImage) {
-            $this->filesystem->copy(
-                $this->imageLocator->getAbsoluteImageFilepath($sourceImage, ImageConfig::ORIGINAL_SIZE_NAME),
-                $this->fileUpload->getTemporaryFilepath($sourceImage->getFilename())
+            $this->mountManager->copy(
+                'main://' . $this->imageLocator->getAbsoluteImageFilepath($sourceImage, ImageConfig::ORIGINAL_SIZE_NAME),
+                'local://' . $this->fileUpload->getTemporaryFilepath($sourceImage->getFilename())
             );
 
             $targetImage = $this->imageFactory->create(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ImageFacade::copyImages is used during creation of the main variant from nonVariant product and all images need to be copied into newly created entity and there was bug when first step of copying copied files into cache on external filesystem instead into local one so the second step could use it and copied it back with the new filenames for newly created entities
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #686   <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
