### PR TITLE
[project-base] ecs-fix phing target fixes result of ecs phing target

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -187,7 +187,7 @@ There you can find links to upgrade notes for other versions too.
         +    - config_file=/var/lib/postgresql/data/postgresql.conf
         ```
 ### Tools
-- add path for tests folder into `ecs-fix` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))
+- add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file ([#980](https://github.com/shopsys/shopsys/pull/980))
     ```diff
       <arg path="${path.src}" />
     + <arg path="${path.tests}" />

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -186,6 +186,12 @@ There you can find links to upgrade notes for other versions too.
         +    - -c
         +    - config_file=/var/lib/postgresql/data/postgresql.conf
         ```
+### Tools
+- add path for tests folder into `ecs-fix` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))
+    ```diff
+      <arg path="${path.src}" />
+    + <arg path="${path.tests}" />
+    ```
 
 [Upgrade from v7.1.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.1.0...HEAD
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -187,7 +187,7 @@ There you can find links to upgrade notes for other versions too.
         +    - config_file=/var/lib/postgresql/data/postgresql.conf
         ```
 ### Tools
-- add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file ([#980](https://github.com/shopsys/shopsys/pull/980))
+- add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file to be able to fix files that were found by `ecs` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))
     ```diff
       <arg path="${path.src}" />
     + <arg path="${path.tests}" />

--- a/project-base/build-dev.xml
+++ b/project-base/build-dev.xml
@@ -245,6 +245,7 @@
             <arg value="--clear-cache" />
             <arg value="--fix" />
             <arg path="${path.src}" />
+            <arg path="${path.tests}" />
             <arg path="${path.root}/*.md" />
             <arg path="${path.root}/docs" />
         </exec>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| during native installation generalization we encountered that ecs-fix from project-base does not fix ShopBundle/Tests namespace so it was added into project-base/build-dev.xml
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
