### PR TITLE
[framework] fix missing service in performance tests of feeds

### DIFF
--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -57,6 +57,11 @@ services:
 
     Shopsys\FrameworkBundle\Model\Feed\Delivery\DeliveryFeedItemRepository: ~
 
+    Shopsys\FrameworkBundle\Model\Feed\FeedRegistry:
+        arguments:
+            $knownTypes: ['daily', 'hourly']
+            $defaultType: 'daily'
+
     Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade:
         arguments:
             - '%shopsys.default_db_schema_filepath%'


### PR DESCRIPTION
`FeedRegistry` service is public in test environment now

It would be best if we wouldn't have to make every service that is taken from DIC in tests public. These copy-pasted service definitions can cause a lot of trouble. Either stop using the container directly (can we autowire services in integration tests?), or have all services public in test env by default (maybe via a compiler pass?)...

| Q             | A
| ------------- | ---
|Description, reason for the PR| Having the service private causes an error during the execution of `tests-performance` phing target. It is taken from the DIC directly in `AllFeedsTest::getAllFeedGenerationData`.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
