### PR TITLE
[project-base] move database_server_version to parameters_common.yml

### DIFF
--- a/docs/contributing/upgrading-monorepo.md
+++ b/docs/contributing/upgrading-monorepo.md
@@ -27,6 +27,7 @@ Typical upgrade sequence should be:
     +       - -c
     +       - config_file=/var/lib/postgresql/data/postgresql.conf
     ```
+- remove `database_server_version` parameter from `parameters.yml` and `parameters.yml.dist` ([#1001](https://github.com/shopsys/shopsys/pull/1001))
 
 ## [From v7.0.0 to v7.1.0]
 

--- a/docs/installation/application-configuration.md
+++ b/docs/installation/application-configuration.md
@@ -9,7 +9,6 @@ From the clean project, during composer installation process it will prompt you 
 | `database_name`                          | ...                                                                                                          |
 | `database_user`                          | ...                                                                                                          |
 | `database_password`                      | ...                                                                                                          |
-| `database_server_version`                | version of your PostgreSQL server                                                                            |
 | `elasticsearch_host`                     | host of your Elasticsearch                                                                                   |
 | `redis_host`                             | host of your Redis storage (credentials are not supported right now)                                         |
 | `mailer_transport`                       | access data of your mail server                                                                              |

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -208,6 +208,15 @@ There you can find links to upgrade notes for other versions too.
         -   - { resource: services/data_fixtures.yml }
         +   - { resource: services/*.yml }
         ```
+- move `database_server_version` parameter to `parameters_common.yml` ([#1001](https://github.com/shopsys/shopsys/pull/1001))
+    - remove parameter from `parameters.yml` and `parameters.yml.dist`
+    - add parameter to `parameters_common.yml`:
+        ```diff
+        parameters:
+            database_driver: pdo_pgsql
+        +   database_server_version: 10.5
+        ...
+        ```
 ### Tools
 - add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file to be able to fix files that were found by `ecs` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))
     ```diff

--- a/project-base/app/config/parameters.yml.dist
+++ b/project-base/app/config/parameters.yml.dist
@@ -4,7 +4,6 @@ parameters:
     database_name: shopsys
     database_user: root
     database_password: root
-    database_server_version: 10.5
 
     elasticsearch_host: elasticsearch:9200
 

--- a/project-base/app/config/parameters_common.yml
+++ b/project-base/app/config/parameters_common.yml
@@ -1,5 +1,6 @@
 parameters:
     database_driver: pdo_pgsql
+    database_server_version: 10.5
     # Symfony's FrameworkBundle sets throw_at (error_reporting) to 0 in production by default
     debug.error_handler.throw_at: -1
     locale: en


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In `parameters.yml` there should be only parameters that you want to change by environment. Database server version should be same for all environments to prevent some unexpected behaviour.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #988 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes