### PR TITLE
[shopsys] UpdateChangelogReleaseWorker: add note about PR targets

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
@@ -76,7 +76,7 @@ final class UpdateChangelogReleaseWorker extends AbstractShopsysReleaseWorker
 
         $this->symfonyStyle->note(sprintf('You need to review the file, resolve unclassified entries, remove uninteresting entries, and commit the changes manually with "changelog is now updated for %s release"', $version->getVersionString()));
         
-        $this->symfonyStyle->note('You need to manually remove mentions of pull requests, that were not merged into the released version (eg. merged into a branch for next major version)');
+        $this->symfonyStyle->note('You need to manually remove mentions of pull requests that were not merged into the released version (eg. merged into a branch for next major version)');
 
         $this->confirm('Confirm you have checked CHANGELOG.md and the changes are committed.');
     }

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
@@ -75,6 +75,8 @@ final class UpdateChangelogReleaseWorker extends AbstractShopsysReleaseWorker
         FileSystem::write($changelogFilePath, $newChangelogContent);
 
         $this->symfonyStyle->note(sprintf('You need to review the file, resolve unclassified entries, remove uninteresting entries, and commit the changes manually with "changelog is now updated for %s release"', $version->getVersionString()));
+        
+        $this->symfonyStyle->note('You need to manually remove mentions of pull requests, that were not merged into the released version (eg. merged into a branch for next major version)');
 
         $this->confirm('Confirm you have checked CHANGELOG.md and the changes are committed.');
     }


### PR DESCRIPTION
- only merged PRs that actually target this version should be mentioned in the changelog
- the automated tool mentions all merged PRs so they have to be deleted manually

| Q             | A
| ------------- | ---
|Description, reason for the PR| when releasing a new version you must not forget to remove changes that were merged into other branches
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
