### PR TITLE
[shopsys] demonstrational extended code in project-base should have the final say over the parent method calls

### DIFF
--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -37,8 +37,9 @@ It is a common modification when you need your e-commerce application and ERP sy
          */
         protected function __construct(BaseProductData $productData, ProductCategoryDomainFactoryInterface $productCategoryDomainFactory, array $variants = null)
         {
-            $this->extId = $productData->extId ?? 0;
             parent::__construct($productData, $productCategoryDomainFactory, $variants);
+
+            $this->extId = $productData->extId ?? 0;
         }
 
         /**
@@ -203,8 +204,9 @@ The original `ProductFormType` is set as the extended type by implementation of 
         BaseProductData $productData,
         ProductPriceRecalculationScheduler $productPriceRecalculationScheduler
     ) {
-        $this->extId = $productData->extId;
         parent::edit($productCategoryDomainFactory, $productData, $productPriceRecalculationScheduler);
+
+        $this->extId = $productData->extId;
     }
     ```
 

--- a/project-base/src/Shopsys/ShopBundle/Model/Article/Article.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Article/Article.php
@@ -25,8 +25,9 @@ class Article extends BaseArticle
      */
     public function __construct(BaseArticleData $articleData)
     {
-        $this->createdAt = $articleData->createdAt ?? new DateTime();
         parent::__construct($articleData);
+
+        $this->createdAt = $articleData->createdAt ?? new DateTime();
     }
 
     /**
@@ -34,8 +35,9 @@ class Article extends BaseArticle
      */
     public function edit(BaseArticleData $articleData)
     {
-        $this->createdAt = $articleData->createdAt ?? new DateTime();
         parent::edit($articleData);
+
+        $this->createdAt = $articleData->createdAt ?? new DateTime();
     }
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/Model/Article/ArticleData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Article/ArticleData.php
@@ -14,7 +14,8 @@ class ArticleData extends BaseArticleData
 
     public function __construct()
     {
-        $this->createdAt = new DateTime();
         parent::__construct();
+
+        $this->createdAt = new DateTime();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When adding a new attribute to an entity or a data object, developers should call the parent methods first, and then add the extended code so it has the final say. This should avoid unexpected behavior if there were some manipulations with the given attribute in the parent class.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
