### PR TITLE
[framework] fixed wrong behaviour while extending ProductFormType and CategoryFormType

### DIFF
--- a/docs/introduction/using-form-types.md
+++ b/docs/introduction/using-form-types.md
@@ -31,6 +31,7 @@ Defaults to `null`.
 This option is used as array with two options (`container_class`, `data_type`) and can be used to wrap your form_row in `<div class="{{ js_container.container_class }}" data-type="{{ js_container.data_type }}">`
 
 ### is_plugin_data_group
+*Using the `is_plugin_data_group` option in forms has been deprecated since Shopsys Framework 7.2 and it will be removed eventually.*  
 Defaults to `false`.  
 This option can be set to `true` in empty FormType if you want to add some part of a form from some plugin.
 You can learn more about this in [separate article](../extensibility/extending-form-from-plugin.md)

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Component\Plugin;
 
 use Shopsys\FrameworkBundle\Form\GroupType;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class PluginCrudExtensionFacade

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
@@ -35,13 +35,9 @@ class PluginCrudExtensionFacade
                 'label' => $crudExtension->getFormLabel(),
             ]);
 
-            $builderExtensionGroup->add($name, FormType::class, [
-                'compound' => true,
+            $builderExtensionGroup->add($key, $crudExtension->getFormTypeClass(), [
                 'render_form_row' => false,
-            ]);
-
-            $builderExtensionGroup->get($name)->add($key, $crudExtension->getFormTypeClass(), [
-                'render_form_row' => false,
+                'property_path' => sprintf('%s[%s]', $name, $key),
             ]);
 
             $builder->add($builderExtensionGroup);

--- a/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
+++ b/packages/framework/src/Component/Plugin/PluginCrudExtensionFacade.php
@@ -28,22 +28,23 @@ class PluginCrudExtensionFacade
      */
     public function extendForm(FormBuilderInterface $builder, $type, $name)
     {
-        $builder->add($name, FormType::class, [
-            'compound' => true,
-            'render_form_row' => false,
-        ]);
-
         $crudExtensions = $this->pluginCrudExtensionRegistry->getCrudExtensions($type);
+
         foreach ($crudExtensions as $key => $crudExtension) {
             $builderExtensionGroup = $builder->create($key . 'Group', GroupType::class, [
                 'label' => $crudExtension->getFormLabel(),
             ]);
 
-            $builderExtensionGroup->add($key, $crudExtension->getFormTypeClass(), [
+            $builderExtensionGroup->add($name, FormType::class, [
+                'compound' => true,
                 'render_form_row' => false,
             ]);
 
-            $builder->get($name)->add($builderExtensionGroup);
+            $builderExtensionGroup->get($name)->add($key, $crudExtension->getFormTypeClass(), [
+                'render_form_row' => false,
+            ]);
+
+            $builder->add($builderExtensionGroup);
         }
     }
 

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -20,7 +20,6 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -234,20 +233,14 @@ class CategoryFormType extends AbstractType
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
 
-        $builderPluginGroup = $builder->create('plugin', FormType::class, [
-            'inherit_data' => true,
-            'is_plugin_data_group' => true,
-        ]);
-
-        $this->pluginCrudExtensionFacade->extendForm($builderPluginGroup, 'category', 'pluginData');
-
         $builder
             ->add($builderSettingsGroup)
             ->add($builderSeoGroup)
             ->add($builderDescriptionGroup)
             ->add($builderImageGroup)
-            ->add($builderPluginGroup)
             ->add('save', SubmitType::class);
+
+        $this->pluginCrudExtensionFacade->extendForm($builder, 'category', 'pluginData');
     }
 
     /**

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -895,9 +895,6 @@ class ProductFormType extends AbstractType
                 'main_product' => $product,
                 'sortable' => true,
                 'label' => t('Accessories'),
-                'attr' => [
-                    'class' => 'wrap-border',
-                ],
             ])
             ->addViewTransformer($this->removeDuplicatesTransformer);
     }

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle\Form;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -26,6 +27,12 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
         $view->vars['js_container'] = $options['js_container'];
         $view->vars['is_plugin_data_group'] = $options['is_plugin_data_group'];
         $view->vars['render_form_row'] = $options['render_form_row'];
+
+        if ($options['is_plugin_data_group']) {
+            $message = 'Using the "is_plugin_data_group" option in forms has been deprecated since Shopsys Framework 7.2 and it will be removed eventually.';
+
+            trigger_error($message, E_USER_DEPRECATED);
+        }
     }
 
     /**

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -25,10 +25,10 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
         $view->vars['icon_title'] = $options['icon_title'];
         $view->vars['display_format'] = $options['display_format'];
         $view->vars['js_container'] = $options['js_container'];
-        $view->vars['is_plugin_data_group'] = $options['is_plugin_data_group'];
+        $view->vars['is_plugin_data_group'] = $options['is_plugin_data_group'] ?? false;
         $view->vars['render_form_row'] = $options['render_form_row'];
 
-        if ($options['is_plugin_data_group']) {
+        if (array_key_exists('is_plugin_data_group', $options)) {
             $message = 'Using the "is_plugin_data_group" option in forms has been deprecated since Shopsys Framework 7.2 and it will be removed eventually.';
 
             trigger_error($message, E_USER_DEPRECATED);
@@ -40,14 +40,15 @@ class FormRenderingConfigurationExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
-            'macro' => null,
-            'icon_title' => null,
-            'display_format' => null,
-            'js_container' => null,
-            'is_plugin_data_group' => false,
-            'render_form_row' => true,
-        ]);
+        $resolver
+            ->setDefined('is_plugin_data_group')
+            ->setDefaults([
+                'macro' => null,
+                'icon_title' => null,
+                'display_format' => null,
+                'js_container' => null,
+                'render_form_row' => true,
+            ]);
     }
 
     /**

--- a/packages/framework/src/Form/FormRenderingConfigurationExtension.php
+++ b/packages/framework/src/Form/FormRenderingConfigurationExtension.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Form;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was no dividing line between new Group added at the bottom of the form and plugin extensions. This PR simplifies the from structure which helps with the rendering of the separators.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

<img width="1222" alt="Screenshot at Apr 16 12-52-19" src="https://user-images.githubusercontent.com/5638367/56205317-b3630180-6049-11e9-86f4-57e010644005.png">

This PR also deprecates the option `is_plugin_data_group` as it is no longer used and can be removed in the next major version.