### PR TITLE
[shopsys] phing target test-db-demo now exports products into elasticsearch with different index

### DIFF
--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -115,7 +115,7 @@ The command is designed to be run only during the first creation of the database
 Drops all data in the database and creates a new one with demo data.
 
 #### test-db-demo
-Drops all data in the test database and creates a new one with demo data.
+Drops all data in the test database and creates a new one with demo data and exports products to elasticsearch test index.
 
 *Note: All database related targets `db-*` have their `test-db-*` variant for the test database.*
 

--- a/docs/introduction/running-acceptance-tests.md
+++ b/docs/introduction/running-acceptance-tests.md
@@ -68,7 +68,7 @@ Sometimes you may want to debug individual test without running the whole accept
 
 ### Prepare database dump and switch to TEST environment
 ```
-# create test database and fill it with demo data and exports products to elasticsearch test index
+# create test database and fill it with demo data and export products to elasticsearch test index
 php phing test-db-demo
 
 # create test database dump with current data which will be restored before each test

--- a/docs/introduction/running-acceptance-tests.md
+++ b/docs/introduction/running-acceptance-tests.md
@@ -68,7 +68,7 @@ Sometimes you may want to debug individual test without running the whole accept
 
 ### Prepare database dump and switch to TEST environment
 ```
-# create test database and fill it with demo data
+# create test database and fill it with demo data and exports products to elasticsearch test index
 php phing test-db-demo
 
 # create test database dump with current data which will be restored before each test

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -29,11 +29,11 @@ There you can find links to upgrade notes for other versions too.
     In case of extending one of these classes, you should add an `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
 
 ### Tools
-- Improve `build-dev.xml` to use test prefix for elasticsearch in tests ([#933](https://github.com/shopsys/shopsys/pull/933))
+- improve `build-dev.xml` to use test prefix for elasticsearch in tests ([#933](https://github.com/shopsys/shopsys/pull/933))
    - add `test-product-search-recreate-structure,test-product-search-export-products` to the end of `test-db-demo` phing target in your `build-dev.xml`
    - add new phing targets:
         ```xml
