### PR TITLE
absolute paths used via local filesystem flysystem now uses paths without drive letters

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -16,7 +16,7 @@ There you can find links to upgrade notes for other versions too.
             $finder->files()->in($origin);
             foreach ($finder as $file) {
         -        $filepath = $file->getPathname();
-        +        $filepath = TransformString::removeDriveLetterFromPath           ($file->getPathname());
+        +        $filepath = TransformString::removeDriveLetterFromPath($file->getPathname());
         ```
 
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -6,6 +6,20 @@ This guide contains instructions to upgrade from version v7.1.0 to Unreleased.
 There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
+### Application
+- add `TransformString::removeDriveLetterFromPath` transformer for all absolute paths that could be based with drive letter file systems and used by `local_filesystem` service ([#942](https://github.com/shopsys/shopsys/pull/942))
+    - add TransformString::removeDriveLetterFromPath into `src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php`
+        ```diff
+        protected function moveFilesFromLocalFilesystemToFilesystem(string $origin, string $target)
+        {
+            $finder = new Finder();
+            $finder->files()->in($origin);
+            foreach ($finder as $file) {
+        -        $filepath = $file->getPathname();
+        +        $filepath = TransformString::removeDriveLetterFromPath           ($file->getPathname());
+        ```
+
+
 ### Configuration
  - *(low priority)* use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))
     - change prefixes in `app/config/packages/snc_redis.yml` and `app/config/packages/test/snc_redis.yml`. Please find inspiration in [#928](https://github.com/shopsys/shopsys/pull/928/files)

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -191,7 +191,7 @@ class FileUpload
         $filesForUpload = $entity->getTemporaryFilesForUpload();
         foreach ($filesForUpload as $fileForUpload) {
             /* @var $fileForUpload FileForUpload */
-            $sourceFilepath = $this->getTemporaryFilepath($fileForUpload->getTemporaryFilename());
+            $sourceFilepath = TransformString::removeDriveLetterFromPath($this->getTemporaryFilepath($fileForUpload->getTemporaryFilename()));
             $originalFilename = $this->fileNamingConvention->getFilenameByNamingConvention(
                 $fileForUpload->getNameConventionType(),
                 $fileForUpload->getTemporaryFilename(),

--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -8,6 +8,7 @@ use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 class ImageFacade
 {
@@ -341,7 +342,7 @@ class ImageFacade
         foreach ($sourceImages as $sourceImage) {
             $this->mountManager->copy(
                 'main://' . $this->imageLocator->getAbsoluteImageFilepath($sourceImage, ImageConfig::ORIGINAL_SIZE_NAME),
-                'local://' . $this->fileUpload->getTemporaryFilepath($sourceImage->getFilename())
+                'local://' . TransformString::removeDriveLetterFromPath($this->fileUpload->getTemporaryFilepath($sourceImage->getFilename()))
             );
 
             $targetImage = $this->imageFactory->create(

--- a/packages/framework/src/Component/String/TransformString.php
+++ b/packages/framework/src/Component/String/TransformString.php
@@ -82,4 +82,16 @@ class TransformString
     {
         return iconv('utf-8', 'us-ascii//TRANSLIT//IGNORE', $string);
     }
+
+    /**
+     * For some cases there is need to have clean absolute paths
+     * Operating systems that use drive letter assignments https://en.wikipedia.org/wiki/Drive_letter_assignment
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function removeDriveLetterFromPath($path)
+    {
+        return preg_replace('#^[A-Z]:#', '', $path);
+    }
 }

--- a/packages/framework/src/Model/Feed/FeedExport.php
+++ b/packages/framework/src/Model/Feed/FeedExport.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 use Symfony\Component\Filesystem\Filesystem;
 
 class FeedExport
@@ -112,7 +113,7 @@ class FeedExport
     public function wakeUp(): void
     {
         if ($this->filesystem->has($this->getTemporaryFilepath())) {
-            $this->mountManager->move('main://' . $this->getTemporaryFilepath(), 'local://' . $this->getTemporaryLocalFilepath());
+            $this->mountManager->move('main://' . $this->getTemporaryFilepath(), 'local://' . TransformString::removeDriveLetterFromPath($this->getTemporaryLocalFilepath()));
         } else {
             $this->localFilesystem->touch($this->getTemporaryLocalFilepath());
         }
@@ -120,7 +121,7 @@ class FeedExport
 
     public function sleep(): void
     {
-        $this->mountManager->move('local://' . $this->getTemporaryLocalFilepath(), 'main://' . $this->getTemporaryFilepath());
+        $this->mountManager->move('local://' . TransformString::removeDriveLetterFromPath($this->getTemporaryLocalFilepath()), 'main://' . $this->getTemporaryFilepath());
     }
 
     public function generateBatch(): void
@@ -188,7 +189,7 @@ class FeedExport
             $this->filesystem->delete($this->feedFilepath);
         }
 
-        $this->mountManager->move('local://' . $this->getTemporaryLocalFilepath(), 'main://' . $this->feedFilepath);
+        $this->mountManager->move('local://' . TransformString::removeDriveLetterFromPath($this->getTemporaryLocalFilepath()), 'main://' . $this->feedFilepath);
 
         $this->finished = true;
     }

--- a/packages/framework/src/Model/Sitemap/SitemapDumper.php
+++ b/packages/framework/src/Model/Sitemap/SitemapDumper.php
@@ -6,6 +6,7 @@ use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
 use Presta\SitemapBundle\DependencyInjection\Configuration;
 use Presta\SitemapBundle\Service\Dumper;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -57,7 +58,10 @@ class SitemapDumper extends Dumper
 
         $finder = new Finder();
         foreach ($finder->files()->in($this->tmpFolder)->getIterator() as $file) {
-            $this->mountManager->move('local://' . $file->getPathname(), 'main://' . $targetDir . '/' . $file->getBasename());
+            $this->mountManager->move(
+                'local://' . TransformString::removeDriveLetterFromPath($file->getPathname()),
+                'main://' . $targetDir . '/' . $file->getBasename()
+            );
         }
 
         parent::cleanup();

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Query\ResultSetMapping;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
@@ -269,7 +270,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         $finder = new Finder();
         $finder->files()->in($origin);
         foreach ($finder as $file) {
-            $filepath = $file->getPathname();
+            $filepath = TransformString::removeDriveLetterFromPath($file->getPathname());
 
             if ($this->localFilesystem->exists($filepath)) {
                 $newFilepath = $target . $file->getRelativePathname();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| methods of flysystem should not use absolute paths. Absolute path should be set in the process of creating the adapter. The problem that occurs for example windows file system uses drive letters and LocalAdapter needs to be initialised with path like `/` or `C:\` but if there is used absolute path like `C:\data\project-base\var\cache` via `LocalAdapter::has` method or others there is appended `/C:\data\project-base\var\cache` or 'C:\C:\data\project-base\var\cache' and used fopen function so the path is not correctly generated.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #913 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
