### PR TITLE
[shopsys] composer.json: revert BC breaking change of snc/redis-bundle dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 
 before_install:
   - phpenv config-add project-base/docker/php-fpm/php-ini-overrides.ini
+  - echo '' | pecl install redis-4.1.1
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
   - phpenv config-rm xdebug.ini || return 0
   - composer global require hirak/prestissimo

--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
     "shopsys/jparser": "^0.1",
     "shopsys/postgres-search-bundle": "^0.1",
     "slevomat/coding-standard": "^4.6.0",
-    "snc/redis-bundle": "^2.1.7",
+    "snc/redis-bundle": "^2.1.8",
     "squizlabs/php_codesniffer": "^3.2.0",
     "stof/doctrine-extensions-bundle": "^1.3.0",
     "superbalist/flysystem-google-storage": "^7.1",
@@ -152,8 +152,7 @@
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
     "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
-    "twig/twig": "2.6.1",
-    "snc/redis-bundle": "2.1.8|2.1.9"
+    "twig/twig": "2.6.1"
   },
   "scripts": {
     "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -81,7 +81,7 @@
         "shopsys/migrations": "dev-master",
         "shopsys/form-types-bundle": "dev-master",
         "shopsys/plugin-interface": "dev-master",
-        "snc/redis-bundle": "^2.1.7",
+        "snc/redis-bundle": "^2.1.8",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/assetic-bundle": "^2.8.2",
@@ -104,7 +104,6 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "twig/twig": "2.6.1",
-        "snc/redis-bundle": "2.1.8|2.1.9"
+        "twig/twig": "2.6.1"
     }
 }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -75,7 +75,7 @@
         "shopsys/product-feed-heureka-delivery": "dev-master",
         "shopsys/product-feed-zbozi": "dev-master",
         "shopsys/product-feed-google": "dev-master",
-        "snc/redis-bundle": "^2.1.7",
+        "snc/redis-bundle": "^2.1.8",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/assetic-bundle": "^2.8.2",
         "symfony/monolog-bundle": "^3.1.2",
@@ -99,8 +99,7 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "twig/twig": "2.6.1",
-        "snc/redis-bundle": "2.1.8|2.1.9"
+        "twig/twig": "2.6.1"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #978 the supported versions of `snc/redis-bundle` package were changed which breaks backward compatibility. Even though we don't define BC in terms of dependencies precisely (see #872), you cannot use `shopsys/framework` in version `dev-master` using the `shopsys/project-base` in the `7.0.0` version as a base repository without further changes (see below).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

When using `shopsys/project-base` in version `7.0.0` and replacing all `shopsys/*` dependencies to `dev-master` (current master is on b3128c4a7) version, following error is thrown during `composer install`:

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - shopsys/framework dev-master requires snc/redis-bundle ^2.1.7 -> satisfiable by snc/redis-bundle[2.1.8, 2.1.9].
    - snc/redis-bundle 2.1.8 conflicts with shopsys/framework[dev-master].
    - snc/redis-bundle 2.1.9 conflicts with shopsys/framework[dev-master].
    - Installation request for shopsys/framework dev-master -> satisfiable by shopsys/framework[dev-master].
```

The modification of `composer.json` was originally done in #978 so that Travis build succeeds (not sure about the exact reason). This goal of this PR is to pass on Travis while still being backward-compatible with `shopsys/project-base` in `7.0.0`.