### PR TITLE
[docs] admin locale is now recommended to be changed in parameters_common.yml

### DIFF
--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -67,7 +67,7 @@ See how to install Shopsys Framework in production and how to proceed when deplo
 
 ## How to set up the administration with a different locale/language (e.g. Czech)?
 The administration uses `en` locale by default.
-If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `parameters.yml` configuration.
+If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `parameters_common.yml` configuration.
 However, the selected locale has to be one of registered domains locale.
 This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
 

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -129,8 +129,9 @@ This means that if you are using a different locale, these multilang attributes 
 #### 3.6 Locale in administration
 Administration is by default in `en` locale.
 This means that for example product list in administration tries to display translations of product names in `en` locale.
-If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `parameters.yml` configuration to desired locale.
+If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `parameters_common.yml` configuration to desired locale.
 However, the selected locale has to be one of registered domains locale.
+When you change admin locale, you have to update acceptance tests, to have administration use cases tested properly.
 
 You can change administration translations by adding messages into your `src/Shopsys/ShopBundle/Resources/translations/messages.xx.po`.
 

--- a/docs/upgrade/UPGRADE-v7.0.0-beta6.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta6.md
@@ -180,7 +180,7 @@ for instance:
     - if you have extended `CountryController` revise your changes – `new` and `edit` actions were added
     - rename `CountryDataFixture::COUNTRY_CZECH_REPUBLIC_1` constant to `CountryDataFixture::COUNTRY_CZECH_REPUBLIC`
 - if you have extended `Localization` class, you have to add type-hints to extended methods because they were added in the parent class ([#806](https://github.com/shopsys/shopsys/pull/806))
-    - if you have extended method `Localization::getAdminLocale()` only to have administration in a different language than english, you can delete it and set parameter `shopsys.admin_locale` in your `parameters.yml` file instead
+    - if you have extended method `Localization::getAdminLocale()` only to have administration in a different language than english, you can delete it and set parameter `shopsys.admin_locale` in your `parameters_common.yml` file instead
 - fixed JS validation of forms in popup windows ([#782](https://github.com/shopsys/shopsys/pull/782))
     - login form in popup is now loaded via AJAX
     - in `window.js` add options `textHeading = ''` and `cssClassHeading: ''` to `var defaults` like this:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In documentation, we advised to change admin locale (the language of the administration) in a `parameters.yml` configuration file. This file should be used for environment dependent configurations as database credentials, Redis host, etc. `parameters.yml` file is ignored by git resulting in the need for every developer to set the locale itself. It makes more sense to have the language set in `parameters_common.yml` file, as usually is no need to have the administration in a different language in production and on (for example) a developer machine.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
