### PR TITLE
[shopsys] add missing upgrade instruction for monorepo

### DIFF
--- a/docs/contributing/upgrading-monorepo.md
+++ b/docs/contributing/upgrading-monorepo.md
@@ -9,6 +9,25 @@ Typical upgrade sequence should be:
 ***Note:** During the execution of `build-demo-dev phing target`, there will be installed 3-rd party software as dependencies of Shopsys Framework by [composer](https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies) and [npm](https://docs.npmjs.com/about-the-public-npm-registry) with licenses that are described in document [Open Source License Acknowledgements and Third-Party Copyrights](../../open-source-license-acknowledgements-and-third-party-copyrights.md)*
 
 ## [From v7.1.0 to Unreleased]
+- update definition of postgres service in your `docker-compose.yml` file to use customized configuration ([#946](https://github.com/shopsys/shopsys/pull/946))
+    ```diff
+    postgres:
+        image: postgres:10.5-alpine
+        container_name: shopsys-framework-postgres
+        volumes:
+            - ./docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
+            - ./var/postgres-data:/var/lib/postgresql/data:cached
+        environment:
+            - PGDATA=/var/lib/postgresql/data/pgdata
+            - POSTGRES_USER=root
+            - POSTGRES_PASSWORD=root
+            - POSTGRES_DB=shopsys
+    +   command:
+    +       - docker-entrypoint.sh
+    +       - postgres
+    +       - -c
+    +       - config_file=/var/lib/postgresql/data/postgresql.conf
+    ```
 
 ## [From v7.0.0 to v7.1.0]
 

--- a/docs/contributing/upgrading-monorepo.md
+++ b/docs/contributing/upgrading-monorepo.md
@@ -23,7 +23,6 @@ Typical upgrade sequence should be:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
     +   command:
-    +       - docker-entrypoint.sh
     +       - postgres
     +       - -c
     +       - config_file=/var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #946 monorepo `docker-compose.yml` templates were changed, but the monorepo upgrade note was missing.This could lead to contributors not using the Postgres configuration after the upgrade to current `master`,
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
