### PR TITLE
all nullable values are now defined using nullability (?) symbol

### DIFF
--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -27,6 +27,7 @@ There you can find links to upgrade notes for other versions too.
     - SliderItemFactory
 
     In case of extending one of these classes, you should add an `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
+- run `php phing standards-fix` so all nullable values will be now defined using nullability (?) symbol ([#1010](https://github.com/shopsys/shopsys/pull/1010))
 
 ### Tools
 - improve `build-dev.xml` to use test prefix for elasticsearch in tests ([#933](https://github.com/shopsys/shopsys/pull/933))

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -18,6 +18,7 @@ services:
 
     # Slevomat Checkers
     SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff: ~
+    SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff: ~
 
     # Shopsys Checkers
     Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer: ~

--- a/packages/coding-standards/src/CsFixer/ForbiddenPrivateVisibilityFixer.php
+++ b/packages/coding-standards/src/CsFixer/ForbiddenPrivateVisibilityFixer.php
@@ -24,7 +24,7 @@ final class ForbiddenPrivateVisibilityFixer implements DefinedFixerInterface, Co
     /**
      * {@inheritdoc}
      */
-    public function configure(array $configuration = null): void
+    public function configure(?array $configuration = null): void
     {
         if ($configuration !== null) {
             $this->analyzedNamespaces = $this->extractNamespaces($configuration);

--- a/packages/framework/src/Command/Exception/CronCommandException.php
+++ b/packages/framework/src/Command/Exception/CronCommandException.php
@@ -10,7 +10,7 @@ class CronCommandException extends Exception implements CommandException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Command/Exception/DifferentTimezonesException.php
+++ b/packages/framework/src/Command/Exception/DifferentTimezonesException.php
@@ -12,7 +12,7 @@ class DifferentTimezonesException extends Exception
      * @param int $code
      * @param \Throwable|null $previous
      */
-    public function __construct($message = '', $code = 0, Throwable $previous = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/packages/framework/src/Command/Exception/MissingLocaleException.php
+++ b/packages/framework/src/Command/Exception/MissingLocaleException.php
@@ -16,7 +16,7 @@ class MissingLocaleException extends Exception
      * @param mixed $missingLocale
      * @param \Throwable|null $previous
      */
-    public function __construct($missingLocale, Throwable $previous = null)
+    public function __construct($missingLocale, ?Throwable $previous = null)
     {
         $message = sprintf(
             'It looks like your operating system does not support locale "%s". '

--- a/packages/framework/src/Command/Exception/RedisNotRunningException.php
+++ b/packages/framework/src/Command/Exception/RedisNotRunningException.php
@@ -12,7 +12,7 @@ class RedisNotRunningException extends Exception
      * @param int $code
      * @param \Throwable|null $previous
      */
-    public function __construct($message = '', $code = 0, Throwable $previous = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/packages/framework/src/Command/Exception/TranslationReplaceSourceCommandException.php
+++ b/packages/framework/src/Command/Exception/TranslationReplaceSourceCommandException.php
@@ -10,7 +10,7 @@ class TranslationReplaceSourceCommandException extends Exception implements Comm
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Command/Exception/UnavailableMicroserviceException.php
+++ b/packages/framework/src/Command/Exception/UnavailableMicroserviceException.php
@@ -12,7 +12,7 @@ class UnavailableMicroserviceException extends Exception
      * @param int $code
      * @param \Throwable|null $previous
      */
-    public function __construct($message = '', $code = 0, Throwable $previous = null)
+    public function __construct($message = '', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/packages/framework/src/Component/Breadcrumb/Exception/BreadcrumbGeneratorNotFoundException.php
+++ b/packages/framework/src/Component/Breadcrumb/Exception/BreadcrumbGeneratorNotFoundException.php
@@ -10,7 +10,7 @@ class BreadcrumbGeneratorNotFoundException extends Exception implements Breadcru
      * @param string $routeName
      * @param \Exception|null $previous
      */
-    public function __construct($routeName, Exception $previous = null)
+    public function __construct($routeName, ?Exception $previous = null)
     {
         parent::__construct('Breadcrumb generator not found for route "' . $routeName . '"', 0, $previous);
     }

--- a/packages/framework/src/Component/Breadcrumb/Exception/UnableToGenerateBreadcrumbItemsException.php
+++ b/packages/framework/src/Component/Breadcrumb/Exception/UnableToGenerateBreadcrumbItemsException.php
@@ -10,7 +10,7 @@ class UnableToGenerateBreadcrumbItemsException extends Exception implements Brea
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/ConfirmDelete/Exception/InvalidEntityPassedException.php
+++ b/packages/framework/src/Component/ConfirmDelete/Exception/InvalidEntityPassedException.php
@@ -10,7 +10,7 @@ class InvalidEntityPassedException extends Exception implements ConfirmDeleteExc
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Console/Exception/NoDomainSetException.php
+++ b/packages/framework/src/Component/Console/Exception/NoDomainSetException.php
@@ -9,7 +9,7 @@ class NoDomainSetException extends Exception implements ConsoleException
     /**
      * @param \Exception|null $previous
      */
-    public function __construct(Exception $previous = null)
+    public function __construct(?Exception $previous = null)
     {
         $message = 'There are no domains set.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Component/Cron/Config/Exception/CronModuleConfigNotFoundException.php
+++ b/packages/framework/src/Component/Cron/Config/Exception/CronModuleConfigNotFoundException.php
@@ -10,7 +10,7 @@ class CronModuleConfigNotFoundException extends Exception implements CronConfigE
      * @param string $serviceId
      * @param \Exception $previous
      */
-    public function __construct($serviceId, Exception $previous = null)
+    public function __construct($serviceId, ?Exception $previous = null)
     {
         parent::__construct('Cron module config with service ID "' . $serviceId . '" not found.', 0, $previous);
     }

--- a/packages/framework/src/Component/Cron/Config/Exception/InvalidTimeFormatException.php
+++ b/packages/framework/src/Component/Cron/Config/Exception/InvalidTimeFormatException.php
@@ -12,7 +12,7 @@ class InvalidTimeFormatException extends Exception implements CronConfigExceptio
      * @param int $divisibleBy
      * @param \Exception $previous
      */
-    public function __construct($timeString, $maxValue, $divisibleBy, Exception $previous = null)
+    public function __construct($timeString, $maxValue, $divisibleBy, ?Exception $previous = null)
     {
         parent::__construct(
             'Time configuration "' . $timeString . '" is invalid. '

--- a/packages/framework/src/Component/Cron/Exception/InvalidCronModuleException.php
+++ b/packages/framework/src/Component/Cron/Exception/InvalidCronModuleException.php
@@ -10,7 +10,7 @@ class InvalidCronModuleException extends Exception implements CronException
      * @param string $serviceId
      * @param \Exception|null $previous
      */
-    public function __construct($serviceId, Exception $previous = null)
+    public function __construct($serviceId, ?Exception $previous = null)
     {
         parent::__construct('Module "' . $serviceId . '" does not have valid interface.', 0, $previous);
     }

--- a/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
+++ b/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
@@ -27,7 +27,7 @@ abstract class AbstractNativeFixture extends AbstractFixture
      * @param array|null $parameters
      * @return mixed
      */
-    protected function executeNativeQuery($sql, array $parameters = null)
+    protected function executeNativeQuery($sql, ?array $parameters = null)
     {
         $nativeQuery = $this->entityManager->createNativeQuery($sql, new ResultSetMapping());
         return $nativeQuery->execute($parameters);

--- a/packages/framework/src/Component/DataFixture/Exception/EntityIdIsNotSetException.php
+++ b/packages/framework/src/Component/DataFixture/Exception/EntityIdIsNotSetException.php
@@ -11,7 +11,7 @@ class EntityIdIsNotSetException extends Exception implements DataFixtureExceptio
      * @param object $object
      * @param \Exception|null $previous
      */
-    public function __construct($referenceName, $object, Exception $previous = null)
+    public function __construct($referenceName, $object, ?Exception $previous = null)
     {
         $message = 'Cannot create persistent reference "' . $referenceName . '" for entity without ID. '
             . 'Flush the entity ("' . get_class($object) . '") before creating a persistent reference.';

--- a/packages/framework/src/Component/DataFixture/Exception/EntityNotFoundException.php
+++ b/packages/framework/src/Component/DataFixture/Exception/EntityNotFoundException.php
@@ -10,7 +10,7 @@ class EntityNotFoundException extends Exception implements DataFixtureException
      * @param string $referenceName
      * @param \Exception|null $previous
      */
-    public function __construct($referenceName, Exception $previous = null)
+    public function __construct($referenceName, ?Exception $previous = null)
     {
         parent::__construct('Entity from reference  "' . $referenceName . '" not found.', 0, $previous);
     }

--- a/packages/framework/src/Component/DataFixture/Exception/MethodGetIdDoesNotExistException.php
+++ b/packages/framework/src/Component/DataFixture/Exception/MethodGetIdDoesNotExistException.php
@@ -10,7 +10,7 @@ class MethodGetIdDoesNotExistException extends Exception implements DataFixtureE
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/DataFixture/Exception/ObjectRequiredException.php
+++ b/packages/framework/src/Component/DataFixture/Exception/ObjectRequiredException.php
@@ -12,7 +12,7 @@ class ObjectRequiredException extends InvalidArgumentException implements DataFi
      * @param mixed $given
      * @param \Exception|null $previous
      */
-    public function __construct($given, Exception $previous = null)
+    public function __construct($given, ?Exception $previous = null)
     {
         parent::__construct('Object required, but given "' . Debug::export($given) . '"', 0, $previous);
     }

--- a/packages/framework/src/Component/DataFixture/Exception/PersistentReferenceNotFoundException.php
+++ b/packages/framework/src/Component/DataFixture/Exception/PersistentReferenceNotFoundException.php
@@ -10,7 +10,7 @@ class PersistentReferenceNotFoundException extends Exception implements DataFixt
      * @param string $referenceName
      * @param \Exception|null $previous
      */
-    public function __construct($referenceName, Exception $previous = null)
+    public function __construct($referenceName, ?Exception $previous = null)
     {
         parent::__construct('Data fixture reference "' . $referenceName . '" not found', 0, $previous);
     }

--- a/packages/framework/src/Component/DataFixture/Exception/UnsupportedLocaleException.php
+++ b/packages/framework/src/Component/DataFixture/Exception/UnsupportedLocaleException.php
@@ -10,7 +10,7 @@ class UnsupportedLocaleException extends Exception implements DataFixtureExcepti
      * @param string $locale
      * @param \Exception|null $previous
      */
-    public function __construct($locale, Exception $previous = null)
+    public function __construct($locale, ?Exception $previous = null)
     {
         parent::__construct('Locale "' . $locale . '" is not supported.', 0, $previous);
     }

--- a/packages/framework/src/Component/DateTimeHelper/Exception/CannotParseDateTimeException.php
+++ b/packages/framework/src/Component/DateTimeHelper/Exception/CannotParseDateTimeException.php
@@ -11,7 +11,7 @@ class CannotParseDateTimeException extends Exception
      * @param string $time
      * @param \Exception|null $previous
      */
-    public function __construct($format, $time, Exception $previous = null)
+    public function __construct($format, $time, ?Exception $previous = null)
     {
         $message = sprintf(
             'Cannot parse string %s using format %s as DateTime.',

--- a/packages/framework/src/Component/Doctrine/Cache/Exception/InvalidArgumentException.php
+++ b/packages/framework/src/Component/Doctrine/Cache/Exception/InvalidArgumentException.php
@@ -10,7 +10,7 @@ class InvalidArgumentException extends Exception implements DoctrineCacheExcepti
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Doctrine/Exception/DefaultSchemaImportException.php
+++ b/packages/framework/src/Component/Doctrine/Exception/DefaultSchemaImportException.php
@@ -10,7 +10,7 @@ class DefaultSchemaImportException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Doctrine/Exception/InvalidCountOfAliasesException.php
+++ b/packages/framework/src/Component/Doctrine/Exception/InvalidCountOfAliasesException.php
@@ -11,7 +11,7 @@ class InvalidCountOfAliasesException extends Exception
      * @param array|null $rootAliases
      * @param \Exception|null $previous
      */
-    public function __construct(array $rootAliases = null, Exception $previous = null)
+    public function __construct(?array $rootAliases = null, ?Exception $previous = null)
     {
         parent::__construct('Query builder has invalid count of root aliases ' . Debug::export($rootAliases), 0, $previous);
     }

--- a/packages/framework/src/Component/Doctrine/Exception/SqlLoggerAlreadyDisabledException.php
+++ b/packages/framework/src/Component/Doctrine/Exception/SqlLoggerAlreadyDisabledException.php
@@ -10,7 +10,7 @@ class SqlLoggerAlreadyDisabledException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Doctrine/Exception/SqlLoggerAlreadyEnabledException.php
+++ b/packages/framework/src/Component/Doctrine/Exception/SqlLoggerAlreadyEnabledException.php
@@ -10,7 +10,7 @@ class SqlLoggerAlreadyEnabledException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Domain/Multidomain/Twig/FilesystemLoader.php
+++ b/packages/framework/src/Component/Domain/Multidomain/Twig/FilesystemLoader.php
@@ -24,7 +24,7 @@ class FilesystemLoader extends BaseFilesystemLoader
         FileLocatorInterface $locator,
         TemplateNameParserInterface $parser,
         ?string $rootPath = null,
-        Domain $domain = null
+        ?Domain $domain = null
     ) {
         $this->domain = $domain;
         parent::__construct($locator, $parser, $rootPath);

--- a/packages/framework/src/Component/Error/Exception/BadErrorPageStatusCodeException.php
+++ b/packages/framework/src/Component/Error/Exception/BadErrorPageStatusCodeException.php
@@ -12,7 +12,7 @@ class BadErrorPageStatusCodeException extends Exception implements ErrorExceptio
      * @param int $actualStatusCode
      * @param \Exception|null $previous
      */
-    public function __construct($url, $expectedStatusCode, $actualStatusCode, Exception $previous = null)
+    public function __construct($url, $expectedStatusCode, $actualStatusCode, ?Exception $previous = null)
     {
         $message = sprintf(
             'Error page "%s" has "%s" status code, expects "%s".',

--- a/packages/framework/src/Component/Error/Exception/ErrorPageNotFoundException.php
+++ b/packages/framework/src/Component/Error/Exception/ErrorPageNotFoundException.php
@@ -11,7 +11,7 @@ class ErrorPageNotFoundException extends Exception implements ErrorException
      * @param int $statusCode
      * @param \Exception|null $previous
      */
-    public function __construct($domainId, $statusCode, Exception $previous = null)
+    public function __construct($domainId, $statusCode, ?Exception $previous = null)
     {
         $message = 'Error page with status code "' . $statusCode . '" on domain with id "' . $domainId . '" not found.';
 

--- a/packages/framework/src/Component/FileUpload/Exception/InvalidFileKeyException.php
+++ b/packages/framework/src/Component/FileUpload/Exception/InvalidFileKeyException.php
@@ -11,7 +11,7 @@ class InvalidFileKeyException extends Exception implements FileUploadException
      * @param mixed $key
      * @param \Exception|null $previous
      */
-    public function __construct($key, Exception $previous = null)
+    public function __construct($key, ?Exception $previous = null)
     {
         parent::__construct('Upload file key ' . Debug::export($key) . ' is invalid', 0, $previous);
     }

--- a/packages/framework/src/Component/FileUpload/Exception/MoveToEntityFailedException.php
+++ b/packages/framework/src/Component/FileUpload/Exception/MoveToEntityFailedException.php
@@ -10,7 +10,7 @@ class MoveToEntityFailedException extends Exception implements FileUploadExcepti
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/FileUpload/Exception/MoveToFolderFailedException.php
+++ b/packages/framework/src/Component/FileUpload/Exception/MoveToFolderFailedException.php
@@ -10,7 +10,7 @@ class MoveToFolderFailedException extends Exception implements FileUploadExcepti
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/FileUpload/Exception/UnresolvedNamingConventionException.php
+++ b/packages/framework/src/Component/FileUpload/Exception/UnresolvedNamingConventionException.php
@@ -10,7 +10,7 @@ class UnresolvedNamingConventionException extends Exception implements FileUploa
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/FileUpload/Exception/UploadFailedException.php
+++ b/packages/framework/src/Component/FileUpload/Exception/UploadFailedException.php
@@ -10,7 +10,7 @@ class UploadFailedException extends Exception implements FileUploadException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Filesystem/Exception/DirectoryDoesNotExistException.php
+++ b/packages/framework/src/Component/Filesystem/Exception/DirectoryDoesNotExistException.php
@@ -10,7 +10,7 @@ class DirectoryDoesNotExistException extends Exception implements FilesystemExce
      * @param string $path
      * @param \Exception|null $previous
      */
-    public function __construct($path, Exception $previous = null)
+    public function __construct($path, ?Exception $previous = null)
     {
         $message = sprintf('Path "%s" must exist.', $path);
 

--- a/packages/framework/src/Component/FlashMessage/Exception/BagNameIsNotValidException.php
+++ b/packages/framework/src/Component/FlashMessage/Exception/BagNameIsNotValidException.php
@@ -10,7 +10,7 @@ class BagNameIsNotValidException extends Exception implements FlashMessageExcept
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Form/Exception/InvertedChoiceNotMultipleException.php
+++ b/packages/framework/src/Component/Form/Exception/InvertedChoiceNotMultipleException.php
@@ -10,7 +10,7 @@ class InvertedChoiceNotMultipleException extends Exception implements FormExcept
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Grid/Exception/DuplicateColumnIdException.php
+++ b/packages/framework/src/Component/Grid/Exception/DuplicateColumnIdException.php
@@ -10,7 +10,7 @@ class DuplicateColumnIdException extends Exception implements GridException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Grid/Exception/EmptyGridIdException.php
+++ b/packages/framework/src/Component/Grid/Exception/EmptyGridIdException.php
@@ -10,7 +10,7 @@ class EmptyGridIdException extends Exception implements GridException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Grid/Exception/OrderingNotSupportedException.php
+++ b/packages/framework/src/Component/Grid/Exception/OrderingNotSupportedException.php
@@ -10,7 +10,7 @@ class OrderingNotSupportedException extends Exception implements GridException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Grid/Exception/PaginationNotSupportedException.php
+++ b/packages/framework/src/Component/Grid/Exception/PaginationNotSupportedException.php
@@ -10,7 +10,7 @@ class PaginationNotSupportedException extends Exception implements GridException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Grid/GridView.php
+++ b/packages/framework/src/Component/Grid/GridView.php
@@ -123,7 +123,7 @@ class GridView
      * @param \Symfony\Component\Form\FormView|null $formView
      * @param \Symfony\Component\Form\FormView
      */
-    public function renderCell(Column $column, array $row = null, FormView $formView = null)
+    public function renderCell(Column $column, ?array $row = null, ?FormView $formView = null)
     {
         if ($row !== null) {
             $value = $this->getCellValue($column, $row);
@@ -199,7 +199,7 @@ class GridView
      * @param array|string|null $removeParameters
      * @return string
      */
-    public function getUrl(array $parameters = null, $removeParameters = null)
+    public function getUrl(?array $parameters = null, $removeParameters = null)
     {
         $masterRequest = $this->requestStack->getMasterRequest();
         $routeParameters = $this->grid->getUrlParameters($parameters, $removeParameters);

--- a/packages/framework/src/Component/Grid/InlineEdit/Exception/InvalidFormDataException.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/Exception/InvalidFormDataException.php
@@ -15,7 +15,7 @@ class InvalidFormDataException extends Exception implements InlineEditException
      * @param array $formErrors
      * @param \Exception|null $previous
      */
-    public function __construct(array $formErrors, Exception $previous = null)
+    public function __construct(array $formErrors, ?Exception $previous = null)
     {
         $this->formErrors = $formErrors;
         parent::__construct('Inline edit form is not valid', 0, $previous);

--- a/packages/framework/src/Component/Grid/InlineEdit/Exception/InvalidServiceException.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/Exception/InvalidServiceException.php
@@ -10,7 +10,7 @@ class InvalidServiceException extends Exception implements InlineEditException
      * @param string $serviceName
      * @param \Exception|null $previous
      */
-    public function __construct($serviceName, Exception $previous = null)
+    public function __construct($serviceName, ?Exception $previous = null)
     {
         $message = 'Service with name "' . $serviceName . '" does not exist or not implement necessary interface.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Component/Grid/Ordering/Exception/EntityIsNotOrderableException.php
+++ b/packages/framework/src/Component/Grid/Ordering/Exception/EntityIsNotOrderableException.php
@@ -10,7 +10,7 @@ class EntityIsNotOrderableException extends Exception implements OrderingExcepti
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/HttpFoundation/Exception/TooManyRedirectResponsesException.php
+++ b/packages/framework/src/Component/HttpFoundation/Exception/TooManyRedirectResponsesException.php
@@ -10,7 +10,7 @@ class TooManyRedirectResponsesException extends Exception implements HttpFoundat
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateEntityNameException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateEntityNameException.php
@@ -15,7 +15,7 @@ class DuplicateEntityNameException extends Exception implements ImageConfigExcep
      * @param string $entityName
      * @param \Exception|null $previous
      */
-    public function __construct($entityName, Exception $previous = null)
+    public function __construct($entityName, ?Exception $previous = null)
     {
         $this->entityName = $entityName;
 

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateMediaException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateMediaException.php
@@ -10,7 +10,7 @@ class DuplicateMediaException extends Exception implements ImageConfigException
      * @param string $media
      * @param \Exception|null $previous
      */
-    public function __construct(string $media, Exception $previous = null)
+    public function __construct(string $media, ?Exception $previous = null)
     {
         $message = sprintf('Additional size media "%s" is not unique.', $media);
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateSizeNameException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateSizeNameException.php
@@ -15,7 +15,7 @@ class DuplicateSizeNameException extends Exception implements ImageConfigExcepti
      * @param string|null $sizeName
      * @param \Exception|null $previous
      */
-    public function __construct($sizeName = null, Exception $previous = null)
+    public function __construct($sizeName = null, ?Exception $previous = null)
     {
         $this->sizeName = $sizeName;
 

--- a/packages/framework/src/Component/Image/Config/Exception/DuplicateTypeNameException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/DuplicateTypeNameException.php
@@ -15,7 +15,7 @@ class DuplicateTypeNameException extends Exception implements ImageConfigExcepti
      * @param string|null $typeName
      * @param \Exception|null $previous
      */
-    public function __construct($typeName = null, Exception $previous = null)
+    public function __construct($typeName = null, ?Exception $previous = null)
     {
         $this->typeName = $typeName;
 

--- a/packages/framework/src/Component/Image/Config/Exception/EntityParseException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/EntityParseException.php
@@ -15,7 +15,7 @@ class EntityParseException extends Exception implements ImageConfigException
      * @param string $entityClass
      * @param \Exception|null $previous
      */
-    public function __construct($entityClass, Exception $previous = null)
+    public function __construct($entityClass, ?Exception $previous = null)
     {
         $this->entityClass = $entityClass;
 

--- a/packages/framework/src/Component/Image/Config/Exception/ImageAdditionalSizeNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageAdditionalSizeNotFoundException.php
@@ -11,7 +11,7 @@ class ImageAdditionalSizeNotFoundException extends Exception implements ImageCon
      * @param int $additionalIndex
      * @param \Exception|null $previous
      */
-    public function __construct(?string $sizeName, int $additionalIndex, Exception $previous = null)
+    public function __construct(?string $sizeName, int $additionalIndex, ?Exception $previous = null)
     {
         $sizeName = $sizeName ?: '~';
         $message = sprintf('Image size "%s" does not contain additional size on index "%s".', $sizeName, $additionalIndex);

--- a/packages/framework/src/Component/Image/Config/Exception/ImageEntityConfigNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageEntityConfigNotFoundException.php
@@ -15,7 +15,7 @@ class ImageEntityConfigNotFoundException extends Exception implements ImageConfi
      * @param string $entityClassOrName
      * @param \Exception|null $previous
      */
-    public function __construct($entityClassOrName, Exception $previous = null)
+    public function __construct($entityClassOrName, ?Exception $previous = null)
     {
         $this->entityClassOrName = $entityClassOrName;
 

--- a/packages/framework/src/Component/Image/Config/Exception/ImageSizeNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageSizeNotFoundException.php
@@ -21,7 +21,7 @@ class ImageSizeNotFoundException extends Exception implements ImageConfigExcepti
      * @param string $sizeName
      * @param \Exception|null $previous
      */
-    public function __construct($entityClass, $sizeName, Exception $previous = null)
+    public function __construct($entityClass, $sizeName, ?Exception $previous = null)
     {
         $this->entityClass = $entityClass;
         $this->sizeName = $sizeName;

--- a/packages/framework/src/Component/Image/Config/Exception/ImageTypeNotFoundException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/ImageTypeNotFoundException.php
@@ -21,7 +21,7 @@ class ImageTypeNotFoundException extends Exception implements ImageConfigExcepti
      * @param string $imageType
      * @param \Exception|null $previous
      */
-    public function __construct($entityClass, $imageType, Exception $previous = null)
+    public function __construct($entityClass, $imageType, ?Exception $previous = null)
     {
         $this->entityClass = $entityClass;
         $this->imageType = $imageType;

--- a/packages/framework/src/Component/Image/Config/Exception/WidthAndHeightMissingException.php
+++ b/packages/framework/src/Component/Image/Config/Exception/WidthAndHeightMissingException.php
@@ -11,7 +11,7 @@ class WidthAndHeightMissingException extends Exception implements ImageConfigExc
      * @param string $additionalSizeName
      * @param \Exception|null $previous
      */
-    public function __construct(string $additionalSizeName, Exception $previous = null)
+    public function __construct(string $additionalSizeName, ?Exception $previous = null)
     {
         $message = sprintf(
             'You have to specify at least one of "%s" or "%s" for additional size "%s"',

--- a/packages/framework/src/Component/Image/Exception/EntityIdentifierException.php
+++ b/packages/framework/src/Component/Image/Exception/EntityIdentifierException.php
@@ -10,7 +10,7 @@ class EntityIdentifierException extends Exception implements ImageException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Image/Exception/EntityMultipleImageException.php
+++ b/packages/framework/src/Component/Image/Exception/EntityMultipleImageException.php
@@ -10,7 +10,7 @@ class EntityMultipleImageException extends Exception implements ImageException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Image/Exception/ImageNotFoundException.php
+++ b/packages/framework/src/Component/Image/Exception/ImageNotFoundException.php
@@ -10,7 +10,7 @@ class ImageNotFoundException extends Exception implements ImageException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Image/Processing/Exception/FileIsNotSupportedImageException.php
+++ b/packages/framework/src/Component/Image/Processing/Exception/FileIsNotSupportedImageException.php
@@ -10,7 +10,7 @@ class FileIsNotSupportedImageException extends Exception implements ImageProcess
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Image/Processing/Exception/OriginalSizeImageCannotBeGeneratedException.php
+++ b/packages/framework/src/Component/Image/Processing/Exception/OriginalSizeImageCannotBeGeneratedException.php
@@ -11,7 +11,7 @@ class OriginalSizeImageCannotBeGeneratedException extends Exception implements I
      * @param \Shopsys\FrameworkBundle\Component\Image\Image $image
      * @param \Exception|null $previous
      */
-    public function __construct(Image $image, Exception $previous = null)
+    public function __construct(Image $image, ?Exception $previous = null)
     {
         $message = 'Original size of ' . $image->getFilename() . ' cannot be resized because it is original uploaded image.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Component/Javascript/Compiler/Constant/Exception/CannotConvertToJsonException.php
+++ b/packages/framework/src/Component/Javascript/Compiler/Constant/Exception/CannotConvertToJsonException.php
@@ -10,7 +10,7 @@ class CannotConvertToJsonException extends Exception implements JsConstantCompil
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Javascript/Compiler/Constant/Exception/ConstantNotFoundException.php
+++ b/packages/framework/src/Component/Javascript/Compiler/Constant/Exception/ConstantNotFoundException.php
@@ -10,7 +10,7 @@ class ConstantNotFoundException extends Exception implements JsConstantCompilerE
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Javascript/Parser/Constant/Exception/JsConstantCallParserException.php
+++ b/packages/framework/src/Component/Javascript/Parser/Constant/Exception/JsConstantCallParserException.php
@@ -11,7 +11,7 @@ class JsConstantCallParserException extends Exception implements JsParserExcepti
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Javascript/Parser/Exception/UnsupportedNodeException.php
+++ b/packages/framework/src/Component/Javascript/Parser/Exception/UnsupportedNodeException.php
@@ -10,7 +10,7 @@ class UnsupportedNodeException extends Exception implements JsParserException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Javascript/Parser/Translator/Exception/JsTranslatorCallParserException.php
+++ b/packages/framework/src/Component/Javascript/Parser/Translator/Exception/JsTranslatorCallParserException.php
@@ -11,7 +11,7 @@ class JsTranslatorCallParserException extends Exception implements JsParserExcep
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Money/Exception/UnsupportedTypeException.php
+++ b/packages/framework/src/Component/Money/Exception/UnsupportedTypeException.php
@@ -14,7 +14,7 @@ final class UnsupportedTypeException extends InvalidArgumentException implements
      * @param string[] $supportedTypes
      * @param \Throwable|null $previous
      */
-    public function __construct($value, array $supportedTypes, Throwable $previous = null)
+    public function __construct($value, array $supportedTypes, ?Throwable $previous = null)
     {
         $message = sprintf('Expected one of: "%s"', implode('", "', $supportedTypes));
         $message .= sprintf(', "%s" given.', \is_object($value) ? \get_class($value) : \gettype($value));

--- a/packages/framework/src/Component/Money/Money.php
+++ b/packages/framework/src/Component/Money/Money.php
@@ -225,7 +225,7 @@ final class Money implements JsonSerializable
      * @param int|null $scale
      * @return \Litipk\BigNumbers\Decimal
      */
-    protected static function createDecimal($value, int $scale = null): Decimal
+    protected static function createDecimal($value, ?int $scale = null): Decimal
     {
         if (is_int($value)) {
             return Decimal::fromInteger($value);

--- a/packages/framework/src/Component/Plugin/Exception/PluginCrudExtensionAlreadyRegisteredException.php
+++ b/packages/framework/src/Component/Plugin/Exception/PluginCrudExtensionAlreadyRegisteredException.php
@@ -11,7 +11,7 @@ class PluginCrudExtensionAlreadyRegisteredException extends Exception implements
      * @param string $key
      * @param \Exception|null $previous
      */
-    public function __construct($type, $key, Exception $previous = null)
+    public function __construct($type, $key, ?Exception $previous = null)
     {
         $message = sprintf('Plugin CRUD extension of type "%s" with key "%s" was already registered.', $type, $key);
 

--- a/packages/framework/src/Component/Plugin/Exception/UnknownPluginCrudExtensionTypeException.php
+++ b/packages/framework/src/Component/Plugin/Exception/UnknownPluginCrudExtensionTypeException.php
@@ -11,7 +11,7 @@ class UnknownPluginCrudExtensionTypeException extends Exception implements Plugi
      * @param string[] $knownTypes
      * @param \Exception|null $previous
      */
-    public function __construct($unknownType, array $knownTypes, Exception $previous = null)
+    public function __construct($unknownType, array $knownTypes, ?Exception $previous = null)
     {
         $message = sprintf(
             'Trying to register unknown type of plugin CRUD extension "%s". Known types are: %s.',

--- a/packages/framework/src/Component/Router/DomainRouter.php
+++ b/packages/framework/src/Component/Router/DomainRouter.php
@@ -33,7 +33,7 @@ class DomainRouter extends ChainRouter
         RouterInterface $basicRouter,
         RouterInterface $localizedRouter,
         FriendlyUrlRouter $friendlyUrlRouter,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         parent::__construct($logger);
         $this->setContext($context);

--- a/packages/framework/src/Component/Router/Exception/LocalizedRoutingConfigFileNotFoundException.php
+++ b/packages/framework/src/Component/Router/Exception/LocalizedRoutingConfigFileNotFoundException.php
@@ -10,7 +10,7 @@ class LocalizedRoutingConfigFileNotFoundException extends Exception implements R
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Router/Exception/NotSupportedException.php
+++ b/packages/framework/src/Component/Router/Exception/NotSupportedException.php
@@ -10,7 +10,7 @@ class NotSupportedException extends Exception implements RouterException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Router/Exception/RouterNotResolvedException.php
+++ b/packages/framework/src/Component/Router/Exception/RouterNotResolvedException.php
@@ -10,7 +10,7 @@ class RouterNotResolvedException extends Exception implements RouterException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Router/FriendlyUrl/Exception/MethodGenerateIsNotSupportedException.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/Exception/MethodGenerateIsNotSupportedException.php
@@ -10,7 +10,7 @@ class MethodGenerateIsNotSupportedException extends Exception implements Friendl
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Router/FriendlyUrl/Exception/ReachMaxUrlUniqueResolveAttemptException.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/Exception/ReachMaxUrlUniqueResolveAttemptException.php
@@ -12,7 +12,7 @@ class ReachMaxUrlUniqueResolveAttemptException extends Exception implements Frie
      * @param int $attempt
      * @param \Exception|null $previous
      */
-    public function __construct(FriendlyUrl $friendlyUrl, $attempt, Exception $previous = null)
+    public function __construct(FriendlyUrl $friendlyUrl, $attempt, ?Exception $previous = null)
     {
         $message = 'Route "' . $friendlyUrl->getRouteName() . '" (param id = "' . $friendlyUrl->getEntityId() . '")'
             . ' reach max attempt (' . $attempt . ') for unique resolving.';

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
@@ -61,7 +61,7 @@ class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
         int $entityId,
         string $entityName,
         int $domainId,
-        int $indexPostfix = null
+        ?int $indexPostfix = null
     ): ?FriendlyUrl {
         if ($entityName === '') {
             return null;

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactoryInterface.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactoryInterface.php
@@ -31,7 +31,7 @@ interface FriendlyUrlFactoryInterface
         int $entityId,
         string $entityName,
         int $domainId,
-        int $indexPostfix = null
+        ?int $indexPostfix = null
     ): ?FriendlyUrl;
 
     /**

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlUniqueResult.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlUniqueResult.php
@@ -18,7 +18,7 @@ class FriendlyUrlUniqueResult
      * @param bool $unique
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl|null $friendlyUrl
      */
-    public function __construct($unique, FriendlyUrl $friendlyUrl = null)
+    public function __construct($unique, ?FriendlyUrl $friendlyUrl = null)
     {
         $this->unique = $unique;
         $this->friendlyUrlForPersist = $friendlyUrl;

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactory.php
@@ -28,7 +28,7 @@ class FriendlyUrlUniqueResultFactory
         int $attempt,
         FriendlyUrl $friendlyUrl,
         string $entityName,
-        array $matchedRouteData = null
+        ?array $matchedRouteData = null
     ) {
         if ($matchedRouteData === null) {
             return new FriendlyUrlUniqueResult(true, $friendlyUrl);

--- a/packages/framework/src/Component/Setting/Exception/InvalidArgumentException.php
+++ b/packages/framework/src/Component/Setting/Exception/InvalidArgumentException.php
@@ -10,7 +10,7 @@ class InvalidArgumentException extends Exception implements SettingException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Setting/Exception/SettingValueNotFoundException.php
+++ b/packages/framework/src/Component/Setting/Exception/SettingValueNotFoundException.php
@@ -10,7 +10,7 @@ class SettingValueNotFoundException extends Exception implements SettingExceptio
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Setting/Exception/SettingValueTypeNotMatchValueException.php
+++ b/packages/framework/src/Component/Setting/Exception/SettingValueTypeNotMatchValueException.php
@@ -10,7 +10,7 @@ class SettingValueTypeNotMatchValueException extends Exception implements Settin
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/System/Exception/UnknownWindowsLocaleException.php
+++ b/packages/framework/src/Component/System/Exception/UnknownWindowsLocaleException.php
@@ -12,7 +12,7 @@ class UnknownWindowsLocaleException extends Exception
      * @param mixed $collation
      * @param \Throwable|null $previous
      */
-    public function __construct($collation, Throwable $previous = null)
+    public function __construct($collation, ?Throwable $previous = null)
     {
         $message = sprintf(
             'Matching Windows locale for collation "%s" is not known. Consider updating %s class.',

--- a/packages/framework/src/Component/Translation/Exception/ExtractionException.php
+++ b/packages/framework/src/Component/Translation/Exception/ExtractionException.php
@@ -10,7 +10,7 @@ class ExtractionException extends Exception implements TranslationException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Translation/Exception/InstanceNotInjectedException.php
+++ b/packages/framework/src/Component/Translation/Exception/InstanceNotInjectedException.php
@@ -10,7 +10,7 @@ class InstanceNotInjectedException extends Exception implements TranslationExcep
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Translation/Exception/MessageIdArgumentNotPresent.php
+++ b/packages/framework/src/Component/Translation/Exception/MessageIdArgumentNotPresent.php
@@ -10,7 +10,7 @@ class MessageIdArgumentNotPresent extends Exception implements TranslationExcept
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/Translation/Exception/StringValueUnextractableException.php
+++ b/packages/framework/src/Component/Translation/Exception/StringValueUnextractableException.php
@@ -10,7 +10,7 @@ class StringValueUnextractableException extends Exception implements Translation
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/UploadedFile/Config/Exception/DuplicateEntityNameException.php
+++ b/packages/framework/src/Component/UploadedFile/Config/Exception/DuplicateEntityNameException.php
@@ -15,7 +15,7 @@ class DuplicateEntityNameException extends Exception implements UploadedFileConf
      * @param string $entityName
      * @param \Exception|null $previous
      */
-    public function __construct($entityName, Exception $previous = null)
+    public function __construct($entityName, ?Exception $previous = null)
     {
         $this->entityName = $entityName;
 

--- a/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileConfigurationParseException.php
+++ b/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileConfigurationParseException.php
@@ -15,7 +15,7 @@ class UploadedFileConfigurationParseException extends Exception implements Uploa
      * @param string $entityClass
      * @param \Exception|null $previous
      */
-    public function __construct($entityClass, Exception $previous = null)
+    public function __construct($entityClass, ?Exception $previous = null)
     {
         $this->entityClass = $entityClass;
 

--- a/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileEntityConfigNotFoundException.php
+++ b/packages/framework/src/Component/UploadedFile/Config/Exception/UploadedFileEntityConfigNotFoundException.php
@@ -15,7 +15,7 @@ class UploadedFileEntityConfigNotFoundException extends Exception implements Upl
      * @param string $entityClassOrName
      * @param \Exception|null $previous
      */
-    public function __construct($entityClassOrName, Exception $previous = null)
+    public function __construct($entityClassOrName, ?Exception $previous = null)
     {
         $this->entityClassOrName = $entityClassOrName;
 

--- a/packages/framework/src/Component/UploadedFile/Exception/EntityIdentifierException.php
+++ b/packages/framework/src/Component/UploadedFile/Exception/EntityIdentifierException.php
@@ -10,7 +10,7 @@ class EntityIdentifierException extends Exception implements FileException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Component/UploadedFile/Exception/FileNotFoundException.php
+++ b/packages/framework/src/Component/UploadedFile/Exception/FileNotFoundException.php
@@ -10,7 +10,7 @@ class FileNotFoundException extends Exception implements FileException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -263,7 +263,7 @@ class CategoryFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $category
      * @return string
      */
-    private function getCategoryNameForPlaceholder(DomainConfig $domainConfig, Category $category = null)
+    private function getCategoryNameForPlaceholder(DomainConfig $domainConfig, ?Category $category = null)
     {
         $domainLocale = $domainConfig->getLocale();
 

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -191,7 +191,7 @@ class BrandFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|null $brand
      * @return string
      */
-    private function getTitlePlaceholder(Brand $brand = null)
+    private function getTitlePlaceholder(?Brand $brand = null)
     {
         return $brand !== null ? $brand->getName() : '';
     }

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -802,7 +802,7 @@ class ProductFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
      * @return string
      */
-    private function getTitlePlaceholder($locale, Product $product = null)
+    private function getTitlePlaceholder($locale, ?Product $product = null)
     {
         return $product !== null ? $product->getName($locale) : '';
     }

--- a/packages/framework/src/Form/Exception/InconsistentChoicesException.php
+++ b/packages/framework/src/Form/Exception/InconsistentChoicesException.php
@@ -10,7 +10,7 @@ class InconsistentChoicesException extends Exception implements FormException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Form/Exception/MissingRouteNameException.php
+++ b/packages/framework/src/Form/Exception/MissingRouteNameException.php
@@ -10,7 +10,7 @@ class MissingRouteNameException extends Exception implements FormException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Administrator/Activity/Exception/CurrentAdministratorActivityNotFoundException.php
+++ b/packages/framework/src/Model/Administrator/Activity/Exception/CurrentAdministratorActivityNotFoundException.php
@@ -10,7 +10,7 @@ class CurrentAdministratorActivityNotFoundException extends Exception implements
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Administrator/Exception/DuplicateUserNameException.php
+++ b/packages/framework/src/Model/Administrator/Exception/DuplicateUserNameException.php
@@ -10,7 +10,7 @@ class DuplicateUserNameException extends Exception implements AdministratorExcep
      * @param string $username
      * @param \Exception|null $previous
      */
-    public function __construct($username, Exception $previous = null)
+    public function __construct($username, ?Exception $previous = null)
     {
         parent::__construct('Administrator with user name ' . $username . ' already exists.', 0, $previous);
     }

--- a/packages/framework/src/Model/Administrator/Exception/InvalidGridLimitValueException.php
+++ b/packages/framework/src/Model/Administrator/Exception/InvalidGridLimitValueException.php
@@ -16,7 +16,7 @@ class InvalidGridLimitValueException extends Exception implements AdministratorE
      * @param mixed $limit
      * @param \Exception|null $previous
      */
-    public function __construct($limit, Exception $previous = null)
+    public function __construct($limit, ?Exception $previous = null)
     {
         parent::__construct('Administrator grid limit value ' . Debug::export($limit) . ' is invalid', 0, $previous);
     }

--- a/packages/framework/src/Model/Administrator/Exception/RememberGridLimitException.php
+++ b/packages/framework/src/Model/Administrator/Exception/RememberGridLimitException.php
@@ -15,7 +15,7 @@ class RememberGridLimitException extends Exception implements AdministratorExcep
      * @param string $gridId
      * @param \Exception|null $previous
      */
-    public function __construct($gridId, Exception $previous = null)
+    public function __construct($gridId, ?Exception $previous = null)
     {
         $this->gridId = $gridId;
         parent::__construct('Grid \'' . $this->gridId . ' \' does not allow paging', 0, $previous);

--- a/packages/framework/src/Model/Administrator/Security/Exception/AdministratorIsNotLoggedException.php
+++ b/packages/framework/src/Model/Administrator/Security/Exception/AdministratorIsNotLoggedException.php
@@ -10,7 +10,7 @@ class AdministratorIsNotLoggedException extends Exception implements SecurityExc
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Administrator/Security/Exception/InvalidTokenException.php
+++ b/packages/framework/src/Model/Administrator/Security/Exception/InvalidTokenException.php
@@ -10,7 +10,7 @@ class InvalidTokenException extends Exception implements SecurityException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/AdvancedSearch/Exception/AdvancedSearchFilterAlreadyExistsException.php
+++ b/packages/framework/src/Model/AdvancedSearch/Exception/AdvancedSearchFilterAlreadyExistsException.php
@@ -10,7 +10,7 @@ class AdvancedSearchFilterAlreadyExistsException extends Exception implements Ad
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/AdvancedSearch/Exception/AdvancedSearchFilterNotFoundException.php
+++ b/packages/framework/src/Model/AdvancedSearch/Exception/AdvancedSearchFilterNotFoundException.php
@@ -10,7 +10,7 @@ class AdvancedSearchFilterNotFoundException extends Exception implements Advance
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/AdvancedSearch/Exception/AdvancedSearchTranslationNotFoundException.php
+++ b/packages/framework/src/Model/AdvancedSearch/Exception/AdvancedSearchTranslationNotFoundException.php
@@ -10,7 +10,7 @@ class AdvancedSearchTranslationNotFoundException extends Exception implements Ad
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/AdvancedSearch/RuleFormViewDataFactory.php
+++ b/packages/framework/src/Model/AdvancedSearch/RuleFormViewDataFactory.php
@@ -13,7 +13,7 @@ class RuleFormViewDataFactory
      * @param array|null $requestData
      * @return array
      */
-    public function createFromRequestData(string $defaultFilterName, array $requestData = null): array
+    public function createFromRequestData(string $defaultFilterName, ?array $requestData = null): array
     {
         if ($requestData === null) {
             $searchRulesViewData = [];

--- a/packages/framework/src/Model/Advert/Exception/AdvertPositionNotKnownException.php
+++ b/packages/framework/src/Model/Advert/Exception/AdvertPositionNotKnownException.php
@@ -11,7 +11,7 @@ class AdvertPositionNotKnownException extends Exception implements AdvertExcepti
      * @param array $knownPositionsNames
      * @param \Exception|null $previous
      */
-    public function __construct(string $positionName, array $knownPositionsNames, Exception $previous = null)
+    public function __construct(string $positionName, array $knownPositionsNames, ?Exception $previous = null)
     {
         $message = sprintf(
             'Unknown advert position name "%s". Known names are %s.',

--- a/packages/framework/src/Model/Cart/Cart.php
+++ b/packages/framework/src/Model/Cart/Cart.php
@@ -66,7 +66,7 @@ class Cart
      * @param string $cartIdentifier
      * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
      */
-    public function __construct(string $cartIdentifier, User $user = null)
+    public function __construct(string $cartIdentifier, ?User $user = null)
     {
         $this->cartIdentifier = $cartIdentifier;
         $this->user = $user;

--- a/packages/framework/src/Model/Cart/Exception/CartIsEmptyException.php
+++ b/packages/framework/src/Model/Cart/Exception/CartIsEmptyException.php
@@ -10,7 +10,7 @@ class CartIsEmptyException extends Exception implements CartException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct(Exception $previous = null)
+    public function __construct(?Exception $previous = null)
     {
         parent::__construct('Cart is empty.', 0, $previous);
     }

--- a/packages/framework/src/Model/Cart/Exception/InvalidCartItemException.php
+++ b/packages/framework/src/Model/Cart/Exception/InvalidCartItemException.php
@@ -10,7 +10,7 @@ class InvalidCartItemException extends Exception implements CartException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Cart/Exception/InvalidQuantityException.php
+++ b/packages/framework/src/Model/Cart/Exception/InvalidQuantityException.php
@@ -16,7 +16,7 @@ class InvalidQuantityException extends Exception implements CartException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($invalidValue, $message = '', Exception $previous = null)
+    public function __construct($invalidValue, $message = '', ?Exception $previous = null)
     {
         $this->invalidValue = $invalidValue;
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Cart/Item/CartItem.php
+++ b/packages/framework/src/Model/Cart/Item/CartItem.php
@@ -117,7 +117,7 @@ class CartItem
      * @param string|null $locale
      * @return string|null
      */
-    public function getName(string $locale = null): ?string
+    public function getName(?string $locale = null): ?string
     {
         return $this->getProduct()->getName($locale);
     }

--- a/packages/framework/src/Model/Category/Category.php
+++ b/packages/framework/src/Model/Category/Category.php
@@ -106,7 +106,7 @@ class Category extends AbstractTranslatableEntity
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $parent
      */
-    public function setParent(self $parent = null)
+    public function setParent(?self $parent = null)
     {
         $this->parent = $parent;
     }

--- a/packages/framework/src/Model/Category/Exception/CategoryDomainNotFoundException.php
+++ b/packages/framework/src/Model/Category/Exception/CategoryDomainNotFoundException.php
@@ -11,7 +11,7 @@ class CategoryDomainNotFoundException extends Exception implements CategoryExcep
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct(int $categoryId = null, int $domainId, Exception $previous = null)
+    public function __construct(?int $categoryId = null, int $domainId, ?Exception $previous = null)
     {
         $categoryDescription = $categoryId !== null ? sprintf('with ID %d', $categoryId) : 'without ID';
         $message = sprintf('CategoryDomain for category %s and domain ID %d not found.', $categoryDescription, $domainId);

--- a/packages/framework/src/Model/Country/Exception/CountryDomainNotFoundException.php
+++ b/packages/framework/src/Model/Country/Exception/CountryDomainNotFoundException.php
@@ -13,7 +13,7 @@ class CountryDomainNotFoundException extends Exception implements CountryExcepti
      * @param int|null $countryId
      * @param \Exception|null $previous
      */
-    public function __construct(int $domainId, int $countryId = null, Exception $previous = null)
+    public function __construct(int $domainId, ?int $countryId = null, ?Exception $previous = null)
     {
         $countryDescription = $countryId !== null ? sprintf('with ID %d', $countryId) : 'without ID';
         $message = sprintf('CountryDomain for country %s and domain ID %d not found.', $countryDescription, $domainId);

--- a/packages/framework/src/Model/Customer/CustomerDataFactory.php
+++ b/packages/framework/src/Model/Customer/CustomerDataFactory.php
@@ -125,7 +125,7 @@ class CustomerDataFactory implements CustomerDataFactoryInterface
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress|null $deliveryAddress
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData
      */
-    protected function getAmendedDeliveryAddressDataByOrder(Order $order, DeliveryAddress $deliveryAddress = null)
+    protected function getAmendedDeliveryAddressDataByOrder(Order $order, ?DeliveryAddress $deliveryAddress = null)
     {
         if ($deliveryAddress === null) {
             $deliveryAddressData = $this->deliveryAddressDataFactory->create();

--- a/packages/framework/src/Model/Customer/CustomerIdentifier.php
+++ b/packages/framework/src/Model/Customer/CustomerIdentifier.php
@@ -18,7 +18,7 @@ class CustomerIdentifier
      * @param string $cartIdentifier
      * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
      */
-    public function __construct($cartIdentifier, User $user = null)
+    public function __construct($cartIdentifier, ?User $user = null)
     {
         if ($cartIdentifier === '' && $user === null) {
             $message = 'Can not be created empty CustomerIdentifier';

--- a/packages/framework/src/Model/Customer/Exception/EmptyCustomerIdentifierException.php
+++ b/packages/framework/src/Model/Customer/Exception/EmptyCustomerIdentifierException.php
@@ -10,7 +10,7 @@ class EmptyCustomerIdentifierException extends Exception implements CustomerExce
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Customer/Exception/InvalidResetPasswordHashException.php
+++ b/packages/framework/src/Model/Customer/Exception/InvalidResetPasswordHashException.php
@@ -10,7 +10,7 @@ class InvalidResetPasswordHashException extends Exception implements CustomerExc
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Customer/Exception/UserNotFoundByEmailAndDomainException.php
+++ b/packages/framework/src/Model/Customer/Exception/UserNotFoundByEmailAndDomainException.php
@@ -21,7 +21,7 @@ class UserNotFoundByEmailAndDomainException extends UserNotFoundException
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct($email, $domainId, Exception $previous = null)
+    public function __construct($email, $domainId, ?Exception $previous = null)
     {
         parent::__construct('User with email "' . $email . '" on domain "' . $domainId . '" not found.', $previous);
 

--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -151,7 +151,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
      * @param int|null $lastSeekId
      * @return \Shopsys\FrameworkBundle\Model\Feed\FeedExport
      */
-    protected function createCurrentFeedExport(int $lastSeekId = null): FeedExport
+    protected function createCurrentFeedExport(?int $lastSeekId = null): FeedExport
     {
         return $this->feedFacade->createFeedExport(
             $this->feedExportCreationDataQueue->getCurrentFeedName(),

--- a/packages/framework/src/Model/Feed/Exception/FeedNameNotUniqueException.php
+++ b/packages/framework/src/Model/Feed/Exception/FeedNameNotUniqueException.php
@@ -10,7 +10,7 @@ class FeedNameNotUniqueException extends Exception implements FeedException
      * @param string $name
      * @param \Exception|null $previous
      */
-    public function __construct(string $name, Exception $previous = null)
+    public function __construct(string $name, ?Exception $previous = null)
     {
         $message = 'Feed with name "' . $name . ' is already registered. Feed names must be unique.';
 

--- a/packages/framework/src/Model/Feed/Exception/FeedNotFoundException.php
+++ b/packages/framework/src/Model/Feed/Exception/FeedNotFoundException.php
@@ -10,7 +10,7 @@ class FeedNotFoundException extends Exception implements FeedException
      * @param string $name
      * @param \Exception|null $previous
      */
-    public function __construct(string $name, Exception $previous = null)
+    public function __construct(string $name, ?Exception $previous = null)
     {
         $message = 'Feed with name "' . $name . ' not found.';
 

--- a/packages/framework/src/Model/Feed/Exception/TemplateBlockNotFoundException.php
+++ b/packages/framework/src/Model/Feed/Exception/TemplateBlockNotFoundException.php
@@ -11,7 +11,7 @@ class TemplateBlockNotFoundException extends Exception implements FeedException
      * @param string $templateName
      * @param \Exception|null $previous
      */
-    public function __construct($blockName, $templateName, Exception $previous = null)
+    public function __construct($blockName, $templateName, ?Exception $previous = null)
     {
         $message = sprintf('Block "%s" does not exist in template "%s".', $blockName, $templateName);
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Feed/Exception/UnknownFeedTypeException.php
+++ b/packages/framework/src/Model/Feed/Exception/UnknownFeedTypeException.php
@@ -11,7 +11,7 @@ class UnknownFeedTypeException extends Exception implements FeedException
      * @param string[] $knownTypes
      * @param \Exception|null $previous
      */
-    public function __construct(string $type, array $knownTypes, Exception $previous = null)
+    public function __construct(string $type, array $knownTypes, ?Exception $previous = null)
     {
         $message = sprintf(
             'Trying to register or access a feed of an unknown type "%s". Allowed types are: %s.',

--- a/packages/framework/src/Model/Feed/FeedExportFactory.php
+++ b/packages/framework/src/Model/Feed/FeedExportFactory.php
@@ -75,7 +75,7 @@ class FeedExportFactory
      * @param string|null $lastSeekId
      * @return \Shopsys\FrameworkBundle\Model\Feed\FeedExport
      */
-    public function create(FeedInterface $feed, DomainConfig $domainConfig, string $lastSeekId = null): FeedExport
+    public function create(FeedInterface $feed, DomainConfig $domainConfig, ?string $lastSeekId = null): FeedExport
     {
         $feedRenderer = $this->feedRendererFactory->create($feed);
         $feedFilepath = $this->feedPathProvider->getFeedFilepath($feed->getInfo(), $domainConfig);

--- a/packages/framework/src/Model/Feed/FeedFacade.php
+++ b/packages/framework/src/Model/Feed/FeedFacade.php
@@ -78,7 +78,7 @@ class FeedFacade
      * @param int|null $lastSeekId
      * @return \Shopsys\FrameworkBundle\Model\Feed\FeedExport
      */
-    public function createFeedExport(string $feedName, DomainConfig $domainConfig, int $lastSeekId = null): FeedExport
+    public function createFeedExport(string $feedName, DomainConfig $domainConfig, ?int $lastSeekId = null): FeedExport
     {
         /*
          * Product is visible, when it has at least one visible category.
@@ -96,7 +96,7 @@ class FeedFacade
      * @param string|null $feedType
      * @return \Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface[]
      */
-    public function getFeedsInfo(string $feedType = null): array
+    public function getFeedsInfo(?string $feedType = null): array
     {
         $feeds = $feedType === null ? $this->feedRegistry->getAllFeeds() : $this->feedRegistry->getFeeds($feedType);
 
@@ -112,7 +112,7 @@ class FeedFacade
      * @param string|null $feedType
      * @return string[]
      */
-    public function getFeedNames(string $feedType = null): array
+    public function getFeedNames(?string $feedType = null): array
     {
         $feedNames = [];
         foreach ($this->getFeedsInfo($feedType) as $feedInfo) {

--- a/packages/framework/src/Model/Feed/FeedRegistry.php
+++ b/packages/framework/src/Model/Feed/FeedRegistry.php
@@ -43,7 +43,7 @@ class FeedRegistry
      * @param \Shopsys\FrameworkBundle\Model\Feed\FeedInterface $feed
      * @param string|null $type
      */
-    public function registerFeed(FeedInterface $feed, string $type = null): void
+    public function registerFeed(FeedInterface $feed, ?string $type = null): void
     {
         $type = Utils::ifNull($type, $this->defaultType);
         $this->assertTypeIsKnown($type);

--- a/packages/framework/src/Model/Heureka/Exception/LocaleNotSupportedException.php
+++ b/packages/framework/src/Model/Heureka/Exception/LocaleNotSupportedException.php
@@ -10,7 +10,7 @@ class LocaleNotSupportedException extends Exception implements HeurekaException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
+++ b/packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
@@ -52,7 +52,7 @@ class LegalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Model\Article\Article|null $termsAndConditions
      * @param int $domainId
      */
-    public function setTermsAndConditions(Article $termsAndConditions = null, $domainId)
+    public function setTermsAndConditions(?Article $termsAndConditions = null, $domainId)
     {
         $this->setArticle(Setting::TERMS_AND_CONDITIONS_ARTICLE_ID, $termsAndConditions, $domainId);
     }
@@ -78,7 +78,7 @@ class LegalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Model\Article\Article|null $privacyPolicy
      * @param int $domainId
      */
-    public function setPrivacyPolicy(Article $privacyPolicy = null, $domainId)
+    public function setPrivacyPolicy(?Article $privacyPolicy = null, $domainId)
     {
         $this->setArticle(Setting::PRIVACY_POLICY_ARTICLE_ID, $privacyPolicy, $domainId);
     }
@@ -124,7 +124,7 @@ class LegalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Model\Article\Article|null $privacyPolicy
      * @param int $domainId
      */
-    protected function setArticle($settingKey, Article $privacyPolicy = null, $domainId)
+    protected function setArticle($settingKey, ?Article $privacyPolicy = null, $domainId)
     {
         $articleId = null;
         if ($privacyPolicy !== null) {

--- a/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
+++ b/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
@@ -14,7 +14,7 @@ class AdminLocaleNotFoundException extends RuntimeException implements Localizat
      * @param string[] $possibleLocales
      * @param \Exception|null $previous
      */
-    public function __construct(string $adminLocale, array $possibleLocales, Exception $previous = null)
+    public function __construct(string $adminLocale, array $possibleLocales, ?Exception $previous = null)
     {
         $message = sprintf(
             'You tried to use administration in "%1$s" locale, but you have registered only ["%2$s"].'

--- a/packages/framework/src/Model/Localization/Exception/ImplicitLocaleNotSetException.php
+++ b/packages/framework/src/Model/Localization/Exception/ImplicitLocaleNotSetException.php
@@ -13,7 +13,7 @@ class ImplicitLocaleNotSetException extends Exception implements LocalizationExc
      * @param mixed $entityId
      * @param \Exception|null $previous
      */
-    public function __construct($entity, $entityId, Exception $previous = null)
+    public function __construct($entity, $entityId, ?Exception $previous = null)
     {
         $message = sprintf(
             'You tried to get a translation of entity %s (ID: "%s") without specifying a locale'

--- a/packages/framework/src/Model/Localization/Exception/InvalidLocaleException.php
+++ b/packages/framework/src/Model/Localization/Exception/InvalidLocaleException.php
@@ -10,7 +10,7 @@ class InvalidLocaleException extends Exception implements LocalizationException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Localization/Exception/UnsupportedCurrencyException.php
+++ b/packages/framework/src/Model/Localization/Exception/UnsupportedCurrencyException.php
@@ -10,7 +10,7 @@ class UnsupportedCurrencyException extends Exception implements LocalizationExce
      * @param string $currencyCode
      * @param \Exception|null $previous
      */
-    public function __construct($currencyCode, Exception $previous = null)
+    public function __construct($currencyCode, ?Exception $previous = null)
     {
         $message = sprintf('Currency code %s is not supported', $currencyCode);
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Mail/Exception/MailTemplateNotFoundException.php
+++ b/packages/framework/src/Model/Mail/Exception/MailTemplateNotFoundException.php
@@ -10,7 +10,7 @@ class MailTemplateNotFoundException extends Exception implements MailException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Mail/Exception/SendMailFailedException.php
+++ b/packages/framework/src/Model/Mail/Exception/SendMailFailedException.php
@@ -16,7 +16,7 @@ class SendMailFailedException extends Exception implements MailException
      * @param array $failedRecipients
      * @param \Exception|null $previous
      */
-    public function __construct(array $failedRecipients, Exception $previous = null)
+    public function __construct(array $failedRecipients, ?Exception $previous = null)
     {
         $this->failedRecipients = $failedRecipients;
         parent::__construct('Order mail was not send to ' . Debug::export($failedRecipients), 0, $previous);

--- a/packages/framework/src/Model/Module/Exception/NotUniqueModuleLabelException.php
+++ b/packages/framework/src/Model/Module/Exception/NotUniqueModuleLabelException.php
@@ -10,7 +10,7 @@ class NotUniqueModuleLabelException extends Exception implements ModuleException
      * @param string[] $moduleLabelsIndexedByNames
      * @param \Exception|null $previous
      */
-    public function __construct(array $moduleLabelsIndexedByNames, Exception $previous = null)
+    public function __construct(array $moduleLabelsIndexedByNames, ?Exception $previous = null)
     {
         $moduleDescriptions = [];
         foreach ($moduleLabelsIndexedByNames as $moduleName => $moduleLabel) {

--- a/packages/framework/src/Model/Module/Exception/UnsupportedModuleException.php
+++ b/packages/framework/src/Model/Module/Exception/UnsupportedModuleException.php
@@ -10,7 +10,7 @@ class UnsupportedModuleException extends Exception implements ModuleException
      * @param string $moduleName
      * @param \Exception|null $previous
      */
-    public function __construct($moduleName, Exception $previous = null)
+    public function __construct($moduleName, ?Exception $previous = null)
     {
         parent::__construct(sprintf('Module "%s" is not supported', $moduleName), 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Exception/OrderHashGenerateException.php
+++ b/packages/framework/src/Model/Order/Exception/OrderHashGenerateException.php
@@ -10,7 +10,7 @@ class OrderHashGenerateException extends Exception implements OrderException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Exception/OrderNumberSequenceNotFoundException.php
+++ b/packages/framework/src/Model/Order/Exception/OrderNumberSequenceNotFoundException.php
@@ -10,7 +10,7 @@ class OrderNumberSequenceNotFoundException extends Exception implements OrderExc
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Item/Exception/InvalidArgumentException.php
+++ b/packages/framework/src/Model/Order/Item/Exception/InvalidArgumentException.php
@@ -10,7 +10,7 @@ class InvalidArgumentException extends Exception implements OrderItemException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Item/Exception/InvalidQuantifiedProductException.php
+++ b/packages/framework/src/Model/Order/Item/Exception/InvalidQuantifiedProductException.php
@@ -10,7 +10,7 @@ class InvalidQuantifiedProductException extends Exception implements OrderItemEx
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Item/Exception/MainVariantCannotBeOrderedException.php
+++ b/packages/framework/src/Model/Order/Item/Exception/MainVariantCannotBeOrderedException.php
@@ -10,7 +10,7 @@ class MainVariantCannotBeOrderedException extends Exception implements OrderItem
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Item/Exception/OrderItemHasNoIdException.php
+++ b/packages/framework/src/Model/Order/Item/Exception/OrderItemHasNoIdException.php
@@ -10,7 +10,7 @@ class OrderItemHasNoIdException extends Exception implements OrderItemException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Item/Exception/WrongItemTypeException.php
+++ b/packages/framework/src/Model/Order/Item/Exception/WrongItemTypeException.php
@@ -13,7 +13,7 @@ class WrongItemTypeException extends Exception implements OrderItemException
      * @param string $actualType
      * @param \Exception|null $previous
      */
-    public function __construct(string $expectedType, string $actualType, Exception $previous = null)
+    public function __construct(string $expectedType, string $actualType, ?Exception $previous = null)
     {
         $message = sprintf('OrderItem has to be of a type "%s", but it is "%s".', $expectedType, $actualType);
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Order/Item/OrderItemFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactory.php
@@ -43,7 +43,7 @@ class OrderItemFactory implements OrderItemFactoryInterface
         int $quantity,
         ?string $unitName,
         ?string $catnum,
-        Product $product = null
+        ?Product $product = null
     ): OrderItem {
         $classData = $this->entityNameResolver->resolve(OrderItem::class);
 

--- a/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
@@ -29,7 +29,7 @@ interface OrderItemFactoryInterface
         int $quantity,
         ?string $unitName,
         ?string $catnum,
-        Product $product = null
+        ?Product $product = null
     ): OrderItem;
 
     /**

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -318,7 +318,7 @@ class Order
         OrderData $orderData,
         $orderNumber,
         $urlHash,
-        User $user = null
+        ?User $user = null
     ) {
         $this->transport = $orderData->transport;
         $this->payment = $orderData->payment;

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -253,7 +253,7 @@ class OrderFacade
      * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
      * @return \Shopsys\FrameworkBundle\Model\Order\Order
      */
-    public function createOrder(OrderData $orderData, OrderPreview $orderPreview, User $user = null)
+    public function createOrder(OrderData $orderData, OrderPreview $orderPreview, ?User $user = null)
     {
         $orderNumber = $this->orderNumberSequenceRepository->getNextNumber();
         $orderUrlHash = $this->orderHashGeneratorRepository->getUniqueHash();

--- a/packages/framework/src/Model/Order/Preview/OrderPreview.php
+++ b/packages/framework/src/Model/Order/Preview/OrderPreview.php
@@ -82,11 +82,11 @@ class OrderPreview
         array $quantifiedItemsDiscountsByIndex,
         Price $productsPrice,
         Price $totalPrice,
-        Transport $transport = null,
-        Price $transportPrice = null,
-        Payment $payment = null,
-        Price $paymentPrice = null,
-        Price $roundingPrice = null,
+        ?Transport $transport = null,
+        ?Price $transportPrice = null,
+        ?Payment $payment = null,
+        ?Price $paymentPrice = null,
+        ?Price $roundingPrice = null,
         $promoCodeDiscountPercent = null
     ) {
         $this->quantifiedProductsByIndex = $quantifiedProductsByIndex;

--- a/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php
+++ b/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php
@@ -77,10 +77,10 @@ class OrderPreviewCalculation
         Currency $currency,
         int $domainId,
         array $quantifiedProducts,
-        Transport $transport = null,
-        Payment $payment = null,
-        User $user = null,
-        string $promoCodeDiscountPercent = null
+        ?Transport $transport = null,
+        ?Payment $payment = null,
+        ?User $user = null,
+        ?string $promoCodeDiscountPercent = null
     ): OrderPreview {
         $quantifiedItemsPrices = $this->quantifiedProductPriceCalculation->calculatePrices(
             $quantifiedProducts,
@@ -158,8 +158,8 @@ class OrderPreviewCalculation
         Payment $payment,
         Currency $currency,
         Price $productsPrice,
-        Price $transportPrice = null,
-        Price $paymentPrice = null
+        ?Price $transportPrice = null,
+        ?Price $paymentPrice = null
     ): ?Price {
         $totalPrice = $this->calculateTotalPrice(
             $productsPrice,
@@ -180,9 +180,9 @@ class OrderPreviewCalculation
      */
     protected function calculateTotalPrice(
         Price $productsPrice,
-        Price $transportPrice = null,
-        Price $paymentPrice = null,
-        Price $roundingPrice = null
+        ?Price $transportPrice = null,
+        ?Price $paymentPrice = null,
+        ?Price $roundingPrice = null
     ): Price {
         $totalPrice = Price::zero();
 

--- a/packages/framework/src/Model/Order/Preview/OrderPreviewFactory.php
+++ b/packages/framework/src/Model/Order/Preview/OrderPreviewFactory.php
@@ -73,7 +73,7 @@ class OrderPreviewFactory
      * @param \Shopsys\FrameworkBundle\Model\Payment\Payment|null $payment
      * @return \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreview
      */
-    public function createForCurrentUser(Transport $transport = null, Payment $payment = null)
+    public function createForCurrentUser(?Transport $transport = null, ?Payment $payment = null)
     {
         $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId());
         $validEnteredPromoCode = $this->currentPromoCodeFacade->getValidEnteredPromoCodeOrNull();
@@ -107,10 +107,10 @@ class OrderPreviewFactory
         Currency $currency,
         $domainId,
         array $quantifiedProducts,
-        Transport $transport = null,
-        Payment $payment = null,
-        User $user = null,
-        string $promoCodeDiscountPercent = null
+        ?Transport $transport = null,
+        ?Payment $payment = null,
+        ?User $user = null,
+        ?string $promoCodeDiscountPercent = null
     ) {
         return $this->orderPreviewCalculation->calculatePreview(
             $currency,

--- a/packages/framework/src/Model/Order/PromoCode/Exception/InvalidPromoCodeException.php
+++ b/packages/framework/src/Model/Order/PromoCode/Exception/InvalidPromoCodeException.php
@@ -10,7 +10,7 @@ class InvalidPromoCodeException extends Exception implements PromoCodeException
      * @param string $invalidPromoCode
      * @param \Exception|null $previous
      */
-    public function __construct($invalidPromoCode, Exception $previous = null)
+    public function __construct($invalidPromoCode, ?Exception $previous = null)
     {
         parent::__construct('Promo code "' . $invalidPromoCode . '" is not valid.', 0, $previous);
     }

--- a/packages/framework/src/Model/Order/Status/Exception/InvalidOrderStatusTypeException.php
+++ b/packages/framework/src/Model/Order/Status/Exception/InvalidOrderStatusTypeException.php
@@ -15,7 +15,7 @@ class InvalidOrderStatusTypeException extends Exception implements OrderStatusEx
      * @param int $orderStatusType
      * @param \Exception|null $previous
      */
-    public function __construct($orderStatusType, Exception $previous = null)
+    public function __construct($orderStatusType, ?Exception $previous = null)
     {
         $this->orderStatusType = $orderStatusType;
         parent::__construct('Order status type ' . $orderStatusType . ' is not valid', 0, $previous);

--- a/packages/framework/src/Model/Order/Status/Exception/OrderStatusDeletionForbiddenException.php
+++ b/packages/framework/src/Model/Order/Status/Exception/OrderStatusDeletionForbiddenException.php
@@ -16,7 +16,7 @@ class OrderStatusDeletionForbiddenException extends Exception implements OrderSt
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatus $orderStatus
      * @param \Exception|null $previous
      */
-    public function __construct(OrderStatus $orderStatus, Exception $previous = null)
+    public function __construct(OrderStatus $orderStatus, ?Exception $previous = null)
     {
         $this->orderStatus = $orderStatus;
         parent::__construct('Deletion of order status ID = ' . $orderStatus->getId() . ' is forbidden', 0, $previous);

--- a/packages/framework/src/Model/Payment/Exception/PaymentDomainNotFoundException.php
+++ b/packages/framework/src/Model/Payment/Exception/PaymentDomainNotFoundException.php
@@ -11,7 +11,7 @@ class PaymentDomainNotFoundException extends Exception implements PaymentExcepti
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct(int $paymentId = null, int $domainId, Exception $previous = null)
+    public function __construct(?int $paymentId = null, int $domainId, ?Exception $previous = null)
     {
         $paymentDescription = $paymentId !== null ? sprintf('with ID %d', $paymentId) : 'without ID';
         $message = sprintf('PaymentDomain for payment %s and domain ID %d not found.', $paymentDescription, $domainId);

--- a/packages/framework/src/Model/Pricing/Currency/Exception/DeletingNotAllowedToDeleteCurrencyException.php
+++ b/packages/framework/src/Model/Pricing/Currency/Exception/DeletingNotAllowedToDeleteCurrencyException.php
@@ -10,7 +10,7 @@ class DeletingNotAllowedToDeleteCurrencyException extends Exception implements C
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Pricing/Exception/InvalidArgumentException.php
+++ b/packages/framework/src/Model/Pricing/Exception/InvalidArgumentException.php
@@ -11,7 +11,7 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements P
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Pricing/Exception/InvalidInputPriceTypeException.php
+++ b/packages/framework/src/Model/Pricing/Exception/InvalidInputPriceTypeException.php
@@ -10,7 +10,7 @@ class InvalidInputPriceTypeException extends Exception implements PricingExcepti
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Pricing/Exception/InvalidRoundingTypeException.php
+++ b/packages/framework/src/Model/Pricing/Exception/InvalidRoundingTypeException.php
@@ -10,7 +10,7 @@ class InvalidRoundingTypeException extends Exception implements PricingException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Pricing/Vat/Exception/VatMarkedAsDeletedDeleteException.php
+++ b/packages/framework/src/Model/Pricing/Vat/Exception/VatMarkedAsDeletedDeleteException.php
@@ -10,7 +10,7 @@ class VatMarkedAsDeletedDeleteException extends Exception implements VatExceptio
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Pricing/Vat/Exception/VatWithReplacedDeleteException.php
+++ b/packages/framework/src/Model/Pricing/Vat/Exception/VatWithReplacedDeleteException.php
@@ -10,7 +10,7 @@ class VatWithReplacedDeleteException extends Exception implements VatException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Product/Brand/Exception/BrandDomainNotFoundException.php
+++ b/packages/framework/src/Model/Product/Brand/Exception/BrandDomainNotFoundException.php
@@ -11,7 +11,7 @@ class BrandDomainNotFoundException extends Exception implements BrandException
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct(int $brandId = null, int $domainId, Exception $previous = null)
+    public function __construct(?int $brandId = null, int $domainId, ?Exception $previous = null)
     {
         $brandDescription = $brandId !== null ? sprintf('with ID %d', $brandId) : 'without ID';
         $message = sprintf('BrandDomain for brand %s and domain ID %d not found.', $brandDescription, $domainId);

--- a/packages/framework/src/Model/Product/Collection/Exception/ProductImageUrlNotLoadedException.php
+++ b/packages/framework/src/Model/Product/Collection/Exception/ProductImageUrlNotLoadedException.php
@@ -13,7 +13,7 @@ class ProductImageUrlNotLoadedException extends Exception implements ProductColl
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @param \Exception|null $previous
      */
-    public function __construct(Product $product, DomainConfig $domainConfig, Exception $previous = null)
+    public function __construct(Product $product, DomainConfig $domainConfig, ?Exception $previous = null)
     {
         $message = sprintf(
             'URL for image of product with ID %d on %s have not been loaded via ProductUrlsBatchLoader::loadForProducts().',

--- a/packages/framework/src/Model/Product/Collection/Exception/ProductParametersNotLoadedException.php
+++ b/packages/framework/src/Model/Product/Collection/Exception/ProductParametersNotLoadedException.php
@@ -13,7 +13,7 @@ class ProductParametersNotLoadedException extends Exception implements ProductCo
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @param \Exception|null $previous
      */
-    public function __construct(Product $product, DomainConfig $domainConfig, Exception $previous = null)
+    public function __construct(Product $product, DomainConfig $domainConfig, ?Exception $previous = null)
     {
         $message = sprintf(
             'Parameters for product with ID %d on %s have not been loaded via ProductParametersBatchLoader::loadForProducts().',

--- a/packages/framework/src/Model/Product/Collection/Exception/ProductUrlNotLoadedException.php
+++ b/packages/framework/src/Model/Product/Collection/Exception/ProductUrlNotLoadedException.php
@@ -13,7 +13,7 @@ class ProductUrlNotLoadedException extends Exception implements ProductCollectio
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @param \Exception|null $previous
      */
-    public function __construct(Product $product, DomainConfig $domainConfig, Exception $previous = null)
+    public function __construct(Product $product, DomainConfig $domainConfig, ?Exception $previous = null)
     {
         $message = sprintf(
             'URL for product with ID %d on %s have not been loaded via ProductUrlsBatchLoader::loadForProducts().',

--- a/packages/framework/src/Model/Product/Exception/InvalidOrderingModeException.php
+++ b/packages/framework/src/Model/Product/Exception/InvalidOrderingModeException.php
@@ -10,7 +10,7 @@ class InvalidOrderingModeException extends Exception implements ProductException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Product/Exception/MainVariantCannotBeVariantException.php
+++ b/packages/framework/src/Model/Product/Exception/MainVariantCannotBeVariantException.php
@@ -10,7 +10,7 @@ class MainVariantCannotBeVariantException extends Exception implements VariantEx
      * @param int $productId
      * @param \Exception|null $previous
      */
-    public function __construct($productId, Exception $previous = null)
+    public function __construct($productId, ?Exception $previous = null)
     {
         $message = 'Product with ID ' . $productId . ' is already main variant.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Product/Exception/ProductDomainNotFoundException.php
+++ b/packages/framework/src/Model/Product/Exception/ProductDomainNotFoundException.php
@@ -11,7 +11,7 @@ class ProductDomainNotFoundException extends Exception implements ProductExcepti
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct(int $productId = null, int $domainId, Exception $previous = null)
+    public function __construct(?int $productId = null, int $domainId, ?Exception $previous = null)
     {
         $productDescription = $productId !== null ? sprintf('with ID %d', $productId) : 'without ID';
         $message = sprintf('ProductDomain for product %s and domain ID %d not found.', $productDescription, $domainId);

--- a/packages/framework/src/Model/Product/Exception/ProductIsAlreadyMainVariantException.php
+++ b/packages/framework/src/Model/Product/Exception/ProductIsAlreadyMainVariantException.php
@@ -10,7 +10,7 @@ class ProductIsAlreadyMainVariantException extends Exception implements VariantE
      * @param int $productId
      * @param \Exception|null $previous
      */
-    public function __construct($productId, Exception $previous = null)
+    public function __construct($productId, ?Exception $previous = null)
     {
         $message = 'Product with ID ' . $productId . ' is already main variant.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Product/Exception/ProductIsAlreadyVariantException.php
+++ b/packages/framework/src/Model/Product/Exception/ProductIsAlreadyVariantException.php
@@ -10,7 +10,7 @@ class ProductIsAlreadyVariantException extends Exception implements VariantExcep
      * @param int $productId
      * @param \Exception|null $previous
      */
-    public function __construct($productId, Exception $previous = null)
+    public function __construct($productId, ?Exception $previous = null)
     {
         $message = 'Product with ID ' . $productId . ' is already variant.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Product/Exception/VariantCanBeAddedOnlyToMainVariantException.php
+++ b/packages/framework/src/Model/Product/Exception/VariantCanBeAddedOnlyToMainVariantException.php
@@ -11,7 +11,7 @@ class VariantCanBeAddedOnlyToMainVariantException extends Exception implements V
      * @param int $variantId
      * @param \Exception|null $previous
      */
-    public function __construct($productId, $variantId, Exception $previous = null)
+    public function __construct($productId, $variantId, ?Exception $previous = null)
     {
         $message = 'Product with ID ' . $productId . ' is not main variant for add variant ID ' . $variantId . '.';
         parent::__construct($message, 0, $previous);

--- a/packages/framework/src/Model/Product/Filter/ParameterFilterChoice.php
+++ b/packages/framework/src/Model/Product/Filter/ParameterFilterChoice.php
@@ -21,7 +21,7 @@ class ParameterFilterChoice
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue[] $values
      */
     public function __construct(
-        Parameter $parameter = null,
+        ?Parameter $parameter = null,
         array $values = []
     ) {
         $this->parameter = $parameter;

--- a/packages/framework/src/Model/Product/MassAction/Exception/UnsupportedSelectionType.php
+++ b/packages/framework/src/Model/Product/MassAction/Exception/UnsupportedSelectionType.php
@@ -10,7 +10,7 @@ class UnsupportedSelectionType extends Exception implements MassActionException
      * @param string $selectionType
      * @param \Exception|null $previous
      */
-    public function __construct($selectionType, Exception $previous = null)
+    public function __construct($selectionType, ?Exception $previous = null)
     {
         parent::__construct(sprintf('Selection type "%s" is not supported', $selectionType), 0, $previous);
     }

--- a/packages/framework/src/Model/Product/Pricing/Exception/MainVariantPriceCalculationException.php
+++ b/packages/framework/src/Model/Product/Pricing/Exception/MainVariantPriceCalculationException.php
@@ -10,7 +10,7 @@ class MainVariantPriceCalculationException extends Exception implements ProductP
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCalculationForUser.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCalculationForUser.php
@@ -67,7 +67,7 @@ class ProductPriceCalculationForUser
      * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
      * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice
      */
-    public function calculatePriceForUserAndDomainId(Product $product, $domainId, User $user = null)
+    public function calculatePriceForUserAndDomainId(Product $product, $domainId, ?User $user = null)
     {
         if ($user === null) {
             $pricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($domainId);

--- a/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
@@ -52,7 +52,7 @@ class QuantifiedProductPriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
      * @return \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice
      */
-    public function calculatePrice(QuantifiedProduct $quantifiedProduct, int $domainId, User $user = null): QuantifiedItemPrice
+    public function calculatePrice(QuantifiedProduct $quantifiedProduct, int $domainId, ?User $user = null): QuantifiedItemPrice
     {
         $product = $quantifiedProduct->getProduct();
         if (!$product instanceof Product) {
@@ -113,7 +113,7 @@ class QuantifiedProductPriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
      * @return \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice[]
      */
-    public function calculatePrices(array $quantifiedProducts, int $domainId, User $user = null): array
+    public function calculatePrices(array $quantifiedProducts, int $domainId, ?User $user = null): array
     {
         $quantifiedItemsPrices = [];
         foreach ($quantifiedProducts as $quantifiedItemIndex => $quantifiedProduct) {

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -279,7 +279,7 @@ class Product extends AbstractTranslatableEntity
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface $productCategoryDomainFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[]|null $variants
      */
-    protected function __construct(ProductData $productData, ProductCategoryDomainFactoryInterface $productCategoryDomainFactory, array $variants = null)
+    protected function __construct(ProductData $productData, ProductCategoryDomainFactoryInterface $productCategoryDomainFactory, ?array $variants = null)
     {
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
@@ -599,7 +599,7 @@ class Product extends AbstractTranslatableEntity
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\Availability|null $outOfStockAvailability
      */
-    public function setOutOfStockAvailability(Availability $outOfStockAvailability = null)
+    public function setOutOfStockAvailability(?Availability $outOfStockAvailability = null)
     {
         $this->outOfStockAvailability = $outOfStockAvailability;
         $this->recalculateAvailability = true;

--- a/packages/framework/src/Model/Product/ProductHiddenRecalculator.php
+++ b/packages/framework/src/Model/Product/ProductHiddenRecalculator.php
@@ -36,7 +36,7 @@ class ProductHiddenRecalculator
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
      */
-    protected function executeQuery(Product $product = null)
+    protected function executeQuery(?Product $product = null)
     {
         $qb = $this->em->createQueryBuilder()
             ->update(Product::class, 'p')

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -175,7 +175,7 @@ class FilterQuery
      * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $maximalPrice
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function filterByPrices(PricingGroup $pricingGroup, Money $minimalPrice = null, Money $maximalPrice = null): self
+    public function filterByPrices(PricingGroup $pricingGroup, ?Money $minimalPrice = null, ?Money $maximalPrice = null): self
     {
         $clone = clone $this;
 

--- a/packages/framework/src/Model/Security/Exception/LoginAsRememberedUserException.php
+++ b/packages/framework/src/Model/Security/Exception/LoginAsRememberedUserException.php
@@ -10,7 +10,7 @@ class LoginAsRememberedUserException extends Exception implements SecurityExcept
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Security/Exception/LoginFailedException.php
+++ b/packages/framework/src/Model/Security/Exception/LoginFailedException.php
@@ -10,7 +10,7 @@ class LoginFailedException extends Exception implements SecurityException
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Security/Filesystem/Exception/InstanceNotInjectedException.php
+++ b/packages/framework/src/Model/Security/Filesystem/Exception/InstanceNotInjectedException.php
@@ -10,7 +10,7 @@ class InstanceNotInjectedException extends Exception implements FilesystemExcept
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Transport/Exception/TransportDomainNotFoundException.php
+++ b/packages/framework/src/Model/Transport/Exception/TransportDomainNotFoundException.php
@@ -11,7 +11,7 @@ class TransportDomainNotFoundException extends Exception implements TransportExc
      * @param int $domainId
      * @param \Exception|null $previous
      */
-    public function __construct(int $transportId = null, int $domainId, Exception $previous = null)
+    public function __construct(?int $transportId = null, int $domainId, ?Exception $previous = null)
     {
         $transportDescription = $transportId !== null ? sprintf('with ID %d', $transportId) : 'without ID';
         $message = sprintf('TransportDomain for transport %s and domain ID %d not found.', $transportDescription, $domainId);

--- a/packages/framework/src/Twig/Exception/HoneyPotRenderedBeforePasswordException.php
+++ b/packages/framework/src/Twig/Exception/HoneyPotRenderedBeforePasswordException.php
@@ -11,7 +11,7 @@ class HoneyPotRenderedBeforePasswordException extends Twig_Error implements Twig
     /**
      * @param \Exception|null $previous
      */
-    public function __construct(Exception $previous = null)
+    public function __construct(?Exception $previous = null)
     {
         $message = sprintf(
             '%s was rendered before password field.'

--- a/packages/framework/src/Twig/Exception/InvalidArgumentException.php
+++ b/packages/framework/src/Twig/Exception/InvalidArgumentException.php
@@ -11,7 +11,7 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements T
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Twig/MoneyExtension.php
+++ b/packages/framework/src/Twig/MoneyExtension.php
@@ -28,7 +28,7 @@ class MoneyExtension extends Twig_Extension
      * @param string $thousandsSeparator
      * @return string
      */
-    public function moneyFormatFilter(Money $money, int $decimal = null, string $decimalPoint = '.', string $thousandsSeparator = '')
+    public function moneyFormatFilter(Money $money, ?int $decimal = null, string $decimalPoint = '.', string $thousandsSeparator = '')
     {
         $moneyString = $money->getAmount();
 

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -231,7 +231,7 @@ class PriceExtension extends Twig_Extension
      * @param string|null $locale
      * @return string
      */
-    private function formatCurrency(Money $price, Currency $currency, string $locale = null): string
+    private function formatCurrency(Money $price, Currency $currency, ?string $locale = null): string
     {
         if ($locale === null) {
             $locale = $this->localization->getLocale();

--- a/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
@@ -181,7 +181,7 @@ class CountryFormTypeTest extends TypeTestCase
      * @param \Shopsys\FrameworkBundle\Model\Country\Country|null $country
      * @return \Symfony\Component\Form\FormInterface
      */
-    private function createCountryForm(Country $country = null): FormInterface
+    private function createCountryForm(?Country $country = null): FormInterface
     {
         return $this->factory->create(CountryFormType::class, null, ['country' => $country]);
     }

--- a/packages/framework/tests/Unit/Model/Customer/CustomerDataFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerDataFactoryTest.php
@@ -229,7 +229,7 @@ class CustomerDataFactoryTest extends TestCase
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData|null $billingAddressData
      * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddress
      */
-    private function createBillingAddress(BillingAddressData $billingAddressData = null)
+    private function createBillingAddress(?BillingAddressData $billingAddressData = null)
     {
         if ($billingAddressData === null) {
             $billingAddressData = new BillingAddressData();
@@ -242,7 +242,7 @@ class CustomerDataFactoryTest extends TestCase
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData|null $deliveryAddressData
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress
      */
-    private function createDeliveryAddress(DeliveryAddressData $deliveryAddressData = null)
+    private function createDeliveryAddress(?DeliveryAddressData $deliveryAddressData = null)
     {
         if ($deliveryAddressData === null) {
             $deliveryAddressData = new DeliveryAddressData();

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderItemTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderItemTest.php
@@ -197,7 +197,7 @@ class OrderItemTest extends TestCase
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
      * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItem
      */
-    private function createOrderProduct(Product $product = null): OrderItem
+    private function createOrderProduct(?Product $product = null): OrderItem
     {
         $orderProduct = new OrderItem(
             $this->createOrderMock(),

--- a/packages/migrations/src/Command/Exception/CheckSchemaCommandException.php
+++ b/packages/migrations/src/Command/Exception/CheckSchemaCommandException.php
@@ -10,7 +10,7 @@ class CheckSchemaCommandException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/migrations/src/Command/Exception/MigrateCommandException.php
+++ b/packages/migrations/src/Command/Exception/MigrateCommandException.php
@@ -10,7 +10,7 @@ class MigrateCommandException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
@@ -24,7 +24,7 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
      * @param \Doctrine\DBAL\Cache\QueryCacheProfile|null $qcp
      * @return \Doctrine\DBAL\Driver\Statement
      */
-    public function sql($query, array $params = [], $types = [], QueryCacheProfile $qcp = null)
+    public function sql($query, array $params = [], $types = [], ?QueryCacheProfile $qcp = null)
     {
         return $this->connection->executeQuery($query, $params, $types, $qcp);
     }

--- a/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
@@ -39,7 +39,7 @@ class Configuration extends DoctrineConfiguration
         Connection $connection,
         OutputWriter $outputWriter,
         MigrationFinderInterface $finder,
-        QueryWriter $queryWriter = null
+        ?QueryWriter $queryWriter = null
     ) {
         $this->migrationsLock = $migrationsLock;
         $this->outputWriter = $outputWriter;

--- a/packages/migrations/src/Component/Doctrine/Migrations/Exception/MethodIsNotAllowedException.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Exception/MethodIsNotAllowedException.php
@@ -10,7 +10,7 @@ class MethodIsNotAllowedException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/packages/product-feed-heureka-delivery/src/Model/FeedItem/HeurekaDeliveryDataMissingException.php
+++ b/packages/product-feed-heureka-delivery/src/Model/FeedItem/HeurekaDeliveryDataMissingException.php
@@ -10,7 +10,7 @@ class HeurekaDeliveryDataMissingException extends Exception
      * @param string $key
      * @param \Exception|null $previous
      */
-    public function __construct(string $key, Exception $previous = null)
+    public function __construct(string $key, ?Exception $previous = null)
     {
         $message = sprintf('Feed item cannot be created - key "%s" missing from data row.', $key);
 

--- a/packages/product-feed-heureka/src/Model/FeedItem/HeurekaProductDataNotLoadedException.php
+++ b/packages/product-feed-heureka/src/Model/FeedItem/HeurekaProductDataNotLoadedException.php
@@ -14,7 +14,7 @@ class HeurekaProductDataNotLoadedException extends Exception
      * @param string $attribute
      * @param \Exception|null $previous
      */
-    public function __construct(Product $product, DomainConfig $domainConfig, string $attribute, Exception $previous = null)
+    public function __construct(Product $product, DomainConfig $domainConfig, string $attribute, ?Exception $previous = null)
     {
         $message = sprintf(
             '%s of product with ID %d on %s have not been loaded via HeurekaProductDataBatchLoader::loadForProducts().',

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -76,7 +76,7 @@ class ErrorController extends FrontBaseController
     public function showAction(
         Request $request,
         FlattenException $exception,
-        DebugLoggerInterface $logger = null
+        ?DebugLoggerInterface $logger = null
     ) {
         if ($this->isUnableToResolveDomainInNotDebug($exception)) {
             return $this->createUnableToResolveDomainResponse($request);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainArticleDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainArticleDataFixture.php
@@ -102,7 +102,7 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
      * @param string|null $referenceName
      */
-    protected function createArticle(ArticleData $articleData, string $referenceName = null)
+    protected function createArticle(ArticleData $articleData, ?string $referenceName = null)
     {
         $article = $this->articleFacade->create($articleData);
         if ($referenceName !== null) {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.php
@@ -210,7 +210,7 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
     protected function createOrder(
         OrderData $orderData,
         array $products,
-        User $user = null
+        ?User $user = null
     ) {
         $quantifiedProducts = [];
         foreach ($products as $productReferenceName => $quantity) {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
@@ -570,7 +570,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
     protected function createOrder(
         OrderData $orderData,
         array $products,
-        User $user = null
+        ?User $user = null
     ) {
         $quantifiedProducts = [];
         foreach ($products as $productReferenceName => $quantity) {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/Exception/UndefinedArrayKeyException.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/Exception/UndefinedArrayKeyException.php
@@ -10,7 +10,7 @@ class UndefinedArrayKeyException extends Exception implements PerformanceExcepti
      * @param string|int $key
      * @param \Exception|null $previous
      */
-    public function __construct($key, Exception $previous = null)
+    public function __construct($key, ?Exception $previous = null)
     {
         parent::__construct('Key "' . $key . '" does not exists.', 0, $previous);
     }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
@@ -194,7 +194,7 @@ class OrderDataFixture
      * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
      * @return \Shopsys\FrameworkBundle\Model\Order\OrderData
      */
-    private function createOrderData(User $user = null)
+    private function createOrderData(?User $user = null)
     {
         $orderData = $this->orderDataFactory->create();
 

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
@@ -19,7 +19,7 @@ class Product extends BaseProduct
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface $productCategoryDomainFactory
      * @param \Shopsys\ShopBundle\Model\Product\Product[]|null $variants
      */
-    protected function __construct(BaseProductData $productData, ProductCategoryDomainFactoryInterface $productCategoryDomainFactory, array $variants = null)
+    protected function __construct(BaseProductData $productData, ProductCategoryDomainFactoryInterface $productCategoryDomainFactory, ?array $variants = null)
     {
         parent::__construct($productData, $productCategoryDomainFactory, $variants);
     }

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
@@ -126,7 +126,7 @@ class ExtendedProduct extends Product
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[]|null $variants
      */
-    protected function __construct(ProductData $productData, array $variants = null)
+    protected function __construct(ProductData $productData, ?array $variants = null)
     {
         parent::__construct($productData, $variants);
         $this->oneToManyBidirectionalEntities = new ArrayCollection();

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -32,10 +32,10 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $usingStock,
         $stockQuantity,
         $outOfStockAction,
-        Availability $availability = null,
-        Availability $outOfStockAvailability = null,
-        Availability $defaultInStockAvailability = null,
-        Availability $expectedCalculatedAvailability = null
+        ?Availability $availability = null,
+        ?Availability $outOfStockAvailability = null,
+        ?Availability $defaultInStockAvailability = null,
+        ?Availability $expectedCalculatedAvailability = null
     ) {
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
         $productData = $productDataFactory->create();

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQueryCounter.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQueryCounter.php
@@ -14,7 +14,7 @@ class PerformanceTestSampleQueryCounter implements SQLLogger
     /**
      * {@inheritdoc}
      */
-    public function startQuery($sql, array $params = null, array $types = null)
+    public function startQuery($sql, ?array $params = null, ?array $types = null)
     {
         $this->queryCount++;
     }

--- a/project-base/tests/ShopBundle/Test/Codeception/Exception/DeprecatedMethodException.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Exception/DeprecatedMethodException.php
@@ -10,7 +10,7 @@ class DeprecatedMethodException extends Exception
      * @param string $message
      * @param \Exception|null $previous
      */
-    public function __construct($message = '', Exception $previous = null)
+    public function __construct($message = '', ?Exception $previous = null)
     {
         parent::__construct($message, 0, $previous);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Using non-question mark variation xxx(int $a = null) is wrong as is greatly explained in doctrine/common#805 (comment)
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #994  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes