### PR TITLE
[shopsys] postgresql.conf is now used by Postgres

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -17,7 +17,11 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
-        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
+        command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -17,6 +17,7 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
+        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -17,7 +17,11 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
-        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
+        command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -17,6 +17,7 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
+        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -17,7 +17,11 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
-        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
+        command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -17,6 +17,7 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
+        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -155,23 +155,33 @@ There you can find links to upgrade notes for other versions too.
     -       query_cache_driver: array
     ```
 - update definition of postgres service in your `docker-compose.yml` file to use customized configuration ([#946](https://github.com/shopsys/shopsys/pull/946))
+    ```diff
+    postgres:
+        image: postgres:10.5-alpine
+        container_name: shopsys-framework-postgres
+        volumes:
+            - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
+            - ./var/postgres-data:/var/lib/postgresql/data:cached
+        environment:
+            - PGDATA=/var/lib/postgresql/data/pgdata
+            - POSTGRES_USER=root
+            - POSTGRES_PASSWORD=root
+            - POSTGRES_DB=shopsys
+    +   command:
+    +       - docker-entrypoint.sh
+    +       - postgres
+    +       - -c
+    +       - config_file=/var/lib/postgresql/data/postgresql.conf
+    ```
+    - update definition of postgres service in your `kubernetes/deployments/postgres.yml`
         ```diff
-        postgres:
-            image: postgres:10.5-alpine
-            container_name: shopsys-framework-postgres
-            volumes:
-                - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
-                - ./var/postgres-data:/var/lib/postgresql/data:cached
-            environment:
-                - PGDATA=/var/lib/postgresql/data/pgdata
-                - POSTGRES_USER=root
-                - POSTGRES_PASSWORD=root
-                - POSTGRES_DB=shopsys
-        +   command: 
-                - docker-entrypoint.sh
-                - postgres 
-                - -c 
-                - config_file=/var/lib/postgresql/data/postgresql.conf
+                -   name: PGDATA
+                    value: /var/lib/postgresql/data/pgdata
+        + command:
+        +    - docker-entrypoint.sh
+        +    - postgres
+        +    - -c
+        +    - config_file=/var/lib/postgresql/data/postgresql.conf
         ```
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -154,6 +154,25 @@ There you can find links to upgrade notes for other versions too.
     -       metadata_cache_driver: array
     -       query_cache_driver: array
     ```
+- update definition of postgres service in your `docker-compose.yml` file to use customized configuration ([#946](https://github.com/shopsys/shopsys/pull/946))
+        ```diff
+        postgres:
+            image: postgres:10.5-alpine
+            container_name: shopsys-framework-postgres
+            volumes:
+                - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
+                - ./var/postgres-data:/var/lib/postgresql/data:cached
+            environment:
+                - PGDATA=/var/lib/postgresql/data/pgdata
+                - POSTGRES_USER=root
+                - POSTGRES_PASSWORD=root
+                - POSTGRES_DB=shopsys
+        +   command: 
+                - docker-entrypoint.sh
+                - postgres 
+                - -c 
+                - config_file=/var/lib/postgresql/data/postgresql.conf
+        ```
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -11,7 +11,11 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
-        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
+        command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -11,6 +11,7 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
+        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -11,7 +11,11 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
-        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
+        command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -11,6 +11,7 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
+        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -11,7 +11,11 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
-        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
+        command:
+            - docker-entrypoint.sh
+            - postgres
+            - -c
+            - config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -11,6 +11,7 @@ services:
             - POSTGRES_USER=root
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
+        command: postgres -c config_file=/var/lib/postgresql/data/postgresql.conf
 
     webserver:
         image: nginx:1.13-alpine

--- a/project-base/kubernetes/deployments/postgres.yml
+++ b/project-base/kubernetes/deployments/postgres.yml
@@ -39,3 +39,8 @@ spec:
                         value: shopsys
                     -   name: PGDATA
                         value: /var/lib/postgresql/data/pgdata
+                command:
+                    - docker-entrypoint.sh
+                    - postgres
+                    - -c
+                    - config_file=/var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
- solution found in https://github.com/docker-library/postgres/issues/105

| Q             | A
| ------------- | ---
|Description, reason for the PR| I found out, that changing configuration in postgresql.conf and restarting container had no effect. After some searching I found this solution that repair that problem.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
