### PR TITLE
[framework] getCollationsByLocale now gets collations by get method

### DIFF
--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -124,8 +124,10 @@ class Localization
      */
     public function getCollationByLocale(string $locale): string
     {
-        if (array_key_exists($locale, $this->collationsByLocale)) {
-            return $this->collationsByLocale[$locale];
+        $collationsByLocale = $this->getAllDefinedCollations();
+
+        if (array_key_exists($locale, $collationsByLocale)) {
+            return $collationsByLocale[$locale];
         } else {
             return static::DEFAULT_COLLATION;
         }


### PR DESCRIPTION
- 
| Q             | A
| ------------- | ---
|Description, reason for the PR| If user uses their own collations by inheritance, this method still returned value from old collation array. 
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No 
|Fixes issues|
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
