### PR TITLE
[coding-standards] include config of better-phpdoc-parser in ECS config

### DIFF
--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -1,6 +1,9 @@
 imports:
     # for PSR-2 description, see: http://www.php-fig.org/psr/psr-2/
     - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/psr2.yml' }
+    # some checkers use BetterPhpdocParser services which must be configured (file renamed in symplify/better-phpdoc-parser v5.4.14)
+    - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yml', ignore_errors: true }
+    - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yaml', ignore_errors: true }
 
 services:
     _defaults:

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDumpFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDumpFixer/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer:

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/config.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer:
         analyzed_namespaces:

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingButtonTypeFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingButtonTypeFixer/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\CsFixer\MissingButtonTypeFixer:

--- a/packages/coding-standards/tests/Unit/CsFixer/OrmJoinColumnRequireNullableFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/OrmJoinColumnRequireNullableFixer/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\CsFixer\OrmJoinColumnRequireNullableFixer:

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/FunctionAnnotationFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/FunctionAnnotationFixer/config.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: '../../../../config.yml' }
+
 services:
     _defaults:
         autowire: true

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/config.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: '../../../../config.yml' }
+
 services:
     _defaults:
         autowire: true

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/config.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: '../../../../config.yml' }
+
 services:
     _defaults:
         autowire: true

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/NoUselessAccessFixer/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\CsFixer\Phpdoc\NoUselessAccessFixer:

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/OrderedParamAnnotationsFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/OrderedParamAnnotationsFixer/config.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: '../../../../config.yml' }
+
 services:
     _defaults:
         autowire: true

--- a/packages/coding-standards/tests/Unit/CsFixer/RedundantMarkDownTrailingSpacesFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/RedundantMarkDownTrailingSpacesFixer/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\CsFixer\RedundantMarkDownTrailingSpacesFixer:

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDumpSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDumpSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenExitSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenExitSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ForbiddenExitSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenSuperGlobalSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenSuperGlobalSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ForbiddenSuperGlobalSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ObjectIsCreatedByFactorySniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ObjectIsCreatedByFactorySniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ValidVariableNameSniff/config.yml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ValidVariableNameSniff/config.yml
@@ -1,2 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
 services:
     Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff:

--- a/packages/coding-standards/tests/config.yml
+++ b/packages/coding-standards/tests/config.yml
@@ -1,0 +1,4 @@
+imports:
+    # some checkers use BetterPhpdocParser services which must be configured (file renamed in symplify/better-phpdoc-parser v5.4.14)
+    - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yml', ignore_errors: true }
+    - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yaml', ignore_errors: true }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Travis builds fail on broken autowiring of services (see #957) due to using different versions of `symplify/better-phpdoc-parser`. This PR fixes the builds of the isolated packages by providing a link to DI service configuration.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #957, closes #923 and closes #962 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

:heavy_check_mark: `shopsys/framework` package passes the Travis build when using the `dev-ph-travis-ecs-fix` version of `shopsys/coding-standards`, see https://github.com/shopsys/framework/compare/ph-travis-ecs-fix

:heavy_check_mark:  `shopsys/coding-standards` package passes the Travis build during unit tests (which were misconfigured previously), see https://github.com/shopsys/coding-standards/compare/ph-travis-ecs-fix

:hourglass_flowing_sand: cannot easily test Travis build after splitting the monorepo as the packages use `shopsys/coding-standards` in the `dev-master` version, due to the two checks above I am confident the build will pass