### PR TITLE
[project-base] kubernetes containers accesspoints are routed via ingress

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -13,6 +13,11 @@ SECOND_DOMAIN_HOSTNAME=2.${JOB_NAME}.${DEVELOPMENT_SERVER_DOMAIN}
 yq write --inplace project-base/kubernetes/ingress.yml spec.rules[0].host ${FIRST_DOMAIN_HOSTNAME}
 yq write --inplace project-base/kubernetes/ingress.yml spec.rules[1].host ${SECOND_DOMAIN_HOSTNAME}
 
+# Set domain into dev-stack (redis-admin, elasticsearch, adminer) hostnames
+yq write --inplace project-base/kubernetes/kustomize/overlays/ci/ingress-patch.yaml [0].value.host adminer.${FIRST_DOMAIN_HOSTNAME}
+yq write --inplace project-base/kubernetes/kustomize/overlays/ci/ingress-patch.yaml [1].value.host elasticsearch.${FIRST_DOMAIN_HOSTNAME}
+yq write --inplace project-base/kubernetes/kustomize/overlays/ci/ingress-patch.yaml [2].value.host redis-admin.${FIRST_DOMAIN_HOSTNAME}
+
 # Set domain into webserver hostnames
 yq write --inplace project-base/kubernetes/deployments/webserver-php-fpm.yml spec.template.spec.hostAliases[0].hostnames[+] ${FIRST_DOMAIN_HOSTNAME}
 yq write --inplace project-base/kubernetes/deployments/webserver-php-fpm.yml spec.template.spec.hostAliases[0].hostnames[+] ${SECOND_DOMAIN_HOSTNAME}

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -217,6 +217,16 @@ There you can find links to upgrade notes for other versions too.
         +   database_server_version: 10.5
         ...
         ```
+
+### Infrastructure
+- remove node ports from kubernetes services ([#888](https://github.com/shopsys/shopsys/pull/888))
+    - remove `NodePort` type from `kubernetes/services/adminer.yml`, `kubernetes/services/redis-admin.yml`, `kubernetes/services/redis-admin.yml`
+    ```diff
+    -    type: NodePort
+     ports:
+     -   name: http
+    ```
+
 ### Tools
 - add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file to be able to fix files that were found by `ecs` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))
     ```diff

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -217,15 +217,59 @@ There you can find links to upgrade notes for other versions too.
         +   database_server_version: 10.5
         ...
         ```
-
 ### Infrastructure
-- remove node ports from kubernetes services ([#888](https://github.com/shopsys/shopsys/pull/888))
+- remove node ports from kubernetes services and add them into the ingress router ([#888](https://github.com/shopsys/shopsys/pull/888))
     - remove `NodePort` type from `kubernetes/services/adminer.yml`, `kubernetes/services/redis-admin.yml`, `kubernetes/services/redis-admin.yml`
-    ```diff
-    -    type: NodePort
-     ports:
-     -   name: http
-    ```
+        ```diff
+        -     type: NodePort
+          ports:
+          -   name: http
+        ```
+    - add ingress kustomize patch for CI deployment into `kubernetes/kustomize/overlays/ci/kustomization.yaml`
+        ```diff
+          -   ../../../services/selenium-server.yml
+        +patchesJson6902:
+        +-   target:
+        +        group: extensions
+        +        version: v1beta1
+        +        kind: Ingress
+        +        name: shopsys
+        +    path: ./ingress-patch.yaml
+          configMapGenerator:
+        ```
+    - add routes for elasticsearch, adminer and redis-admin into `kubernetes/kustomize/overlays/ci/ingress-patch.yaml`
+        ```diff
+        +- op: add
+        +  path: /spec/rules/-
+        +  value:
+        +    host: ~
+        +    http:
+        +        paths:
+        +        -   path: /
+        +            backend:
+        +                serviceName: adminer
+        +                servicePort: 80
+        +- op: add
+        +  path: /spec/rules/-
+        +  value:
+        +    host: ~
+        +    http:
+        +        paths:
+        +        -   path: /
+        +            backend:
+        +                serviceName: elasticsearch
+        +                servicePort: 9200
+        +- op: add
+        +  path: /spec/rules/-
+        +  value:
+        +    host: ~
+        +    http:
+        +        paths:
+        +        -   path: /
+        +            backend:
+        +                serviceName: redis-admin
+        +                servicePort: 80
+        ```
 
 ### Tools
 - add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file to be able to fix files that were found by `ecs` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))

--- a/project-base/kubernetes/kustomize/overlays/ci/ingress-patch.yaml
+++ b/project-base/kubernetes/kustomize/overlays/ci/ingress-patch.yaml
@@ -1,0 +1,30 @@
+- op: add
+  path: /spec/rules/-
+  value:
+    host: ~
+    http:
+        paths:
+        -   path: /
+            backend:
+                serviceName: adminer
+                servicePort: 80
+- op: add
+  path: /spec/rules/-
+  value:
+    host: ~
+    http:
+        paths:
+        -   path: /
+            backend:
+                serviceName: elasticsearch
+                servicePort: 9200
+- op: add
+  path: /spec/rules/-
+  value:
+    host: ~
+    http:
+        paths:
+        -   path: /
+            backend:
+                serviceName: redis-admin
+                servicePort: 80

--- a/project-base/kubernetes/kustomize/overlays/ci/kustomization.yaml
+++ b/project-base/kubernetes/kustomize/overlays/ci/kustomization.yaml
@@ -7,6 +7,13 @@ resources:
 -   ../../../services/adminer.yml
 -   ../../../services/redis-admin.yml
 -   ../../../services/selenium-server.yml
+patchesJson6902:
+-   target:
+        group: extensions
+        version: v1beta1
+        kind: Ingress
+        name: shopsys
+    path: ./ingress-patch.yaml
 configMapGenerator:
 -   name: nginx-configuration
     files:

--- a/project-base/kubernetes/services/adminer.yml
+++ b/project-base/kubernetes/services/adminer.yml
@@ -5,7 +5,6 @@ metadata:
 spec:
     selector:
         app: adminer
-    type: NodePort
     ports:
     -   name: http
         port: 80

--- a/project-base/kubernetes/services/redis-admin.yml
+++ b/project-base/kubernetes/services/redis-admin.yml
@@ -5,7 +5,6 @@ metadata:
 spec:
     selector:
         app: redis-admin
-    type: NodePort
     ports:
     -   name: http
         port: 80

--- a/project-base/kubernetes/services/webserver-php-fpm.yml
+++ b/project-base/kubernetes/services/webserver-php-fpm.yml
@@ -5,7 +5,6 @@ metadata:
 spec:
     selector:
         app: webserver-php-fpm
-    type: NodePort
     ports:
     -   name: http
         port: 8080


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| now for ci kustomize overlays, there are redis-admin, adminer, webserver-php-fpm bound as NodePort accessible and ingress is used only for webserver-php-fpm service in CI deployment. All NodePort services should be bound as ClusterIP and ingress should route redis-admin, adminer, webserver-php-fpm, elasticsearch so Testing and Business Validation could be done easily for the specific Pull Requests. `adminer.${FIRST_DOMAIN_URL}`<br>`elasticsearch.${FIRST_DOMAIN_URL}`<br>`redis-admin.${FIRST_DOMAIN_URL}`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| - <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
