### PR TITLE
[shopsys] make link to BC promise absolute in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 | ------------- | ---
 |Description, reason for the PR| ...
 |New feature| Yes/No <!-- Do not forget to update docs/ -->
-|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| Yes/No <!-- Do not forget to update UPGRADE.md -->
+|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes/No <!-- Do not forget to update UPGRADE.md -->
 |Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
 |Standards and tests pass| Yes/No
 |Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes/No


### PR DESCRIPTION
- in PR description the link was relative to github.com, not the repository root
- that meant the link was directed to https://github.com/docs/contributing/backward-compatibility-promise.md instead of https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md
- see the link *BC breaks* in the table below (not fixed yet as the fix is not merged)

| Q             | A
| ------------- | ---
|Description, reason for the PR| Link in all PR descriptions created after #800 was merged returned 404
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
