### PR TITLE
[shopsys] new class for representing monetary values PHASE 6

### DIFF
--- a/docs/contributing/coding-standards.md
+++ b/docs/contributing/coding-standards.md
@@ -87,3 +87,4 @@ Besides the rules that are checked by automatic tools, we have few rules for whi
     }
     ```
 - Entities have to be created by factories. Only allowed exception are `*Translation` entities that are created by their owner entity.
+- All monetary values (*prices, account balances, discount amounts, price limits etc.*) must be represented and manipulated by [the `Money` class](/docs/introduction/how-to-work-with-money.md).

--- a/docs/cookbook/basic-data-import.md
+++ b/docs/cookbook/basic-data-import.md
@@ -301,8 +301,9 @@ Finally, we can implement the private method for filling data object
 
 // ...
 
-use Shopsys\ShopBundle\Model\Pricing\Vat\VatFacade;
+use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Product\ProductData;
+use Shopsys\ShopBundle\Model\Pricing\Vat\VatFacade;
 
 // ...
 
@@ -335,7 +336,7 @@ public function __construct(
 private function fillProductData(ProductData $productData, array $externalProductData)
 {
     $productData->name[self::LOCALE] = $externalProductData['name'];
-    $productData->manualInputPricesByPricingGroupId[self::PRICING_GROUP_ID] = $externalProductData['price_without_vat'];
+    $productData->manualInputPricesByPricingGroupId[self::PRICING_GROUP_ID] = Money::create($externalProductData['price_without_vat']);
     $productData->vat = $this->vatFacade->getVatByPercent($externalProductData['vat_percent']); // will be implemented in next step
     $productData->ean = $externalProductData['ean'];
     $productData->descriptions[self::DOMAIN_ID] = $externalProductData['description'];
@@ -351,6 +352,10 @@ private function fillProductData(ProductData $productData, array $externalProduc
 in [`ProductData`](../../packages/framework/src/Model/Product/ProductData.php).
 So we will extend [`VatRepository`](../../packages/framework/src/Model/Pricing/Vat/VatRepository.php)
 and [`VatFacade`](../../packages/framework/src/Model/Pricing/Vat/VatFacade.php) and implement appropriate methods.*
+
+*Note 3: `Money::create()` can be used only for integers and numeric strings.
+If you use floats in your `$externalProductData` array you should always use `Money::createFromFloat()` and specify scale explicitly.
+Read more about monetary values in [How to Work with Money](/docs/introduction/how-to-work-with-money.md).*
 
 #### 3.6 - Extend [`VatRepository`](../../packages/framework/src/Model/Pricing/Vat/VatRepository.php) and implement method `getVatByPercent()` in order to load [`Vat`](../../packages/framework/src/Model/Pricing/Vat/Vat.php) by percent
 ```php

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@
 * [How to Set Up Domains and Locales (Languages)](./introduction/how-to-set-up-domains-and-locales.md)
 * [Shopsys Framework Development Workflow](introduction/shopsys-framework-development-workflow.md)
 * [How to Work with Products](./introduction/how-to-work-with-products.md)
+* [How to Work with Money](./introduction/how-to-work-with-money.md)
 * [Translations](./introduction/translations.md)
 * [Directories](./introduction/directories.md)
 * [Cron](./introduction/cron.md)

--- a/docs/introduction/entities.md
+++ b/docs/introduction/entities.md
@@ -386,6 +386,13 @@ It is common that you need to transfer an entity to form or other parts of the s
 If you need to transfer one entity, use PHPDoc annotation `entity|null`, eg. `\Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat|null` in [`TransportData::$vat`](/packages/framework/src/Model/Transport/TransportData.php).
 If you need to transfer a collection of entities, use PHPDoc annotation `entity[]` and initialize the array in the constructor, eg. `\Shopsys\FrameworkBundle\Model\Payment\Payment[]` in [`TransportData::$payments`](/packages/framework/src/Model/Transport/TransportData.php).
 
+#### Money
+
+To transfer monetary values (*prices, account balances, discount amounts, price limits etc.*) you should always use `\Shopsys\FrameworkBundle\Component\Money\Money` (optionally nullable or as an array).
+You may initialize a default value in the constructor or in the data factory (eg. with `Money::zero()`).
+
+You can read more about the `Money` class in [How to Work with Money](/docs/introduction/how-to-work-with-money.md).
+
 #### Images
 
 To transfer images via the system, use PHPDoc annotation `\Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadData` and initialize the field in the constructor as you can see in `BrandData` example above.

--- a/docs/introduction/framework-extensibility.md
+++ b/docs/introduction/framework-extensibility.md
@@ -46,6 +46,7 @@ as well as a list of customizations that are not (and will not be) possible at a
 * Removing an attribute from a framework entity
 * Changing a data type of an entity attribute
 * Removing existing entities and features
