### PR TITLE
fields in forms can be ordered

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
     "doctrine/doctrine-migrations-bundle": "^1.3.0",
     "doctrine/migrations": "^1.6.0",
     "egeloen/ckeditor-bundle": "^4.0.6",
+    "egeloen/ordered-form": "^3.0",
     "elasticsearch/elasticsearch": "^6.0.1",
     "friendsofphp/php-cs-fixer": "^2.14.0",
     "fp/jsformvalidator-bundle": "^1.5.1",

--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -184,6 +184,7 @@ The original `ProductFormType` is set as the extended type by implementation of 
         }
     }
     ```
+    *Note: If you want to change order for your newly created field, please look at section [Changing order of groups and fields](https://github.com/shopsys/shopsys/blob/master/docs/extensibility/form-extension.md#changing-order-of-groups-and-fields)*
 1. In your `Product` class, overwrite the `edit()` method.
     ```php
     namespace Shopsys\ShopBundle\Model\Product;

--- a/docs/extensibility/form-extension.md
+++ b/docs/extensibility/form-extension.md
@@ -67,3 +67,33 @@ It contains definition of blocks that are used for rendering forms
 
 and blocks of custom form widgets for various [FormTypes](../introduction/using-form-types.md) eg.:
 - `date_picker_widget` - is rendered as `form_widget` for [`DatePickerType`](../../packages/framework/src/Form/DatePickerType.php)
