### PR TITLE
[coding-standards] marked symplify/better-phpdoc-parser in version >=5.4.14 as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,6 +149,7 @@
   },
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
+    "symplify/better-phpdoc-parser": ">=5.4.14",
     "twig/twig": "2.6.1"
   },
   "scripts": {

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -25,6 +25,9 @@
         "phpunit/phpunit": "^7.0",
         "symplify/easy-coding-standard-tester": "^5.2.17"
     },
+    "conflict": {
+        "symplify/better-phpdoc-parser": ">=5.4.14"
+    },
     "autoload": {
         "psr-4": {
             "Shopsys\\CodingStandards\\": "src/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| https://travis-ci.org/shopsys/coding-standards/jobs/501932502 & https://travis-ci.org/Symplify/CodingStandard/builds/501418213
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
