### PR TITLE
[shopsys] releaser docs: removed note about confusing message

### DIFF
--- a/docs/contributing/releasing-a-new-version-of-shopsys-framework.md
+++ b/docs/contributing/releasing-a-new-version-of-shopsys-framework.md
@@ -48,7 +48,6 @@ as the folder is currently ignored for performance reasons.
 There is [an issue](https://github.com/shopsys/shopsys/issues/536) on Github that mentions the problem.
 However, there is a workaround - you can add new `docker-sync` volume just for git.
 - Releasing a stage is a continuously running process so do not exit your CLI if it is not necessary.
-- Do not get a fright when you see "Version 'XY' is now released!" message after a stage is finished - this is a default behavior of `monorepo-builder` package
 - When updating mutual dependencies in shopsys packages, the dependency on `coding-standards` is kept untouched in `http-smoke-testing` package
 as it is dependent on an obsolete version of the `coding-standards` package. See `Shopsys\Releaser\DependencyUpdater`.
 This behaviour should be discarded once the `http-smoke-testing` is dependent on `dev-master` version of `coding-standards` like all the other Shopsys packages.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the success message is not confusing anymore (fixed by https://github.com/Symplify/Symplify/pull/1323)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes/No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
