### PR TITLE
[coding-standards] helper PhpToDocTypeTransformer is updated for use with new version of phpcs-fixer package

### DIFF
--- a/packages/coding-standards/src/Helper/PhpToDocTypeTransformer.php
+++ b/packages/coding-standards/src/Helper/PhpToDocTypeTransformer.php
@@ -31,10 +31,12 @@ final class PhpToDocTypeTransformer
      */
     public function transform(Tokens $tokens, ?TypeAnalysis $typeAnalysis, $default = null): string
     {
+        $isNullable = false;
         if ($typeAnalysis === null) {
             $type = 'mixed';
         } else {
-            if ($typeAnalysis->isReservedType() && $default === null) {
+            $isNullable = method_exists($typeAnalysis, 'isNullable') && $typeAnalysis->isNullable();
+            if ($typeAnalysis->isReservedType() && !$isNullable && $default === null) {
                 return $typeAnalysis->getName();
             }
 
@@ -42,7 +44,7 @@ final class PhpToDocTypeTransformer
         }
 
         // nullable
-        if ($type[0] === '?' || (is_string($default) && strtolower($default) === 'null')) {
+        if ($type[0] === '?' || (is_string($default) && strtolower($default) === 'null') || $isNullable) {
             return $this->createFromNullable($tokens, $type);
         }
 

--- a/packages/coding-standards/src/Helper/PhpToDocTypeTransformer.php
+++ b/packages/coding-standards/src/Helper/PhpToDocTypeTransformer.php
@@ -31,20 +31,21 @@ final class PhpToDocTypeTransformer
      */
     public function transform(Tokens $tokens, ?TypeAnalysis $typeAnalysis, $default = null): string
     {
-        $isNullable = false;
         if ($typeAnalysis === null) {
             $type = 'mixed';
+            $isNullable = false;
         } else {
-            $isNullable = method_exists($typeAnalysis, 'isNullable') && $typeAnalysis->isNullable();
-            if ($typeAnalysis->isReservedType() && !$isNullable && $default === null) {
-                return $typeAnalysis->getName();
-            }
-
             $type = $typeAnalysis->getName();
+            if (method_exists($typeAnalysis, 'isNullable')) {
+                $isNullable = $typeAnalysis->isNullable();
+            } else {
+                // backward-compatibility with friendsofphp/php-cs-fixer in <2.14.3
+                $isNullable = $type[0] === '?';
+            }
         }
 
-        // nullable
-        if ($type[0] === '?' || (is_string($default) && strtolower($default) === 'null') || $isNullable) {
+        // nullable parameter or with a default value of null
+        if ($isNullable || (is_string($default) && strtolower($default) === 'null')) {
             return $this->createFromNullable($tokens, $type);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| after update of `friendsofphp/php-cs-fixer` to patch version 2.14.3 there were many changes https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.14.3 and one of them was change in  `\PhpCsFixer\Tokenizer\Analyzer\Analysis\TypeAnalysis` so we need to fix our `CodingStandards\Helper\PhpToDocTypeTransformer` so nullable docblock can be generated from typehint ?(int,string,bool) and since we have caret notation `"friendsofphp/php-cs-fixer": "^2.14.0"` this will be compatible with previous version.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| - <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
