### PR TITLE
[framework] autoload helper classes from Tests\FrameworkBundle\Test namespace

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -5,7 +5,8 @@
     "license": "proprietary",
     "autoload": {
         "psr-4": {
-            "Shopsys\\FrameworkBundle\\": "src/"
+            "Shopsys\\FrameworkBundle\\": "src/",
+            "Tests\\FrameworkBundle\\Test\\": "tests/Test/"
         },
         "files": [
             "src/Component/Translation/functions.php",


### PR DESCRIPTION
- otherwise the helper classes cannot be used in unit tests in projects depending on `shopsys/framework` (as [autoload-dev is root-only](https://getcomposer.org/doc/04-schema.md#autoload-dev))
- the namespace currently contains only 2 classes (`IsMoneyEqual` and `MoneyExporter`)
- a cleaner solution (that does not pollute autoload rules for production build) would be to extract the namespace into its own package (eg. `shopsys/unit-testing`) and use it inside `require-dev` (similarly to `shopsys/http-smoke-testing`)

| Q             | A
| ------------- | ---
|Description, reason for the PR| Unit tests of packages using shopsys/framework as a dependency cannot use `IsMoneyEqual` constraint
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| failing Travis builds of product feeds (on `Error: Class 'Tests\FrameworkBundle\Test\IsMoneyEqual' not found`)<br />*- issue introduced in #821* <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
