### PR TITLE
[framework] revert removed service from #943

### DIFF
--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -180,6 +180,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade: ~
 
+    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository: ~
+
     Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory: ~
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes BC break introduced in #943. This PR revert removal of service from services.yml
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
