### PR TITLE
[framework] fix correct creating friendly url without indexPostfix

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
@@ -55,7 +55,7 @@ class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
             return null;
         }
 
-        $nameForUrl = $entityName . ($entityName === null ? '' : '-' . $indexPostfix);
+        $nameForUrl = $entityName . ($indexPostfix === null ? '' : '-' . $indexPostfix);
         $slug = TransformString::stringToFriendlyUrlSlug($nameForUrl) . '/';
 
         return $this->create($routeName, $entityId, $domainId, $slug);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In framework there was a bug in method FriendlyUrlFactory::createIfValid. Name for URL was created with dash (e.g. entityname-) even if there was not postfix. This issue was originally posted on our slack (http://slack.shopsys-framework.com/).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
