### PR TITLE
[framework] parameters moved from services to parameters_common

### DIFF
--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -20,6 +20,7 @@ class ShopsysFrameworkExtension extends Extension
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('directories.yml');
+        $loader->load('parameters_common.yml');
         $loader->load('services.yml');
         $loader->load('paths.yml');
 

--- a/packages/framework/src/Resources/config/parameters_common.yml
+++ b/packages/framework/src/Resources/config/parameters_common.yml
@@ -5,15 +5,6 @@ parameters:
     # Seed for demo data generation
     faker.seed: 1234
 
-    # Use Shopsys validator factory for fp/jsformvalidator-bundle
-    fp_js_form_validator.factory.class: Shopsys\FrameworkBundle\Form\JsFormValidatorFactory
-
-    # Use Shopsys routing for knplabs/knp-menu-bundle that ignores missing parameters in routes
-    knp_menu.factory_extension.routing.class: Shopsys\FrameworkBundle\Model\AdminNavigation\RoutingExtension
-
-    # Use Shopsys Translatable listener for prezent/doctrine-translatable to allow set fallback language on postPersist event
-    prezent_doctrine_translatable.listener.class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
-
     # Administration locale. Must be registered in domains.yml
     shopsys.admin_locale: en
 

--- a/packages/framework/src/Resources/config/parameters_common.yml
+++ b/packages/framework/src/Resources/config/parameters_common.yml
@@ -1,0 +1,21 @@
+parameters:
+    # Default Redis keys prefix
+    build-version: '0000000000000000'
+
+    # Seed for demo data generation
+    faker.seed: 1234
+
+    # Use Shopsys validator factory for fp/jsformvalidator-bundle
+    fp_js_form_validator.factory.class: Shopsys\FrameworkBundle\Form\JsFormValidatorFactory
+
+    # Use Shopsys routing for knplabs/knp-menu-bundle that ignores missing parameters in routes
+    knp_menu.factory_extension.routing.class: Shopsys\FrameworkBundle\Model\AdminNavigation\RoutingExtension
+
+    # Use Shopsys Translatable listener for prezent/doctrine-translatable to allow set fallback language on postPersist event
+    prezent_doctrine_translatable.listener.class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
+
+    # Administration locale. Must be registered in domains.yml
+    shopsys.admin_locale: en
+
+    # Default extended classes mapping
+    shopsys.entity_extension.map: {}

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -1,15 +1,6 @@
 imports:
     - { resource: services/*.yml }
 
-parameters:
-    fp_js_form_validator.factory.class: Shopsys\FrameworkBundle\Form\JsFormValidatorFactory
-    knp_menu.factory_extension.routing.class: Shopsys\FrameworkBundle\Model\AdminNavigation\RoutingExtension
-    prezent_doctrine_translatable.listener.class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
-    faker.seed: 1234
-    shopsys.entity_extension.map: {}
-    shopsys.admin_locale: en
-    build-version: '0000000000000000'
-
 services:
     _defaults:
         autowire: true

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -1,6 +1,16 @@
 imports:
     - { resource: services/*.yml }
 
+parameters:
+    # Use Shopsys validator factory for fp/jsformvalidator-bundle
+    fp_js_form_validator.factory.class: Shopsys\FrameworkBundle\Form\JsFormValidatorFactory
+
+    # Use Shopsys routing for knplabs/knp-menu-bundle that ignores missing parameters in routes
+    knp_menu.factory_extension.routing.class: Shopsys\FrameworkBundle\Model\AdminNavigation\RoutingExtension
+
+    # Use Shopsys Translatable listener for prezent/doctrine-translatable to allow set fallback language on postPersist event
+    prezent_doctrine_translatable.listener.class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
+
 services:
     _defaults:
         autowire: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Now it's easier to be aware of possible parameters that can be overriden from framework in a project, because now they're in separate file.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #976 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
