### PR TITLE
[framework] Set adaptive width to selectboxes created by selectize

### DIFF
--- a/packages/framework/src/Resources/styles/admin/libs/selectize/selectize-custom.less
+++ b/packages/framework/src/Resources/styles/admin/libs/selectize/selectize-custom.less
@@ -16,7 +16,6 @@
 
 @import "selectize";
 
-@selectize-height-control: 32px;
 @selectize-color-dropdown-item-active: @color-message-info;
 @selectize-color-dropdown-item-active-text: @color-base;
 @selectize-color-highlight: @color-message-info;
@@ -24,8 +23,8 @@
 @selectize-right-padding-input: 25px;
 
 .selectize-control {
-    height: @selectize-height-control;
-    line-height: @selectize-height-control;
+    height: @input-height;
+    line-height: @input-height;
     max-width: 100%;
     padding: 0;
 
@@ -45,8 +44,8 @@
     overflow: hidden;
 
     > * {
-        line-height: calc(~"@{selectize-height-control} - 2 * @{selectize-padding-input}");
-        height: calc(~"@{selectize-height-control} - 2 * @{selectize-padding-input}");
+        line-height: calc(~"@{input-height} - 2 * @{selectize-padding-input}");
+        height: calc(~"@{input-height} - 2 * @{selectize-padding-input}");
         overflow: hidden;
     }
 

--- a/packages/framework/src/Resources/styles/admin/libs/selectize/selectize-custom.less
+++ b/packages/framework/src/Resources/styles/admin/libs/selectize/selectize-custom.less
@@ -16,27 +16,48 @@
 
 @import "selectize";
 
+@selectize-height-control: 32px;
 @selectize-color-dropdown-item-active: @color-message-info;
 @selectize-color-dropdown-item-active-text: @color-base;
 @selectize-color-highlight: @color-message-info;
+@selectize-padding-input: 6px;
+@selectize-right-padding-input: 25px;
 
 .selectize-control {
-    height: 32px;
-    line-height: 32px;
+    height: @selectize-height-control;
+    line-height: @selectize-height-control;
     max-width: 100%;
     padding: 0;
 
     border: none;
 
     box-shadow: none;
+
+    &.input {
+        width: auto;
+        min-width: @input-width;
+    }
 }
 
 .selectize-input {
-    padding: 6px;
+    height: 100%;
+    padding: @selectize-padding-input @selectize-right-padding-input @selectize-padding-input @selectize-padding-input;
+    overflow: hidden;
+
+    > * {
+        line-height: calc(~"@{selectize-height-control} - 2 * @{selectize-padding-input}");
+        height: calc(~"@{selectize-height-control} - 2 * @{selectize-padding-input}");
+        overflow: hidden;
+    }
+
+    input {
+        display: none !important;
+    }
 }
 
 .selectize-control.single .selectize-input::after {
     right: 6px;
+    margin-top: 0;
 }
 
 .selectize-dropdown {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Select boxes have adaptive width. This can be applied to very long text in the select box.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| closes #862
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
