### PR TITLE
[shopsys] constants are now extendable

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -2,3 +2,9 @@ imports:
     - { resource: 'packages/coding-standards/easy-coding-standard.yml' }
     - { resource: 'packages/*/easy-coding-standard.yml' }
     - { resource: 'project-base/easy-coding-standard.yml' }
+
+parameters:
+    skip:
+        Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff:
+            - '*/src/Shopsys/ShopBundle/*'
+            - '*/tests/ShopBundle/*'

--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -8,3 +8,7 @@ parameters:
         Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff:
             - '*/src/Shopsys/ShopBundle/*'
             - '*/tests/ShopBundle/*'
+
+        Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff:
+            - '*/src/Shopsys/ShopBundle/*'
+            - '*/tests/ShopBundle/*'

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -32,6 +32,7 @@ services:
     # add all @param, @return and @var annotations, in FQN
     Shopsys\CodingStandards\CsFixer\Phpdoc\MissingParamAnnotationsFixer: ~
     Shopsys\CodingStandards\CsFixer\Phpdoc\MissingReturnAnnotationFixer: ~
+    Shopsys\CodingStandards\CsFixer\Phpdoc\NoUselessAccessFixer: ~
     Shopsys\CodingStandards\CsFixer\Phpdoc\OrderedParamAnnotationsFixer: ~
     SlevomatCodingStandard\Sniffs\Namespaces\FullyQualifiedClassNameInAnnotationSniff: ~
 
@@ -117,7 +118,6 @@ services:
     PhpCsFixer\Fixer\Phpdoc\PhpdocAnnotationWithoutDotFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoUselessInheritdocFixer: ~
-    PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer:
         type: var
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer: ~

