### PR TITLE
[project-base] fixed: translations are now extracted also from overwritten templates in `app/Resources`

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -53,6 +53,24 @@ There you can find links to upgrade notes for other versions too.
     - once you finish this change, you still should deal with older redis cache keys that don't use new prefixes. Such keys are not removed even by `clean-redis-old`, please find and remove them manually (via console or UI)
 
     **Be careful, this upgrade will remove sessions**
+- in order to have translations extracted even from overwritten templates update your `build-dev.xml` file accordingly ([#931](https://github.com/shopsys/shopsys/pull/931)):
+    ```diff
+        <target name="dump-translations-project-base" description="Extracts translatable messages from all source files in project base.">
+            <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                <arg value="${path.bin-console}" />
+                <arg value="translation:extract" />
+                <arg value="--bundle=ShopsysShopBundle" />
+                <arg value="--dir=${path.src}/Shopsys/ShopBundle" />
+    +           <arg value="--dir=${path.app}/Resources" />
+                <arg value="--exclude-dir=frontend/plugins" />
+                <arg value="--output-format=po" />
+                <arg value="--output-dir=${path.src}/Shopsys/ShopBundle/Resources/translations" />
+                <arg value="--keep" />
+                <arg value="cs" />
+                <arg value="en" />
+            </exec>
+        </target>
+    ```
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -54,6 +54,7 @@
             <arg value="translation:extract" />
             <arg value="--bundle=ShopsysShopBundle" />
             <arg value="--dir=${path.src}/Shopsys/ShopBundle" />
+            <arg value="--dir=${path.app}/Resources" />
             <arg value="--exclude-dir=frontend/plugins" />
             <arg value="--output-format=po" />
             <arg value="--output-dir=${path.src}/Shopsys/ShopBundle/Resources/translations" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were no translations extracted from overwritten templates
|New feature|No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
