### PR TITLE
[shopsys] fix error in javascript validation of ChoiceType

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -153,6 +153,7 @@ There you can find links to upgrade notes for other versions too.
     - and include `generate-build-version` and `clean-redis-old` to your build phing targets. Please find inspiration in [#886](https://github.com/shopsys/shopsys/pull/886/files)
     - once you finish this change (include the `build-version` into caches), you still should deal with older redis cache keys that don't use `build-version` prefix (16 digits).
       Such keys are not removed even by `clean-redis-old`, please find and remove them manually (via console or UI)
+- *(low priority)* remove option `choice_name` from `flags` and `brands` in `ShopBundle/Form/Front/Product/ProductFilterFormType.php` ([#891](https://github.com/shopsys/shopsys/pull/891))
 
 ## [shopsys/coding-standards]
 - We disallow using [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html) in the Shopsys Framework

--- a/packages/framework/src/Form/JsFormValidatorFactory.php
+++ b/packages/framework/src/Form/JsFormValidatorFactory.php
@@ -52,17 +52,14 @@ class JsFormValidatorFactory extends BaseJsFormValidatorFactory
                 : ['name' => $namespace . 'ChoiceToBooleanArrayTransformer'];
 
             $transformer['choiceList'] = [];
-            $optionsItemsThatAreNotInstanceOfParameterValue = [];
             foreach ($config->getOption('choices') as $formOptionChoiceItem) {
                 if ($formOptionChoiceItem instanceof ParameterValue) {
                     $optionItemId = $formOptionChoiceItem->getId();
                     $transformer['choiceList'][$optionItemId] = $formOptionChoiceItem;
                 } else {
-                    $optionsItemsThatAreNotInstanceOfParameterValue[] = $formOptionChoiceItem;
+                    $transformer['choiceList'][] = $formOptionChoiceItem;
                 }
             }
-
-            array_push($transformer['choiceList'], $optionsItemsThatAreNotInstanceOfParameterValue);
 
             array_unshift($viewTransformers, $transformer);
         }

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
@@ -54,7 +54,6 @@ class ProductFilterFormType extends AbstractType
                 'choices' => $config->getFlagChoices(),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'choice_name' => 'id',
                 'multiple' => true,
                 'expanded' => true,
             ])
@@ -63,7 +62,6 @@ class ProductFilterFormType extends AbstractType
                 'choices' => $config->getBrandChoices(),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'choice_name' => 'id',
                 'multiple' => true,
                 'expanded' => true,
             ])


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| Javascript validation throws error when you have ChoiceType with checkboxes
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #374  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
