### PR TITLE
[shopsys] Elastic search filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -550,7 +550,7 @@ The changelog is generated during the release process using [ChangelogLinker](ht
     - added new phing targets for working with Elasticsearch
     - added CRON module for exporting products' data into Elasticsearch
     - product search uses Elasticsearch
-    - docs: added [article](./docs/model/product-search-via-elasticsearch.md) with Elasticsearch overview
+    - docs: added [article](https://github.com/shopsys/shopsys/blob/v7.0.0-alpha5/docs/introduction/product-search-via-elasticsearch.md) with Elasticsearch overview
 - [#375 ProductFormType should be extensible](https://github.com/shopsys/shopsys/pull/375)
     - `WarningMessageType` is ready to use
     - `DisplayOnlyUrlType` is ready to use

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Shopsys Framework is fully functional e-commerce platform with all basic functio
 * Registered customers
 * Basic orders management
 * Back-end administration
-* Front-end [full-text search](./docs/model/product-search-via-elasticsearch.md) and product filtering
+* Front-end [full-text search](./docs/model/front-end-product-searching.md) and [product filtering](./docs/model/front-end-product-filtering.md)
 * 3-step ordering process
 * Basic CMS
 * Support for several currencies, [languages, and domains](./docs/introduction/domain-multidomain-multilanguage.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,9 @@
 * [How to Work with Money](./model/how-to-work-with-money.md)
 * [Product Feeds](./model/product-feeds.md)
 * [Custom Entities](./model/custom-entities.md)
-* [Product Searching via Elasticsearch](./model/product-search-via-elasticsearch.md)
+* [Elasticsearch](./model/elasticsearch.md)
+* [Front-end Product Searching](./model/front-end-product-searching.md)
+* [Front-end Product Filtering](./model/front-end-product-filtering.md)
 
 ## Cookbook
 * [Dumping and Importing the Database](./cookbook/dumping-and-importing-the-database.md)

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -106,4 +106,4 @@ E.g., by default, all our services are defined as private. However, in tests, we
 
 ## How to change the behavior of the product search on the front-end?
 Full-text product search on the front-end is handled via Elasticsearch.
-If you want to change its behavior (e.g. make the EAN not as important or change the way the search string is handled - whether to use an n-gram or not) please see [Product Searching via Elasticsearch](/docs/model/product-search-via-elasticsearch.md#how-to-change-the-default-index-data-export-setting-and-searching-behavior).
+If you want to change its behavior (e.g. make the EAN not as important or change the way the search string is handled - whether to use an n-gram or not) please see [Product Searching](/docs/model/front-end-product-searching.md).

--- a/docs/model/elasticsearch.md
+++ b/docs/model/elasticsearch.md
@@ -1,12 +1,12 @@
-# Product Searching via Elasticsearch
-To provide the best possible performance, frontend product searching and autocomplete
+# Elasticsearch
+To provide the best possible performance, frontend product searching, filtering and autocomplete
 leverages [Elasticsearch technology](https://www.elastic.co/products/elasticsearch).
 Elasticsearch is a super fast no-SQL database where data are stored in JSON format as so-called [documents](https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html#_document) in one or more [indexes](https://www.elastic.co/guide/en/elasticsearch/reference/current/_basic_concepts.html#_index).
 
 ## How does it work
-All product data are stored in PostgreSQL by default but searching in the relational database might not be fast enough.
+All product data are stored in PostgreSQL by default but querying relational database might not be fast enough.
 Therefore, relevant product attributes are also stored in Elasticsearch index under the same ID.
-When the product search action is performed on frontend, the query is send to Elasticsearch.
+When products need to be searched or filtered on the frontend, the query is sent to Elasticsearch.
 As a result, found product IDs are returned from Elasticsearch and then the product data are loaded from PostgreSQL database into entities using Doctrine ORM.
 
 ### Elasticsearch index setting
@@ -23,54 +23,41 @@ that are located in `src/Shopsys/ShopBundle/Resources/definition/` directory in 
 The directory is configured using `%shopsys.elasticsearch.structure_dir%` parameter.
 
 ### Product data export
-No data are automaticly stored in Elasticsearch by "itself". When you store data into a relational database, they are not stored in Elasticsearch.
-You have to export data from database into Elasticsearch actively.
+No data are automatically stored in Elasticsearch by "itself".
+When you store data into a relational database, they are not stored in Elasticsearch.
+You have to export data from the database into Elasticsearch actively.
 
-Following product attributes are exported into Elasticsearch (i.e. the search is performed on these fields only):
+Following product attributes are exported into Elasticsearch (i.e. the search or filtering can be performed on these fields only):
 * name
 * catnum
 * partno
 * ean
 * description
 * short description
+* flags (IDs of assigned flags)
+* brand (ID of assigned brand)
+* categories (IDs of assigned categories)
+* prices (all the prices for all pricing groups)
+* in_stock (true/false value whether the product is in stock)
+* parameters (pairs of parameter IDs and parameter value IDs)
+* ordering_priority (priority number)
+* calculated_selling_denied (true/false value whether the product is already sold out)
 
 Data of all products are exported into Elasticsearch by CRON module (`ProductSearchExportCronModule.php`) once an hour.
-Alternatively, you can force the export manually using `product-search-export-products` phing target.
+Alternatively, you can force the export manually using `product-search-export-products` Phing target.
 
-### Searching for products
-
-We use the same method for searching and for autocomplete, so results are always the same.
-
-Understanding Elasticsearch searching is difficult.
-But if we simplify, we can say that the search term is searched in attributes and is prioritized in following order:
-* ean - exact match
-* name - match any of words
-* name - match any of words ignoring diacritics
-* catnum - exact match
-* name - match any of words in root form
-* partno - exact match
-* name - match in first couple of letters of any word
-* name - match in first couple of letters of any word ignoring diacritics
-* ean - exact match in first characters
-* catnum - exact match in first characters
-* partno - exact match in first characters
-* short description - match anywhere
-* description - match anywhere
-
-The searched fields and their priority are defined directly in the `Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository::createQuery()` function.
-
-If you want to improve searching, you can learn more in [Elasticsearch analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html).
+## Use of Elasticsearch
+Elasticsearch is used for search and filter products on frontend.
+You can learn more about [Product searching](/docs/model/front-end-product-searching.md) and [Product filtering](/docs/model/front-end-product-filtering.md) in particular articles.
 
 ## Where does Elasticsearch run?
 When using docker installation, Elasticsearch API is available on the address [http://127.0.0.1:9200](http://127.0.0.1:9200).
 
-## How to change the default index, data export setting, and searching behavior?
+## How to change the default index and data export setting?
 If you wish to reconfigure the indexes setting, simply change the JSON configurations in `src/Shopsys/ShopBundle/Resources/Resources/definition/`.
 Configurations use the `<index>/<domain_id>.json` naming pattern.
 
-If you need to change the data that are exported into Elasticsearch, overwrite appropriate methods in `ProductSearchExportRepository` and `ProductElasticsearchConverter` classes.
-
-You can also change the searching behavior by overwriting product search, specifically `ProductElasticsearchRepository` class.
+If you need to change the data that are exported into Elasticsearch, overwrite appropriate methods in `ProductSearchExportWithFilterRepository` and `ProductElasticsearchConverter` classes.
 
 ## Known issues
 * When you need to add a new domain, you have to do following steps

--- a/docs/model/front-end-product-filtering.md
+++ b/docs/model/front-end-product-filtering.md
@@ -1,0 +1,44 @@
+# Front-end Product Filtering
+Products can be by default filtered by price, flags, brand, parameters and in stock availability.
+
+Filtering can be performed on category list and search results.  
+These two pages are represented by `ProductController` and `SearchController`, where is used the interface (`Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface`) that describes common methods to get a filtered result:
+ - `getPaginatedProductsInCategory()` to obtain filtered products in category
+ - `getPaginatedProductsForSearch()` to obtain filtered products from search results
+
+Currently, there are two implementations of `ProductOnCurrentDomainFacadeInterface`:
+ - `ProductOnCurrentDomainElasticFacade` *(default)*
+    - filters data through Elasticsearch
+    - much faster than filtering through SQL and remains fast independently on the number of selected filters
+ - `ProductOnCurrentDomainFacade`
+    - filters data through SQL
+    - slower than Elasticsearch, but on the other hand can be used easily on more complex pricing models (for example exact price is calculated with SQL function)
+
+## Filtering through Elasticsearch
+Behavior of the filter is defined in the class `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade`.
+
+Each filtering method internally uses their own factory method `createProducts*FilterQuery` to create `Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery` object that represents the query for Elasticsearch.
+
+Elasticsearch return a sorted list of product IDs and products itself are loaded from PostgreSQL.
+
+Aggregation numbers are counted with help of Elasticsearch too thanks to methods `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade::getProductFilterCountDataInCategory` and
+`Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade::getProductFilterCountDataForSearch`.
+
+List of choices (exact parameters, brands, flags) is loaded from PostgreSQL as there is no benefit from loading them from Elasticsearch.
+
+## Filtering through SQL
+Behavior of the filter is defined in the class `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade`.
+
+Each filtering method calls appropriate method in `Shopsys\FrameworkBundle\Model\Product\ProductRepository` class in which a Doctrine `QueryBuilder` object is composed to get proper products with SQL query.
+
+## Choose an Implementation
+You can choose which one of them will be used by setting one of the previously mentioned implementations in your `services.yml` file:
+```yaml
+    # Elasticsearch filtering
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade'
+```
+or
+```yaml
+    # SQL filtering
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
+```

--- a/docs/model/front-end-product-searching.md
+++ b/docs/model/front-end-product-searching.md
@@ -1,0 +1,31 @@
+# Front-end Product Searching
+We use the same method for searching and for autocomplete, so results are always the same.
+
+Understanding Elasticsearch searching is difficult.
+But if we simplify, we can say that the search term is searched in attributes and is prioritized in following order:
+* ean - exact match
+* name - match any of words
+* name - match any of words ignoring diacritics
+* catnum - exact match
+* name - match any of words in root form
+* partno - exact match
+* name - match in first couple of letters of any word
+* name - match in first couple of letters of any word ignoring diacritics
+* ean - exact match in first characters
+* catnum - exact match in first characters
+* partno - exact match in first characters
+* short description - match anywhere
+* description - match anywhere
+
+If you want to improve searching, you can learn more in [Elasticsearch analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html).
+
+## Change searching behavior
+Searching is performed with `ProductElasticsearchRepository` class, more specifically its method `getProductIdsBySearchText()`.
+This method gets product IDs from Elasticsearch with a query that is represented by `Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery` object.
+
+The searched fields and their priority are defined directly in the `FilterQuery::search()` method,
+so to change the search behavior is enough to extend the `FilterQuery` class and use your implementation in `services.yml` file
+```yaml
+Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery:
+    alias: Shopsys\ShopBundle\Model\Product\Search\FilterQuery
+```

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -62,7 +62,8 @@ There you can find links to upgrade notes for other versions too.
     - read the section about proxying the URL content subpaths via webserver domain [`docs/introduction/abstract-filesystem.md`](https://github.com/shopsys/shopsys/blob/master/docs/introduction/abstract-filesystem.md)
 - to be more descriptive about error caused by active TEST environment ([#701](https://github.com/shopsys/shopsys/pull/701))
     - modify `ErrorController::createUnableToResolveDomainResponse()` by these [changes](https://github.com/shopsys/shopsys/pull/701/files#diff-0b1aecbf82624ce474ca3cb8bd75811c).
-
+- use interchangeable product filtering ([#943](https://github.com/shopsys/shopsys/pull/943))
+    - you'll find detailed instructions in separate article [Upgrade Instructions for Interchangeable Filtering](/docs/upgrade/interchangeable-filtering.md)
 
 ### Configuration
  - use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))

--- a/docs/upgrade/UPGRADE-v7.0.0-alpha5.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-alpha5.md
@@ -8,7 +8,7 @@ There you can find links to upgrade notes for other versions too.
 *Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
 
 ## [shopsys/framework]
-- for [product search via Elasticsearch](/docs/model/product-search-via-elasticsearch.md), you'll have to:
+- for [product search via Elasticsearch](https://github.com/shopsys/shopsys/blob/v7.0.0-alpha5/docs/introduction/product-search-via-elasticsearch.md), you'll have to:
     - check changes in the [`docker-compose.yml`](https://github.com/shopsys/shopsys/blob/v7.0.0-alpha5/docker/conf) template you used and replicate them, there is a new container with Elasticsearch
         - *since `docker-compose.yml` is not versioned, apply changes also in your `docker-compose.yml.dist` templates so it is easier to upgrade for your team members or for server upgrade*
     - since the fully installed and ready [Microservice Product Search](https://github.com/shopsys/microservice-product-search) is a necessary condition for the Shopsys Framework to run, the installation procedure of this microservice is a part of Shopsys Framework [installation guide](https://github.com/shopsys/shopsys/blob/v7.0.0-alpha5/docs/installation/installation-using-docker-application-setup.md)

--- a/docs/upgrade/interchangeable-filtering.md
+++ b/docs/upgrade/interchangeable-filtering.md
@@ -1,0 +1,79 @@
+# Upgrade Instructions for Interchangeable Filtering
+
+This article describes upgrade instructions for [#943 Elastic search filtering](https://github.com/shopsys/shopsys/pull/943).
+Upgrade instructions are in a separate article because there is a lot of instructions and we don't want to jam the [UPGRADE-unreleased.md](/docs/upgrade/UPGRADE-unreleased.md). <!--- TODO change to released version -->
+Instructions are meant to be followed when you upgrade from `v7.1.0` to `v7.2.0`.
+
+In order to avoid a BC break and to ease upgrade to the new version of Shopsys Framework,
+we decided to allow to use either current (SQL) or newly created (Elasticsearch) implementation of filtering.
+Thanks to this, you can still easily upgrade to the new version without the need to rewrite your application
+or use faster filtering with Elasticsearch we were able to deliver in the minor version as it does not break our BC promise.
+
+You can learn more about [Product filtering](/docs/model/front-end-product-filtering.md) in the particular article.
+
+## Use current SQL Filtering
+You can still filter products via SQL if your filtering is more complex and/or don't want to implement your custom modification in Elasticsearch.
+
+You should even then make some upgrade steps to have your code tested properly and follow the recommendation for the project-base.
+
+- replace occurrences of class `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade` with the interface `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface` in
+    - `src/Shopsys/ShopBundle/Controller/Front/ProductController.php`
+    - `src/Shopsys/ShopBundle/Controller/Front/SearchController.php`
+- add service definition for facade interface to your `services.yml` like
+    ```yaml
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
+    ```
+- in order to have your code properly tested, copy following [tests from shopsys/project-base](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product) into your project
+    - `ProductOnCurrentDomainFacadeTest.php`
+    - `ProductOnCurrentDomainFacadeCountDataTest.php`
+    - `ProductOnCurrentDomainSqlFacadeTest.php`
+    - `ProductOnCurrentDomainSqlFacadeCountDataTest.php`
+    - `Filter/BrandFilterChoiceRepositoryTest.php`
+    - `Filter/FlagFilterChoiceRepositoryTest.php`
+    - `Filter/ParameterFilterChoiceRepositoryTest.php`
+    - `Search/FilterQueryTest.php`
+- skip path `'*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'` for following coding standard sniffs in your `easy-coding-standard.yml` file
+    `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff`
+    `ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff`
+- to ease your life in a future you should
+    - replace Elasticsearch structure files in `src/Shopsys/ShopBundle/Resources/definition/products/` folder in your project with new ones from [definitions in shopsys/project-base](https://github.com/shopsys/project-base/blob/master/src/Shopsys/ShopBundle/Resources/definition/product/)
+    - add following alias to `services.yml` and `services_test.yml` to start exporting more data into Elasticsearch
+        ```yaml
+       Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
+           alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
+        ```
+    - update test of export repository `tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php` to match the new Elasticsearch structure
+        you can copy [`ProductSearchExportRepositoryTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php)
+    - recreate structure and export products to Elasticsearch with `./phing product-search-recreate-structure product-search-export-products`
+
+## Use new Elasticsearch Filtering
+To start filtering products via Elasticsearch you have to do this steps.
+
+- replace Elasticsearch structure files in `src/Shopsys/ShopBundle/Resources/definition/products/` folder in your project with new ones from [definitions in shopsys/project-base](https://github.com/shopsys/project-base/blob/master/src/Shopsys/ShopBundle/Resources/definition/product/)
+- replace class `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade` with the interface `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface` in
+    - `src/Shopsys/ShopBundle/Controller/Front/ProductController.php`
+    - `src/Shopsys/ShopBundle/Controller/Front/SearchController.php`
+- add service definition for facade interface to your `services.yml` like
+    ```yaml
+   Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade'
+    ```
+- add following alias to `services.yml` and `services_test.yml` to start exporting more data into Elasticsearch
+    ```yaml
+   Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
+       alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
+    ```
+- update test of export repository `tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php` to match the new Elasticsearch structure
+    you can copy [`ProductSearchExportRepositoryTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php)
+- in order to have your code properly tested, copy following [tests from shopsys/project-base](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product) to your project
+    - `ProductOnCurrentDomainFacadeTest.php`
+    - `ProductOnCurrentDomainFacadeCountDataTest.php`
+    - `ProductOnCurrentDomainElasticFacadeTest.php`
+    - `ProductOnCurrentDomainElasticFacadeCountDataTest.php`
+    - `Filter/BrandFilterChoiceRepositoryTest.php`
+    - `Filter/FlagFilterChoiceRepositoryTest.php`
+    - `Filter/ParameterFilterChoiceRepositoryTest.php`
+    - `Search/FilterQueryTest.php`
+- skip path `'*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'` for following coding standard sniffs in your `easy-coding-standard.yml` file
+    `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff`
+    `ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff`
+- don't forget to recreate structure and export products to Elasticsearch with `./phing product-search-recreate-structure product-search-export-products`

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -45,6 +45,7 @@ parameters:
             - '*/src/Model/Product/Product.php'
             - '*/src/Model/Product/ProductRepository.php'
             - '*/tests/Unit/Component/Money/MoneyTest.php'
+            - '*/src/Model/Product/Search/FilterQuery.php'
 
         PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.DetectedWhile:
             - '*/src/Model/Product/Availability/ProductAvailabilityRecalculator.php'

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -25,6 +25,7 @@ parameters:
             - '*/src/Model/AdminNavigation/SideMenuBuilder.php'
             - '*/src/Model/Order/Preview/OrderPreviewCalculation.php'
             - '*/src/Model/Product/ProductVisibilityRepository.php'
+            - '*/src/Model/Product/Search/FilterQuery.php'
             - '*/src/Controller/Admin/AdministratorController.php'
             - '*/tests/Unit/Model/Customer/CustomerDataFactoryTest.php'
             - '*/tests/Unit/Component/Domain/DomainDataCreatorTest.php'

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager;
+use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
+use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer;
+use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
+use Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery;
+use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository;
+use Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer;
+
+class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacadeInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer
+     */
+    protected $currentCustomer;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository
+     */
+    protected $productAccessoryRepository;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository
+     */
+    protected $productElasticsearchRepository;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager
+     */
+    protected $elasticsearchStructureManager;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
+     */
+    protected $productFilterDataToQueryTransformer;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer $currentCustomer
+     * @param \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository $productAccessoryRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticsearchStructureManager
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer
+     */
+    public function __construct(
+        ProductRepository $productRepository,
+        Domain $domain,
+        CurrentCustomer $currentCustomer,
+        ProductAccessoryRepository $productAccessoryRepository,
+        ProductElasticsearchRepository $productElasticsearchRepository,
+        ElasticsearchStructureManager $elasticsearchStructureManager,
+        ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer
+    ) {
+        $this->productRepository = $productRepository;
+        $this->domain = $domain;
+        $this->currentCustomer = $currentCustomer;
+        $this->productAccessoryRepository = $productAccessoryRepository;
+        $this->productElasticsearchRepository = $productElasticsearchRepository;
+        $this->elasticsearchStructureManager = $elasticsearchStructureManager;
+        $this->productFilterDataToQueryTransformer = $productFilterDataToQueryTransformer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVisibleProductById($productId): Product
+    {
+        return $this->productRepository->getVisible(
+            $productId,
+            $this->domain->getId(),
+            $this->currentCustomer->getPricingGroup()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessoriesForProduct(Product $product): array
+    {
+        return $this->productAccessoryRepository->getAllOfferedAccessoriesByProduct(
+            $product,
+            $this->domain->getId(),
+            $this->currentCustomer->getPricingGroup()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVariantsForProduct(Product $product): array
+    {
+        return $this->productRepository->getAllSellableVariantsByMainVariant(
+            $product,
+            $this->domain->getId(),
+            $this->currentCustomer->getPricingGroup()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaginatedProductsInCategory(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId): PaginationResult
+    {
+        $filterQuery = $this->createProductsInCategoryFilterQuery($productFilterData, $orderingModeId, $page, $limit, $categoryId);
+
+        $productIds = $this->productElasticsearchRepository->getSortedProductIdsByFilterQuery($filterQuery);
+
+        $listableProductsByIds = $this->productRepository->getListableByIds($this->domain->getId(), $this->currentCustomer->getPricingGroup(), $productIds->getIds());
+
+        return new PaginationResult($page, $limit, $productIds->getTotal(), $listableProductsByIds);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param int $categoryId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    protected function createProductsInCategoryFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId): FilterQuery
+    {
+        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+            ->filterByCategory([$categoryId]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaginatedProductsForBrand($orderingModeId, $page, $limit, $brandId): PaginationResult
+    {
+        $emptyProductFilterData = new ProductFilterData();
+
+        $filterQuery = $this->createProductsForBrandFilterQuery($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
+
+        $productIds = $this->productElasticsearchRepository->getSortedProductIdsByFilterQuery($filterQuery);
+
+        $listableProductsByIds = $this->productRepository->getListableByIds($this->domain->getId(), $this->currentCustomer->getPricingGroup(), $productIds->getIds());
+
+        return new PaginationResult($page, $limit, $productIds->getTotal(), $listableProductsByIds);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param int $brandId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    protected function createProductsForBrandFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $brandId): FilterQuery
+    {
+        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+            ->filterByBrands([$brandId]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaginatedProductsForSearch($searchText, ProductFilterData $productFilterData, $orderingModeId, $page, $limit): PaginationResult
+    {
+        $filterQuery = $this->createProductsForSearchTextFilterQuery($productFilterData, $orderingModeId, $page, $limit, $searchText);
+
+        $productIds = $this->productElasticsearchRepository->getSortedProductIdsByFilterQuery($filterQuery);
+
+        $listableProductsByIds = $this->productRepository->getListableByIds($this->domain->getId(), $this->currentCustomer->getPricingGroup(), $productIds->getIds());
+
+        return new PaginationResult($page, $limit, $productIds->getTotal(), $listableProductsByIds);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param string $searchText
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    protected function createProductsForSearchTextFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $searchText): FilterQuery
+    {
+        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+            ->search($searchText);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    protected function createFilterQueryWithProductFilterData(ProductFilterData $productFilterData, $orderingModeId, $page, $limit): FilterQuery
+    {
+        $filterQuery = (new FilterQuery($this->getIndexName()))
+            ->filterOnlySellable()
+            ->setPage($page)
+            ->setLimit($limit)
+            ->applyOrdering($orderingModeId, $this->currentCustomer->getPricingGroup());
+
+        $filterQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addParametersToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $filterQuery, $this->currentCustomer->getPricingGroup());
+
+        return $filterQuery;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchAutocompleteProducts($searchText, $limit): PaginationResult
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $page = 1;
+
+        return $this->getPaginatedProductsForSearch($searchText, $emptyProductFilterData, ProductListOrderingConfig::ORDER_BY_RELEVANCE, $page, $limit);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
+    {
+        // TODO: Implement getProductFilterCountDataInCategory() method.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getProductFilterCountDataForSearch($searchText, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
+    {
+        // TODO: Implement getProductFilterCountDataForSearch() method.
+    }
+
+    /**
+     * @return string
+     */
+    protected function getIndexName(): string
+    {
+        return $this->elasticsearchStructureManager->getIndexName(
+            $this->domain->getId(),
+            ProductElasticsearchRepository::ELASTICSEARCH_INDEX
+        );
+    }
+}

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -208,6 +208,8 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     protected function createProductsForSearchTextFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $searchText): FilterQuery
     {
+        $searchText = $searchText ?? '';
+
         return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->search($searchText);
     }
@@ -252,11 +254,11 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
     {
-        $baseFilterQuery = new FilterQuery($this->getIndexName());
-        $baseFilterQuery->filterByCategory([$categoryId]);
-        $baseFilterQuery->filterOnlySellable();
-        $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $baseFilterQuery, $this->currentCustomer->getPricingGroup());
-        $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $baseFilterQuery);
+        $baseFilterQuery = (new FilterQuery($this->getIndexName()))
+            ->filterByCategory([$categoryId])
+            ->filterOnlySellable();
+        $baseFilterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $baseFilterQuery, $this->currentCustomer->getPricingGroup());
+        $baseFilterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $baseFilterQuery);
 
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInCategory(
             $productFilterData,
@@ -269,11 +271,13 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     public function getProductFilterCountDataForSearch($searchText, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
     {
-        $baseFilterQuery = new FilterQuery($this->getIndexName());
-        $baseFilterQuery->search($searchText);
-        $baseFilterQuery->filterOnlySellable();
-        $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $baseFilterQuery, $this->currentCustomer->getPricingGroup());
-        $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $baseFilterQuery);
+        $searchText = $searchText ?? '';
+
+        $baseFilterQuery = (new FilterQuery($this->getIndexName()))
+            ->search($searchText)
+            ->filterOnlySellable();
+        $baseFilterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $baseFilterQuery, $this->currentCustomer->getPricingGroup());
+        $baseFilterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $baseFilterQuery);
 
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInSearch(
             $productFilterData,

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -12,7 +12,7 @@ use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountRepository;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 
-class ProductOnCurrentDomainFacade
+class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+
+interface ProductOnCurrentDomainFacadeInterface
+{
+    /**
+     * @param int $productId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     */
+    public function getVisibleProductById($productId);
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getAccessoriesForProduct(Product $product);
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getVariantsForProduct(Product $product);
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param int $categoryId
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getPaginatedProductsInCategory(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId);
+
+    /**
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param int $brandId
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getPaginatedProductsForBrand($orderingModeId, $page, $limit, $brandId);
+
+    /**
+     * @param string|null $searchText
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getPaginatedProductsForSearch($searchText, ProductFilterData $productFilterData, $orderingModeId, $page, $limit);
+
+    /**
+     * @param string|null $searchText
+     * @param int $limit
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getSearchAutocompleteProducts($searchText, $limit);
+
+    /**
+     * @param int $categoryId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig $productFilterConfig
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData);
+
+    /**
+     * @param string|null $searchText
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig $productFilterConfig
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    public function getProductFilterCountDataForSearch($searchText, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData);
+}

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Product;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -699,6 +701,28 @@ class ProductRepository
         }
 
         $queryBuilder = $this->getAllOfferedQueryBuilder($domainId, $pricingGroup);
+        $queryBuilder
+            ->andWhere('p.id IN (:productIds)')
+            ->setParameter('productIds', $sortedProductIds)
+            ->addSelect('field(p.id, ' . implode(',', $sortedProductIds) . ') AS HIDDEN relevance')
+            ->orderBy('relevance');
+
+        return $queryBuilder->getQuery()->execute();
+    }
+
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @param int[] $sortedProductIds
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getListableByIds(int $domainId, PricingGroup $pricingGroup, array $sortedProductIds): array
+    {
+        if (count($sortedProductIds) === 0) {
+            return [];
+        }
+
+        $queryBuilder = $this->getAllListableQueryBuilder($domainId, $pricingGroup);
         $queryBuilder
             ->andWhere('p.id IN (:productIds)')
             ->setParameter('productIds', $sortedProductIds)

--- a/packages/framework/src/Model/Product/Search/AggregationResultToProductFilterCountDataTransformer.php
+++ b/packages/framework/src/Model/Product/Search/AggregationResultToProductFilterCountDataTransformer.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData;
+
+class AggregationResultToProductFilterCountDataTransformer
+{
+    /**
+     * @param array $aggregationResult
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    public function translateAbsoluteNumbers(array $aggregationResult): ProductFilterCountData
+    {
+        $countData = new ProductFilterCountData();
+        $countData->countByFlagId = $this->getFlagCount($aggregationResult);
+        $countData->countByBrandId = $this->getBrandCount($aggregationResult);
+        $countData->countInStock = $this->getStockCount($aggregationResult);
+
+        return $countData;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int[]
+     */
+    protected function getFlagCount(array $aggregationResult): array
+    {
+        $result = [];
+
+        $flagsBucket = $aggregationResult['aggregations']['flags']['buckets'];
+        foreach ($flagsBucket as $flagBucket) {
+            $flagId = $flagBucket['key'];
+            $flagCount = $flagBucket['doc_count'];
+            $result[$flagId] = $flagCount;
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int[]
+     */
+    protected function getBrandCount(array $aggregationResult): array
+    {
+        $result = [];
+
+        $brandsBucket = $aggregationResult['aggregations']['brands']['buckets'];
+        foreach ($brandsBucket as $brandBucket) {
+            $brandId = $brandBucket['key'];
+            $brandCount = $brandBucket['doc_count'];
+            $result[$brandId] = $brandCount;
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int
+     */
+    protected function getStockCount(array $aggregationResult): int
+    {
+        return $aggregationResult['aggregations']['stock']['doc_count'];
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    public function translateAbsoluteNumbersWithParameters(array $aggregationResult): ProductFilterCountData
+    {
+        $countData = $this->translateAbsoluteNumbers($aggregationResult);
+        $countData->countByParameterIdAndValueId = $this->getParametersCount($aggregationResult);
+
+        return $countData;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int[][]
+     */
+    protected function getParametersCount(array $aggregationResult): array
+    {
+        $result = [];
+
+        $parametersBucket = $aggregationResult['aggregations']['parameters']['by_parameters']['buckets'];
+        foreach ($parametersBucket as $parameterBucket) {
+            $parameterId = $parameterBucket['key'];
+            $result[$parameterId] = $this->getValuesCount($parameterBucket);
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $parameterBucket
+     * @return int[]
+     */
+    protected function getValuesCount(array $parameterBucket): array
+    {
+        $valueBuckets = $parameterBucket['by_value']['buckets'];
+        $values = [];
+        foreach ($valueBuckets as $valueBucket) {
+            $valueKey = $valueBucket['key'];
+            $valueCount = $valueBucket['doc_count'];
+            $values[$valueKey] = $valueCount;
+        }
+        return $values;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int[]
+     */
+    public function translateFlagsPlusNumbers(array $aggregationResult): array
+    {
+        $result = [];
+        $flagsBucket = $aggregationResult['aggregations']['flags']['buckets'];
+        foreach ($flagsBucket as $flagBucket) {
+            $flagId = $flagBucket['key'];
+            $flagCount = $flagBucket['doc_count'];
+            $result[$flagId] = $flagCount;
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int[]
+     */
+    public function translateBrandsPlusNumbers(array $aggregationResult): array
+    {
+        $result = [];
+        $brandsBucket = $aggregationResult['aggregations']['brands']['buckets'];
+        foreach ($brandsBucket as $flagBucket) {
+            $brandId = $flagBucket['key'];
+            $brandCount = $flagBucket['doc_count'];
+            $result[$brandId] = $brandCount;
+        }
+        return $result;
+    }
+
+    /**
+     * @param array $aggregationResult
+     * @return int[]
+     */
+    public function translateParameterValuesPlusNumbers(array $aggregationResult): array
+    {
+        $parametersBuckets = $aggregationResult['aggregations']['parameters']['filtered_for_parameter']['by_parameters']['buckets'];
+        if (empty($parametersBuckets)) {
+            return [];
+        }
+        $thePossibleBucket = $parametersBuckets[0];
+
+        $result = [];
+        foreach ($thePossibleBucket['by_value']['buckets'] as $bucket) {
+            $valueId = $bucket['key'];
+            $valueCount = $bucket['doc_count'];
+            $result[$valueId] = $valueCount;
+        }
+        return $result;
+    }
+}

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportRepository.php
@@ -8,6 +8,9 @@ use Doctrine\ORM\QueryBuilder;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibility;
 
+/**
+ * @deprecated Use ProductSearchExportWithFilterRepository instead
+ */
 class ProductSearchExportRepository
 {
     /**

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductVisibility;
+
+class ProductSearchExportWithFilterRepository extends ProductSearchExportRepository
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository
+     */
+    protected $parameterRepository;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    protected $productFacade;
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository $parameterRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
+     */
+    public function __construct(EntityManagerInterface $em, ParameterRepository $parameterRepository, ProductFacade $productFacade)
+    {
+        parent::__construct($em);
+
+        $this->parameterRepository = $parameterRepository;
+        $this->productFacade = $productFacade;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $locale
+     * @param int $startFrom
+     * @param int $batchSize
+     * @return array
+     */
+    public function getProductsData(int $domainId, string $locale, int $startFrom, int $batchSize): array
+    {
+        $queryBuilder = $this->createQueryBuilder($domainId, $locale)
+            ->setFirstResult($startFrom)
+            ->setMaxResults($batchSize);
+
+        $query = $queryBuilder->getQuery();
+
+        $result = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
+        foreach ($query->getResult() as $product) {
+            $flagIds = $this->extractFlags($product);
+            $categoryIds = $this->extractCategories($domainId, $product);
+            $parameters = $this->extractParameters($locale, $product);
+            $prices = $this->extractPrices($domainId, $product);
+
+            $result[] = [
+                'id' => $product->getId(),
+                'catnum' => $product->getCatnum(),
+                'partno' => $product->getPartno(),
+                'ean' => $product->getEan(),
+                'name' => $product->getName($locale),
+                'description' => $product->getDescription($domainId),
+                'shortDescription' => $product->getShortDescription($domainId),
+                'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
+                'flags' => $flagIds,
+                'categories' => $categoryIds,
+                'in_stock' => $product->getCalculatedAvailability()->getDispatchTime() === 0,
+                'prices' => $prices,
+                'parameters' => $parameters,
+                'ordering_priority' => $product->getOrderingPriority(),
+                'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $locale
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    protected function createQueryBuilder(int $domainId, string $locale): QueryBuilder
+    {
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->select('p')
+            ->from(Product::class, 'p')
+                ->where('p.variantType != :variantTypeVariant')
+            ->join(ProductVisibility::class, 'prv', Join::WITH, 'prv.product = p.id')
+                ->andWhere('prv.domainId = :domainId')
+                ->andWhere('prv.visible = TRUE')
+            ->groupBy('p.id')
+            ->orderBy('p.id');
+
+        $queryBuilder->setParameter('domainId', $domainId)
+            ->setParameter('variantTypeVariant', Product::VARIANT_TYPE_VARIANT);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return int[]
+     */
+    protected function extractFlags(Product $product): array
+    {
+        $flagIds = [];
+        foreach ($product->getFlags() as $flag) {
+            $flagIds[] = $flag->getId();
+        }
+
+        return $flagIds;
+    }
+
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return int[]
+     */
+    protected function extractCategories(int $domainId, Product $product): array
+    {
+        $categoryIds = [];
+        foreach ($product->getCategoriesIndexedByDomainId()[$domainId] as $category) {
+            $categoryIds[] = $category->getId();
+        }
+
+        return $categoryIds;
+    }
+
+    /**
+     * @param string $locale
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return array
+     */
+    protected function extractParameters(string $locale, Product $product): array
+    {
+        $parameters = [];
+        $productParameterValues = $this->parameterRepository->getProductParameterValuesByProductSortedByName($product, $locale);
+        foreach ($productParameterValues as $productParameterValue) {
+            $parameter = $productParameterValue->getParameter();
+            $parameterValue = $productParameterValue->getValue();
+            if ($parameter->getName($locale) !== null && $parameterValue->getLocale() === $locale) {
+                $parameters[] = [
+                    'parameter_id' => $parameter->getId(),
+                    'parameter_value_id' => $parameterValue->getId(),
+                ];
+            }
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return array
+     */
+    protected function extractPrices(int $domainId, Product $product): array
+    {
+        $prices = [];
+        $productSellingPrices = $this->productFacade->getAllProductSellingPricesIndexedByDomainId($product)[$domainId];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice $productSellingPrice */
+        foreach ($productSellingPrices as $productSellingPrice) {
+            $prices[] = [
+                'pricing_group_id' => $productSellingPrice->getPricingGroup()->getId(),
+                'amount' => (float)$productSellingPrice->getSellingPrice()->getPriceWithVat()->getAmount(),
+            ];
+        }
+
+        return $prices;
+    }
+}

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
+
+class FilterQuery
+{
+    /** @var array */
+    protected $filters = [];
+
+    /** @var string */
+    protected $indexName;
+
+    /** @var array */
+    protected $sorting = [];
+
+    /** @var int */
+    protected $limit = 1000;
+
+    /** @var int */
+    protected $page = 1;
+
+    /** @var array */
+    protected $match;
+
+    /**
+     * @param string $indexName
+     */
+    public function __construct(string $indexName)
+    {
+        $this->indexName = $indexName;
+        $this->match = $this->matchAll();
+    }
+
+    /**
+     * @param string $orderingModeId
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function applyOrdering(string $orderingModeId, PricingGroup $pricingGroup): self
+    {
+        $clone = clone $this;
+
+        if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_PRIORITY) {
+            $clone->sorting = [
+                'ordering_priority' => 'desc',
+                'name.keyword' => 'asc',
+            ];
+
+            return $clone;
+        }
+
+        if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_NAME_ASC) {
+            $clone->sorting = [
+                'name.keyword' => 'asc',
+            ];
+
+            return $clone;
+        }
+
+        if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_NAME_DESC) {
+            $clone->sorting = [
+                'name.keyword' => 'desc',
+            ];
+
+            return $clone;
+        }
+
+        if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_PRICE_ASC) {
+            $clone->sorting = [
+                'prices.amount' => [
+                    'order' => 'asc',
+                    'nested' => [
+                        'path' => 'prices',
+                        'filter' => [
+                            'term' => [
+                                'prices.pricing_group_id' => $pricingGroup->getId(),
+                            ],
+                        ],
+                    ],
+                ],
+                'ordering_priority' => 'asc',
+                'name.keyword' => 'asc',
+            ];
+
+            return $clone;
+        }
+
+        if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_PRICE_DESC) {
+            $clone->sorting = [
+                'prices.amount' => [
+                    'order' => 'desc',
+                    'nested' => [
+                        'path' => 'prices',
+                        'filter' => [
+                            'term' => [
+                                'prices.pricing_group_id' => $pricingGroup->getId(),
+                            ],
+                        ],
+                    ],
+                ],
+                'ordering_priority' => 'asc',
+                'name.keyword' => 'desc',
+            ];
+
+            return $clone;
+        }
+
+        return $clone;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function applyDefaultOrdering(): self
+    {
+        $clone = clone $this;
+
+        $clone->sorting = [
+            'ordering_priority' => 'desc',
+            'name.keyword' => 'asc',
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @param array $parameters
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterByParameters(array $parameters): self
+    {
+        $clone = clone $this;
+
+        foreach ($parameters as $parameterId => $parameterValues) {
+            $clone->filters[] = [
+                'nested' => [
+                    'path' => 'parameters',
+                    'query' => [
+                        'bool' => [
+                            'must' => [
+                                'match_all' => new \stdClass(),
+                            ],
+                            'filter' => [
+                                [
+                                    'term' => [
+                                        'parameters.parameter_id' => $parameterId,
+                                    ],
+                                ],
+                                [
+                                    'terms' => [
+                                        'parameters.parameter_value_id' => $parameterValues,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+        }
+
+        return $clone;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $minimalPrice
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $maximalPrice
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterByPrices(PricingGroup $pricingGroup, Money $minimalPrice = null, Money $maximalPrice = null): self
+    {
+        $clone = clone $this;
+
+        $prices = [];
+        if ($minimalPrice !== null) {
+            $prices['gte'] = (float)$minimalPrice->getAmount();
+        }
+        if ($maximalPrice !== null) {
+            $prices['lte'] = (float)$maximalPrice->getAmount();
+        }
+
+        $clone->filters[] = [
+            'nested' => [
+                'path' => 'prices',
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            'match_all' => new \stdClass(),
+                        ],
+                        'filter' => [
+                            [
+                                'term' => [
+                                    'prices.pricing_group_id' => $pricingGroup->getId(),
+                                ],
+                            ],
+                            [
+                                'range' => [
+                                    'prices.amount' => $prices,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @param int[] $categoryIds
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterByCategory(array $categoryIds): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'terms' => [
+                'categories' => $categoryIds,
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @param int[] $brandIds
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterByBrands(array $brandIds): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'terms' => [
+                'brand' => $brandIds,
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @param int[] $flagIds
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterByFlags(array $flagIds): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'terms' => [
+                'flags' => $flagIds,
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterOnlyInStock(): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'term' => [
+                'in_stock' => true,
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterOnlySellable(): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'term' => [
+                'calculated_selling_denied' => false,
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @param string $text
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function search(string $text): self
+    {
+        $clone = clone $this;
+
+        $clone->match = [
+            'multi_match' => [
+                'query' => $text,
+                'fields' => [
+                    'name.full_with_diacritic^60',
+                    'name.full_without_diacritic^50',
+                    'name^45',
+                    'name.edge_ngram_with_diacritic^40',
+                    'name.edge_ngram_without_diacritic^35',
+                    'catnum^50',
+                    'catnum.edge_ngram^25',
+                    'partno^40',
+                    'partno.edge_ngram^20',
+                    'ean^60',
+                    'ean.edge_ngram^30',
+                    'short_description^5',
+                    'description^5',
+                ],
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
+     * @param int $page
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function setPage(int $page): self
+    {
+        $clone = clone $this;
+
+        $clone->page = $page;
+
+        return $clone;
+    }
+
+    /**
+     * @param int $limit
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function setLimit(int $limit): self
+    {
+        $clone = clone $this;
+
+        $clone->limit = $limit;
+
+        return $clone;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQuery(): array
+    {
+        $query = [
+            'index' => $this->indexName,
+            'type' => '_doc',
+            'body' => [
+                'from' => $this->countFrom($this->page, $this->limit),
+                'size' => $this->limit,
+                'sort' => $this->sorting,
+                'query' => [
+                    'bool' => [
+                        'must' => $this->match,
+                        'filter' => $this->filters,
+                    ],
+                ],
+            ],
+        ];
+
+        return $query;
+    }
+
+    /**
+     * @return array
+     */
+    protected function matchAll(): array
+    {
+        return [
+            'match_all' => new \stdClass(),
+        ];
+    }
+
+    /**
+     * @param int $page
+     * @param int $limit
+     * @return int
+     */
+    protected function countFrom(int $page, int $limit): int
+    {
+        return ($page - 1) * $limit;
+    }
+}

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+class FilterQueryFactory
+{
+    /**
+     * @param string $indexName
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function create(string $indexName): FilterQuery
+    {
+        return new FilterQuery($indexName);
+    }
+}

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -38,11 +38,6 @@ class ProductElasticsearchRepository
     protected $elasticsearchStructureManager;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
-     */
-    protected $productFilterDataToQueryTransformer;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
      */
     protected $filterQueryFactory;
@@ -63,8 +58,16 @@ class ProductElasticsearchRepository
         $this->client = $client;
         $this->productElasticsearchConverter = $productElasticsearchConverter;
         $this->elasticsearchStructureManager = $elasticsearchStructureManager;
-        $this->productFilterDataToQueryTransformer = new ProductFilterDataToQueryTransformer();
-        $this->filterQueryFactory = new FilterQueryFactory();
+        $this->filterQueryFactory = $this->createFilterQueryFactory();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
+     * @deprecated Will be replaced with constructor injection in the next major release
+     */
+    protected function createFilterQueryFactory(): FilterQueryFactory
+    {
+        return new FilterQueryFactory();
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -43,6 +43,11 @@ class ProductElasticsearchRepository
     protected $productFilterDataToQueryTransformer;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
+     */
+    protected $filterQueryFactory;
+
+    /**
      * @param string $indexPrefix
      * @param \Elasticsearch\Client $client
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter $productElasticsearchConverter
@@ -59,6 +64,7 @@ class ProductElasticsearchRepository
         $this->productElasticsearchConverter = $productElasticsearchConverter;
         $this->elasticsearchStructureManager = $elasticsearchStructureManager;
         $this->productFilterDataToQueryTransformer = new ProductFilterDataToQueryTransformer();
+        $this->filterQueryFactory = new FilterQueryFactory();
     }
 
     /**
@@ -155,7 +161,7 @@ class ProductElasticsearchRepository
     {
         $searchText = $searchText ?? '';
 
-        $query = (new FilterQuery($indexName))
+        $query = $this->filterQueryFactory->create($indexName)
             ->search($searchText);
         return $query->getQuery();
     }

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -133,34 +133,9 @@ class ProductElasticsearchRepository
      */
     protected function createQuery(string $indexName, string $searchText): array
     {
-        return [
-            'index' => $indexName,
-            'type' => '_doc',
-            'size' => 1000,
-            'body' => [
-                '_source' => false,
-                'query' => [
-                    'multi_match' => [
-                        'query' => $searchText,
-                        'fields' => [
-                            'name.full_with_diacritic^60',
-                            'name.full_without_diacritic^50',
-                            'name^45',
-                            'name.edge_ngram_with_diacritic^40',
-                            'name.edge_ngram_without_diacritic^35',
-                            'catnum^50',
-                            'catnum.edge_ngram^25',
-                            'partno^40',
-                            'partno.edge_ngram^20',
-                            'ean^60',
-                            'ean.edge_ngram^30',
-                            'short_description^5',
-                            'description^5',
-                        ],
-                    ],
-                ],
-            ],
-        ];
+        $query = new FilterQuery($indexName);
+        $query->search($searchText);
+        return $query->getQuery();
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -153,6 +153,8 @@ class ProductElasticsearchRepository
      */
     protected function createQuery(string $indexName, string $searchText): array
     {
+        $searchText = $searchText ?? '';
+
         $query = (new FilterQuery($indexName))
             ->search($searchText);
         return $query->getQuery();

--- a/packages/framework/src/Model/Product/Search/ProductFilterCountDataElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductFilterCountDataElasticsearchRepository.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+
+class ProductFilterCountDataElasticsearchRepository
+{
+    /**
+     * @var \Elasticsearch\Client
+     */
+    protected $client;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
+     */
+    protected $productFilterDataToQueryTransformer;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\AggregationResultToProductFilterCountDataTransformer
+     */
+    protected $aggregationResultToCountDataTransformer;
+
+    /**
+     * @param \Elasticsearch\Client $client
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\AggregationResultToProductFilterCountDataTransformer $aggregationResultToCountDataTransformer
+     */
+    public function __construct(
+        Client $client,
+        ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer,
+        AggregationResultToProductFilterCountDataTransformer $aggregationResultToCountDataTransformer
+    ) {
+        $this->client = $client;
+        $this->productFilterDataToQueryTransformer = $productFilterDataToQueryTransformer;
+        $this->aggregationResultToCountDataTransformer = $aggregationResultToCountDataTransformer;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $baseFilterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    public function getProductFilterCountDataInSearch(ProductFilterData $productFilterData, FilterQuery $baseFilterQuery): ProductFilterCountData
+    {
+        $absoluteNumbersFilterQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $baseFilterQuery);
+        $absoluteNumbersFilterQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $absoluteNumbersFilterQuery);
+
+        $aggregationResult = $this->client->search($absoluteNumbersFilterQuery->getAbsoluteNumbersAggregationQuery());
+        $countData = $this->aggregationResultToCountDataTransformer->translateAbsoluteNumbers($aggregationResult);
+
+        if (count($productFilterData->flags) > 0) {
+            $plusFlagsQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $baseFilterQuery);
+            $countData->countByFlagId = $this->calculateFlagsPlusNumbers($productFilterData, $plusFlagsQuery);
+        }
+
+        if (count($productFilterData->brands) > 0) {
+            $plusBrandsQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $baseFilterQuery);
+            $countData->countByBrandId = $this->calculateBrandsPlusNumbers($productFilterData, $plusBrandsQuery);
+        }
+
+        return $countData;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $baseFilterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    public function getProductFilterCountDataInCategory(ProductFilterData $productFilterData, FilterQuery $baseFilterQuery): ProductFilterCountData
+    {
+        $absoluteNumbersFilterQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $baseFilterQuery);
+        $absoluteNumbersFilterQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $absoluteNumbersFilterQuery);
+        $absoluteNumbersFilterQuery = $this->productFilterDataToQueryTransformer->addParametersToQuery($productFilterData, $absoluteNumbersFilterQuery);
+
+        $aggregationResult = $this->client->search($absoluteNumbersFilterQuery->getAbsoluteNumbersWithParametersQuery());
+        $countData = $this->aggregationResultToCountDataTransformer->translateAbsoluteNumbersWithParameters($aggregationResult);
+
+        if (count($productFilterData->flags) > 0) {
+            $plusFlagsQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $baseFilterQuery);
+            $plusFlagsQuery = $this->productFilterDataToQueryTransformer->addParametersToQuery($productFilterData, $plusFlagsQuery);
+            $countData->countByFlagId = $this->calculateFlagsPlusNumbers($productFilterData, $plusFlagsQuery);
+        }
+
+        if (count($productFilterData->brands) > 0) {
+            $plusBrandsQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $baseFilterQuery);
+            $plusBrandsQuery = $this->productFilterDataToQueryTransformer->addParametersToQuery($productFilterData, $plusBrandsQuery);
+            $countData->countByBrandId = $this->calculateBrandsPlusNumbers($productFilterData, $plusBrandsQuery);
+        }
+
+        if (count($productFilterData->parameters) > 0) {
+            $plusParametersQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $baseFilterQuery);
+            $plusParametersQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $plusParametersQuery);
+
+            $this->replaceParametersPlusNumbers($productFilterData, $countData, $plusParametersQuery);
+        }
+
+        return $countData;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $plusFlagsQuery
+     * @return int[]
+     */
+    protected function calculateFlagsPlusNumbers(ProductFilterData $productFilterData, FilterQuery $plusFlagsQuery): array
+    {
+        $flagIds = [];
+        foreach ($productFilterData->flags as $flag) {
+            $flagIds[] = $flag->getId();
+        }
+        $flagsPlusNumberResult = $this->client->search($plusFlagsQuery->getFlagsPlusNumbersQuery($flagIds));
+        return $this->aggregationResultToCountDataTransformer->translateFlagsPlusNumbers($flagsPlusNumberResult);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $plusFlagsQuery
+     * @return int[]
+     */
+    protected function calculateBrandsPlusNumbers(ProductFilterData $productFilterData, FilterQuery $plusFlagsQuery): array
+    {
+        $brandsIds = [];
+        foreach ($productFilterData->brands as $brand) {
+            $brandsIds[] = $brand->getId();
+        }
+        $brandsPlusNumberResult = $this->client->search($plusFlagsQuery->getBrandsPlusNumbersQuery($brandsIds));
+        return $this->aggregationResultToCountDataTransformer->translateBrandsPlusNumbers($brandsPlusNumberResult);
+    }
+
+    /**
+     * When calculating plus numbers for a parameter, this parameter must be excluded from filter query (clone and unset)
+     *
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $countData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $plusParametersQuery
+     */
+    protected function replaceParametersPlusNumbers(ProductFilterData $productFilterData, ProductFilterCountData $countData, FilterQuery $plusParametersQuery): void
+    {
+        foreach ($productFilterData->parameters as $key => $currentParameterFilterData) {
+            $currentFilterData = clone $productFilterData;
+            unset($currentFilterData->parameters[$key]);
+
+            $currentQuery = $this->productFilterDataToQueryTransformer->addParametersToQuery($currentFilterData, $plusParametersQuery);
+
+            $plusParameterNumbers = $this->calculateParameterPlusNumbers($currentParameterFilterData, $currentQuery);
+            $this->mergeParameterCountData($countData, $plusParameterNumbers, $currentParameterFilterData->parameter->getId());
+        }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData $parameterFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $parameterFilterQuery
+     * @return array
+     */
+    protected function calculateParameterPlusNumbers(
+        ParameterFilterData $parameterFilterData,
+        FilterQuery $parameterFilterQuery
+    ): array {
+        $parameterId = $parameterFilterData->parameter->getId();
+        $valuesIds = [];
+        foreach ($parameterFilterData->values as $parameterValue) {
+            $valuesIds[] = $parameterValue->getId();
+        }
+
+        $currentQueryResult = $this->client->search($parameterFilterQuery->getParametersPlusNumbersQuery($parameterId, $valuesIds));
+        return $this->aggregationResultToCountDataTransformer->translateParameterValuesPlusNumbers($currentQueryResult);
+    }
+
+    /**
+     * Plus numbers are not replaced as expected, they are "added" to meet the original SQL implementation
+     *
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $countData
+     * @param array $plusParameterNumbers
+     * @param int $parameterId
+     */
+    protected function mergeParameterCountData(ProductFilterCountData $countData, array $plusParameterNumbers, int $parameterId): void
+    {
+        if (isset($countData->countByParameterIdAndValueId[$parameterId])) {
+            $countData->countByParameterIdAndValueId[$parameterId] += $plusParameterNumbers;
+        } else {
+            $countData->countByParameterIdAndValueId[$parameterId] = $plusParameterNumbers;
+        }
+    }
+}

--- a/packages/framework/src/Model/Product/Search/ProductFilterDataToQueryTransformer.php
+++ b/packages/framework/src/Model/Product/Search/ProductFilterDataToQueryTransformer.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue;
+
+class ProductFilterDataToQueryTransformer
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function addBrandsToQuery(ProductFilterData $productFilterData, FilterQuery $filterQuery): FilterQuery
+    {
+        if (count($productFilterData->brands) === 0) {
+            return $filterQuery;
+        }
+
+        $brandIds = \array_map(
+            static function (Brand $brand) {
+                return $brand->getId();
+            },
+            $productFilterData->brands
+        );
+
+        return $filterQuery->filterByBrands($brandIds);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function addFlagsToQuery(ProductFilterData $productFilterData, FilterQuery $filterQuery): FilterQuery
+    {
+        if (count($productFilterData->flags) === 0) {
+            return $filterQuery;
+        }
+
+        $flagIds = \array_map(
+            static function (Flag $flag) {
+                return $flag->getId();
+            },
+            $productFilterData->flags
+        );
+
+        return $filterQuery->filterByFlags($flagIds);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function addParametersToQuery(ProductFilterData $productFilterData, FilterQuery $filterQuery): FilterQuery
+    {
+        if (count($productFilterData->parameters) === 0) {
+            return $filterQuery;
+        }
+
+        $parameters = $this->flattenParameterFilterData($productFilterData->parameters);
+
+        return $filterQuery->filterByParameters($parameters);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData[] $parameters
+     * @return array
+     */
+    protected function flattenParameterFilterData(array $parameters): array
+    {
+        $result = [];
+
+        foreach ($parameters as $parameterFilterData) {
+            if (\count($parameterFilterData->values) === 0) {
+                continue;
+            }
+
+            $result[$parameterFilterData->parameter->getId()] =
+                \array_map(
+                    static function (ParameterValue $item) {
+                        return $item->getId();
+                    },
+                    $parameterFilterData->values
+                );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function addStockToQuery(ProductFilterData $productFilterData, FilterQuery $filterQuery): FilterQuery
+    {
+        if ($productFilterData->inStock === false) {
+            return $filterQuery;
+        }
+
+        return $filterQuery->filterOnlyInStock();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function addPricesToQuery(ProductFilterData $productFilterData, FilterQuery $filterQuery, PricingGroup $pricingGroup): FilterQuery
+    {
+        if ($productFilterData->maximalPrice === null && $productFilterData->minimalPrice === null) {
+            return $filterQuery;
+        }
+
+        return $filterQuery->filterByPrices($pricingGroup, $productFilterData->minimalPrice, $productFilterData->maximalPrice);
+    }
+}

--- a/packages/framework/src/Model/Product/Search/ProductIdsResult.php
+++ b/packages/framework/src/Model/Product/Search/ProductIdsResult.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+class ProductIdsResult
+{
+    /**
+     * @var int
+     */
+    protected $total;
+
+    /**
+     * @var int[]
+     */
+    protected $ids;
+
+    /**
+     * @param int $total
+     * @param int[] $ids
+     */
+    public function __construct(int $total, array $ids)
+    {
+        $this->total = $total;
+        $this->ids = $ids;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getIds(): array
+    {
+        return $this->ids;
+    }
+}

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -172,7 +172,7 @@ services:
 
     Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository: ~
+    Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory: ~
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade: ~
 

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -150,6 +150,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade: ~
 
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade: ~
+
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser: ~
 
     Shopsys\FrameworkBundle\Model\Product\ProductRepository: ~

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -110,6 +110,12 @@ services:
 
     Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory: ~
 
+    Shopsys\FrameworkBundle\Model\Product\Filter\BrandFilterChoiceRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Filter\FlagFilterChoiceRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoiceRepository: ~
+
     Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterInlineEdit: ~
 
     Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository: ~

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -185,3 +185,5 @@ services:
     Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade:
         arguments:
             - '@shopsys.shop.component.flash_message.sender.front'
+
+    Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory: ~

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -19,11 +19,13 @@ parameters:
             - '*/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php'
             - '*/tests/ShopBundle/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php'
             - '*/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php'
+            - '*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'
 
         ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff:
             - '*/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php'
             - '*/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.phpFixture.php'
             - '*/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php'
+            - '*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'
 
         Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff:
             - '*/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php'

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -13,7 +13,7 @@ use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade;
-use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
 use Shopsys\FrameworkBundle\Twig\RequestExtension;
 use Shopsys\ShopBundle\Form\Front\Product\ProductFilterFormType;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +40,7 @@ class ProductController extends FrontBaseController
     private $domain;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
      */
     private $productOnCurrentDomainFacade;
 
@@ -78,7 +78,7 @@ class ProductController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Twig\RequestExtension $requestExtension
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade $productOnCurrentDomainFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory $productFilterConfigFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade $productListOrderingModeForListFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade $productListOrderingModeForBrandFacade
@@ -90,7 +90,7 @@ class ProductController extends FrontBaseController
         RequestExtension $requestExtension,
         CategoryFacade $categoryFacade,
         Domain $domain,
-        ProductOnCurrentDomainFacade $productOnCurrentDomainFacade,
+        ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade,
         ProductFilterConfigFactory $productFilterConfigFactory,
         ProductListOrderingModeForListFacade $productListOrderingModeForListFacade,
         ProductListOrderingModeForBrandFacade $productListOrderingModeForBrandFacade,

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/SearchController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/SearchController.php
@@ -3,7 +3,7 @@
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
-use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class SearchController extends FrontBaseController
@@ -17,17 +17,17 @@ class SearchController extends FrontBaseController
     private $categoryFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
      */
     private $productOnCurrentDomainFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade $productOnCurrentDomainFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
      */
     public function __construct(
         CategoryFacade $categoryFacade,
-        ProductOnCurrentDomainFacade $productOnCurrentDomainFacade
+        ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
     ) {
         $this->categoryFacade = $categoryFacade;
         $this->productOnCurrentDomainFacade = $productOnCurrentDomainFacade;

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -52,7 +52,7 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\ProductDataFactory'
 
-    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade'
 
     Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
         alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -52,6 +52,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\ProductDataFactory'
 
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
+
     Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
         alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -52,6 +52,9 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\ProductDataFactory'
 
+    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
+        alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
+
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\Brand\BrandDataFactory'
 
     Shopsys\ShopBundle\DataFixtures\ProductDataFixtureReferenceInjector: ~

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services_test.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services_test.yml
@@ -46,6 +46,9 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\ProductDataFactory'
 
+    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
+        alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
+
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\Brand\BrandDataFactory'
 
     Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~

--- a/project-base/src/Shopsys/ShopBundle/Resources/definition/product/1.json
+++ b/project-base/src/Shopsys/ShopBundle/Resources/definition/product/1.json
@@ -104,6 +104,9 @@
             "edge_ngram_without_diacritic": {
               "type": "text",
               "analyzer": "edge_ngram_without_diacritic"
+            },
+            "keyword": {
+              "type": "keyword"
             }
           }
         },
@@ -147,6 +150,46 @@
         "description": {
           "type": "text",
           "analyzer": "edge_ngram_without_diacritic_html"
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "brand": {
+          "type": "integer"
+        },
+        "categories": {
+          "type": "integer"
+        },
+        "prices": {
+          "type": "nested",
+          "properties": {
+            "pricing_group_id": {
+              "type": "integer"
+            },
+            "amount": {
+              "type": "float"
+            }
+          }
+        },
+        "in_stock": {
+          "type": "boolean"
+        },
+        "parameters": {
+          "type": "nested",
+          "properties": {
+            "parameter_id": {
+              "type": "integer"
+            },
+            "parameter_value_id": {
+              "type": "integer"
+            }
+          }
+        },
+        "ordering_priority": {
+          "type": "integer"
+        },
+        "calculated_selling_denied": {
+          "type": "boolean"
         }
       }
     }

--- a/project-base/src/Shopsys/ShopBundle/Resources/definition/product/2.json
+++ b/project-base/src/Shopsys/ShopBundle/Resources/definition/product/2.json
@@ -104,6 +104,9 @@
             "edge_ngram_without_diacritic": {
               "type": "text",
               "analyzer": "edge_ngram_without_diacritic"
+            },
+            "keyword": {
+              "type": "keyword"
             }
           }
         },
@@ -147,6 +150,46 @@
         "description": {
           "type": "text",
           "analyzer": "edge_ngram_without_diacritic_html"
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "brand": {
+          "type": "integer"
+        },
+        "categories": {
+          "type": "integer"
+        },
+        "prices": {
+          "type": "nested",
+          "properties": {
+            "pricing_group_id": {
+              "type": "integer"
+            },
+            "amount": {
+              "type": "float"
+            }
+          }
+        },
+        "in_stock": {
+          "type": "boolean"
+        },
+        "parameters": {
+          "type": "nested",
+          "properties": {
+            "parameter_id": {
+              "type": "integer"
+            },
+            "parameter_value_id": {
+              "type": "integer"
+            }
+          }
+        },
+        "ordering_priority": {
+          "type": "integer"
+        },
+        "calculated_selling_denied": {
+          "type": "boolean"
         }
       }
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product\Filter;
+
+use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
+use Shopsys\FrameworkBundle\Model\Product\Filter\BrandFilterChoiceRepository;
+use Shopsys\ShopBundle\DataFixtures\Demo\CategoryDataFixture;
+use Shopsys\ShopBundle\DataFixtures\Demo\PricingGroupDataFixture;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
+{
+    public function testBrandFilterChoicesFromCategoryWithNoBrands(): void
+    {
+        $brandFilterChoices = $this->getChoicesForCategoryReference(CategoryDataFixture::CATEGORY_BOOKS);
+
+        $this->assertCount(0, $brandFilterChoices);
+    }
+
+    public function testBrandFilterChoicesFromCategoryWithBrands(): void
+    {
+        $brandFilterChoices = $this->getChoicesForCategoryReference(CategoryDataFixture::CATEGORY_ELECTRONICS);
+
+        $this->assertCount(4, $brandFilterChoices);
+
+        $ids = array_map(
+            static function (Brand $brand) {
+                return $brand->getId();
+            },
+            $brandFilterChoices
+        );
+
+        $this->assertContains(4, $ids);
+        $this->assertContains(6, $ids);
+        $this->assertContains(3, $ids);
+        $this->assertContains(5, $ids);
+    }
+
+    public function testGetBrandFilterChoicesForSearchPhone(): void
+    {
+        $brandFilterChoices = $this->getChoicesForSearchText('phone');
+
+        $this->assertCount(7, $brandFilterChoices);
+
+        $ids = array_map(
+            static function (Brand $brand) {
+                return $brand->getId();
+            },
+            $brandFilterChoices
+        );
+
+        $this->assertContains(1, $ids);
+        $this->assertContains(2, $ids);
+        $this->assertContains(15, $ids);
+        $this->assertContains(3, $ids);
+        $this->assertContains(4, $ids);
+        $this->assertContains(20, $ids);
+        $this->assertContains(19, $ids);
+    }
+
+    public function testGetBrandFilterChoicesForSearch47(): void
+    {
+        $brandFilterChoices = $this->getChoicesForSearchText('47');
+
+        $this->assertCount(1, $brandFilterChoices);
+
+        $this->assertSame(3, $brandFilterChoices[0]->getId());
+    }
+
+    /**
+     * @param string $categoryReferenceName
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     */
+    protected function getChoicesForCategoryReference(string $categoryReferenceName): array
+    {
+        $repository = $this->getBrandFilterChoiceRepository();
+
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Category\Category $category */
+        $category = $this->getReference($categoryReferenceName);
+
+        return $repository->getBrandFilterChoicesInCategory(1, $pricingGroup, $category);
+    }
+
+    /**
+     * @param string $searchText
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     */
+    protected function getChoicesForSearchText(string $searchText): array
+    {
+        $repository = $this->getBrandFilterChoiceRepository();
+
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        return $repository->getBrandFilterChoicesForSearch(1, $pricingGroup, 'en', $searchText);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\BrandFilterChoiceRepository
+     */
+    public function getBrandFilterChoiceRepository(): BrandFilterChoiceRepository
+    {
+        return $this->getContainer()->get(BrandFilterChoiceRepository::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product\Filter;
+
+use Shopsys\FrameworkBundle\Model\Product\Filter\FlagFilterChoiceRepository;
+use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
+use Shopsys\ShopBundle\DataFixtures\Demo\CategoryDataFixture;
+use Shopsys\ShopBundle\DataFixtures\Demo\PricingGroupDataFixture;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+class FlagFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
+{
+    public function testFlagFilterChoicesFromCategoryWithNoFlags(): void
+    {
+        $flagFilterChoices = $this->getChoicesForCategoryReference(CategoryDataFixture::CATEGORY_GARDEN_TOOLS);
+
+        $this->assertCount(0, $flagFilterChoices);
+    }
+
+    public function testFlagFilterChoicesFromCategoryWithFlags(): void
+    {
+        $flagFilterChoices = $this->getChoicesForCategoryReference(CategoryDataFixture::CATEGORY_ELECTRONICS);
+
+        $this->assertCount(2, $flagFilterChoices);
+
+        $ids = array_map(
+            static function (Flag $flag) {
+                return $flag->getId();
+            },
+            $flagFilterChoices
+        );
+
+        $this->assertContains(2, $ids);
+        $this->assertContains(3, $ids);
+    }
+
+    public function testGetFlagFilterChoicesForSearchPhone(): void
+    {
+        $flagFilterChoices = $this->getChoicesForSearchText('phone');
+
+        $this->assertCount(3, $flagFilterChoices);
+
+        $ids = array_map(
+            static function (Flag $flag) {
+                return $flag->getId();
+            },
+            $flagFilterChoices
+        );
+
+        $this->assertContains(1, $ids);
+        $this->assertContains(2, $ids);
+        $this->assertContains(3, $ids);
+    }
+
+    public function testGetFlagFilterChoicesForBook(): void
+    {
+        $flagFilterChoices = $this->getChoicesForSearchText('book');
+
+        $this->assertCount(2, $flagFilterChoices);
+
+        $ids = array_map(
+            static function (Flag $flag) {
+                return $flag->getId();
+            },
+            $flagFilterChoices
+        );
+
+        $this->assertContains(1, $ids);
+        $this->assertContains(2, $ids);
+    }
+
+    /**
+     * @param string $categoryReferenceName
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    protected function getChoicesForCategoryReference(string $categoryReferenceName): array
+    {
+        $repository = $this->getFlagFilterChoiceRepository();
+
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Category\Category $category */
+        $category = $this->getReference($categoryReferenceName);
+
+        return $repository->getFlagFilterChoicesInCategory(1, $pricingGroup, 'en', $category);
+    }
+
+    /**
+     * @param string $searchText
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    protected function getChoicesForSearchText(string $searchText): array
+    {
+        $repository = $this->getFlagFilterChoiceRepository();
+
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        return $repository->getFlagFilterChoicesForSearch(1, $pricingGroup, 'en', $searchText);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\FlagFilterChoiceRepository
+     */
+    public function getFlagFilterChoiceRepository(): FlagFilterChoiceRepository
+    {
+        return $this->getContainer()->get(FlagFilterChoiceRepository::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product\Filter;
+
+use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoiceRepository;
+use Shopsys\ShopBundle\DataFixtures\Demo\CategoryDataFixture;
+use Shopsys\ShopBundle\DataFixtures\Demo\PricingGroupDataFixture;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+class ParameterFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
+{
+    public function testParameterFilterChoicesFromCategoryWithNoParameters(): void
+    {
+        $parameterFilterChoices = $this->getChoicesForCategoryReference(CategoryDataFixture::CATEGORY_GARDEN_TOOLS);
+
+        $this->assertCount(0, $parameterFilterChoices);
+    }
+
+    public function testParameterFilterChoicesFromCategory(): void
+    {
+        $parameterFilterChoices = $this->getChoicesForCategoryReference(CategoryDataFixture::CATEGORY_BOOKS);
+
+        $this->assertCount(3, $parameterFilterChoices);
+
+        $ids = array_map(
+            static function (ParameterFilterChoice $parameterFilterChoice) {
+                return $parameterFilterChoice->getParameter()->getId();
+            },
+            $parameterFilterChoices
+        );
+
+        $this->assertContains(50, $ids);
+        $this->assertContains(49, $ids);
+        $this->assertContains(10, $ids);
+
+        $parameterParameterValuePair = [
+            0 => [109, 115],
+            1 => [117, 121, 111, 105],
+            2 => [113, 119, 107],
+        ];
+
+        foreach ($parameterParameterValuePair as $i => $parameterValues) {
+            foreach ($parameterValues as $j => $value) {
+                $this->assertSame($value, $parameterFilterChoices[$i]->getValues()[$j]->getId());
+            }
+        }
+    }
+
+    /**
+     * @param string $categoryReferenceName
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice[]
+     */
+    protected function getChoicesForCategoryReference(string $categoryReferenceName): array
+    {
+        $repository = $this->getParameterFilterChoiceRepository();
+
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Category\Category $category */
+        $category = $this->getReference($categoryReferenceName);
+
+        return $repository->getParameterFilterChoicesInCategory(1, $pricingGroup, 'en', $category);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoiceRepository
+     */
+    public function getParameterFilterChoiceRepository(): ParameterFilterChoiceRepository
+    {
+        return $this->getContainer()->get(ParameterFilterChoiceRepository::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+
+class ProductOnCurrentDomainElasticFacadeCountDataTest extends ProductOnCurrentDomainFacadeCountDataTest
+{
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface
+    {
+        return $this->getContainer()->get(ProductOnCurrentDomainElasticFacade::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+
+class ProductOnCurrentDomainElasticFacadeTest extends ProductOnCurrentDomainFacadeTest
+{
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface
+    {
+        return $this->getContainer()->get(ProductOnCurrentDomainElasticFacade::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
@@ -1,0 +1,620 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Category\Category;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+use Shopsys\ShopBundle\DataFixtures\Demo\BrandDataFixture;
+use Shopsys\ShopBundle\DataFixtures\Demo\CategoryDataFixture;
+use Shopsys\ShopBundle\DataFixtures\Demo\FlagDataFixture;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunctionalTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory
+     */
+    protected $productFilterConfigFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    protected $productOnCurrentDomainFacade;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->productFilterConfigFactory = $this->getContainer()->get(ProductFilterConfigFactory::class);
+        $this->domain = $this->getContainer()->get(Domain::class);
+        $this->productOnCurrentDomainFacade = $this->getProductOnCurrentDomainFacade();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    abstract public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $filterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $expectedCountData
+     * @dataProvider categoryTestCasesProvider
+     */
+    public function testCategory(Category $category, ProductFilterData $filterData, ProductFilterCountData $expectedCountData): void
+    {
+        $filterConfig = $this->productFilterConfigFactory->createForCategory($this->domain->getId(), $this->domain->getLocale(), $category);
+        $countData = $this->productOnCurrentDomainFacade->getProductFilterCountDataInCategory($category->getId(), $filterConfig, $filterData);
+
+        $this->assertEquals($expectedCountData, $countData);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function categoryTestCasesProvider(): array
+    {
+        return [
+            'no-filter' => $this->categoryNoFilterTestCase(),
+            'one-flag' => $this->categoryOneFlagTestCase(),
+            'one-brand' => $this->categoryOneBrandTestCase(),
+            'all-flags-all-brands' => $this->categoryAllFlagsAllBrandsTestCase(),
+            'price' => $this->categoryPrice(),
+            'stock' => $this->categoryStock(),
+            'flag-brand-parameters' => $this->categoryFlagBrandAndParameters(),
+            'parameters' => $this->categoryParameters(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryNoFilterTestCase(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $countData = new ProductFilterCountData();
+
+        $countData->countInStock = 10;
+        $countData->countByBrandId = [
+            2 => 6,
+            14 => 2,
+        ];
+        $countData->countByFlagId = [
+            1 => 5,
+            2 => 2,
+        ];
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 10,
+            ],
+            11 => [
+                58 => 8,
+                124 => 2,
+            ],
+            30 => [
+                8 => 5,
+                12 => 5,
+            ],
+            29 => [
+                54 => 7,
+                189 => 3,
+            ],
+            31 => [
+                56 => 3,
+                97 => 7,
+            ],
+            28 => [
+                52 => 10,
+            ],
+            4 => [
+                8 => 10,
+            ],
+            10 => [
+                60 => 1,
+                62 => 9,
+            ],
+            33 => [
+                8 => 8,
+                12 => 2,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryOneFlagTestCase(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $filterData->flags[] = $this->getReference(FlagDataFixture::FLAG_TOP_PRODUCT);
+
+        $countData = new ProductFilterCountData();
+
+        $countData->countInStock = 2;
+        $countData->countByBrandId = [
+            2 => 2,
+        ];
+        $countData->countByFlagId = [
+            1 => 3,
+        ];
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 2,
+            ],
+            11 => [
+                58 => 2,
+            ],
+            30 => [
+                8 => 1,
+                12 => 1,
+            ],
+            29 => [
+                54 => 1,
+                189 => 1,
+            ],
+            31 => [
+                56 => 1,
+                97 => 1,
+            ],
+            28 => [
+                52 => 2,
+            ],
+            4 => [
+                8 => 2,
+            ],
+            10 => [
+                60 => 1,
+                62 => 1,
+            ],
+            33 => [
+                8 => 2,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryOneBrandTestCase(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_CANON);
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 6;
+        $countData->countByFlagId = [
+            1 => 3,
+            2 => 2,
+        ];
+        $countData->countByBrandId = [
+            14 => 2,
+        ];
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 6,
+            ],
+            11 => [
+                58 => 6,
+            ],
+            30 => [
+                8 => 3,
+                12 => 3,
+            ],
+            29 => [
+                54 => 3,
+                189 => 3,
+            ],
+            31 => [
+                56 => 2,
+                97 => 4,
+            ],
+            28 => [
+                52 => 6,
+            ],
+            4 => [
+                8 => 6,
+            ],
+            10 => [
+                60 => 1,
+                62 => 5,
+            ],
+            33 => [
+                8 => 6,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryAllFlagsAllBrandsTestCase(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_CANON);
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_HP);
+        $filterData->flags[] = $this->getReference(FlagDataFixture::FLAG_TOP_PRODUCT);
+        $filterData->flags[] = $this->getReference(FlagDataFixture::FLAG_NEW_PRODUCT);
+
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 4;
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 4,
+            ],
+            11 => [
+                58 => 4,
+            ],
+            30 => [
+                8 => 2,
+                12 => 2,
+            ],
+            29 => [
+                54 => 3,
+                189 => 1,
+            ],
+            31 => [
+                56 => 2,
+                97 => 2,
+            ],
+            28 => [
+                52 => 4,
+            ],
+            4 => [
+                8 => 4,
+            ],
+            10 => [
+                60 => 1,
+                62 => 3,
+            ],
+            33 => [
+                8 => 4,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryPrice(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $filterData->minimalPrice = Money::create(1000);
+        $filterData->maximalPrice = Money::create(80000);
+
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 6;
+        $countData->countByBrandId = [
+            2 => 4,
+            14 => 2,
+        ];
+        $countData->countByFlagId = [
+            1 => 3,
+            2 => 2,
+        ];
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 6,
+            ],
+            11 => [
+                58 => 6,
+            ],
+            30 => [
+                8 => 3,
+                12 => 3,
+            ],
+            29 => [
+                54 => 4,
+                189 => 2,
+            ],
+            31 => [
+                56 => 1,
+                97 => 5,
+            ],
+            28 => [
+                52 => 6,
+            ],
+            4 => [
+                8 => 6,
+            ],
+            10 => [
+                60 => 1,
+                62 => 5,
+            ],
+            33 => [
+                8 => 6,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryStock(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PHONES);
+        $filterData = new ProductFilterData();
+        $filterData->inStock = true;
+
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 2;
+        $countData->countByBrandId = [
+            3 => 1,
+            20 => 1,
+        ];
+        $countData->countByFlagId = [
+            1 => 2,
+        ];
+        $countData->countByParameterIdAndValueId = [
+            51 => [],
+            17 => [
+                8 => 1,
+            ],
+            11 => [
+                24 => 1,
+            ],
+            46 => [],
+            47 => [],
+            19 => [
+                12 => 1,
+            ],
+            12 => [
+                12 => 1,
+            ],
+            18 => [
+                12 => 1,
+            ],
+            14 => [
+                28 => 1,
+            ],
+            16 => [
+                32 => 1,
+            ],
+            15 => [
+                30 => 1,
+            ],
+            13 => [
+                26 => 1,
+            ],
+            3 => [],
+            48 => [],
+            10 => [
+                22 => 1,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryFlagBrandAndParameters(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_CANON);
+        $filterData->flags[] = $this->getReference(FlagDataFixture::FLAG_NEW_PRODUCT);
+        $filterData->parameters[] = $this->createParameterFilterData(
+            ['en' => 'Dimensions'],
+            [['en' => '449x304x152 mm']]
+        );
+        $filterData->parameters[] = $this->createParameterFilterData(
+            ['en' => 'Print resolution'],
+            [['en' => '2400x600'], ['en' => '4800x1200']]
+        );
+        $filterData->parameters[] = $this->createParameterFilterData(
+            ['en' => 'Weight'],
+            [['en' => '3.5 kg']]
+        );
+
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 2;
+        $countData->countByBrandId = [
+            14 => 1,
+        ];
+        $countData->countByFlagId = [];
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 2,
+            ],
+            11 => [
+                58 => 2,
+            ],
+            30 => [
+                8 => 1,
+                12 => 1,
+            ],
+            29 => [
+                54 => 1,
+                189 => 1,
+            ],
+            31 => [
+                56 => 1,
+                97 => 1,
+            ],
+            28 => [
+                52 => 2,
+            ],
+            4 => [
+                8 => 2,
+            ],
+            10 => [
+                60 => 1,
+                62 => 2,
+            ],
+            33 => [
+                8 => 2,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function categoryParameters(): array
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+        $filterData = new ProductFilterData();
+        $filterData->parameters[] = $this->createParameterFilterData(
+            ['en' => 'Dimensions'],
+            [['en' => '449x304x152 mm']]
+        );
+        $filterData->parameters[] = $this->createParameterFilterData(
+            ['en' => 'Print resolution'],
+            [['en' => '2400x600'], ['en' => '4800x1200']]
+        );
+        $filterData->parameters[] = $this->createParameterFilterData(
+            ['en' => 'Weight'],
+            [['en' => '3.5 kg']]
+        );
+
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 7;
+        $countData->countByBrandId = [
+            14 => 2,
+            2 => 5,
+        ];
+        $countData->countByFlagId = [
+            1 => 3,
+            2 => 1,
+        ];
+        $countData->countByParameterIdAndValueId = [
+            32 => [
+                8 => 7,
+            ],
+            11 => [
+                58 => 7,
+                124 => 2,
+            ],
+            30 => [
+                8 => 3,
+                12 => 4,
+            ],
+            29 => [
+                54 => 4,
+                189 => 3,
+            ],
+            31 => [
+                56 => 1,
+                97 => 6,
+            ],
+            28 => [
+                52 => 7,
+            ],
+            4 => [
+                8 => 7,
+            ],
+            10 => [
+                60 => 1,
+                62 => 7,
+            ],
+            33 => [
+                8 => 7,
+            ],
+        ];
+
+        return [
+            $category,
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @param array $namesByLocale
+     * @param array $valuesTextsByLocales
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData
+     */
+    private function createParameterFilterData(array $namesByLocale, array $valuesTextsByLocales)
+    {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository $parameterRepository */
+        $parameterRepository = $this->getContainer()->get(ParameterRepository::class);
+
+        $parameter = $parameterRepository->findParameterByNames($namesByLocale);
+        $parameterValues = $this->getParameterValuesByLocalesAndTexts($valuesTextsByLocales);
+
+        $parameterFilterData = new ParameterFilterData();
+        $parameterFilterData->parameter = $parameter;
+        $parameterFilterData->values = $parameterValues;
+
+        return $parameterFilterData;
+    }
+
+    /**
+     * @param array[] $valuesTextsByLocales
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue[]
+     */
+    private function getParameterValuesByLocalesAndTexts(array $valuesTextsByLocales)
+    {
+        /** @var \Doctrine\ORM\EntityManager $em */
+        $em = $this->getContainer()->get('doctrine.orm.default_entity_manager');
+        $parameterValues = [];
+
+        foreach ($valuesTextsByLocales as $valueTextsByLocales) {
+            foreach ($valueTextsByLocales as $locale => $text) {
+                $parameterValues[] = $em->getRepository(ParameterValue::class)->findOneBy([
+                    'text' => $text,
+                    'locale' => $locale,
+                ]);
+            }
+        }
+
+        return $parameterValues;
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
@@ -58,7 +58,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
         $filterConfig = $this->productFilterConfigFactory->createForCategory($this->domain->getId(), $this->domain->getLocale(), $category);
         $countData = $this->productOnCurrentDomainFacade->getProductFilterCountDataInCategory($category->getId(), $filterConfig, $filterData);
 
-        $this->assertEquals($expectedCountData, $countData);
+        $this->assertEquals($expectedCountData, $this->removeEmptyParameters($countData));
     }
 
     /**
@@ -89,7 +89,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
         $filterConfig = $this->productFilterConfigFactory->createForSearch($this->domain->getId(), $this->domain->getLocale(), $searchText);
         $countData = $this->productOnCurrentDomainFacade->getProductFilterCountDataForSearch($searchText, $filterConfig, $filterData);
 
-        $this->assertEquals($expectedCountData, $countData);
+        $this->assertEquals($expectedCountData, $this->removeEmptyParameters($countData));
     }
 
     /**
@@ -420,15 +420,12 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
             1 => 2,
         ];
         $countData->countByParameterIdAndValueId = [
-            51 => [],
             17 => [
                 8 => 1,
             ],
             11 => [
                 24 => 1,
             ],
-            46 => [],
-            47 => [],
             19 => [
                 12 => 1,
             ],
@@ -450,8 +447,6 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
             13 => [
                 26 => 1,
             ],
-            3 => [],
-            48 => [],
             10 => [
                 22 => 1,
             ],
@@ -838,5 +833,20 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
             $filterData,
             $countData,
         ];
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $countData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
+     */
+    private function removeEmptyParameters(ProductFilterCountData $countData): ProductFilterCountData
+    {
+        $result = clone $countData;
+        foreach ($countData->countByParameterIdAndValueId as $parameterId => $values) {
+            if (empty($values)) {
+                unset($result->countByParameterIdAndValueId[$parameterId]);
+            }
+        }
+        return $result;
     }
 }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
@@ -71,10 +71,39 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
             'one-flag' => $this->categoryOneFlagTestCase(),
             'one-brand' => $this->categoryOneBrandTestCase(),
             'all-flags-all-brands' => $this->categoryAllFlagsAllBrandsTestCase(),
-            'price' => $this->categoryPrice(),
-            'stock' => $this->categoryStock(),
-            'flag-brand-parameters' => $this->categoryFlagBrandAndParameters(),
-            'parameters' => $this->categoryParameters(),
+            'price' => $this->categoryPriceTestCase(),
+            'stock' => $this->categoryStockTestCase(),
+            'flag-brand-parameters' => $this->categoryFlagBrandAndParametersTestCase(),
+            'parameters' => $this->categoryParametersTestCase(),
+        ];
+    }
+
+    /**
+     * @param string $searchText
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $filterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $expectedCountData
+     * @dataProvider searchTestCasesProvider
+     */
+    public function testSearch(string $searchText, ProductFilterData $filterData, ProductFilterCountData $expectedCountData): void
+    {
+        $filterConfig = $this->productFilterConfigFactory->createForSearch($this->domain->getId(), $this->domain->getLocale(), $searchText);
+        $countData = $this->productOnCurrentDomainFacade->getProductFilterCountDataForSearch($searchText, $filterConfig, $filterData);
+
+        $this->assertEquals($expectedCountData, $countData);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function searchTestCasesProvider(): array
+    {
+        return [
+            'no-filter' => $this->searchNoFilterTestCase(),
+            'one-flag' => $this->searchOneFlagTestCase(),
+            'one-brand' => $this->searchOneBrandTestCase(),
+            'price' => $this->searchPriceTestCase(),
+            'stock' => $this->searchStockTestCase(),
+            'price-stock-flag-brands' => $this->searchPriceStockFlagBrandsTestCase(),
         ];
     }
 
@@ -314,7 +343,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
     /**
      * @return array
      */
-    private function categoryPrice(): array
+    private function categoryPriceTestCase(): array
     {
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
         $filterData = new ProductFilterData();
@@ -375,7 +404,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
     /**
      * @return array
      */
-    private function categoryStock(): array
+    private function categoryStockTestCase(): array
     {
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PHONES);
         $filterData = new ProductFilterData();
@@ -438,7 +467,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
     /**
      * @return array
      */
-    private function categoryFlagBrandAndParameters(): array
+    private function categoryFlagBrandAndParametersTestCase(): array
     {
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
         $filterData = new ProductFilterData();
@@ -507,7 +536,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
     /**
      * @return array
      */
-    private function categoryParameters(): array
+    private function categoryParametersTestCase(): array
     {
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
         $filterData = new ProductFilterData();
@@ -616,5 +645,198 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
         }
 
         return $parameterValues;
+    }
+
+    /**
+     * @return array
+     */
+    private function searchNoFilterTestCase(): array
+    {
+        $filterData = new ProductFilterData();
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 38;
+        $countData->countByBrandId = [
+            8 => 1,
+            11 => 1,
+            19 => 2,
+            10 => 1,
+            2 => 10,
+            4 => 1,
+            16 => 1,
+            15 => 1,
+            6 => 1,
+            14 => 2,
+            12 => 2,
+            3 => 2,
+        ];
+        $countData->countByFlagId = [
+            1 => 15,
+            2 => 5,
+            3 => 3,
+        ];
+
+        return [
+            'print',
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function searchOneFlagTestCase(): array
+    {
+        $filterData = new ProductFilterData();
+        $filterData->flags[] = $this->getReference(FlagDataFixture::FLAG_NEW_PRODUCT);
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 11;
+        $countData->countByBrandId = [
+            2 => 3,
+            3 => 1,
+            10 => 1,
+            11 => 1,
+            12 => 1,
+            14 => 1,
+            15 => 1,
+            16 => 1,
+            19 => 2,
+        ];
+        $countData->countByFlagId = [
+            2 => 2,
+            3 => 2,
+        ];
+
+        return [
+            'print',
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function searchOneBrandTestCase(): array
+    {
+        $filterData = new ProductFilterData();
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_CANON);
+        $countData = new ProductFilterCountData();
+
+        $countData->countInStock = 10;
+        $countData->countByBrandId = [
+            3 => 2,
+            4 => 1,
+            6 => 1,
+            8 => 1,
+            10 => 1,
+            11 => 1,
+            12 => 2,
+            14 => 2,
+            15 => 1,
+            16 => 1,
+            19 => 2,
+        ];
+        $countData->countByFlagId = [
+            1 => 3,
+            2 => 2,
+        ];
+
+        return [
+            'print',
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function searchPriceTestCase(): array
+    {
+        $filterData = new ProductFilterData();
+        $filterData->minimalPrice = Money::create(5000);
+        $filterData->maximalPrice = Money::create(50000);
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 9;
+        $countData->countByBrandId = [
+            2 => 4,
+            3 => 1,
+            4 => 1,
+            11 => 1,
+            15 => 1,
+        ];
+        $countData->countByFlagId = [
+            1 => 2,
+            2 => 2,
+        ];
+
+        return [
+            'print',
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function searchStockTestCase(): array
+    {
+        $filterData = new ProductFilterData();
+        $filterData->inStock = true;
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 38;
+        $countData->countByBrandId = [
+            2 => 10,
+            3 => 2,
+            4 => 1,
+            6 => 1,
+            8 => 1,
+            10 => 1,
+            11 => 1,
+            12 => 2,
+            14 => 2,
+            16 => 1,
+        ];
+        $countData->countByFlagId = [
+            1 => 11,
+            2 => 4,
+            3 => 2,
+        ];
+
+        return [
+            'print',
+            $filterData,
+            $countData,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function searchPriceStockFlagBrandsTestCase(): array
+    {
+        $filterData = new ProductFilterData();
+        $filterData->inStock = true;
+        $filterData->flags[] = $this->getReference(FlagDataFixture::FLAG_NEW_PRODUCT);
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_DELONGHI);
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_DEFENDER);
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_GENIUS);
+        $filterData->brands[] = $this->getReference(BrandDataFixture::BRAND_HP);
+        $filterData->maximalPrice = Money::create(20000);
+
+        $countData = new ProductFilterCountData();
+        $countData->countInStock = 3;
+        $countData->countByBrandId = [
+            2 => 3,
+            3 => 1,
+        ];
+
+        return [
+            'print',
+            $filterData,
+            $countData,
+        ];
     }
 }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -105,9 +105,10 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
 
         $parameterFilterData = $this->createParameterFilterData(
-            ['cs' => 'Rozlišení tisku'],
-            [['cs' => '4800x1200']]
+            ['en' => 'Print resolution'],
+            [['en' => '4800x1200']]
         );
+
         $productFilterData = new ProductFilterData();
         $productFilterData->parameters = [$parameterFilterData];
 
@@ -121,10 +122,10 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
 
         $parameterFilterData = $this->createParameterFilterData(
-            ['cs' => 'Rozlišení tisku'],
+            ['en' => 'Print resolution'],
             [
-                ['cs' => '4800x1200'],
-                ['cs' => '2400x600'],
+                ['en' => '4800x1200'],
+                ['en' => '2400x600'],
             ]
         );
         $productFilterData = new ProductFilterData();
@@ -139,12 +140,12 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
 
         $parameterFilterData1 = $this->createParameterFilterData(
-            ['cs' => 'Rozlišení tisku'],
-            [['cs' => '2400x600']]
+            ['en' => 'Print resolution'],
+            [['en' => '2400x600']]
         );
         $parameterFilterData2 = $this->createParameterFilterData(
-            ['cs' => 'LCD'],
-            [['cs' => 'Ano']]
+            ['en' => 'LCD'],
+            [['en' => 'Yes']]
         );
         $productFilterData = new ProductFilterData();
         $productFilterData->parameters = [$parameterFilterData1, $parameterFilterData2];
@@ -185,7 +186,7 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
 
         foreach ($valuesTextsByLocales as $valueTextsByLocales) {
             foreach ($valueTextsByLocales as $locale => $text) {
-                $parameterValues[] = $em->getRepository(ParameterValue::class)->findBy([
+                $parameterValues[] = $em->getRepository(ParameterValue::class)->findOneBy([
                     'text' => $text,
                     'locale' => $locale,
                 ]);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -4,6 +4,7 @@ namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
+use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
@@ -227,6 +228,75 @@ abstract class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTes
         return $this->getPaginationResultInCategoryWithPageAndLimit($productFilterData, $category, 1, 1000);
     }
 
+    public function testGetProductsForBrand(): void
+    {
+        $brand = $this->getReference(BrandDataFixture::BRAND_CANON);
+
+        $paginationResult = $this->getPaginatedProductsForBrand($brand);
+
+        $this->assertCount(10, $paginationResult->getResults());
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand $brand
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getPaginatedProductsForBrand(Brand $brand): PaginationResult
+    {
+        $productOnCurrentDomainFacade = $this->getProductOnCurrentDomainFacade();
+        $page = 1;
+        $limit = 1000;
+
+        return $productOnCurrentDomainFacade->getPaginatedProductsForBrand(
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC,
+            $page,
+            $limit,
+            $brand->getId()
+        );
+    }
+
+    public function testGetPaginatedProductsForSearchWithFlagsAndBrand(): void
+    {
+        $productFilterData = new ProductFilterData();
+
+        $flagTopProduct = $this->getReference(FlagDataFixture::FLAG_NEW_PRODUCT);
+        $productFilterData->flags = [$flagTopProduct];
+
+        $brandCanon = $this->getReference(BrandDataFixture::BRAND_CANON);
+        $productFilterData->brands = [$brandCanon];
+
+        $paginationResult = $this->getPaginationResultInSearch($productFilterData, 'mg3550');
+
+        $this->assertCount(3, $paginationResult->getResults());
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $searchText
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getPaginationResultInSearch(ProductFilterData $productFilterData, string $searchText): PaginationResult
+    {
+        $productOnCurrentDomainFacade = $this->getProductOnCurrentDomainFacade();
+        $page = 1;
+        $limit = 1000;
+
+        return $productOnCurrentDomainFacade->getPaginatedProductsForSearch(
+            $searchText,
+            $productFilterData,
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC,
+            $page,
+            $limit
+        );
+    }
+
+    public function testGetSearchAutocompleteProducts(): void
+    {
+        $paginationResult = $this->getSearchAutocompleteProducts('mg3550');
+
+        $this->assertCount(4, $paginationResult->getResults());
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @param \Shopsys\ShopBundle\Model\Category\Category $category
@@ -244,6 +314,21 @@ abstract class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTes
             $page,
             $limit,
             $category->getId()
+        );
+    }
+
+    /**
+     * @param string $searchText
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getSearchAutocompleteProducts(string $searchText): PaginationResult
+    {
+        $productOnCurrentDomainFacade = $this->getProductOnCurrentDomainFacade();
+        $limit = 1000;
+
+        return $productOnCurrentDomainFacade->getSearchAutocompleteProducts(
+            $searchText,
+            $limit
         );
     }
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -137,6 +137,29 @@ abstract class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTes
         $this->assertCount(10, $paginationResult->getResults());
     }
 
+    public function testFilterByParametersWithEmptyValue(): void
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);
+
+        $parameterFilterData1 = $this->createParameterFilterData(
+            ['en' => 'Print resolution'],
+            [
+                ['en' => '4800x1200'],
+                ['en' => '2400x600'],
+            ]
+        );
+        $parameterFilterData2 = $this->createParameterFilterData(
+            ['en' => 'LCD'],
+            []
+        );
+
+        $productFilterData = new ProductFilterData();
+        $productFilterData->parameters = [$parameterFilterData1, $parameterFilterData2];
+        $paginationResult = $this->getPaginationResultInCategory($productFilterData, $category);
+
+        $this->assertCount(10, $paginationResult->getResults());
+    }
+
     public function testFilterByParametersUsesAndWithinDistinctParameters()
     {
         $category = $this->getReference(CategoryDataFixture::CATEGORY_PRINTERS);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -197,6 +197,26 @@ abstract class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTes
         return $parameterValues;
     }
 
+    public function testPagination(): void
+    {
+        $category = $this->getReference(CategoryDataFixture::CATEGORY_TV);
+
+        $productFilterData = new ProductFilterData();
+        $productFilterData->minimalPrice = Money::create(1000);
+
+        $paginationResult = $this->getPaginationResultInCategoryWithPageAndLimit($productFilterData, $category, 1, 10);
+        $this->assertCount(10, $paginationResult->getResults());
+        $this->assertSame(22, $paginationResult->getTotalCount());
+
+        $paginationResult = $this->getPaginationResultInCategoryWithPageAndLimit($productFilterData, $category, 2, 10);
+        $this->assertCount(10, $paginationResult->getResults());
+        $this->assertSame(22, $paginationResult->getTotalCount());
+
+        $paginationResult = $this->getPaginationResultInCategoryWithPageAndLimit($productFilterData, $category, 3, 2);
+        $this->assertCount(2, $paginationResult->getResults());
+        $this->assertSame(22, $paginationResult->getTotalCount());
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @param \Shopsys\ShopBundle\Model\Category\Category $category

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -3,19 +3,20 @@
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue;
-use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
 use Shopsys\ShopBundle\DataFixtures\Demo\BrandDataFixture;
 use Shopsys\ShopBundle\DataFixtures\Demo\CategoryDataFixture;
 use Shopsys\ShopBundle\DataFixtures\Demo\FlagDataFixture;
 use Shopsys\ShopBundle\Model\Category\Category;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
-class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
+abstract class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
 {
     public function testFilterByMinimalPrice()
     {
@@ -201,12 +202,21 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
      * @param \Shopsys\ShopBundle\Model\Category\Category $category
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    private function getPaginationResultInCategory(ProductFilterData $productFilterData, Category $category)
+    public function getPaginationResultInCategory(ProductFilterData $productFilterData, Category $category): PaginationResult
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade $productOnCurrentDomainFacade */
-        $productOnCurrentDomainFacade = $this->getContainer()->get(ProductOnCurrentDomainFacade::class);
-        $page = 1;
-        $limit = PHP_INT_MAX;
+        return $this->getPaginationResultInCategoryWithPageAndLimit($productFilterData, $category, 1, 1000);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\ShopBundle\Model\Category\Category $category
+     * @param int $page
+     * @param int $limit
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    public function getPaginationResultInCategoryWithPageAndLimit(ProductFilterData $productFilterData, Category $category, int $page, int $limit): PaginationResult
+    {
+        $productOnCurrentDomainFacade = $this->getProductOnCurrentDomainFacade();
 
         return $productOnCurrentDomainFacade->getPaginatedProductsInCategory(
             $productFilterData,
@@ -216,4 +226,9 @@ class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTestCase
             $category->getId()
         );
     }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    abstract public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface;
 }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainSqlFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainSqlFacadeCountDataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+
+class ProductOnCurrentDomainSqlFacadeCountDataTest extends ProductOnCurrentDomainFacadeCountDataTest
+{
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface
+    {
+        return $this->getContainer()->get(ProductOnCurrentDomainFacade::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainSqlFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainSqlFacadeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Functional\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+
+class ProductOnCurrentDomainSqlFacadeTest extends ProductOnCurrentDomainFacadeTest
+{
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     */
+    public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface
+    {
+        return $this->getContainer()->get(ProductOnCurrentDomainFacade::class);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
@@ -6,6 +6,7 @@ use Elasticsearch\Client;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 use Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery;
+use Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory;
 use Shopsys\ShopBundle\DataFixtures\Demo\PricingGroupDataFixture;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
@@ -162,7 +163,9 @@ class FilterQueryTest extends TransactionFunctionalTestCase
      */
     protected function createFilter(): FilterQuery
     {
-        $filter = new FilterQuery(self::ELASTICSEARCH_INDEX);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory */
+        $filterQueryFactory = $this->getContainer()->get(FilterQueryFactory::class);
+        $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
 
         return $filter->filterOnlySellable();
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\ShopBundle\Functional\Model\Product\Search;
+
+use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
+use Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery;
+use Shopsys\ShopBundle\DataFixtures\Demo\PricingGroupDataFixture;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+class FilterQueryTest extends TransactionFunctionalTestCase
+{
+    private const ELASTICSEARCH_INDEX = 'product1';
+
+    public function testBrand(): void
+    {
+        $filter = $this->createFilter()
+            ->filterByBrands([1]);
+
+        $this->assertIdWithFilter($filter, [5]);
+    }
+
+    public function testFlag(): void
+    {
+        $filter = $this->createFilter()
+            ->filterByFlags([3])
+            ->applyDefaultOrdering();
+
+        $this->assertIdWithFilter($filter, [1, 5, 50, 16, 33, 39, 70, 40, 45]);
+    }
+
+    public function testFlagBrand(): void
+    {
+        $filter = $this->createFilter()
+            ->filterByBrands([12])
+            ->filterByFlags([1])
+            ->applyDefaultOrdering();
+
+        $this->assertIdWithFilter($filter, [19, 17]);
+    }
+
+    public function testMultiFilter(): void
+    {
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        $filter = $this->createFilter()
+            ->filterOnlyInStock()
+            ->filterByCategory([9])
+            ->filterByFlags([1])
+            ->filterByPrices($pricingGroup, null, Money::create(20));
+
+        $this->assertIdWithFilter($filter, [50]);
+    }
+
+    public function testParameters(): void
+    {
+        $parameters = [50 => [109, 115], 49 => [105, 121], 10 => [107]];
+
+        $filter = $this->createFilter()
+            ->filterByParameters($parameters);
+
+        $this->assertIdWithFilter($filter, [25, 28]);
+    }
+
+    public function testOrdering(): void
+    {
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
+        $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+
+        $filter = $this->createFilter()
+            ->filterByCategory([9])
+            ->applyDefaultOrdering();
+
+        $this->assertIdWithFilter($filter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40], 'top');
+
+        $nameAscFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_NAME_ASC, $pricingGroup);
+        $this->assertIdWithFilter($nameAscFilter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40], 'name asc');
+
+        $nameDescFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_NAME_DESC, $pricingGroup);
+        $this->assertIdWithFilter($nameDescFilter, [40, 39, 33, 50, 26, 28, 29, 27, 25, 72], 'name desc');
+
+        $priceAscFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRICE_ASC, $pricingGroup);
+        $this->assertIdWithFilter($priceAscFilter, [40, 33, 50, 39, 29, 25, 26, 27, 28, 72], 'price asc');
+
+        $priceDescFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRICE_DESC, $pricingGroup);
+        $this->assertIdWithFilter($priceDescFilter, [72, 28, 27, 26, 25, 29, 39, 50, 33, 40], 'price desc');
+    }
+
+    public function testMatchQuery(): void
+    {
+        $filter = $this->createFilter();
+
+        $kittyFilter = $filter->search('kitty');
+        $this->assertIdWithFilter($kittyFilter, [1, 102, 101]);
+
+        $mg3550Filer = $filter->search('mg3550');
+        $this->assertIdWithFilter($mg3550Filer, [9, 144, 10, 145]);
+    }
+
+    public function testPagination(): void
+    {
+        $filter = $this->createFilter()
+            ->filterByCategory([9])
+            ->applyDefaultOrdering();
+
+        $this->assertIdWithFilter($filter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40]);
+
+        $limit5Filter = $filter->setLimit(5);
+        $this->assertIdWithFilter($limit5Filter, [72, 25, 27, 29, 28]);
+
+        $limit1Filter = $filter->setLimit(1);
+        $this->assertIdWithFilter($limit1Filter, [72]);
+
+        $limit4Page2Filter = $filter->setLimit(4)
+            ->setPage(2);
+        $this->assertIdWithFilter($limit4Page2Filter, [28, 26, 50, 33]);
+
+        $limit4Page3Filter = $filter->setLimit(4)
+            ->setPage(3);
+        $this->assertIdWithFilter($limit4Page3Filter, [39, 40]);
+
+        $limit4Page4Filter = $filter->setLimit(4)
+            ->setPage(4);
+        $this->assertIdWithFilter($limit4Page4Filter, []);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @param int[] $ids
+     * @param string $message
+     */
+    protected function assertIdWithFilter(FilterQuery $filterQuery, array $ids, string $message = ''): void
+    {
+        /** @var \Elasticsearch\Client $es */
+        $es = $this->getContainer()->get(Client::class);
+
+        $params = $filterQuery->getQuery();
+
+        $params['_source'] = false;
+
+        $result = $es->search($params);
+        $this->assertSame($ids, $this->extractIds($result), $message);
+    }
+
+    /**
+     * @param array $result
+     * @return int[]
+     */
+    protected function extractIds(array $result): array
+    {
+        $hits = $result['hits']['hits'];
+
+        return array_map(static function ($element) {
+            return (int)$element['_id'];
+        }, $hits);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    protected function createFilter(): FilterQuery
+    {
+        $filter = new FilterQuery(self::ELASTICSEARCH_INDEX);
+
+        return $filter->filterOnlySellable();
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\ShopBundle\Functional\Model\Product\Search;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository;
+use Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class ProductSearchExportRepositoryTest extends TransactionFunctionalTestCase
@@ -33,7 +34,20 @@ class ProductSearchExportRepositoryTest extends TransactionFunctionalTestCase
         $structure = array_keys(reset($data));
         sort($structure);
 
-        $expectedStructure = [
+        $expectedStructure = $this->getExpectedStructureForRepository($this->repository);
+
+        sort($expectedStructure);
+
+        $this->assertSame($expectedStructure, $structure);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository $productSearchExportRepository
+     * @return string[]
+     */
+    private function getExpectedStructureForRepository(ProductSearchExportRepository $productSearchExportRepository): array
+    {
+        $structure = [
             'id',
             'name',
             'catnum',
@@ -42,8 +56,20 @@ class ProductSearchExportRepositoryTest extends TransactionFunctionalTestCase
             'description',
             'shortDescription',
         ];
-        sort($expectedStructure);
 
-        $this->assertSame($expectedStructure, $structure);
+        if ($productSearchExportRepository instanceof ProductSearchExportWithFilterRepository) {
+            $structure = \array_merge($structure, [
+                'brand',
+                'flags',
+                'categories',
+                'in_stock',
+                'prices',
+                'parameters',
+                'ordering_priority',
+                'calculated_selling_denied',
+            ]);
+        }
+
+        return $structure;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Allows to use Elasticsearch for filtering products (in search and product list) to avoid burdening the database and filter data faster.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| **No** <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

From Elastic is retrieved filtered data, sorting, aggregation numbers, pagination and a total number of products.
A new structure files was introduced to avoid BC break.
It's still possible to use filtering from SQL by don't applying the upgrade notes.

Filtering through Elasticsearch has a serious performance gain. The difference will be more pronounced the more the filtering options are applied. 
Measuring on demo dataset in "TV, audio" category with 6 options applied, shows approx three times improvement on time per request.