### PR TITLE
[framework] used ICU collations to assure correct sorting throughout OSs

### DIFF
--- a/packages/framework/src/Command/CreateDatabaseCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseCommand.php
@@ -186,7 +186,7 @@ class CreateDatabaseCommand extends Command
             'SELECT 1
             FROM pg_collation
             WHERE collnamespace = (SELECT oid FROM pg_namespace WHERE nspname = \'pg_catalog\')
-            AND collencoding = pg_char_to_encoding(\'UTF8\')
+            AND (collencoding = pg_char_to_encoding(\'UTF8\') OR collencoding = -1)
             AND collname = ?',
             [$collation]
         );

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -28,12 +28,12 @@ class Localization
      * @var string[]
      */
     protected $collationsByLocale = [
-        'cs' => 'cs_CZ',
-        'de' => 'de_DE',
-        'en' => 'en_US',
-        'hu' => 'hu_HU',
-        'pl' => 'pl_PL',
-        'sk' => 'sk_SK',
+        'cs' => 'cs-CZ-x-icu',
+        'de' => 'de-DE-x-icu',
+        'en' => 'en-US-x-icu',
+        'hu' => 'hu-HU-x-icu',
+        'pl' => 'pl-PL-x-icu',
+        'sk' => 'sk-SK-x-icu',
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| According to https://www.2ndquadrant.com/en/blog/icu-support-postgresql-10/, it is much more better to use ICU collations. These colllations are always available, not like ones we are using now. Also for example, for current collations letter "Ú" is sorted behind letter "Z"
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No 
|Fixes issues| 
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
