### PR TITLE
[framework] cron: Error page: don't log fake exception after generate error page

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -578,12 +578,17 @@ services:
             - '@twig'
             - '%kernel.debug%'
 
-    Shopsys\FrameworkBundle\Component\Error\NotLogFakeHttpExceptionsExceptionListener:
+    Shopsys\FrameworkBundle\Component\Error\NotLogFakeHttpExceptionsExceptionListener: '@twig.exception_listener'
+
+    twig.exception_listener:
+        class: Shopsys\FrameworkBundle\Component\Error\NotLogFakeHttpExceptionsExceptionListener
         tags:
+            - { name: 'kernel.event_subscriber' }
             - { name: 'monolog.logger', channel: 'request' }
         arguments:
             - '%twig.exception_listener.controller%'
             - '@?logger'
+            - '%kernel.debug%'
 
     twig.stringloader:
         class: Twig_Loader_Array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fake exception that is used for generating error pages is written to logs and it shouldn't be
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

After you run `php bin/console shopsys:cron --module="Shopsys\FrameworkBundle\Component\Error\ErrorPageCronModule"` in `PRODUCTION` mode, then is logged exeption: 
```
request.CRITICAL: Uncaught PHP Exception Shopsys\FrameworkBundle\Component\Error\Exception\FakeHttpException: "" at /var/www/html/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php line 66 {"exception":"[object] (Shopsys\\FrameworkBundle\\Component\\Error\\Exception\\FakeHttpException(code: 0):  at /var/www/html/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php:66)
```

I fixed this error in our project and it seems as ok.