### PR TITLE
[project-base] overflow of long e-mail for unique e-mail validation

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -67,6 +67,17 @@ There you can find links to upgrade notes for other versions too.
     ```
     - generate new `Grtuntfile.js` by running command `php phing gruntfile`
     - generate new CSS files by running command `php phing grunt`
+- *(low priority)* add custom message for unique e-mail validation in `/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php` ([#885](https://github.com/shopsys/shopsys/pull/885))
+    ```diff
+    -                    new UniqueEmail(),
+    +                    new UniqueEmail(['message' => 'This e-mail is already registered']),
+    ```
+    - dump translations via `php phing dump-translations`
+    - fix `CustomerRegistrationCest::testAlreadyUsedEmail` acceptation test
+        ```diff
+        -        $registrationPage->seeEmailError('Email no-reply@shopsys.com is already registered');
+        +        $registrationPage->seeEmailError('This e-mail is already registered');
+        ```
 
 ## [shopsys/coding-standards]
 - We disallow using [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html) in the Shopsys Framework

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php
@@ -46,7 +46,7 @@ class RegistrationFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter e-mail']),
                     new Email(['message' => 'Please enter valid e-mail']),
                     new Constraints\Length(['max' => 255, 'maxMessage' => 'Email cannot be longer then {{ limit }} characters']),
-                    new UniqueEmail(),
+                    new UniqueEmail(['message' => 'This e-mail is already registered']),
                 ],
             ])
             ->add('password', RepeatedType::class, [

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.cs.po
@@ -124,6 +124,9 @@ msgstr "DIČ nesmí být delší než {{ limit }} znaků"
 msgid "Telephone number cannot be longer than {{ limit }} characters"
 msgstr "Telefon nesmí být delší než {{ limit }} znaků"
 
+msgid "This e-mail is already registered"
+msgstr "Tento e-mail je již registrován"
+
 msgid "You have to agree with privacy policy"
 msgstr "Musíte souhlasit se zpracováním osobních údajů"
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.en.po
@@ -124,6 +124,9 @@ msgstr ""
 msgid "Telephone number cannot be longer than {{ limit }} characters"
 msgstr ""
 
+msgid "This e-mail is already registered"
+msgstr ""
+
 msgid "You have to agree with privacy policy"
 msgstr ""
 

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerRegistrationCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerRegistrationCest.php
@@ -39,7 +39,7 @@ class CustomerRegistrationCest
         $me->wantTo('use already used email while registration');
         $me->amOnPage('/registration/');
         $registrationPage->register('Roman', 'Štěpánek', 'no-reply@shopsys.com', 'user123', 'user123');
-        $registrationPage->seeEmailError('Email no-reply@shopsys.com is already registered');
+        $registrationPage->seeEmailError('This e-mail is already registered');
     }
 
     /**


### PR DESCRIPTION
- validation message was changed to not use e-mail value because long e-mails were cut from the popup message

| Q             | A
| ------------- | ---
|Description, reason for the PR| during registration of customer if customer want to create account with already registered mail the validation message print also input value and the long mails are cut of in the design so we decided to not use input value into validation message
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #832 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
