### PR TITLE
[shopsys] consistent spelling: behavior, color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1314,7 +1314,7 @@ That's why is this section formatted differently.
     - phpunit/phpunit 5.7.21
     - twig/twig 1.34.0
     - twig/extensions 1.3.0
-- New automatic test that is controlling right behaviour of plugin 
+- New automatic test that is controlling right behavior of plugin
 - Added travis build icon into [README.md](https://github.com/shopsys/product-feed-heureka/blob/master/README.md) 
 ##### Changed
 - Dependency [shopsys/product-feed-interface] upgraded from ~0.2.0 to ~0.3.0 
@@ -1370,7 +1370,7 @@ That's why is this section formatted differently.
     - phpunit/phpunit >=5.0.0,<6.0
     - twig/twig 1.34.0
     - twig/extensions 1.3.0
-- New automatic test that is controlling right behaviour of plugin 
+- New automatic test that is controlling right behavior of plugin
 - Added travis build icon into [README.md](https://github.com/shopsys/product-feed-zbozi/blob/master/README.md) 
 ##### Changed
 - Dependency [product-feed-interface](https://github.com/shopsys/product-feed-zbozi/blob/master/shopsys/product-feed-interface) upgraded from ~0.2.0 to ~0.3.0 
@@ -1429,7 +1429,7 @@ That's why is this section formatted differently.
     - phpunit/phpunit >=5.0.0,<6.0
     - twig/twig 1.34.0
     - twig/extensions 1.3.0
-- New automatic test that is controlling right behaviour of plugin
+- New automatic test that is controlling right behavior of plugin
 - Added travis build icon into [README.md](https://github.com/shopsys/product-feed-heureka-delivery/blob/master/README.md)
 ##### Changed
 - Dependency [plugin-interface](https://github.com/shopsys/product-feed-interface) upgraded from ~0.2.0 to ~0.3.0

--- a/docs/contributing/releasing-a-new-version-of-shopsys-framework.md
+++ b/docs/contributing/releasing-a-new-version-of-shopsys-framework.md
@@ -50,4 +50,4 @@ However, there is a workaround - you can add new `docker-sync` volume just for g
 - Releasing a stage is a continuously running process so do not exit your CLI if it is not necessary.
 - When updating mutual dependencies in shopsys packages, the dependency on `coding-standards` is kept untouched in `http-smoke-testing` package
 as it is dependent on an obsolete version of the `coding-standards` package. See `Shopsys\Releaser\DependencyUpdater`.
-This behaviour should be discarded once the `http-smoke-testing` is dependent on `dev-master` version of `coding-standards` like all the other Shopsys packages.
+This behavior should be discarded once the `http-smoke-testing` is dependent on `dev-master` version of `coding-standards` like all the other Shopsys packages.

--- a/docs/introduction/monorepo.md
+++ b/docs/introduction/monorepo.md
@@ -49,7 +49,7 @@ Monorepo can be installed and used as standard application. This requires some a
 * **docker/** - templates for configuration of docker in monorepo.
 
 * **build.xml** - definitions of targets for use in the monorepo, some already defined targets
-have modified behaviour in such a way that their actions are launched over all monorepo packages
+have modified behavior in such a way that their actions are launched over all monorepo packages
 
 * **composer.json** - contains the dependencies required by individual packages and by Shopsys Framework.
 It is not generated automatically, so each change made in the `composer.json` of the specific package must be reflected

--- a/docs/introduction/product-search-via-elasticsearch.md
+++ b/docs/introduction/product-search-via-elasticsearch.md
@@ -64,7 +64,7 @@ If you want to improve searching, you can learn more in [Elasticsearch analysis]
 ## Where does Elasticsearch run?
 When using docker installation, Elasticsearch API is available on the address [http://127.0.0.1:9200](http://127.0.0.1:9200).
 
-## How to change the default index, data export setting, and searching behaviour?
+## How to change the default index, data export setting, and searching behavior?
 If you wish to reconfigure the indexes setting, simply change the JSON configurations in `src/Shopsys/ShopBundle/Resources/Resources/definition/`.
 Configurations use the `<index>/<domain_id>.json` naming pattern.
 

--- a/packages/framework/src/Command/ServerRunWithCustomRouterCommand.php
+++ b/packages/framework/src/Command/ServerRunWithCustomRouterCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Overrides default "server:run" command because web/index.php is used as front controller.
  *
- * Default behaviour of Symfony is to use router_<environment>.php that requires specific front controller.
+ * Default behavior of Symfony is to use router_<environment>.php that requires specific front controller.
  * Front controllers web/app.php and web/app_dev.php were removed because environment is determined by a file
  * in project root.
  */

--- a/packages/framework/src/Command/ServerStartWithCustomRouterCommand.php
+++ b/packages/framework/src/Command/ServerStartWithCustomRouterCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Overrides default "server:start" command because web/index.php is used as front controller.
  *
- * Default behaviour of Symfony is to use router_<environment>.php that requires specific front controller.
+ * Default behavior of Symfony is to use router_<environment>.php that requires specific front controller.
  * Front controllers web/app.php and web/app_dev.php were removed because environment is determined by a file
  * in project root.
  */

--- a/packages/framework/src/Model/Customer/CustomerIdentifierFactory.php
+++ b/packages/framework/src/Model/Customer/CustomerIdentifierFactory.php
@@ -33,7 +33,7 @@ class CustomerIdentifierFactory
     {
         $cartIdentifier = $this->session->getId();
 
-        // when session is not started, returning empty string is behaviour of session_id()
+        // when session is not started, returning empty string is behavior of session_id()
         if ($cartIdentifier === '') {
             $this->session->start();
             $cartIdentifier = $this->session->getId();

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -389,7 +389,7 @@ msgid "Coefficient"
 msgstr ""
 
 msgid "Colour"
-msgstr ""
+msgstr "Color"
 
 msgid "Communication with customer"
 msgstr ""

--- a/packages/framework/src/Resources/views/Admin/Content/Superadmin/cssDocumentation.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Superadmin/cssDocumentation.html.twig
@@ -176,7 +176,7 @@
         <h2 id="messages">Messages</h2>
 
         <p>
-            Various messages and flash messages, there is more type and colour modifications. Thanks to this it is possible to create even combinations of types and colours
+            Various messages and flash messages, there is more type and color modifications. Thanks to this it is possible to create even combinations of types and colors
         </p>
 
         <h3>In-message</h3>
@@ -184,13 +184,13 @@
         <div class="in-article__preview">
             <span class="in-article__preview__info">Live view of the component in white window</span>
             <div class="in-message">
-                <span>Base message text is without colours and outstretched only to the end of the text, therefore it needs at least to identify the colour type.</span>
+                <span>Base message text is without colors and outstretched only to the end of the text, therefore it needs at least to identify the color type.</span>
             </div>
         </div>
 
-        <h4>Colouring in-message</h4>
+        <h4>Coloring in-message</h4>
         <p>
-            Colours present event that happened.
+            Colors present event that happened.
         </p>
 
         <div class="in-article__preview">
@@ -214,7 +214,7 @@
 
         <h4>In-message types</h4>
         <p>
-            Types can be combined with each other and mixed with various colours
+            Types can be combined with each other and mixed with various colors
         </p>
 
         <div class="in-article__preview">
@@ -243,11 +243,11 @@
 
     <div class="wrap-border in-article">
         <h2 id="buttons">Buttons</h2>
-        <p>There are more types of buttons, each can have a lot of modifications. These modifications can be combined with each other (colour ones with type ones)</p>
+        <p>There are more types of buttons, each can have a lot of modifications. These modifications can be combined with each other (color ones with type ones)</p>
 
         <h3>Btn</h3>
 
-        <h4>Colour modification</h4>
+        <h4>Color modification</h4>
 
         <div class="in-article__preview">
             <span class="in-article__preview__info">Live view of the component in white window</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We're using American spelling, not British, but there were occurrences of *behaviour* and *colour*. Fixed in all comments, markdown and translation messages.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No (only the English translation was changed, not the message ID) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
