### PR TITLE
[framework] fixed empty cart when no listable product left in cart

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -10,5 +10,8 @@ There you can find links to upgrade notes for other versions too.
 - *(low priority)* add `product-search-export-products` as a dependency of `build-demo` phing target in your `build.xml`
 if you want to have products data exported to Elasticsearch after `build-demo` target is run ([#824](https://github.com/shopsys/shopsys/pull/824/files))
 
+### Application
+- *(low priority)* if you want to test behavior of cart when no listable product left in cart, implement functional test as it is in [#852](https://github.com/shopsys/shopsys/pull/852)
+
 [Upgrade from v7.0.0-beta6 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta6...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -11,7 +11,7 @@ There you can find links to upgrade notes for other versions too.
 if you want to have products data exported to Elasticsearch after `build-demo` target is run ([#824](https://github.com/shopsys/shopsys/pull/824/files))
 
 ### Application
-- *(low priority)* if you want to test behavior of cart when no listable product left in cart, implement functional test as it is in [#852](https://github.com/shopsys/shopsys/pull/852)
+- *(low priority)* if you want to test behavior of cart with no listable product in it, implement functional test as it is in [#852](https://github.com/shopsys/shopsys/pull/852)
 
 [Upgrade from v7.0.0-beta6 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta6...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -222,6 +222,12 @@ class CartFacade
 
         if ($cart !== null) {
             $this->cartWatcherFacade->checkCartModifications($cart);
+
+            if ($cart->isEmpty()) {
+                $this->deleteCart($cart);
+
+                return null;
+            }
         }
 
         return $cart;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
@@ -7,7 +7,6 @@ use Shopsys\FrameworkBundle\DataFixtures\Demo\ProductDataFixture;
 use Shopsys\FrameworkBundle\Model\Cart\CartFacade;
 use Shopsys\FrameworkBundle\Model\Cart\CartFactory;
 use Shopsys\FrameworkBundle\Model\Cart\CartRepository;
-use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory;
 use Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade;
 use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer;
@@ -148,11 +147,12 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     public function testCartNotExistIfNoListableProductIsInCart(int $productId, bool $cartShouldBeNull): void
     {
         $cartFacade = $this->getContainer()->get(CartFacade::class);
+        $cartItemFactory = $this->getContainer()->get(CartItemFactory::class);
 
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productId);
 
         $cart = $cartFacade->getCartOfCurrentCustomerCreateIfNotExists();
-        $cartItem = new CartItem($cart, $product, 1, 10);
+        $cartItem = $cartItemFactory->create($cart, $product, 1, 10);
         $cart->addItem($cartItem);
 
         $this->getEntityManager()->persist($cartItem);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Log in as user with only not-listable products in cart (products that are no longer available for any reason) caused exception. This is fixed in this PR. More informations can be found in #842.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #842  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

During consultation with @vitek-rostislav, we thought the changes will be made in `CartWatcherFacade`, but after some prototyping, I've decided to update `CartFacade` instead.

I need to delete Cart from the database and doing it in `CartWatcherFacade` would mean to create a circular reference (`CartFacade` already need `CartWatcherFacade`) or duplicate behavior of `deleteCart` method to `CartWatcherFacade`.