--- a/packages/coding-standards/src/CsFixer/Phpdoc/NoUselessAccessFixer.php
+++ b/packages/coding-standards/src/CsFixer/Phpdoc/NoUselessAccessFixer.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer\Phpdoc;
+
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class NoUselessAccessFixer implements FixerInterface, DefinedFixerInterface
+{
+    private const ACCESS_TOKENS = [
+        \T_PUBLIC,
+        \T_PROTECTED,
+        \T_PRIVATE,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return new FixerDefinition(
+            '`@access` annotations should be omitted from PHPDoc when it is useless',
+            [
+                new CodeSample(
+                    '<?php
+class Foo
+{
+    /**
+     * @internal
+     * @access private
+     */
+    private $bar;
+}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(\T_DOC_COMMENT) && $tokens->isAnyTokenKindsFound(self::ACCESS_TOKENS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        $allDocBlocks = $this->findAllDocBlocks($tokens);
+
+        foreach ($allDocBlocks as $position => $docBlock) {
+            if (!$this->areThereAnyAccessAnnotation($docBlock)) {
+                continue;
+            }
+
+            if ($this->followingTokenIsAccessModifier($tokens, $position)) {
+                $this->removeAllAccessAnnotations($docBlock);
+                $this->rewriteDocBlock($tokens, $docBlock, $position);
+            }
+
+            if ($this->areThereAnyEmptyAccessAnnotation($docBlock)) {
+                $this->removeEmptyAccessAnnotations($docBlock);
+                $this->rewriteDocBlock($tokens, $docBlock, $position);
+            }
+        }
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return \PhpCsFixer\DocBlock\DocBlock[]
+     */
+    private function findAllDocBlocks(Tokens $tokens): array
+    {
+        return \array_map(function (Token $token) {
+            return new DocBlock($token->getContent());
+        }, $tokens->findGivenKind(\T_DOC_COMMENT));
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\DocBlock $docBlock
+     * @return bool
+     */
+    private function areThereAnyAccessAnnotation(DocBlock $docBlock): bool
+    {
+        $annotations = $docBlock->getAnnotationsOfType('access');
+
+        return !empty($annotations);
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\DocBlock $docBlock
+     * @return bool
+     */
+    private function areThereAnyEmptyAccessAnnotation(DocBlock $docBlock): bool
+    {
+        $annotations = $docBlock->getAnnotationsOfType('access');
+
+        foreach ($annotations as $annotation) {
+            if (\preg_match('~(public|protected|private)~', $annotation->getContent()) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\DocBlock $docBlock
+     */
+    private function removeEmptyAccessAnnotations(DocBlock $docBlock): void
+    {
+        $annotations = $docBlock->getAnnotationsOfType('access');
+
+        foreach ($annotations as $annotation) {
+            if (\preg_match('~(public|protected|private)~', $annotation->getContent()) === 0) {
+                $annotation->remove();
+            }
+        }
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param int $position
+     * @return bool
+     */
+    private function followingTokenIsAccessModifier(Tokens $tokens, int $position): bool
+    {
+        $nextMeaningfulTokenId = $tokens[$tokens->getNextMeaningfulToken($position)]->getId();
+
+        return \in_array($nextMeaningfulTokenId, self::ACCESS_TOKENS, true);
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\DocBlock $docBlock
+     */
+    private function removeAllAccessAnnotations(DocBlock $docBlock): void
+    {
+        $annotations = $docBlock->getAnnotationsOfType('access');
+
+        foreach ($annotations as $annotation) {
+            $annotation->remove();
+        }
+    }
+
+    /**
+     * @param \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param \PhpCsFixer\DocBlock\DocBlock $docBlock
+     * @param int $position
+     */
+    private function rewriteDocBlock(Tokens $tokens, DocBlock $docBlock, int $position): void
+    {
+        if ($docBlock->getContent() === '' || $this->isDocBlockEmpty($docBlock)) {
+            $tokens->clearTokenAndMergeSurroundingWhitespace($position);
+        } else {
+            $tokens[$position] = new Token([T_DOC_COMMENT, $docBlock->getContent()]);
+        }
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\DocBlock $docBlock
+     * @return bool
+     */
+    private function isDocBlockEmpty(DocBlock $docBlock): bool
+    {
+        foreach ($docBlock->getLines() as $line) {
+            if ($line->containsUsefulContent()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Shopsys/phpdoc_no_useless_access';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(\SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/src/Sniffs/ConstantVisibilityRequiredSniff.php
+++ b/packages/coding-standards/src/Sniffs/ConstantVisibilityRequiredSniff.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+class ConstantVisibilityRequiredSniff implements Sniff
+{
+    /**
+     * @return int[]
+     */
+    public function register(): array
+    {
+        return [\T_CONST];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param $constPosition
+     */
+    public function process(File $file, $constPosition): void
+    {
+        if (!$this->isConstInsideClass($file, $constPosition)) {
+            return;
+        }
+
+        if ($this->isConstWithAccessModifier($file, $constPosition)) {
+            return;
+        }
+
+        if ($this->isConstWithAccessAnnotation($file, $constPosition)) {
+            return;
+        }
+
+        $file->addError('Constant must have access modifier', $constPosition, self::class);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $constPosition
+     * @return bool
+     */
+    private function isConstInsideClass(File $file, int $constPosition): bool
+    {
+        $classStartPosition = $file->findPrevious(\T_CLASS, $constPosition);
+        if ($classStartPosition === false) {
+            return false;
+        }
+
+        $tokens = $file->getTokens();
+        $classEndPosition = $tokens[$classStartPosition]['scope_closer'];
+
+        return $constPosition > $classStartPosition && $constPosition < $classEndPosition;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $constPosition
+     * @return bool
+     */
+    private function isConstWithAccessModifier(File $file, int $constPosition): bool
+    {
+        $previousTokenEndPosition = $this->findScopeSearchEndPosition($file, $constPosition);
+
+        $accessModifierStartPosition = $file->findPrevious(Tokens::$scopeModifiers, $constPosition, $previousTokenEndPosition);
+
+        return (bool)$accessModifierStartPosition;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $constPosition
+     * @return bool
+     */
+    private function isConstWithAccessAnnotation(File $file, int $constPosition): bool
+    {
+        $previousTokenEndPosition = $this->findScopeSearchEndPosition($file, $constPosition);
+
+        $phpDocStartPosition = $file->findPrevious(\T_DOC_COMMENT_OPEN_TAG, $constPosition, $previousTokenEndPosition ?: 0);
+
+        if ($phpDocStartPosition === false) {
+            return false;
+        }
+        return $this->phpDocContainsAccessTag($file, $phpDocStartPosition);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $phpDocStartPosition
+     * @return bool
+     */
+    private function phpDocContainsAccessTag(File $file, int $phpDocStartPosition): bool
+    {
+        $tokens = $file->getTokens();
+
+        $commentTagPositions = \array_reverse($tokens[$phpDocStartPosition]['comment_tags']);
+
+        $lastPosition = $tokens[$phpDocStartPosition]['comment_closer'];
+
+        foreach ($commentTagPositions as $commentTagPosition) {
+            if ($tokens[$commentTagPosition]['content'] === '@access') {
+                $possibleAccessModifierPosition = $file->findNext(\T_DOC_COMMENT_STRING, $commentTagPosition, $lastPosition);
+
+                if (\preg_match('~(public|protected|private)~', $tokens[$possibleAccessModifierPosition]['content']) === 1) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $constPosition
+     * @return int
+     */
+    private function findScopeSearchEndPosition(File $file, int $constPosition): int
+    {
+        return $file->findPrevious([\T_SEMICOLON, \T_CLOSE_CURLY_BRACKET], $constPosition) ?: 0;
+    }
+}

--- a/packages/coding-standards/src/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff.php
+++ b/packages/coding-standards/src/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\AnnotationHelper;
+use SlevomatCodingStandard\Helpers\ConstantHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class ForceLateStaticBindingForProtectedConstantsSniff implements Sniff
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function register(): array
+    {
+        return [\T_CLASS];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(File $file, $classPosition)
+    {
+        $protectedConstants = $this->getAllProtectedConstantsInClass($file);
+
+        $selfPositions = TokenHelper::findNextAll($file, \T_SELF, $classPosition);
+
+        foreach ($selfPositions as $selfPosition) {
+            $constantName = $this->findConstantNameFromSelfCall($file, $selfPosition);
+
+            if ($constantName === null) {
+                continue;
+            }
+
+            if (\in_array($constantName, $protectedConstants, true)) {
+                $file->addFixableError(
+                    'For better extensibility use late static binding.',
+                    $selfPosition,
+                    self::class
+                );
+
+                $file->fixer->beginChangeset();
+                $file->fixer->replaceToken($selfPosition, 'static');
+                $file->fixer->endChangeset();
+            }
+        }
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $selfPosition
+     * @return string|null
+     */
+    private function findConstantNameFromSelfCall(File $file, int $selfPosition): ?string
+    {
+        $tokens = $file->getTokens();
+
+        $doubleColonPosition = TokenHelper::findNextEffective($file, $selfPosition + 1);
+        if ($tokens[$doubleColonPosition]['code'] !== T_DOUBLE_COLON) {
+            return null;
+        }
+
+        $stringPosition = TokenHelper::findNextEffective($file, $doubleColonPosition + 1);
+        if ($tokens[$stringPosition]['code'] !== T_STRING) {
+            return null;
+        }
+
+        if (strtolower($tokens[$stringPosition]['content']) === 'class') {
+            return null;
+        }
+
+        $positionAfterString = TokenHelper::findNextEffective($file, $stringPosition + 1);
+        if ($tokens[$positionAfterString]['code'] === T_OPEN_PARENTHESIS) {
+            return null;
+        }
+
+        return $tokens[$stringPosition]['content'];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @return string[]
+     */
+    private function getAllProtectedConstantsInClass(File $file): array
+    {
+        $constPositions = TokenHelper::findNextAll($file, \T_CONST, 0);
+
+        $protectedConstants = [];
+
+        foreach ($constPositions as $constPosition) {
+            if ($this->isProtectedVisibility($file, $constPosition)) {
+                $protectedConstants[] = ConstantHelper::getName($file, $constPosition);
+
+                continue;
+            }
+
+            if ($this->hasProtectedAccess($file, $constPosition)) {
+                $protectedConstants[] = ConstantHelper::getName($file, $constPosition);
+
+                continue;
+            }
+        }
+
+        return $protectedConstants;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $constPosition
+     * @return bool
+     */
+    private function isProtectedVisibility(File $file, int $constPosition): bool
+    {
+        $protectedModifierPosition = TokenHelper::findPreviousLocal($file, \T_PROTECTED, $constPosition);
+
+        return $protectedModifierPosition !== null;
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $constPosition
+     * @return bool
+     */
+    private function hasProtectedAccess(File $file, int $constPosition): bool
+    {
+        $accessAnnotations = AnnotationHelper::getAnnotationsByName($file, $constPosition, '@access');
+        foreach ($accessAnnotations as $accessAnnotation) {
+            if ($accessAnnotation->getContent() === 'protected') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/NoUselessAccessFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/NoUselessAccessFixerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\CsFixer\OrmJoinColumnRequireNullableFixer;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class NoUselessAccessFixerTest extends AbstractCheckerTestCase
+{
+    public function testFix(): void
+    {
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/Simple.php', __DIR__ . '/fixed/Simple.php');
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/Complex.php', __DIR__ . '/fixed/Complex.php');
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/DifferentAnnotationAndVisibility.php', __DIR__ . '/fixed/DifferentAnnotationAndVisibility.php');
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/EmptyAccessAnnotation.php', __DIR__ . '/fixed/EmptyAccessAnnotation.php');
+    }
+
+    public function testCorrect(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/fixed/Simple.php');
+        $this->doTestCorrectFile(__DIR__ . '/fixed/Complex.php');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/config.yml
@@ -1,0 +1,2 @@
+services:
+    Shopsys\CodingStandards\CsFixer\Phpdoc\NoUselessAccessFixer:

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/Complex.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/Complex.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class Complex
+{
+    public const A = 'value';
+    /**
+     * @internal
+     */
+    private const B = 'value';
+    /**
+     * @access protected
+     * @internal
+     */
+    const C = 'value';
+    
+    private const D = 'value';
+    
+    private const E = 'value';
+    /** @access protected */
+    const F = 'value';
+
+    
+    public function methodA(): void
+    {
+
+    }
+
+    /**
+     * @param string $argumentA
+     * @param string $argumentB
+     * @return bool
+     */
+    protected function methodB(string $argumentA, string $argumentB): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param string $argumentA
+     * @param string $argumentB
+     * @return bool
+     */
+    protected function methodC(string $argumentA, string $argumentB): bool
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/DifferentAnnotationAndVisibility.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/DifferentAnnotationAndVisibility.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class DifferentAnnotationAndVisibility
+{
+    
+    public const A = 'value';
+    
+    private const B = 'value';
+    
+    protected const C = 'value';
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/EmptyAccessAnnotation.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/EmptyAccessAnnotation.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class EmptyAccessAnnotation
+{
+    
+    const A = 'value';
+    
+    public const B = 'value';
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/Simple.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/fixed/Simple.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class Simple
+{
+    
+    public const A = 'value';
+    
+    protected const B = 'value';
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/Complex.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/Complex.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class Complex
+{
+    public const A = 'value';
+    /**
+     * @access private
+     * @internal
+     */
+    private const B = 'value';
+    /**
+     * @access protected
+     * @internal
+     */
+    const C = 'value';
+    /**
+     * @access private
+     */
+    private const D = 'value';
+    /** @access private */
+    private const E = 'value';
+    /** @access protected */
+    const F = 'value';
+
+    /**
+     * @access public
+     */
+    public function methodA(): void
+    {
+
+    }
+
+    /**
+     * @access protected
+     * @param string $argumentA
+     * @param string $argumentB
+     * @return bool
+     */
+    protected function methodB(string $argumentA, string $argumentB): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param string $argumentA
+     * @param string $argumentB
+     * @return bool
+     */
+    protected function methodC(string $argumentA, string $argumentB): bool
+    {
+        return true;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/DifferentAnnotationAndVisibility.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/DifferentAnnotationAndVisibility.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class DifferentAnnotationAndVisibility
+{
+    /** @access protected */
+    public const A = 'value';
+    /** @access public */
+    private const B = 'value';
+    /** @access private */
+    protected const C = 'value';
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/EmptyAccessAnnotation.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/EmptyAccessAnnotation.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class EmptyAccessAnnotation
+{
+    /**
+     * @access
+     */
+    const A = 'value';
+    /**
+     * @access private
+     */
+    public const B = 'value';
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/Simple.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/wrong/Simple.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\NoUselessAccessFixer;
+
+class Simple
+{
+    /**
+     * @access public
+     */
+    public const A = 'value';
+    /** @access protected */
+    protected const B = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/ConstantVisibilityRequiredSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/ConstantVisibilityRequiredSniffTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class ConstantVisibilityRequiredSniffTest extends AbstractCheckerTestCase
+{
+    public function testCorrect(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/correct/Annotation.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/SingleValueWithoutNamespace.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/SingleValueAfterMethodWithoutNamespace.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/MultipleValues.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/Mixed.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/MixedVisibilities.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/noClass.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/OutsideClass.php');
+    }
+
+    public function testWrong(): void
+    {
+        $this->doTestWrongFile(__DIR__ . '/wrong/SingleValue.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/MissingAnnotation.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/Mixed.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/MixedAtTheEnd.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/MixedInTheMiddle.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/SingleValueAfterMethodWithoutNamespace.php');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/config.yml
@@ -1,0 +1,2 @@
+services:
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/Annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/Annotation.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Correct;
+
+class Annotation
+{
+    /** @access private */
+    const A = 'value';
+    /**
+     * @access private
+     */
+    const B = 'value';
+    /**
+     * @access public
+     */
+    const C = 'value';
+    /**
+     * @access protected
+     */
+    const D = 'value';
+    /**
+     * @access private
+     */
+    const E = 'value';
+    /**
+     * @access private
+     * @deprecated
+     */
+    const F = 'value';
+    /**
+     * @deprecated
+     * @access private
+     */
+    const G = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/Mixed.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/Mixed.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Correct;
+
+class Mixed
+{
+    /** @access private */
+    const A = 'value';
+    public const B = 'value';
+    protected const C = 'value';
+    /**
+     * @access protected
+     */
+    const D = 'value';
+    private const E = 'value';
+    /**
+     * @access private
+     * @deprecated
+     */
+    const F = 'value';
+    /**
+     * @deprecated
+     */
+    protected const G = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/MixedVisibilities.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/MixedVisibilities.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Correct;
+
+class MixedVisibilities
+{
+    /** @access private */
+    protected const A = 'value';
+    /** @access private */
+    public const B = 'value';
+    /** @access public */
+    protected const C = 'value';
+    /** @access public */
+    private const D = 'value';
+    /** @access protected */
+    private const E = 'value';
+    /** @access protected */
+    public const F = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/MultipleValues.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/MultipleValues.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Correct;
+
+class MultipleValues
+{
+    public const A = 'value';
+    protected const B = 'value';
+    private const C = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/OutsideClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/OutsideClass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Correct;
+
+const B = 'value';
+
+class OutsideClass
+{
+    public const A = 'value';
+}
+
+const A = 'value';

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/SingleValueAfterMethodWithoutNamespace.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/SingleValueAfterMethodWithoutNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+class SingleValueAfterMethodWithoutNamespace
+{
+    public function method()
+    {
+
+    }
+
+    public const A = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/SingleValueWithoutNamespace.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/SingleValueWithoutNamespace.php
@@ -1,0 +1,6 @@
+<?php
+
+class SingleValueWithoutNamespace
+{
+    public const A = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/noClass.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/noClass.php
@@ -1,0 +1,3 @@
+<?php
+
+const A = 'value';

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/MissingAnnotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/MissingAnnotation.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Wrong;
+
+class MissingAnnotation
+{
+    /**
+     * @deprecated
+     */
+    const A = 'value';
+    /**
+     * @access
+     */
+    const B = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/Mixed.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/Mixed.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Wrong;
+
+class Mixed
+{
+    const A = 'value';
+    public const B = 'value';
+    /**
+     * @access private
+     */
+    const C = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/MixedAtTheEnd.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/MixedAtTheEnd.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Wrong;
+
+class MixedAtTheEnd
+{
+    public const B = 'value';
+    /**
+     * @access private
+     */
+    const C = 'value';
+    const A = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/MixedInTheMiddle.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/MixedInTheMiddle.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Wrong;
+
+class MixedInTheMiddle
+{
+    /** @access private */
+    public const OPTION_MODULE = 'module';
+
+    const OPTION_LIST = 'list';
+
+    private const OPTION_INSTANCE_NAME = 'instance-name';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/SingleValue.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/SingleValue.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Wrong;
+
+class SingleValue
+{
+    const A = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/SingleValueAfterMethodWithoutNamespace.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/SingleValueAfterMethodWithoutNamespace.php
@@ -1,0 +1,11 @@
+<?php
+
+class SingleValueAfterMethodWithoutNamespace
+{
+    public function method()
+    {
+
+    }
+
+    const A = 'value';
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/ForceLateStaticBindingForProtectedConstantsSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/ForceLateStaticBindingForProtectedConstantsSniffTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class ForceLateStaticBindingForProtectedConstantsSniffTest extends AbstractCheckerTestCase
+{
+    public function testFix(): void
+    {
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/SingleValue.php', __DIR__ . '/fixed/SingleValue.php');
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/SelfWithMethodsAndVariables.php', __DIR__ . '/fixed/SelfWithMethodsAndVariables.php');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/config.yml
@@ -1,0 +1,2 @@
+services:
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/fixed/SelfWithMethodsAndVariables.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/fixed/SelfWithMethodsAndVariables.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
+
+class SelfWithMethodsAndVariables
+{
+    public const A = 'value';
+    protected const B = 'value';
+    private const C = 'value';
+
+    public static $publicProperty;
+
+    protected static $protectedProperty;
+
+    private static $privateProperty;
+
+    public function method()
+    {
+        echo self::A;
+        self::class;
+        self::publicStaticMethod();
+        self::protectedStaticMethod();
+        self::privateStaticMethod();
+
+        echo static::B;
+        self::class;
+        self::publicStaticMethod();
+        self::protectedStaticMethod();
+        self::privateStaticMethod();
+
+        echo self::C;
+        self::class;
+        self::publicStaticMethod();
+        self::protectedStaticMethod();
+        self::privateStaticMethod();
+
+        echo self::A;
+        echo static::B;
+        echo self::C;
+
+        echo self::$publicProperty;
+        echo self::$protectedProperty;
+        echo self::$privateProperty;
+
+        echo static::$publicProperty;
+        echo static::$protectedProperty;
+        echo static::$privateProperty;
+    }
+
+    public static function publicStaticMethod()
+    {
+        echo 'value';
+    }
+
+    protected static function protectedStaticMethod()
+    {
+        echo 'value';
+    }
+
+    private static function privateStaticMethod()
+    {
+        echo 'value';
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/fixed/SingleValue.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/fixed/SingleValue.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
+
+class SingleValue
+{
+    public const A = 'value';
+    protected const B = 'value';
+    private const C = 'value';
+    /** @access public */
+    const D = 'value';
+    /**
+     * @access protected
+     */
+    const E = 'value';
+    /** @access private */
+    const F = 'value';
+    const G = 'value';
+
+    public function method()
+    {
+        echo self::A;
+        echo static::B;
+        echo self::C;
+        echo self::D;
+        echo static::E;
+        echo self::F;
+        echo self::G;
+
+        echo static::A;
+        echo static::B;
+        echo static::C;
+        echo static::D;
+        echo static::E;
+        echo static::F;
+        echo static::G;
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/wrong/SelfWithMethodsAndVariables.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/wrong/SelfWithMethodsAndVariables.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
+
+class SelfWithMethodsAndVariables
+{
+    public const A = 'value';
+    protected const B = 'value';
+    private const C = 'value';
+
+    public static $publicProperty;
+
+    protected static $protectedProperty;
+
+    private static $privateProperty;
+
+    public function method()
+    {
+        echo self::A;
+        self::class;
+        self::publicStaticMethod();
+        self::protectedStaticMethod();
+        self::privateStaticMethod();
+
+        echo self::B;
+        self::class;
+        self::publicStaticMethod();
+        self::protectedStaticMethod();
+        self::privateStaticMethod();
+
+        echo self::C;
+        self::class;
+        self::publicStaticMethod();
+        self::protectedStaticMethod();
+        self::privateStaticMethod();
+
+        echo self::A;
+        echo self::B;
+        echo self::C;
+
+        echo self::$publicProperty;
+        echo self::$protectedProperty;
+        echo self::$privateProperty;
+
+        echo static::$publicProperty;
+        echo static::$protectedProperty;
+        echo static::$privateProperty;
+    }
+
+    public static function publicStaticMethod()
+    {
+        echo 'value';
+    }
+
+    protected static function protectedStaticMethod()
+    {
+        echo 'value';
+    }
+
+    private static function privateStaticMethod()
+    {
+        echo 'value';
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/wrong/SingleValue.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/wrong/SingleValue.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
+
+class SingleValue
+{
+    public const A = 'value';
+    protected const B = 'value';
+    private const C = 'value';
+    /** @access public */
+    const D = 'value';
+    /**
+     * @access protected
+     */
+    const E = 'value';
+    /** @access private */
+    const F = 'value';
+    const G = 'value';
+
+    public function method()
+    {
+        echo self::A;
+        echo self::B;
+        echo self::C;
+        echo self::D;
+        echo self::E;
+        echo self::F;
+        echo self::G;
+
+        echo static::A;
+        echo static::B;
+        echo static::C;
+        echo static::D;
+        echo static::E;
+        echo static::F;
+        echo static::G;
+    }
+}

--- a/packages/form-types-bundle/easy-coding-standard.yml
+++ b/packages/form-types-bundle/easy-coding-standard.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/form-types-bundle/easy-coding-standard.yml
+++ b/packages/form-types-bundle/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
                     - Shopsys\FrameworkBundle\Component
                     - Shopsys\FrameworkBundle\Controller
 
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -15,6 +15,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/framework/src/Command/ChangeAdminPasswordCommand.php
+++ b/packages/framework/src/Command/ChangeAdminPasswordCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ChangeAdminPasswordCommand extends Command
 {
+    /** @access private */
     const ARG_USERNAME = 'username';
 
     /**

--- a/packages/framework/src/Command/ChangeEnvironmentCommand.php
+++ b/packages/framework/src/Command/ChangeEnvironmentCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ChangeEnvironmentCommand extends Command
 {
+    /** @access private */
     const ARG_ENVIRONMENT = 'environment';
 
     /**

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -15,7 +15,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CronCommand extends Command
 {
+    /** @access private */
     const OPTION_MODULE = 'module';
+    /** @access private */
     const OPTION_LIST = 'list';
     private const OPTION_INSTANCE_NAME = 'instance-name';
 

--- a/packages/framework/src/Command/DatabaseDumpCommand.php
+++ b/packages/framework/src/Command/DatabaseDumpCommand.php
@@ -11,7 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DatabaseDumpCommand extends Command
 {
+    /** @access private */
     const ARG_OUTPUT_FILE = 'outputFile';
+    /** @access private */
     const OPT_PGDUMP_BIN = 'pgdump-bin';
 
     /**

--- a/packages/framework/src/Command/TranslationReplaceSourceCommand.php
+++ b/packages/framework/src/Command/TranslationReplaceSourceCommand.php
@@ -14,10 +14,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TranslationReplaceSourceCommand extends Command
 {
+    /** @access private */
     const ARG_TRANSLATIONS_DIR = 'translationsDir';
+    /** @access private */
     const ARG_SOURCE_CODE_DIR = 'sourceCodeDir';
+    /** @access private */
     const ARG_TARGET_LOCALE = 'targetLocale';
 
+    /** @access private */
     const FILE_NAME_REPLACEMENT_ERRORS = 'replacement_errors.log';
 
     /**

--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -9,6 +9,7 @@ use Symfony\Bridge\Monolog\Logger;
 
 class CronFacade
 {
+    /** @access protected */
     const TIMEOUT_SECONDS = 4 * 60;
 
     /**

--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -56,7 +56,7 @@ class CronFacade
      */
     public function runScheduledModules()
     {
-        $cronModuleExecutor = new CronModuleExecutor(self::TIMEOUT_SECONDS);
+        $cronModuleExecutor = new CronModuleExecutor(static::TIMEOUT_SECONDS);
 
         $cronModuleConfigs = $this->cronConfig->getAllCronModuleConfigs();
 
@@ -69,7 +69,7 @@ class CronFacade
      */
     public function runScheduledModulesForInstance(string $instanceName): void
     {
-        $cronModuleExecutor = new CronModuleExecutor(self::TIMEOUT_SECONDS);
+        $cronModuleExecutor = new CronModuleExecutor(static::TIMEOUT_SECONDS);
 
         $cronModuleConfigs = $this->cronConfig->getCronModuleConfigsForInstance($instanceName);
 
@@ -113,7 +113,7 @@ class CronFacade
     {
         $cronModuleConfig = $this->cronConfig->getCronModuleConfigByServiceId($serviceId);
 
-        $cronModuleExecutor = new CronModuleExecutor(self::TIMEOUT_SECONDS);
+        $cronModuleExecutor = new CronModuleExecutor(static::TIMEOUT_SECONDS);
         $this->runModule($cronModuleExecutor, $cronModuleConfig);
     }
 

--- a/packages/framework/src/Component/Cron/CronModuleExecutor.php
+++ b/packages/framework/src/Component/Cron/CronModuleExecutor.php
@@ -8,9 +8,9 @@ use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 
 class CronModuleExecutor
 {
-    const RUN_STATUS_OK = 'ok';
-    const RUN_STATUS_TIMEOUT = 'timeout';
-    const RUN_STATUS_SUSPENDED = 'suspended';
+    public const RUN_STATUS_OK = 'ok';
+    public const RUN_STATUS_TIMEOUT = 'timeout';
+    public const RUN_STATUS_SUSPENDED = 'suspended';
 
     /**
      * @var \DateTimeImmutable|null

--- a/packages/framework/src/Component/Cron/MutexFactory.php
+++ b/packages/framework/src/Component/Cron/MutexFactory.php
@@ -7,6 +7,7 @@ use NinjaMutex\Mutex;
 
 class MutexFactory
 {
+    /** @access protected */
     const MUTEX_CRON_NAME = 'cron';
 
     /**

--- a/packages/framework/src/Component/Cron/MutexFactory.php
+++ b/packages/framework/src/Component/Cron/MutexFactory.php
@@ -35,7 +35,7 @@ class MutexFactory
      */
     public function getCronMutex()
     {
-        return $this->getMutexByName(self::MUTEX_CRON_NAME);
+        return $this->getMutexByName(static::MUTEX_CRON_NAME);
     }
 
     /**
@@ -44,7 +44,7 @@ class MutexFactory
      */
     public function getPrefixedCronMutex(string $prefix): Mutex
     {
-        return $this->getMutexByName($prefix . '-' . self::MUTEX_CRON_NAME);
+        return $this->getMutexByName($prefix . '-' . static::MUTEX_CRON_NAME);
     }
 
     /**

--- a/packages/framework/src/Component/Doctrine/GroupedScalarHydrator.php
+++ b/packages/framework/src/Component/Doctrine/GroupedScalarHydrator.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
 
 class GroupedScalarHydrator extends AbstractHydrator
 {
-    const HYDRATION_MODE = 'GroupedScalarHydrator';
+    public const HYDRATION_MODE = 'GroupedScalarHydrator';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Component/Doctrine/NormalizeFunction.php
+++ b/packages/framework/src/Component/Doctrine/NormalizeFunction.php
@@ -34,6 +34,6 @@ class NormalizeFunction extends FunctionNode
      */
     public function getSql(SqlWalker $sqlWalker)
     {
-        return self::FUNCTION_NORMALIZE . '(' . $this->stringExpression->dispatch($sqlWalker) . ')';
+        return static::FUNCTION_NORMALIZE . '(' . $this->stringExpression->dispatch($sqlWalker) . ')';
     }
 }

--- a/packages/framework/src/Component/Doctrine/NormalizeFunction.php
+++ b/packages/framework/src/Component/Doctrine/NormalizeFunction.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\SqlWalker;
 
 class NormalizeFunction extends FunctionNode
 {
+    /** @access protected */
     const FUNCTION_NORMALIZE = 'normalize';
 
     /**

--- a/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
+++ b/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\QueryBuilder;
 
 class QueryBuilderExtender
 {
+    /** @access protected */
     const REQUIRED_ALIASES_COUNT = 1;
 
     /**

--- a/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
+++ b/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
@@ -52,7 +52,7 @@ class QueryBuilderExtender
     protected function getRootAlias(QueryBuilder $queryBuilder)
     {
         $rootAliases = $queryBuilder->getRootAliases();
-        if (count($rootAliases) !== self::REQUIRED_ALIASES_COUNT) {
+        if (count($rootAliases) !== static::REQUIRED_ALIASES_COUNT) {
             throw new \Shopsys\FrameworkBundle\Component\Doctrine\Exception\InvalidCountOfAliasesException($rootAliases);
         }
         $firstAlias = reset($rootAliases);

--- a/packages/framework/src/Component/Doctrine/SortableNullsWalker.php
+++ b/packages/framework/src/Component/Doctrine/SortableNullsWalker.php
@@ -10,7 +10,9 @@ use Doctrine\ORM\Query\SqlWalker;
  */
 class SortableNullsWalker extends SqlWalker
 {
+    /** @access protected */
     const NULLS_FIRST = 'NULLS FIRST';
+    /** @access protected */
     const NULLS_LAST = 'NULLS LAST';
 
     /**

--- a/packages/framework/src/Component/Doctrine/SortableNullsWalker.php
+++ b/packages/framework/src/Component/Doctrine/SortableNullsWalker.php
@@ -24,9 +24,9 @@ class SortableNullsWalker extends SqlWalker
         $sql = parent::walkOrderByItem($orderByItem);
 
         if ($orderByItem->isAsc()) {
-            $sql .= ' ' . self::NULLS_FIRST;
+            $sql .= ' ' . static::NULLS_FIRST;
         } elseif ($orderByItem->isDesc()) {
-            $sql .= ' ' . self::NULLS_LAST;
+            $sql .= ' ' . static::NULLS_LAST;
         }
 
         return $sql;

--- a/packages/framework/src/Component/Domain/AdminDomainTabsFacade.php
+++ b/packages/framework/src/Component/Domain/AdminDomainTabsFacade.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class AdminDomainTabsFacade
 {
+    /** @access protected */
     const SESSION_SELECTED_DOMAIN = 'selected_domain_id';
 
     /**

--- a/packages/framework/src/Component/Domain/AdminDomainTabsFacade.php
+++ b/packages/framework/src/Component/Domain/AdminDomainTabsFacade.php
@@ -40,7 +40,7 @@ class AdminDomainTabsFacade
     public function setSelectedDomainId($domainId)
     {
         $domainConfig = $this->domain->getDomainConfigById($domainId);
-        $this->session->set(self::SESSION_SELECTED_DOMAIN, $domainConfig->getId());
+        $this->session->set(static::SESSION_SELECTED_DOMAIN, $domainConfig->getId());
     }
 
     /**
@@ -49,7 +49,7 @@ class AdminDomainTabsFacade
     public function getSelectedDomainConfig()
     {
         try {
-            $domainId = $this->session->get(self::SESSION_SELECTED_DOMAIN);
+            $domainId = $this->session->get(static::SESSION_SELECTED_DOMAIN);
             return $this->domain->getDomainConfigById($domainId);
         } catch (\Shopsys\FrameworkBundle\Component\Domain\Exception\InvalidDomainIdException $e) {
             $allDomains = $this->domain->getAll();

--- a/packages/framework/src/Component/Domain/Config/DomainConfig.php
+++ b/packages/framework/src/Component/Domain/Config/DomainConfig.php
@@ -4,7 +4,7 @@ namespace Shopsys\FrameworkBundle\Component\Domain\Config;
 
 class DomainConfig
 {
-    const STYLES_DIRECTORY_DEFAULT = 'common';
+    public const STYLES_DIRECTORY_DEFAULT = 'common';
 
     /**
      * @var int

--- a/packages/framework/src/Component/Domain/Config/DomainsConfigDefinition.php
+++ b/packages/framework/src/Component/Domain/Config/DomainsConfigDefinition.php
@@ -7,12 +7,12 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class DomainsConfigDefinition implements ConfigurationInterface
 {
-    const CONFIG_DOMAINS = 'domains';
-    const CONFIG_ID = 'id';
-    const CONFIG_NAME = 'name';
-    const CONFIG_LOCALE = 'locale';
-    const CONFIG_STYLES_DIRECTORY = 'styles_directory';
-    const CONFIG_DESIGN_ID = 'design_id';
+    public const CONFIG_DOMAINS = 'domains';
+    public const CONFIG_ID = 'id';
+    public const CONFIG_NAME = 'name';
+    public const CONFIG_LOCALE = 'locale';
+    public const CONFIG_STYLES_DIRECTORY = 'styles_directory';
+    public const CONFIG_DESIGN_ID = 'design_id';
 
     /**
      * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder

--- a/packages/framework/src/Component/Domain/Config/DomainsUrlsConfigDefinition.php
+++ b/packages/framework/src/Component/Domain/Config/DomainsUrlsConfigDefinition.php
@@ -7,9 +7,9 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class DomainsUrlsConfigDefinition implements ConfigurationInterface
 {
-    const CONFIG_DOMAINS_URLS = 'domains_urls';
-    const CONFIG_ID = 'id';
-    const CONFIG_URL = 'url';
+    public const CONFIG_DOMAINS_URLS = 'domains_urls';
+    public const CONFIG_ID = 'id';
+    public const CONFIG_URL = 'url';
 
     /**
      * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder

--- a/packages/framework/src/Component/Domain/Domain.php
+++ b/packages/framework/src/Component/Domain/Domain.php
@@ -8,8 +8,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class Domain implements DomainIdsProviderInterface
 {
-    const FIRST_DOMAIN_ID = 1;
-    const MAIN_ADMIN_DOMAIN_ID = 1;
+    public const FIRST_DOMAIN_ID = 1;
+    public const MAIN_ADMIN_DOMAIN_ID = 1;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig|null

--- a/packages/framework/src/Component/Domain/DomainDataCreator.php
+++ b/packages/framework/src/Component/Domain/DomainDataCreator.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 
 class DomainDataCreator
 {
-    const TEMPLATE_DOMAIN_ID = 1;
+    public const TEMPLATE_DOMAIN_ID = 1;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain

--- a/packages/framework/src/Component/Domain/DomainIconResizer.php
+++ b/packages/framework/src/Component/Domain/DomainIconResizer.php
@@ -54,9 +54,9 @@ class DomainIconResizer
     {
         $resizedImage = $this->imageProcessor->resize(
             $this->imageProcessor->createInterventionImage($filepath),
-            self::DOMAIN_ICON_WIDTH,
-            self::DOMAIN_ICON_HEIGHT,
-            self::DOMAIN_ICON_CROP
+            static::DOMAIN_ICON_WIDTH,
+            static::DOMAIN_ICON_HEIGHT,
+            static::DOMAIN_ICON_CROP
         );
         $resizedImage->encode(ImageProcessor::EXTENSION_PNG);
 

--- a/packages/framework/src/Component/Domain/DomainIconResizer.php
+++ b/packages/framework/src/Component/Domain/DomainIconResizer.php
@@ -8,8 +8,11 @@ use Symfony\Bridge\Monolog\Logger;
 
 class DomainIconResizer
 {
+    /** @access protected */
     const DOMAIN_ICON_WIDTH = 48;
+    /** @access protected */
     const DOMAIN_ICON_HEIGHT = 33;
+    /** @access protected */
     const DOMAIN_ICON_CROP = false;
 
     /**

--- a/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
+++ b/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
@@ -35,7 +35,7 @@ class EnvironmentFileSetting
      */
     public function getEnvironment(bool $console): string
     {
-        $environments = $console ? self::ENVIRONMENTS_CONSOLE : self::ENVIRONMENTS_DEFAULT;
+        $environments = $console ? static::ENVIRONMENTS_CONSOLE : static::ENVIRONMENTS_DEFAULT;
         foreach ($environments as $environment) {
             if (is_file($this->getEnvironmentFilePath($environment))) {
                 return $environment;
@@ -84,6 +84,6 @@ class EnvironmentFileSetting
      */
     public function getEnvironmentFilePath(string $environment): string
     {
-        return $this->environmentFileDirectory . '/' . self::FILE_NAMES_BY_ENVIRONMENT[$environment];
+        return $this->environmentFileDirectory . '/' . static::FILE_NAMES_BY_ENVIRONMENT[$environment];
     }
 }

--- a/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
+++ b/packages/framework/src/Component/Environment/EnvironmentFileSetting.php
@@ -4,13 +4,16 @@ namespace Shopsys\FrameworkBundle\Component\Environment;
 
 class EnvironmentFileSetting
 {
+    /** @access protected */
     const FILE_NAMES_BY_ENVIRONMENT = [
         EnvironmentType::DEVELOPMENT => 'DEVELOPMENT',
         EnvironmentType::PRODUCTION => 'PRODUCTION',
         EnvironmentType::TEST => 'TEST',
     ];
 
+    /** @access protected */
     const ENVIRONMENTS_CONSOLE = [EnvironmentType::DEVELOPMENT, EnvironmentType::PRODUCTION];
+    /** @access protected */
     const ENVIRONMENTS_DEFAULT = [EnvironmentType::TEST, EnvironmentType::DEVELOPMENT, EnvironmentType::PRODUCTION];
 
     /**

--- a/packages/framework/src/Component/Environment/EnvironmentType.php
+++ b/packages/framework/src/Component/Environment/EnvironmentType.php
@@ -4,11 +4,11 @@ namespace Shopsys\FrameworkBundle\Component\Environment;
 
 class EnvironmentType
 {
-    const DEVELOPMENT = 'dev';
-    const PRODUCTION = 'prod';
-    const TEST = 'test';
+    public const DEVELOPMENT = 'dev';
+    public const PRODUCTION = 'prod';
+    public const TEST = 'test';
 
-    const ALL = [self::DEVELOPMENT, self::PRODUCTION, self::TEST];
+    public const ALL = [self::DEVELOPMENT, self::PRODUCTION, self::TEST];
 
     /**
      * @param string $environment

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -59,8 +59,8 @@ class ErrorPagesFacade
     public function generateAllErrorPagesForProduction()
     {
         foreach ($this->domain->getAll() as $domainConfig) {
-            $this->generateAndSaveErrorPage($domainConfig->getId(), self::PAGE_STATUS_CODE_404);
-            $this->generateAndSaveErrorPage($domainConfig->getId(), self::PAGE_STATUS_CODE_500);
+            $this->generateAndSaveErrorPage($domainConfig->getId(), static::PAGE_STATUS_CODE_404);
+            $this->generateAndSaveErrorPage($domainConfig->getId(), static::PAGE_STATUS_CODE_500);
         }
     }
 
@@ -86,9 +86,9 @@ class ErrorPagesFacade
     public function getErrorPageStatusCodeByStatusCode($statusCode)
     {
         if ($statusCode === Response::HTTP_NOT_FOUND || $statusCode === Response::HTTP_FORBIDDEN) {
-            return self::PAGE_STATUS_CODE_404;
+            return static::PAGE_STATUS_CODE_404;
         } else {
-            return self::PAGE_STATUS_CODE_500;
+            return static::PAGE_STATUS_CODE_500;
         }
     }
 

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -13,7 +13,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ErrorPagesFacade
 {
+    /** @access protected */
     const PAGE_STATUS_CODE_404 = Response::HTTP_NOT_FOUND;
+    /** @access protected */
     const PAGE_STATUS_CODE_500 = Response::HTTP_INTERNAL_SERVER_ERROR;
 
     /**

--- a/packages/framework/src/Component/FileUpload/FileNamingConvention.php
+++ b/packages/framework/src/Component/FileUpload/FileNamingConvention.php
@@ -18,7 +18,7 @@ class FileNamingConvention
     {
         if ($namingConventionType === self::TYPE_ID && is_int($entityId)) {
             return $entityId . '.' . pathinfo($originalFilename, PATHINFO_EXTENSION);
-        } elseif ($namingConventionType === self::TYPE_ORIGINAL_NAME) {
+        } elseif ($namingConventionType === static::TYPE_ORIGINAL_NAME) {
             return $originalFilename;
         } else {
             $message = 'Naming convention ' . $namingConventionType . ' cannot by resolved to filename';

--- a/packages/framework/src/Component/FileUpload/FileNamingConvention.php
+++ b/packages/framework/src/Component/FileUpload/FileNamingConvention.php
@@ -4,7 +4,8 @@ namespace Shopsys\FrameworkBundle\Component\FileUpload;
 
 class FileNamingConvention
 {
-    const TYPE_ID = 1;
+    public const TYPE_ID = 1;
+    /** @access protected */
     const TYPE_ORIGINAL_NAME = 2;
 
     /**

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -131,7 +131,7 @@ class FileUpload
      */
     public function getTemporaryDirectory()
     {
-        return $this->temporaryDir . '/' . self::TEMPORARY_DIRECTORY;
+        return $this->temporaryDir . '/' . static::TEMPORARY_DIRECTORY;
     }
 
     /**

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FileUpload
 {
+    /** @access protected */
     const TEMPORARY_DIRECTORY = 'fileUploads';
 
     /**

--- a/packages/framework/src/Component/FlashMessage/Bag.php
+++ b/packages/framework/src/Component/FlashMessage/Bag.php
@@ -6,10 +6,14 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class Bag
 {
+    /** @access protected */
     const MAIN_KEY = 'messages';
 
+    /** @access protected */
     const KEY_ERROR = 'error';
+    /** @access protected */
     const KEY_INFO = 'info';
+    /** @access protected */
     const KEY_SUCCESS = 'success';
 
     /**

--- a/packages/framework/src/Component/FlashMessage/Bag.php
+++ b/packages/framework/src/Component/FlashMessage/Bag.php
@@ -47,7 +47,7 @@ class Bag
      */
     public function addError($message, $escape = true)
     {
-        $this->addMessage($message, $escape, self::KEY_ERROR);
+        $this->addMessage($message, $escape, static::KEY_ERROR);
     }
 
     /**
@@ -56,7 +56,7 @@ class Bag
      */
     public function addInfo($message, $escape = true)
     {
-        $this->addMessage($message, $escape, self::KEY_INFO);
+        $this->addMessage($message, $escape, static::KEY_INFO);
     }
 
     /**
@@ -65,7 +65,7 @@ class Bag
      */
     public function addSuccess($message, $escape = true)
     {
-        $this->addMessage($message, $escape, self::KEY_SUCCESS);
+        $this->addMessage($message, $escape, static::KEY_SUCCESS);
     }
 
     /**
@@ -73,7 +73,7 @@ class Bag
      */
     public function getErrorMessages()
     {
-        return $this->getMessages(self::KEY_ERROR);
+        return $this->getMessages(static::KEY_ERROR);
     }
 
     /**
@@ -81,7 +81,7 @@ class Bag
      */
     public function getInfoMessages()
     {
-        return $this->getMessages(self::KEY_INFO);
+        return $this->getMessages(static::KEY_INFO);
     }
 
     /**
@@ -89,7 +89,7 @@ class Bag
      */
     public function getSuccessMessages()
     {
-        return $this->getMessages(self::KEY_SUCCESS);
+        return $this->getMessages(static::KEY_SUCCESS);
     }
 
     /**
@@ -99,9 +99,9 @@ class Bag
     {
         $flashBag = $this->session->getFlashBag();
 
-        return !$flashBag->has($this->getFullbagName(self::KEY_ERROR))
-            && !$flashBag->has($this->getFullbagName(self::KEY_INFO))
-            && !$flashBag->has($this->getFullbagName(self::KEY_SUCCESS));
+        return !$flashBag->has($this->getFullbagName(static::KEY_ERROR))
+            && !$flashBag->has($this->getFullbagName(static::KEY_INFO))
+            && !$flashBag->has($this->getFullbagName(static::KEY_SUCCESS));
     }
 
     /**
@@ -110,7 +110,7 @@ class Bag
      */
     protected function getFullbagName($key)
     {
-        return self::MAIN_KEY . '__' . $this->bagName . '__' . $key;
+        return static::MAIN_KEY . '__' . $this->bagName . '__' . $key;
     }
 
     /**

--- a/packages/framework/src/Component/Form/MultipleFormSetting.php
+++ b/packages/framework/src/Component/Form/MultipleFormSetting.php
@@ -4,7 +4,7 @@ namespace Shopsys\FrameworkBundle\Component\Form;
 
 class MultipleFormSetting
 {
-    const DEFAULT_MULTIPLE = false;
+    public const DEFAULT_MULTIPLE = false;
 
     /**
      * @var bool

--- a/packages/framework/src/Component/Form/TimedFormTypeExtension.php
+++ b/packages/framework/src/Component/Form/TimedFormTypeExtension.php
@@ -11,9 +11,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class TimedFormTypeExtension extends AbstractTypeExtension
 {
-    const MINIMUM_FORM_FILLING_SECONDS = 5;
-    const OPTION_ENABLED = 'timed_spam_enabled';
-    const OPTION_MINIMUM_SECONDS = 'timed_spam_minimum_seconds';
+    public const MINIMUM_FORM_FILLING_SECONDS = 5;
+    public const OPTION_ENABLED = 'timed_spam_enabled';
+    public const OPTION_MINIMUM_SECONDS = 'timed_spam_minimum_seconds';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Form\FormTimeProvider

--- a/packages/framework/src/Component/Grid/ActionColumn.php
+++ b/packages/framework/src/Component/Grid/ActionColumn.php
@@ -8,8 +8,8 @@ use Symfony\Component\Routing\RouterInterface;
 
 class ActionColumn
 {
-    const TYPE_DELETE = 'delete';
-    const TYPE_EDIT = 'edit';
+    public const TYPE_DELETE = 'delete';
+    public const TYPE_EDIT = 'edit';
 
     /**
      * @var \Symfony\Component\Routing\RouterInterface

--- a/packages/framework/src/Component/Grid/DataSourceInterface.php
+++ b/packages/framework/src/Component/Grid/DataSourceInterface.php
@@ -4,8 +4,8 @@ namespace Shopsys\FrameworkBundle\Component\Grid;
 
 interface DataSourceInterface
 {
-    const ORDER_ASC = 'asc';
-    const ORDER_DESC = 'desc';
+    public const ORDER_ASC = 'asc';
+    public const ORDER_DESC = 'desc';
 
     /**
      * @param int|null $limit

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -184,10 +184,10 @@ class Grid
         $this->routeCsrfProtector = $routeCsrfProtector;
         $this->twig = $twig;
 
-        $this->limit = self::DEFAULT_LIMIT;
+        $this->limit = static::DEFAULT_LIMIT;
         $this->page = 1;
 
-        $this->viewTheme = self::DEFAULT_VIEW_THEME;
+        $this->viewTheme = static::DEFAULT_VIEW_THEME;
         $this->viewTemplateParameters = [];
 
         $this->selectedRowIds = [];

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -10,8 +10,10 @@ use Twig_Environment;
 
 class Grid
 {
-    const GET_PARAMETER = 'g';
+    public const GET_PARAMETER = 'g';
+    /** @access protected */
     const DEFAULT_VIEW_THEME = '@ShopsysFramework/Admin/Grid/Grid.html.twig';
+    /** @access protected */
     const DEFAULT_LIMIT = 30;
 
     /**

--- a/packages/framework/src/Component/Image/Config/ImageConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfig.php
@@ -6,8 +6,8 @@ use Shopsys\FrameworkBundle\Component\Image\Image;
 
 class ImageConfig
 {
-    const ORIGINAL_SIZE_NAME = 'original';
-    const DEFAULT_SIZE_NAME = 'default';
+    public const ORIGINAL_SIZE_NAME = 'original';
+    public const DEFAULT_SIZE_NAME = 'default';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[]

--- a/packages/framework/src/Component/Image/Config/ImageConfigDefinition.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigDefinition.php
@@ -8,19 +8,19 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class ImageConfigDefinition implements ConfigurationInterface
 {
-    const CONFIG_CLASS = 'class';
-    const CONFIG_ENTITY_NAME = 'name';
-    const CONFIG_MULTIPLE = 'multiple';
-    const CONFIG_TYPES = 'types';
-    const CONFIG_TYPE_NAME = 'name';
-    const CONFIG_SIZES = 'sizes';
-    const CONFIG_SIZE_NAME = 'name';
-    const CONFIG_SIZE_WIDTH = 'width';
-    const CONFIG_SIZE_HEIGHT = 'height';
-    const CONFIG_SIZE_CROP = 'crop';
-    const CONFIG_SIZE_OCCURRENCE = 'occurrence';
-    const CONFIG_SIZE_ADDITIONAL_SIZES = 'additionalSizes';
-    const CONFIG_SIZE_ADDITIONAL_SIZE_MEDIA = 'media';
+    public const CONFIG_CLASS = 'class';
+    public const CONFIG_ENTITY_NAME = 'name';
+    public const CONFIG_MULTIPLE = 'multiple';
+    public const CONFIG_TYPES = 'types';
+    public const CONFIG_TYPE_NAME = 'name';
+    public const CONFIG_SIZES = 'sizes';
+    public const CONFIG_SIZE_NAME = 'name';
+    public const CONFIG_SIZE_WIDTH = 'width';
+    public const CONFIG_SIZE_HEIGHT = 'height';
+    public const CONFIG_SIZE_CROP = 'crop';
+    public const CONFIG_SIZE_OCCURRENCE = 'occurrence';
+    public const CONFIG_SIZE_ADDITIONAL_SIZES = 'additionalSizes';
+    public const CONFIG_SIZE_ADDITIONAL_SIZE_MEDIA = 'media';
 
     /**
      * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder

--- a/packages/framework/src/Component/Image/Config/ImageEntityConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageEntityConfig.php
@@ -6,7 +6,7 @@ use Shopsys\FrameworkBundle\Component\Utils\Utils;
 
 class ImageEntityConfig
 {
-    const WITHOUT_NAME_KEY = '__NULL__';
+    public const WITHOUT_NAME_KEY = '__NULL__';
 
     /**
      * @var string

--- a/packages/framework/src/Component/Image/Image.php
+++ b/packages/framework/src/Component/Image/Image.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
  */
 class Image implements EntityFileUploadInterface
 {
+    /** @access protected */
     const UPLOAD_KEY = 'image';
 
     /**

--- a/packages/framework/src/Component/Image/Image.php
+++ b/packages/framework/src/Component/Image/Image.php
@@ -95,7 +95,7 @@ class Image implements EntityFileUploadInterface
     {
         $files = [];
         if ($this->temporaryFilename !== null) {
-            $files[self::UPLOAD_KEY] = new FileForUpload(
+            $files[static::UPLOAD_KEY] = new FileForUpload(
                 $this->temporaryFilename,
                 true,
                 $this->entityName,
@@ -112,7 +112,7 @@ class Image implements EntityFileUploadInterface
      */
     public function setFileAsUploaded($key, $originalFilename)
     {
-        if ($key === self::UPLOAD_KEY) {
+        if ($key === static::UPLOAD_KEY) {
             $this->extension = pathinfo($originalFilename, PATHINFO_EXTENSION);
         } else {
             throw new \Shopsys\FrameworkBundle\Component\FileUpload\Exception\InvalidFileKeyException($key);

--- a/packages/framework/src/Component/Image/ImageLocator.php
+++ b/packages/framework/src/Component/Image/ImageLocator.php
@@ -61,7 +61,7 @@ class ImageLocator
         $filename = str_replace(
             ['{index}', '{filename}'],
             [$additionalIndex, $image->getFilename()],
-            self::ADDITIONAL_IMAGE_MASK
+            static::ADDITIONAL_IMAGE_MASK
         );
 
         return $path . $filename;

--- a/packages/framework/src/Component/Image/Processing/ImageProcessor.php
+++ b/packages/framework/src/Component/Image/Processing/ImageProcessor.php
@@ -12,10 +12,10 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class ImageProcessor
 {
-    const EXTENSION_JPEG = 'jpeg';
-    const EXTENSION_JPG = 'jpg';
-    const EXTENSION_PNG = 'png';
-    const EXTENSION_GIF = 'gif';
+    public const EXTENSION_JPEG = 'jpeg';
+    public const EXTENSION_JPG = 'jpg';
+    public const EXTENSION_PNG = 'png';
+    public const EXTENSION_GIF = 'gif';
 
     /**
      * @var string[]

--- a/packages/framework/src/Component/Image/Processing/ImageThumbnailFactory.php
+++ b/packages/framework/src/Component/Image/Processing/ImageThumbnailFactory.php
@@ -4,7 +4,9 @@ namespace Shopsys\FrameworkBundle\Component\Image\Processing;
 
 class ImageThumbnailFactory
 {
+    /** @access protected */
     const THUMBNAIL_WIDTH = 140;
+    /** @access protected */
     const THUMBNAIL_HEIGHT = 200;
 
     /**

--- a/packages/framework/src/Component/Image/Processing/ImageThumbnailFactory.php
+++ b/packages/framework/src/Component/Image/Processing/ImageThumbnailFactory.php
@@ -29,7 +29,7 @@ class ImageThumbnailFactory
     public function getImageThumbnail($filepath)
     {
         $image = $this->imageProcessor->createInterventionImage($filepath);
-        $this->imageProcessor->resize($image, self::THUMBNAIL_WIDTH, self::THUMBNAIL_HEIGHT);
+        $this->imageProcessor->resize($image, static::THUMBNAIL_WIDTH, static::THUMBNAIL_HEIGHT);
 
         return $image;
     }

--- a/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCallParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCallParser.php
@@ -71,7 +71,7 @@ class JsConstantCallParser
     {
         $functionName = $this->jsFunctionCallParser->getFunctionName($callExprNode);
 
-        return $functionName === self::FUNCTION_NAME;
+        return $functionName === static::FUNCTION_NAME;
     }
 
     /**
@@ -101,13 +101,13 @@ class JsConstantCallParser
     protected function getConstantNameArgumentNode(JCallExprNode $callExprNode)
     {
         $argumentNodes = $this->jsFunctionCallParser->getArgumentNodes($callExprNode);
-        if (!isset($argumentNodes[self::NAME_ARGUMENT_INDEX])) {
+        if (!isset($argumentNodes[static::NAME_ARGUMENT_INDEX])) {
             throw new \Shopsys\FrameworkBundle\Component\Javascript\Parser\Constant\Exception\JsConstantCallParserException(
                 'Constant name argument not specified at line ' . $callExprNode->get_line_num()
                     . ', column ' . $callExprNode->get_col_num()
             );
         }
 
-        return $argumentNodes[self::NAME_ARGUMENT_INDEX];
+        return $argumentNodes[static::NAME_ARGUMENT_INDEX];
     }
 }

--- a/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCallParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/Constant/JsConstantCallParser.php
@@ -11,7 +11,9 @@ use Shopsys\FrameworkBundle\Component\Javascript\Parser\JsStringParser;
 
 class JsConstantCallParser
 {
+    /** @access protected */
     const FUNCTION_NAME = 'Shopsys.constant';
+    /** @access protected */
     const NAME_ARGUMENT_INDEX = 0;
 
     /**

--- a/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParser.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Javascript\Parser\JsStringParser;
 
 class JsTranslatorCallParser
 {
+    /** @access protected */
     const DEFAULT_MESSAGE_DOMAIN = 'messages';
 
     /**

--- a/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParser.php
+++ b/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParser.php
@@ -137,7 +137,7 @@ class JsTranslatorCallParser
 
             return $domain;
         } else {
-            return self::DEFAULT_MESSAGE_DOMAIN;
+            return static::DEFAULT_MESSAGE_DOMAIN;
         }
     }
 

--- a/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParserFactory.php
+++ b/packages/framework/src/Component/Javascript/Parser/Translator/JsTranslatorCallParserFactory.php
@@ -8,8 +8,8 @@ use Shopsys\FrameworkBundle\Component\Translation\TransMethodSpecification;
 
 class JsTranslatorCallParserFactory
 {
-    const METHOD_NAME_TRANS = 'Shopsys.translator.trans';
-    const METHOD_NAME_TRANS_CHOICE = 'Shopsys.translator.transChoice';
+    public const METHOD_NAME_TRANS = 'Shopsys.translator.trans';
+    public const METHOD_NAME_TRANS_CHOICE = 'Shopsys.translator.transChoice';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Parser\JsFunctionCallParser

--- a/packages/framework/src/Component/Log/SlowLogSubscriber.php
+++ b/packages/framework/src/Component/Log/SlowLogSubscriber.php
@@ -48,7 +48,7 @@ class SlowLogSubscriber implements EventSubscriberInterface
     public function addNotice(PostResponseEvent $event)
     {
         $requestTime = $this->getRequestTime();
-        if ($requestTime > self::REQUEST_TIME_LIMIT_SECONDS) {
+        if ($requestTime > static::REQUEST_TIME_LIMIT_SECONDS) {
             $requestUri = $event->getRequest()->getRequestUri();
             $controllerNameAndAction = $event->getRequest()->get('_controller');
 

--- a/packages/framework/src/Component/Log/SlowLogSubscriber.php
+++ b/packages/framework/src/Component/Log/SlowLogSubscriber.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class SlowLogSubscriber implements EventSubscriberInterface
 {
+    /** @access protected */
     const REQUEST_TIME_LIMIT_SECONDS = 2;
 
     /**

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionRegistry.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionRegistry.php
@@ -51,8 +51,8 @@ class PluginCrudExtensionRegistry
      */
     public static function assertTypeIsKnown($type)
     {
-        if (!in_array($type, self::KNOWN_TYPES, true)) {
-            throw new UnknownPluginCrudExtensionTypeException($type, self::KNOWN_TYPES);
+        if (!in_array($type, static::KNOWN_TYPES, true)) {
+            throw new UnknownPluginCrudExtensionTypeException($type, static::KNOWN_TYPES);
         }
     }
 }

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionRegistry.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionRegistry.php
@@ -9,6 +9,7 @@ use Shopsys\Plugin\PluginCrudExtensionInterface;
 
 class PluginCrudExtensionRegistry
 {
+    /** @access protected */
     const KNOWN_TYPES = [
         'product',
         'category',

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -102,7 +102,7 @@ class FriendlyUrlFacade
         $attempt = 0;
         do {
             $attempt++;
-            if ($attempt > self::MAX_URL_UNIQUE_RESOLVE_ATTEMPT) {
+            if ($attempt > static::MAX_URL_UNIQUE_RESOLVE_ATTEMPT) {
                 throw new \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\ReachMaxUrlUniqueResolveAttemptException(
                     $friendlyUrl,
                     $attempt

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
 
 class FriendlyUrlFacade
 {
+    /** @access protected */
     const MAX_URL_UNIQUE_RESOLVE_ATTEMPT = 100;
 
     /**

--- a/packages/framework/src/Component/Router/FriendlyUrl/UrlListData.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/UrlListData.php
@@ -4,8 +4,8 @@ namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
 class UrlListData
 {
-    const FIELD_DOMAIN = 'domain';
-    const FIELD_SLUG = 'slug';
+    public const FIELD_DOMAIN = 'domain';
+    public const FIELD_SLUG = 'slug';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl[]

--- a/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
+++ b/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
@@ -13,7 +13,8 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class RouteCsrfProtector implements EventSubscriberInterface
 {
-    const CSRF_TOKEN_REQUEST_PARAMETER = 'routeCsrfToken';
+    public const CSRF_TOKEN_REQUEST_PARAMETER = 'routeCsrfToken';
+    /** @access protected */
     const CSRF_TOKEN_ID_PREFIX = 'route_';
 
     /**

--- a/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
+++ b/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
@@ -69,7 +69,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
      */
     public function getCsrfTokenId($routeName)
     {
-        return self::CSRF_TOKEN_ID_PREFIX . $routeName;
+        return static::CSRF_TOKEN_ID_PREFIX . $routeName;
     }
 
     /**

--- a/packages/framework/src/Component/Setting/Setting.php
+++ b/packages/framework/src/Component/Setting/Setting.php
@@ -6,21 +6,21 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class Setting
 {
-    const ORDER_SENT_PAGE_CONTENT = 'orderSubmittedText';
-    const PERSONAL_DATA_DISPLAY_SITE_CONTENT = 'personalDataDisplaySiteContent';
-    const PERSONAL_DATA_EXPORT_SITE_CONTENT = 'personalDataExportSiteContent';
-    const DEFAULT_PRICING_GROUP = 'defaultPricingGroupId';
-    const DEFAULT_AVAILABILITY_IN_STOCK = 'defaultAvailabilityInStockId';
-    const TERMS_AND_CONDITIONS_ARTICLE_ID = 'termsAndConditionsArticleId';
-    const PRIVACY_POLICY_ARTICLE_ID = 'privacyPolicyArticleId';
-    const COOKIES_ARTICLE_ID = 'cookiesArticleId';
-    const DOMAIN_DATA_CREATED = 'domainDataCreated';
-    const FEED_HASH = 'feedHash';
-    const DEFAULT_UNIT = 'defaultUnitId';
-    const BASE_URL = 'baseUrl';
-    const FEED_NAME_TO_CONTINUE = 'feedNameToContinue';
-    const FEED_DOMAIN_ID_TO_CONTINUE = 'feedDomainIdToContinue';
-    const FEED_ITEM_ID_TO_CONTINUE = 'feedItemIdToContinue';
+    public const ORDER_SENT_PAGE_CONTENT = 'orderSubmittedText';
+    public const PERSONAL_DATA_DISPLAY_SITE_CONTENT = 'personalDataDisplaySiteContent';
+    public const PERSONAL_DATA_EXPORT_SITE_CONTENT = 'personalDataExportSiteContent';
+    public const DEFAULT_PRICING_GROUP = 'defaultPricingGroupId';
+    public const DEFAULT_AVAILABILITY_IN_STOCK = 'defaultAvailabilityInStockId';
+    public const TERMS_AND_CONDITIONS_ARTICLE_ID = 'termsAndConditionsArticleId';
+    public const PRIVACY_POLICY_ARTICLE_ID = 'privacyPolicyArticleId';
+    public const COOKIES_ARTICLE_ID = 'cookiesArticleId';
+    public const DOMAIN_DATA_CREATED = 'domainDataCreated';
+    public const FEED_HASH = 'feedHash';
+    public const DEFAULT_UNIT = 'defaultUnitId';
+    public const BASE_URL = 'baseUrl';
+    public const FEED_NAME_TO_CONTINUE = 'feedNameToContinue';
+    public const FEED_DOMAIN_ID_TO_CONTINUE = 'feedDomainIdToContinue';
+    public const FEED_ITEM_ID_TO_CONTINUE = 'feedItemIdToContinue';
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface

--- a/packages/framework/src/Component/Setting/SettingValue.php
+++ b/packages/framework/src/Component/Setting/SettingValue.php
@@ -13,20 +13,30 @@ use Shopsys\FrameworkBundle\Component\Money\Money;
  */
 class SettingValue
 {
+    /** @access protected */
     const DATETIME_STORED_FORMAT = DateTime::ISO8601;
 
+    /** @access protected */
     const TYPE_STRING = 'string';
+    /** @access protected */
     const TYPE_INTEGER = 'integer';
+    /** @access protected */
     const TYPE_FLOAT = 'float';
+    /** @access protected */
     const TYPE_BOOLEAN = 'boolean';
+    /** @access protected */
     const TYPE_DATETIME = 'datetime';
+    /** @access protected */
     const TYPE_MONEY = 'money';
+    /** @access protected */
     const TYPE_NULL = 'none';
 
+    /** @access protected */
     const BOOLEAN_TRUE = 'true';
+    /** @access protected */
     const BOOLEAN_FALSE = 'false';
 
-    const DOMAIN_ID_COMMON = 0;
+    public const DOMAIN_ID_COMMON = 0;
 
     /**
      * @var string

--- a/packages/framework/src/Component/Setting/SettingValue.php
+++ b/packages/framework/src/Component/Setting/SettingValue.php
@@ -101,21 +101,21 @@ class SettingValue
      */
     public function getValue()
     {
-        if ($this->value === null && $this->type !== self::TYPE_NULL) {
+        if ($this->value === null && $this->type !== static::TYPE_NULL) {
             $message = 'Setting value type "' . $this->type . '" does not allow null value.';
             throw new \Shopsys\FrameworkBundle\Component\Setting\Exception\SettingValueTypeNotMatchValueException($message);
         }
 
         switch ($this->type) {
-            case self::TYPE_INTEGER:
+            case static::TYPE_INTEGER:
                 return (int)$this->value;
-            case self::TYPE_FLOAT:
+            case static::TYPE_FLOAT:
                 return (float)$this->value;
-            case self::TYPE_BOOLEAN:
-                return $this->value === self::BOOLEAN_TRUE;
-            case self::TYPE_DATETIME:
-                return DateTimeHelper::createFromFormat(self::DATETIME_STORED_FORMAT, $this->value);
-            case self::TYPE_MONEY:
+            case static::TYPE_BOOLEAN:
+                return $this->value === static::BOOLEAN_TRUE;
+            case static::TYPE_DATETIME:
+                return DateTimeHelper::createFromFormat(static::DATETIME_STORED_FORMAT, $this->value);
+            case static::TYPE_MONEY:
                 return Money::create($this->value);
             default:
                 return $this->value;
@@ -136,13 +136,13 @@ class SettingValue
     protected function setValue($value)
     {
         $this->type = $this->getValueType($value);
-        if ($this->type === self::TYPE_BOOLEAN) {
-            $this->value = $value === true ? self::BOOLEAN_TRUE : self::BOOLEAN_FALSE;
-        } elseif ($this->type === self::TYPE_NULL) {
+        if ($this->type === static::TYPE_BOOLEAN) {
+            $this->value = $value === true ? static::BOOLEAN_TRUE : static::BOOLEAN_FALSE;
+        } elseif ($this->type === static::TYPE_NULL) {
             $this->value = $value;
-        } elseif ($this->type === self::TYPE_DATETIME) {
-            $this->value = $value->format(self::DATETIME_STORED_FORMAT);
-        } elseif ($this->type === self::TYPE_MONEY) {
+        } elseif ($this->type === static::TYPE_DATETIME) {
+            $this->value = $value->format(static::DATETIME_STORED_FORMAT);
+        } elseif ($this->type === static::TYPE_MONEY) {
             $this->value = $value->getAmount();
         } else {
             $this->value = (string)$value;
@@ -156,19 +156,19 @@ class SettingValue
     protected function getValueType($value)
     {
         if (is_int($value)) {
-            return self::TYPE_INTEGER;
+            return static::TYPE_INTEGER;
         } elseif (is_float($value)) {
-            return self::TYPE_FLOAT;
+            return static::TYPE_FLOAT;
         } elseif (is_bool($value)) {
-            return self::TYPE_BOOLEAN;
+            return static::TYPE_BOOLEAN;
         } elseif (is_string($value)) {
-            return self::TYPE_STRING;
+            return static::TYPE_STRING;
         } elseif (is_null($value)) {
-            return self::TYPE_NULL;
+            return static::TYPE_NULL;
         } elseif ($value instanceof DateTime) {
-            return self::TYPE_DATETIME;
+            return static::TYPE_DATETIME;
         } elseif ($value instanceof Money) {
-            return self::TYPE_MONEY;
+            return static::TYPE_MONEY;
         }
 
         $message = sprintf('Setting value type of "%s" is unsupported.', \is_object($value) ? \get_class($value) : \gettype($value))

--- a/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
@@ -33,7 +33,7 @@ use Twig_Node;
  */
 class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
 {
-    const CONSTRAINT_MESSAGE_DOMAIN = 'validators';
+    public const CONSTRAINT_MESSAGE_DOMAIN = 'validators';
 
     /**
      * @var \PhpParser\NodeTraverser

--- a/packages/framework/src/Component/Translation/CustomTransFiltersVisitor.php
+++ b/packages/framework/src/Component/Translation/CustomTransFiltersVisitor.php
@@ -16,10 +16,12 @@ use Twig_Node_Expression_Filter;
  */
 class CustomTransFiltersVisitor extends Twig_BaseNodeVisitor
 {
+    /** @access protected */
     const CUSTOM_TO_DEFAULT_TRANS_FILTERS_MAP = [
         'transHtml' => 'trans',
         'transchoiceHtml' => 'transchoice',
     ];
+    /** @access protected */
     const PRIORITY = -1;
 
     /**

--- a/packages/framework/src/Component/Translation/CustomTransFiltersVisitor.php
+++ b/packages/framework/src/Component/Translation/CustomTransFiltersVisitor.php
@@ -32,8 +32,8 @@ class CustomTransFiltersVisitor extends Twig_BaseNodeVisitor
         if ($node instanceof Twig_Node_Expression_Filter) {
             $filterNameConstantNode = $node->getNode('filter');
             $filterName = $filterNameConstantNode->getAttribute('value');
-            if (array_key_exists($filterName, self::CUSTOM_TO_DEFAULT_TRANS_FILTERS_MAP)) {
-                $newFilterName = self::CUSTOM_TO_DEFAULT_TRANS_FILTERS_MAP[$filterName];
+            if (array_key_exists($filterName, static::CUSTOM_TO_DEFAULT_TRANS_FILTERS_MAP)) {
+                $newFilterName = static::CUSTOM_TO_DEFAULT_TRANS_FILTERS_MAP[$filterName];
                 $this->replaceCustomFilterName($node, $newFilterName);
             }
         }
@@ -69,6 +69,6 @@ class CustomTransFiltersVisitor extends Twig_BaseNodeVisitor
      */
     public function getPriority()
     {
-        return self::PRIORITY;
+        return static::PRIORITY;
     }
 }

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -130,7 +130,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
         if ($domainArgumentIndex !== null && isset($node->args[$domainArgumentIndex])) {
             return PhpParserNodeHelper::getConcatenatedStringValue($node->args[$domainArgumentIndex]->value, $this->file);
         } else {
-            return self::DEFAULT_MESSAGE_DOMAIN;
+            return static::DEFAULT_MESSAGE_DOMAIN;
         }
     }
 

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -19,6 +19,7 @@ use Twig_Node;
 
 class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
 {
+    /** @access protected */
     const DEFAULT_MESSAGE_DOMAIN = 'messages';
 
     /**

--- a/packages/framework/src/Component/Translation/Translator.php
+++ b/packages/framework/src/Component/Translation/Translator.php
@@ -124,7 +124,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface
     protected function resolveDomain($domain)
     {
         if ($domain === null) {
-            return self::DEFAULT_DOMAIN;
+            return static::DEFAULT_DOMAIN;
         }
 
         return $domain;

--- a/packages/framework/src/Component/Translation/Translator.php
+++ b/packages/framework/src/Component/Translation/Translator.php
@@ -7,8 +7,9 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class Translator implements TranslatorInterface, TranslatorBagInterface
 {
+    /** @access protected */
     const DEFAULT_DOMAIN = 'messages';
-    const SOURCE_LOCALE = 'en';
+    public const SOURCE_LOCALE = 'en';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Translation\Translator|null

--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigDefinition.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigDefinition.php
@@ -8,8 +8,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class UploadedFileConfigDefinition implements ConfigurationInterface
 {
-    const CONFIG_CLASS = 'class';
-    const CONFIG_ENTITY_NAME = 'name';
+    public const CONFIG_CLASS = 'class';
+    public const CONFIG_ENTITY_NAME = 'name';
 
     /**
      * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder

--- a/packages/framework/src/Component/UploadedFile/UploadedFile.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFile.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Component\FileUpload\FileNamingConvention;
  */
 class UploadedFile implements EntityFileUploadInterface
 {
+    /** @access protected */
     const UPLOAD_KEY = 'uploadedFile';
 
     /**

--- a/packages/framework/src/Component/UploadedFile/UploadedFile.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFile.php
@@ -81,7 +81,7 @@ class UploadedFile implements EntityFileUploadInterface
         }
 
         return [
-            self::UPLOAD_KEY => new FileForUpload(
+            static::UPLOAD_KEY => new FileForUpload(
                 $this->temporaryFilename,
                 false,
                 $this->entityName,
@@ -97,7 +97,7 @@ class UploadedFile implements EntityFileUploadInterface
      */
     public function setFileAsUploaded($key, $originalFilename)
     {
-        if ($key === self::UPLOAD_KEY) {
+        if ($key === static::UPLOAD_KEY) {
             $this->extension = pathinfo($originalFilename, PATHINFO_EXTENSION);
         } else {
             throw new \Shopsys\FrameworkBundle\Component\FileUpload\Exception\InvalidFileKeyException($key);

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -152,7 +152,7 @@ class AdministratorController extends AdminBaseController
 
         $lastAdminActivities = $this->administratorActivityFacade->getLastAdministratorActivities(
             $administrator,
-            self::MAX_ADMINISTRATOR_ACTIVITIES_COUNT
+            static::MAX_ADMINISTRATOR_ACTIVITIES_COUNT
         );
 
         return $this->render('@ShopsysFramework/Admin/Content/Administrator/edit.html.twig', [

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class AdministratorController extends AdminBaseController
 {
+    /** @access protected */
     const MAX_ADMINISTRATOR_ACTIVITIES_COUNT = 10;
 
     /**

--- a/packages/framework/src/Controller/Admin/CategoryController.php
+++ b/packages/framework/src/Controller/Admin/CategoryController.php
@@ -154,23 +154,23 @@ class CategoryController extends AdminBaseController
             if ($request->query->has('domain')) {
                 $domainId = (int)$request->query->get('domain');
             } else {
-                $domainId = (int)$this->session->get('categories_selected_domain_id', self::ALL_DOMAINS);
+                $domainId = (int)$this->session->get('categories_selected_domain_id', static::ALL_DOMAINS);
             }
         } else {
-            $domainId = self::ALL_DOMAINS;
+            $domainId = static::ALL_DOMAINS;
         }
 
-        if ($domainId !== self::ALL_DOMAINS) {
+        if ($domainId !== static::ALL_DOMAINS) {
             try {
                 $this->domain->getDomainConfigById($domainId);
             } catch (\Shopsys\FrameworkBundle\Component\Domain\Exception\InvalidDomainIdException $ex) {
-                $domainId = self::ALL_DOMAINS;
+                $domainId = static::ALL_DOMAINS;
             }
         }
 
         $this->session->set('categories_selected_domain_id', $domainId);
 
-        if ($domainId === self::ALL_DOMAINS) {
+        if ($domainId === static::ALL_DOMAINS) {
             $categoriesWithPreloadedChildren = $this->categoryFacade->getAllCategoriesWithPreloadedChildren($request->getLocale());
         } else {
             $categoriesWithPreloadedChildren = $this->categoryFacade->getVisibleCategoriesWithPreloadedChildrenForDomain($domainId, $request->getLocale());
@@ -178,7 +178,7 @@ class CategoryController extends AdminBaseController
 
         return $this->render('@ShopsysFramework/Admin/Content/Category/list.html.twig', [
             'categoriesWithPreloadedChildren' => $categoriesWithPreloadedChildren,
-            'isForAllDomains' => ($domainId === self::ALL_DOMAINS),
+            'isForAllDomains' => ($domainId === static::ALL_DOMAINS),
         ]);
     }
 
@@ -229,7 +229,7 @@ class CategoryController extends AdminBaseController
 
     public function listDomainTabsAction()
     {
-        $domainId = $this->session->get('categories_selected_domain_id', self::ALL_DOMAINS);
+        $domainId = $this->session->get('categories_selected_domain_id', static::ALL_DOMAINS);
 
         return $this->render('@ShopsysFramework/Admin/Content/Category/domainTabs.html.twig', [
             'domainConfigs' => $this->domain->getAll(),

--- a/packages/framework/src/Controller/Admin/CategoryController.php
+++ b/packages/framework/src/Controller/Admin/CategoryController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class CategoryController extends AdminBaseController
 {
+    /** @access protected */
     const ALL_DOMAINS = 0;
 
     /**

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -27,6 +27,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CustomerController extends AdminBaseController
 {
+    /** @access protected */
     const LOGIN_AS_TOKEN_ID_PREFIX = 'loginAs';
 
     /**

--- a/packages/framework/src/Controller/Admin/LoginController.php
+++ b/packages/framework/src/Controller/Admin/LoginController.php
@@ -115,7 +115,7 @@ class LoginController extends AdminBaseController
         $redirectTo = $originalDomainRouter->generate(
             'admin_login_authorization',
             [
-                self::MULTIDOMAIN_LOGIN_TOKEN_PARAMETER_NAME => $multidomainToken,
+                static::MULTIDOMAIN_LOGIN_TOKEN_PARAMETER_NAME => $multidomainToken,
                 self::ORIGINAL_REFERER_PARAMETER_NAME => $request->get(self::ORIGINAL_REFERER_PARAMETER_NAME),
             ],
             UrlGeneratorInterface::ABSOLUTE_URL
@@ -130,7 +130,7 @@ class LoginController extends AdminBaseController
      */
     public function authorizationAction(Request $request)
     {
-        $multidomainLoginToken = $request->get(self::MULTIDOMAIN_LOGIN_TOKEN_PARAMETER_NAME);
+        $multidomainLoginToken = $request->get(static::MULTIDOMAIN_LOGIN_TOKEN_PARAMETER_NAME);
         $originalReferer = $request->get(self::ORIGINAL_REFERER_PARAMETER_NAME);
         try {
             $this->administratorLoginFacade->loginByMultidomainToken($request, $multidomainLoginToken);

--- a/packages/framework/src/Controller/Admin/LoginController.php
+++ b/packages/framework/src/Controller/Admin/LoginController.php
@@ -14,9 +14,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class LoginController extends AdminBaseController
 {
+    /** @access protected */
     const MULTIDOMAIN_LOGIN_TOKEN_PARAMETER_NAME = 'multidomainLoginToken';
-    const ORIGINAL_DOMAIN_ID_PARAMETER_NAME = 'originalDomainId';
-    const ORIGINAL_REFERER_PARAMETER_NAME = 'originalReferer';
+    public const ORIGINAL_DOMAIN_ID_PARAMETER_NAME = 'originalDomainId';
+    public const ORIGINAL_REFERER_PARAMETER_NAME = 'originalReferer';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Security\Authenticator

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -20,8 +20,8 @@ use Symfony\Component\Validator\Constraints;
 
 class AdministratorFormType extends AbstractType
 {
-    const SCENARIO_CREATE = 'create';
-    const SCENARIO_EDIT = 'edit';
+    public const SCENARIO_CREATE = 'create';
+    public const SCENARIO_EDIT = 'edit';
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -24,10 +24,12 @@ use Symfony\Component\Validator\Constraints;
 
 class AdvertFormType extends AbstractType
 {
+    /** @access protected */
     const VALIDATION_GROUP_TYPE_IMAGE = 'typeImage';
+    /** @access protected */
     const VALIDATION_GROUP_TYPE_CODE = 'typeCode';
-    const SCENARIO_CREATE = 'create';
-    const SCENARIO_EDIT = 'edit';
+    public const SCENARIO_CREATE = 'create';
+    public const SCENARIO_EDIT = 'edit';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -62,7 +62,7 @@ class AdvertFormType extends AbstractType
         $imageConstraints = [
             new Constraints\NotBlank([
                 'message' => 'Choose image',
-                'groups' => [self::VALIDATION_GROUP_TYPE_IMAGE],
+                'groups' => [static::VALIDATION_GROUP_TYPE_IMAGE],
             ]),
         ];
 
@@ -131,7 +131,7 @@ class AdvertFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank([
                         'message' => 'Please enter HTML code for advertisement area',
-                        'groups' => [self::VALIDATION_GROUP_TYPE_CODE],
+                        'groups' => [static::VALIDATION_GROUP_TYPE_CODE],
                     ]),
                 ],
                 'attr' => [
@@ -202,9 +202,9 @@ class AdvertFormType extends AbstractType
                     /* @var $advertData \Shopsys\FrameworkBundle\Model\Advert\AdvertData */
 
                     if ($advertData->type === Advert::TYPE_CODE) {
-                        $validationGroups[] = self::VALIDATION_GROUP_TYPE_CODE;
+                        $validationGroups[] = static::VALIDATION_GROUP_TYPE_CODE;
                     } elseif ($advertData->type === Advert::TYPE_IMAGE) {
-                        $validationGroups[] = self::VALIDATION_GROUP_TYPE_IMAGE;
+                        $validationGroups[] = static::VALIDATION_GROUP_TYPE_IMAGE;
                     }
                     return $validationGroups;
                 },

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -30,8 +30,8 @@ use Symfony\Component\Validator\Constraints;
 
 class CategoryFormType extends AbstractType
 {
-    const SCENARIO_CREATE = 'create';
-    const SCENARIO_EDIT = 'edit';
+    public const SCENARIO_CREATE = 'create';
+    public const SCENARIO_EDIT = 'edit';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraints;
 
 class BillingAddressFormType extends AbstractType
 {
+    /** @access protected */
     const VALIDATION_GROUP_COMPANY_CUSTOMER = 'companyCustomer';
 
     /**

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -70,12 +70,12 @@ class BillingAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter company name',
-                                'groups' => [self::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'Company name cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                         ],
                         'label' => t('Company'),
@@ -85,12 +85,12 @@ class BillingAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter identification number',
-                                'groups' => [self::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                             new Constraints\Length([
                                 'max' => 50,
                                 'maxMessage' => 'Identification number cannot be longer then {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                         ],
                         'label' => t('Company number'),
@@ -101,7 +101,7 @@ class BillingAddressFormType extends AbstractType
                             new Constraints\Length([
                                 'max' => 50,
                                 'maxMessage' => 'Tax number cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_COMPANY_CUSTOMER],
+                                'groups' => [static::VALIDATION_GROUP_COMPANY_CUSTOMER],
                             ]),
                         ],
                         'label' => t('Tax number'),
@@ -174,7 +174,7 @@ class BillingAddressFormType extends AbstractType
                     /* @var $billingAddressData \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData */
 
                     if ($billingAddressData->companyCustomer) {
-                        $validationGroups[] = self::VALIDATION_GROUP_COMPANY_CUSTOMER;
+                        $validationGroups[] = static::VALIDATION_GROUP_COMPANY_CUSTOMER;
                     }
 
                     return $validationGroups;

--- a/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
@@ -79,7 +79,7 @@ class DeliveryAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter first name of contact person',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
@@ -93,7 +93,7 @@ class DeliveryAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter last name of contact person',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
@@ -117,12 +117,12 @@ class DeliveryAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter street',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                         ],
                         'label' => t('Street'),
@@ -132,12 +132,12 @@ class DeliveryAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter city',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                         ],
                         'label' => t('City'),
@@ -147,12 +147,12 @@ class DeliveryAddressFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter zip code',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 30,
                                 'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS],
                             ]),
                         ],
                         'label' => t('Postcode'),
@@ -190,7 +190,7 @@ class DeliveryAddressFormType extends AbstractType
                     /* @var $deliveryAddressData \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData */
 
                     if ($deliveryAddressData->addressFilled) {
-                        $validationGroups[] = self::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS;
+                        $validationGroups[] = static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS;
                     }
 
                     return $validationGroups;

--- a/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Validator\Constraints;
 
 class DeliveryAddressFormType extends AbstractType
 {
+    /** @access protected */
     const VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS = 'differentDeliveryAddress';
 
     /**

--- a/packages/framework/src/Form/Admin/Domain/DomainFormType.php
+++ b/packages/framework/src/Form/Admin/Domain/DomainFormType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints;
 
 class DomainFormType extends AbstractType
 {
-    const FIELD_ICON = 'icon';
+    public const FIELD_ICON = 'icon';
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
@@ -75,7 +75,7 @@ class MailTemplateFormType extends AbstractType
 
         $subjectConstraints[] = new Constraints\NotBlank([
             'message' => 'Please enter subject',
-            'groups' => [self::VALIDATION_GROUP_SEND_MAIL],
+            'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
         ]);
         $subjectConstraints[] = new Constraints\Length([
             'max' => 255,
@@ -86,7 +86,7 @@ class MailTemplateFormType extends AbstractType
             $subjectConstraints[] = new Contains([
                 'needle' => $variableName,
                 'message' => 'Variable {{ needle }} is required',
-                'groups' => [self::VALIDATION_GROUP_SEND_MAIL],
+                'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
             ]);
         }
 
@@ -103,14 +103,14 @@ class MailTemplateFormType extends AbstractType
 
         $bodyConstraints[] = new Constraints\NotBlank([
             'message' => 'Please enter e-mail content',
-            'groups' => [self::VALIDATION_GROUP_SEND_MAIL],
+            'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
         ]);
 
         foreach ($options['required_body_variables'] as $variableName) {
             $bodyConstraints[] = new Contains([
                 'needle' => $variableName,
                 'message' => 'Variable {{ needle }} is required',
-                'groups' => [self::VALIDATION_GROUP_SEND_MAIL],
+                'groups' => [static::VALIDATION_GROUP_SEND_MAIL],
             ]);
         }
 
@@ -137,7 +137,7 @@ class MailTemplateFormType extends AbstractType
                     /* @var $mailTemplateData \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData */
 
                     if ($mailTemplateData->sendMail) {
-                        $validationGroups[] = self::VALIDATION_GROUP_SEND_MAIL;
+                        $validationGroups[] = static::VALIDATION_GROUP_SEND_MAIL;
                     }
 
                     return $validationGroups;

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Constraints;
 
 class MailTemplateFormType extends AbstractType
 {
+    /** @access protected */
     const VALIDATION_GROUP_SEND_MAIL = 'sendMail';
 
     /**

--- a/packages/framework/src/Form/Admin/Order/OrderFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderFormType.php
@@ -112,7 +112,7 @@ class OrderFormType extends AbstractType
                     $orderData = $form->getData();
 
                     if (!$orderData->deliveryAddressSameAsBillingAddress) {
-                        $validationGroups[] = self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS;
+                        $validationGroups[] = static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS;
                     }
 
                     return $validationGroups;
@@ -383,12 +383,12 @@ class OrderFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter first name of contact person',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'First name of contact person cannot be longer then {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])
@@ -398,12 +398,12 @@ class OrderFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter last name of contact person',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'Last name of contact person cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])
@@ -414,7 +414,7 @@ class OrderFormType extends AbstractType
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'Name cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])
@@ -425,7 +425,7 @@ class OrderFormType extends AbstractType
                             new Constraints\Length([
                                 'max' => 30,
                                 'maxMessage' => 'Telephone number cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])
@@ -435,12 +435,12 @@ class OrderFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter street',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 100,
                                 'maxMessage' => 'Street name cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])
@@ -450,11 +450,11 @@ class OrderFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter city',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                             new Constraints\Length(['max' => 100,
                                 'maxMessage' => 'City name cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])
@@ -464,12 +464,12 @@ class OrderFormType extends AbstractType
                         'constraints' => [
                             new Constraints\NotBlank([
                                 'message' => 'Please enter zip code',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                             new Constraints\Length([
                                 'max' => 30,
                                 'maxMessage' => 'Zip code cannot be longer than {{ limit }} characters',
-                                'groups' => [self::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
+                                'groups' => [static::VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS],
                             ]),
                         ],
                     ])

--- a/packages/framework/src/Form/Admin/Order/OrderFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderFormType.php
@@ -31,6 +31,7 @@ use Symfony\Component\Validator\Constraints;
 
 class OrderFormType extends AbstractType
 {
+    /** @access protected */
     const VALIDATION_GROUP_DELIVERY_ADDRESS_SAME_AS_BILLING_ADDRESS = 'deliveryAddressSameAsBillingAddress';
 
     /**

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -52,11 +52,14 @@ use Symfony\Component\Validator\Constraints;
 
 class ProductFormType extends AbstractType
 {
+    /** @access protected */
     const VALIDATION_GROUP_USING_STOCK = 'usingStock';
+    /** @access protected */
     const VALIDATION_GROUP_USING_STOCK_AND_ALTERNATE_AVAILABILITY = 'usingStockAndAlternateAvailability';
+    /** @access protected */
     const VALIDATION_GROUP_NOT_USING_STOCK = 'notUsingStock';
 
-    const CSRF_TOKEN_ID = 'product_edit_type';
+    public const CSRF_TOKEN_ID = 'product_edit_type';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -227,12 +227,12 @@ class ProductFormType extends AbstractType
                     /* @var $productData \Shopsys\FrameworkBundle\Model\Product\ProductData */
 
                     if ($productData->usingStock) {
-                        $validationGroups[] = self::VALIDATION_GROUP_USING_STOCK;
+                        $validationGroups[] = static::VALIDATION_GROUP_USING_STOCK;
                         if ($productData->outOfStockAction === Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY) {
-                            $validationGroups[] = self::VALIDATION_GROUP_USING_STOCK_AND_ALTERNATE_AVAILABILITY;
+                            $validationGroups[] = static::VALIDATION_GROUP_USING_STOCK_AND_ALTERNATE_AVAILABILITY;
                         }
                     } else {
-                        $validationGroups[] = self::VALIDATION_GROUP_NOT_USING_STOCK;
+                        $validationGroups[] = static::VALIDATION_GROUP_NOT_USING_STOCK;
                     }
 
                     return $validationGroups;
@@ -529,7 +529,7 @@ class ProductFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank([
                         'message' => 'Please enter stock quantity',
-                        'groups' => self::VALIDATION_GROUP_USING_STOCK,
+                        'groups' => static::VALIDATION_GROUP_USING_STOCK,
                     ]),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
@@ -548,7 +548,7 @@ class ProductFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank([
                         'message' => 'Please choose action',
-                        'groups' => self::VALIDATION_GROUP_USING_STOCK,
+                        'groups' => static::VALIDATION_GROUP_USING_STOCK,
                     ]),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
@@ -566,7 +566,7 @@ class ProductFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank([
                         'message' => 'Please choose availability',
-                        'groups' => self::VALIDATION_GROUP_USING_STOCK_AND_ALTERNATE_AVAILABILITY,
+                        'groups' => static::VALIDATION_GROUP_USING_STOCK_AND_ALTERNATE_AVAILABILITY,
                     ]),
                 ],
                 'disabled' => $this->isProductMainVariant($product),
@@ -586,7 +586,7 @@ class ProductFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank([
                         'message' => 'Please choose availability',
-                        'groups' => self::VALIDATION_GROUP_NOT_USING_STOCK,
+                        'groups' => static::VALIDATION_GROUP_NOT_USING_STOCK,
                     ]),
                 ],
                 'disabled' => $this->isProductMainVariant($product),

--- a/packages/framework/src/Form/Admin/Product/VariantFormType.php
+++ b/packages/framework/src/Form/Admin/Product/VariantFormType.php
@@ -13,8 +13,8 @@ use Symfony\Component\Validator\Constraints;
 
 class VariantFormType extends AbstractType
 {
-    const MAIN_VARIANT = 'mainVariant';
-    const VARIANTS = 'variants';
+    public const MAIN_VARIANT = 'mainVariant';
+    public const VARIANTS = 'variants';
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -19,8 +19,8 @@ use Symfony\Component\Validator\Constraints;
 
 class SliderItemFormType extends AbstractType
 {
-    const SCENARIO_CREATE = 'create';
-    const SCENARIO_EDIT = 'edit';
+    public const SCENARIO_CREATE = 'create';
+    public const SCENARIO_EDIT = 'edit';
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
+++ b/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
@@ -61,7 +61,7 @@ class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
                         $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
                         $formData = $form->getData();
                         if ($formData[self::FIELD_ENABLED]) {
-                            $validationGroups[] = self::VALIDATION_GROUP_PRICE_LIMIT_ENABLED;
+                            $validationGroups[] = static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED;
                         }
 
                         return $validationGroups;
@@ -75,11 +75,11 @@ class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
                     'constraints' => [
                         new NotNegativeMoneyAmount([
                             'message' => 'Price must be greater or equal to zero',
-                            'groups' => [self::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
+                            'groups' => [static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
                         ]),
                         new Constraints\NotBlank([
                             'message' => 'Please enter price',
-                            'groups' => [self::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
+                            'groups' => [static::VALIDATION_GROUP_PRICE_LIMIT_ENABLED],
                         ]),
                     ],
                 ]);

--- a/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
+++ b/packages/framework/src/Form/Admin/TransportAndPayment/FreeTransportAndPaymentPriceLimitsFormType.php
@@ -16,9 +16,10 @@ use Symfony\Component\Validator\Constraints;
 
 class FreeTransportAndPaymentPriceLimitsFormType extends AbstractType
 {
-    const DOMAINS_SUBFORM_NAME = 'priceLimits';
-    const FIELD_ENABLED = 'enabled';
-    const FIELD_PRICE_LIMIT = 'priceLimit';
+    public const DOMAINS_SUBFORM_NAME = 'priceLimits';
+    public const FIELD_ENABLED = 'enabled';
+    public const FIELD_PRICE_LIMIT = 'priceLimit';
+    /** @access protected */
     const VALIDATION_GROUP_PRICE_LIMIT_ENABLED = 'priceLimitEnabled';
 
     /**

--- a/packages/framework/src/Form/Admin/Vat/VatFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatFormType.php
@@ -12,8 +12,8 @@ use Symfony\Component\Validator\Constraints;
 
 class VatFormType extends AbstractType
 {
-    const SCENARIO_CREATE = 'create';
-    const SCENARIO_EDIT = 'edit';
+    public const SCENARIO_CREATE = 'create';
+    public const SCENARIO_EDIT = 'edit';
 
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder

--- a/packages/framework/src/Form/Constraints/ConstraintValue.php
+++ b/packages/framework/src/Form/Constraints/ConstraintValue.php
@@ -4,5 +4,5 @@ namespace Shopsys\FrameworkBundle\Form\Constraints;
 
 class ConstraintValue
 {
-    const INTEGER_MAX_VALUE = 2147483647;
+    public const INTEGER_MAX_VALUE = 2147483647;
 }

--- a/packages/framework/src/Form/DatePickerType.php
+++ b/packages/framework/src/Form/DatePickerType.php
@@ -20,7 +20,7 @@ class DatePickerType extends AbstractType
     {
         $resolver->setDefaults([
             'widget' => 'single_text',
-            'format' => self::FORMAT_PHP,
+            'format' => static::FORMAT_PHP,
         ]);
     }
 

--- a/packages/framework/src/Form/DatePickerType.php
+++ b/packages/framework/src/Form/DatePickerType.php
@@ -8,7 +8,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DatePickerType extends AbstractType
 {
+    /** @access protected */
     const FORMAT_PHP = 'dd.MM.yyyy';
+    /** @access protected */
     const FORMAT_JS = 'dd.mm.yy';
 
     /**

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FormRenderingConfigurationExtension extends AbstractTypeExtension
 {
-    const DISPLAY_FORMAT_MULTIDOMAIN_ROWS_NO_PADDING = 'multidomain_form_rows_no_padding';
+    public const DISPLAY_FORMAT_MULTIDOMAIN_ROWS_NO_PADDING = 'multidomain_form_rows_no_padding';
 
     /**
      * @param \Symfony\Component\Form\FormView $view

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -27,7 +27,7 @@ class FriendlyUrlType extends AbstractType
             'required' => true,
             'constraints' => [
                 new Constraints\NotBlank(),
-                new Constraints\Regex(self::SLUG_REGEX),
+                new Constraints\Regex(static::SLUG_REGEX),
             ],
         ]);
     }

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -10,6 +10,7 @@ use Symfony\Component\Validator\Constraints;
 
 class FriendlyUrlType extends AbstractType
 {
+    /** @access protected */
     const SLUG_REGEX = '/^[\w_\-\/]+$/';
 
     /**

--- a/packages/framework/src/Form/InvertChoiceTypeExtension.php
+++ b/packages/framework/src/Form/InvertChoiceTypeExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class InvertChoiceTypeExtension extends AbstractTypeExtension
 {
+    /** @access protected */
     const INVERT_OPTION = 'invert';
 
     /**

--- a/packages/framework/src/Form/InvertChoiceTypeExtension.php
+++ b/packages/framework/src/Form/InvertChoiceTypeExtension.php
@@ -28,13 +28,13 @@ class InvertChoiceTypeExtension extends AbstractTypeExtension
     {
         parent::buildForm($builder, $options);
 
-        if ($options[self::INVERT_OPTION] && !$options['multiple']) {
+        if ($options[static::INVERT_OPTION] && !$options['multiple']) {
             throw new \Shopsys\FrameworkBundle\Component\Form\Exception\InvertedChoiceNotMultipleException(
                 'The "invert" option can be enabled only with "multiple" set to true.'
             );
         }
 
-        if ($options[self::INVERT_OPTION]) {
+        if ($options[static::INVERT_OPTION]) {
             $builder->addModelTransformer(new InverseMultipleChoiceTransformer($options['choices']));
         }
     }
@@ -46,10 +46,10 @@ class InvertChoiceTypeExtension extends AbstractTypeExtension
     {
         parent::configureOptions($resolver);
 
-        $resolver->setRequired(self::INVERT_OPTION)
-            ->setAllowedTypes(self::INVERT_OPTION, 'bool')
+        $resolver->setRequired(static::INVERT_OPTION)
+            ->setAllowedTypes(static::INVERT_OPTION, 'bool')
             ->setDefaults([
-                self::INVERT_OPTION => false,
+                static::INVERT_OPTION => false,
             ]);
     }
 }

--- a/packages/framework/src/Form/ValidationGroup.php
+++ b/packages/framework/src/Form/ValidationGroup.php
@@ -4,5 +4,5 @@ namespace Shopsys\FrameworkBundle\Form;
 
 class ValidationGroup
 {
-    const VALIDATION_GROUP_DEFAULT = 'Default';
+    public const VALIDATION_GROUP_DEFAULT = 'Default';
 }

--- a/packages/framework/src/Form/WysiwygTypeExtension.php
+++ b/packages/framework/src/Form/WysiwygTypeExtension.php
@@ -46,7 +46,7 @@ class WysiwygTypeExtension extends AbstractTypeExtension
                     'assets/admin/styles/wysiwyg_' . $cssVersion . '.css',
                 ],
                 'language' => $this->localization->getLocale(),
-                'format_tags' => self::ALLOWED_FORMAT_TAGS,
+                'format_tags' => static::ALLOWED_FORMAT_TAGS,
             ],
         ]);
     }

--- a/packages/framework/src/Form/WysiwygTypeExtension.php
+++ b/packages/framework/src/Form/WysiwygTypeExtension.php
@@ -10,6 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class WysiwygTypeExtension extends AbstractTypeExtension
 {
+    /** @access protected */
     const ALLOWED_FORMAT_TAGS = 'p;h2;h3;h4;h5;h6;pre;div;address';
 
     /**

--- a/packages/framework/src/Migrations/Version20160512152113.php
+++ b/packages/framework/src/Migrations/Version20160512152113.php
@@ -9,6 +9,7 @@ class Version20160512152113 extends AbstractMigration
 {
     use MultidomainMigrationTrait;
 
+    /** @access private */
     const COUNTRIES_SEQUENCE_NAME = 'countries_id_seq';
 
     /**

--- a/packages/framework/src/Model/AdminNavigation/ConfigureMenuEvent.php
+++ b/packages/framework/src/Model/AdminNavigation/ConfigureMenuEvent.php
@@ -8,15 +8,15 @@ use Symfony\Component\EventDispatcher\Event;
 
 class ConfigureMenuEvent extends Event
 {
-    const SIDE_MENU_ROOT = 'shopsys.admin_side_menu.configure_root';
-    const SIDE_MENU_DASHBOARD = 'shopsys.admin_side_menu.configure_dashboard';
-    const SIDE_MENU_ORDERS = 'shopsys.admin_side_menu.configure_orders';
-    const SIDE_MENU_CUSTOMERS = 'shopsys.admin_side_menu.configure_customers';
-    const SIDE_MENU_PRODUCTS = 'shopsys.admin_side_menu.configure_products';
-    const SIDE_MENU_PRICING = 'shopsys.admin_side_menu.configure_pricing';
-    const SIDE_MENU_MARKETING = 'shopsys.admin_side_menu.configure_marketing';
-    const SIDE_MENU_ADMINISTRATORS = 'shopsys.admin_side_menu.configure_administrators';
-    const SIDE_MENU_SETTINGS = 'shopsys.admin_side_menu.configure_settings';
+    public const SIDE_MENU_ROOT = 'shopsys.admin_side_menu.configure_root';
+    public const SIDE_MENU_DASHBOARD = 'shopsys.admin_side_menu.configure_dashboard';
+    public const SIDE_MENU_ORDERS = 'shopsys.admin_side_menu.configure_orders';
+    public const SIDE_MENU_CUSTOMERS = 'shopsys.admin_side_menu.configure_customers';
+    public const SIDE_MENU_PRODUCTS = 'shopsys.admin_side_menu.configure_products';
+    public const SIDE_MENU_PRICING = 'shopsys.admin_side_menu.configure_pricing';
+    public const SIDE_MENU_MARKETING = 'shopsys.admin_side_menu.configure_marketing';
+    public const SIDE_MENU_ADMINISTRATORS = 'shopsys.admin_side_menu.configure_administrators';
+    public const SIDE_MENU_SETTINGS = 'shopsys.admin_side_menu.configure_settings';
 
     /**
      * @var \Knp\Menu\FactoryInterface

--- a/packages/framework/src/Model/Administrator/Security/AdministratorFrontSecurityFacade.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorFrontSecurityFacade.php
@@ -102,7 +102,7 @@ class AdministratorFrontSecurityFacade
      */
     protected function getAdministratorToken()
     {
-        $serializedToken = $this->session->get('_security_' . self::ADMINISTRATION_CONTEXT);
+        $serializedToken = $this->session->get('_security_' . static::ADMINISTRATION_CONTEXT);
         if ($serializedToken === null) {
             $message = 'Token not found.';
             throw new \Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\InvalidTokenException($message);

--- a/packages/framework/src/Model/Administrator/Security/AdministratorFrontSecurityFacade.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorFrontSecurityFacade.php
@@ -12,6 +12,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class AdministratorFrontSecurityFacade
 {
     // same as in security.yml
+    /** @access protected */
     const ADMINISTRATION_CONTEXT = 'administration';
 
     /**

--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchFilterInterface.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchFilterInterface.php
@@ -6,19 +6,19 @@ use Doctrine\ORM\QueryBuilder;
 
 interface AdvancedSearchFilterInterface
 {
-    const OPERATOR_CONTAINS = 'contains';
-    const OPERATOR_NOT_CONTAINS = 'notContains';
-    const OPERATOR_NOT_SET = 'notSet';
-    const OPERATOR_IS = 'is';
-    const OPERATOR_IS_NOT = 'isNot';
-    const OPERATOR_IS_USED = 'isUsed';
-    const OPERATOR_IS_NOT_USED = 'isNotUsed';
-    const OPERATOR_BEFORE = 'before';
-    const OPERATOR_AFTER = 'after';
-    const OPERATOR_GT = 'gt';
-    const OPERATOR_GTE = 'gte';
-    const OPERATOR_LT = 'lt';
-    const OPERATOR_LTE = 'lte';
+    public const OPERATOR_CONTAINS = 'contains';
+    public const OPERATOR_NOT_CONTAINS = 'notContains';
+    public const OPERATOR_NOT_SET = 'notSet';
+    public const OPERATOR_IS = 'is';
+    public const OPERATOR_IS_NOT = 'isNot';
+    public const OPERATOR_IS_USED = 'isUsed';
+    public const OPERATOR_IS_NOT_USED = 'isNotUsed';
+    public const OPERATOR_BEFORE = 'before';
+    public const OPERATOR_AFTER = 'after';
+    public const OPERATOR_GT = 'gt';
+    public const OPERATOR_GTE = 'gte';
+    public const OPERATOR_LT = 'lt';
+    public const OPERATOR_LTE = 'lte';
 
     /**
      * Returns a unique name of the filter

--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
@@ -55,10 +55,10 @@ class AdvancedSearchProductFacade
      */
     public function createAdvancedSearchForm(Request $request)
     {
-        $rulesData = (array)$request->get(self::RULES_FORM_NAME);
+        $rulesData = (array)$request->get(static::RULES_FORM_NAME);
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(ProductNameFilter::NAME, $rulesData);
 
-        return $this->advancedSearchFormFactory->createRulesForm(self::RULES_FORM_NAME, $rulesFormData);
+        return $this->advancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesFormData);
     }
 
     /**
@@ -72,7 +72,7 @@ class AdvancedSearchProductFacade
             $index => $this->ruleFormViewDataFactory->createDefault($filterName),
         ];
 
-        return $this->advancedSearchFormFactory->createRulesForm(self::RULES_FORM_NAME, $rulesData);
+        return $this->advancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesData);
     }
 
     /**
@@ -93,7 +93,7 @@ class AdvancedSearchProductFacade
      */
     public function isAdvancedSearchFormSubmitted(Request $request)
     {
-        $rulesData = $request->get(self::RULES_FORM_NAME);
+        $rulesData = $request->get(static::RULES_FORM_NAME);
 
         return $rulesData !== null;
     }

--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AdvancedSearchProductFacade
 {
+    /** @access protected */
     const RULES_FORM_NAME = 'as';
 
     /**

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductAvailabilityFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductAvailabilityFilter.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class ProductAvailabilityFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productAvailability';
+    public const NAME = 'productAvailability';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductBrandFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductBrandFilter.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class ProductBrandFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productBrand';
+    public const NAME = 'productBrand';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCalculatedSellingDeniedFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCalculatedSellingDeniedFilter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class ProductCalculatedSellingDeniedFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productCalculatedSellingDenied';
+    public const NAME = 'productCalculatedSellingDenied';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCatnumFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCatnumFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class ProductCatnumFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productCatnum';
+    public const NAME = 'productCatnum';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductFlagFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductFlagFilter.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class ProductFlagFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productFlag';
+    public const NAME = 'productFlag';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductNameFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class ProductNameFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productName';
+    public const NAME = 'productName';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductPartnoFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductPartnoFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class ProductPartnoFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productPartno';
+    public const NAME = 'productPartno';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductStockFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductStockFilter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class ProductStockFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'productStock';
+    public const NAME = 'productStock';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearch/RuleFormViewDataFactory.php
+++ b/packages/framework/src/Model/AdvancedSearch/RuleFormViewDataFactory.php
@@ -6,7 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\AdvancedSearch;
 
 class RuleFormViewDataFactory
 {
-    const TEMPLATE_RULE_FORM_KEY = '__template__';
+    public const TEMPLATE_RULE_FORM_KEY = '__template__';
 
     /**
      * @param string $defaultFilterName

--- a/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
@@ -58,10 +58,10 @@ class AdvancedSearchOrderFacade
      */
     public function createAdvancedSearchOrderForm(Request $request)
     {
-        $rulesData = (array)$request->get(self::RULES_FORM_NAME);
+        $rulesData = (array)$request->get(static::RULES_FORM_NAME);
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(OrderPriceFilterWithVatFilter::NAME, $rulesData);
 
-        return $this->orderAdvancedSearchFormFactory->createRulesForm(self::RULES_FORM_NAME, $rulesFormData);
+        return $this->orderAdvancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesFormData);
     }
 
     /**
@@ -75,7 +75,7 @@ class AdvancedSearchOrderFacade
             $index => $this->ruleFormViewDataFactory->createDefault($filterName),
         ];
 
-        return $this->orderAdvancedSearchFormFactory->createRulesForm(self::RULES_FORM_NAME, $rulesData);
+        return $this->orderAdvancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesData);
     }
 
     /**
@@ -96,7 +96,7 @@ class AdvancedSearchOrderFacade
      */
     public function isAdvancedSearchOrderFormSubmitted(Request $request)
     {
-        $rulesData = $request->get(self::RULES_FORM_NAME);
+        $rulesData = $request->get(static::RULES_FORM_NAME);
 
         return $rulesData !== null;
     }

--- a/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AdvancedSearchOrderFacade
 {
+    /** @access protected */
     const RULES_FORM_NAME = 'as';
 
     /**

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class OrderCityFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'customerCity';
+    public const NAME = 'customerCity';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCreateDateFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCreateDateFilter.php
@@ -8,7 +8,7 @@ use Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface;
 
 class OrderCreateDateFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'orderCreatedAt';
+    public const NAME = 'orderCreatedAt';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderDomainFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderDomainFilter.php
@@ -8,7 +8,7 @@ use Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface;
 
 class OrderDomainFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'orderDomain';
+    public const NAME = 'orderDomain';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
 class OrderEmailFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'customerEmail';
+    public const NAME = 'customerEmail';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class OrderLastNameFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'customerLastName';
+    public const NAME = 'customerLastName';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class OrderNameFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'customerName';
+    public const NAME = 'customerName';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNumberFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class OrderNumberFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'orderNumber';
+    public const NAME = 'orderNumber';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class OrderPhoneNumberFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'customerPhoneNumber';
+    public const NAME = 'customerPhoneNumber';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPriceFilterWithVatFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPriceFilterWithVatFilter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 
 class OrderPriceFilterWithVatFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'orderTotalPriceWithVat';
+    public const NAME = 'orderTotalPriceWithVat';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderProductFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderProductFilter.php
@@ -9,7 +9,7 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItem;
 
 class OrderProductFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'orderProduct';
+    public const NAME = 'orderProduct';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStatusFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStatusFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class OrderStatusFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'orderStatus';
+    public const NAME = 'orderStatus';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class OrderStreetFilter implements AdvancedSearchFilterInterface
 {
-    const NAME = 'customerStreet';
+    public const NAME = 'customerStreet';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Model/Advert/Advert.php
+++ b/packages/framework/src/Model/Advert/Advert.php
@@ -10,16 +10,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Advert
 {
-    const TYPE_IMAGE = 'image';
-    const TYPE_CODE = 'code';
+    public const TYPE_IMAGE = 'image';
+    public const TYPE_CODE = 'code';
 
     /**
      * @deprecated use of position constants is discouraged, use literal strings instead
      */
-    const POSITION_HEADER = 'header';
-    const POSITION_FOOTER = 'footer';
-    const POSITION_PRODUCT_LIST = 'productList';
-    const POSITION_LEFT_SIDEBAR = 'leftSidebar';
+    public const POSITION_HEADER = 'header';
+    public const POSITION_FOOTER = 'footer';
+    public const POSITION_PRODUCT_LIST = 'productList';
+    public const POSITION_LEFT_SIDEBAR = 'leftSidebar';
 
     /**
      * @var int

--- a/packages/framework/src/Model/Article/Article.php
+++ b/packages/framework/src/Model/Article/Article.php
@@ -105,7 +105,7 @@ class Article implements OrderableEntityInterface
         $this->seoMetaDescription = $articleData->seoMetaDescription;
         $this->seoH1 = $articleData->seoH1;
         $this->placement = $articleData->placement;
-        $this->position = self::GEDMO_SORTABLE_LAST_POSITION;
+        $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->hidden = $articleData->hidden;
     }
 

--- a/packages/framework/src/Model/Article/Article.php
+++ b/packages/framework/src/Model/Article/Article.php
@@ -12,9 +12,9 @@ use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
  */
 class Article implements OrderableEntityInterface
 {
-    const PLACEMENT_TOP_MENU = 'topMenu';
-    const PLACEMENT_FOOTER = 'footer';
-    const PLACEMENT_NONE = 'none';
+    public const PLACEMENT_TOP_MENU = 'topMenu';
+    public const PLACEMENT_FOOTER = 'footer';
+    public const PLACEMENT_NONE = 'none';
 
     protected const GEDMO_SORTABLE_LAST_POSITION = -1;
 

--- a/packages/framework/src/Model/Article/ArticleDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Article/ArticleDetailFriendlyUrlDataProvider.php
@@ -46,7 +46,7 @@ class ArticleDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInt
             ->distinct()
             ->from(Article::class, 'a')
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'a.id = f.entityId AND f.routeName = :routeName AND f.domainId = a.domainId')
-            ->setParameter('routeName', self::ROUTE_NAME)
+            ->setParameter('routeName', static::ROUTE_NAME)
             ->where('f.entityId IS NULL AND a.domainId = :domainId')
             ->setParameter('domainId', $domainConfig->getId());
         $scalarData = $queryBuilder->getQuery()->getScalarResult();
@@ -68,6 +68,6 @@ class ArticleDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInt
      */
     public function getRouteName(): string
     {
-        return self::ROUTE_NAME;
+        return static::ROUTE_NAME;
     }
 }

--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -15,7 +15,9 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 
 class CartFacade
 {
+    /** @access protected */
     const DAYS_LIMIT_FOR_UNREGISTERED = 60;
+    /** @access protected */
     const DAYS_LIMIT_FOR_REGISTERED = 120;
 
     /**

--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -289,7 +289,7 @@ class CartFacade
 
     public function deleteOldCarts()
     {
-        $this->cartRepository->deleteOldCartsForUnregisteredCustomers(self::DAYS_LIMIT_FOR_UNREGISTERED);
-        $this->cartRepository->deleteOldCartsForRegisteredCustomers(self::DAYS_LIMIT_FOR_REGISTERED);
+        $this->cartRepository->deleteOldCartsForUnregisteredCustomers(static::DAYS_LIMIT_FOR_UNREGISTERED);
+        $this->cartRepository->deleteOldCartsForRegisteredCustomers(static::DAYS_LIMIT_FOR_REGISTERED);
     }
 }

--- a/packages/framework/src/Model/Cart/CartMigrationFacade.php
+++ b/packages/framework/src/Model/Cart/CartMigrationFacade.php
@@ -75,7 +75,7 @@ class CartMigrationFacade
     {
         $session = $filterControllerEvent->getRequest()->getSession();
 
-        $previousCartIdentifier = $session->get(self::SESSION_PREVIOUS_CART_IDENTIFIER);
+        $previousCartIdentifier = $session->get(static::SESSION_PREVIOUS_CART_IDENTIFIER);
         if (!empty($previousCartIdentifier) && $previousCartIdentifier !== $session->getId()) {
             $previousCustomerIdentifier = $this->customerIdentifierFactory->getOnlyWithCartIdentifier($previousCartIdentifier);
             $cart = $this->cartFacade->findCartByCustomerIdentifier($previousCustomerIdentifier);
@@ -84,6 +84,6 @@ class CartMigrationFacade
                 $this->mergeCurrentCartWithCart($cart);
             }
         }
-        $session->set(self::SESSION_PREVIOUS_CART_IDENTIFIER, $session->getId());
+        $session->set(static::SESSION_PREVIOUS_CART_IDENTIFIER, $session->getId());
     }
 }

--- a/packages/framework/src/Model/Cart/CartMigrationFacade.php
+++ b/packages/framework/src/Model/Cart/CartMigrationFacade.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 
 class CartMigrationFacade
 {
+    /** @access protected */
     const SESSION_PREVIOUS_CART_IDENTIFIER = 'previous_id';
 
     /**

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -17,7 +17,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 
 class CategoryRepository extends NestedTreeRepository
 {
-    const MOVE_DOWN_TO_BOTTOM = true;
+    public const MOVE_DOWN_TO_BOTTOM = true;
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface

--- a/packages/framework/src/Model/Cookies/CookiesFacade.php
+++ b/packages/framework/src/Model/Cookies/CookiesFacade.php
@@ -120,6 +120,6 @@ class CookiesFacade
         }
         $masterRequest = $this->requestStack->getMasterRequest();
 
-        return $masterRequest->cookies->has(self::EU_COOKIES_COOKIE_CONSENT_NAME);
+        return $masterRequest->cookies->has(static::EU_COOKIES_COOKIE_CONSENT_NAME);
     }
 }

--- a/packages/framework/src/Model/Cookies/CookiesFacade.php
+++ b/packages/framework/src/Model/Cookies/CookiesFacade.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class CookiesFacade
 {
+    /** @access protected */
     const EU_COOKIES_COOKIE_CONSENT_NAME = 'eu-cookies';
 
     /**

--- a/packages/framework/src/Model/Customer/Mail/RegistrationMail.php
+++ b/packages/framework/src/Model/Customer/Mail/RegistrationMail.php
@@ -13,11 +13,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class RegistrationMail implements MessageFactoryInterface
 {
-    const VARIABLE_FIRST_NAME = '{first_name}';
-    const VARIABLE_LAST_NAME = '{last_name}';
-    const VARIABLE_EMAIL = '{email}';
-    const VARIABLE_URL = '{url}';
-    const VARIABLE_LOGIN_PAGE = '{login_page}';
+    public const VARIABLE_FIRST_NAME = '{first_name}';
+    public const VARIABLE_LAST_NAME = '{last_name}';
+    public const VARIABLE_EMAIL = '{email}';
+    public const VARIABLE_URL = '{url}';
+    public const VARIABLE_LOGIN_PAGE = '{login_page}';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting

--- a/packages/framework/src/Model/Customer/Mail/ResetPasswordMail.php
+++ b/packages/framework/src/Model/Customer/Mail/ResetPasswordMail.php
@@ -14,8 +14,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ResetPasswordMail implements MailTypeInterface, MessageFactoryInterface
 {
-    const VARIABLE_EMAIL = '{email}';
-    const VARIABLE_NEW_PASSWORD_URL = '{new_password_url}';
+    public const VARIABLE_EMAIL = '{email}';
+    public const VARIABLE_NEW_PASSWORD_URL = '{new_password_url}';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting

--- a/packages/framework/src/Model/Customer/User.php
+++ b/packages/framework/src/Model/Customer/User.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class User implements UserInterface, TimelimitLoginInterface, Serializable
 {
+    /** @access protected */
     const RESET_PASSWORD_HASH_LENGTH = 50;
 
     /**

--- a/packages/framework/src/Model/Customer/User.php
+++ b/packages/framework/src/Model/Customer/User.php
@@ -441,7 +441,7 @@ class User implements UserInterface, TimelimitLoginInterface, Serializable
      */
     public function resetPassword(HashGenerator $hashGenerator): void
     {
-        $hash = $hashGenerator->generateHash(self::RESET_PASSWORD_HASH_LENGTH);
+        $hash = $hashGenerator->generateHash(static::RESET_PASSWORD_HASH_LENGTH);
         $this->resetPasswordHash = $hash;
         $this->resetPasswordHashValidThrough = new DateTime('+48 hours');
     }

--- a/packages/framework/src/Model/Feed/FeedExport.php
+++ b/packages/framework/src/Model/Feed/FeedExport.php
@@ -11,7 +11,9 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class FeedExport
 {
+    /** @access protected */
     const TEMPORARY_FILENAME_SUFFIX = '.tmp';
+    /** @access protected */
     const BATCH_SIZE = 1000;
 
     /**

--- a/packages/framework/src/Model/Feed/FeedExport.php
+++ b/packages/framework/src/Model/Feed/FeedExport.php
@@ -132,7 +132,7 @@ class FeedExport
             return;
         }
 
-        $itemsInBatch = $this->feed->getItems($this->domainConfig, $this->lastSeekId, self::BATCH_SIZE);
+        $itemsInBatch = $this->feed->getItems($this->domainConfig, $this->lastSeekId, static::BATCH_SIZE);
 
         if ($this->lastSeekId === null) {
             $this->writeToFeed($this->feedRenderer->renderBegin($this->domainConfig));
@@ -145,7 +145,7 @@ class FeedExport
             $countInBatch++;
         }
 
-        if ($countInBatch < self::BATCH_SIZE) {
+        if ($countInBatch < static::BATCH_SIZE) {
             $this->writeToFeed($this->feedRenderer->renderEnd($this->domainConfig));
             $this->finishFile();
         }
@@ -209,7 +209,7 @@ class FeedExport
      */
     protected function getTemporaryFilepath(): string
     {
-        return $this->feedFilepath . self::TEMPORARY_FILENAME_SUFFIX;
+        return $this->feedFilepath . static::TEMPORARY_FILENAME_SUFFIX;
     }
 
     /**
@@ -217,6 +217,6 @@ class FeedExport
      */
     protected function getTemporaryLocalFilepath(): string
     {
-        return $this->feedLocalFilepath . '_local' . self::TEMPORARY_FILENAME_SUFFIX;
+        return $this->feedLocalFilepath . '_local' . static::TEMPORARY_FILENAME_SUFFIX;
     }
 }

--- a/packages/framework/src/Model/Feed/FeedExportFactory.php
+++ b/packages/framework/src/Model/Feed/FeedExportFactory.php
@@ -10,7 +10,9 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class FeedExportFactory
 {
+    /** @access protected */
     const TEMPORARY_FILENAME_SUFFIX = '.tmp';
+    /** @access protected */
     const BATCH_SIZE = 1000;
 
     /**

--- a/packages/framework/src/Model/Feed/FeedFacade.php
+++ b/packages/framework/src/Model/Feed/FeedFacade.php
@@ -8,7 +8,9 @@ use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 
 class FeedFacade
 {
+    /** @access protected */
     const TEMPORARY_FILENAME_SUFFIX = '.tmp';
+    /** @access protected */
     const BATCH_SIZE = 1000;
 
     /**

--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -30,7 +30,7 @@ class HeurekaSetting
      */
     public function getApiKeyByDomainId($domainId)
     {
-        return $this->setting->getForDomain(self::HEUREKA_API_KEY, $domainId);
+        return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId);
     }
 
     /**
@@ -39,7 +39,7 @@ class HeurekaSetting
      */
     public function getHeurekaShopCertificationWidgetByDomainId($domainId)
     {
-        return $this->setting->getForDomain(self::HEUREKA_WIDGET_CODE, $domainId);
+        return $this->setting->getForDomain(static::HEUREKA_WIDGET_CODE, $domainId);
     }
 
     /**
@@ -48,7 +48,7 @@ class HeurekaSetting
      */
     public function setApiKeyForDomain($apiKey, $domainId)
     {
-        $this->setting->setForDomain(self::HEUREKA_API_KEY, $apiKey, $domainId);
+        $this->setting->setForDomain(static::HEUREKA_API_KEY, $apiKey, $domainId);
     }
 
     /**
@@ -57,7 +57,7 @@ class HeurekaSetting
      */
     public function setHeurekaShopCertificationWidgetForDomain($heurekaWidgetCode, $domainId)
     {
-        $this->setting->setForDomain(self::HEUREKA_WIDGET_CODE, $heurekaWidgetCode, $domainId);
+        $this->setting->setForDomain(static::HEUREKA_WIDGET_CODE, $heurekaWidgetCode, $domainId);
     }
 
     /**
@@ -66,7 +66,7 @@ class HeurekaSetting
      */
     public function isHeurekaShopCertificationActivated($domainId)
     {
-        return !empty($this->setting->getForDomain(self::HEUREKA_API_KEY, $domainId));
+        return !empty($this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId));
     }
 
     /**
@@ -75,6 +75,6 @@ class HeurekaSetting
      */
     public function isHeurekaWidgetActivated($domainId)
     {
-        return !empty($this->setting->getForDomain(self::HEUREKA_WIDGET_CODE, $domainId));
+        return !empty($this->setting->getForDomain(static::HEUREKA_WIDGET_CODE, $domainId));
     }
 }

--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -6,7 +6,9 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
 class HeurekaSetting
 {
+    /** @access protected */
     const HEUREKA_API_KEY = 'heurekaApiKey';
+    /** @access protected */
     const HEUREKA_WIDGET_CODE = 'heurekaWidgetCode';
 
     /**

--- a/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
+++ b/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
@@ -6,7 +6,7 @@ use CommerceGuys\Intl\Currency\CurrencyRepository as BaseCurrencyRepository;
 
 class IntlCurrencyRepository extends BaseCurrencyRepository
 {
-    const SUPPORTED_CURRENCY_CODES = [
+    public const SUPPORTED_CURRENCY_CODES = [
         'AED',
         'AFN',
         'ALL',

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundExce
 
 class Localization
 {
+    /** @access protected */
     const DEFAULT_COLLATION = 'en_US';
 
     /**

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -127,7 +127,7 @@ class Localization
         if (array_key_exists($locale, $this->collationsByLocale)) {
             return $this->collationsByLocale[$locale];
         } else {
-            return self::DEFAULT_COLLATION;
+            return static::DEFAULT_COLLATION;
         }
     }
 }

--- a/packages/framework/src/Model/Mail/MailTemplate.php
+++ b/packages/framework/src/Model/Mail/MailTemplate.php
@@ -15,10 +15,10 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class MailTemplate
 {
-    const REGISTRATION_CONFIRM_NAME = 'registration_confirm';
-    const RESET_PASSWORD_NAME = 'reset_password';
-    const PERSONAL_DATA_ACCESS_NAME = 'personal_data_access';
-    const PERSONAL_DATA_EXPORT_NAME = 'personal_data_export';
+    public const REGISTRATION_CONFIRM_NAME = 'registration_confirm';
+    public const RESET_PASSWORD_NAME = 'reset_password';
+    public const PERSONAL_DATA_ACCESS_NAME = 'personal_data_access';
+    public const PERSONAL_DATA_EXPORT_NAME = 'personal_data_export';
 
     /**
      * @ORM\Column(type="integer")

--- a/packages/framework/src/Model/Mail/Setting/MailSetting.php
+++ b/packages/framework/src/Model/Mail/Setting/MailSetting.php
@@ -4,6 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Mail\Setting;
 
 class MailSetting
 {
-    const MAIN_ADMIN_MAIL = 'mainAdminMail';
-    const MAIN_ADMIN_MAIL_NAME = 'mainAdminMailName';
+    public const MAIN_ADMIN_MAIL = 'mainAdminMail';
+    public const MAIN_ADMIN_MAIL_NAME = 'mainAdminMailName';
 }

--- a/packages/framework/src/Model/Module/ModuleList.php
+++ b/packages/framework/src/Model/Module/ModuleList.php
@@ -4,9 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Module;
 
 class ModuleList
 {
-    const ACCESSORIES_ON_BUY = 'accessoriesOnBuy';
-    const PRODUCT_FILTER_COUNTS = 'productFilterCounts';
-    const PRODUCT_STOCK_CALCULATIONS = 'productStockCalculations';
+    public const ACCESSORIES_ON_BUY = 'accessoriesOnBuy';
+    public const PRODUCT_FILTER_COUNTS = 'productFilterCounts';
+    public const PRODUCT_STOCK_CALCULATIONS = 'productStockCalculations';
 
     /**
      * @return string[]

--- a/packages/framework/src/Model/Order/Mail/OrderMail.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMail.php
@@ -20,20 +20,21 @@ use Twig_Environment;
 
 class OrderMail implements MessageFactoryInterface
 {
+    /** @access protected */
     const MAIL_TEMPLATE_NAME_PREFIX = 'order_status_';
-    const VARIABLE_NUMBER = '{number}';
-    const VARIABLE_DATE = '{date}';
-    const VARIABLE_URL = '{url}';
-    const VARIABLE_TRANSPORT = '{transport}';
-    const VARIABLE_PAYMENT = '{payment}';
-    const VARIABLE_TOTAL_PRICE = '{total_price}';
-    const VARIABLE_BILLING_ADDRESS = '{billing_address}';
-    const VARIABLE_DELIVERY_ADDRESS = '{delivery_address}';
-    const VARIABLE_NOTE = '{note}';
-    const VARIABLE_PRODUCTS = '{products}';
-    const VARIABLE_ORDER_DETAIL_URL = '{order_detail_url}';
-    const VARIABLE_TRANSPORT_INSTRUCTIONS = '{transport_instructions}';
-    const VARIABLE_PAYMENT_INSTRUCTIONS = '{payment_instructions}';
+    public const VARIABLE_NUMBER = '{number}';
+    public const VARIABLE_DATE = '{date}';
+    public const VARIABLE_URL = '{url}';
+    public const VARIABLE_TRANSPORT = '{transport}';
+    public const VARIABLE_PAYMENT = '{payment}';
+    public const VARIABLE_TOTAL_PRICE = '{total_price}';
+    public const VARIABLE_BILLING_ADDRESS = '{billing_address}';
+    public const VARIABLE_DELIVERY_ADDRESS = '{delivery_address}';
+    public const VARIABLE_NOTE = '{note}';
+    public const VARIABLE_PRODUCTS = '{products}';
+    public const VARIABLE_ORDER_DETAIL_URL = '{order_detail_url}';
+    public const VARIABLE_TRANSPORT_INSTRUCTIONS = '{transport_instructions}';
+    public const VARIABLE_PAYMENT_INSTRUCTIONS = '{payment_instructions}';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting

--- a/packages/framework/src/Model/Order/Mail/OrderMail.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMail.php
@@ -131,7 +131,7 @@ class OrderMail implements MessageFactoryInterface
      */
     public static function getMailTemplateNameByStatus(OrderStatus $orderStatus)
     {
-        return self::MAIL_TEMPLATE_NAME_PREFIX . $orderStatus->getId();
+        return static::MAIL_TEMPLATE_NAME_PREFIX . $orderStatus->getId();
     }
 
     /**

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -25,6 +25,7 @@ use Shopsys\FrameworkBundle\Twig\NumberFormatterExtension;
  */
 class Order
 {
+    /** @access protected */
     const DEFAULT_PRODUCT_QUANTITY = 1;
 
     /**

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -969,7 +969,7 @@ class Order
             $product->getName($orderDomainConfig->getLocale()),
             $productPrice,
             $product->getVat()->getPercent(),
-            self::DEFAULT_PRODUCT_QUANTITY,
+            static::DEFAULT_PRODUCT_QUANTITY,
             $product->getUnit()->getName($orderDomainConfig->getLocale()),
             $product->getCatnum(),
             $product

--- a/packages/framework/src/Model/Order/OrderData.php
+++ b/packages/framework/src/Model/Order/OrderData.php
@@ -4,7 +4,7 @@ namespace Shopsys\FrameworkBundle\Model\Order;
 
 class OrderData
 {
-    const NEW_ITEM_PREFIX = 'new_';
+    public const NEW_ITEM_PREFIX = 'new_';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\Transport|null

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -28,10 +28,10 @@ use Shopsys\FrameworkBundle\Twig\NumberFormatterExtension;
 
 class OrderFacade
 {
-    const VARIABLE_NUMBER = '{number}';
-    const VARIABLE_ORDER_DETAIL_URL = '{order_detail_url}';
-    const VARIABLE_PAYMENT_INSTRUCTIONS = '{payment_instructions}';
-    const VARIABLE_TRANSPORT_INSTRUCTIONS = '{transport_instructions}';
+    public const VARIABLE_NUMBER = '{number}';
+    public const VARIABLE_ORDER_DETAIL_URL = '{order_detail_url}';
+    public const VARIABLE_PAYMENT_INSTRUCTIONS = '{payment_instructions}';
+    public const VARIABLE_TRANSPORT_INSTRUCTIONS = '{transport_instructions}';
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface

--- a/packages/framework/src/Model/Order/OrderHashGeneratorRepository.php
+++ b/packages/framework/src/Model/Order/OrderHashGeneratorRepository.php
@@ -6,7 +6,9 @@ use Shopsys\FrameworkBundle\Component\String\HashGenerator;
 
 class OrderHashGeneratorRepository
 {
+    /** @access protected */
     const HASH_LENGTH = 50;
+    /** @access protected */
     const MAX_GENERATE_TRIES = 100;
 
     /**

--- a/packages/framework/src/Model/Order/OrderHashGeneratorRepository.php
+++ b/packages/framework/src/Model/Order/OrderHashGeneratorRepository.php
@@ -40,10 +40,10 @@ class OrderHashGeneratorRepository
     {
         $triesCount = 0;
         do {
-            $hash = $this->hashGenerator->generateHash(self::HASH_LENGTH);
+            $hash = $this->hashGenerator->generateHash(static::HASH_LENGTH);
             $order = $this->orderRepository->findByUrlHashIncludingDeletedOrders($hash);
             $triesCount++;
-            if ($triesCount > self::MAX_GENERATE_TRIES) {
+            if ($triesCount > static::MAX_GENERATE_TRIES) {
                 throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderHashGenerateException('Trying generate hash reached the limit.');
             }
         } while ($order !== null);

--- a/packages/framework/src/Model/Order/OrderNumberSequenceRepository.php
+++ b/packages/framework/src/Model/Order/OrderNumberSequenceRepository.php
@@ -41,11 +41,11 @@ class OrderNumberSequenceRepository
 
             $requestedNumber = time();
 
-            $orderNumberSequence = $this->getOrderNumberSequenceRepository()->find(self::ID, LockMode::PESSIMISTIC_WRITE);
+            $orderNumberSequence = $this->getOrderNumberSequenceRepository()->find(static::ID, LockMode::PESSIMISTIC_WRITE);
             /* @var $orderNumberSequence \Shopsys\FrameworkBundle\Model\Order\OrderNumberSequence|null */
             if ($orderNumberSequence === null) {
                 throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNumberSequenceNotFoundException(
-                    'Order number sequence ID ' . self::ID . ' not found.'
+                    'Order number sequence ID ' . static::ID . ' not found.'
                 );
             }
 

--- a/packages/framework/src/Model/Order/OrderNumberSequenceRepository.php
+++ b/packages/framework/src/Model/Order/OrderNumberSequenceRepository.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class OrderNumberSequenceRepository
 {
+    /** @access protected */
     const ID = 1;
 
     /**

--- a/packages/framework/src/Model/Order/PromoCode/CurrentPromoCodeFacade.php
+++ b/packages/framework/src/Model/Order/PromoCode/CurrentPromoCodeFacade.php
@@ -34,7 +34,7 @@ class CurrentPromoCodeFacade
      */
     public function getValidEnteredPromoCodeOrNull()
     {
-        $enteredCode = $this->session->get(self::PROMO_CODE_SESSION_KEY);
+        $enteredCode = $this->session->get(static::PROMO_CODE_SESSION_KEY);
         if ($enteredCode === null) {
             return null;
         }
@@ -51,12 +51,12 @@ class CurrentPromoCodeFacade
         if ($promoCode === null) {
             throw new \Shopsys\FrameworkBundle\Model\Order\PromoCode\Exception\InvalidPromoCodeException($enteredCode);
         } else {
-            $this->session->set(self::PROMO_CODE_SESSION_KEY, $enteredCode);
+            $this->session->set(static::PROMO_CODE_SESSION_KEY, $enteredCode);
         }
     }
 
     public function removeEnteredPromoCode()
     {
-        $this->session->remove(self::PROMO_CODE_SESSION_KEY);
+        $this->session->remove(static::PROMO_CODE_SESSION_KEY);
     }
 }

--- a/packages/framework/src/Model/Order/PromoCode/CurrentPromoCodeFacade.php
+++ b/packages/framework/src/Model/Order/PromoCode/CurrentPromoCodeFacade.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class CurrentPromoCodeFacade
 {
+    /** @access protected */
     const PROMO_CODE_SESSION_KEY = 'promoCode';
 
     /**

--- a/packages/framework/src/Model/Order/Status/OrderStatus.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatus.php
@@ -13,10 +13,10 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
  */
 class OrderStatus extends AbstractTranslatableEntity
 {
-    const TYPE_NEW = 1;
-    const TYPE_IN_PROGRESS = 2;
-    const TYPE_DONE = 3;
-    const TYPE_CANCELED = 4;
+    public const TYPE_NEW = 1;
+    public const TYPE_IN_PROGRESS = 2;
+    public const TYPE_DONE = 3;
+    public const TYPE_CANCELED = 4;
 
     /**
      * @var int

--- a/packages/framework/src/Model/Order/Watcher/TransportAndPaymentWatcher.php
+++ b/packages/framework/src/Model/Order/Watcher/TransportAndPaymentWatcher.php
@@ -16,8 +16,11 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class TransportAndPaymentWatcher
 {
+    /** @access protected */
     const SESSION_ROOT = 'transport_and_payment_watcher';
+    /** @access protected */
     const SESSION_TRANSPORT_PRICES = 'transport_prices';
+    /** @access protected */
     const SESSION_PAYMENT_PRICES = 'payment_prices';
 
     /**

--- a/packages/framework/src/Model/Order/Watcher/TransportAndPaymentWatcher.php
+++ b/packages/framework/src/Model/Order/Watcher/TransportAndPaymentWatcher.php
@@ -250,14 +250,14 @@ class TransportAndPaymentWatcher
         OrderPreview $orderPreview,
         int $domainId
     ): void {
-        $this->session->set(self::SESSION_ROOT, [
-            self::SESSION_TRANSPORT_PRICES => $this->getTransportPrices(
+        $this->session->set(static::SESSION_ROOT, [
+            static::SESSION_TRANSPORT_PRICES => $this->getTransportPrices(
                 $transports,
                 $currency,
                 $orderPreview,
                 $domainId
             ),
-            self::SESSION_PAYMENT_PRICES => $this->getPaymentPrices(
+            static::SESSION_PAYMENT_PRICES => $this->getPaymentPrices(
                 $payments,
                 $currency,
                 $orderPreview,
@@ -271,9 +271,9 @@ class TransportAndPaymentWatcher
      */
     protected function getRememberedTransportAndPayment(): array
     {
-        return $this->session->get(self::SESSION_ROOT, [
-            self::SESSION_TRANSPORT_PRICES => [],
-            self::SESSION_PAYMENT_PRICES => [],
+        return $this->session->get(static::SESSION_ROOT, [
+            static::SESSION_TRANSPORT_PRICES => [],
+            static::SESSION_PAYMENT_PRICES => [],
         ]);
     }
 
@@ -282,7 +282,7 @@ class TransportAndPaymentWatcher
      */
     protected function getRememberedTransportPrices(): array
     {
-        return $this->getRememberedTransportAndPayment()[self::SESSION_TRANSPORT_PRICES];
+        return $this->getRememberedTransportAndPayment()[static::SESSION_TRANSPORT_PRICES];
     }
 
     /**
@@ -290,7 +290,7 @@ class TransportAndPaymentWatcher
      */
     protected function getRememberedPaymentPrices(): array
     {
-        return $this->getRememberedTransportAndPayment()[self::SESSION_PAYMENT_PRICES];
+        return $this->getRememberedTransportAndPayment()[static::SESSION_PAYMENT_PRICES];
     }
 
     /**

--- a/packages/framework/src/Model/Payment/Grid/PaymentGridFactory.php
+++ b/packages/framework/src/Model/Payment/Grid/PaymentGridFactory.php
@@ -97,6 +97,6 @@ class PaymentGridFactory implements GridFactoryInterface
     {
         $transportBasePricesIndexedByCurrencyId = $this->paymentFacade->getIndependentBasePricesIndexedByCurrencyId($payment);
 
-        return $transportBasePricesIndexedByCurrencyId[self::CURRENCY_ID_FOR_LIST]->getPriceWithVat();
+        return $transportBasePricesIndexedByCurrencyId[static::CURRENCY_ID_FOR_LIST]->getPriceWithVat();
     }
 }

--- a/packages/framework/src/Model/Payment/Grid/PaymentGridFactory.php
+++ b/packages/framework/src/Model/Payment/Grid/PaymentGridFactory.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentRepository;
 
 class PaymentGridFactory implements GridFactoryInterface
 {
+    /** @access protected */
     const CURRENCY_ID_FOR_LIST = 1;
 
     /**

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -111,7 +111,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
         $this->createDomains($paymentData);
         $this->prices = new ArrayCollection();
         $this->czkRounding = $paymentData->czkRounding;
-        $this->position = self::GEDMO_SORTABLE_LAST_POSITION;
+        $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
     }
 
     /**

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMail.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMail.php
@@ -14,9 +14,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PersonalDataAccessMail implements MailTypeInterface, MessageFactoryInterface
 {
-    const VARIABLE_EMAIL = '{e-mail}';
-    const VARIABLE_URL = '{url}';
-    const VARIABLE_DOMAIN = '{domain}';
+    public const VARIABLE_EMAIL = '{e-mail}';
+    public const VARIABLE_URL = '{url}';
+    public const VARIABLE_DOMAIN = '{domain}';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataExportMail.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataExportMail.php
@@ -14,9 +14,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PersonalDataExportMail implements MailTypeInterface, MessageFactoryInterface
 {
-    const VARIABLE_EMAIL = '{e-mail}';
-    const VARIABLE_URL = '{url}';
-    const VARIABLE_DOMAIN = '{domain}';
+    public const VARIABLE_EMAIL = '{e-mail}';
+    public const VARIABLE_URL = '{url}';
+    public const VARIABLE_DOMAIN = '{domain}';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequest.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequest.php
@@ -11,8 +11,8 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class PersonalDataAccessRequest
 {
-    const TYPE_DISPLAY = 'display';
-    const TYPE_EXPORT = 'export';
+    public const TYPE_DISPLAY = 'display';
+    public const TYPE_EXPORT = 'export';
 
     /**
      * @var int

--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -10,10 +10,10 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Currency
 {
-    const CODE_CZK = 'CZK';
-    const CODE_EUR = 'EUR';
+    public const CODE_CZK = 'CZK';
+    public const CODE_EUR = 'EUR';
 
-    const DEFAULT_EXCHANGE_RATE = '1';
+    public const DEFAULT_EXCHANGE_RATE = '1';
 
     /**
      * @var int

--- a/packages/framework/src/Model/Pricing/InputPriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/InputPriceCalculation.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Money\Money;
 
 class InputPriceCalculation
 {
+    /** @access protected */
     const INPUT_PRICE_SCALE = 6;
 
     /**

--- a/packages/framework/src/Model/Pricing/InputPriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/InputPriceCalculation.php
@@ -22,7 +22,7 @@ class InputPriceCalculation
         if ($inputPriceType === PricingSetting::INPUT_PRICE_TYPE_WITHOUT_VAT) {
             $inputPrice = $this->getInputPriceWithoutVat($basePriceWithVat, $vatPercent);
         } elseif ($inputPriceType === PricingSetting::INPUT_PRICE_TYPE_WITH_VAT) {
-            $inputPrice = $basePriceWithVat->round(self::INPUT_PRICE_SCALE);
+            $inputPrice = $basePriceWithVat->round(static::INPUT_PRICE_SCALE);
         } else {
             throw new \Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException(
                 sprintf('Input price type "%s" is not valid', $inputPriceType)
@@ -41,6 +41,6 @@ class InputPriceCalculation
     {
         $divisor = (string)(1 + $vatPercent / 100);
 
-        return $basePriceWithVat->divide($divisor, self::INPUT_PRICE_SCALE);
+        return $basePriceWithVat->divide($divisor, static::INPUT_PRICE_SCALE);
     }
 }

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation;
 
 class InputPriceRecalculator
 {
+    /** @access protected */
     const BATCH_SIZE = 500;
 
     /**

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
@@ -142,7 +142,7 @@ class InputPriceRecalculator
 
             $callback($object);
 
-            if (($iteration % self::BATCH_SIZE) == 0) {
+            if (($iteration % static::BATCH_SIZE) == 0) {
                 $this->em->flush();
             }
         }

--- a/packages/framework/src/Model/Pricing/PricingSetting.php
+++ b/packages/framework/src/Model/Pricing/PricingSetting.php
@@ -9,18 +9,18 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationSched
 
 class PricingSetting
 {
-    const INPUT_PRICE_TYPE = 'inputPriceType';
-    const ROUNDING_TYPE = 'roundingType';
-    const DEFAULT_CURRENCY = 'defaultCurrencyId';
-    const DEFAULT_DOMAIN_CURRENCY = 'defaultDomainCurrencyId';
-    const FREE_TRANSPORT_AND_PAYMENT_PRICE_LIMIT = 'freeTransportAndPaymentPriceLimit';
+    public const INPUT_PRICE_TYPE = 'inputPriceType';
+    public const ROUNDING_TYPE = 'roundingType';
+    public const DEFAULT_CURRENCY = 'defaultCurrencyId';
+    public const DEFAULT_DOMAIN_CURRENCY = 'defaultDomainCurrencyId';
+    public const FREE_TRANSPORT_AND_PAYMENT_PRICE_LIMIT = 'freeTransportAndPaymentPriceLimit';
 
-    const INPUT_PRICE_TYPE_WITH_VAT = 1;
-    const INPUT_PRICE_TYPE_WITHOUT_VAT = 2;
+    public const INPUT_PRICE_TYPE_WITH_VAT = 1;
+    public const INPUT_PRICE_TYPE_WITHOUT_VAT = 2;
 
-    const ROUNDING_TYPE_HUNDREDTHS = 1;
-    const ROUNDING_TYPE_FIFTIES = 2;
-    const ROUNDING_TYPE_INTEGER = 3;
+    public const ROUNDING_TYPE_HUNDREDTHS = 1;
+    public const ROUNDING_TYPE_FIFTIES = 2;
+    public const ROUNDING_TYPE_INTEGER = 3;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting

--- a/packages/framework/src/Model/Pricing/Vat/Vat.php
+++ b/packages/framework/src/Model/Pricing/Vat/Vat.php
@@ -10,7 +10,7 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Vat
 {
-    const SETTING_DEFAULT_VAT = 'defaultVatId';
+    public const SETTING_DEFAULT_VAT = 'defaultVatId';
 
     /**
      * @var int

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class ProductAvailabilityRecalculator
 {
+    /** @access protected */
     const BATCH_SIZE = 100;
 
     /**

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
@@ -62,7 +62,7 @@ class ProductAvailabilityRecalculator
             $this->productRowsIterator = $this->productAvailabilityRecalculationScheduler->getProductsIteratorForDelayedRecalculation();
         }
 
-        for ($count = 0; $count < self::BATCH_SIZE; $count++) {
+        for ($count = 0; $count < static::BATCH_SIZE; $count++) {
             $row = $this->productRowsIterator->next();
             if ($row === false) {
                 $this->em->clear();

--- a/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductFacade.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductFacade.php
@@ -8,9 +8,11 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 
 class BestsellingProductFacade
 {
+    /** @access protected */
     const MAX_RESULTS = 10;
+    /** @access protected */
     const ORDERS_CREATED_AT_LIMIT = '-1 month';
-    const MAX_SHOW_RESULTS = 3;
+    public const MAX_SHOW_RESULTS = 3;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\AutomaticBestsellingProductRepository

--- a/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductFacade.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductFacade.php
@@ -67,14 +67,14 @@ class BestsellingProductFacade
             $domainId,
             $category,
             $pricingGroup,
-            new DateTime(self::ORDERS_CREATED_AT_LIMIT),
-            self::MAX_RESULTS
+            new DateTime(static::ORDERS_CREATED_AT_LIMIT),
+            static::MAX_RESULTS
         );
 
         return $this->bestsellingProductCombinator->combineManualAndAutomaticProducts(
             $manualProductsIndexedByPosition,
             $automaticProducts,
-            self::MAX_RESULTS
+            static::MAX_RESULTS
         );
     }
 }

--- a/packages/framework/src/Model/Product/BestsellingProduct/CachedBestsellingProductFacade.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/CachedBestsellingProductFacade.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 
 class CachedBestsellingProductFacade
 {
+    /** @access protected */
     const LIFETIME = 43200; // 12h
 
     /**

--- a/packages/framework/src/Model/Product/BestsellingProduct/CachedBestsellingProductFacade.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/CachedBestsellingProductFacade.php
@@ -100,7 +100,7 @@ class CachedBestsellingProductFacade
             $sortedProductIds[] = $product->getId();
         }
 
-        $this->cacheProvider->save($cacheId, $sortedProductIds, self::LIFETIME);
+        $this->cacheProvider->save($cacheId, $sortedProductIds, static::LIFETIME);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Brand/BrandDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDetailFriendlyUrlDataProvider.php
@@ -47,7 +47,7 @@ class BrandDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInter
             ->distinct()
             ->from(Brand::class, 'b')
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'b.id = f.entityId AND f.routeName = :routeName AND f.domainId = :domainId')
-            ->setParameter('routeName', self::ROUTE_NAME)
+            ->setParameter('routeName', static::ROUTE_NAME)
             ->setParameter('domainId', $domainConfig->getId())
             ->where('f.entityId IS NULL');
 
@@ -70,6 +70,6 @@ class BrandDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInter
      */
     public function getRouteName(): string
     {
-        return self::ROUTE_NAME;
+        return static::ROUTE_NAME;
     }
 }

--- a/packages/framework/src/Model/Product/Brand/BrandDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDetailFriendlyUrlDataProvider.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryI
 
 class BrandDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInterface
 {
+    /** @access protected */
     const ROUTE_NAME = 'front_brand_detail';
 
     /**

--- a/packages/framework/src/Model/Product/Filter/ProductFilterRepository.php
+++ b/packages/framework/src/Model/Product/Filter/ProductFilterRepository.php
@@ -118,7 +118,7 @@ class ProductFilterRepository
                 'p.calculatedAvailability = a'
             );
             $productsQueryBuilder->andWhere('a.dispatchTime = :dispatchTime');
-            $productsQueryBuilder->setParameter('dispatchTime', self::DAYS_FOR_STOCK_FILTER);
+            $productsQueryBuilder->setParameter('dispatchTime', static::DAYS_FOR_STOCK_FILTER);
         }
     }
 

--- a/packages/framework/src/Model/Product/Filter/ProductFilterRepository.php
+++ b/packages/framework/src/Model/Product/Filter/ProductFilterRepository.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductFilterRepository
 {
+    /** @access protected */
     const DAYS_FOR_STOCK_FILTER = 0;
 
     /**

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
@@ -36,7 +36,7 @@ class ProductListOrderingModeForBrandFacade
                 ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
             ],
             ProductListOrderingConfig::ORDER_BY_PRIORITY,
-            self::COOKIE_NAME
+            static::COOKIE_NAME
         );
     }
 

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ProductListOrderingModeForBrandFacade
 {
+    /** @access protected */
     const COOKIE_NAME = 'productListOrderingModeForBrand';
 
     /**

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
@@ -36,7 +36,7 @@ class ProductListOrderingModeForListFacade
                 ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
             ],
             ProductListOrderingConfig::ORDER_BY_PRIORITY,
-            self::COOKIE_NAME
+            static::COOKIE_NAME
         );
     }
 

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ProductListOrderingModeForListFacade
 {
+    /** @access protected */
     const COOKIE_NAME = 'productListOrderingMode';
 
     /**

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
@@ -37,7 +37,7 @@ class ProductListOrderingModeForSearchFacade
                 ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
             ],
             ProductListOrderingConfig::ORDER_BY_RELEVANCE,
-            self::COOKIE_NAME
+            static::COOKIE_NAME
         );
     }
 

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ProductListOrderingModeForSearchFacade
 {
+    /** @access protected */
     const COOKIE_NAME = 'productSearchOrderingMode';
 
     /**

--- a/packages/framework/src/Model/Product/MassAction/ProductMassActionData.php
+++ b/packages/framework/src/Model/Product/MassAction/ProductMassActionData.php
@@ -4,15 +4,15 @@ namespace Shopsys\FrameworkBundle\Model\Product\MassAction;
 
 class ProductMassActionData
 {
-    const SELECT_TYPE_CHECKED = 'selectTypeChecked';
-    const SELECT_TYPE_ALL_RESULTS = 'selectTypeAllResults';
+    public const SELECT_TYPE_CHECKED = 'selectTypeChecked';
+    public const SELECT_TYPE_ALL_RESULTS = 'selectTypeAllResults';
 
-    const ACTION_SET = 'actionSet';
+    public const ACTION_SET = 'actionSet';
 
-    const SUBJECT_PRODUCT_HIDDEN = 'subjectProductHidden';
+    public const SUBJECT_PRODUCT_HIDDEN = 'subjectProductHidden';
 
-    const VALUE_PRODUCT_SHOW = 0;
-    const VALUE_PRODUCT_HIDE = 1;
+    public const VALUE_PRODUCT_SHOW = 0;
+    public const VALUE_PRODUCT_HIDE = 1;
 
     /**
      * @var string|null

--- a/packages/framework/src/Model/Product/Pricing/ProductInputPriceFacade.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductInputPriceFacade.php
@@ -123,7 +123,7 @@ class ProductInputPriceFacade
             $this->productRowsIterator = $this->productRepository->getProductIteratorForReplaceVat();
         }
 
-        for ($count = 0; $count < self::BATCH_SIZE; $count++) {
+        for ($count = 0; $count < static::BATCH_SIZE; $count++) {
             $row = $this->productRowsIterator->next();
             if ($row === false) {
                 $this->em->flush();

--- a/packages/framework/src/Model/Product/Pricing/ProductInputPriceFacade.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductInputPriceFacade.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 
 class ProductInputPriceFacade
 {
+    /** @access protected */
     const BATCH_SIZE = 50;
 
     /**

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
@@ -77,7 +77,7 @@ class ProductPriceRecalculator
             $this->productRowsIterator = $this->productPriceRecalculationScheduler->getProductsIteratorForDelayedRecalculation();
         }
 
-        for ($count = 0; $count < self::BATCH_SIZE; $count++) {
+        for ($count = 0; $count < static::BATCH_SIZE; $count++) {
             $row = $this->productRowsIterator->next();
             if ($row === false) {
                 $this->clearCache();

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 class ProductPriceRecalculator
 {
+    /** @access protected */
     const BATCH_SIZE = 250;
 
     /**

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -24,12 +24,12 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationSched
  */
 class Product extends AbstractTranslatableEntity
 {
-    const OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY = 'setAlternateAvailability';
-    const OUT_OF_STOCK_ACTION_EXCLUDE_FROM_SALE = 'excludeFromSale';
-    const OUT_OF_STOCK_ACTION_HIDE = 'hide';
-    const VARIANT_TYPE_NONE = 'none';
-    const VARIANT_TYPE_MAIN = 'main';
-    const VARIANT_TYPE_VARIANT = 'variant';
+    public const OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY = 'setAlternateAvailability';
+    public const OUT_OF_STOCK_ACTION_EXCLUDE_FROM_SALE = 'excludeFromSale';
+    public const OUT_OF_STOCK_ACTION_HIDE = 'hide';
+    public const VARIANT_TYPE_NONE = 'none';
+    public const VARIANT_TYPE_MAIN = 'main';
+    public const VARIANT_TYPE_VARIANT = 'variant';
 
     /**
      * @var int

--- a/packages/framework/src/Model/Product/ProductDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/ProductDetailFriendlyUrlDataProvider.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryI
 
 class ProductDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInterface
 {
+    /** @access protected */
     const ROUTE_NAME = 'front_product_detail';
 
     /**

--- a/packages/framework/src/Model/Product/ProductDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/ProductDetailFriendlyUrlDataProvider.php
@@ -49,7 +49,7 @@ class ProductDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInt
             ->join('p.translations', 'pt', Join::WITH, 'pt.locale = :locale')
             ->setParameter('locale', $domainConfig->getId())
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'p.id = f.entityId AND f.routeName = :routeName AND f.domainId = :domainId')
-            ->setParameter('routeName', self::ROUTE_NAME)
+            ->setParameter('routeName', static::ROUTE_NAME)
             ->setParameter('domainId', $domainConfig->getId())
             ->where('f.entityId IS NULL AND pt.name IS NOT NULL');
 
@@ -72,6 +72,6 @@ class ProductDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInt
      */
     public function getRouteName(): string
     {
-        return self::ROUTE_NAME;
+        return static::ROUTE_NAME;
     }
 }

--- a/packages/framework/src/Model/Product/ProductListFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/ProductListFriendlyUrlDataProvider.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class ProductListFriendlyUrlDataProvider implements FriendlyUrlDataProviderInterface
 {
+    /** @access protected */
     const ROUTE_NAME = 'front_product_list';
 
     /**

--- a/packages/framework/src/Model/Product/ProductListFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/ProductListFriendlyUrlDataProvider.php
@@ -50,7 +50,7 @@ class ProductListFriendlyUrlDataProvider implements FriendlyUrlDataProviderInter
             ->join('c.translations', 'ct', Join::WITH, 'ct.locale = :locale')
             ->setParameter('locale', $domainConfig->getId())
             ->leftJoin(FriendlyUrl::class, 'f', Join::WITH, 'c.id = f.entityId AND f.routeName = :routeName AND f.domainId = :domainId')
-            ->setParameter('routeName', self::ROUTE_NAME)
+            ->setParameter('routeName', static::ROUTE_NAME)
             ->setParameter('domainId', $domainConfig->getId())
             ->where('f.entityId IS NULL AND ct.name IS NOT NULL');
 
@@ -73,6 +73,6 @@ class ProductListFriendlyUrlDataProvider implements FriendlyUrlDataProviderInter
      */
     public function getRouteName(): string
     {
-        return self::ROUTE_NAME;
+        return static::ROUTE_NAME;
     }
 }

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
@@ -7,6 +7,7 @@ use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository;
 
 class ProductSearchExporter
 {
+    /** @access protected */
     const BATCH_SIZE = 100;
 
     /**

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
@@ -51,7 +51,7 @@ class ProductSearchExporter
         do {
             $batchExportedIds = $this->exportBatch($domainId, $locale, $startFrom);
             $exportedIds = array_merge($exportedIds, $batchExportedIds);
-            $startFrom += self::BATCH_SIZE;
+            $startFrom += static::BATCH_SIZE;
         } while (!empty($batchExportedIds));
         $this->removeNotUpdated((string)$domainId, $exportedIds);
     }
@@ -64,7 +64,7 @@ class ProductSearchExporter
      */
     protected function exportBatch(int $domainId, string $locale, int $startFrom): array
     {
-        $productsData = $this->productSearchExportRepository->getProductsData($domainId, $locale, $startFrom, self::BATCH_SIZE);
+        $productsData = $this->productSearchExportRepository->getProductsData($domainId, $locale, $startFrom, static::BATCH_SIZE);
         if (count($productsData) === 0) {
             return [];
         }

--- a/packages/framework/src/Model/Script/Script.php
+++ b/packages/framework/src/Model/Script/Script.php
@@ -10,9 +10,9 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class Script
 {
-    const PLACEMENT_ORDER_SENT_PAGE = 'placementOrderSentPage';
-    const PLACEMENT_ALL_PAGES = 'placementAllPages';
-    const GOOGLE_ANALYTICS_TRACKING_ID_SETTING_NAME = 'googleAnalyticsTrackingId';
+    public const PLACEMENT_ORDER_SENT_PAGE = 'placementOrderSentPage';
+    public const PLACEMENT_ALL_PAGES = 'placementAllPages';
+    public const GOOGLE_ANALYTICS_TRACKING_ID_SETTING_NAME = 'googleAnalyticsTrackingId';
 
     /**
      * @var int

--- a/packages/framework/src/Model/Script/ScriptFacade.php
+++ b/packages/framework/src/Model/Script/ScriptFacade.php
@@ -9,8 +9,8 @@ use Shopsys\FrameworkBundle\Twig\MoneyExtension;
 
 class ScriptFacade
 {
-    const VARIABLE_NUMBER = '{number}';
-    const VARIABLE_TOTAL_PRICE = '{total_price}';
+    public const VARIABLE_NUMBER = '{number}';
+    public const VARIABLE_TOTAL_PRICE = '{total_price}';
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface

--- a/packages/framework/src/Model/Security/AdministratorLoginFacade.php
+++ b/packages/framework/src/Model/Security/AdministratorLoginFacade.php
@@ -16,7 +16,9 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class AdministratorLoginFacade
 {
+    /** @access protected */
     const MULTIDOMAIN_LOGIN_TOKEN_LENGTH = 50;
+    /** @access protected */
     const MULTIDOMAIN_LOGIN_TOKEN_VALID_SECONDS = 10;
 
     /**

--- a/packages/framework/src/Model/Security/AdministratorLoginFacade.php
+++ b/packages/framework/src/Model/Security/AdministratorLoginFacade.php
@@ -73,8 +73,8 @@ class AdministratorLoginFacade
      */
     public function generateMultidomainLoginTokenWithExpiration(Administrator $administrator)
     {
-        $multidomainLoginToken = $this->hashGenerator->generateHash(self::MULTIDOMAIN_LOGIN_TOKEN_LENGTH);
-        $multidomainLoginTokenExpirationDateTime = new DateTime('+' . self::MULTIDOMAIN_LOGIN_TOKEN_VALID_SECONDS . 'seconds');
+        $multidomainLoginToken = $this->hashGenerator->generateHash(static::MULTIDOMAIN_LOGIN_TOKEN_LENGTH);
+        $multidomainLoginTokenExpirationDateTime = new DateTime('+' . static::MULTIDOMAIN_LOGIN_TOKEN_VALID_SECONDS . 'seconds');
         $administrator->setMultidomainLoginTokenWithExpiration($multidomainLoginToken, $multidomainLoginTokenExpirationDateTime);
         $this->em->flush();
 

--- a/packages/framework/src/Model/Security/LoginAsUserFacade.php
+++ b/packages/framework/src/Model/Security/LoginAsUserFacade.php
@@ -69,7 +69,7 @@ class LoginAsUserFacade
      */
     public function rememberLoginAsUser(User $user)
     {
-        $this->session->set(self::SESSION_LOGIN_AS, serialize($user));
+        $this->session->set(static::SESSION_LOGIN_AS, serialize($user));
     }
 
     /**
@@ -81,13 +81,13 @@ class LoginAsUserFacade
             throw new \Shopsys\FrameworkBundle\Model\Security\Exception\LoginAsRememberedUserException('Access denied');
         }
 
-        if (!$this->session->has(self::SESSION_LOGIN_AS)) {
+        if (!$this->session->has(static::SESSION_LOGIN_AS)) {
             throw new \Shopsys\FrameworkBundle\Model\Security\Exception\LoginAsRememberedUserException('User not set.');
         }
 
-        $unserializedUser = unserialize($this->session->get(self::SESSION_LOGIN_AS));
+        $unserializedUser = unserialize($this->session->get(static::SESSION_LOGIN_AS));
         /* @var $unserializedUser \Shopsys\FrameworkBundle\Model\Customer\User */
-        $this->session->remove(self::SESSION_LOGIN_AS);
+        $this->session->remove(static::SESSION_LOGIN_AS);
         $freshUser = $this->userRepository->getUserById($unserializedUser->getId());
 
         $password = '';

--- a/packages/framework/src/Model/Security/LoginAsUserFacade.php
+++ b/packages/framework/src/Model/Security/LoginAsUserFacade.php
@@ -15,6 +15,7 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 class LoginAsUserFacade
 {
+    /** @access protected */
     const SESSION_LOGIN_AS = 'loginAsUser';
 
     /**

--- a/packages/framework/src/Model/Security/Roles.php
+++ b/packages/framework/src/Model/Security/Roles.php
@@ -4,8 +4,8 @@ namespace Shopsys\FrameworkBundle\Model\Security;
 
 class Roles
 {
-    const ROLE_ADMIN = 'ROLE_ADMIN';
-    const ROLE_ADMIN_AS_CUSTOMER = 'ROLE_ADMIN_AS_CUSTOMER';
-    const ROLE_LOGGED_CUSTOMER = 'ROLE_LOGGED_CUSTOMER';
-    const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
+    public const ROLE_ADMIN = 'ROLE_ADMIN';
+    public const ROLE_ADMIN_AS_CUSTOMER = 'ROLE_ADMIN_AS_CUSTOMER';
+    public const ROLE_LOGGED_CUSTOMER = 'ROLE_LOGGED_CUSTOMER';
+    public const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
 }

--- a/packages/framework/src/Model/Seo/SeoSettingFacade.php
+++ b/packages/framework/src/Model/Seo/SeoSettingFacade.php
@@ -6,9 +6,9 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
 class SeoSettingFacade
 {
-    const SEO_TITLE_MAIN_PAGE = 'seoTitleMainPage';
-    const SEO_TITLE_ADD_ON = 'seoTitleAddOn';
-    const SEO_META_DESCRIPTION_MAIN_PAGE = 'seoMetaDescriptionMainPage';
+    public const SEO_TITLE_MAIN_PAGE = 'seoTitleMainPage';
+    public const SEO_TITLE_ADD_ON = 'seoTitleAddOn';
+    public const SEO_META_DESCRIPTION_MAIN_PAGE = 'seoMetaDescriptionMainPage';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting

--- a/packages/framework/src/Model/ShopInfo/ShopInfoSettingFacade.php
+++ b/packages/framework/src/Model/ShopInfo/ShopInfoSettingFacade.php
@@ -6,9 +6,9 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
 class ShopInfoSettingFacade
 {
-    const SHOP_INFO_PHONE_NUMBER = 'shopInfoPhoneNumber';
-    const SHOP_INFO_EMAIL = 'shopInfoEmail';
-    const SHOP_INFO_PHONE_HOURS = 'shopInfoPhoneHours';
+    public const SHOP_INFO_PHONE_NUMBER = 'shopInfoPhoneNumber';
+    public const SHOP_INFO_EMAIL = 'shopInfoEmail';
+    public const SHOP_INFO_PHONE_HOURS = 'shopInfoPhoneHours';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Setting\Setting

--- a/packages/framework/src/Model/Sitemap/SitemapDumperFactory.php
+++ b/packages/framework/src/Model/Sitemap/SitemapDumperFactory.php
@@ -70,7 +70,7 @@ class SitemapDumperFactory
             $this->filesystem,
             $this->mountManager,
             $this->sitemapFilePrefixer->getSitemapFilePrefixForDomain($domainId),
-            self::MAX_ITEMS_IN_FILE
+            static::MAX_ITEMS_IN_FILE
         );
     }
 }

--- a/packages/framework/src/Model/Sitemap/SitemapDumperFactory.php
+++ b/packages/framework/src/Model/Sitemap/SitemapDumperFactory.php
@@ -9,6 +9,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class SitemapDumperFactory
 {
+    /** @access protected */
     const MAX_ITEMS_IN_FILE = 50000;
 
     /**

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -73,16 +73,16 @@ class SitemapListener implements EventSubscriberInterface
         $generator = $event->getUrlContainer();
         $domainConfig = $this->domain->getDomainConfigById($domainId);
 
-        $this->addHomepageUrl($generator, $domainConfig, $section, self::PRIORITY_HOMEPAGE);
+        $this->addHomepageUrl($generator, $domainConfig, $section, static::PRIORITY_HOMEPAGE);
 
         $productSitemapItems = $this->sitemapFacade->getSitemapItemsForVisibleProducts($domainConfig);
-        $this->addUrlsBySitemapItems($productSitemapItems, $generator, $domainConfig, $section, self::PRIORITY_PRODUCTS);
+        $this->addUrlsBySitemapItems($productSitemapItems, $generator, $domainConfig, $section, static::PRIORITY_PRODUCTS);
 
         $categorySitemapItems = $this->sitemapFacade->getSitemapItemsForVisibleCategories($domainConfig);
-        $this->addUrlsBySitemapItems($categorySitemapItems, $generator, $domainConfig, $section, self::PRIORITY_CATEGORIES);
+        $this->addUrlsBySitemapItems($categorySitemapItems, $generator, $domainConfig, $section, static::PRIORITY_CATEGORIES);
 
         $articleSitemapItems = $this->sitemapFacade->getSitemapItemsForArticlesOnDomain($domainConfig);
-        $this->addUrlsBySitemapItems($articleSitemapItems, $generator, $domainConfig, $section, self::PRIORITY_ARTICLES);
+        $this->addUrlsBySitemapItems($articleSitemapItems, $generator, $domainConfig, $section, static::PRIORITY_ARTICLES);
     }
 
     /**

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -13,9 +13,13 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SitemapListener implements EventSubscriberInterface
 {
+    /** @access protected */
     const PRIORITY_HOMEPAGE = 1;
+    /** @access protected */
     const PRIORITY_CATEGORIES = 0.8;
+    /** @access protected */
     const PRIORITY_PRODUCTS = 0.7;
+    /** @access protected */
     const PRIORITY_ARTICLES = 0.5;
 
     /**

--- a/packages/framework/src/Model/Transport/Grid/TransportGridFactory.php
+++ b/packages/framework/src/Model/Transport/Grid/TransportGridFactory.php
@@ -97,6 +97,6 @@ class TransportGridFactory implements GridFactoryInterface
     {
         $transportBasePricesIndexedByCurrencyId = $this->transportFacade->getIndependentBasePricesIndexedByCurrencyId($transport);
 
-        return $transportBasePricesIndexedByCurrencyId[self::CURRENCY_ID_FOR_LIST]->getPriceWithVat();
+        return $transportBasePricesIndexedByCurrencyId[static::CURRENCY_ID_FOR_LIST]->getPriceWithVat();
     }
 }

--- a/packages/framework/src/Model/Transport/Grid/TransportGridFactory.php
+++ b/packages/framework/src/Model/Transport/Grid/TransportGridFactory.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportRepository;
 
 class TransportGridFactory implements GridFactoryInterface
 {
+    /** @access protected */
     const CURRENCY_ID_FOR_LIST = 1;
 
     /**

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -101,7 +101,7 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
         $this->setTranslations($transportData);
         $this->createDomains($transportData);
         $this->prices = new ArrayCollection();
-        $this->position = self::GEDMO_SORTABLE_LAST_POSITION;
+        $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->payments = new ArrayCollection();
     }
 

--- a/packages/framework/src/Twig/FileThumbnail/FileThumbnailExtension.php
+++ b/packages/framework/src/Twig/FileThumbnail/FileThumbnailExtension.php
@@ -9,7 +9,8 @@ use Twig_SimpleFunction;
 
 class FileThumbnailExtension extends Twig_Extension
 {
-    const DEFAULT_ICON_TYPE = 'all';
+    public const DEFAULT_ICON_TYPE = 'all';
+    /** @access protected */
     const IMAGE_THUMBNAIL_QUALITY = 80;
 
     /**

--- a/packages/framework/src/Twig/FileThumbnail/FileThumbnailExtension.php
+++ b/packages/framework/src/Twig/FileThumbnail/FileThumbnailExtension.php
@@ -102,7 +102,7 @@ class FileThumbnailExtension extends Twig_Extension
     {
         $image = $this->imageThumbnailFactory->getImageThumbnail($filepath);
 
-        return new FileThumbnailInfo(null, $image->encode('data-url', self::IMAGE_THUMBNAIL_QUALITY)->getEncoded());
+        return new FileThumbnailInfo(null, $image->encode('data-url', static::IMAGE_THUMBNAIL_QUALITY)->getEncoded());
     }
 
     /**

--- a/packages/framework/src/Twig/FormThemeExtension.php
+++ b/packages/framework/src/Twig/FormThemeExtension.php
@@ -9,7 +9,9 @@ use Twig_SimpleFunction;
 
 class FormThemeExtension extends \Twig_Extension
 {
+    /** @access protected */
     const ADMIN_THEME = '@ShopsysFramework/Admin/Form/theme.html.twig';
+    /** @access protected */
     const FRONT_THEME = '@ShopsysShop/Front/Form/theme.html.twig';
 
     /**

--- a/packages/framework/src/Twig/FormThemeExtension.php
+++ b/packages/framework/src/Twig/FormThemeExtension.php
@@ -44,9 +44,9 @@ class FormThemeExtension extends \Twig_Extension
     {
         $masterRequest = $this->requestStack->getMasterRequest();
         if ($this->isAdmin($masterRequest->get('_controller'))) {
-            return self::ADMIN_THEME;
+            return static::ADMIN_THEME;
         } else {
-            return self::FRONT_THEME;
+            return static::FRONT_THEME;
         }
     }
 

--- a/packages/framework/src/Twig/HoneyPotExtension.php
+++ b/packages/framework/src/Twig/HoneyPotExtension.php
@@ -66,7 +66,7 @@ class HoneyPotExtension extends Twig_Extension
     private function containsNotRenderedPassword(FormView $formView)
     {
         foreach ($formView->children as $childForm) {
-            if (strpos($childForm->vars['name'], self::PASSWORD_FIELD_NAME) !== false && !$childForm->isRendered()) {
+            if (strpos($childForm->vars['name'], static::PASSWORD_FIELD_NAME) !== false && !$childForm->isRendered()) {
                 return true;
             } elseif ($this->containsNotRenderedPassword($childForm)) {
                 return true;

--- a/packages/framework/src/Twig/HoneyPotExtension.php
+++ b/packages/framework/src/Twig/HoneyPotExtension.php
@@ -8,6 +8,7 @@ use Twig_SimpleFunction;
 
 class HoneyPotExtension extends Twig_Extension
 {
+    /** @access protected */
     const PASSWORD_FIELD_NAME = 'password';
 
     /**

--- a/packages/framework/src/Twig/ImageExtension.php
+++ b/packages/framework/src/Twig/ImageExtension.php
@@ -12,6 +12,7 @@ use Twig_SimpleFunction;
 
 class ImageExtension extends Twig_Extension
 {
+    /** @access protected */
     const NOIMAGE_FILENAME = 'noimage.png';
 
     /**

--- a/packages/framework/src/Twig/ImageExtension.php
+++ b/packages/framework/src/Twig/ImageExtension.php
@@ -158,7 +158,7 @@ class ImageExtension extends Twig_Extension
      */
     private function getEmptyImageUrl()
     {
-        return $this->domain->getUrl() . $this->frontDesignImageUrlPrefix . self::NOIMAGE_FILENAME;
+        return $this->domain->getUrl() . $this->frontDesignImageUrlPrefix . static::NOIMAGE_FILENAME;
     }
 
     /**

--- a/packages/framework/src/Twig/Javascript/JavascriptCompiler.php
+++ b/packages/framework/src/Twig/Javascript/JavascriptCompiler.php
@@ -203,7 +203,7 @@ class JavascriptCompiler
         if (!$this->isCompiledFileFresh($compiledFilename, $sourceFilename)) {
             $content = file_get_contents($sourceFilename);
 
-            if (strpos($sourceFilename, self::NOT_COMPILED_FOLDER) === false) {
+            if (strpos($sourceFilename, static::NOT_COMPILED_FOLDER) === false) {
                 $newContent = $this->jsCompiler->compile($content);
             } else {
                 $newContent = $content;

--- a/packages/framework/src/Twig/Javascript/JavascriptCompiler.php
+++ b/packages/framework/src/Twig/Javascript/JavascriptCompiler.php
@@ -9,6 +9,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class JavascriptCompiler
 {
+    /** @access protected */
     const NOT_COMPILED_FOLDER = '/plugins/';
 
     /**

--- a/packages/framework/src/Twig/NumberFormatterExtension.php
+++ b/packages/framework/src/Twig/NumberFormatterExtension.php
@@ -9,7 +9,9 @@ use Twig_Extension;
 
 class NumberFormatterExtension extends Twig_Extension
 {
+    /** @access protected */
     const MINIMUM_FRACTION_DIGITS = 0;
+    /** @access protected */
     const MAXIMUM_FRACTION_DIGITS = 10;
 
     /**

--- a/packages/framework/src/Twig/NumberFormatterExtension.php
+++ b/packages/framework/src/Twig/NumberFormatterExtension.php
@@ -66,8 +66,8 @@ class NumberFormatterExtension extends Twig_Extension
     {
         $numberFormat = $this->numberFormatRepository->get($this->getLocale($locale));
         $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::DECIMAL);
-        $numberFormatter->setMinimumFractionDigits(self::MINIMUM_FRACTION_DIGITS);
-        $numberFormatter->setMaximumFractionDigits(self::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMinimumFractionDigits(static::MINIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
 
         return $numberFormatter->format($number);
     }
@@ -83,7 +83,7 @@ class NumberFormatterExtension extends Twig_Extension
         $numberFormat = $this->numberFormatRepository->get($this->getLocale($locale));
         $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::DECIMAL);
         $numberFormatter->setMinimumFractionDigits($minimumFractionDigits);
-        $numberFormatter->setMaximumFractionDigits(self::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
 
         return $numberFormatter->format($number);
     }
@@ -97,8 +97,8 @@ class NumberFormatterExtension extends Twig_Extension
     {
         $numberFormat = $this->numberFormatRepository->get($this->getLocale($locale));
         $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::PERCENT);
-        $numberFormatter->setMinimumFractionDigits(self::MINIMUM_FRACTION_DIGITS);
-        $numberFormatter->setMaximumFractionDigits(self::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMinimumFractionDigits(static::MINIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
 
         return $numberFormatter->format($number);
     }

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -254,8 +254,8 @@ class PriceExtension extends Twig_Extension
     {
         $numberFormat = $this->numberFormatRepository->get($locale);
         $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::CURRENCY);
-        $numberFormatter->setMinimumFractionDigits(self::MINIMUM_FRACTION_DIGITS);
-        $numberFormatter->setMaximumFractionDigits(self::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMinimumFractionDigits(static::MINIMUM_FRACTION_DIGITS);
+        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
 
         return $numberFormatter;
     }

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -18,7 +18,9 @@ use Twig_SimpleFunction;
 
 class PriceExtension extends Twig_Extension
 {
+    /** @access protected */
     const MINIMUM_FRACTION_DIGITS = 2;
+    /** @access protected */
     const MAXIMUM_FRACTION_DIGITS = 10;
 
     /**

--- a/packages/framework/tests/Unit/Component/Elasticsearch/ElasticsearchStructureManagerTest.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/ElasticsearchStructureManagerTest.php
@@ -50,19 +50,19 @@ class ElasticsearchStructureManagerTest extends TestCase
         ];
         $this->indices->expects($this->once())->method('create')->with($expected);
 
-        $this->structureManager->createIndex(1, self::ELASTICSEARCH_INDEX);
+        $this->structureManager->createIndex(1, static::ELASTICSEARCH_INDEX);
     }
 
     public function testCreateWhileJsonNotExistsFails(): void
     {
         $this->expectException(ElasticsearchStructureException::class);
-        $this->structureManager->createIndex(3, self::ELASTICSEARCH_INDEX);
+        $this->structureManager->createIndex(3, static::ELASTICSEARCH_INDEX);
     }
 
     public function testCreateWhileJsonIsNotValidFails(): void
     {
         $this->expectException(ElasticsearchStructureException::class);
-        $this->structureManager->createIndex(0, self::ELASTICSEARCH_INDEX);
+        $this->structureManager->createIndex(0, static::ELASTICSEARCH_INDEX);
     }
 
     public function testDeleteSuccess(): void
@@ -72,7 +72,7 @@ class ElasticsearchStructureManagerTest extends TestCase
         $expectedDelete = ['index' => 'test-product1'];
         $this->indices->expects($this->once())->method('delete')->with($expectedDelete);
 
-        $this->structureManager->deleteIndex(1, self::ELASTICSEARCH_INDEX);
+        $this->structureManager->deleteIndex(1, static::ELASTICSEARCH_INDEX);
     }
 
     public function testDeleteNotExisting(): void
@@ -81,6 +81,6 @@ class ElasticsearchStructureManagerTest extends TestCase
 
         $this->indices->expects($this->never())->method('delete');
 
-        $this->structureManager->deleteIndex(1, self::ELASTICSEARCH_INDEX);
+        $this->structureManager->deleteIndex(1, static::ELASTICSEARCH_INDEX);
     }
 }

--- a/packages/framework/tests/Unit/Component/EntityExtension/EntityNameResolverTest.php
+++ b/packages/framework/tests/Unit/Component/EntityExtension/EntityNameResolverTest.php
@@ -8,10 +8,10 @@ use stdClass;
 
 class EntityNameResolverTest extends TestCase
 {
-    const PARENT_ENTITY_FQCN = 'Vendor\Bundle\Folder\ParentEntityName';
-    const CUSTOM_ENTITY_FQCN = 'MyBundle\MyFolder\MyEntityName';
-    const STRING_WITH_SPACES_ON_BORDERS = ' string ';
-    const STRING_WITHOUT_SPACES_ON_BORDERS = 'string';
+    public const PARENT_ENTITY_FQCN = 'Vendor\Bundle\Folder\ParentEntityName';
+    public const CUSTOM_ENTITY_FQCN = 'MyBundle\MyFolder\MyEntityName';
+    public const STRING_WITH_SPACES_ON_BORDERS = ' string ';
+    public const STRING_WITHOUT_SPACES_ON_BORDERS = 'string';
 
     /**
      * @return array

--- a/packages/framework/tests/Unit/Component/String/EncodingConverterTest.php
+++ b/packages/framework/tests/Unit/Component/String/EncodingConverterTest.php
@@ -8,6 +8,7 @@ use stdClass;
 
 class EncodingConverterTest extends TestCase
 {
+    /** @access private */
     const STRING_UTF8 = 'příšerně žluťoučký kůň úpěl ďábelské ódy. PŘÍŠERNĚ ŽLUŤOUČKÝ KŮŇ ÚPĚL ĎÁBELSKÉ ÓDY.';
 
     private function getUtf8String()

--- a/packages/framework/tests/Unit/Model/Customer/CustomerDataFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerDataFactoryTest.php
@@ -28,6 +28,7 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportData;
 
 class CustomerDataFactoryTest extends TestCase
 {
+    /** @access private */
     const DOMAIN_ID = 1;
 
     public function testGetAmendedCustomerDataByOrderWithoutChanges()

--- a/packages/framework/tests/Unit/Model/Order/OrderTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderTest.php
@@ -16,6 +16,7 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 
 class OrderTest extends TestCase
 {
+    /** @access private */
     const DOMAIN_ID = 1;
 
     public function testGetProductItems()

--- a/packages/google-cloud-bundle/easy-coding-standard.yml
+++ b/packages/google-cloud-bundle/easy-coding-standard.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/google-cloud-bundle/easy-coding-standard.yml
+++ b/packages/google-cloud-bundle/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/http-smoke-testing/src/RequestDataSet.php
+++ b/packages/http-smoke-testing/src/RequestDataSet.php
@@ -8,6 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RequestDataSet implements RequestDataSetConfig
 {
+    /** @access private */
     const DEFAULT_EXPECTED_STATUS_CODE = 200;
 
     /**

--- a/packages/migrations/easy-coding-standard.yml
+++ b/packages/migrations/easy-coding-standard.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     exclude_files:
         - '*/src/Resources/views/Migration/migration.php.twig'

--- a/packages/migrations/easy-coding-standard.yml
+++ b/packages/migrations/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     exclude_files:
         - '*/src/Resources/views/Migration/migration.php.twig'

--- a/packages/migrations/src/Command/CheckDatabaseSchemaCommand.php
+++ b/packages/migrations/src/Command/CheckDatabaseSchemaCommand.php
@@ -8,7 +8,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CheckDatabaseSchemaCommand extends AbstractCommand
 {
+    /** @access private */
     const RETURN_CODE_OK = 0;
+    /** @access private */
     const RETURN_CODE_ERROR = 1;
 
     /**

--- a/packages/migrations/src/Command/CheckOrmMappingCommand.php
+++ b/packages/migrations/src/Command/CheckOrmMappingCommand.php
@@ -9,7 +9,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CheckOrmMappingCommand extends AbstractCommand
 {
+    /** @access private */
     const RETURN_CODE_OK = 0;
+    /** @access private */
     const RETURN_CODE_ERROR = 1;
 
     /**

--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -13,7 +13,9 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class GenerateMigrationCommand extends AbstractCommand
 {
+    /** @access private */
     const RETURN_CODE_OK = 0;
+    /** @access private */
     const RETURN_CODE_ERROR = 1;
 
     /**

--- a/packages/migrations/src/Command/MigrateCommand.php
+++ b/packages/migrations/src/Command/MigrateCommand.php
@@ -10,7 +10,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class MigrateCommand extends AbstractCommand
 {
+    /** @access private */
     const RETURN_CODE_OK = 0;
+    /** @access private */
     const RETURN_CODE_ERROR = 1;
 
     /**

--- a/packages/migrations/src/Component/Generator/MigrationsGenerator.php
+++ b/packages/migrations/src/Component/Generator/MigrationsGenerator.php
@@ -71,7 +71,7 @@ class MigrationsGenerator
     {
         $formattedSqlCommands = [];
         foreach ($filteredSchemaDiffSqlCommands as $key => $filteredSchemaDiffSqlCommand) {
-            if (strlen($filteredSchemaDiffSqlCommand) > self::LINE_LENGTH_LIMIT) {
+            if (strlen($filteredSchemaDiffSqlCommand) > static::LINE_LENGTH_LIMIT) {
                 $formattedSqlCommands[] = $this->formatSqlCommand($filteredSchemaDiffSqlCommand);
             } else {
                 $formattedSqlCommands[] = $filteredSchemaDiffSqlCommand;
@@ -100,9 +100,9 @@ class MigrationsGenerator
     private function formatSqlQueryWithTabs($query)
     {
         $previousTab = SqlFormatter::$tab;
-        SqlFormatter::$tab = self::INDENT_CHARACTERS;
+        SqlFormatter::$tab = static::INDENT_CHARACTERS;
 
-        $formattedQuery = SqlFormatter::format($query, self::HIGHLIGHT_OFF);
+        $formattedQuery = SqlFormatter::format($query, static::HIGHLIGHT_OFF);
 
         SqlFormatter::$tab = $previousTab;
 
@@ -116,7 +116,7 @@ class MigrationsGenerator
     private function indentSqlCommandLines(array $queryLines)
     {
         return array_map(function ($queryLine) {
-            return str_repeat(self::INDENT_CHARACTERS, self::INDENT_TABULATOR_COUNT) . $queryLine;
+            return str_repeat(static::INDENT_CHARACTERS, static::INDENT_TABULATOR_COUNT) . $queryLine;
         }, $queryLines);
     }
 

--- a/packages/migrations/src/Component/Generator/MigrationsGenerator.php
+++ b/packages/migrations/src/Component/Generator/MigrationsGenerator.php
@@ -9,9 +9,13 @@ use Symfony\Component\Templating\EngineInterface;
 
 class MigrationsGenerator
 {
+    /** @access protected */
     const LINE_LENGTH_LIMIT = 100;
+    /** @access protected */
     const HIGHLIGHT_OFF = false;
+    /** @access protected */
     const INDENT_CHARACTERS = '    ';
+    /** @access protected */
     const INDENT_TABULATOR_COUNT = 3;
 
     /**

--- a/packages/migrations/tests/Unit/Component/Doctrine/Migrations/MigrationsLockTest.php
+++ b/packages/migrations/tests/Unit/Component/Doctrine/Migrations/MigrationsLockTest.php
@@ -12,7 +12,9 @@ use Tests\MigrationBundle\Unit\Component\Doctrine\Migrations\Resources\Version20
 
 class MigrationsLockTest extends TestCase
 {
+    /** @access private */
     const MIGRATION_LOCK_TEMPLATE = __DIR__ . '/Resources/migrations-lock.yml';
+    /** @access private */
     const MIGRATION_LOCK = __DIR__ . '/Resources/migrations-lock.yml.tmp';
 
     /**

--- a/packages/plugin-interface/easy-coding-standard.yml
+++ b/packages/plugin-interface/easy-coding-standard.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/plugin-interface/easy-coding-standard.yml
+++ b/packages/plugin-interface/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-google/easy-coding-standard.yml
+++ b/packages/product-feed-google/easy-coding-standard.yml
@@ -11,6 +11,9 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\GoogleBundle\Model
 
+
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-google/easy-coding-standard.yml
+++ b/packages/product-feed-google/easy-coding-standard.yml
@@ -14,6 +14,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-google/src/Model/FeedItem/GoogleFeedItem.php
+++ b/packages/product-feed-google/src/Model/FeedItem/GoogleFeedItem.php
@@ -173,7 +173,7 @@ class GoogleFeedItem implements FeedItemInterface
      */
     public function getAvailability(): string
     {
-        return $this->sellingDenied ? self::AVAILABILITY_OUT_OF_STOCK : self::AVAILABILITY_IN_STOCK;
+        return $this->sellingDenied ? static::AVAILABILITY_OUT_OF_STOCK : static::AVAILABILITY_IN_STOCK;
     }
 
     /**
@@ -198,8 +198,8 @@ class GoogleFeedItem implements FeedItemInterface
     public function getIdentifiers(): array
     {
         return array_filter([
-            self::IDENTIFIER_TYPE_EAN => $this->ean,
-            self::IDENTIFIER_TYPE_PARTNO => $this->partno,
+            static::IDENTIFIER_TYPE_EAN => $this->ean,
+            static::IDENTIFIER_TYPE_PARTNO => $this->partno,
         ]);
     }
 }

--- a/packages/product-feed-google/src/Model/FeedItem/GoogleFeedItem.php
+++ b/packages/product-feed-google/src/Model/FeedItem/GoogleFeedItem.php
@@ -8,10 +8,14 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 
 class GoogleFeedItem implements FeedItemInterface
 {
+    /** @access protected */
     const IDENTIFIER_TYPE_EAN = 'gtin';
+    /** @access protected */
     const IDENTIFIER_TYPE_PARTNO = 'mpn';
 
+    /** @access protected */
     const AVAILABILITY_OUT_OF_STOCK = 'out of stock';
+    /** @access protected */
     const AVAILABILITY_IN_STOCK = 'in stock';
 
     /**

--- a/packages/product-feed-heureka-delivery/easy-coding-standard.yml
+++ b/packages/product-feed-heureka-delivery/easy-coding-standard.yml
@@ -11,6 +11,8 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\HeurekaDeliveryBundle\Model
 
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-heureka-delivery/easy-coding-standard.yml
+++ b/packages/product-feed-heureka-delivery/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -11,6 +11,8 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\HeurekaBundle\Model
 
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/product-feed-heureka/src/DataFixtures/HeurekaCategoryDataFixture.php
+++ b/packages/product-feed-heureka/src/DataFixtures/HeurekaCategoryDataFixture.php
@@ -8,14 +8,22 @@ use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacad
 
 class HeurekaCategoryDataFixture implements PluginDataFixtureInterface
 {
+    /** @access protected */
     const HEUREKA_CATEGORY_ID_FIRST = 1;
+    /** @access protected */
     const HEUREKA_CATEGORY_ID_SECOND = 2;
+    /** @access protected */
     const HEUREKA_CATEGORY_ID_THIRD = 3;
 
+    /** @access protected */
     const CATEGORY_ID_FIRST = 2;
+    /** @access protected */
     const CATEGORY_ID_SECOND = 3;
+    /** @access protected */
     const CATEGORY_ID_THIRD = 4;
+    /** @access protected */
     const CATEGORY_ID_FOURTH = 5;
+    /** @access protected */
     const CATEGORY_ID_FIFTH = 6;
 
     /**

--- a/packages/product-feed-heureka/src/DataFixtures/HeurekaCategoryDataFixture.php
+++ b/packages/product-feed-heureka/src/DataFixtures/HeurekaCategoryDataFixture.php
@@ -53,21 +53,21 @@ class HeurekaCategoryDataFixture implements PluginDataFixtureInterface
         $heurekaCategoriesData = [];
 
         $firsHeurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-        $firsHeurekaCategoryData->id = self::HEUREKA_CATEGORY_ID_FIRST;
+        $firsHeurekaCategoryData->id = static::HEUREKA_CATEGORY_ID_FIRST;
         $firsHeurekaCategoryData->name = 'Autobaterie';
         $firsHeurekaCategoryData->fullName = 'Heureka.cz | Auto-moto | Autodoplňky | Autobaterie';
 
         $heurekaCategoriesData[] = $firsHeurekaCategoryData;
 
         $secondHeurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-        $secondHeurekaCategoryData->id = self::HEUREKA_CATEGORY_ID_SECOND;
+        $secondHeurekaCategoryData->id = static::HEUREKA_CATEGORY_ID_SECOND;
         $secondHeurekaCategoryData->name = 'Bublifuky';
         $secondHeurekaCategoryData->fullName = 'Heureka.cz | Dětské zboží | Hračky | Hry na zahradu | Bublifuky';
 
         $heurekaCategoriesData[] = $secondHeurekaCategoryData;
 
         $thirdHeurekaCategoryData = $this->heurekaCategoryDataFactory->create();
-        $thirdHeurekaCategoryData->id = self::HEUREKA_CATEGORY_ID_THIRD;
+        $thirdHeurekaCategoryData->id = static::HEUREKA_CATEGORY_ID_THIRD;
         $thirdHeurekaCategoryData->name = 'Cukřenky';
         $thirdHeurekaCategoryData->fullName = 'Heureka.cz | Dům a zahrada | Domácnost | Kuchyně | Stolování | Cukřenky';
 
@@ -75,15 +75,15 @@ class HeurekaCategoryDataFixture implements PluginDataFixtureInterface
 
         $this->heurekaCategoryFacade->saveHeurekaCategories($heurekaCategoriesData);
 
-        $heurekaCategoryFirst = $this->heurekaCategoryFacade->getOneById(self::HEUREKA_CATEGORY_ID_FIRST);
-        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(self::CATEGORY_ID_FIRST, $heurekaCategoryFirst);
+        $heurekaCategoryFirst = $this->heurekaCategoryFacade->getOneById(static::HEUREKA_CATEGORY_ID_FIRST);
+        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(static::CATEGORY_ID_FIRST, $heurekaCategoryFirst);
 
-        $heurekaCategorySecond = $this->heurekaCategoryFacade->getOneById(self::HEUREKA_CATEGORY_ID_SECOND);
-        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(self::CATEGORY_ID_SECOND, $heurekaCategorySecond);
-        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(self::CATEGORY_ID_THIRD, $heurekaCategorySecond);
+        $heurekaCategorySecond = $this->heurekaCategoryFacade->getOneById(static::HEUREKA_CATEGORY_ID_SECOND);
+        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(static::CATEGORY_ID_SECOND, $heurekaCategorySecond);
+        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(static::CATEGORY_ID_THIRD, $heurekaCategorySecond);
 
-        $heurekaCategoryThird = $this->heurekaCategoryFacade->getOneById(self::HEUREKA_CATEGORY_ID_THIRD);
-        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(self::CATEGORY_ID_FOURTH, $heurekaCategoryThird);
-        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(self::CATEGORY_ID_FIFTH, $heurekaCategoryThird);
+        $heurekaCategoryThird = $this->heurekaCategoryFacade->getOneById(static::HEUREKA_CATEGORY_ID_THIRD);
+        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(static::CATEGORY_ID_FOURTH, $heurekaCategoryThird);
+        $this->heurekaCategoryFacade->changeHeurekaCategoryForCategoryId(static::CATEGORY_ID_FIFTH, $heurekaCategoryThird);
     }
 }

--- a/packages/product-feed-heureka/src/DataFixtures/HeurekaProductDataFixture.php
+++ b/packages/product-feed-heureka/src/DataFixtures/HeurekaProductDataFixture.php
@@ -49,63 +49,63 @@ class HeurekaProductDataFixture implements PluginDataFixtureInterface
     public function load()
     {
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(12);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_FIRST, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_FIRST, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(5);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_FIRST, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_FIRST, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(3);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_SECOND, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_SECOND, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(2);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_SECOND, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_SECOND, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(1);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_THIRD, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_THIRD, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(1);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_THIRD, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_THIRD, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(5);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_FOURTH, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_FOURTH, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(8);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_FOURTH, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_FOURTH, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(10);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_FIFTH, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_FIFTH, $heurekaProductDomainData);
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
-        $heurekaProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(5);
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(self::PRODUCT_ID_FIFTH, $heurekaProductDomainData);
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(static::PRODUCT_ID_FIFTH, $heurekaProductDomainData);
     }
 }

--- a/packages/product-feed-heureka/src/DataFixtures/HeurekaProductDataFixture.php
+++ b/packages/product-feed-heureka/src/DataFixtures/HeurekaProductDataFixture.php
@@ -9,12 +9,19 @@ use Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainFacade;
 
 class HeurekaProductDataFixture implements PluginDataFixtureInterface
 {
+    /** @access protected */
     const DOMAIN_ID_FIRST = 1;
+    /** @access protected */
     const DOMAIN_ID_SECOND = 2;
+    /** @access protected */
     const PRODUCT_ID_FIRST = 1;
+    /** @access protected */
     const PRODUCT_ID_SECOND = 2;
+    /** @access protected */
     const PRODUCT_ID_THIRD = 3;
+    /** @access protected */
     const PRODUCT_ID_FOURTH = 4;
+    /** @access protected */
     const PRODUCT_ID_FIFTH = 5;
 
     /**

--- a/packages/product-feed-zbozi/easy-coding-standard.yml
+++ b/packages/product-feed-zbozi/easy-coding-standard.yml
@@ -11,6 +11,8 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\ZboziBundle\Model
 
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/product-feed-zbozi/easy-coding-standard.yml
+++ b/packages/product-feed-zbozi/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php
+++ b/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php
@@ -9,12 +9,19 @@ use Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainFacade;
 
 class ZboziPluginDataFixture implements PluginDataFixtureInterface
 {
+    /** @access protected */
     const DOMAIN_ID_FIRST = 1;
+    /** @access protected */
     const DOMAIN_ID_SECOND = 2;
+    /** @access protected */
     const PRODUCT_ID_FIRST = 1;
+    /** @access protected */
     const PRODUCT_ID_SECOND = 2;
+    /** @access protected */
     const PRODUCT_ID_THIRD = 3;
+    /** @access protected */
     const PRODUCT_ID_FOURTH = 4;
+    /** @access protected */
     const PRODUCT_ID_FIFTH = 5;
 
     /**

--- a/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php
+++ b/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php
@@ -49,83 +49,83 @@ class ZboziPluginDataFixture implements PluginDataFixtureInterface
     public function load()
     {
         $firstZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $firstZboziProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $firstZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $firstZboziProductDomainData->cpc = Money::create(15);
         $firstZboziProductDomainData->cpcSearch = Money::create(8);
         $firstZboziProductDomainData->show = true;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_FIRST, $firstZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_FIRST, $firstZboziProductDomainData);
 
         $secondZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $secondZboziProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $secondZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $secondZboziProductDomainData->cpc = Money::create(12);
         $secondZboziProductDomainData->cpcSearch = Money::create(15);
         $secondZboziProductDomainData->show = true;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_FIRST, $secondZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_FIRST, $secondZboziProductDomainData);
 
         $thirdZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $thirdZboziProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $thirdZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $thirdZboziProductDomainData->cpc = Money::create(5);
         $thirdZboziProductDomainData->cpcSearch = Money::create(3);
         $thirdZboziProductDomainData->show = false;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_SECOND, $thirdZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_SECOND, $thirdZboziProductDomainData);
 
         $fourthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $fourthZboziProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $fourthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $fourthZboziProductDomainData->cpc = Money::create(20);
         $fourthZboziProductDomainData->cpcSearch = Money::create(5);
         $fourthZboziProductDomainData->show = true;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_SECOND, $fourthZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_SECOND, $fourthZboziProductDomainData);
 
         $fifthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $fifthZboziProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $fifthZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $fifthZboziProductDomainData->cpc = Money::create(10);
         $fifthZboziProductDomainData->cpcSearch = Money::create(5);
         $fifthZboziProductDomainData->show = false;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_THIRD, $fifthZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_THIRD, $fifthZboziProductDomainData);
 
         $sixthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $sixthZboziProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $sixthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $sixthZboziProductDomainData->cpc = Money::create(15);
         $sixthZboziProductDomainData->cpcSearch = Money::create(7);
         $sixthZboziProductDomainData->show = false;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_THIRD, $sixthZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_THIRD, $sixthZboziProductDomainData);
 
         $seventhZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $seventhZboziProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $seventhZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $seventhZboziProductDomainData->cpc = Money::create(9);
         $seventhZboziProductDomainData->cpcSearch = Money::create(8);
         $seventhZboziProductDomainData->show = true;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_FOURTH, $seventhZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_FOURTH, $seventhZboziProductDomainData);
 
         $eighthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $eighthZboziProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $eighthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $eighthZboziProductDomainData->cpc = Money::create(4);
         $eighthZboziProductDomainData->cpcSearch = Money::create(3);
         $eighthZboziProductDomainData->show = true;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_FOURTH, $eighthZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_FOURTH, $eighthZboziProductDomainData);
 
         $ninthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $ninthZboziProductDomainData->domainId = self::DOMAIN_ID_FIRST;
+        $ninthZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $ninthZboziProductDomainData->cpc = Money::create(4);
         $ninthZboziProductDomainData->cpcSearch = Money::create(2);
         $ninthZboziProductDomainData->show = true;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_FIFTH, $ninthZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_FIFTH, $ninthZboziProductDomainData);
 
         $tenthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $tenthZboziProductDomainData->domainId = self::DOMAIN_ID_SECOND;
+        $tenthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $tenthZboziProductDomainData->cpc = Money::create(5);
         $tenthZboziProductDomainData->cpcSearch = Money::create(6);
         $tenthZboziProductDomainData->show = false;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(self::PRODUCT_ID_FIFTH, $tenthZboziProductDomainData);
+        $this->zboziProductDomainFacade->saveZboziProductDomain(static::PRODUCT_ID_FIFTH, $tenthZboziProductDomainData);
     }
 }

--- a/packages/product-feed-zbozi/src/Model/FeedItem/ZboziFeedItem.php
+++ b/packages/product-feed-zbozi/src/Model/FeedItem/ZboziFeedItem.php
@@ -238,7 +238,7 @@ class ZboziFeedItem implements FeedItemInterface
      */
     public function getCategoryText(): ?string
     {
-        return implode(self::CATEGORY_PATH_SEPARATOR, $this->pathToMainCategory);
+        return implode(static::CATEGORY_PATH_SEPARATOR, $this->pathToMainCategory);
     }
 
     /**

--- a/packages/product-feed-zbozi/src/Model/FeedItem/ZboziFeedItem.php
+++ b/packages/product-feed-zbozi/src/Model/FeedItem/ZboziFeedItem.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 
 class ZboziFeedItem implements FeedItemInterface
 {
+    /** @access protected */
     const CATEGORY_PATH_SEPARATOR = ' | ';
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CartController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CartController.php
@@ -19,9 +19,9 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 
 class CartController extends FrontBaseController
 {
-    const AFTER_ADD_WINDOW_ACCESSORIES_LIMIT = 3;
+    public const AFTER_ADD_WINDOW_ACCESSORIES_LIMIT = 3;
 
-    const RECALCULATE_ONLY_PARAMETER_NAME = 'recalculateOnly';
+    public const RECALCULATE_ONLY_PARAMETER_NAME = 'recalculateOnly';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Cart\CartFacade

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -29,7 +29,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class OrderController extends FrontBaseController
 {
-    const SESSION_CREATED_ORDER = 'created_order_id';
+    public const SESSION_CREATED_ORDER = 'created_order_id';
 
     /**
      * @var \Shopsys\ShopBundle\Form\Front\Order\DomainAwareOrderFlowFactory

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ProductController extends FrontBaseController
 {
-    const SEARCH_TEXT_PARAMETER = 'q';
-    const PAGE_QUERY_PARAMETER = 'page';
-    const PRODUCTS_PER_PAGE = 12;
+    public const SEARCH_TEXT_PARAMETER = 'q';
+    public const PAGE_QUERY_PARAMETER = 'page';
+    public const PRODUCTS_PER_PAGE = 12;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class PromoCodeController extends FrontBaseController
 {
-    const PROMO_CODE_PARAMETER = 'code';
+    public const PROMO_CODE_PARAMETER = 'code';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\CurrentPromoCodeFacade

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/SearchController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/SearchController.php
@@ -8,8 +8,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SearchController extends FrontBaseController
 {
-    const AUTOCOMPLETE_CATEGORY_LIMIT = 3;
-    const AUTOCOMPLETE_PRODUCT_LIMIT = 5;
+    protected const AUTOCOMPLETE_CATEGORY_LIMIT = 3;
+    protected const AUTOCOMPLETE_PRODUCT_LIMIT = 5;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AdministratorDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AdministratorDataFixture.php
@@ -8,8 +8,8 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
 
 class AdministratorDataFixture extends AbstractReferenceFixture
 {
-    const SUPERADMINISTRATOR = 'administrator_superadministrator';
-    const ADMINISTRATOR = 'administrator_administrator';
+    public const SUPERADMINISTRATOR = 'administrator_superadministrator';
+    public const ADMINISTRATOR = 'administrator_administrator';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ArticleDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ArticleDataFixture.php
@@ -12,9 +12,9 @@ use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
 
 class ArticleDataFixture extends AbstractReferenceFixture
 {
-    const ARTICLE_TERMS_AND_CONDITIONS_1 = 'article_terms_and_conditions_1';
-    const ARTICLE_PRIVACY_POLICY_1 = 'article_privacy_policy_1';
-    const ARTICLE_COOKIES_1 = 'article_cookies_1';
+    public const ARTICLE_TERMS_AND_CONDITIONS_1 = 'article_terms_and_conditions_1';
+    public const ARTICLE_PRIVACY_POLICY_1 = 'article_privacy_policy_1';
+    public const ARTICLE_COOKIES_1 = 'article_cookies_1';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AvailabilityDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AvailabilityDataFixture.php
@@ -11,10 +11,10 @@ use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 
 class AvailabilityDataFixture extends AbstractReferenceFixture
 {
-    const AVAILABILITY_IN_STOCK = 'availability_in_stock';
-    const AVAILABILITY_ON_REQUEST = 'availability_on_request';
-    const AVAILABILITY_OUT_OF_STOCK = 'availability_out_of_stock';
-    const AVAILABILITY_PREPARING = 'availability_preparing';
+    public const AVAILABILITY_IN_STOCK = 'availability_in_stock';
+    public const AVAILABILITY_ON_REQUEST = 'availability_on_request';
+    public const AVAILABILITY_OUT_OF_STOCK = 'availability_out_of_stock';
+    public const AVAILABILITY_PREPARING = 'availability_preparing';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BrandDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BrandDataFixture.php
@@ -9,30 +9,30 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 
 class BrandDataFixture extends AbstractReferenceFixture
 {
-    const BRAND_APPLE = 'brand_apple';
-    const BRAND_CANON = 'brand_canon';
-    const BRAND_LG = 'brand_lg';
-    const BRAND_PHILIPS = 'brand_philips';
-    const BRAND_SENCOR = 'brand_sencor';
-    const BRAND_A4TECH = 'brand_a4tech';
-    const BRAND_BROTHER = 'brand_brother';
-    const BRAND_VERBATIM = 'brand_verbatim';
-    const BRAND_DLINK = 'brand_dlink';
-    const BRAND_DEFENDER = 'brand_defender';
-    const BRAND_DELONGHI = 'brand_delonghi';
-    const BRAND_GENIUS = 'brand_genius';
-    const BRAND_GIGABYTE = 'brand_gigabyte';
-    const BRAND_HP = 'brand_hp';
-    const BRAND_HTC = 'brand_htc';
-    const BRAND_JURA = 'brand_jura';
-    const BRAND_LOGITECH = 'brand_logitech';
-    const BRAND_MICROSOFT = 'brand_microsoft';
-    const BRAND_SAMSUNG = 'brand_samsung';
-    const BRAND_SONY = 'brand_sony';
-    const BRAND_ORAVA = 'brand_orava';
-    const BRAND_OLYMPUS = 'brand_olympus';
-    const BRAND_HYUNDAI = 'brand_hyundai';
-    const BRAND_NIKON = 'brand_nikon';
+    public const BRAND_APPLE = 'brand_apple';
+    public const BRAND_CANON = 'brand_canon';
+    public const BRAND_LG = 'brand_lg';
+    public const BRAND_PHILIPS = 'brand_philips';
+    public const BRAND_SENCOR = 'brand_sencor';
+    public const BRAND_A4TECH = 'brand_a4tech';
+    public const BRAND_BROTHER = 'brand_brother';
+    public const BRAND_VERBATIM = 'brand_verbatim';
+    public const BRAND_DLINK = 'brand_dlink';
+    public const BRAND_DEFENDER = 'brand_defender';
+    public const BRAND_DELONGHI = 'brand_delonghi';
+    public const BRAND_GENIUS = 'brand_genius';
+    public const BRAND_GIGABYTE = 'brand_gigabyte';
+    public const BRAND_HP = 'brand_hp';
+    public const BRAND_HTC = 'brand_htc';
+    public const BRAND_JURA = 'brand_jura';
+    public const BRAND_LOGITECH = 'brand_logitech';
+    public const BRAND_MICROSOFT = 'brand_microsoft';
+    public const BRAND_SAMSUNG = 'brand_samsung';
+    public const BRAND_SONY = 'brand_sony';
+    public const BRAND_ORAVA = 'brand_orava';
+    public const BRAND_OLYMPUS = 'brand_olympus';
+    public const BRAND_HYUNDAI = 'brand_hyundai';
+    public const BRAND_NIKON = 'brand_nikon';
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade */
     protected $brandFacade;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
@@ -11,17 +11,17 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 
 class CategoryDataFixture extends AbstractReferenceFixture
 {
-    const CATEGORY_ELECTRONICS = 'category_electronics';
-    const CATEGORY_TV = 'category_tv';
-    const CATEGORY_PHOTO = 'category_photo';
-    const CATEGORY_PRINTERS = 'category_printers';
-    const CATEGORY_PC = 'category_pc';
-    const CATEGORY_PHONES = 'category_phones';
-    const CATEGORY_COFFEE = 'category_coffee';
-    const CATEGORY_BOOKS = 'category_books';
-    const CATEGORY_TOYS = 'category_toys';
-    const CATEGORY_GARDEN_TOOLS = 'category_garden_tools';
-    const CATEGORY_FOOD = 'category_food';
+    public const CATEGORY_ELECTRONICS = 'category_electronics';
+    public const CATEGORY_TV = 'category_tv';
+    public const CATEGORY_PHOTO = 'category_photo';
+    public const CATEGORY_PRINTERS = 'category_printers';
+    public const CATEGORY_PC = 'category_pc';
+    public const CATEGORY_PHONES = 'category_phones';
+    public const CATEGORY_COFFEE = 'category_coffee';
+    public const CATEGORY_BOOKS = 'category_books';
+    public const CATEGORY_TOYS = 'category_toys';
+    public const CATEGORY_GARDEN_TOOLS = 'category_garden_tools';
+    public const CATEGORY_FOOD = 'category_food';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
@@ -10,8 +10,8 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 
 class CurrencyDataFixture extends AbstractReferenceFixture
 {
-    const CURRENCY_CZK = 'currency_czk';
-    const CURRENCY_EUR = 'currency_eur';
+    public const CURRENCY_CZK = 'currency_czk';
+    public const CURRENCY_EUR = 'currency_eur';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/FlagDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/FlagDataFixture.php
@@ -10,9 +10,9 @@ use Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade;
 
 class FlagDataFixture extends AbstractReferenceFixture
 {
-    const FLAG_NEW_PRODUCT = 'flag_new_product';
-    const FLAG_TOP_PRODUCT = 'flag_top_product';
-    const FLAG_ACTION_PRODUCT = 'flag_action';
+    public const FLAG_NEW_PRODUCT = 'flag_new_product';
+    public const FLAG_TOP_PRODUCT = 'flag_top_product';
+    public const FLAG_ACTION_PRODUCT = 'flag_action';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
@@ -15,9 +15,9 @@ use Symfony\Component\Finder\Finder;
 
 class ImageDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const IMAGES_TABLE_NAME = 'images';
+    public const IMAGES_TABLE_NAME = 'images';
 
-    const IMAGE_TYPE = 'jpg';
+    public const IMAGE_TYPE = 'jpg';
 
     /**
      * @var string

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainArticleDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainArticleDataFixture.php
@@ -15,9 +15,9 @@ use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
 
 class MultidomainArticleDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const ARTICLE_TERMS_AND_CONDITIONS = 'article_terms_and_conditions';
-    const ARTICLE_PRIVACY_POLICY = 'article_privacy_policy';
-    const ARTICLE_COOKIES = 'article_cookies';
+    public const ARTICLE_TERMS_AND_CONDITIONS = 'article_terms_and_conditions';
+    public const ARTICLE_PRIVACY_POLICY = 'article_privacy_policy';
+    public const ARTICLE_COOKIES = 'article_cookies';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainPricingGroupDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainPricingGroupDataFixture.php
@@ -14,8 +14,8 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 
 class MultidomainPricingGroupDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const PRICING_GROUP_ORDINARY_DOMAIN = 'pricing_group_ordinary_domain';
-    const PRICING_GROUP_VIP_DOMAIN = 'pricing_group_vip_domain';
+    public const PRICING_GROUP_ORDINARY_DOMAIN = 'pricing_group_ordinary_domain';
+    public const PRICING_GROUP_VIP_DOMAIN = 'pricing_group_vip_domain';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainSettingValueShopInfoDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainSettingValueShopInfoDataFixture.php
@@ -13,7 +13,7 @@ use Shopsys\FrameworkBundle\Model\ShopInfo\ShopInfoSettingFacade;
 
 class MultidomainSettingValueShopInfoDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const SETTING_VALUES = [
+    public const SETTING_VALUES = [
         ShopInfoSettingFacade::SHOP_INFO_PHONE_NUMBER => '+420123456789',
         ShopInfoSettingFacade::SHOP_INFO_PHONE_HOURS => '(po-pá, 10:00 - 16:00)',
         ShopInfoSettingFacade::SHOP_INFO_EMAIL => 'no-reply@shopsys.cz',

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/NewsletterSubscriberDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/NewsletterSubscriberDataFixture.php
@@ -8,7 +8,7 @@ use Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade;
 
 class NewsletterSubscriberDataFixture extends AbstractReferenceFixture
 {
-    const FIRST_DOMAIN_ID = 1;
+    public const FIRST_DOMAIN_ID = 1;
 
     /** @var \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade */
     protected $newsletterFacade;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
@@ -17,7 +17,7 @@ use Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory;
 
 class OrderDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const ORDER_PREFIX = 'order_';
+    public const ORDER_PREFIX = 'order_';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\UserRepository

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderStatusDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderStatusDataFixture.php
@@ -8,10 +8,10 @@ use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade;
 
 class OrderStatusDataFixture extends AbstractReferenceFixture
 {
-    const ORDER_STATUS_NEW = 'order_status_new';
-    const ORDER_STATUS_IN_PROGRESS = 'order_status_in_progress';
-    const ORDER_STATUS_DONE = 'order_status_done';
-    const ORDER_STATUS_CANCELED = 'order_status_canceled';
+    public const ORDER_STATUS_NEW = 'order_status_new';
+    public const ORDER_STATUS_IN_PROGRESS = 'order_status_in_progress';
+    public const ORDER_STATUS_DONE = 'order_status_done';
+    public const ORDER_STATUS_CANCELED = 'order_status_canceled';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PaymentDataFixture.php
@@ -12,9 +12,9 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 
 class PaymentDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const PAYMENT_CARD = 'payment_card';
-    const PAYMENT_CASH_ON_DELIVERY = 'payment_cash_on_delivery';
-    const PAYMENT_CASH = 'payment_cash';
+    public const PAYMENT_CARD = 'payment_card';
+    public const PAYMENT_CASH_ON_DELIVERY = 'payment_cash_on_delivery';
+    public const PAYMENT_CASH = 'payment_cash';
 
     /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade */
     protected $paymentFacade;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
@@ -10,8 +10,8 @@ use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade;
 
 class PersonalDataAccessRequestDataFixture extends AbstractReferenceFixture
 {
-    const REFERENCE_ACCESS_DISPLAY_REQUEST = 'reference_access_display_request';
-    const REFERENCE_ACCESS_EXPORT_REQUEST = 'reference_access_export_request';
+    public const REFERENCE_ACCESS_DISPLAY_REQUEST = 'reference_access_display_request';
+    public const REFERENCE_ACCESS_EXPORT_REQUEST = 'reference_access_export_request';
 
     /** @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade */
     protected $personalDataFacade;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PricingGroupDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PricingGroupDataFixture.php
@@ -11,9 +11,9 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 
 class PricingGroupDataFixture extends AbstractReferenceFixture
 {
-    const PRICING_GROUP_ORDINARY_DOMAIN_1 = 'pricing_group_ordinary_domain_1';
-    const PRICING_GROUP_PARTNER_DOMAIN_1 = 'pricing_group_partner_domain_1';
-    const PRICING_GROUP_VIP_DOMAIN_1 = 'pricing_group_vip_domain_1';
+    public const PRICING_GROUP_ORDINARY_DOMAIN_1 = 'pricing_group_ordinary_domain_1';
+    public const PRICING_GROUP_PARTNER_DOMAIN_1 = 'pricing_group_partner_domain_1';
+    public const PRICING_GROUP_VIP_DOMAIN_1 = 'pricing_group_vip_domain_1';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
@@ -14,7 +14,7 @@ use Shopsys\ShopBundle\DataFixtures\ProductDataFixtureReferenceInjector;
 
 class ProductDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const PRODUCT_PREFIX = 'product_';
+    public const PRODUCT_PREFIX = 'product_';
 
     /** @var \Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureLoader */
     protected $productDataFixtureLoader;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureLoader.php
@@ -12,30 +12,30 @@ use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
 
 class ProductDataFixtureLoader
 {
-    const COLUMN_NAME_CS = 0;
-    const COLUMN_NAME_EN = 1;
-    const COLUMN_CATNUM = 2;
-    const COLUMN_PARTNO = 3;
-    const COLUMN_EAN = 4;
-    const COLUMN_DESCRIPTION_CS = 5;
-    const COLUMN_DESCRIPTION_EN = 6;
-    const COLUMN_SHORT_DESCRIPTION_CS = 7;
-    const COLUMN_SHORT_DESCRIPTION_EN = 8;
-    const COLUMN_MANUAL_PRICES_DOMAIN_1 = 9;
-    const COLUMN_MANUAL_PRICES_DOMAIN_2 = 10;
-    const COLUMN_VAT = 11;
-    const COLUMN_SELLING_FROM = 12;
-    const COLUMN_SELLING_TO = 13;
-    const COLUMN_STOCK_QUANTITY = 14;
-    const COLUMN_UNIT = 15;
-    const COLUMN_AVAILABILITY = 16;
-    const COLUMN_PARAMETERS = 17;
-    const COLUMN_CATEGORIES_1 = 18;
-    const COLUMN_CATEGORIES_2 = 19;
-    const COLUMN_FLAGS = 20;
-    const COLUMN_SELLING_DENIED = 21;
-    const COLUMN_BRAND = 22;
-    const COLUMN_MAIN_VARIANT_CATNUM = 23;
+    protected const COLUMN_NAME_CS = 0;
+    protected const COLUMN_NAME_EN = 1;
+    protected const COLUMN_CATNUM = 2;
+    protected const COLUMN_PARTNO = 3;
+    protected const COLUMN_EAN = 4;
+    protected const COLUMN_DESCRIPTION_CS = 5;
+    protected const COLUMN_DESCRIPTION_EN = 6;
+    protected const COLUMN_SHORT_DESCRIPTION_CS = 7;
+    protected const COLUMN_SHORT_DESCRIPTION_EN = 8;
+    protected const COLUMN_MANUAL_PRICES_DOMAIN_1 = 9;
+    protected const COLUMN_MANUAL_PRICES_DOMAIN_2 = 10;
+    protected const COLUMN_VAT = 11;
+    protected const COLUMN_SELLING_FROM = 12;
+    protected const COLUMN_SELLING_TO = 13;
+    protected const COLUMN_STOCK_QUANTITY = 14;
+    protected const COLUMN_UNIT = 15;
+    protected const COLUMN_AVAILABILITY = 16;
+    protected const COLUMN_PARAMETERS = 17;
+    protected const COLUMN_CATEGORIES_1 = 18;
+    protected const COLUMN_CATEGORIES_2 = 19;
+    protected const COLUMN_FLAGS = 20;
+    protected const COLUMN_SELLING_DENIED = 21;
+    protected const COLUMN_BRAND = 22;
+    protected const COLUMN_MAIN_VARIANT_CATNUM = 23;
 
     /**
      * @var \Shopsys\ShopBundle\DataFixtures\Demo\ProductParametersFixtureLoader

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueShopInfoDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueShopInfoDataFixture.php
@@ -15,7 +15,7 @@ class SettingValueShopInfoDataFixture extends AbstractReferenceFixture
      */
     protected $setting;
 
-    const SETTING_VALUES = [
+    public const SETTING_VALUES = [
         ShopInfoSettingFacade::SHOP_INFO_PHONE_NUMBER => '+1-234-567-8989',
         ShopInfoSettingFacade::SHOP_INFO_PHONE_HOURS => '(Mon - Sat: 9 - 10 a.m. to 8 - 10 p.m.)',
         ShopInfoSettingFacade::SHOP_INFO_EMAIL => 'no-reply@shopsys.com',

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TransportDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TransportDataFixture.php
@@ -12,9 +12,9 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
 
 class TransportDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const TRANSPORT_CZECH_POST = 'transport_cp';
-    const TRANSPORT_PPL = 'transport_ppl';
-    const TRANSPORT_PERSONAL = 'transport_personal';
+    public const TRANSPORT_CZECH_POST = 'transport_cp';
+    public const TRANSPORT_PPL = 'transport_ppl';
+    public const TRANSPORT_PERSONAL = 'transport_personal';
 
     /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade */
     protected $transportFacade;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UnitDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UnitDataFixture.php
@@ -11,8 +11,8 @@ use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
 
 class UnitDataFixture extends AbstractReferenceFixture
 {
-    const UNIT_CUBIC_METERS = 'unit_m3';
-    const UNIT_PIECES = 'unit_pcs';
+    public const UNIT_CUBIC_METERS = 'unit_m3';
+    public const UNIT_PIECES = 'unit_pcs';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User;
 
 class UserDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    const USER_WITH_RESET_PASSWORD_HASH = 'user_with_reset_password_hash';
+    public const USER_WITH_RESET_PASSWORD_HASH = 'user_with_reset_password_hash';
 
     /** @var \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade */
     protected $customerFacade;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixtureLoader.php
@@ -14,29 +14,29 @@ use Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface;
 
 class UserDataFixtureLoader
 {
-    const COLUMN_FIRSTNAME = 0;
-    const COLUMN_LASTNAME = 1;
-    const COLUMN_EMAIL = 2;
-    const COLUMN_PASSWORD = 3;
-    const COLUMN_COMPANY_CUSTOMER = 4;
-    const COLUMN_COMPANY_NAME = 5;
-    const COLUMN_COMPANY_NUMBER = 6;
-    const COLUMN_COMPANY_TAX_NUMBER = 7;
-    const COLUMN_STREET = 8;
-    const COLUMN_CITY = 9;
-    const COLUMN_POSTCODE = 10;
-    const COLUMN_TELEPHONE = 11;
-    const COLUMN_COUNTRY = 12;
-    const COLUMN_DELIVERY_ADDRESS_FILLED = 13;
-    const COLUMN_DELIVERY_CITY = 14;
-    const COLUMN_DELIVERY_COMPANY_NAME = 15;
-    const COLUMN_DELIVERY_FIRST_NAME = 16;
-    const COLUMN_DELIVERY_LAST_NAME = 17;
-    const COLUMN_DELIVERY_POSTCODE = 18;
-    const COLUMN_DELIVERY_STREET = 19;
-    const COLUMN_DELIVERY_TELEPHONE = 20;
-    const COLUMN_DELIVERY_COUNTRY = 21;
-    const COLUMN_DOMAIN_ID = 22;
+    protected const COLUMN_FIRSTNAME = 0;
+    protected const COLUMN_LASTNAME = 1;
+    protected const COLUMN_EMAIL = 2;
+    protected const COLUMN_PASSWORD = 3;
+    protected const COLUMN_COMPANY_CUSTOMER = 4;
+    protected const COLUMN_COMPANY_NAME = 5;
+    protected const COLUMN_COMPANY_NUMBER = 6;
+    protected const COLUMN_COMPANY_TAX_NUMBER = 7;
+    protected const COLUMN_STREET = 8;
+    protected const COLUMN_CITY = 9;
+    protected const COLUMN_POSTCODE = 10;
+    protected const COLUMN_TELEPHONE = 11;
+    protected const COLUMN_COUNTRY = 12;
+    protected const COLUMN_DELIVERY_ADDRESS_FILLED = 13;
+    protected const COLUMN_DELIVERY_CITY = 14;
+    protected const COLUMN_DELIVERY_COMPANY_NAME = 15;
+    protected const COLUMN_DELIVERY_FIRST_NAME = 16;
+    protected const COLUMN_DELIVERY_LAST_NAME = 17;
+    protected const COLUMN_DELIVERY_POSTCODE = 18;
+    protected const COLUMN_DELIVERY_STREET = 19;
+    protected const COLUMN_DELIVERY_TELEPHONE = 20;
+    protected const COLUMN_DELIVERY_COUNTRY = 21;
+    protected const COLUMN_DOMAIN_ID = 22;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Csv\CsvReader

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/VatDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/VatDataFixture.php
@@ -12,10 +12,10 @@ use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 
 class VatDataFixture extends AbstractReferenceFixture
 {
-    const VAT_ZERO = 'vat_zero';
-    const VAT_SECOND_LOW = 'vat_second_low';
-    const VAT_LOW = 'vat_low';
-    const VAT_HIGH = 'vat_high';
+    public const VAT_ZERO = 'vat_zero';
+    public const VAT_SECOND_LOW = 'vat_second_low';
+    public const VAT_LOW = 'vat_low';
+    public const VAT_HIGH = 'vat_high';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CategoryDataFixture
 {
-    const FIRST_PERFORMANCE_CATEGORY = 'first_performance_category';
+    public const FIRST_PERFORMANCE_CATEGORY = 'first_performance_category';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
@@ -26,9 +26,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class OrderDataFixture
 {
-    const PERCENTAGE_OF_ORDERS_BY_REGISTERED_USERS = 25;
+    protected const PERCENTAGE_OF_ORDERS_BY_REGISTERED_USERS = 25;
 
-    const BATCH_SIZE = 10;
+    protected const BATCH_SIZE = 10;
 
     /**
      * @var int

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
@@ -22,9 +22,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProductDataFixture
 {
-    const BATCH_SIZE = 1000;
+    protected const BATCH_SIZE = 1000;
 
-    const FIRST_PERFORMANCE_PRODUCT = 'first_performance_product';
+    public const FIRST_PERFORMANCE_PRODUCT = 'first_performance_product';
 
     /**
      * @var int

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UserDataFixture
 {
-    const FIRST_PERFORMANCE_USER = 'first_performance_user';
+    public const FIRST_PERFORMANCE_USER = 'first_performance_user';
 
     /**
      * @var int

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/BillingAddressFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/BillingAddressFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints;
 
 class BillingAddressFormType extends AbstractType
 {
-    const VALIDATION_GROUP_COMPANY_CUSTOMER = 'companyCustomer';
+    public const VALIDATION_GROUP_COMPANY_CUSTOMER = 'companyCustomer';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\CountryFacade

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/DeliveryAddressFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/DeliveryAddressFormType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints;
 
 class DeliveryAddressFormType extends AbstractType
 {
-    const VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS = 'differentDeliveryAddress';
+    public const VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS = 'differentDeliveryAddress';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\CountryFacade

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
@@ -23,8 +23,8 @@ use Symfony\Component\Validator\Constraints;
 
 class PersonalInfoFormType extends AbstractType
 {
-    const VALIDATION_GROUP_COMPANY_CUSTOMER = 'companyCustomer';
-    const VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS = 'differentDeliveryAddress';
+    public const VALIDATION_GROUP_COMPANY_CUSTOMER = 'companyCustomer';
+    public const VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS = 'differentDeliveryAddress';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\CountryFacade

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerRegistrationCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerRegistrationCest.php
@@ -8,7 +8,7 @@ use Tests\ShopBundle\Test\Codeception\AcceptanceTester;
 
 class CustomerRegistrationCest
 {
-    const MINIMUM_FORM_SUBMIT_WAIT_TIME = 10;
+    protected const MINIMUM_FORM_SUBMIT_WAIT_TIME = 10;
 
     /**
      * @param \Tests\ShopBundle\Acceptance\acceptance\PageObject\Front\RegistrationPage $registrationPage

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/LoginPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/LoginPage.php
@@ -6,8 +6,8 @@ use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;
 
 class LoginPage extends AbstractPage
 {
-    const ADMIN_USERNAME = 'admin';
-    const ADMIN_PASSWORD = 'admin123';
+    public const ADMIN_USERNAME = 'admin';
+    public const ADMIN_PASSWORD = 'admin123';
 
     /**
      * @param string $username

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/ProductAdvancedSearchPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/ProductAdvancedSearchPage.php
@@ -8,7 +8,7 @@ use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;
 
 class ProductAdvancedSearchPage extends AbstractPage
 {
-    const SEARCH_SUBJECT_CATNUM = 'productCatnum';
+    public const SEARCH_SUBJECT_CATNUM = 'productCatnum';
 
     /**
      * @param string $searchSubject

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/OrderPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/OrderPage.php
@@ -6,7 +6,7 @@ use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;
 
 class OrderPage extends AbstractPage
 {
-    const FIRST_NAME_FIELD_NAME = 'order_personal_info_form[firstName]';
+    protected const FIRST_NAME_FIELD_NAME = 'order_personal_info_form[firstName]';
 
     /**
      * @param string $transportTitle

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductDetailPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductDetailPage.php
@@ -7,8 +7,8 @@ use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;
 
 class ProductDetailPage extends AbstractPage
 {
-    const PRODUCT_DETAIL_QUANTITY_INPUT = '.js-product-detail-main-add-to-cart-wrapper input[name="add_product_form[quantity]"]';
-    const PRODUCT_DETAIL_MAIN_WRAPPER = '.js-product-detail-main-add-to-cart-wrapper';
+    protected const PRODUCT_DETAIL_QUANTITY_INPUT = '.js-product-detail-main-add-to-cart-wrapper input[name="add_product_form[quantity]"]';
+    protected const PRODUCT_DETAIL_MAIN_WRAPPER = '.js-product-detail-main-add-to-cart-wrapper';
 
     /**
      * @param int $quantity

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductFilterPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductFilterPage.php
@@ -11,7 +11,7 @@ use Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver;
 class ProductFilterPage extends AbstractPage
 {
     // Product filter waits for more requests before evaluation
-    const PRE_EVALUATION_WAIT = 2;
+    protected const PRE_EVALUATION_WAIT = 2;
 
     /**
      * @param \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver $strictWebDriver

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PaymentImageUploadCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PaymentImageUploadCest.php
@@ -8,12 +8,12 @@ use Tests\ShopBundle\Test\Codeception\AcceptanceTester;
 
 class PaymentImageUploadCest
 {
-    const IMAGE_UPLOAD_FIELD_ID = 'payment_form_image_image_file';
-    const SAVE_BUTTON_NAME = 'payment_form[save]';
+    protected const IMAGE_UPLOAD_FIELD_ID = 'payment_form_image_image_file';
+    protected const SAVE_BUTTON_NAME = 'payment_form[save]';
 
-    const EXPECTED_SUCCESS_MESSAGE = 'Payment Credit card modified';
+    protected const EXPECTED_SUCCESS_MESSAGE = 'Payment Credit card modified';
 
-    const TEST_IMAGE_NAME = 'paymentTestImage.png';
+    protected const TEST_IMAGE_NAME = 'paymentTestImage.png';
 
     /**
      * @param \Tests\ShopBundle\Test\Codeception\AcceptanceTester $me

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/ProductImageUploadCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/ProductImageUploadCest.php
@@ -8,12 +8,12 @@ use Tests\ShopBundle\Test\Codeception\AcceptanceTester;
 
 class ProductImageUploadCest
 {
-    const IMAGE_UPLOAD_FIELD_ID = 'product_form_imageGroup_images_file';
-    const SAVE_BUTTON_NAME = 'product_form[save]';
+    protected const IMAGE_UPLOAD_FIELD_ID = 'product_form_imageGroup_images_file';
+    protected const SAVE_BUTTON_NAME = 'product_form[save]';
 
-    const EXPECTED_SUCCESS_MESSAGE = 'Product 22" Sencor SLE 22F46DM4 HELLO KITTY modified';
+    protected const EXPECTED_SUCCESS_MESSAGE = 'Product 22" Sencor SLE 22F46DM4 HELLO KITTY modified';
 
-    const TEST_IMAGE_NAME = 'productTestImage.png';
+    protected const TEST_IMAGE_NAME = 'productTestImage.png';
 
     /**
      * @param \Tests\ShopBundle\Test\Codeception\AcceptanceTester $me

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/TransportImageUploadCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/TransportImageUploadCest.php
@@ -8,12 +8,12 @@ use Tests\ShopBundle\Test\Codeception\AcceptanceTester;
 
 class TransportImageUploadCest
 {
-    const IMAGE_UPLOAD_FIELD_ID = 'transport_form_image_image_file';
-    const SAVE_BUTTON_NAME = 'transport_form[save]';
+    protected const IMAGE_UPLOAD_FIELD_ID = 'transport_form_image_image_file';
+    protected const SAVE_BUTTON_NAME = 'transport_form[save]';
 
-    const EXPECTED_SUCCESS_MESSAGE = 'Shipping Czech post was modified';
+    protected const EXPECTED_SUCCESS_MESSAGE = 'Shipping Czech post was modified';
 
-    const TEST_IMAGE_NAME = 'transportTestImage.png';
+    protected const TEST_IMAGE_NAME = 'transportTestImage.png';
 
     /**
      * @param \Tests\ShopBundle\Test\Codeception\AcceptanceTester $me

--- a/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Constant/Testclass.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Constant/Testclass.php
@@ -4,7 +4,7 @@ namespace Tests\ShopBundle\Functional\Component\Javascript\Compiler\Constant;
 
 class Testclass
 {
-    const FOO = 'bar';
+    public const FOO = 'bar';
 
-    const FOO2 = 'bar2';
+    public const FOO2 = 'bar2';
 }

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
@@ -30,17 +30,17 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class EntityExtensionTest extends TransactionFunctionalTestCase
 {
-    const MAIN_PRODUCT_ID = 1;
-    const ONE_TO_ONE_SELF_REFERENCING_PRODUCT_ID = 2;
-    const ONE_TO_MANY_SELF_REFERENCING_PRODUCT_ID = 3;
-    const MANY_TO_MANY_SELF_REFERENCING_PRODUCT_ID = 4;
+    protected const MAIN_PRODUCT_ID = 1;
+    protected const ONE_TO_ONE_SELF_REFERENCING_PRODUCT_ID = 2;
+    protected const ONE_TO_MANY_SELF_REFERENCING_PRODUCT_ID = 3;
+    protected const MANY_TO_MANY_SELF_REFERENCING_PRODUCT_ID = 4;
 
-    const MAIN_CATEGORY_ID = 1;
-    const ONE_TO_ONE_SELF_REFERENCING_CATEGORY_ID = 2;
-    const ONE_TO_MANY_SELF_REFERENCING_CATEGORY_ID = 3;
-    const MANY_TO_MANY_SELF_REFERENCING_CATEGORY_ID = 4;
+    protected const MAIN_CATEGORY_ID = 1;
+    protected const ONE_TO_ONE_SELF_REFERENCING_CATEGORY_ID = 2;
+    protected const ONE_TO_MANY_SELF_REFERENCING_CATEGORY_ID = 3;
+    protected const MANY_TO_MANY_SELF_REFERENCING_CATEGORY_ID = 4;
 
-    const ORDER_ITEM_ID = 1;
+    protected const ORDER_ITEM_ID = 1;
 
     /**
      * @var \Doctrine\ORM\EntityManager

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryDomainTest.php
@@ -9,11 +9,11 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class CategoryDomainTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
-    const DEMONSTRATIVE_SEO_TITLE = 'Demonstrative seo title';
-    const DEMONSTRATIVE_SEO_META_DESCRIPTION = 'Demonstrative seo description';
-    const DEMONSTRATIVE_SEO_H1 = 'Demonstrative seo H1';
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
+    protected const DEMONSTRATIVE_SEO_TITLE = 'Demonstrative seo title';
+    protected const DEMONSTRATIVE_SEO_META_DESCRIPTION = 'Demonstrative seo description';
+    protected const DEMONSTRATIVE_SEO_H1 = 'Demonstrative seo H1';
 
     /**
      * @var \Shopsys\ShopBundle\Model\Category\CategoryDataFactory

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
@@ -10,8 +10,8 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class CategoryRepositoryTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
 
     public function testDoNotGetCategoriesWithoutVisibleChildren()
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
@@ -9,7 +9,7 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class GetAllEmailsDataIteratorMethodTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_SUBSCRIBER_EMAIL = 'james.black@no-reply.com';
+    protected const FIRST_DOMAIN_SUBSCRIBER_EMAIL = 'james.black@no-reply.com';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterRepository

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
@@ -11,8 +11,8 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class IndependentPaymentVisibilityCalculationTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
 
     public function testIsIndependentlyVisible()
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentDomainTest.php
@@ -9,8 +9,8 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class PaymentDomainTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
 
     /**
      * @var \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Brand/BrandDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Brand/BrandDomainTest.php
@@ -9,10 +9,10 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class BrandDomainTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
-    const DEMONSTRATIVE_SEO_TITLE = 'Demonstrative seo title';
-    const DEMONSTRATIVE_SEO_H1 = 'Demonstrative seo h1';
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
+    protected const DEMONSTRATIVE_SEO_TITLE = 'Demonstrative seo title';
+    protected const DEMONSTRATIVE_SEO_H1 = 'Demonstrative seo h1';
 
     /**
      * @var \Shopsys\ShopBundle\Model\Product\Brand\BrandDataFactory

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductDomainTest.php
@@ -10,13 +10,13 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class ProductDomainTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
-    const DEMONSTRATIVE_DESCRIPTION = 'Demonstrative description';
-    const DEMONSTRATIVE_SEO_TITLE = 'Demonstrative seo title';
-    const DEMONSTRATIVE_SEO_META_DESCRIPTION = 'Demonstrative seo description';
-    const DEMONSTRATIVE_SEO_H1 = 'Demonstrative seo H1';
-    const DEMONSTRATIVE_SHORT_DESCRIPTION = 'Demonstrative short description';
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
+    protected const DEMONSTRATIVE_DESCRIPTION = 'Demonstrative description';
+    protected const DEMONSTRATIVE_SEO_TITLE = 'Demonstrative seo title';
+    protected const DEMONSTRATIVE_SEO_META_DESCRIPTION = 'Demonstrative seo description';
+    protected const DEMONSTRATIVE_SEO_H1 = 'Demonstrative seo H1';
+    protected const DEMONSTRATIVE_SHORT_DESCRIPTION = 'Demonstrative short description';
 
     /**
      * @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory

--- a/project-base/tests/ShopBundle/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
@@ -11,8 +11,8 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class IndependentTransportVisibilityCalculationTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
 
     public function testIsIndependentlyVisible()
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Transport/TransportDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Transport/TransportDomainTest.php
@@ -9,8 +9,8 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class TransportDomainTest extends TransactionFunctionalTestCase
 {
-    const FIRST_DOMAIN_ID = 1;
-    const SECOND_DOMAIN_ID = 2;
+    protected const FIRST_DOMAIN_ID = 1;
+    protected const SECOND_DOMAIN_ID = 2;
 
     /**
      * @var \Shopsys\ShopBundle\Model\Transport\TransportDataFactory

--- a/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
+++ b/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
@@ -25,9 +25,9 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class PersonalDataExportXmlTest extends TransactionFunctionalTestCase
 {
-    const EMAIL = 'no-reply@shopsys.com';
-    const EXPECTED_XML_FILE_NAME = 'test.xml';
-    const DOMAIN_ID_FIRST = Domain::FIRST_DOMAIN_ID;
+    protected const EMAIL = 'no-reply@shopsys.com';
+    protected const EXPECTED_XML_FILE_NAME = 'test.xml';
+    protected const DOMAIN_ID_FIRST = Domain::FIRST_DOMAIN_ID;
 
     public function testExportXml()
     {

--- a/project-base/tests/ShopBundle/Functional/Twig/NumberFormatterExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/NumberFormatterExtensionTest.php
@@ -9,7 +9,7 @@ use Tests\ShopBundle\Test\FunctionalTestCase;
 
 class NumberFormatterExtensionTest extends FunctionalTestCase
 {
-    const NBSP = "\xc2\xa0";
+    protected const NBSP = "\xc2\xa0";
 
     public function formatNumberDataProvider()
     {

--- a/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
@@ -13,7 +13,7 @@ use Tests\ShopBundle\Test\FunctionalTestCase;
 
 class PriceExtensionTest extends FunctionalTestCase
 {
-    const NBSP = "\xc2\xa0";
+    protected const NBSP = "\xc2\xa0";
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade

--- a/project-base/tests/ShopBundle/Performance/Feed/AllFeedsTest.php
+++ b/project-base/tests/ShopBundle/Performance/Feed/AllFeedsTest.php
@@ -15,9 +15,9 @@ use Tests\ShopBundle\Performance\JmeterCsvReporter;
 
 class AllFeedsTest extends KernelTestCase
 {
-    const ROUTE_NAME_GENERATE_FEED = 'admin_feed_generate';
-    const ADMIN_USERNAME = 'admin';
-    const ADMIN_PASSWORD = 'admin123';
+    public const ROUTE_NAME_GENERATE_FEED = 'admin_feed_generate';
+    public const ADMIN_USERNAME = 'admin';
+    public const ADMIN_PASSWORD = 'admin123';
 
     /**
      * @var int

--- a/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
+++ b/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
@@ -20,7 +20,7 @@ use Tests\ShopBundle\Smoke\Http\RouteConfigCustomization;
 
 class AllPagesTest extends KernelTestCase
 {
-    const PASSES = 5;
+    protected const PASSES = 5;
 
     protected function setUp()
     {

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQualifier.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQualifier.php
@@ -4,9 +4,9 @@ namespace Tests\ShopBundle\Performance\Page;
 
 class PerformanceTestSampleQualifier
 {
-    const STATUS_OK = 0;
-    const STATUS_WARNING = 1;
-    const STATUS_CRITICAL = 2;
+    public const STATUS_OK = 0;
+    public const STATUS_WARNING = 1;
+    public const STATUS_CRITICAL = 2;
 
     /**
      * @var int

--- a/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RouteConfigCustomization
 {
-    const DEFAULT_ID_VALUE = 1;
+    protected const DEFAULT_ID_VALUE = 1;
 
     /**
      * @var \Symfony\Component\DependencyInjection\ContainerInterface

--- a/project-base/tests/ShopBundle/Test/Codeception/AcceptanceTester.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/AcceptanceTester.php
@@ -22,8 +22,8 @@ use Tests\ShopBundle\Test\Codeception\_generated\AcceptanceTesterActions;
  */
 class AcceptanceTester extends Actor
 {
-    const DEFAULT_AJAX_TIMEOUT_SEC = 10;
-    const WAIT_TIMEOUT_SEC = 10;
+    protected const DEFAULT_AJAX_TIMEOUT_SEC = 10;
+    protected const WAIT_TIMEOUT_SEC = 10;
 
     use AcceptanceTesterActions;
 

--- a/project-base/tests/ShopBundle/Test/Codeception/Module/StrictWebDriver.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Module/StrictWebDriver.php
@@ -10,7 +10,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class StrictWebDriver extends WebDriver
 {
-    const WAIT_AFTER_CLICK_MICROSECONDS = 50000;
+    protected const WAIT_AFTER_CLICK_MICROSECONDS = 50000;
 
     /**
      * @param string[] $alternatives


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We need rules for class constants in framework and other packages to allow their extensibility from project. More description follows.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #827 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

In this PR is done several changes, all with the same goal to set some rules for constants.

# 1. Useless access annotation
Sniff disallowing access annotation in phpdoc was changed a little bit, so now it disallows only redundant access annotations. (`Shopsys\CodingStandards\CsFixer\Phpdoc\NoUselessAccessFixer`)
Meaning this is wrong
```php
/** @access protected */
protected const A = 'value';
```

but this is valid 
```php
/** @access protected */
const A = 'value';
```

This is done to keep backward compatibility with a possibility to mark somehow constants, that are meant to be "extendible".

# 2. Mandatory visibility for constants
Every constant have to have visibility defined with the access modifier or with `@access` annotation.
The first is recommended and in the future, the access annotation will not be present in the code at all.

# 3. Force late static binding for protected constants in packages
Constants in packages (framework, etc.) have to use protected constants with `static` keyword instead of self, so it's possible to, adjust the value only with extending the class and redefine the constant needed (with `self` is mandatory to extend all methods with the usages too).
