### PR TITLE
[shopsys] use redis for doctrine and framework cache

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -131,7 +131,7 @@ There you can find links to upgrade notes for other versions too.
     +   id: shopsys.doctrine.cache_driver.metadata_cache
     query_cache_driver:
         type: service
-    -   id: Doctrine\Common\Cache\RedisCache
+    -   id: Doctrine\Common\Cache\ChainCache
     +   id: shopsys.doctrine.cache_driver.query_cache
     ```
     - update `app/config/packages/test/doctrine.yml`:

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -104,7 +104,7 @@ There you can find links to upgrade notes for other versions too.
             rules:
         ```
     - check and update also all parent proxy servers for each project
-- *(low priority)* use redis as cache for doctrine and framework ([#930](https://github.com/shopsys/shopsys/pull/930))
+- use redis as cache for doctrine and framework ([#930](https://github.com/shopsys/shopsys/pull/930))
     - update `app/config/packages/framework.yml`:
     ```diff
     framework:

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -127,7 +127,7 @@ There you can find links to upgrade notes for other versions too.
     ```diff
     metadata_cache_driver:
         type: service
-    -   id: Doctrine\Common\Cache\RedisCache
+    -   id: Doctrine\Common\Cache\ChainCache
     +   id: shopsys.doctrine.cache_driver.metadata_cache
     query_cache_driver:
         type: service

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -104,6 +104,56 @@ There you can find links to upgrade notes for other versions too.
             rules:
         ```
     - check and update also all parent proxy servers for each project
+- *(low priority)* use redis as cache for doctrine and framework ([#930](https://github.com/shopsys/shopsys/pull/928))
+    - update `app/config/packages/framework.yml`:
+    ```diff
+    framework:
+    +    annotations:
+    +        cache: shopsys.framework.cache_driver.annotations_cache
+    ```
+    - update `app/config/packages/snc_redis.yml`:
+    ```diff
+    snc_redis:
+        clients:
+            ...
+    +       framework_annotations:
+    +           type: 'phpredis'
+    +           alias: 'framework_annotations'
+    +           dsn: 'redis://%redis_host%'
+    +           options:
+    +               prefix: '%env(REDIS_PREFIX)%%build-version%:cache:framework:annotations:'
+    ```
+    - update `app/config/packages/doctrine.yml`:
+    ```diff
+    metadata_cache_driver:
+        type: service
+    -   id: Doctrine\Common\Cache\RedisCache
+    +   id: shopsys.doctrine.cache_driver.metadata_cache
+    query_cache_driver:
+        type: service
+    -   id: Doctrine\Common\Cache\RedisCache
+    +   id: shopsys.doctrine.cache_driver.query_cache
+    ```
+    - update `app/config/packages/test/doctrine.yml`:
+    ```diff
+    doctrine:
+        ...
+    +   orm:
+    +       metadata_cache_driver:
+    +           type: service
+    +           id: Doctrine\Common\Cache\ArrayCache
+    +       query_cache_driver:
+    +           type: service
+    +           id: Doctrine\Common\Cache\ArrayCache
+    ```
+    - update `app/config/packages/dev/doctrine.yml`:
+    ```diff
+    doctrine:
+        orm:
+            auto_generate_proxy_classes: true
+    -       metadata_cache_driver: array
+    -       query_cache_driver: array
+    ```
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -104,7 +104,7 @@ There you can find links to upgrade notes for other versions too.
             rules:
         ```
     - check and update also all parent proxy servers for each project
-- *(low priority)* use redis as cache for doctrine and framework ([#930](https://github.com/shopsys/shopsys/pull/928))
+- *(low priority)* use redis as cache for doctrine and framework ([#930](https://github.com/shopsys/shopsys/pull/930))
     - update `app/config/packages/framework.yml`:
     ```diff
     framework:

--- a/packages/framework/src/Component/Doctrine/Cache/FallbackCacheFactory.php
+++ b/packages/framework/src/Component/Doctrine/Cache/FallbackCacheFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Component\Doctrine\Cache;
+
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\RedisCache;
+use Exception;
+use Redis;
+
+class FallbackCacheFactory
+{
+    /**
+     * @param \Redis $redis
+     * @return \Doctrine\Common\Cache\CacheProvider
+     */
+    public function create(Redis $redis)
+    {
+        try {
+            $redisCache = new RedisCache();
+            $redisCache->setRedis($redis);
+
+            return $redisCache;
+        } catch (Exception $exception) {
+        }
+
+        return new ArrayCache();
+    }
+}

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -113,6 +113,12 @@ services:
                 - '@Doctrine\Common\Cache\ArrayCache'
                 - '@shopsys.shop.component.doctrine.cache.metadata.redis_cache'
 
+    shopsys.framework.cache_driver.annotations_cache:
+        class: Doctrine\Common\Cache\RedisCache
+        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
+        arguments:
+            - '@snc_redis.framework_annotations'
+
     Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider: ~
 
     Shopsys\FrameworkBundle\Model\AdminNavigation\SideMenuBuilder:

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -98,24 +98,20 @@ services:
             - '@annotation_reader'
 
     shopsys.doctrine.cache_driver.query_cache:
-        class: Doctrine\Common\Cache\ChainCache
-        arguments:
-            -
-                - '@Doctrine\Common\Cache\ArrayCache'
-                - '@shopsys.shop.component.doctrine.cache.query.redis_cache'
-
-    Doctrine\Common\Cache\ArrayCache: ~
-
-    shopsys.doctrine.cache_driver.metadata_cache:
-        class: Doctrine\Common\Cache\ChainCache
-        arguments:
-            -
-                - '@Doctrine\Common\Cache\ArrayCache'
-                - '@shopsys.shop.component.doctrine.cache.metadata.redis_cache'
-
-    shopsys.framework.cache_driver.annotations_cache:
         class: Doctrine\Common\Cache\RedisCache
         factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
+        arguments:
+            - '@snc_redis.doctrine_query'
+
+    shopsys.doctrine.cache_driver.metadata_cache:
+        class: Doctrine\Common\Cache\CacheProvider
+        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\FallbackCacheFactory:create'
+        arguments:
+            - '@snc_redis.doctrine_metadata'
+
+    shopsys.framework.cache_driver.annotations_cache:
+        class: Doctrine\Common\Cache\CacheProvider
+        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\FallbackCacheFactory:create'
         arguments:
             - '@snc_redis.framework_annotations'
 
@@ -168,18 +164,6 @@ services:
 
     Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade:
         public: true
-
-    shopsys.shop.component.doctrine.cache.metadata.redis_cache:
-        class: Doctrine\Common\Cache\RedisCache
-        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
-        arguments:
-            - '@snc_redis.doctrine_metadata'
-
-    shopsys.shop.component.doctrine.cache.query.redis_cache:
-        class: Doctrine\Common\Cache\RedisCache
-        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
-        arguments:
-            - '@snc_redis.doctrine_query'
 
     Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade:
         arguments:

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -4,6 +4,8 @@ services:
         autoconfigure: true
         public: true
 
+    Doctrine\Common\Cache\ArrayCache: ~
+
     Shopsys\FrameworkBundle\Component\Domain\DomainFactory:
         class: Shopsys\FrameworkBundle\Component\Domain\DomainFactoryOverwritingDomainUrl
         arguments:

--- a/project-base/app/config/packages/dev/doctrine.yml
+++ b/project-base/app/config/packages/dev/doctrine.yml
@@ -1,5 +1,3 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: true
-        metadata_cache_driver: array
-        query_cache_driver: array

--- a/project-base/app/config/packages/doctrine.yml
+++ b/project-base/app/config/packages/doctrine.yml
@@ -24,10 +24,10 @@ doctrine:
         naming_strategy: doctrine.orm.naming_strategy.underscore
         metadata_cache_driver:
             type: service
-            id: Doctrine\Common\Cache\ChainCache
+            id: shopsys.doctrine.cache_driver.metadata_cache
         query_cache_driver:
             type: service
-            id: Doctrine\Common\Cache\ChainCache
+            id: shopsys.doctrine.cache_driver.query_cache
         auto_mapping: false
         mappings:
             ShopsysFrameworkBundle:

--- a/project-base/app/config/packages/framework.yml
+++ b/project-base/app/config/packages/framework.yml
@@ -1,4 +1,6 @@
 framework:
+    annotations:
+        cache: shopsys.framework.cache_driver.annotations_cache
     secret: "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"

--- a/project-base/app/config/packages/snc_redis.yml
+++ b/project-base/app/config/packages/snc_redis.yml
@@ -17,7 +17,13 @@ snc_redis:
             alias: 'doctrine_query'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:query:'
+              prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:query:'
+        framework_annotations:
+            type: 'phpredis'
+            alias: 'framework_annotations'
+            dsn: 'redis://%redis_host%'
+            options:
+                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:framework:annotations:'
         global:
             type: 'phpredis'
             alias: 'global'

--- a/project-base/app/config/packages/snc_redis.yml
+++ b/project-base/app/config/packages/snc_redis.yml
@@ -17,7 +17,7 @@ snc_redis:
             alias: 'doctrine_query'
             dsn: 'redis://%redis_host%'
             options:
-              prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:query:'
+                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:query:'
         framework_annotations:
             type: 'phpredis'
             alias: 'framework_annotations'

--- a/project-base/app/config/packages/test/doctrine.yml
+++ b/project-base/app/config/packages/test/doctrine.yml
@@ -5,3 +5,10 @@ doctrine:
         dbname: "%test_database_name%"
         user: "%test_database_user%"
         password: "%test_database_password%"
+    orm:
+        metadata_cache_driver:
+            type: service
+            id: Doctrine\Common\Cache\ArrayCache
+        query_cache_driver:
+            type: service
+            id: Doctrine\Common\Cache\ArrayCache


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Moving doctrine and framework cache to redis storage will increase performance.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
