### PR TITLE
[framework] Current domain router match route for POST and ajax condition

### DIFF
--- a/packages/framework/src/Component/Router/CurrentDomainRouter.php
+++ b/packages/framework/src/Component/Router/CurrentDomainRouter.php
@@ -3,10 +3,11 @@
 namespace Shopsys\FrameworkBundle\Component\Router;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Cmf\Component\Routing\ChainRouterInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RequestContext;
-use Symfony\Component\Routing\RouterInterface;
 
-class CurrentDomainRouter implements RouterInterface
+class CurrentDomainRouter implements ChainRouterInterface
 {
     /**
      * @var \Symfony\Component\Routing\RequestContext
@@ -83,5 +84,31 @@ class CurrentDomainRouter implements RouterInterface
     protected function getDomainRouter()
     {
         return $this->domainRouterFactory->getRouter($this->domain->getId());
+    }
+
+    /**
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     * @param int $priority
+     */
+    public function add($router, $priority = 0)
+    {
+        $this->getDomainRouter()->add($router, $priority);
+    }
+
+    /**
+     * @return \Symfony\Component\Routing\RouterInterface[]
+     */
+    public function all()
+    {
+        return $this->getDomainRouter()->all();
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return array
+     */
+    public function matchRequest(Request $request)
+    {
+        return $this->getDomainRouter()->matchRequest($request);
     }
 }

--- a/packages/framework/src/Component/Router/DomainRouterFactory.php
+++ b/packages/framework/src/Component/Router/DomainRouterFactory.php
@@ -6,6 +6,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Router;
 
@@ -42,6 +43,11 @@ class DomainRouterFactory
     protected $routersByDomainId = [];
 
     /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    protected $requestStack;
+
+    /**
      * @param mixed $routerConfiguration
      * @param \Symfony\Component\Config\Loader\LoaderInterface $configLoader
      * @param \Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory $localizedRouterFactory
@@ -60,6 +66,14 @@ class DomainRouterFactory
         $this->localizedRouterFactory = $localizedRouterFactory;
         $this->domain = $domain;
         $this->friendlyUrlRouterFactory = $friendlyUrlRouterFactory;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     */
+    public function setRequestStack(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -111,6 +125,10 @@ class DomainRouterFactory
     {
         $urlComponents = parse_url($domainConfig->getUrl());
         $requestContext = new RequestContext();
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request !== null) {
+            $requestContext->fromRequest($request);
+        }
 
         if (array_key_exists('path', $urlComponents)) {
             $requestContext->setBaseUrl($urlComponents['path']);

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -522,6 +522,8 @@ services:
 
     Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory:
         arguments: ['%router.resource%']
+        calls:
+            - method: setRequestStack
 
     Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory:
         arguments: ['%shopsys.router.friendly_url_router_filepath%']

--- a/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactor
 use Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -57,6 +58,7 @@ class DomainRouterFactoryTest extends TestCase
             );
 
         $delegatingLoaderMock = $this->createMock(DelegatingLoader::class);
+        $requestStackMock = $this->createMock(RequestStack::class);
 
         $domainRouterFactory = new DomainRouterFactory(
             'routerConfiguration',
@@ -65,6 +67,8 @@ class DomainRouterFactoryTest extends TestCase
             $friendlyUrlRouterFactoryMock,
             $domain
         );
+
+        $domainRouterFactory->setRequestStack($requestStackMock);
         $router = $domainRouterFactory->getRouter(3);
 
         $this->assertInstanceOf(RouterInterface::class, $router);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Previously for domain-specific front route with ajax condition and POST method, the 404 exception was thrown, even if the route should be matched. This is fixed now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**If I declare route in routing_%locale%.yml:**
```
front_contact_form_send:
    path: /contactForm/
    defaults: { _controller: ShopsysShopBundle:Front\ContactForm:send }
    methods: [POST]
    condition: "request.isXmlHttpRequest()"
```

This route not found in routing. In Symfony profiler this route [matched](https://ibb.co/PcCz5HT) but [return 404 exception](https://ibb.co/txmWCX3).