-        <target name="test-product-search-recreate-structure" depends="test-product-search-delete-structure,test-product-search-create-structure" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)" />
+        <target name="test-product-search-recreate-structure" depends="test-product-search-delete-structure,test-product-search-create-structure" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)." />
         ```
         and
         ```xml

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -28,4 +28,38 @@ There you can find links to upgrade notes for other versions too.
 
     In case of extending one of these classes, you should add an `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
 
+### Tools
+- Improve `build-dev.xml` to use test prefix for elasticsearch in tests ([#933](https://github.com/shopsys/shopsys/pull/933))
+   - add `test-product-search-recreate-structure,test-product-search-export-products` to the end of `test-db-demo` phing target in your `build-dev.xml`
+   - add new phing targets:
+        ```xml
+        <target name="test-product-search-recreate-structure" depends="test-product-search-delete-structure,test-product-search-create-structure" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)" />
+        ```
+        and
+        ```xml
+        <target name="test-product-search-create-structure" description="Creates structure for searching via elasticsearch for test environment.">
+            <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                <arg value="${path.bin-console}" />
+                <arg value="--env=test" />
+                <arg value="shopsys:product-search:create-structure" />
+            </exec>
+        </target>
+
+        <target name="test-product-search-delete-structure" description="Deletes structure for searching via elasticsearch for test environment.">
+            <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                <arg value="${path.bin-console}" />
+                <arg value="--env=test" />
+                <arg value="shopsys:product-search:delete-structure" />
+            </exec>
+        </target>
+
+        <target name="test-product-search-export-products" description="Exports all products for searching via elasticsearch for test environment.">
+            <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                <arg value="${path.bin-console}" />
+                <arg value="--env=test" />
+                <arg value="shopsys:product-search:export-products" />
+            </exec>
+        </target>
+        ```
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -176,3 +176,12 @@ services:
     Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade:
         arguments:
             - '@shopsys.shop.component.flash_message.sender.front'
+
+    Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository:
+        arguments:
+            $indexPrefix: 'test-%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
+
+    Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager:
+        arguments:
+            - '%shopsys.elasticsearch.structure_dir%'
+            - 'test-%env(ELASTIC_SEARCH_INDEX_PREFIX)%'

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -16,7 +16,7 @@
     <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check" description="Checks coding standards."/>
     <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff" description="Checks coding standards on changed files."/>
 
-    <target name="test-db-demo" depends="clean,redis-check,clean-redis,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-create-domains-data,test-db-fixtures-demo,test-generate-friendly-urls,test-load-plugin-demo-data,test-replace-domains-urls,test-product-search-recreate-structure,test-product-search-export-products" description="Drops all data in test database and creates a new one with demo data."/>
+    <target name="test-db-demo" depends="clean,redis-check,clean-redis,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-create-domains-data,test-db-fixtures-demo,test-generate-friendly-urls,test-load-plugin-demo-data,test-replace-domains-urls,test-product-search-recreate-structure,test-product-search-export-products" description="Drops all data in test database and creates a new one with demo data and exports products to elasticsearch test index."/>
     <target name="test-db-performance" depends="test-db-demo,test-db-fixtures-performance" description="Drops all data in test database and creates a new one with performance data."/>
     <target name="tests-static" depends="tests-unit" description="Runs unit tests."/>
     <target name="tests" depends="test-db-demo,tests-static,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests on a newly built test database."/>

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -16,12 +16,13 @@
     <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-lint,eslint-check" description="Checks coding standards."/>
     <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-lint,eslint-check-diff" description="Checks coding standards on changed files."/>
 
-    <target name="test-db-demo" depends="clean,redis-check,clean-redis,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-create-domains-data,test-db-fixtures-demo,test-generate-friendly-urls,test-load-plugin-demo-data,test-replace-domains-urls" description="Drops all data in test database and creates a new one with demo data."/>
+    <target name="test-db-demo" depends="clean,redis-check,clean-redis,test-db-wipe-public-schema,test-db-import-basic-structure,test-db-migrations,test-create-domains-data,test-db-fixtures-demo,test-generate-friendly-urls,test-load-plugin-demo-data,test-replace-domains-urls,test-product-search-recreate-structure,test-product-search-export-products" description="Drops all data in test database and creates a new one with demo data."/>
     <target name="test-db-performance" depends="test-db-demo,test-db-fixtures-performance" description="Drops all data in test database and creates a new one with performance data."/>
     <target name="tests-static" depends="tests-unit" description="Runs unit tests."/>
     <target name="tests" depends="test-db-demo,tests-static,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests on a newly built test database."/>
 
     <target name="tests-performance-run" depends="clean,redis-check,clean-redis,test-db-performance,tests-performance-warmup,tests-performance" description="Runs performance tests on a newly built test database with performance data."/>
+    <target name="test-product-search-recreate-structure" depends="test-product-search-delete-structure,test-product-search-create-structure" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)" />
 
     <target name="composer-check" description="Checks if Composer lock file is valid.">
         <exec
@@ -663,6 +664,30 @@
             <arg value="${path.bin-console}" />
             <arg value="--env=test" />
             <arg value="shopsys:plugin-data-fixtures:load" />
+        </exec>
+    </target>
+
+    <target name="test-product-search-create-structure" description="Creates structure for searching via elasticsearch for test environment.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="--env=test" />
+            <arg value="shopsys:product-search:create-structure" />
+        </exec>
+    </target>
+
+    <target name="test-product-search-delete-structure" description="Deletes structure for searching via elasticsearch for test environment.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="--env=test" />
+            <arg value="shopsys:product-search:delete-structure" />
+        </exec>
+    </target>
+
+    <target name="test-product-search-export-products" description="Exports all products for searching via elasticsearch for test environment.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="--env=test" />
+            <arg value="shopsys:product-search:export-products" />
         </exec>
     </target>
 

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -22,7 +22,7 @@
     <target name="tests" depends="test-db-demo,tests-static,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests on a newly built test database."/>
 
     <target name="tests-performance-run" depends="clean,redis-check,clean-redis,test-db-performance,tests-performance-warmup,tests-performance" description="Runs performance tests on a newly built test database with performance data."/>
-    <target name="test-product-search-recreate-structure" depends="test-product-search-delete-structure,test-product-search-create-structure" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)" />
+    <target name="test-product-search-recreate-structure" depends="test-product-search-delete-structure,test-product-search-create-structure" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)." />
 
     <target name="composer-check" description="Checks if Composer lock file is valid.">
         <exec


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Tests do not export data to elasticsearch. That would be problem if i have some products changed. This PR supports export products to elasticsearch with his own index for tests.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #865, closes #866 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
