### PR TITLE
Revert "only failing versions of better-phpdoc-parser are set as conflicting"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
   },
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
-    "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
+    "symplify/better-phpdoc-parser": ">=5.4.14",
     "twig/twig": "2.6.1"
   },
   "scripts": {

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -26,7 +26,7 @@
         "symplify/easy-coding-standard-tester": "^5.2.17"
     },
     "conflict": {
-        "symplify/better-phpdoc-parser": "5.4.14|5.4.15"
+        "symplify/better-phpdoc-parser": ">=5.4.14"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| During release of 7.1.0 were only versions 5.4.14 and 5.4.15 of better-phpdoc-parser set as conflicting, but after split the original problem reappeared on the Travis
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
