### PR TITLE
[project-base] Use redis standard prefix delimiter

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -9,8 +9,8 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 ### Configuration
- - *(low priority)* Use standard format for redis prefixes (#928)
-    - change prefixes in `app/config/packages/snc_redis.yml` and `app/config/packages/test/snc_redis.yml`. Please find inspiration in https://github.com/shopsys/shopsys/pull/928/files
+ - *(low priority)* use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))
+    - change prefixes in `app/config/packages/snc_redis.yml` and `app/config/packages/test/snc_redis.yml`. Please find inspiration in [#928](https://github.com/shopsys/shopsys/pull/928/files)
 
     **Be careful, this upgrade will remove sessions**
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -6,3 +6,11 @@ This guide contains instructions to upgrade from version v7.1.0 to Unreleased.
 There you can find links to upgrade notes for other versions too.
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
+
+## [shopsys/framework]
+### Configuration
+ - *(low priority)* Use standard format for redis prefixes (#928)
+    - change prefixes in `app/config/packages/snc_redis.yml` and `app/config/packages/test/snc_redis.yml`. Please find inspiration in https://github.com/shopsys/shopsys/pull/928/files
+
+    **Be careful, this upgrade will remove sessions**
+

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -5,12 +5,13 @@ This guide contains instructions to upgrade from version v7.1.0 to Unreleased.
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
-[Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
-
 ## [shopsys/framework]
 ### Configuration
  - *(low priority)* use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))
     - change prefixes in `app/config/packages/snc_redis.yml` and `app/config/packages/test/snc_redis.yml`. Please find inspiration in [#928](https://github.com/shopsys/shopsys/pull/928/files)
+    - once you finish this change, you still should deal with older redis cache keys that don't use new prefixes. Such keys are not removed even by `clean-redis-old`, please find and remove them manually (via console or UI)
 
     **Be careful, this upgrade will remove sessions**
 
+
+[Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD

--- a/project-base/app/config/packages/snc_redis.yml
+++ b/project-base/app/config/packages/snc_redis.yml
@@ -5,19 +5,19 @@ snc_redis:
             alias: 'bestselling_products'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%bestselling_products_'
+                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:bestselling_products:'
         doctrine_metadata:
             type: 'phpredis'
             alias: 'doctrine_metadata'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%doctrine_metadata_'
+                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:metadata:'
         doctrine_query:
             type: 'phpredis'
             alias: 'doctrine_query'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%doctrine_query_'
+                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:query:'
         global:
             type: 'phpredis'
             alias: 'global'
@@ -30,4 +30,4 @@ snc_redis:
             dsn: 'redis://%redis_host%'
     session:
         client: 'session'
-        prefix: '%env(REDIS_PREFIX)%session_'
+        prefix: '%env(REDIS_PREFIX)%session:'

--- a/project-base/app/config/packages/test/snc_redis.yml
+++ b/project-base/app/config/packages/test/snc_redis.yml
@@ -5,4 +5,4 @@ snc_redis:
             alias: 'test'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%:test:'
+                prefix: '%env(REDIS_PREFIX)%test:'

--- a/project-base/app/config/packages/test/snc_redis.yml
+++ b/project-base/app/config/packages/test/snc_redis.yml
@@ -5,4 +5,4 @@ snc_redis:
             alias: 'test'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%test_'
+                prefix: '%env(REDIS_PREFIX)%:test:'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Redis prefixes should use standard format that is described here https://redis.io/topics/data-types-intro
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes