### PR TITLE
[shopsys] Remove duplication test database build in kubernetes ci script

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -86,4 +86,4 @@ kubectl rollout status --namespace=${JOB_NAME} deployment/webserver-php-fpm --wa
 PHP_FPM_POD=$(kubectl get pods --namespace=${JOB_NAME} -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
 
 # Run phing build targets for build of the application
-kubectl exec ${PHP_FPM_POD} --namespace=${JOB_NAME} ./phing test-db-create test-db-demo test-dirs-create checks-ci
+kubectl exec ${PHP_FPM_POD} --namespace=${JOB_NAME} ./phing test-db-create test-dirs-create checks-ci


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Kubernetes CI build script was building test database twice. This PR remove useless phing target test-db-demo that is called in checks-ci target
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
