### PR TITLE
[framework] Entity factories now all uses EntityNameResolver

### DIFF
--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -25,7 +25,7 @@ There you can find links to upgrade notes for other versions too.
     - ProductVisibilityFactory
     - ScriptFactory
     - SliderItemFactory
-    
-    In case of extending one of these classes, you should add a `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
+
+    In case of extending one of these classes, you should add an `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -12,5 +12,20 @@ There you can find links to upgrade notes for other versions too.
     - `CronFacade::__construct(Logger $logger, CronConfig $cronConfig, CronModuleFacade $cronModuleFacade, Mailer $mailer)`
     - `Mailer::__construct(Swift_Mailer $swiftMailer, Swift_Transport $realSwiftTransport)`
     - find all usages of the constructors and fix them
+- `EntityNameResolver` was added into constructor of these classes: ([#918](https://github.com/shopsys/shopsys/pull/918))
+    - CronModuleFactory
+    - PersistentReferenceFactory
+    - ImageFactory
+    - FriendlyUrlFactory
+    - SettingValueFactory
+    - UploadedFileFactory
+    - AdministratorGridLimitFactory
+    - EnabledModuleFactory
+    - ProductCategoryDomainFactory
+    - ProductVisibilityFactory
+    - ScriptFactory
+    - SliderItemFactory
+    
+    In case of extending one of these classes, you should add a `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/src/Component/Cron/CronModuleFactory.php
+++ b/packages/framework/src/Component/Cron/CronModuleFactory.php
@@ -2,14 +2,31 @@
 
 namespace Shopsys\FrameworkBundle\Component\Cron;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class CronModuleFactory implements CronModuleFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param string $serviceId
      * @return \Shopsys\FrameworkBundle\Component\Cron\CronModule
      */
     public function create(string $serviceId): CronModule
     {
-        return new CronModule($serviceId);
+        $classData = $this->entityNameResolver->resolve(CronModule::class);
+
+        return new $classData($serviceId);
     }
 }

--- a/packages/framework/src/Component/DataFixture/PersistentReferenceFactory.php
+++ b/packages/framework/src/Component/DataFixture/PersistentReferenceFactory.php
@@ -2,8 +2,23 @@
 
 namespace Shopsys\FrameworkBundle\Component\DataFixture;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class PersistentReferenceFactory implements PersistentReferenceFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param string $referenceName
      * @param string $entityName
@@ -15,6 +30,8 @@ class PersistentReferenceFactory implements PersistentReferenceFactoryInterface
         string $entityName,
         int $entityId
     ): PersistentReference {
-        return new PersistentReference($referenceName, $entityName, $entityId);
+        $classData = $this->entityNameResolver->resolve(PersistentReference::class);
+
+        return new $classData($referenceName, $entityName, $entityId);
     }
 }

--- a/packages/framework/src/Component/Image/ImageFactory.php
+++ b/packages/framework/src/Component/Image/ImageFactory.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
 use Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor;
@@ -19,13 +20,23 @@ class ImageFactory implements ImageFactoryInterface
     protected $fileUpload;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor $imageProcessor
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      */
-    public function __construct(ImageProcessor $imageProcessor, FileUpload $fileUpload)
-    {
+    public function __construct(
+        ImageProcessor $imageProcessor,
+        FileUpload $fileUpload,
+        EntityNameResolver $entityNameResolver
+    ) {
         $this->imageProcessor = $imageProcessor;
         $this->fileUpload = $fileUpload;
+        $this->entityNameResolver = $entityNameResolver;
     }
 
     /**
@@ -44,7 +55,9 @@ class ImageFactory implements ImageFactoryInterface
         $temporaryFilePath = $this->fileUpload->getTemporaryFilepath($temporaryFilename);
         $convertedFilePath = $this->imageProcessor->convertToShopFormatAndGetNewFilename($temporaryFilePath);
 
-        return new Image($entityName, $entityId, $type, $convertedFilePath);
+        $classData = $this->entityNameResolver->resolve(Image::class);
+
+        return new $classData($entityName, $entityId, $type, $convertedFilePath);
     }
 
     /**

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
@@ -3,10 +3,16 @@
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
@@ -14,10 +20,14 @@ class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      */
-    public function __construct(Domain $domain)
-    {
+    public function __construct(
+        Domain $domain,
+        EntityNameResolver $entityNameResolver
+    ) {
         $this->domain = $domain;
+        $this->entityNameResolver = $entityNameResolver;
     }
 
     /**
@@ -33,7 +43,9 @@ class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
         int $domainId,
         string $slug
     ): FriendlyUrl {
-        return new FriendlyUrl($routeName, $entityId, $domainId, $slug);
+        $classData = $this->entityNameResolver->resolve(FriendlyUrl::class);
+
+        return new $classData($routeName, $entityId, $domainId, $slug);
     }
 
     /**

--- a/packages/framework/src/Component/Setting/SettingValueFactory.php
+++ b/packages/framework/src/Component/Setting/SettingValueFactory.php
@@ -2,8 +2,23 @@
 
 namespace Shopsys\FrameworkBundle\Component\Setting;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class SettingValueFactory implements SettingValueFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param string $name
      * @param \DateTime|string|int|float|bool|null $value
@@ -15,6 +30,8 @@ class SettingValueFactory implements SettingValueFactoryInterface
         $value,
         int $domainId
     ): SettingValue {
-        return new SettingValue($name, $value, $domainId);
+        $classData = $this->entityNameResolver->resolve(SettingValue::class);
+
+        return new $classData($name, $value, $domainId);
     }
 }

--- a/packages/framework/src/Component/UploadedFile/UploadedFileFactory.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileFactory.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\UploadedFile;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 
 class UploadedFileFactory implements UploadedFileFactoryInterface
@@ -12,11 +13,20 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
     protected $fileUpload;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
      */
-    public function __construct(FileUpload $fileUpload)
-    {
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        FileUpload $fileUpload,
+        EntityNameResolver $entityNameResolver
+    ) {
         $this->fileUpload = $fileUpload;
+        $this->entityNameResolver = $entityNameResolver;
     }
 
     /**
@@ -32,6 +42,8 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
     ): UploadedFile {
         $temporaryFilepath = $this->fileUpload->getTemporaryFilepath(array_pop($temporaryFilenames));
 
-        return new UploadedFile($entityName, $entityId, pathinfo($temporaryFilepath, PATHINFO_BASENAME));
+        $classData = $this->entityNameResolver->resolve(UploadedFile::class);
+
+        return new $classData($entityName, $entityId, pathinfo($temporaryFilepath, PATHINFO_BASENAME));
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorGridLimitFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorGridLimitFactory.php
@@ -2,8 +2,23 @@
 
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class AdministratorGridLimitFactory implements AdministratorGridLimitFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
      * @param string $gridId
@@ -12,6 +27,8 @@ class AdministratorGridLimitFactory implements AdministratorGridLimitFactoryInte
      */
     public function create(Administrator $administrator, string $gridId, int $limit): AdministratorGridLimit
     {
-        return new AdministratorGridLimit($administrator, $gridId, $limit);
+        $classData = $this->entityNameResolver->resolve(AdministratorGridLimit::class);
+
+        return new $classData($administrator, $gridId, $limit);
     }
 }

--- a/packages/framework/src/Model/Module/EnabledModuleFactory.php
+++ b/packages/framework/src/Model/Module/EnabledModuleFactory.php
@@ -2,14 +2,31 @@
 
 namespace Shopsys\FrameworkBundle\Model\Module;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class EnabledModuleFactory implements EnabledModuleFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param string $name
      * @return \Shopsys\FrameworkBundle\Model\Module\EnabledModule
      */
     public function create(string $name): EnabledModule
     {
-        return new EnabledModule($name);
+        $classData = $this->entityNameResolver->resolve(EnabledModule::class);
+
+        return new $classData($name);
     }
 }

--- a/packages/framework/src/Model/Product/ProductCategoryDomainFactory.php
+++ b/packages/framework/src/Model/Product/ProductCategoryDomainFactory.php
@@ -2,10 +2,24 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class ProductCategoryDomainFactory implements ProductCategoryDomainFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
@@ -17,6 +31,8 @@ class ProductCategoryDomainFactory implements ProductCategoryDomainFactoryInterf
         Category $category,
         int $domainId
     ): ProductCategoryDomain {
-        return new ProductCategoryDomain($product, $category, $domainId);
+        $classData = $this->entityNameResolver->resolve(ProductCategoryDomain::class);
+
+        return new $classData($product, $category, $domainId);
     }
 }

--- a/packages/framework/src/Model/Product/ProductVisibilityFactory.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityFactory.php
@@ -2,10 +2,24 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 
 class ProductVisibilityFactory implements ProductVisibilityFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
@@ -17,6 +31,8 @@ class ProductVisibilityFactory implements ProductVisibilityFactoryInterface
         PricingGroup $pricingGroup,
         int $domainId
     ): ProductVisibility {
-        return new ProductVisibility($product, $pricingGroup, $domainId);
+        $classData = $this->entityNameResolver->resolve(ProductVisibility::class);
+
+        return new $classData($product, $pricingGroup, $domainId);
     }
 }

--- a/packages/framework/src/Model/Script/ScriptFactory.php
+++ b/packages/framework/src/Model/Script/ScriptFactory.php
@@ -2,14 +2,31 @@
 
 namespace Shopsys\FrameworkBundle\Model\Script;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class ScriptFactory implements ScriptFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Script\ScriptData $data
      * @return \Shopsys\FrameworkBundle\Model\Script\Script
      */
     public function create(ScriptData $data): Script
     {
-        return new Script($data);
+        $classData = $this->entityNameResolver->resolve(Script::class);
+
+        return new $classData($data);
     }
 }

--- a/packages/framework/src/Model/Slider/SliderItemFactory.php
+++ b/packages/framework/src/Model/Slider/SliderItemFactory.php
@@ -2,14 +2,31 @@
 
 namespace Shopsys\FrameworkBundle\Model\Slider;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class SliderItemFactory implements SliderItemFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemData $data
      * @return \Shopsys\FrameworkBundle\Model\Slider\SliderItem
      */
     public function create(SliderItemData $data): SliderItem
     {
-        return new SliderItem($data);
+        $classData = $this->entityNameResolver->resolve(SliderItem::class);
+
+        return new $classData($data);
     }
 }

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleRepositoryTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleRepositoryTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Cron\CronModule;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleFactory;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleRepository;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 
 class CronModuleRepositoryTest extends TestCase
 {
@@ -16,7 +17,7 @@ class CronModuleRepositoryTest extends TestCase
         $doctrineRepositoryMock = $this->createNullDoctrineRepositoryMock();
         $em = $this->createEntityManagerMockWithRepository($doctrineRepositoryMock);
 
-        $repository = new CronModuleRepository($em, new CronModuleFactory());
+        $repository = new CronModuleRepository($em, new CronModuleFactory(new EntityNameResolver([])));
         $cronModule = $repository->getCronModuleByServiceId('serviceId');
         $this->assertInstanceOf(CronModule::class, $cronModule);
     }

--- a/packages/framework/tests/Unit/Component/DataFixture/PersistentReferenceFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/DataFixture/PersistentReferenceFacadeTest.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReference;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFactory;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceRepository;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use stdClass;
 
@@ -31,7 +32,7 @@ class PersistentReferenceFacadeTest extends TestCase
         $persistentReferenceFacade = new PersistentReferenceFacade(
             $emMock,
             $persistentReferenceRepositoryMock,
-            new PersistentReferenceFactory()
+            new PersistentReferenceFactory(new EntityNameResolver([]))
         );
         $this->expectException(\Shopsys\FrameworkBundle\Component\DataFixture\Exception\MethodGetIdDoesNotExistException::class);
         $persistentReferenceFacade->persistReference('referenceName', new stdClass());
@@ -64,7 +65,7 @@ class PersistentReferenceFacadeTest extends TestCase
         $persistentReferenceFacade = new PersistentReferenceFacade(
             $emMock,
             $persistentReferenceRepositoryMock,
-            new PersistentReferenceFactory()
+            new PersistentReferenceFactory(new EntityNameResolver([]))
         );
         $persistentReferenceFacade->persistReference('newReferenceName', $productMock);
     }
@@ -92,7 +93,7 @@ class PersistentReferenceFacadeTest extends TestCase
         $persistentReferenceFacade = new PersistentReferenceFacade(
             $emMock,
             $persistentReferenceRepositoryMock,
-            new PersistentReferenceFactory()
+            new PersistentReferenceFactory(new EntityNameResolver([]))
         );
 
         $this->assertSame($expectedObject, $persistentReferenceFacade->getReference('referenceName'));
@@ -120,7 +121,7 @@ class PersistentReferenceFacadeTest extends TestCase
         $persistentReferenceFacade = new PersistentReferenceFacade(
             $emMock,
             $persistentReferenceRepositoryMock,
-            new PersistentReferenceFactory()
+            new PersistentReferenceFactory(new EntityNameResolver([]))
         );
 
         $this->expectException(\Shopsys\FrameworkBundle\Component\DataFixture\Exception\EntityNotFoundException::class);

--- a/packages/framework/tests/Unit/Component/Image/ImageFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Image/ImageFactoryTest.php
@@ -7,6 +7,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Image;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileNamingConvention;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
@@ -25,7 +26,7 @@ class ImageFactoryTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $imageFactory = new ImageFactory($imageProcessorMock, $this->getFileUpload());
+        $imageFactory = new ImageFactory($imageProcessorMock, $this->getFileUpload(), new EntityNameResolver([]));
 
         $this->expectException(\Shopsys\FrameworkBundle\Component\Image\Exception\EntityMultipleImageException::class);
         $imageFactory->createMultiple($imageEntityConfig, 1, 'type', []);
@@ -45,7 +46,7 @@ class ImageFactoryTest extends TestCase
                 return pathinfo($filepath, PATHINFO_BASENAME);
             });
 
-        $imageFactory = new ImageFactory($imageProcessorMock, $this->getFileUpload());
+        $imageFactory = new ImageFactory($imageProcessorMock, $this->getFileUpload(), new EntityNameResolver([]));
         $images = $imageFactory->createMultiple($imageEntityConfig, 1, 'type', $filenames);
 
         $this->assertCount(2, $images);
@@ -68,7 +69,7 @@ class ImageFactoryTest extends TestCase
             ->getMock();
         $imageProcessorMock->expects($this->any())->method('convertToShopFormatAndGetNewFilename')->willReturn($filename);
 
-        $imageFactory = new ImageFactory($imageProcessorMock, $this->getFileUpload());
+        $imageFactory = new ImageFactory($imageProcessorMock, $this->getFileUpload(), new EntityNameResolver([]));
         $image = $imageFactory->create($imageEntityConfig->getEntityName(), 1, 'type', $filename);
         $temporaryFiles = $image->getTemporaryFilesForUpload();
 

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
@@ -7,6 +7,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Router\FriendlyUrl;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactory;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
@@ -21,7 +22,7 @@ class FriendlyUrlFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($domainConfigs, $settingMock);
 
-        $friendlyUrlFactory = new FriendlyUrlFactory($domain);
+        $friendlyUrlFactory = new FriendlyUrlFactory($domain, new EntityNameResolver([]));
 
         $routeName = 'route_name';
         $entityId = 7;

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Router\FriendlyUrl;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactory;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlUniqueResultFactory;
@@ -20,7 +21,7 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($domainConfigs, $settingMock);
 
-        $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain));
+        $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain, new EntityNameResolver([])));
 
         $attempt = 1;
         $friendlyUrl = new FriendlyUrl('route_name', 7, 1, 'name');
@@ -44,7 +45,7 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($domainConfigs, $settingMock);
 
-        $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain));
+        $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain, new EntityNameResolver([])));
 
         $attempt = 1;
         $friendlyUrl = new FriendlyUrl('route_name', 7, 1, 'name');
@@ -71,7 +72,7 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($domainConfigs, $settingMock);
 
-        $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain));
+        $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain, new EntityNameResolver([])));
 
         $attempt = 3;
         $friendlyUrl = new FriendlyUrl('route_name', 7, 1, 'name');

--- a/packages/framework/tests/Unit/Component/UploadedFile/UploadedFileFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/UploadedFile/UploadedFileFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Component\UploadedFile;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFactory;
 
@@ -26,7 +27,7 @@ class UploadedFileFactoryTest extends TestCase
             ->with($this->equalTo($temporaryFilename))
             ->willReturn($temporaryFilepath);
 
-        $uploadedFileFactory = new UploadedFileFactory($fileUploadMock);
+        $uploadedFileFactory = new UploadedFileFactory($fileUploadMock, new EntityNameResolver([]));
         $uploadedFile = $uploadedFileFactory->create($entityName, $entityId, $temporaryFilenames);
         $filesForUpload = $uploadedFile->getTemporaryFilesForUpload();
         $fileForUpload = array_pop($filesForUpload);

--- a/packages/framework/tests/Unit/Model/Cart/CartTest.php
+++ b/packages/framework/tests/Unit/Model/Cart/CartTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Cart;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
@@ -34,12 +35,12 @@ class CartTest extends TestCase
         $productData1 = new ProductData();
         $productData1->name = ['cs' => 'Product 1'];
         $productData1->vat = $vat;
-        $product1 = Product::create($productData1, new ProductCategoryDomainFactory());
+        $product1 = Product::create($productData1, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productData2 = new ProductData();
         $productData2->name = ['cs' => 'Product 2'];
         $productData2->vat = $vat;
-        $product2 = Product::create($productData2, new ProductCategoryDomainFactory());
+        $product2 = Product::create($productData2, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $cart = new Cart($customerIdentifier->getCartIdentifier());
 
@@ -72,7 +73,7 @@ class CartTest extends TestCase
         $productData = new ProductData();
         $productData->name = ['cs' => 'Product 1'];
         $productData->vat = $vat;
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $cart = new Cart($customerIdentifier->getCartIdentifier());
 
@@ -93,12 +94,12 @@ class CartTest extends TestCase
         $productData1 = new ProductData();
         $productData1->name = ['cs' => 'Product 1'];
         $productData1->vat = $vat;
-        $product1 = Product::create($productData1, new ProductCategoryDomainFactory());
+        $product1 = Product::create($productData1, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productData2 = new ProductData();
         $productData2->name = ['cs' => 'Product 2'];
         $productData2->vat = $vat;
-        $product2 = Product::create($productData2, new ProductCategoryDomainFactory());
+        $product2 = Product::create($productData2, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $cart = new Cart($customerIdentifier->getCartIdentifier());
 

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderItemTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderItemTest.php
@@ -6,6 +6,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Order\Item;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\MainVariantCannotBeOrderedException;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\WrongItemTypeException;
@@ -146,8 +147,8 @@ class OrderItemTest extends TestCase
 
     public function testConstructWithMainVariantThrowsException()
     {
-        $variant = Product::create(new ProductData(), new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant(new ProductData(), new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create(new ProductData(), new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant(new ProductData(), new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->expectException(MainVariantCannotBeOrderedException::class);
 

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
@@ -4,6 +4,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Order\Item;
 
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Module\ModuleFacade;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItem;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderProductFacade;
@@ -29,7 +30,7 @@ class OrderProductFacadeTest extends TestCase
         $productData = new ProductData();
         $productData->usingStock = true;
         $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $productPrice = Price::zero();
 
         $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
@@ -51,7 +52,7 @@ class OrderProductFacadeTest extends TestCase
         $productData = new ProductData();
         $productData->usingStock = false;
         $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $productPrice = Price::zero();
 
         $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
@@ -73,7 +74,7 @@ class OrderProductFacadeTest extends TestCase
         $productData = new ProductData();
         $productData->usingStock = true;
         $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $productPrice = Price::zero();
 
         $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
@@ -95,7 +96,7 @@ class OrderProductFacadeTest extends TestCase
         $productData = new ProductData();
         $productData->usingStock = false;
         $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $productPrice = Price::zero();
 
         $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);

--- a/packages/framework/tests/Unit/Model/Product/BestsellingProduct/BestsellingProductCombinatorTest.php
+++ b/packages/framework/tests/Unit/Model/Product/BestsellingProduct/BestsellingProductCombinatorTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Product\BestsellingProduct;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData;
 use Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\BestsellingProductCombinator;
@@ -25,11 +26,11 @@ class BestsellingProductCombinatorTest extends TestCase
         $productData = new ProductData();
         $productData->name = ['cs' => 'Product 1'];
         $productData->vat = $vat;
-        $product1 = Product::create($productData, new ProductCategoryDomainFactory());
-        $product2 = Product::create($productData, new ProductCategoryDomainFactory());
-        $product3 = Product::create($productData, new ProductCategoryDomainFactory());
-        $product4 = Product::create($productData, new ProductCategoryDomainFactory());
-        $product5 = Product::create($productData, new ProductCategoryDomainFactory());
+        $product1 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product2 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product3 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product4 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product5 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $manualProductsIndexedByPosition = [
             0 => $product1,

--- a/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Product\Pricing;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
@@ -76,8 +77,8 @@ class ProductPriceCalculationTest extends TestCase
         $pricingGroupData->name = 'name';
         $pricingGroup = new PricingGroup($pricingGroupData, 1);
 
-        $variant = Product::create(new ProductData(), new ProductCategoryDomainFactory());
-        $product = Product::createMainVariant(new ProductData(), new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create(new ProductData(), new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product = Product::createMainVariant(new ProductData(), new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->expectException(\Shopsys\FrameworkBundle\Model\Product\Pricing\Exception\MainVariantPriceCalculationException::class);
 

--- a/packages/framework/tests/Unit/Model/Product/ProductFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Product/ProductFactoryTest.php
@@ -24,14 +24,14 @@ class ProductFactoryTest extends TestCase
      */
     protected function setUp()
     {
-        $this->productFactory = new ProductFactory(new EntityNameResolver([]), $this->getProductAvailabilityCalculationMock(), new ProductCategoryDomainFactory());
+        $this->productFactory = new ProductFactory(new EntityNameResolver([]), $this->getProductAvailabilityCalculationMock(), new ProductCategoryDomainFactory(new EntityNameResolver([])));
         parent::setUp();
     }
 
     public function testCreateVariant()
     {
         $mainVariantData = new ProductData();
-        $mainProduct = Product::create(new ProductData(), new ProductCategoryDomainFactory());
+        $mainProduct = Product::create(new ProductData(), new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $variants = [];
 
         $mainVariant = $this->productFactory->createMainVariant($mainVariantData, $mainProduct, $variants);

--- a/packages/framework/tests/Unit/Model/Product/ProductTest.php
+++ b/packages/framework/tests/Unit/Model/Product/ProductTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Product;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactory;
@@ -13,7 +14,7 @@ class ProductTest extends TestCase
     public function testNoVariant()
     {
         $productData = new ProductData();
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $this->assertFalse($product->isVariant());
         $this->assertFalse($product->isMainVariant());
@@ -22,8 +23,8 @@ class ProductTest extends TestCase
     public function testIsVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->assertTrue($variant->isVariant());
         $this->assertFalse($variant->isMainVariant());
@@ -32,8 +33,8 @@ class ProductTest extends TestCase
     public function testIsMainVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->assertFalse($mainVariant->isVariant());
         $this->assertTrue($mainVariant->isMainVariant());
@@ -42,8 +43,8 @@ class ProductTest extends TestCase
     public function testGetMainVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->assertSame($mainVariant, $variant->getMainVariant());
     }
@@ -51,7 +52,7 @@ class ProductTest extends TestCase
     public function testGetMainVariantException()
     {
         $productData = new ProductData();
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $this->expectException(\Shopsys\FrameworkBundle\Model\Product\Exception\ProductIsNotVariantException::class);
         $product->getMainVariant();
@@ -59,7 +60,7 @@ class ProductTest extends TestCase
 
     public function testCreateVariantFromVariantException()
     {
-        $productCategoryDomainFactory = new ProductCategoryDomainFactory();
+        $productCategoryDomainFactory = new ProductCategoryDomainFactory(new EntityNameResolver([]));
         $productData = new ProductData();
         $variant = Product::create($productData, $productCategoryDomainFactory);
         $variant2 = Product::create($productData, $productCategoryDomainFactory);
@@ -72,7 +73,7 @@ class ProductTest extends TestCase
 
     public function testCreateVariantFromMainVariantException()
     {
-        $productCategoryDomainFactory = new ProductCategoryDomainFactory();
+        $productCategoryDomainFactory = new ProductCategoryDomainFactory(new EntityNameResolver([]));
         $productData = new ProductData();
         $variant = Product::create($productData, $productCategoryDomainFactory);
         $variant2 = Product::create($productData, $productCategoryDomainFactory);
@@ -85,7 +86,7 @@ class ProductTest extends TestCase
 
     public function testCreateMainVariantFromVariantException()
     {
-        $productCategoryDomainFactory = new ProductCategoryDomainFactory();
+        $productCategoryDomainFactory = new ProductCategoryDomainFactory(new EntityNameResolver([]));
         $productData = new ProductData();
         $variant = Product::create($productData, $productCategoryDomainFactory);
         $variant2 = Product::create($productData, $productCategoryDomainFactory);
@@ -99,7 +100,7 @@ class ProductTest extends TestCase
 
     public function testAddSelfAsVariantException()
     {
-        $productCategoryDomainFactory = new ProductCategoryDomainFactory();
+        $productCategoryDomainFactory = new ProductCategoryDomainFactory(new EntityNameResolver([]));
         $productData = new ProductData();
         $variant = Product::create($productData, $productCategoryDomainFactory);
         $mainVariant = Product::createMainVariant($productData, $productCategoryDomainFactory, [$variant]);
@@ -111,7 +112,7 @@ class ProductTest extends TestCase
     public function testMarkForVisibilityRecalculation()
     {
         $productData = new ProductData();
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $product->markForVisibilityRecalculation();
         $this->assertTrue($product->isMarkedForVisibilityRecalculation());
     }
@@ -119,8 +120,8 @@ class ProductTest extends TestCase
     public function testMarkForVisibilityRecalculationMainVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
         $mainVariant->markForVisibilityRecalculation();
         $this->assertTrue($mainVariant->isMarkedForVisibilityRecalculation());
         $this->assertTrue($variant->isMarkedForVisibilityRecalculation());
@@ -129,8 +130,8 @@ class ProductTest extends TestCase
     public function testMarkForVisibilityRecalculationVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
         $variant->markForVisibilityRecalculation();
         $this->assertTrue($variant->isMarkedForVisibilityRecalculation());
         $this->assertTrue($mainVariant->isMarkedForVisibilityRecalculation());
@@ -139,7 +140,7 @@ class ProductTest extends TestCase
     public function testDeleteResultNotVariant()
     {
         $productData = new ProductData();
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $this->assertEmpty($product->getProductDeleteResult()->getProductsForRecalculations());
     }
@@ -147,8 +148,8 @@ class ProductTest extends TestCase
     public function testDeleteResultVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->assertSame([$mainVariant], $variant->getProductDeleteResult()->getProductsForRecalculations());
     }
@@ -156,8 +157,8 @@ class ProductTest extends TestCase
     public function testDeleteResultMainVariant()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->assertEmpty($mainVariant->getProductDeleteResult()->getProductsForRecalculations());
         $this->assertFalse($variant->isVariant());
@@ -171,16 +172,16 @@ class ProductTest extends TestCase
         $productPriceRecalculationSchedulerMock->expects($this->once())->method('scheduleProductForImmediateRecalculation');
 
         $productData = new ProductData();
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
-        $product->edit(new ProductCategoryDomainFactory(), $productData, $productPriceRecalculationSchedulerMock);
+        $product->edit(new ProductCategoryDomainFactory(new EntityNameResolver([])), $productData, $productPriceRecalculationSchedulerMock);
     }
 
     public function testCheckIsNotMainVariantException()
     {
         $productData = new ProductData();
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant]);
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $this->expectException(\Shopsys\FrameworkBundle\Model\Product\Exception\ProductIsAlreadyMainVariantException::class);
         $mainVariant->checkIsNotMainVariant();
@@ -189,13 +190,13 @@ class ProductTest extends TestCase
     public function testRefreshVariants()
     {
         $productData = new ProductData();
-        $variant1 = Product::create($productData, new ProductCategoryDomainFactory());
-        $variant2 = Product::create($productData, new ProductCategoryDomainFactory());
-        $variant3 = Product::create($productData, new ProductCategoryDomainFactory());
-        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(), [$variant1, $variant2]);
+        $variant1 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $variant2 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $variant3 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $mainVariant = Product::createMainVariant($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant1, $variant2]);
 
         $currentVariants = [$variant2, $variant3];
-        $mainVariant->refreshVariants($currentVariants, new ProductCategoryDomainFactory());
+        $mainVariant->refreshVariants($currentVariants, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $variantsArray = $mainVariant->getVariants();
 

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
@@ -39,8 +40,8 @@ class CartItemTest extends TransactionFunctionalTestCase
         $productData->availability = $availability;
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);
 
-        $product1 = Product::create($productData, new ProductCategoryDomainFactory());
-        $product2 = Product::create($productData, new ProductCategoryDomainFactory());
+        $product1 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product2 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
         $em->persist($vat);
         $em->persist($availability);
         $em->persist($product1);

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
@@ -3,6 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
 use ReflectionClass;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
@@ -41,8 +42,8 @@ class CartTest extends TransactionFunctionalTestCase
         $productData->vat = $vat;
         $productData->availability = $availability;
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);
-        $product1 = Product::create($productData, new ProductCategoryDomainFactory());
-        $product2 = Product::create($productData, new ProductCategoryDomainFactory());
+        $product1 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+        $product2 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $cart = new Cart($customerIdentifier->getCartIdentifier());
 
@@ -139,7 +140,7 @@ class CartTest extends TransactionFunctionalTestCase
         $productData->name = ['cs' => 'Any name'];
         $productData->price = $price;
         $productData->vat = $vat;
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         return $product;
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php
@@ -3,6 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Cart\Watcher;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
@@ -96,7 +97,7 @@ class CartWatcherTest extends TransactionFunctionalTestCase
         $vatData->name = 'vat';
         $vatData->percent = 21;
         $productData->vat = new Vat($vatData);
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $cartItemMock = $this->getMockBuilder(CartItem::class)
             ->disableOriginalConstructor()

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/ProductManualInputPriceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/ProductManualInputPriceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\ShopBundle\Functional\Model\Pricing;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
@@ -45,7 +46,7 @@ class ProductManualInputPriceTest extends TransactionFunctionalTestCase
         $productData = $producDataFactory->create();
         $productData->vat = $vat;
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productManualInputPrice = new ProductManualInputPrice($product, $pricingGroup, Money::create(1000));
         $inputPriceType = $pricingSetting->getInputPriceType();
@@ -79,7 +80,7 @@ class ProductManualInputPriceTest extends TransactionFunctionalTestCase
         $productData = $productDataFactory->create();
         $productData->vat = $vat;
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productManualInputPrice = new ProductManualInputPrice($product, $pricingGroup, Money::create(1000));
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Product\Availability;
 
 use Doctrine\ORM\EntityManager;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityCalculation;
@@ -44,7 +45,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $productData->outOfStockAction = $outOfStockAction;
         $productData->outOfStockAvailability = $outOfStockAvailability;
 
-        $product = Product::create($productData, new ProductCategoryDomainFactory());
+        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $availabilityFacadeMock = $this->getMockBuilder(AvailabilityFacade::class)
             ->setMethods(['getDefaultInStockAvailability'])
@@ -129,19 +130,19 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $productData = $productDataFactory->create();
 
         $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK);
-        $variant1 = Product::create($productData, new ProductCategoryDomainFactory());
+        $variant1 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_ON_REQUEST);
-        $variant2 = Product::create($productData, new ProductCategoryDomainFactory());
+        $variant2 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_OUT_OF_STOCK);
-        $variant3 = Product::create($productData, new ProductCategoryDomainFactory());
+        $variant3 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_PREPARING);
-        $variant4 = Product::create($productData, new ProductCategoryDomainFactory());
+        $variant4 = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
         $variants = [$variant1, $variant2, $variant3, $variant4];
-        $mainVariant = Product::createMainVariant($productDataFactory->create(), new ProductCategoryDomainFactory(), $variants);
+        $mainVariant = Product::createMainVariant($productDataFactory->create(), new ProductCategoryDomainFactory(new EntityNameResolver([])), $variants);
 
         $availabilityFacadeMock = $this->createMock(AvailabilityFacade::class);
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
@@ -179,9 +180,9 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
 
         $productData = $productDataFactory->create();
         $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_ON_REQUEST);
-        $variant = Product::create($productData, new ProductCategoryDomainFactory());
+        $variant = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
 
-        $mainVariant = Product::createMainVariant($productDataFactory->create(), new ProductCategoryDomainFactory(), [$variant]);
+        $mainVariant = Product::createMainVariant($productDataFactory->create(), new ProductCategoryDomainFactory(new EntityNameResolver([])), [$variant]);
 
         $availabilityFacadeMock = $this->getMockBuilder(AvailabilityFacade::class)
             ->setMethods(['getDefaultInStockAvailability'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| All entity factories should use EntityNameResolver as was decided here #622 
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md) | Yes
|Fixes issues| close #622 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
