### PR TITLE
[shopsys] remove duplicate entrypoint call in commands in postgres container

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -18,7 +18,6 @@ services:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
-            - docker-entrypoint.sh
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -18,7 +18,6 @@ services:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
-            - docker-entrypoint.sh
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -18,7 +18,6 @@ services:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
-            - docker-entrypoint.sh
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -175,11 +175,11 @@ There you can find links to upgrade notes for other versions too.
     +       - -c
     +       - config_file=/var/lib/postgresql/data/postgresql.conf
     ```
-    - update definition of postgres service in your `kubernetes/deployments/postgres.yml`
+    - update postgres deployment manifest in your `kubernetes/deployments/postgres.yml`
         ```diff
                 -   name: PGDATA
                     value: /var/lib/postgresql/data/pgdata
-        + command:
+        + args:
         +    - postgres
         +    - -c
         +    - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -171,7 +171,6 @@ There you can find links to upgrade notes for other versions too.
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
     +   command:
-    +       - docker-entrypoint.sh
     +       - postgres
     +       - -c
     +       - config_file=/var/lib/postgresql/data/postgresql.conf
@@ -181,7 +180,6 @@ There you can find links to upgrade notes for other versions too.
                 -   name: PGDATA
                     value: /var/lib/postgresql/data/pgdata
         + command:
-        +    - docker-entrypoint.sh
         +    - postgres
         +    - -c
         +    - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -12,7 +12,6 @@ services:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
-            - docker-entrypoint.sh
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -12,7 +12,6 @@ services:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
-            - docker-entrypoint.sh
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -12,7 +12,6 @@ services:
             - POSTGRES_PASSWORD=root
             - POSTGRES_DB=shopsys
         command:
-            - docker-entrypoint.sh
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/project-base/kubernetes/deployments/postgres.yml
+++ b/project-base/kubernetes/deployments/postgres.yml
@@ -39,7 +39,7 @@ spec:
                         value: shopsys
                     -   name: PGDATA
                         value: /var/lib/postgresql/data/pgdata
-                command:
+                args:
                     - postgres
                     - -c
                     - config_file=/var/lib/postgresql/data/postgresql.conf

--- a/project-base/kubernetes/deployments/postgres.yml
+++ b/project-base/kubernetes/deployments/postgres.yml
@@ -40,7 +40,6 @@ spec:
                     -   name: PGDATA
                         value: /var/lib/postgresql/data/pgdata
                 command:
-                    - docker-entrypoint.sh
                     - postgres
                     - -c
                     - config_file=/var/lib/postgresql/data/postgresql.conf


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #946, Docker command for the Postgres container were changed and the entrypoint call was included as well. This leads to duplicate call of the entrypoint which can lead to unforeseen consequences. See [the upstream Dockerfile](https://github.com/docker-library/postgres/blob/master/10/Dockerfile#L173-L176) to verify that only `postgres` command should be listed as the container's command.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Links to docs:**
- [Docker Compose command](https://docs.docker.com/compose/compose-file/#command)
- [Docker CMD](https://docs.docker.com/engine/reference/builder/#cmd)
- [Docker ENTRYPOINT](https://docs.docker.com/engine/reference/builder/#entrypoint)
- [Kubernetes command and argument definition notes](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes) with a summary of the field names used by Docker and Kubernetes

**Before the change** (see the duplicate call of `docker-entrypoint.sh`):
`> docker-compose ps`
```               Name                             Command               State                       Ports                     
----------------------------------------------------------------------------------------------------------------------------
shopsys-framework                    docker-php-entrypoint php-fpm    Up      0.0.0.0:35729->35729/tcp, 9000/tcp            
shopsys-framework-acceptance-tests   /opt/bin/entry_point.sh          Up      0.0.0.0:4400->4444/tcp, 0.0.0.0:5900->5900/tcp
shopsys-framework-adminer            entrypoint.sh docker-php-e ...   Up      0.0.0.0:1100->8080/tcp                        
shopsys-framework-elasticsearch      /usr/local/bin/docker-entr ...   Up      0.0.0.0:9200->9200/tcp, 9300/tcp              
shopsys-framework-postgres           docker-entrypoint.sh docke ...   Up      5432/tcp                                      
shopsys-framework-redis              docker-entrypoint.sh redis ...   Up      6379/tcp                                      
shopsys-framework-redis-admin        php -S 0.0.0.0:80                Up      0.0.0.0:1600->80/tcp                          
shopsys-framework-smtp-server        /bin/entrypoint.sh exim -b ...   Up      25/tcp                                        
shopsys-framework-webserver          nginx -g daemon off;             Up      80/tcp, 0.0.0.0:8000->8080/tcp      
```
`> docker ps --no-trunc | grep postgres`
```
8c51f4a1643f11e49c766ebe59a071293afd26ea294918e7664244dc1818c0ec   postgres:10.5-alpine                                      "docker-entrypoint.sh docker-entrypoint.sh postgres -c config_file=/var/lib/postgresql/data/postgresql.conf"   About a minute ago   Up About a minute   5432/tcp                                         shopsys-framework-postgres
```

**After the change** (no duplicate call of `docker-entrypoint.sh`):
`> docker-compose ps`
```
               Name                             Command               State                       Ports                     
----------------------------------------------------------------------------------------------------------------------------
shopsys-framework                    docker-php-entrypoint php-fpm    Up      0.0.0.0:35729->35729/tcp, 9000/tcp            
shopsys-framework-acceptance-tests   /opt/bin/entry_point.sh          Up      0.0.0.0:4400->4444/tcp, 0.0.0.0:5900->5900/tcp
shopsys-framework-adminer            entrypoint.sh docker-php-e ...   Up      0.0.0.0:1100->8080/tcp                        
shopsys-framework-elasticsearch      /usr/local/bin/docker-entr ...   Up      0.0.0.0:9200->9200/tcp, 9300/tcp              
shopsys-framework-postgres           docker-entrypoint.sh postg ...   Up      5432/tcp                                      
shopsys-framework-redis              docker-entrypoint.sh redis ...   Up      6379/tcp                                      
shopsys-framework-redis-admin        php -S 0.0.0.0:80                Up      0.0.0.0:1600->80/tcp                          
shopsys-framework-smtp-server        /bin/entrypoint.sh exim -b ...   Up      25/tcp                                        
shopsys-framework-webserver          nginx -g daemon off;             Up      80/tcp, 0.0.0.0:8000->8080/tcp   
```
`> docker ps --no-trunc | grep postgres`
```
eccdee83995ba129169a637008f33e9e1e474aa6db9cadc83c07b178b3c5e480   postgres:10.5-alpine                                      "docker-entrypoint.sh postgres -c config_file=/var/lib/postgresql/data/postgresql.conf"   44 seconds ago      Up 43 seconds       5432/tcp                                         shopsys-framework-postgres
```