### PR TITLE
[project-base] Performance\CategoryDataFixture: fix maximum count in progress bar

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -161,6 +161,7 @@ There you can find links to upgrade notes for other versions too.
         +Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~
         +Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: '@Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig'
         ```
+- *(low priority)* use private method `recursivelyCountCategoriesInCategoryTree` instead of `array_sum` to get maximum for the progress bar in `Shopsys\ShopBundle\DataFixtures\Performance\CategoryDataFixture` ([#902](https://github.com/shopsys/shopsys/pull/902))
 
 ## [shopsys/coding-standards]
 - We disallow using [Doctrine inheritance mapping](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html) in the Shopsys Framework

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
@@ -89,7 +89,7 @@ class CategoryDataFixture
      */
     public function load(OutputInterface $output)
     {
-        $progressBar = $this->progressBarFactory->create($output, array_sum($this->categoryCountsByLevel));
+        $progressBar = $this->progressBarFactory->create($output, $this->recursivelyCountCategoriesInCategoryTree());
 
         $rootCategory = $this->categoryFacade->getRootCategory();
         $this->sqlLoggerFacade->temporarilyDisableLogging();


### PR DESCRIPTION
- the numbers in the array `$categoryCountsByLevel` define how many categories should be created on each level
- private method `recursivelyCountCategoriesInCategoryTree` should be used instead of `array_sum`
- error introduced in 25d65995199621f960107ac2d1dc80a79f5e719e when the `ProgressBarFactory` class was created

| Q             | A
| ------------- | ---
|Description, reason for the PR| progress bar for performance data of categories wasn't working
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
