### PR TITLE
[shopsys] factories that use interfaces are now fetched from container via their interface in tests

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -77,6 +77,8 @@ There you can find links to upgrade notes for other versions too.
         +     'attr' => ['autocomplete' => 'new-password'],
           ],
         ```
+- update your tests to use interfaces of factories fetched from dependency injection container
+    -  update tests same way as in PR ([#970](https://github.com/shopsys/shopsys/pull/970/files))
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -27,7 +27,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactory: ~
+    Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactory
 
     Shopsys\FrameworkBundle\Model\Security\CustomerLoginHandler: ~
 
@@ -41,7 +42,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Category\CategoryFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Category\CategoryFactory: ~
+    Shopsys\FrameworkBundle\Model\Category\CategoryFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Category\CategoryFactory
 
     Shopsys\FrameworkBundle\Model\Cart\Item\CartItemRepository: ~
 
@@ -56,6 +58,9 @@ services:
     Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer: ~
 
     Shopsys\FrameworkBundle\Model\Order\PromoCode\CurrentPromoCodeFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactory
 
     Shopsys\FrameworkBundle\Model\Feed\Delivery\DeliveryFeedItemRepository: ~
 
@@ -120,9 +125,11 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository: ~
 
-    Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory: ~
+    Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory
 
-    Shopsys\FrameworkBundle\Model\Payment\PaymentFactory: ~
+    Shopsys\FrameworkBundle\Model\Payment\PaymentFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Payment\PaymentFactory
 
     Shopsys\FrameworkBundle\Model\Payment\PaymentFacade: ~
 
@@ -140,11 +147,13 @@ services:
 
     Shopsys\FrameworkBundle\Component\System\PostgresqlLocaleMapper: ~
 
-    Shopsys\FrameworkBundle\Model\Product\ProductDataFactory: ~
+    Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Product\ProductDataFactory
 
     Shopsys\FrameworkBundle\Model\Product\ProductFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Product\ProductFactory: ~
+    Shopsys\FrameworkBundle\Model\Product\ProductFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Product\ProductFactory
 
     Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator: ~
 
@@ -168,11 +177,13 @@ services:
 
     Shopsys\FrameworkBundle\Model\Localization\TranslatableListener: ~
 
-    Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory: ~
+    Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory
 
     Shopsys\FrameworkBundle\Model\Transport\TransportFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Transport\TransportFactory: ~
+    Shopsys\FrameworkBundle\Model\Transport\TransportFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Transport\TransportFactory
 
     Shopsys\FrameworkBundle\Model\Transport\TransportRepository: ~
 
@@ -186,7 +197,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory: ~
+    Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory
 
     Shopsys\FrameworkBundle\Model\Cart\CartRepository: ~
 

--- a/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ShopBundle\Functional\Controller;
 
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
-use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory;
+use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixture;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
@@ -18,7 +18,7 @@ class ProductRenameRedirectPreviousUrlTest extends TransactionFunctionalTestCase
         $productFacade = $this->getContainer()->get(ProductFacade::class);
 
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactory $productDataFactory */
-        $productDataFactory = $this->getContainer()->get(ProductDataFactory::class);
+        $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
 
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . self::TESTED_PRODUCT_ID);
 

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -9,7 +9,7 @@ use Shopsys\FrameworkBundle\Model\Cart\CartFacade;
 use Shopsys\FrameworkBundle\Model\Cart\CartFactory;
 use Shopsys\FrameworkBundle\Model\Cart\CartRepository;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
-use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory;
+use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade;
 use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer;
 use Shopsys\FrameworkBundle\Model\Customer\CustomerFacade;
@@ -135,7 +135,7 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
             $this->getContainer()->get(CurrentCustomer::class),
             $this->getContainer()->get(CurrentPromoCodeFacade::class),
             $this->getContainer()->get(ProductPriceCalculationForUser::class),
-            $this->getContainer()->get(CartItemFactory::class),
+            $this->getContainer()->get(CartItemFactoryInterface::class),
             $this->getContainer()->get(CartRepository::class),
             $this->getContainer()->get(CartWatcherFacade::class)
         );

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
@@ -7,7 +7,7 @@ use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\CartFacade;
 use Shopsys\FrameworkBundle\Model\Cart\CartFactory;
 use Shopsys\FrameworkBundle\Model\Cart\CartRepository;
-use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory;
+use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade;
 use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer;
 use Shopsys\FrameworkBundle\Model\Customer\CustomerIdentifier;
@@ -150,7 +150,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Cart\CartFacade $cartFacade */
         $cartFacade = $this->getContainer()->get(CartFacade::class);
         /** @var \Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory $cartItemFactory */
-        $cartItemFactory = $this->getContainer()->get(CartItemFactory::class);
+        $cartItemFactory = $this->getContainer()->get(CartItemFactoryInterface::class);
         /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productId);
 
@@ -196,7 +196,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
             $this->getContainer()->get(CurrentCustomer::class),
             $this->getContainer()->get(CurrentPromoCodeFacade::class),
             $this->getContainer()->get(ProductPriceCalculationForUser::class),
-            $this->getContainer()->get(CartItemFactory::class),
+            $this->getContainer()->get(CartItemFactoryInterface::class),
             $this->getContainer()->get(CartRepository::class),
             $this->getContainer()->get(CartWatcherFacade::class)
         );

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
@@ -6,7 +6,7 @@ use ReflectionClass;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
-use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory;
+use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Customer\CustomerIdentifier;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData;
@@ -261,7 +261,7 @@ class CartTest extends TransactionFunctionalTestCase
      */
     private function getCartItemFactory()
     {
-        return $this->getContainer()->get(CartItemFactory::class);
+        return $this->getContainer()->get(CartItemFactoryInterface::class);
     }
 
     /**

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryDomainTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface;
-use Shopsys\FrameworkBundle\Model\Category\CategoryFactory;
+use Shopsys\FrameworkBundle\Model\Category\CategoryFactoryInterface;
 use Shopsys\ShopBundle\Model\Category\Category;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
@@ -34,7 +34,7 @@ class CategoryDomainTest extends TransactionFunctionalTestCase
     {
         parent::setUp();
         $this->categoryDataFactory = $this->getContainer()->get(CategoryDataFactoryInterface::class);
-        $this->categoryFactory = $this->getContainer()->get(CategoryFactory::class);
+        $this->categoryFactory = $this->getContainer()->get(CategoryFactoryInterface::class);
         $this->em = $this->getEntityManager();
     }
 

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
@@ -5,7 +5,7 @@ namespace Tests\ShopBundle\Functional\Model\Order;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\CartFacade;
-use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory;
+use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
@@ -44,7 +44,7 @@ class OrderFacadeTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser $productPriceCalculation */
         $productPriceCalculation = $this->getContainer()->get(ProductPriceCalculationForUser::class);
         /** @var \Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory $cartItemFactory */
-        $cartItemFactory = $this->getContainer()->get(CartItemFactory::class);
+        $cartItemFactory = $this->getContainer()->get(CartItemFactoryInterface::class);
 
         $cart = $cartFacade->getCartOfCurrentCustomerCreateIfNotExists();
         $product = $productRepository->getById(1);

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentDomainTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface;
-use Shopsys\FrameworkBundle\Model\Payment\PaymentFactory;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentFactoryInterface;
 use Shopsys\ShopBundle\Model\Payment\Payment;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
@@ -31,7 +31,7 @@ class PaymentDomainTest extends TransactionFunctionalTestCase
     {
         parent::setUp();
         $this->paymentDataFactory = $this->getContainer()->get(PaymentDataFactoryInterface::class);
-        $this->paymentFactory = $this->getContainer()->get(PaymentFactory::class);
+        $this->paymentFactory = $this->getContainer()->get(PaymentFactoryInterface::class);
         $this->em = $this->getEntityManager();
     }
 

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\ShopBundle\Functional\Model\Pricing\Group;
 
-use Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactory;
+use Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Customer\CustomerFacade;
 use Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData;
@@ -57,7 +57,7 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
         $userDataFactory = $this->getContainer()->get(UserDataFactoryInterface::class);
         $userData = $userDataFactory->createFromUser($user);
         /** @var \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactory $customerDataFactory */
-        $customerDataFactory = $this->getContainer()->get(CustomerDataFactory::class);
+        $customerDataFactory = $this->getContainer()->get(CustomerDataFactoryInterface::class);
 
         $userData->pricingGroup = $pricingGroupToDelete;
         $customerData = $customerDataFactory->create();

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Brand/BrandDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Brand/BrandDomainTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Product\Brand;
 
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface;
-use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactory;
+use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactoryInterface;
 use Shopsys\ShopBundle\Model\Product\Brand\Brand;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
@@ -33,7 +33,7 @@ class BrandDomainTest extends TransactionFunctionalTestCase
     {
         parent::setUp();
         $this->brandDataFactory = $this->getContainer()->get(BrandDataFactoryInterface::class);
-        $this->brandFactory = $this->getContainer()->get(BrandFactory::class);
+        $this->brandFactory = $this->getContainer()->get(BrandFactoryInterface::class);
         $this->em = $this->getEntityManager();
     }
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductDomainTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
-use Shopsys\FrameworkBundle\Model\Product\ProductFactory;
+use Shopsys\FrameworkBundle\Model\Product\ProductFactoryInterface;
 use Shopsys\ShopBundle\DataFixtures\Demo\AvailabilityDataFixture;
 use Shopsys\ShopBundle\Model\Product\Product;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
@@ -37,7 +37,7 @@ class ProductDomainTest extends TransactionFunctionalTestCase
     {
         parent::setUp();
         $this->productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        $this->productFactory = $this->getContainer()->get(ProductFactory::class);
+        $this->productFactory = $this->getContainer()->get(ProductFactoryInterface::class);
         $this->em = $this->getEntityManager();
     }
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\Product;
-use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory;
+use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade;
 use Shopsys\ShopBundle\DataFixtures\Demo\AvailabilityDataFixture;
@@ -35,7 +35,7 @@ final class ProductVariantCreationTest extends TransactionFunctionalTestCase
         $container = $this->getContainer();
         $this->productFacade = $container->get(ProductFacade::class);
         $this->productVariantFacade = $container->get(ProductVariantFacade::class);
-        $this->productDataFactory = $container->get(ProductDataFactory::class);
+        $this->productDataFactory = $container->get(ProductDataFactoryInterface::class);
     }
 
     /**

--- a/project-base/tests/ShopBundle/Functional/Model/Transport/TransportDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Transport/TransportDomainTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Transport;
 
 use Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface;
-use Shopsys\FrameworkBundle\Model\Transport\TransportFactory;
+use Shopsys\FrameworkBundle\Model\Transport\TransportFactoryInterface;
 use Shopsys\ShopBundle\Model\Transport\Transport;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
@@ -31,7 +31,7 @@ class TransportDomainTest extends TransactionFunctionalTestCase
     {
         parent::setUp();
         $this->transportDataFactory = $this->getContainer()->get(TransportDataFactoryInterface::class);
-        $this->transportFactory = $this->getContainer()->get(TransportFactory::class);
+        $this->transportFactory = $this->getContainer()->get(TransportFactoryInterface::class);
         $this->em = $this->getEntityManager();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When man overwrites factories in their project they need to update all tests, that use such factory. This PR prevents such need.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