+
+## Changing order of groups and fields
+All form types contain option called `position`. With this option you can specify position of your group or field **on the same hierarchical layer**.
+
+Option `position` can contain four different values:
+
+```php
+$builder
+    ->add('g', TextType::class, ['position' => 'last'])
+    ->add('a', TextType::class, ['position' => 'first'])
+    ->add('c', TextType::class)
+    ->add('f', TextType::class)
+    ->add('e', TextType::class, ['position' => ['before' => 'f']])
+    ->add('d', TextType::class, ['position' => ['after' => 'c']])
+    ->add('b', TextType::class, ['position' => 'first']);
+```
+
+The output will be: A => B => C => D => E => F => G.
+
+*Note: More examples can be found [here](https://github.com/egeloen/ivory-ordered-form/blob/master/doc/usage.md#position).*
+
+### Changing order of existing groups and fields
+
+Implementation of `FormBuilderInterface` contains method `setPosition` that can change order of existing field.
+
+```php
+$builder->get('a')->setPosition('first');
+$builder->get('c')->setPosition(['after' => 'b']);
+```
+*Note: Because `FormBuilderInterface` doesn't declare method `setPosition`, your IDE will warn you that method doesn't exist.*

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -18,6 +18,7 @@ There you can find links to upgrade notes for other versions too.
         -        $filepath = $file->getPathname();
         +        $filepath = TransformString::removeDriveLetterFromPath($file->getPathname());
         ```
+- `PaymentFormType` fields `vat` and `czkRounding` were moved from `basicInformation` to `prices` group ([#956](https://github.com/shopsys/shopsys/pull/956))
 
 - *(low priority)* reconfigure fm_elfinder to use main_filesystem ([#932](https://github.com/shopsys/shopsys/pull/932))
     - upgrade version of `helios-ag/fm-elfinder-bundle` to `^9.2` in `composer.json`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -18,7 +18,9 @@ There you can find links to upgrade notes for other versions too.
         -        $filepath = $file->getPathname();
         +        $filepath = TransformString::removeDriveLetterFromPath($file->getPathname());
         ```
-- `PaymentFormType` fields `vat` and `czkRounding` were moved from `basicInformation` to `prices` group ([#956](https://github.com/shopsys/shopsys/pull/956))
+- if you extended one of these form fields listed below, you need to change group from `basicInformation` to `prices` ([#956](https://github.com/shopsys/shopsys/pull/956))
+    - in `PaymentFormType` fields `vat` and `czkRounding`
+    - in `TransportFormType` field `vat`
 
 - *(low priority)* reconfigure fm_elfinder to use main_filesystem ([#932](https://github.com/shopsys/shopsys/pull/932))
     - upgrade version of `helios-ag/fm-elfinder-bundle` to `^9.2` in `composer.json`

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -53,6 +53,7 @@
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "egeloen/ckeditor-bundle": "^4.0.6",
+        "egeloen/ordered-form": "^3.0",
         "elasticsearch/elasticsearch": "^6.0.1",
         "fp/jsformvalidator-bundle": "^1.5.1",
         "fzaninotto/faker": "^1.7.1",

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -103,11 +103,21 @@ class PaymentFormType extends AbstractType
                 'required' => false,
                 'label' => t('Hidden'),
             ])
-            ->add('czkRounding', YesNoType::class, [
+            ->add('transports', ChoiceType::class, [
                 'required' => false,
-                'label' => t('Order in CZK round to whole crowns'),
-                'icon_title' => t('Rounding item with 0 % VAT will be added to your order. It is used for payment in cash.'),
-            ])
+                'choices' => $this->transportFacade->getAll(),
+                'choice_label' => 'name',
+                'choice_value' => 'id',
+                'multiple' => true,
+                'expanded' => true,
+                'empty_message' => t('You have to create some shipping first.'),
+                'label' => t('Available shipping methods'),
+            ]);
+
+        $builderPriceGroup = $builder->create('prices', GroupType::class, [
+            'label' => t('Prices'),
+        ]);
+        $builderPriceGroup
             ->add('vat', ChoiceType::class, [
                 'required' => true,
                 'choices' => $this->vatFacade->getAll(),
@@ -118,15 +128,14 @@ class PaymentFormType extends AbstractType
                 ],
                 'label' => t('VAT'),
             ])
-            ->add('transports', ChoiceType::class, [
+            ->add('czkRounding', YesNoType::class, [
                 'required' => false,
-                'choices' => $this->transportFacade->getAll(),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
-                'multiple' => true,
-                'expanded' => true,
-                'empty_message' => t('You have to create some shipping first.'),
-                'label' => t('Available shipping methods'),
+                'label' => t('Order in CZK round to whole crowns'),
+                'icon_title' => t('Rounding item with 0 % VAT will be added to your order. It is used for payment in cash.'),
+            ])
+            ->add('pricesByCurrencyId', PriceTableType::class, [
+                'currencies' => $this->currencyFacade->getAllIndexedById(),
+                'base_prices' => $payment !== null ? $this->paymentFacade->getIndependentBasePricesIndexedByCurrencyId($payment) : [],
             ]);
 
         $builderAdditionalInformationGroup = $builder->create('additionalInformation', GroupType::class, [
@@ -165,20 +174,11 @@ class PaymentFormType extends AbstractType
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
 
-        $builderPriceGroup = $builder->create('prices', GroupType::class, [
-            'label' => t('Prices'),
-        ]);
-        $builderPriceGroup
-            ->add('pricesByCurrencyId', PriceTableType::class, [
-                'currencies' => $this->currencyFacade->getAllIndexedById(),
-                'base_prices' => $payment !== null ? $this->paymentFacade->getIndependentBasePricesIndexedByCurrencyId($payment) : [],
-            ]);
-
         $builder
             ->add($builderBasicInformationGroup)
+            ->add($builderPriceGroup)
             ->add($builderAdditionalInformationGroup)
             ->add($builderImageGroup)
-            ->add($builderPriceGroup)
             ->add('save', SubmitType::class);
     }
 

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -104,6 +104,21 @@ class TransportFormType extends AbstractType
                 'required' => false,
                 'label' => t('Hidden'),
             ])
+            ->add('payments', ChoiceType::class, [
+                'required' => false,
+                'choices' => $this->paymentFacade->getAll(),
+                'choice_label' => 'name',
+                'choice_value' => 'id',
+                'multiple' => true,
+                'expanded' => true,
+                'empty_message' => t('You have to create some payment first.'),
+                'label' => t('Available payment methods'),
+            ]);
+
+        $builderPricesGroup = $builder->create('prices', GroupType::class, [
+            'label' => t('Prices'),
+        ]);
+        $builderPricesGroup
             ->add('vat', ChoiceType::class, [
                 'required' => true,
                 'choices' => $this->vatFacade->getAll(),
@@ -114,15 +129,9 @@ class TransportFormType extends AbstractType
                 ],
                 'label' => t('VAT'),
             ])
-            ->add('payments', ChoiceType::class, [
-                'required' => false,
-                'choices' => $this->paymentFacade->getAll(),
-                'choice_label' => 'name',
-                'choice_value' => 'id',
-                'multiple' => true,
-                'expanded' => true,
-                'empty_message' => t('You have to create some payment first.'),
-                'label' => t('Available payment methods'),
+            ->add('pricesByCurrencyId', PriceTableType::class, [
+                'currencies' => $this->currencyFacade->getAllIndexedById(),
+                'base_prices' => $transport !== null ? $this->transportFacade->getIndependentBasePricesIndexedByCurrencyId($transport) : [],
             ]);
 
         $builderAdditionalInformationGroup = $builder->create('additionalInformation', GroupType::class, [
@@ -162,20 +171,11 @@ class TransportFormType extends AbstractType
                 'info_text' => t('You can upload following formats: PNG, JPG, GIF'),
             ]);
 
-        $builderPricesGroup = $builder->create('prices', GroupType::class, [
-            'label' => t('Prices'),
-        ]);
-        $builderPricesGroup
-            ->add('pricesByCurrencyId', PriceTableType::class, [
-                'currencies' => $this->currencyFacade->getAllIndexedById(),
-                'base_prices' => $transport !== null ? $this->transportFacade->getIndependentBasePricesIndexedByCurrencyId($transport) : [],
-            ]);
-
         $builder
             ->add($builderBasicInformationGroup)
+            ->add($builderPricesGroup)
             ->add($builderAdditionalInformationGroup)
             ->add($builderImageGroup)
-            ->add($builderPricesGroup)
             ->add('save', SubmitType::class);
     }
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -60,6 +60,13 @@ services:
 
     Doctrine\Common\Annotations\DocParser: '@jms_translation.doc_parser'
 
+    Ivory\OrderedForm\Orderer\FormOrderer: ~
+
+    form.resolved_type_factory:
+        class: Ivory\OrderedForm\OrderedResolvedFormTypeFactory
+        arguments:
+            - '@Ivory\OrderedForm\Orderer\FormOrderer'
+
     # disable original DefaultPhpFileExtractor
     jms_translation.extractor.file.default_php_extractor:
         alias: Shopsys\FrameworkBundle\Component\Translation\PhpFileExtractor

--- a/packages/framework/src/Resources/config/services/forms.yml
+++ b/packages/framework/src/Resources/config/services/forms.yml
@@ -7,6 +7,14 @@ services:
     Shopsys\FrameworkBundle\Form\:
         resource: '../../Form/'
 
+    Ivory\OrderedForm\Extension\OrderedFormExtension:
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }
+
+    Ivory\OrderedForm\Extension\OrderedButtonExtension:
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\ButtonType }
+
     Shopsys\FrameworkBundle\Form\InvertChoiceTypeExtension:
         tags:
             - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\ChoiceType }

--- a/project-base/tests/ShopBundle/Functional/Form/PositionExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/PositionExtensionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Functional\Form;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Tests\ShopBundle\Test\FunctionalTestCase;
+
+class PositionExtensionTest extends FunctionalTestCase
+{
+    public function testFormFieldsPosition(): void
+    {
+        $form = $this->getForm();
+        $this->assertPositions($form->createView(), ['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    }
+
+    /**
+     * @return \Symfony\Component\Form\FormInterface
+     */
+    private function getForm(): FormInterface
+    {
+        /** @var \Symfony\Component\Form\FormFactoryInterface $formFactory */
+        $formFactory = $this->getContainer()->get('form.factory');
+
+        $builder = $formFactory->createBuilder();
+
+        $builder
+            ->add('g', TextType::class, ['position' => 'last'])
+            ->add('a', TextType::class, ['position' => 'first'])
+            ->add('c', TextType::class)
+            ->add('f', TextType::class)
+            ->add('e', TextType::class, ['position' => ['before' => 'f']])
+            ->add('d', TextType::class, ['position' => ['after' => 'c']])
+            ->add('b', TextType::class, ['position' => 'first']);
+
+        return $builder->getForm();
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormView $view
+     * @param string[] $expected
+     */
+    private function assertPositions(FormView $view, array $expected): void
+    {
+        $children = array_values($view->children);
+
+        foreach ($expected as $index => $fieldName) {
+            $this->assertArrayHasKey($index, $children);
+            $this->assertArrayHasKey($fieldName, $view->children);
+            $this->assertSame($children[$index], $view->children[$fieldName]);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If i wanted to change order of form fields in administration after i extended form i wasn't able to do it easily. With this feature it takes less time and i do not need render form manually.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes