### PR TITLE
[shopsys] marked twig/twig conflicting in version >=2.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,7 @@
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
     "symplify/better-phpdoc-parser": ">=5.4.14",
-    "twig/twig": "2.6.1"
+    "twig/twig": "2.6.1|>=2.7.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -99,6 +99,6 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "twig/twig": "2.6.1"
+        "twig/twig": "2.6.1|>=2.7.0"
     }
 }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -100,7 +100,7 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "twig/twig": "2.6.1"
+        "twig/twig": "2.6.1|>=2.7.0"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the assetic bundle is not compatible with newer version of twig
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
