### PR TITLE
[framework] added x-powered-by to response headers

### DIFF
--- a/packages/framework/src/Component/HttpFoundation/ResponseListener.php
+++ b/packages/framework/src/Component/HttpFoundation/ResponseListener.php
@@ -14,5 +14,6 @@ class ResponseListener
         $event->getResponse()->headers->set('X-Frame-Options', 'sameorigin');
         $event->getResponse()->headers->set('X-XSS-Protection', '1; mode=block');
         $event->getResponse()->headers->set('X-Content-Type-Options', 'nosniff');
+        $event->getResponse()->headers->set('X-Powered-By', 'Shopsys Framework');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| we are proud of our work and we want to know who use shopsys framework
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
