### PR TITLE
[framework] Fix typo, $hidden is boolean, not string

### DIFF
--- a/packages/framework/src/Model/Article/Article.php
+++ b/packages/framework/src/Model/Article/Article.php
@@ -87,7 +87,7 @@ class Article implements OrderableEntityInterface
     protected $placement;
 
     /**
-     * @var string
+     * @var bool
      *
      * @ORM\Column(type="boolean")
      */


### PR DESCRIPTION
Fixed var annotation in Article::$hidden, colum is boolean and variable appears to be string.