### PR TITLE
[framework] don't log administrator was disconnected because admin was too long inactive

### DIFF
--- a/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
@@ -77,7 +77,7 @@ class AdministratorUserProvider implements UserProviderInterface
 
         if ($administrator instanceof TimelimitLoginInterface) {
             if (time() - $administrator->getLastActivity()->getTimestamp() > 3600 * 5) {
-                throw new \Symfony\Component\Security\Core\Exception\UsernameNotFoundException('Admin was too long unactive.');
+                throw new \Symfony\Component\Security\Core\Exception\AuthenticationExpiredException('Admin was too long inactive.');
             }
             if ($freshAdministrator !== null) {
                 $freshAdministrator->setLastActivity(new DateTime());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| don't log inactive administrator logout
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

If admin is inactive for a certain time (https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php#L79) and he reload page, then is logged error message:
```
[2019-04-17 10:37:55] security.WARNING: Username could not be found in the selected user provider. {"username":null,"provider":"Shopsys\\FrameworkBundle\\Model\\Administrator\\Security\\AdministratorUserProvider"} []
```
The solution is throw `AuthenticationExpiredException` instead of `UsernameNotFoundException`.

Thanks