+* Extending [the `Money` class](/docs/introduction/how-to-work-with-money.md) and closely related classes (eg. `MoneyType`)
 
 ## Successfully implemented features
 * [Shipping method with pickup places](https://github.com/shopsys/demoshop/pull/6)

--- a/docs/introduction/how-to-work-with-money.md
+++ b/docs/introduction/how-to-work-with-money.md
@@ -1,0 +1,438 @@
+# How to Work with Money
+
+Money is a very important concept for every e-commerce project.
+In Shopsys Framework, all monetary values (*prices, account balances, discount amounts, price limits etc.*) are represented by an instance of [the `Money` class](#money-class).
+
+This approach has several advantages:
+- it avoids problems with floating point number calculations and comparisons (see [official PHP documentation](http://php.net/manual/en/language.types.float.php) for details)
+- allows easy-to-use interfaces with consistent type-hinting so you can be sure what type of value you should be using
+- prevents accidental conversion to unexpected types (which may be problematic eg. when using the `===` operator)
+- makes the application design clearer and future changes easier
+
+**Table of Contents:**
+- [General Concept](#general-concept)
+- [Money Class](#money-class)
+- [Money in Forms](#money-in-forms)
+- [Money in Twig Templates](#money-in-twig-templates)
+- [Money in Javascript](#money-in-javascript)
+- [Money in Doctrine](#money-in-doctrine)
+- [Unit and Functional Tests](#unit-and-functional-tests)
+- [Price Class](#price-class)
+
+## General Concept
+The money concept in Shopsys Framework represents and encapsulates monetary values with a decimal part, like `100`, `0.50`, `10.99`, `0.0005`, ...
+Money is represented without currency.
+
+### Scale
+Scale defines the precision of the decimal part and it can be a bit tricky.
+
+Imagine you want to represent `1/3` (one third) in your application. In a `float`, it would be actually represented as `0.333333333333333314829616256247390992939472198486328125` because of [the floating-point precision](http://php.net/manual/en/language.types.float.php).
+
+When you want to work with one third in terms of money, you have to specify the scale - the number of places after the decimal point that should be taken into account.
+So you can create a monetary value from `1/3` in the scale of 2 (`0.33`), or in the scale of 8 (`0.33333333`).
+But it will never be exactly one third as it is inexpressible using a finite decimal.
+
+The money concept keeps the computation and comparisons precise up to the defined scale.
+Eg. if you have `1/3` with the scale of 4 (`0.3333`) and multiply it by `3` you'll get `0.9999`, not `1`.
+You can get around it using [rounding](#rounding).
+
+The scale has to be specified during [rounding](#rounding), [creating from floats](#construction) and [division](#computation).
+
+## Money Class
+
+[`Money`](/packages/framework/src/Component/Money/Money.php) is an immutable [value object](https://codete.com/blog/value-objects/).
+
+It uses a decimal representation of the money amount and it does not contain any reference to the used currency.
+You can get the decimal representation as a `string` via the `getAmount` method.
+
+*Note: If in doubt about the results of any method, you can take a look at [its unit tests](/packages/framework/tests/Unit/Component/Money/MoneyTest.php) which contain many examples of the class' behavior.*
+
+### Construction
+
+`Money` can be constructed directly from integers and numeric strings as they are able to represent decimal numbers precisely: `$tenDollars = Money::create(10)`, `$oneAndHalfEuro = Money::create('1.50')`.
+
+It may be also constructed from floating point numbers, but the scale (number of decimal places) must be explicitly specified: `Money::createFromFloat($floatFromExternalSource, 2)`.
+The created value will be [rounded](#rounding) to the provided scale.
+
+Zero amount of money can be constructed by calling `Money::zero()`.
+
+### Computation
+
+To compute with monetary values you have to use the object's methods instead of arithmetic operators (`+`, `-`, `*`, `/`):
+
+- `Money::add(Money $addend) : Money`
+- `Money::subtract(Money $subtrahend) : Money`
+- `Money::multiply(int|string $multiplier) : Money`
+- `Money::divide(int|string $divisor, int $scale) : Money`
+
+*Note: `Money` is immutable, which means that all these methods create a new object and the original is never modified.*
+
+For addition and subtraction, the other parameter has to be also a `Money` instance.
+For multiplication and division, the other parameter has to be an integer or a numeric string (as they are able to represent decimal numbers precisely), not a float.
+
+The scale (number of decimal places) of the result is assigned automatically to all operations except division, keeping the results as precise as possible.
+Results of a division may be inexpressible with a finite decimal (eg. 1 / 3 = 0.3333...), so it's up to the user to specify the requested scale.
+- scale of the result of `add` and `subtract` is the *maximal scale* of both money values
+- scale of the result of `multiply` is the *sum of scales* of both money values
+- scale of the result of `divide` must be *explicitly specified*, the last decimal place will be rounded to minimize the error
+
+*Note: The scale of the money amount is always preserved - `getAmount` will use all decimal places of its scale (eg. zero money with scale 6 would return `0.000000`).*
+
+### Rounding
+
+You may use `Money::round(int $scale) : Money` method that rounds the amount of money up to `$scale` decimal places, it rounds 0.5 away from zero (making 1.5 into 2 and -1.5 into -2).
+This behavior is consistent with `PHP_ROUND_HALF_UP` rounding mode, which is the default mode for [the `round` function](http://php.net/manual/en/function.round.php).
+
+The scale of the result will always be equal to the provided `$scale`.
+
+### Comparing
+
+To compare two monetary values you have to use the object's methods instead of [comparison operators](http://php.net/manual/en/language.operators.comparison.php):
+
+- `Money::equals(Money $other) : bool` instead of `===` and `==`
+- `Money::isLessThan(Money $other) : bool` instead of `<`
+- `Money::isGreaterThan(Money $other) : bool` instead of `>`
+- `Money::isLessThanOrEqualTo(Money $other) : bool` instead of `<=`
+- `Money::isGreaterThanOrEqualTo(Money $other) : bool` instead of `>=`
+- `Money::compare(Money $other) : int` instead of the Spaceship operator `<=>`
+
+To compare a value with zero you may use the short-hand methods`isPositive`, `isNegative` or `isZero`.
+A zero is considered neither positive nor negative.
+
+All methods compare the amounts of both objects counting all decimal places.
+
+## Money in Forms
+
+For the user input of monetary values use the `MoneyType` (see [Symfony docs](https://symfony.com/doc/3.4/reference/forms/types/money.html) for details).
+
+```php
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+// ...
+
+$orderItemFormBuilder->add('priceWithVat', MoneyType::class, [
+    'scale' => 6,
+    'constraints' => [
+        new NotBlank(['message' => 'Please enter unit price with VAT']),
+    ],
+]);
+```
+
+The form type is configured with a model data transformer that converts the value into a `Money` object automatically ([`NumericToMoneyTransformer`](/packages/framework/src/Form/Transformers/NumericToMoneyTransformer.php)).
+Thanks to this approach you can use `Money` in your [data objects](/docs/introduction/entities.md#entity-data) directly.
+
+In Shopsys Framework, the default value of the `currency` option is `false` instead of `EUR`, hiding the currency symbol by default.
+
+*Note: For non-monetary numeric values use `NumberType` (see [Symfony docs](https://symfony.com/doc/3.4/reference/forms/types/number.html) for details).*
+
+### Form Constraints
+
+There are two form constraints to be used specifically with the `MoneyType` form fields.
+Because of model data transformation, you cannot use constraints that are validating scalar values (eg. `GreaterThan`).
+
+#### NotNegativeMoneyAmount
+
+Validates that the amount of money is greater or equal to zero.
+
+It has only the `message` option specifying the validation error message in case the entered value is negative.
+Specifying the validation message is optional, there is a default value.
+
+```php
+use Shopsys\FrameworkBundle\Form\Constraints\NotNegativeMoneyAmount;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+// ...
+
+$priceTableFormBuilder->add($key, MoneyType::class, [
+    'scale' => 6,
+    'required' => true,
+    'invalid_message' => 'Please enter price in correct format (a number with decimal separator)',
+    'constraints' => [
+        new NotBlank(['message' => 'Please enter price']),
+        new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+    ],
+]);
+```
+
+#### MoneyRange
+
+Similarly to [the Symfony `Range` constraint](https://symfony.com/doc/3.4/reference/constraints/Range.html), it validates that the amount of money is between some minimum and maximum.
+
+It has four options:
+- `min` specifies the minimum value, has to be an instance of `Money` or `null`
+- `max` specifies the maximum value, has to be an instance of `Money` or `null`
+- `minMessage` specifies the validation error message in case the entered value is less than the `min` value
+- `maxMessage` specifies the validation error message in case the entered value is greater than the `max` value
+
+At least one of the `min` and `max` options has to be provided for the constraint to make sense.
+Specifying the validation messages is optional, there are default values.
+
+```php
+use Shopsys\FormTypesBundle\MultidomainType;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Form\Constraints\MoneyRange;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+
+// ...
+
+$zboziFeedProductFormBuilder->add('cpc', MultidomainType::class, [
+    'label' => $this->translator->trans('Maximum price per click'),
+    'entry_type' => MoneyType::class,
+    'required' => false,
+    'entry_options' => [
+        'currency' => 'CZK',
+        'constraints' => [
+            new MoneyRange([
+                'min' => Money::create(1),
+                'max' => Money::create(500),
+            ]),
+        ],
+    ],
+]);
+```
+
+## Money in Twig Templates
+
+Instances of the `Money` class cannot be directly converted to strings.
+To be able to display a monetary value in a template you should use one of the prepared Twig filters.
+
+These filters can be used only with an instance of `Money`.
+
+### price
+
+Filter `price` formats the amount of money in a localized manner, including the currency symbol.
+It uses basic frontend currency on the current domain and the current locale (language) to format it.
+
+For example, one thousand Czech crowns would be rendered as *"CZK1,000.00"* on an English domain and as *"1 000,00 Kč"* on a Czech one.
+
+The filter expects the value to be already rounded.
+If not, it will render the extra decimal places.
+
+All `price*` Twig filters use this format.
+They usually differ only in the currency and locale they use.
+
+### priceText
+
+Filter `priceText` formats the amount of money in a localized manner, similarly to the `price` filter.
+The only difference is that it outputs the text *"Free"* (or the corresponding [translation](/docs/introduction/translations.md)) when zero amount of money is provided.
+
+### priceTextWithCurrencyByCurrencyIdAndLocale
+
+Filter `priceTextWithCurrencyByCurrencyIdAndLocale` can be used to format the amount of money in any currency and locale.
+It outputs the text *"Free"* when zero amount of money is provided.
+
+The *currency ID* (`int`) and the *locale* (`string`) must be provided as parameters.
+
+### priceWithCurrency
+
+Filter `priceWithCurrency` can be used to format the amount of money in any currency.
+It uses the current locale (the locale of current domain or administration) to format it.
+
+The *currency* (`Currency` entity) must be provided as a parameter.
+
+### priceWithCurrencyAdmin
+
+It works similarly to `priceWithCurrency`, but it uses the default administration currency.
+
+It has no parameters.
+
+### priceWithCurrencyByCurrencyId
+
+It works similarly to `priceWithCurrency`, but it uses currency ID instead of the `Currency` entity.
+
+The *currency ID* (`int`) must be provided as a parameter.
+
+### priceWithCurrencyByDomainId
+
+It works similarly to `priceWithCurrency`, but it uses the basic frontend currency of the provided domain.
+
+The *domain ID* (`int`) must be provided as a parameter.
+
+### moneyFormat
+
+Formats the amount of money as a decimal number without any currency symbol.
+
+Three optional parameters can be provided:
+- *number of decimal places* - `null` by default (meaning all), it will [round](#rounding) the value if necessary
+- *decimal point character* - `"."` by default
+- *separator of thousands* - `""` by default
+
+```twig
+{# the "money" variable contains Money::create('1234.5670') #}
+
+{{ money|moneyFormat }}                  {# renders "1234.5670" #}
+{{ money|moneyFormat(0) }}               {# renders "1235" #}
+{{ money|moneyFormat(2, ',') }}          {# renders "1234,57" #}
+{{ money|moneyFormat(null, '.', ',') }}  {# renders "1,234.5670" #}
+```
+
+## Money in Javascript
+
+`Money` implements the `JsonSerializable` interface, which means it can be serialized into JSON format with `json_encode` into an object with the following structure:
+
+```json
+{
+  "amount": "1234.5670"
+}
+```
+
+This format can be readily used in Javascript when JSON is rendered in Twig:
+
+```twig
+{# the "money" variable contains Money::create('1234.5670') #}
+
+<div id="my-money" data-money="{{ money|json_encode }}"/>
+```
+
+```js
+(function ($) {
+
+    $(document).ready(function () {
+        var money = $('#my-money').data('money');
+
+        // Displays "1234.5670"
+        alert(money.amount);
+    });
+
+})(jQuery);
+```
+
+See the native Javascript method [`.toFixed()`](https://www.w3schools.com/jsref/jsref_tofixed.asp) and the function [`parseFloat()`](https://www.w3schools.com/jsref/jsref_parsefloat.asp) to see how to convert between decimal strings and numbers.
+
+## Money in Doctrine
+
+In Shopsys Framework, there is a custom Doctrine type `money` which can be used in similar fashion as `decimal` type.
+The entity property value will be automatically hydrated to an instance of `Money` if it's configured to use the type:
+
+```php
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class MyEntity
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Money\Money|null
+     *
+     * @ORM\Column(type="money", precision=20, scale=6, nullable=true)
+     */
+    protected $price;
+
+    // ...
+}
+```
+
+### In Parameters
+
+When you want to use a `Money` instance as a parameter in DQL, use the `getAmount` method in your [repository class](/docs/introduction/basics-about-model-architecture.md#repository):
+
+```php
+use Shopsys\FrameworkBundle\Component\Money\Money;
+
+// ...
+
+$priceLimit = Money::create(1000);
+
+/** @var \Doctrine\ORM\QueryBuilder $builder */
+$builder->setParameter('priceLimit', $priceLimit->getAmount());
+```
+
+### In Function Results
+
+Doctrine hydrates values to an instance of `Money` when selecting an entity property:
+
+```php
+use Shopsys\FrameworkBundle\Model\Order\Order;
+
+/** @var \Doctrine\ORM\EntityManager $em */
+$result = $em->createQuery('SELECT o.totalPriceWithVat FROM ' . Order::class . ' o WHERE o.id = :id')
+    ->setParameter('id', 1)
+    ->getSingleResult();
+
+// The result is automatically hydrated into Money
+$money = $result['totalPriceWithVat'];
+```
+
+But when you're working with aggregate functions (such as `MIN()`, `MAX()`, `SUM()`, etc.) Doctrine cannot infer the type.
+In such a case, you have to convert the fetched decimal string into a `Money` instance yourself using `Money::create()`:
+
+```php
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Order\Order;
+
+/** @var \Doctrine\ORM\EntityManager $em */
+$result = $em->createQuery('SELECT AVG(o.totalPriceWithVat) AS averagePriceWithVat FROM ' . Order::class . ' o')
+    ->getSingleResult();
+
+// The result of a function is a decimal string (eg. '19590.772727272727') and it must be converted manually
+$money = Money::create($result['averagePriceWithVat']);
+```
+
+## Unit and Functional Tests
+
+You should use `Money` for all monetary values even in tests.
+
+Create the instances via `Money::create(int|string)` in your data providers or directly in your test methods if you don't use providers.
+
+You can use a custom PHPUnit constraint `IsMoneyEqual` for an assertion that two monetary values are equal using the `assertThat($value, Constraint $constraint)` method.
+
+Example:
+
+```php
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Tests\FrameworkBundle\Test\IsMoneyEqual;
+use Tests\ShopBundle\Test\FunctionalTestCase;
+
+class MyTest extends FunctionalTestCase
+{
+    // ...
+
+    /**
+     * @return array
+     */
+    public function customerLoyaltyCreditAmountProvider(): array
+    {
+        return [
+            [self::CUSTOMER_ID_WITHOUT_LOYALTY_CREDIT, Money::zero()],
+            [self::CUSTOMER_ID_WITH_LOW_LOYALTY_CREDIT, Money::create('12.5')],
+            [self::CUSTOMER_ID_WITH_HIGH_LOYALTY_CREDIT, Money::create(1000)],
+        ];
+    }
+
+    /**
+     * @dataProvider customerLoyaltyCreditAmountProvider
+     * @param int $customerId
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $expectedCreditAmount
+     */
+    public function testCustomerLoyaltyCreditAmount(int $customerId, Money $expectedCreditAmount) {
+        $customer = $this->getCustomerFromDatabase($customerId);
+
+        $creditAmount = $this->customerLoyaltyFacade->calculateCreditAmount($customer);
+
+        $this->assertThat($creditAmount, new IsMoneyEqual($expectedCreditAmount));
+    }
+}
+```
+
+## Price Class
+
+[`Price`](/packages/framework/src/Model/Pricing/Price.php) is also an immutable [value object](https://codete.com/blog/value-objects/) used in pricing.
+
+It represents a price with and without VAT and is used in many parts of Shopsys Framework.
+Price calculation classes usually output instances of `Price`.
+
+It can be constructed by calling `new Price(Money $priceWithoutVat, Money $priceWithVat)`.
+For a zero price, you can use a short-hand method `Price::zero()`.
+
+The class has three getters you can use to retrieve the prices or the VAT amount:
+- `Price::getPriceWithoutVat() : Money`
+- `Price::getPriceWithVat() : Money`
+- `Price::getVatAmount() : Money`
+
+And you can calculate with prices using its methods:
+- `Price::add(Price $addend) : Price`
+- `Price::subtract(Price $subtrahend) : Price`
+- `Price::inverse() : Price`

--- a/docs/upgrade/UPGRADE-v7.0.0.md
+++ b/docs/upgrade/UPGRADE-v7.0.0.md
@@ -20,8 +20,10 @@ if you want to have products data exported to Elasticsearch after `build-demo` t
     - dump translations using `php phing dump-translations` and fill in the translations based on the changes from pull request
 - check whether you extended class or method `ImageFacade::copyImages` or used it in your project and make sure it works like you intended ([#851](https://github.com/shopsys/shopsys/pull/851))
     - *(low priority)* remove `/var/www/html/var/cache` folder from your `@main_filesystem` filesystem storage if exists, set as local filesystem storage in path `%kernel.project_dir%` by default
-- use `\Shopsys\FrameworkBundle\Component\Money\Money` class for representing monetary values in the whole application ([#821](https://github.com/shopsys/shopsys/pull/821))
-    - detailed upgrade instruction will be added shortly, see the PR for more information
+- use `Money` class for representing monetary values in the whole application ([#821](https://github.com/shopsys/shopsys/pull/821))
+    - we recommend first reading the article [How to Work with Money](/docs/introduction/how-to-work-with-money.md) which explains the concept
+    - you can take a look at [what was modified in `shopsys/project-base` during this change](https://github.com/shopsys/project-base/compare/cb6d02f335819aeff575dec01bda5b228263a2eb...c08cac7b55ebc46b43c2e988d36e2f122cbb4598#files_bucket) (24 files)
+    - you'll find detailed instructions in separate article [Upgrade Instructions for Money Class](/docs/upgrade/money-class.md)
 - you need to provide `$temporaryFilenames` parameter anywhere you use `ImageFactoryInterface::create()` and `ImageFacade::uploadImage()` functions ([#869](https://github.com/shopsys/shopsys/pull/869))
     - the parameter is not nullable now
 - if you're using protected method `ImageProcessor::removeFileIfRenamed()` in your code, remove the usage due to the method was removed and the code was moved to `convertToShopFormatAndGetNewFilename()` ([#869](https://github.com/shopsys/shopsys/pull/869))

--- a/docs/upgrade/money-class.md
+++ b/docs/upgrade/money-class.md
@@ -1,0 +1,467 @@
+# Upgrade Instructions for Money Class
+
+This article describes upgrade instructions for [#821 new class for representing monetary values](https://github.com/shopsys/shopsys/pull/821).
+Upgrade instructions are in a separate article because there is a lot of instructions and we don't want to jam the [UPGRADE-v7.0.0.md](/docs/upgrade/UPGRADE-v7.0.0.md).
+Follow these instructions only if you upgrade from `v7.0.0-beta6` to `v7.0.0`.
+
+All monetary values (*prices, account balances, discount amounts, price limits etc.*) should be represented by an instance of the class `\Shopsys\FrameworkBundle\Component\Money\Money`.
+
+Before the upgrade, we recommend reading the article [How to Work with Money](/docs/introduction/how-to-work-with-money.md) which explains the concept in detail.
+
+**When in doubt, you can take a look at [what was modified in `shopsys/project-base` during this change](https://github.com/shopsys/project-base/compare/cb6d02f335819aeff575dec01bda5b228263a2eb...c08cac7b55ebc46b43c2e988d36e2f122cbb4598#files_bucket).**
+
+## Configuration
+Register the new Doctrine type in `doctrine.dbal.types` in your `app/config/packages/doctrine.yml`:
+```diff
+         password: "%database_password%"
+         charset: UTF8
+         server_version: "%database_server_version%"
++        types:
++            money: \Shopsys\FrameworkBundle\Component\Doctrine\MoneyType
+
+     orm:
+         auto_generate_proxy_classes: false
+```
+
+## Extended and Custom Entities
+If you have created your custom entities that store monetary value or added a new such column [by entity extension](/docs/extensibility/entity-extension.md), change your `decimal` Doctrine type to the new `money` type:
+
+```diff
+  /**
+-  * @var string
+-  * @ORM\Column(type="decimal", precision=20, scale=6)
++  * @var \Shopsys\FrameworkBundle\Component\Money\Money
++  * @ORM\Column(type="money", precision=20, scale=6)
+   */
+  protected $myMonetaryValue;
+```
+
+If you do so, you'll have to create [a database migration](/docs/introduction/database-migrations.md) which will add a `(DC2Type:money)` comment on the columns, informing Doctrine about the specified type (similarly to the [`Version20190215092226`](/packages/framework/src/Migrations/Version20190215092226.php) in `shopsys/framework`).
+
+Because the entity property now changed the type, its usages (along with the related [entity data class](/docs/introduction/entities.md#entity-data)) have to be reviewed and changed as well.
+We recommend using type-hinting in the changed methods as explained in [Working With Money in PHP](#working-with-money-in-php) below.
+
+If you need to set a value to the property in these custom entities or data objects directly, you should use the `Money::create()` method that accepts a string or an integer (or another [construction method](/docs/introduction/how-to-work-with-money.md#construction)).
+
+For more details read [the Money in Doctrine section](/docs/introduction/how-to-work-with-money.md#money-in-doctrine) of the documentation.
+
+## Working With Money in PHP
+You should use `Money` for all monetary values across your project.
+We strongly recommend declaring the `Money` type for both [the method arguments](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) and [the return values](http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration) in your methods.
+
+If you need to compute money, use its methods `add`, `subtract`, `multiply` and `divide` instead of the operators `+`, `-`, `*` and `/`.
+
+If you need to compare two instances of `Money`, use its methods `equals`, `isGreaterThan`, `isGreaterThanOrEqualTo`, `isLessThan`, `isLessThanOrEqualTo` and `compare` instead of the operators `==`/`===`, `>`, `>=`, `<`, `<=` and `<=>`.
+If you want to compare `Money` with zero, you can use the methods `isZero`, `isPositive` and `isNegative`.
+
+For more details read [the Money Class section](/docs/introduction/how-to-work-with-money.md#money-class) of the documentation.
+
+There were no changes needed in `shopsys/project-base` as most PHP implementation is in `shopsys/framework`.
+You might need to update your custom classes working with prices and overridden services, because of the changed types.
+
+*Note: Running the `phpstan` [Phing target](/docs/introduction/console-commands-for-application-management-phing-targets.md) will help you find out problems with incompatible method declarations mentioned in this section and in [Strict Typing](#strict-typing) below.*
+*In case of problems, it will fail on a `PHP Fatal error` with a reference to the incompatible method (unfortunately it is unable to continue with the checks as it cannot recover from this error).*
+
+## Strict Typing
+In the process of spreading the use of `Money` across the methods, we enabled [strict typing](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict) in some classes.
+A type declaration was added into all method parameters and return values when possible, so you can be sure about the accepted and expected variable types.
+Strict typing was also enabled in all newly created classes.
+
+Check how you use or extend these classes, into which the statement `declare(strict_types=1);` was added:
+- `\Shopsys\FrameworkBundle\Model\Cart\Item\CartItem`
+- `\Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice`
+- `\Shopsys\FrameworkBundle\Model\Order\OrderPriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewCalculation`
+- `\Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode`
+- `\Shopsys\FrameworkBundle\Model\Order\Watcher\TransportAndPaymentWatcher`
+- `\Shopsys\FrameworkBundle\Model\Payment\PaymentPrice`
+- `\Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Pricing\InputPriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Pricing\Rounding`
+- `\Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Product\Pricing\QuantifiedProductDiscountCalculation`
+- `\Shopsys\FrameworkBundle\Model\Product\Pricing\QuantifiedProductPriceCalculation`
+- `\Shopsys\FrameworkBundle\Model\Transport\TransportPrice`
+- `\Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation`
+- `\Shopsys\FrameworkBundle\Twig\PriceExtension`
+
+*Note: Running the `phpstan` [Phing target](/docs/introduction/console-commands-for-application-management-phing-targets.md) will help you find out problems with incompatible method declarations as mentioned in the note above.*
+
+## Twig Templates
+Templates mostly use [the `price` Twig filter](/docs/introduction/how-to-work-with-money.md#price) (or one of its `price*` variants) for rendering monetary values.
+The filters work the same way, but they now require an instance of `Money` to be provided.
+If you pass a value of a different type into one of the `price*` filters (it would fail on a `TypeError`) you should check where it came from and fix it there - all monetary values have to be represented by the new `Money` value object.
+Because the monetary value is mostly taken from a `Price` object and its getters use `Money` as a return type now, the templates usually don't need any changes.
+
+*Note: [HTTP smoke tests](/docs/introduction/automated-testing.md#http-smoke-tests) can be very helpful when finding issues in your templates.*
+*You can run them by executing the `tests-smoke` [Phing target](/docs/introduction/console-commands-for-application-management-phing-targets.md).*
+
+There are some cases in which you'll have to modify your templates:
+
+### Manipulation with money before rendering
+Instead of arithmetic operators, you should use the methods for [computation with Money](/docs/introduction/how-to-work-with-money.md#computation) such as `add`, `subtract`, `multiply`, etc.
+Also, you can use the `Price::inverse()` for inverting the value, which might come handy in presenting discounts.
+
+As an example, see the change in `@ShopsysShop/Front/Content/Order/preview.html.twig` from `shopsys/project-base`:
+```diff
+-    {{ (-quantifiedProductDiscount.priceWithVat)|price }}
++    {{ quantifiedProductDiscount.inverse.priceWithVat|price }}
+```
+
+Code manipulating with prices in a complex way does not belong into templates.
+In such situation, you should probably refactor your code and move the logic into your [model](/docs/introduction/basics-about-model-architecture.md).
+
+### Comparing monetary values in templates
+Instead of comparison operators, you should use the methods for [comparing Money](/docs/introduction/how-to-work-with-money.md#comparing) such as `equals`, `isGreaterThan`, `isGreaterOrEqualTo`, etc.
+To compare a value with zero, you may use `isZero`, `isPositive`, or `isNegative`.
+
+Don't forget to check conditions without any operators (such as `{% if money %}` / `{% if not money %}`).
+These could have been used to compare with zero, but now the actual value would have no effect on the conditions as [every object is converted to `true`](http://php.net/manual/en/language.types.boolean.php#language.types.boolean.casting) in PHP.
+You should replace such conditions with the negated `isZero` call (such as `{% if not money.isZero %}` / `{% if money.isZero %}`).
+
+For values of type `Money|null` you'll have to check the `null` value separately to avoid calling methods on `null`, eg.: `{% if money is not null and not money.isZero %}`.
+
+As an example, see the change in `@ShopsysShop/Front/Content/PersonalData/orders.xml.twig` from `shopsys/project-base`:
+```diff
+-    {% if item.priceWithoutVat %}
+-        <item_unit_price_without_vat>{{ item.priceWithoutVat }}</item_unit_price_without_vat>
++    {% if not item.priceWithoutVat.isZero %}
++        <item_unit_price_without_vat>{{ item.priceWithoutVat|moneyFormat }}</item_unit_price_without_vat>
+     {% endif %}
+-    {% if item.priceWithVat %}
+-        <item_unit_price_with_vat>{{ item.priceWithVat }}</item_unit_price_with_vat>
++    {% if not item.priceWithVat.isZero %}
++        <item_unit_price_with_vat>{{ item.priceWithVat|moneyFormat }}</item_unit_price_with_vat>
+```
+
+### Displaying money without a currency symbol
+Instead of rendering a monetary value directly, you should use [the new `moneyFormat` Twig filter](/docs/introduction/how-to-work-with-money.md#moneyformat) which accepts `Money` instances.
+So instead of `{{ money }}`, you should use `{{ money|moneyFormat }}`.
+
+See all the changes that were needed in `shopsys/project-base`:
+- in `@ShopsysShop/Front/Content/Product/detail.html.twig`:
+    ```diff
+        content="{{ currencyCode(domain.id) }}"
+        >
+        <meta itemprop="price"
+    -        content="{{ getProductSellingPrice(product).priceWithVat }}"
+    +        content="{{ getProductSellingPrice(product).priceWithVat|moneyFormat }}"
+        >
+        <link itemprop="availability"
+            href="{{ product.calculatedSellingDenied ? 'http://schema.org/OutOfStock' : 'http://schema.org/InStock' }}"
+    ```
+    ```diff
+        content="{{ currencyCode(domain.id) }}"
+        >
+        <meta itemprop="lowPrice"
+    -        content="{{ getProductSellingPrice(product).priceWithVat }}"
+    +        content="{{ getProductSellingPrice(product).priceWithVat|moneyFormat }}"
+        >
+        <link itemprop="availability"
+            href="{{ product.calculatedSellingDenied ? 'http://schema.org/OutOfStock' : 'http://schema.org/InStock' }}"
+    ```
+- in `@ShopsysShop/Front/Content/Product/filterFormMacro.html.twig`:
+    ```diff
+        <div
+                class="js-range-slider"
+                data-minimum-input-id="{{ filterForm.minimalPrice.vars.id }}"
+    -            data-minimal-value="{{ priceRange.minimalPrice }}"
+    +            data-minimal-value="{{ priceRange.minimalPrice|moneyFormat }}"
+                data-maximum-input-id="{{ filterForm.maximalPrice.vars.id }}"
+    -            data-maximal-value="{{ priceRange.maximalPrice }}"
+    +            data-maximal-value="{{ priceRange.maximalPrice|moneyFormat }}"
+            ></div>
+        </div>
+    ```
+- in `@ShopsysShop/Front/Inline/MeasuringScript/googleAnalyticsEcommerce.html.twig`:
+    ```diff
+        ga('ecommerce:addTransaction', {
+            'id': '{{ order.number|escape('js') }}',
+    -       'revenue': '{{ order.totalPriceWithVat }}',
+    -       'shipping': '{{ order.transportAndPaymentPrice.priceWithVat }}',
+    -       'tax': '{{ order.totalVatAmount }}',
+    +       'revenue': '{{ order.totalPriceWithVat|moneyFormat }}',
+    +       'shipping': '{{ order.transportAndPaymentPrice.priceWithVat|moneyFormat }}',
+    +       'tax': '{{ order.totalVatAmount|moneyFormat }}',
+            'currency': '{{ order.currency.code|escape('js') }}'
+        });
+    ```
+    ```diff
+                    'category': '{{ productMainCategory.name|escape('js') }}',
+                    {% endif %}
+                {% endif %}
+    -           'price': '{{ orderProduct.priceWithVat }}',
+    +           'price': '{{ orderProduct.priceWithVat|moneyFormat }}',
+                'quantity': '{{ orderProduct.quantity }}'
+            });
+        {% endfor %}
+    ```
+
+## Forms
+Review all usage of the `MoneyType` field in your project.
+
+If you are using `MoneyType` field for non-monetary values, change it to `NumberType` instead.
+Otherwise, take in mind that its value will automatically convert to a `Money` instance now.
+
+This means you cannot use constraints that are validating scalar values (`GreaterThan`, `Range`, etc.).
+You can keep using `NotBlank` to validate `null` values and use the new constraints `NotNegativeMoneyAmount` and `MoneyRange`:
+- `Shopsys\FrameworkBundle\Form\Constraints\MoneyRange` for setting acceptable range (only one side of the interval is required)
+- `Shopsys\FrameworkBundle\Form\Constraints\NotNegativeMoneyAmount` for setting that entered amount of money has to be zero or higher
+
+If none of these constraints is sufficient for your use case, create your own.
+For inspiration, [see the commit where we implemented the MoneyRange constraint](https://github.com/shopsys/shopsys/pull/821/commits/390b21416e54ca8bf34a7f7deec4e5c3eed5cd51).
+
+*Note: You don't have to specify the option `'currency' => false` for the `MoneyType` field as this is its new default value.*
+
+You'll find more info about the form type and constraints in [the Money in Forms section](/docs/introduction/how-to-work-with-money.md#money-in-forms) of the documentation.
+
+---
+
+As a rather complex example, you can see how we changed the `ProductFilterFormType` class in `shopsys/project-base` (which was the only form changed in the repository).
+
+Note how the constraints have been changed from `GreaterThanOrEqual` to `NotNegativeMoneyAmount`.
+
+The `'currency' => false` and  `'scale' => 2` options have been removed as those are the default values for the options.
+
+The most significant was the newly added protected method `transformMoneyToView` that uses the same model and view transformers as the `MoneyType` to transform the placeholders from `Money` to a string.
+Previously, the `MoneyToLocalizedStringTransformer` (which is a default view transformer in the `MoneyType` field) was used explicitly - now, the transformers are taken from the passed `FormBuilder`.
+
+```diff
+  namespace Shopsys\ShopBundle\Form\Front\Product;
+
++ use Shopsys\FrameworkBundle\Component\Money\Money;
++ use Shopsys\FrameworkBundle\Form\Constraints\NotNegativeMoneyAmount;
+  // ...
+- use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
+  // ...
+- use Symfony\Component\Validator\Constraints;
+
+  class ProductFilterFormType extends AbstractType
+  {
+      // ...
+      public function buildForm(FormBuilderInterface $builder, array $options)
+      {
+-         $priceScale = 2;
+-         $priceTransformer = new MoneyToLocalizedStringTransformer($priceScale, false);
+          /** @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig $config */
+          $config = $options['product_filter_config'];
+
++         $moneyBuilder = $builder->create('money', MoneyType::class);
++
+          $builder
+              ->add('minimalPrice', MoneyType::class, [
+-                 'currency' => false,
+-                 'scale' => $priceScale,
+                  'required' => false,
+-                 'attr' => ['placeholder' => $priceTransformer->transform($config->getPriceRange()->getMinimalPrice())],
++                 'attr' => ['placeholder' => $this->transformMoneyToView($config->getPriceRange()->getMinimalPrice(), $moneyBuilder)],
+                  'invalid_message' => 'Please enter price in correct format (positive number with decimal separator)',
+                  'constraints' => [
+-                     new Constraints\GreaterThanOrEqual([
+-                         'value' => 0,
+-                         'message' => 'Price must be greater or equal to {{ compared_value }}',
+-                     ]),
++                     new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+                  ],
+              ])
+              ->add('maximalPrice', MoneyType::class, [
+-                 'currency' => false,
+-                 'scale' => $priceScale,
+                  'required' => false,
+-                 'attr' => ['placeholder' => $priceTransformer->transform($config->getPriceRange()->getMaximalPrice())],
++                 'attr' => ['placeholder' => $this->transformMoneyToView($config->getPriceRange()->getMaximalPrice(), $moneyBuilder)],
+                  'invalid_message' => 'Please enter price in correct format (positive number with decimal separator)',
+                  'constraints' => [
+-                     new Constraints\GreaterThanOrEqual([
+-                         'value' => 0,
+-                         'message' => 'Price must be greater or equal to {{ compared_value }}',
+-                     ]),
++                     new NotNegativeMoneyAmount(['message' => 'Price must be greater or equal to zero']),
+                  ],
+              ])
+      // ...
++
++     /**
++      * @param \Shopsys\FrameworkBundle\Component\Money\Money $money
++      * @param \Symfony\Component\Form\FormBuilderInterface $moneyBuilder
++      * @return string
++      */
++     protected function transformMoneyToView(Money $money, FormBuilderInterface $moneyBuilder): string
++     {
++         foreach ($moneyBuilder->getModelTransformers() as $modelTransformer) {
++             /** @var \Symfony\Component\Form\DataTransformerInterface $modelTransformer */
++             $money = $modelTransformer->transform($money);
++         }
++         foreach ($moneyBuilder->getViewTransformers() as $viewTransformer) {
++             /** @var \Symfony\Component\Form\DataTransformerInterface $viewTransformer */
++             $money = $viewTransformer->transform($money);
++         }
++
++         return $money;
++     }
+  }
+```
+
+## Data in SettingValue Entities
+The [`Setting`](/packages/framework/src/Component/Setting/Setting.php) component is now able to save and load [`SettingValue`](/packages/framework/src/Component/Setting/SettingValue.php) entities with an instance of `Money` as a value.
+To make sure that monetary values that are currently saved as a decimal string will be loaded as a `Money` instance, you have to manually create [a database migration](/docs/introduction/database-migrations.md) that changes the `type` to `money` for all `SettingValue` entities holding monetary values that you added into your project.
+Previously, any of types `string`, `integer` or `float` might have been used to save a numeric value into the database.
+
+For example see the `up` method of migration class [`Version20190220101938`](/packages/framework/src/Migrations/Version20190220101938.php) that migrates the `freeTransportAndPaymentPriceLimit` setting values to the `Money` type:
+```php
+/**
+ * @param \Doctrine\DBAL\Schema\Schema $schema
+ */
+public function up(Schema $schema)
+{
+    $this->sql('UPDATE setting_values SET type = \'money\' WHERE name = \'freeTransportAndPaymentPriceLimit\' AND type != \'none\'');
+}
+```
+
+*Note: If you didn't add any new `SettingValue` entities that hold monetary values you can safely skip this step.*
+*The migration in `shopsys/framework` mentioned above will take care of changing the type of the limits for free transport and payment in your DB.*
+
+## Data Fixtures
+All monetary values in data fixtures should use `Money` as well.
+If you haven't altered the data fixtures in any way, you should be ready to go when you copy the data fixtures from `shopsys/project-base` in `v7.0.0` (as explained in the upgrade notes of [PR #854](https://github.com/shopsys/shopsys/pull/854/files#diff-da18024d2b6b8b4b2fafe94d18cb2866)).
+
+You should manage to upgrade your custom data fixtures by using [the static methods `Money::create()` and `Money::zero()`](/docs/introduction/how-to-work-with-money.md#construction) when setting a monetary value.
+
+These 3 data fixture classes had to be changed in `shopsys/project-base`:
+- `\Shopsys\ShopBundle\DataFixtures\Demo\PaymentDataFixture.php`
+- `\Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureLoader.php`
+- `\Shopsys\ShopBundle\DataFixtures\Demo\TransportDataFixture.php`
+
+*Note: Thanks to [the parameter type declarations](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) you should be able to see very quickly if your data fixtures use a wrong type when you run the `db-demo` [Phing target](/docs/introduction/console-commands-for-application-management-phing-targets.md).*
+
+## Tests
+Changes will be required in all your [unit tests](/docs/introduction/automated-testing.md#unit-tests) and [functional tests](/docs/introduction/automated-testing.md#functional-tests) that deal with money.
+
+You'll have to create instances of `Money` instead of using integers, floats or strings in your data providers (or directly in your test methods) like in these examples:
+
+```diff
+- $cartItem = $cartItemFactory->create($cart, $product, 1, 10);
++ $cartItem = $cartItemFactory->create($cart, $product, 1, Money::create(10));
+```
+
+```diff
+  public function inputPricesTestDataProvider()
+  {
+      return [
+          [
+-             'inputPriceWithoutVat' => '100',
+-             'inputPriceWithVat' => '121',
++             'inputPriceWithoutVat' => Money::create(100),
++             'inputPriceWithVat' => Money::create(121),
+              'vatPercent' => '21',
+          ],
+          [
+-             'inputPriceWithoutVat' => '17261.983471',
+-             'inputPriceWithVat' => '20887',
++             'inputPriceWithoutVat' => Money::create('17261.983471'),
++             'inputPriceWithVat' => Money::create(20887),
+              'vatPercent' => '21',
+          ],
+      ];
+  }
+```
+
+Also, when you assert that two monetary values are equal, you should use the `$this->assertThat` method with the new constraint `IsMoneyEqual` instead of asserting the equality (you can drop the rounding as well).
+Take a look at the examples:
+
+```diff
++ use Tests\FrameworkBundle\Test\IsMoneyEqual;
+  // ...
+- $this->assertSame('1000', (string)$productManualInputPrice->getInputPrice());
++ $this->assertThat($productManualInputPrice->getInputPrice(), new IsMoneyEqual(Money::create(1000)));
+```
+
+```diff
++ use Tests\FrameworkBundle\Test\IsMoneyEqual;
+  // ...
+- $this->assertSame(round($inputPriceWithoutVat, 6), round($payment->getPrice($currency)->getPrice(), 6));
+- $this->assertSame(round($inputPriceWithoutVat, 6), round($transport->getPrice($currency)->getPrice(), 6));
++ $this->assertThat($payment->getPrice($currency)->getPrice(), new IsMoneyEqual($inputPriceWithoutVat));
++ $this->assertThat($transport->getPrice($currency)->getPrice(), new IsMoneyEqual($inputPriceWithoutVat));
+```
+
+```diff
++ use Tests\FrameworkBundle\Test\IsMoneyEqual;
+  // ...
+  $this->assertNull($orderPreview->getPayment());
+  $this->assertNull($orderPreview->getPaymentPrice());
+- $this->assertSame(400 * 2, $orderPreview->getTotalPrice()->getVatAmount());
+- $this->assertSame(2400 * 2, $orderPreview->getTotalPrice()->getPriceWithVat());
+- $this->assertSame(2000 * 2, $orderPreview->getTotalPrice()->getPriceWithoutVat());
++ $this->assertThat($orderPreview->getTotalPrice()->getVatAmount(), new IsMoneyEqual(Money::create(400 * 2)));
++ $this->assertThat($orderPreview->getTotalPrice()->getPriceWithVat(), new IsMoneyEqual(Money::create(2400 * 2)));
++ $this->assertThat($orderPreview->getTotalPrice()->getPriceWithoutVat(), new IsMoneyEqual(Money::create(2000 * 2)));
+  $this->assertNull($orderPreview->getTransport());
+  $this->assertNull($orderPreview->getTransportPrice());
+```
+
+Furthermore, you'll have to apply same changes as in [section Working with Money in PHP](#working-with-money-in-php) if your tests make arithmetic operations or comparisons with Money.
+
+You can read more about it in [the Unit and Functional Tests section](/docs/introduction/how-to-work-with-money.md#unit-and-functional-tests).
+
+These 13 functional test classes had to be changed in `shopsys/project-base`:
+- `\Tests\ShopBundle\Functional\Model\Cart\CartFacadeDeleteOldCartsTest`
+- `\Tests\ShopBundle\Functional\Model\Cart\CartFacadeTest`
+- `\Tests\ShopBundle\Functional\Model\Cart\CartItemTest`
+- `\Tests\ShopBundle\Functional\Model\Cart\CartTest`
+- `\Tests\ShopBundle\Functional\Model\Cart\Watcher.php`
+- `\Tests\ShopBundle\Functional\Model\Order\OrderFacadeTest`
+- `\Tests\ShopBundle\Functional\Model\Order\Preview\OrderPreviewCalculationTest`
+- `\Tests\ShopBundle\Functional\Model\Pricing\InputPriceRecalculationSchedulerTest`
+- `\Tests\ShopBundle\Functional\Model\Pricing\ProductManualInputPriceTest`
+- `\Tests\ShopBundle\Functional\Model\Product\ProductOnCurrentDomainFacadeTest`
+- `\Tests\ShopBundle\Functional\Model\Product\ProductVisibilityRepositoryTest`
+- `\Tests\ShopBundle\Functional\PersonalData\PersonalDataExportXmlTest`
+- `\Tests\ShopBundle\Functional\Twig\PriceExtensionTest`
+
+Your [HTTP smoke tests](/docs/introduction/automated-testing.md#http-smoke-tests) and [acceptance test](/docs/introduction/automated-testing.md#acceptance-tests-aka-functional-tests-or-selenium-tests) shouldn't require any changes.
+
+## Javascript
+The `Money` class implements the `JsonSerializable` interface so it can be serialized using `json_encode` into an object usable in JS.
+
+You can read more about it in [the Money in Javascript section](/docs/introduction/how-to-work-with-money.md#money-in-javascript) of the documentation if you work with monetary values using JS in your project.
+There were no changes needed in `shopsys/project-base`.
+
+## Other
+The method `Cart::getQuantifiedProductsIndexedByItemId()` was renamed to `Cart::getQuantifiedProducts()` and no longer uses the product IDs for indexing.
+This was done due to the fact that it could lead to unexpected behavior when the `CartItem` entities have not yet been persisted (and thus they don't have been assigned an ID).
+
+Similarly, `CartFacade::getQuantifiedProductsOfCurrentCustomerIndexedByCartItemId()` was renamed to `CartFacade::getQuantifiedProductsOfCurrentCustomer()` and also no longer uses the product IDs for indexing.
+
+Check your usage of the methods and make appropriate changes.
+
+Note that the indexing may be used in Twig templates as well.
+As an example, see the change that was required in `@ShopsysShop/Front/Content/Cart/index.html.twig` in `shopsys/project-base`:
+```diff
+
+    <tbody>
+-       {% for cartItem in cartItems %}
+-           {% set cartItemPrice = cartItemPrices[cartItem.id] %}
+-           {% set cartItemDiscount = cartItemDiscounts[cartItem.id] %}
++       {% for index, cartItem in cartItems %}
++           {% set cartItemPrice = cartItemPrices[index] %}
++           {% set cartItemDiscount = cartItemDiscounts[index] %}
+                <tr class="table-cart__row js-cart-item">
+                    <td class="table-cart__cell table-cart__cell--image">
+```
+
+If you extended `QuantifiedProductPriceCalculation`, check your usage of the protected methods `getTotalPriceWithoutVat()`, `getTotalPriceWithVat()` and `getTotalPriceVatAmount()`.
+The signatures were changed and they now require two parameters to be provided.
+
+This was done to prevent the protected parameters `$quantifiedProduct`, `$product`, and `$productPrice` from being used to pass values between methods.
+These protected parameters were removed.
+Refactor your code if you have used them (you can take a look at [the original commit for inspiration](https://github.com/shopsys/shopsys/pull/821/commits/deb643e3d9d3ee077488250d50cc10936086c6a5)).
+
+---
+
+We know that the change is huge and upgrading might be difficult.
+We want to keep improving Shopsys Framework for you, we hope that this article helped you to safely upgrade your project.
+If you find anything we missed or if you'll need to explain anything more, please [create an issue](https://github.com/shopsys/shopsys/issues/new) or contact us on [our Slack](http://slack.shopsys-framework.com/).


### PR DESCRIPTION
In this PR, we're adding documentation and upgrade notes related to the `Money` object (#821).

| Q             | A
| ------------- | ---
|Description, reason for the PR| PR for easier review and management of #821
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
