### PR TITLE
Remove zoopy.cz from reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Shopsys Framework is fully functional e-commerce platform with all basic functio
 
 ## Sites Built on Shopsys Framework
 List of typical projects built on previous versions of Shopsys Framework:
-* [Zoopy](https://www.zoopy.cz/)
 * [Prumex](https://www.prumex.cz/)
 * [Elektro Vlášek](https://www.elektrovlasek.cz/)
 * [AB COM CZECH](https://www.ab-com.cz/)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| As you can see on https://www.zoopy.cz/, this eshop is blocked. I think it's not good reference link to dysfunctional eshop. Judge yourself.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| ...
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
