### PR TITLE
Tests refactoring - remove wrong annotations and use shorter way of writing return value

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -27,6 +27,12 @@ There you can find links to upgrade notes for other versions too.
         - $emMock->expects($this->once())->method('find')->will($this->returnValue($expectedObject));
         + $emMock->expects($this->once())->method('find')->willReturn($expectedObject);
         ```
+- *(low priority)* remove unused dataProvider annotation from `Tests\ShopBundle\Functional\Twig\PriceExtensionTest:checkPriceFilter` method ([#939](https://github.com/shopsys/shopsys/pull/939))
+    ```diff
+      /**
+    -   * @dataProvider priceFilterDataProvider
+        * @param mixed $input
+    ```
 - *(low priority)* reconfigure fm_elfinder to use main_filesystem ([#932](https://github.com/shopsys/shopsys/pull/932))
     - upgrade version of `helios-ag/fm-elfinder-bundle` to `^9.2` in `composer.json`
     - remove `barryvdh/elfinder-flysystem-driver": "^0.2"` from `composer.json`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -21,7 +21,12 @@ There you can find links to upgrade notes for other versions too.
 - if you extended one of these form fields listed below, you need to change group from `basicInformation` to `prices` ([#956](https://github.com/shopsys/shopsys/pull/956))
     - in `PaymentFormType` fields `vat` and `czkRounding`
     - in `TransportFormType` field `vat`
-
+- *(low priority)* change all occurences of `->will($this->returnValue(` into `->willReturn(` in all `TestCase` tests ([#939](https://github.com/shopsys/shopsys/pull/939))
+    - example:
+        ```diff
+        - $emMock->expects($this->once())->method('find')->will($this->returnValue($expectedObject));
+        + $emMock->expects($this->once())->method('find')->willReturn($expectedObject);
+        ```
 - *(low priority)* reconfigure fm_elfinder to use main_filesystem ([#932](https://github.com/shopsys/shopsys/pull/932))
     - upgrade version of `helios-ag/fm-elfinder-bundle` to `^9.2` in `composer.json`
     - remove `barryvdh/elfinder-flysystem-driver": "^0.2"` from `composer.json`

--- a/packages/framework/tests/Unit/Component/DataFixture/PersistentReferenceFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/DataFixture/PersistentReferenceFacadeTest.php
@@ -78,7 +78,7 @@ class PersistentReferenceFacadeTest extends TestCase
             ->setMethods(['__construct', 'find'])
             ->disableOriginalConstructor()
             ->getMock();
-        $emMock->expects($this->once())->method('find')->will($this->returnValue($expectedObject));
+        $emMock->expects($this->once())->method('find')->willReturn($expectedObject);
 
         $persistentReferenceRepositoryMock = $this->getMockBuilder(PersistentReferenceRepository::class)
             ->setMethods(['__construct', 'getByReferenceName'])
@@ -87,7 +87,7 @@ class PersistentReferenceFacadeTest extends TestCase
         $persistentReferenceRepositoryMock
             ->expects($this->once())
             ->method('getByReferenceName')
-            ->will($this->returnValue($persistentReference));
+            ->willReturn($persistentReference);
 
         $persistentReferenceFacade = new PersistentReferenceFacade(
             $emMock,
@@ -106,7 +106,7 @@ class PersistentReferenceFacadeTest extends TestCase
             ->setMethods(['__construct', 'find'])
             ->disableOriginalConstructor()
             ->getMock();
-        $emMock->expects($this->once())->method('find')->will($this->returnValue(null));
+        $emMock->expects($this->once())->method('find')->willReturn(null);
 
         $persistentReferenceRepositoryMock = $this->getMockBuilder(PersistentReferenceRepository::class)
             ->setMethods(['__construct', 'getByReferenceName'])
@@ -115,7 +115,7 @@ class PersistentReferenceFacadeTest extends TestCase
         $persistentReferenceRepositoryMock
             ->expects($this->once())
             ->method('getByReferenceName')
-            ->will($this->returnValue($persistentReference));
+            ->willReturn($persistentReference);
 
         $persistentReferenceFacade = new PersistentReferenceFacade(
             $emMock,

--- a/packages/framework/tests/Unit/Component/Domain/DomainSubscriberTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainSubscriberTest.php
@@ -17,7 +17,7 @@ class DomainSubscriberTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
+        $eventMock->expects($this->once())->method('isMasterRequest')->willReturn(false);
         $settingMock = $this->createMock(Setting::class);
 
         $domain = new Domain([], $settingMock);
@@ -32,7 +32,7 @@ class DomainSubscriberTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('isMasterRequest')->will($this->returnValue(true));
+        $eventMock->expects($this->once())->method('isMasterRequest')->willReturn(true);
 
         $domainMock = $this->getMockBuilder(Domain::class)
             ->setMethods(['__construct', 'getId'])
@@ -51,8 +51,8 @@ class DomainSubscriberTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('isMasterRequest')->will($this->returnValue(true));
-        $eventMock->expects($this->once())->method('getRequest')->will($this->returnValue($getRequestResult));
+        $eventMock->expects($this->once())->method('isMasterRequest')->willReturn(true);
+        $eventMock->expects($this->once())->method('getRequest')->willReturn($getRequestResult);
 
         $exception = new \Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException();
         $domainMock = $this->getMockBuilder(Domain::class)

--- a/packages/framework/tests/Unit/Component/Domain/DomainTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainTest.php
@@ -39,7 +39,7 @@ class DomainTest extends TestCase
         $requestMock
             ->expects($this->atLeastOnce())
             ->method('getSchemeAndHttpHost')
-            ->will($this->returnValue('http://example.com:8080'));
+            ->willReturn('http://example.com:8080');
 
         $domain->switchDomainByRequest($requestMock);
         $this->assertSame(1, $domain->getId());

--- a/packages/framework/tests/Unit/Component/Form/FormTimeProviderTest.php
+++ b/packages/framework/tests/Unit/Component/Form/FormTimeProviderTest.php
@@ -30,8 +30,8 @@ class FormTimeProviderTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['get', 'has'])
             ->getMock();
-        $sessionMock->expects($this->atLeastOnce())->method('get')->will($this->returnValue(new DateTime($formCreatedAt)));
-        $sessionMock->expects($this->atLeastOnce())->method('has')->will($this->returnValue(true));
+        $sessionMock->expects($this->atLeastOnce())->method('get')->willReturn(new DateTime($formCreatedAt));
+        $sessionMock->expects($this->atLeastOnce())->method('has')->willReturn(true);
 
         $formTimeProvider = new FormTimeProvider($sessionMock);
 

--- a/packages/framework/tests/Unit/Component/Grid/GridTest.php
+++ b/packages/framework/tests/Unit/Component/Grid/GridTest.php
@@ -237,7 +237,7 @@ class GridTest extends TestCase
             ->getMockForAbstractClass();
         $dataSourceMock->expects($this->never())->method('getTotalRowsCount');
         $dataSourceMock->expects($this->once())->method('getPaginatedRows')
-            ->will($this->returnValue(new PaginationResult(1, 1, 0, [])));
+            ->willReturn(new PaginationResult(1, 1, 0, []));
 
         $grid = new Grid(
             'gridId',
@@ -264,9 +264,9 @@ class GridTest extends TestCase
         $dataSourceMock = $this->getMockBuilder(DataSourceInterface::class)
             ->setMethods(['getTotalRowsCount', 'getPaginatedRows'])
             ->getMockForAbstractClass();
-        $dataSourceMock->expects($this->once())->method('getTotalRowsCount')->will($this->returnValue(0));
+        $dataSourceMock->expects($this->once())->method('getTotalRowsCount')->willReturn(0);
         $dataSourceMock->expects($this->once())->method('getPaginatedRows')
-            ->will($this->returnValue(new PaginationResult(1, 1, 0, [])));
+            ->willReturn(new PaginationResult(1, 1, 0, []));
 
         $grid = new Grid(
             'gridId',

--- a/packages/framework/tests/Unit/Component/HttpFoundation/FragmentHandlerTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/FragmentHandlerTest.php
@@ -15,7 +15,7 @@ class FragmentHandlerTest extends TestCase
     public function testRenderNotIgnoreErrorsWithoutDebug()
     {
         $rendererMock = $this->createMock(FragmentRendererInterface::class);
-        $rendererMock->expects($this->once())->method('getName')->will($this->returnValue('rendererName'));
+        $rendererMock->expects($this->once())->method('getName')->willReturn('rendererName');
         $rendererMock->expects($this->atLeastOnce())
             ->method('render')
             ->with(
@@ -28,10 +28,10 @@ class FragmentHandlerTest extends TestCase
             ->willThrowException(new \Exception());
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStackMock->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $containerMock = $this->createMock(ContainerInterface::class);
-        $containerMock->expects($this->once())->method('get')->will($this->returnValue($rendererMock));
+        $containerMock->expects($this->once())->method('get')->willReturn($rendererMock);
 
         $debug = false;
         $fragmentHandler = new FragmentHandler($containerMock, $requestStackMock, $debug);
@@ -46,14 +46,14 @@ class FragmentHandlerTest extends TestCase
         $response = new Response('', 301);
 
         $rendererMock = $this->createMock(FragmentRendererInterface::class);
-        $rendererMock->expects($this->once())->method('getName')->will($this->returnValue('rendererName'));
+        $rendererMock->expects($this->once())->method('getName')->willReturn('rendererName');
         $rendererMock->expects($this->any())->method('render')->willReturn($response);
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStackMock->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $containerMock = $this->createMock(ContainerInterface::class);
-        $containerMock->expects($this->once())->method('get')->will($this->returnValue($rendererMock));
+        $containerMock->expects($this->once())->method('get')->willReturn($rendererMock);
 
         $fragmentHandler = new FragmentHandler($containerMock, $requestStackMock, false);
         $fragmentHandler->addRendererService('rendererName', 'rendererName');
@@ -66,14 +66,14 @@ class FragmentHandlerTest extends TestCase
         $response = new Response('', 500);
 
         $rendererMock = $this->createMock(FragmentRendererInterface::class);
-        $rendererMock->expects($this->once())->method('getName')->will($this->returnValue('rendererName'));
+        $rendererMock->expects($this->once())->method('getName')->willReturn('rendererName');
         $rendererMock->expects($this->any())->method('render')->willReturn($response);
 
         $requestStackMock = $this->createMock(RequestStack::class);
-        $requestStackMock->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+        $requestStackMock->expects($this->any())->method('getCurrentRequest')->willReturn(Request::create('/'));
 
         $containerMock = $this->createMock(ContainerInterface::class);
-        $containerMock->expects($this->once())->method('get')->will($this->returnValue($rendererMock));
+        $containerMock->expects($this->once())->method('get')->willReturn($rendererMock);
 
         $fragmentHandler = new FragmentHandler($containerMock, $requestStackMock, false);
         $fragmentHandler->addRendererService('rendererName', 'rendererName');

--- a/packages/framework/tests/Unit/Component/HttpFoundation/SubRequestListenerTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/SubRequestListenerTest.php
@@ -21,7 +21,7 @@ class SubRequestListenerTest extends TestCase
         $responseMock = $this->getMockBuilder(Response::class)
             ->setMethods(['isRedirection', 'send'])
             ->getMock();
-        $responseMock->expects($this->once())->method('isRedirection')->will($this->returnValue($redirect));
+        $responseMock->expects($this->once())->method('isRedirection')->willReturn($redirect);
         $responseMock->expects($send ? $this->once() : $this->never())->method('send');
 
         return $responseMock;
@@ -33,7 +33,7 @@ class SubRequestListenerTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('isMasterRequest')->will($this->returnValue(true));
+        $eventMock->expects($this->once())->method('isMasterRequest')->willReturn(true);
 
         $subRequestListener = new SubRequestListener();
         $subRequestListener->onKernelResponse($eventMock);
@@ -45,22 +45,22 @@ class SubRequestListenerTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock1->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
-        $eventMock1->expects($this->once())->method('getResponse')->will($this->returnValue($this->getResponseMock(true)));
+        $eventMock1->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $eventMock1->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock(true));
 
         $eventMock2 = $this->getMockBuilder(FilterResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock2->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
-        $eventMock2->expects($this->once())->method('getResponse')->will($this->returnValue($this->getResponseMock()));
+        $eventMock2->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $eventMock2->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock());
 
         $eventMock3 = $this->getMockBuilder(FilterResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock3->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
-        $eventMock3->expects($this->once())->method('getResponse')->will($this->returnValue($this->getResponseMock(true)));
+        $eventMock3->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $eventMock3->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock(true));
 
         $subRequestListener = new SubRequestListener();
         $subRequestListener->onKernelResponse($eventMock1);
@@ -76,21 +76,21 @@ class SubRequestListenerTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock1->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
-        $eventMock1->expects($this->once())->method('getResponse')->will($this->returnValue($this->getResponseMock(true, true)));
+        $eventMock1->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $eventMock1->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock(true, true));
 
         $eventMock2 = $this->getMockBuilder(FilterResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock2->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
-        $eventMock2->expects($this->once())->method('getResponse')->will($this->returnValue($this->getResponseMock()));
+        $eventMock2->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $eventMock2->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock());
 
         $eventMock3 = $this->getMockBuilder(FilterResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock3->expects($this->once())->method('isMasterRequest')->will($this->returnValue(true));
+        $eventMock3->expects($this->once())->method('isMasterRequest')->willReturn(true);
 
         $subRequestListener = new SubRequestListener();
         $subRequestListener->onKernelResponse($eventMock1);
@@ -104,7 +104,7 @@ class SubRequestListenerTest extends TestCase
             ->setMethods(['getMethod'])
             ->getMock();
         /* @var $masterRequestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
-        $masterRequestMock->expects($this->once())->method('getMethod')->will($this->returnValue('POST'));
+        $masterRequestMock->expects($this->once())->method('getMethod')->willReturn('POST');
         $masterRequestMock->query->replace([
             'key1' => 'value1',
             'key2' => 'value2',
@@ -125,15 +125,15 @@ class SubRequestListenerTest extends TestCase
             ->setMethods(['__construct', 'isMasterRequest', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock1->expects($this->once())->method('isMasterRequest')->will($this->returnValue(true));
-        $eventMock1->expects($this->atLeastOnce())->method('getRequest')->will($this->returnValue($masterRequestMock));
+        $eventMock1->expects($this->once())->method('isMasterRequest')->willReturn(true);
+        $eventMock1->expects($this->atLeastOnce())->method('getRequest')->willReturn($masterRequestMock);
 
         $eventMock2 = $this->getMockBuilder(FilterControllerEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock2->expects($this->once())->method('isMasterRequest')->will($this->returnValue(false));
-        $eventMock2->expects($this->atLeastOnce())->method('getRequest')->will($this->returnValue($subRequestMock));
+        $eventMock2->expects($this->once())->method('isMasterRequest')->willReturn(false);
+        $eventMock2->expects($this->atLeastOnce())->method('getRequest')->willReturn($subRequestMock);
 
         $subRequestListener = new SubRequestListener();
         $subRequestListener->onKernelController($eventMock1);

--- a/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
@@ -85,10 +85,10 @@ class PaymentPriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
-                ->will($this->returnValue($inputPriceType));
+                ->willReturn($inputPriceType);
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
 
@@ -139,13 +139,13 @@ class PaymentPriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
-                ->will($this->returnValue($inputPriceType));
+                ->willReturn($inputPriceType);
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
         $pricingSettingMock
             ->expects($this->any())->method('getFreeTransportAndPaymentPriceLimit')
-                ->will($this->returnValue($priceLimit));
+                ->willReturn($priceLimit);
 
         $rounding = new Rounding($pricingSettingMock);
 

--- a/packages/framework/tests/Unit/Model/Pricing/BasePriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/BasePriceCalculationTest.php
@@ -60,7 +60,7 @@ class BasePriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
         $priceCalculation = new PriceCalculation($rounding);

--- a/packages/framework/tests/Unit/Model/Pricing/PriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/PriceCalculationTest.php
@@ -56,7 +56,7 @@ class PriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
         $priceCalculation = new PriceCalculation($rounding);
@@ -108,7 +108,7 @@ class PriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
         $priceCalculation = new PriceCalculation($rounding);

--- a/packages/framework/tests/Unit/Model/Pricing/RoundingTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/RoundingTest.php
@@ -71,7 +71,7 @@ class RoundingTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
 
@@ -146,7 +146,7 @@ class RoundingTest extends TestCase
             ->setMethods(['getRoundingType'])
             ->disableOriginalConstructor()
             ->getMock();
-        $pricingSettingMock->expects($this->any())->method('getRoundingType')->will($this->returnValue($roundingType));
+        $pricingSettingMock->expects($this->any())->method('getRoundingType')->willReturn($roundingType);
 
         $rounding = new Rounding($pricingSettingMock);
         $roundedPrice = $rounding->roundPriceWithVat($inputPrice);

--- a/packages/framework/tests/Unit/Model/Pricing/Vat/VatFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/Vat/VatFacadeTest.php
@@ -28,7 +28,7 @@ class VatFacadeTest extends TestCase
             ->expects($this->once())
             ->method('get')
             ->with($this->equalTo(Vat::SETTING_DEFAULT_VAT))
-            ->will($this->returnValue(1));
+            ->willReturn(1);
 
         $vatRepositoryMock = $this->getMockBuilder(VatRepository::class)
             ->setMethods(['findById', '__construct'])
@@ -38,7 +38,7 @@ class VatFacadeTest extends TestCase
             ->expects($this->once())
             ->method('findById')
             ->with($this->equalTo(1))
-            ->will($this->returnValue($expected));
+            ->willReturn($expected);
 
         $productPriceRecalculationSchedulerMock = $this->getMockBuilder(ProductPriceRecalculationScheduler::class)
             ->disableOriginalConstructor()
@@ -64,7 +64,7 @@ class VatFacadeTest extends TestCase
             ->setMethods(['getId', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
-        $vatMock->expects($this->once())->method('getId')->will($this->returnValue(1));
+        $vatMock->expects($this->once())->method('getId')->willReturn(1);
 
         $settingMock = $this->getMockBuilder(Setting::class)
             ->setMethods(['set', '__construct'])

--- a/packages/framework/tests/Unit/Model/Product/Availability/ProductAvailabilityRecalculatorTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Availability/ProductAvailabilityRecalculatorTest.php
@@ -39,7 +39,7 @@ class ProductAvailabilityRecalculatorTest extends TestCase
         $productAvailabilityRecalculationSchedulerMock
             ->expects($this->once())
             ->method('getProductsForImmediateRecalculation')
-            ->will($this->returnValue([$productMock]));
+            ->willReturn([$productMock]);
 
         $productAvailabilityRecalculator = new ProductAvailabilityRecalculator(
             $emMock,

--- a/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationTest.php
@@ -33,13 +33,13 @@ class ProductPriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
-                ->will($this->returnValue($inputPriceType));
+                ->willReturn($inputPriceType);
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
         $pricingSettingMock
             ->expects($this->any())->method('getDomainDefaultCurrencyIdByDomainId')
-                ->will($this->returnValue(1));
+                ->willReturn(1);
 
         $productManualInputPriceRepositoryMock = $this->getMockBuilder(ProductManualInputPriceRepository::class)
             ->disableOriginalConstructor()
@@ -51,7 +51,7 @@ class ProductPriceCalculationTest extends TestCase
             ->getMock();
         $productRepositoryMock
             ->expects($this->any())->method('getAllSellableVariantsByMainVariant')
-            ->will($this->returnValue($variants));
+            ->willReturn($variants);
 
         $rounding = new Rounding($pricingSettingMock);
         $priceCalculation = new PriceCalculation($rounding);

--- a/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceRecalculatorTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceRecalculatorTest.php
@@ -38,7 +38,7 @@ class ProductPriceRecalculatorTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getProductsForImmediateRecalculation'])
             ->getMock();
-        $productPriceRecalculationSchedulerMock->expects($this->once())->method('getProductsForImmediateRecalculation')->will($this->returnValue([$productMock]));
+        $productPriceRecalculationSchedulerMock->expects($this->once())->method('getProductsForImmediateRecalculation')->willReturn([$productMock]);
         $pricingGroupFacadeMock = $this->getMockBuilder(PricingGroupFacade::class)
             ->disableOriginalConstructor()
             ->setMethods(['getAll'])

--- a/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
+++ b/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
@@ -19,8 +19,8 @@ class AuthenticatorTest extends TestCase
         $requestMock->expects($this->never())->method('getSession');
 
         $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
-        $requestMock->attributes->expects($this->once())->method('has')->will($this->returnValue(true));
-        $requestMock->attributes->expects($this->once())->method('get')->will($this->returnValue(new stdClass()));
+        $requestMock->attributes->expects($this->once())->method('has')->willReturn(true);
+        $requestMock->attributes->expects($this->once())->method('get')->willReturn(new stdClass());
 
         $this->expectException('Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException');
         $authenticator->checkLoginProcess($requestMock);
@@ -31,15 +31,15 @@ class AuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator();
 
         $sessionMock = $this->createMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
-        $sessionMock->expects($this->atLeastOnce())->method('get')->will($this->returnValue(new stdClass()));
+        $sessionMock->expects($this->atLeastOnce())->method('get')->willReturn(new stdClass());
         $sessionMock->expects($this->atLeastOnce())->method('remove');
 
         $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         /* @var $requestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
-        $requestMock->expects($this->once())->method('getSession')->will($this->returnValue($sessionMock));
+        $requestMock->expects($this->once())->method('getSession')->willReturn($sessionMock);
 
         $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
-        $requestMock->attributes->expects($this->once())->method('has')->will($this->returnValue(false));
+        $requestMock->attributes->expects($this->once())->method('has')->willReturn(false);
         $requestMock->attributes->expects($this->never())->method('get');
 
         $this->expectException('Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException');
@@ -51,15 +51,15 @@ class AuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator();
 
         $sessionMock = $this->createMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
-        $sessionMock->expects($this->once())->method('get')->will($this->returnValue(null));
+        $sessionMock->expects($this->once())->method('get')->willReturn(null);
         $sessionMock->expects($this->once())->method('remove');
 
         $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
         /* @var $requestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
-        $requestMock->expects($this->once())->method('getSession')->will($this->returnValue($sessionMock));
+        $requestMock->expects($this->once())->method('getSession')->willReturn($sessionMock);
 
         $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
-        $requestMock->attributes->expects($this->once())->method('has')->will($this->returnValue(false));
+        $requestMock->attributes->expects($this->once())->method('has')->willReturn(false);
         $requestMock->attributes->expects($this->never())->method('get');
 
         $this->assertSame(true, $authenticator->checkLoginProcess($requestMock));

--- a/packages/framework/tests/Unit/Model/Security/LoginListenerTest.php
+++ b/packages/framework/tests/Unit/Model/Security/LoginListenerTest.php
@@ -29,13 +29,13 @@ class LoginListenerTest extends TestCase
         $userMock->expects($this->once())->method('setLoginToken');
 
         $tokenMock = $this->createMock(TokenInterface::class);
-        $tokenMock->expects($this->once())->method('getUser')->will($this->returnValue($userMock));
+        $tokenMock->expects($this->once())->method('getUser')->willReturn($userMock);
 
         $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
             ->setMethods(['__construct', 'getAuthenticationToken'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->will($this->returnValue($tokenMock));
+        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
 
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
             ->setMethods(['__construct'])
@@ -60,13 +60,13 @@ class LoginListenerTest extends TestCase
         $userMock->expects($this->once())->method('setLastActivity');
 
         $tokenMock = $this->createMock(TokenInterface::class);
-        $tokenMock->expects($this->once())->method('getUser')->will($this->returnValue($userMock));
+        $tokenMock->expects($this->once())->method('getUser')->willReturn($userMock);
 
         $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
             ->setMethods(['__construct', 'getAuthenticationToken'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->will($this->returnValue($tokenMock));
+        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
 
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
             ->setMethods(['__construct'])
@@ -93,13 +93,13 @@ class LoginListenerTest extends TestCase
             ->getMock();
 
         $tokenMock = $this->createMock(TokenInterface::class);
-        $tokenMock->expects($this->once())->method('getUser')->will($this->returnValue($userMock));
+        $tokenMock->expects($this->once())->method('getUser')->willReturn($userMock);
 
         $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
             ->setMethods(['__construct', 'getAuthenticationToken'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->will($this->returnValue($tokenMock));
+        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
 
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
             ->setMethods(['__construct', 'resetOrderForm'])
@@ -125,14 +125,14 @@ class LoginListenerTest extends TestCase
         $administratorMock->expects($this->once())->method('setLoginToken');
 
         $tokenMock = $this->createMock(TokenInterface::class);
-        $tokenMock->expects($this->once())->method('getUser')->will($this->returnValue($administratorMock));
+        $tokenMock->expects($this->once())->method('getUser')->willReturn($administratorMock);
 
         $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
             ->setMethods(['__construct', 'getAuthenticationToken', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->will($this->returnValue($tokenMock));
-        $eventMock->expects($this->once())->method('getRequest')->will($this->returnValue(new Request()));
+        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
+        $eventMock->expects($this->once())->method('getRequest')->willReturn(new Request());
 
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
             ->setMethods(['__construct'])

--- a/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
@@ -62,10 +62,10 @@ class TransportPriceCalculationTest extends TestCase
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
-                ->will($this->returnValue($inputPriceType));
+                ->willReturn($inputPriceType);
         $pricingSettingMock
             ->expects($this->any())->method('getRoundingType')
-                ->will($this->returnValue(PricingSetting::ROUNDING_TYPE_INTEGER));
+                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
         $priceCalculation = new PriceCalculation($rounding);

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
@@ -47,26 +47,26 @@ class OrderPreviewCalculationTest extends FunctionalTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $quantifiedProductPriceCalculationMock->expects($this->once())->method('calculatePrices')
-            ->will($this->returnValue($quantifiedItemsPrices));
+            ->willReturn($quantifiedItemsPrices);
 
         $quantifiedProductDiscountCalculationMock = $this->getMockBuilder(QuantifiedProductDiscountCalculation::class)
             ->setMethods(['calculateDiscounts', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
         $quantifiedProductDiscountCalculationMock->expects($this->once())->method('calculateDiscounts')
-            ->will($this->returnValue($quantifiedProductsDiscounts));
+            ->willReturn($quantifiedProductsDiscounts);
 
         $paymentPriceCalculationMock = $this->getMockBuilder(PaymentPriceCalculation::class)
             ->setMethods(['calculatePrice', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
-        $paymentPriceCalculationMock->expects($this->once())->method('calculatePrice')->will($this->returnValue($paymentPrice));
+        $paymentPriceCalculationMock->expects($this->once())->method('calculatePrice')->willReturn($paymentPrice);
 
         $transportPriceCalculationMock = $this->getMockBuilder(TransportPriceCalculation::class)
             ->setMethods(['calculatePrice', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
-        $transportPriceCalculationMock->expects($this->once())->method('calculatePrice')->will($this->returnValue($transportPrice));
+        $transportPriceCalculationMock->expects($this->once())->method('calculatePrice')->willReturn($transportPrice);
 
         $orderPriceCalculationMock = $this->getMockBuilder(OrderPriceCalculation::class)
             ->setMethods(['calculateOrderRoundingPrice'])
@@ -132,14 +132,14 @@ class OrderPreviewCalculationTest extends FunctionalTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $quantifiedProductPriceCalculationMock->expects($this->once())->method('calculatePrices')
-            ->will($this->returnValue($quantifiedItemsPrices));
+            ->willReturn($quantifiedItemsPrices);
 
         $quantifiedProductDiscountCalculationMock = $this->getMockBuilder(QuantifiedProductDiscountCalculation::class)
             ->setMethods(['calculateDiscounts', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
         $quantifiedProductDiscountCalculationMock->expects($this->once())->method('calculateDiscounts')
-            ->will($this->returnValue($quantifiedProductsDiscounts));
+            ->willReturn($quantifiedProductsDiscounts);
 
         $paymentPriceCalculationMock = $this->getMockBuilder(PaymentPriceCalculation::class)
             ->setMethods(['calculatePrice', '__construct'])

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -51,7 +51,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $availabilityFacadeMock->expects($this->any())->method('getDefaultInStockAvailability')
-            ->will($this->returnValue($defaultInStockAvailability));
+            ->willReturn($defaultInStockAvailability);
 
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);

--- a/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
@@ -124,7 +124,6 @@ class PriceExtensionTest extends FunctionalTestCase
     }
 
     /**
-     * @dataProvider priceFilterDataProvider
      * @param mixed $input
      * @param mixed $domainId
      * @param mixed $result


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| remove wrong annotations and use smarter method in tests
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| I hope that No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| nope <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Sorry, I didnt update UPGRADE.md...