### PR TITLE
upgrading notes: "low prioity" tag is not used anymore (after the stable release)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,8 +14,7 @@ Follow instructions in a [monorepo upgrade guide](docs/contributing/upgrading-mo
 * upgrade only your composer dependencies and follow instructions
 * check all instructions in all sections, any of them could be relevant for you
 * if you want update your project with the changes from [shopsys/project-base],
-    you should follow the *(low priority)* instructions or cherry-pick from the repository whatever is relevant for you but we do not recommend rebasing or merging everything because the changes might not be compatible with your project as it probably evolves in time
-* instructions marked as *(low priority)* are not vital and can be done last and we recommend to perform them as well during upgrading as it might ease your work in the future
+    you should cherry-pick from the repository whatever is relevant for you but we do not recommend rebasing or merging everything because the changes might not be compatible with your project as it probably evolves in time
 * upgrade locally first. After you fix all issues caused by the upgrade, commit your changes and then continue with upgrading application on a server
 * upgrade one version at a time:
     * Start with a working application

--- a/docs/contributing/guidelines-for-writing-upgrade.md
+++ b/docs/contributing/guidelines-for-writing-upgrade.md
@@ -19,10 +19,6 @@ Keep in mind that upgrade instructions are written for users that do not underst
 * Write instructions
     * Good example: *"Do this, then that"*
     * Bad example: *"This was done, this was changed"*
-* If there are any upgrading steps that are not vital for project developers but could be helpful for them,
-    they should be mentioned in the upgrading notes as well and marked as (low priority).
-    The general UPGRADE.md then mentions that the low priority steps are not vital,
-    however we recommend to perform them as well during upgrading as it might ease their work in the future.
 
 ## Files related to upgrade
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -21,19 +21,19 @@ There you can find links to upgrade notes for other versions too.
 - if you extended one of these form fields listed below, you need to change group from `basicInformation` to `prices` ([#956](https://github.com/shopsys/shopsys/pull/956))
     - in `PaymentFormType` fields `vat` and `czkRounding`
     - in `TransportFormType` field `vat`
-- *(low priority)* change all occurences of `->will($this->returnValue(` into `->willReturn(` in all `TestCase` tests ([#939](https://github.com/shopsys/shopsys/pull/939))
+- change all occurences of `->will($this->returnValue(` into `->willReturn(` in all `TestCase` tests ([#939](https://github.com/shopsys/shopsys/pull/939))
     - example:
         ```diff
         - $emMock->expects($this->once())->method('find')->will($this->returnValue($expectedObject));
         + $emMock->expects($this->once())->method('find')->willReturn($expectedObject);
         ```
-- *(low priority)* remove unused dataProvider annotation from `Tests\ShopBundle\Functional\Twig\PriceExtensionTest:checkPriceFilter` method ([#939](https://github.com/shopsys/shopsys/pull/939))
+- remove unused dataProvider annotation from `Tests\ShopBundle\Functional\Twig\PriceExtensionTest:checkPriceFilter` method ([#939](https://github.com/shopsys/shopsys/pull/939))
     ```diff
       /**
     -   * @dataProvider priceFilterDataProvider
         * @param mixed $input
     ```
-- *(low priority)* reconfigure fm_elfinder to use main_filesystem ([#932](https://github.com/shopsys/shopsys/pull/932))
+- reconfigure fm_elfinder to use main_filesystem ([#932](https://github.com/shopsys/shopsys/pull/932))
     - upgrade version of `helios-ag/fm-elfinder-bundle` to `^9.2` in `composer.json`
     - remove `barryvdh/elfinder-flysystem-driver": "^0.2"` from `composer.json`
     - update `fm_elfinder.yml` config
@@ -62,7 +62,7 @@ There you can find links to upgrade notes for other versions too.
     - read the section about proxying the URL content subpaths via webserver domain [`docs/introduction/abstract-filesystem.md`](https://github.com/shopsys/shopsys/blob/master/docs/introduction/abstract-filesystem.md)
 
 ### Configuration
- - *(low priority)* use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))
+ - use standard format for redis prefixes ([#928](https://github.com/shopsys/shopsys/pull/928))
     - change prefixes in `app/config/packages/snc_redis.yml` and `app/config/packages/test/snc_redis.yml`. Please find inspiration in [#928](https://github.com/shopsys/shopsys/pull/928/files)
     - once you finish this change, you still should deal with older redis cache keys that don't use new prefixes. Such keys are not removed even by `clean-redis-old`, please find and remove them manually (via console or UI)
 

--- a/docs/upgrade/UPGRADE-v7.0.0-alpha5.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-alpha5.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-alpha4 to v7.0.0
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 - for [product search via Elasticsearch](/docs/model/product-search-via-elasticsearch.md), you'll have to:
     - check changes in the [`docker-compose.yml`](https://github.com/shopsys/shopsys/blob/v7.0.0-alpha5/docker/conf) template you used and replicate them, there is a new container with Elasticsearch

--- a/docs/upgrade/UPGRADE-v7.0.0-alpha6.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-alpha6.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-alpha5 to v7.0.0
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 - check for usages of `TransportEditFormType` - it was removed and all it's attributes were moved to `TransportFormType` so use this form instead
 - check for usages of `PaymentEditFormType` - it was removed and all it's attributes were moved to `PaymentFormType` so use this form instead

--- a/docs/upgrade/UPGRADE-v7.0.0-beta1.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta1.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-alpha6 to v7.0.0
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 - *(low priority)* [#468 - Setting for docker on mac are now more optimized](https://github.com/shopsys/shopsys/pull/468)
     - if you use the Shopsys Framework with docker on the platform Mac, modify your

--- a/docs/upgrade/UPGRADE-v7.0.0-beta2.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta2.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-beta1 to v7.0.0-
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/project-base]
 - *(low priority)* [#497 adding php.ini to image is now done only in dockerfiles](https://github.com/shopsys/shopsys/pull/497)
     - you should make the same changes in your repository for the php.ini configuration files to be added to your Docker images

--- a/docs/upgrade/UPGRADE-v7.0.0-beta3.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta3.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-beta2 to v7.0.0-
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 ### Infrastructure
 - replace your `docker/php-fpm/Dockerfile` file with [version from GitHub](https://github.com/shopsys/shopsys/blob/v7.0.0-beta3/project-base/docker/php-fpm/Dockerfile), with following changes

--- a/docs/upgrade/UPGRADE-v7.0.0-beta4.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta4.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-beta3 to v7.0.0-
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 ### Infrastructure
 - set `ENV COMPOSER_MEMORY_LIMIT=-1` in base stage in your `docker/php-fpm/Dockerfile` as composer consumes huge amount of memory during dependencies installation ([#635](https://github.com/shopsys/shopsys/pull/635/files))

--- a/docs/upgrade/UPGRADE-v7.0.0-beta5.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta5.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-beta4 to v7.0.0-
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 ### Infrastructure
 - Google Cloud deploy using Terraform, Kustomize and Kubernetes ([#633](https://github.com/shopsys/shopsys/pull/633))

--- a/docs/upgrade/UPGRADE-v7.0.0-beta6.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta6.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-beta5 to v7.0.0-
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 ### Infrastructure
 - *(low priority)* in your `docker/php-fpm/Dockerfile` change base image to `php:7.3-fpm-stretch` ([#694](https://github.com/shopsys/shopsys/pull/694))

--- a/docs/upgrade/UPGRADE-v7.0.0.md
+++ b/docs/upgrade/UPGRADE-v7.0.0.md
@@ -5,6 +5,8 @@ This guide contains instructions to upgrade from version v7.0.0-beta6 to v7.0.0.
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+*Note: instructions marked as "low priority" are not vital, however, we recommend to perform them as well during upgrading as it might ease your work in the future.*
+
 ## [shopsys/framework]
 
 ### Tools

--- a/docs/upgrade/UPGRADE-v7.1.0.md
+++ b/docs/upgrade/UPGRADE-v7.1.0.md
@@ -7,10 +7,10 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 ### Application
-- *(low priority)* to add support of functional tests of Redis ([#846](https://github.com/shopsys/shopsys/pull/846))
+- to add support of functional tests of Redis ([#846](https://github.com/shopsys/shopsys/pull/846))
     - download [`snc_redis.yml`](https://github.com/shopsys/project-base/blob/v7.1.0/app/config/packages/test/snc_redis.yml) to `app/config/packages/test/snc_redis.yml`
     - download [`RedisFacadeTest.php`](https://github.com/shopsys/project-base/tree/v7.1.0/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php) to your tests directory `tests/ShopBundle/Functional/Component/Redis/`
-- *(low-priority)* by changes implemented in [#808 redesign print page of product detail page](https://github.com/shopsys/shopsys/pull/808) was created new folder `print` in `src/Shopsys/ShopBundle/Resources/styles/front/common`. In the pull request were implemented changes for styling print page of initial Shopsys Framework configuration. In order to apply changes in your project there is need to do following steps.
+- by changes implemented in [#808 redesign print page of product detail page](https://github.com/shopsys/shopsys/pull/808) was created new folder `print` in `src/Shopsys/ShopBundle/Resources/styles/front/common`. In the pull request were implemented changes for styling print page of initial Shopsys Framework configuration. In order to apply changes in your project there is need to do following steps.
     - copy whole `print` folders from `src/Shopsys/ShopBundle/Resources/styles/front/common/print` and `src/Shopsys/ShopBundle/Resources/styles/front/domain2/print` of [shopsys/project-base](https://github.com/shopsys/project-base/)
     - add `dont-print` class to HTML elements which you want to hide. You can inspire by [changes](https://github.com/shopsys/shopsys/pull/808/files) implemented in [pull request](https://github.com/shopsys/shopsys/pull/808).
     - add new `less` subtask in `src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig`
@@ -67,7 +67,7 @@ There you can find links to upgrade notes for other versions too.
     ```
     - generate new `Grtuntfile.js` by running command `php phing gruntfile`
     - generate new CSS files by running command `php phing grunt`
-- *(low priority)* add custom message for unique e-mail validation in `/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php` ([#885](https://github.com/shopsys/shopsys/pull/885))
+- add custom message for unique e-mail validation in `/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php` ([#885](https://github.com/shopsys/shopsys/pull/885))
     ```diff
     -                    new UniqueEmail(),
     +                    new UniqueEmail(['message' => 'This e-mail is already registered']),
@@ -78,7 +78,7 @@ There you can find links to upgrade notes for other versions too.
         -        $registrationPage->seeEmailError('Email no-reply@shopsys.com is already registered');
         +        $registrationPage->seeEmailError('This e-mail is already registered');
         ```
-- *(low priority)* remove option `choice_name` from `flags` and `brands` in `ShopBundle/Form/Front/Product/ProductFilterFormType.php` ([#891](https://github.com/shopsys/shopsys/pull/891))
+- remove option `choice_name` from `flags` and `brands` in `ShopBundle/Form/Front/Product/ProductFilterFormType.php` ([#891](https://github.com/shopsys/shopsys/pull/891))
 - create `Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig` by extending `Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig` ([#895](https://github.com/shopsys/shopsys/pull/895))
     - register `\Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductCategoryFilter` filter via method `registerFilter` in constructor
     - register it as service alias via `ShopBundle/Resources/config/services.yml` and `ShopBundle/Resources/config/services_test.yml`
@@ -86,7 +86,7 @@ There you can find links to upgrade notes for other versions too.
         +Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~
         +Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: '@Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig'
         ```
-- *(low priority)* use private method `recursivelyCountCategoriesInCategoryTree` instead of `array_sum` to get maximum for the progress bar in `Shopsys\ShopBundle\DataFixtures\Performance\CategoryDataFixture` ([#902](https://github.com/shopsys/shopsys/pull/902))
+- use private method `recursivelyCountCategoriesInCategoryTree` instead of `array_sum` to get maximum for the progress bar in `Shopsys\ShopBundle\DataFixtures\Performance\CategoryDataFixture` ([#902](https://github.com/shopsys/shopsys/pull/902))
 - fix EntityExtensionTest ([899](https://github.com/shopsys/shopsys/pull/899))
     - add this code to your `setUp()` method in `tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php`
         ```diff
@@ -109,7 +109,7 @@ There you can find links to upgrade notes for other versions too.
         ```
 
 ### Configuration
-- *(low priority)* to improve your deployment process and avoid possible Redis cache problems during deployment, include `build-version` into your builds ([#886](https://github.com/shopsys/shopsys/pull/886))
+- to improve your deployment process and avoid possible Redis cache problems during deployment, include `build-version` into your builds ([#886](https://github.com/shopsys/shopsys/pull/886))
     - to `app/AppKernel.php` into function `getConfig()` add
         ```diff
         private function getConfig()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Upgrading to each minor version should be achievable without any additional steps so all upgrading instructions are somewhat optional. Therefore, using "low priority" tag is useless, confusing for project developers and the discussions about using this tag for particular upgrading notes are a burden for the developers of the framework itself. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
