### PR TITLE
[shopsys] nginx has now same limit for file size as is set in php.ini

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -7,6 +7,7 @@ server {
     access_log /var/log/nginx/shopsys-framework.access.log;
     root /var/www/html/project-base/web;
     server_tokens off;
+    client_max_body_size 32M;
 
     location ~ /\. {
         # hide dotfiles (send to @app)

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -83,6 +83,16 @@ There you can find links to upgrade notes for other versions too.
         server_tokens off;
     +   client_max_body_size 32M;
     ```
+    - update your [ingress.yml](../../project-base/kubernetes/ingress.yml) config file
+        ```diff
+        metadata:
+            name: shopsys
+        +   annotations:
+        +       nginx.ingress.kubernetes.io/proxy-body-size: "32m"
+        spec:
+            rules:
+        ```
+    - check and update also all parent proxy servers for each project
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -88,7 +88,7 @@ There you can find links to upgrade notes for other versions too.
         metadata:
             name: shopsys
         +   annotations:
-        +       nginx.ingress.kubernetes.io/proxy-body-size: "32m"
+        +       nginx.ingress.kubernetes.io/proxy-body-size: 32m
         spec:
             rules:
         ```

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -74,6 +74,15 @@ There you can find links to upgrade notes for other versions too.
             </exec>
         </target>
     ```
+- update your [nginx.conf](../../project-base/docker/nginx/nginx.conf) file like this to have in nginx the same limit for file size as for php from [php.ini](../../project-base/docker/php-fpm/php-ini-overrides.ini) ([#947](https://github.com/shopsys/shopsys/pull/947))
+    ```diff
+    server {
+        listen 8080;
+        access_log /var/log/nginx/shopsys-framework.access.log;
+        root /var/www/html/web;
+        server_tokens off;
+    +   client_max_body_size 32M;
+    ```
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/docker/nginx/google-cloud/nginx.conf
+++ b/project-base/docker/nginx/google-cloud/nginx.conf
@@ -7,6 +7,7 @@ server {
     access_log /var/log/nginx/shopsys-framework.access.log;
     root /var/www/html/web;
     server_tokens off;
+    client_max_body_size 32M;
 
     location ~ /\. {
         # hide dotfiles (send to @app)

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -7,6 +7,7 @@ server {
     access_log /var/log/nginx/shopsys-framework.access.log;
     root /var/www/html/web;
     server_tokens off;
+    client_max_body_size 32M;
 
     location ~ /\. {
         # hide dotfiles (send to @app)

--- a/project-base/kubernetes/ingress.yml
+++ b/project-base/kubernetes/ingress.yml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
     name: shopsys
+    annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "32m"
 spec:
     rules:
     -   host: ~

--- a/project-base/kubernetes/ingress.yml
+++ b/project-base/kubernetes/ingress.yml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
     name: shopsys
     annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: "32m"
+        nginx.ingress.kubernetes.io/proxy-body-size: 32m
 spec:
     rules:
     -   host: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Default limit of client_max_body_size that affects uploaded files in Nginx is 1MB. In php-ini-overrides.ini is limit set to 32MB. Default file size in administration is set to 2MB. We want to have services configured the same by default to 32MB and for appliacation configuration in administration forms we will keep limit of 2MB.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
