### PR TITLE
[google-cloud-bundle] travis tests also php 7.3

### DIFF
--- a/packages/google-cloud-bundle/.travis.yml
+++ b/packages/google-cloud-bundle/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
 
 cache:
     directories:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| all travis tests in all our packages should test php version 7.3
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
