### PR TITLE
[shopsys] obsolete note in BC promise removed

### DIFF
--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -4,8 +4,6 @@ Smooth and safe upgrades of your own e-commerce project are very important to us
 In the same time, we need to be able to improve Shopsys Framework for you by adding functionality, enhancing or simplifying current functions and fixing bugs.
 After reading this promise you'll understand backward compatibility, what changes you can expect and how we plan to make changes in the future.
 
-*Note: This BC promise becomes effective with the first stable release (`7.0.0`).*
-
 ## Releases and Versioning
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html), which means its release versions are in format `MAJOR.MINOR.PATCH`:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are well past the 7.0.0 release so there is no reason for further keeping this note. Also, we are still extending and refining the promise, so saying that it is effective since 7.0.0 may be even misleading in the future.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
