### PR TITLE
[framework] CategoryDomainNotFoundException $categoryId is now mandatory

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -18,6 +18,7 @@ There you can find links to upgrade notes for other versions too.
         -        $filepath = $file->getPathname();
         +        $filepath = TransformString::removeDriveLetterFromPath($file->getPathname());
         ```
+- always provide first parameter `$categoryId` of `CategoryDomainNotFoundException` because it is set as mandatory now ([#981](https://github.com/shopsys/shopsys/issues/981))
 
 
 ### Configuration

--- a/packages/framework/src/Model/Category/Exception/CategoryDomainNotFoundException.php
+++ b/packages/framework/src/Model/Category/Exception/CategoryDomainNotFoundException.php
@@ -7,14 +7,13 @@ use Exception;
 class CategoryDomainNotFoundException extends Exception implements CategoryException
 {
     /**
-     * @param int|null $categoryId
+     * @param int $categoryId
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct(int $categoryId = null, int $domainId, Exception $previous = null)
+    public function __construct(int $categoryId, int $domainId, Exception $previous = null)
     {
-        $categoryDescription = $categoryId !== null ? sprintf('with ID %d', $categoryId) : 'without ID';
-        $message = sprintf('CategoryDomain for category %s and domain ID %d not found.', $categoryDescription, $domainId);
+        $message = sprintf('CategoryDomain for category with ID %d and domain ID %d not found.', $categoryId, $domainId);
 
         parent::__construct($message, 0, $previous);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was optional parameter when it should be mandatory
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
