### PR TITLE
[shopsys] guidelines-for-pull-request.md: added note about branch targeting

### DIFF
--- a/docs/contributing/guidelines-for-pull-request.md
+++ b/docs/contributing/guidelines-for-pull-request.md
@@ -25,7 +25,7 @@ git rebase origin/master
 ```
 
 **Important note:**
-If your pull request contains any BC breaks (see [Backward Compatibility Promise](/docs/contributing/backward-compatibility-promise.md)), it should not be targeted against the current master but against a branch where the next major release is being prepared. 
+If your pull request contains any BC breaks (see [Backward Compatibility Promise](/docs/contributing/backward-compatibility-promise.md)), it should not be targeted against the current master but against a branch where the next major release is being prepared.
 E.g., if the latest release is `v7.1.0` and you want to introduce a breaking change, you need to rebase your branch on `8.0` branch and target your PR against it. If no such a branch exists, you need to create one.
 
 * You have to check your change using the command `php phing standards tests tests-acceptance` as it’s mentioned in [contributing](../../project-base/CONTRIBUTING.md).

--- a/docs/contributing/guidelines-for-pull-request.md
+++ b/docs/contributing/guidelines-for-pull-request.md
@@ -24,6 +24,10 @@ git fetch
 git rebase origin/master
 ```
 
+**Important note:**
+If your pull request contains any BC breaks (see [Backward Compatibility Promise](/docs/contributing/backward-compatibility-promise.md)), it should not be targeted against the current master but against a branch where the next major release is being prepared. 
+E.g., if the latest release is `v7.1.0` and you want to introduce a breaking change, you need to rebase your branch on `8.0` branch and target your PR against it. If no such a branch exists, you need to create one.
+
 * You have to check your change using the command `php phing standards tests tests-acceptance` as it’s mentioned in [contributing](../../project-base/CONTRIBUTING.md).
 
     *Note: In this step you were using multiple Phing targets.


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| Contributors should be aware of our process when creating a PR that contains a BC break.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
