### PR TITLE
[http-smoke-testing] use current shopsys/coding-standards package

### DIFF
--- a/packages/http-smoke-testing/.travis.yml
+++ b/packages/http-smoke-testing/.travis.yml
@@ -21,8 +21,8 @@ matrix:
             env: CHECK_STANDARDS="true"
 
 install:
-    - travis_retry composer update $DEPENDENCIES
     - if [[ "$CHECK_STANDARDS" = "true" ]]; then composer require --dev shopsys/coding-standards:dev-master; fi
+    - travis_retry composer update $DEPENDENCIES
 
 script:
     - php vendor/bin/parallel-lint ./src ./tests

--- a/packages/http-smoke-testing/.travis.yml
+++ b/packages/http-smoke-testing/.travis.yml
@@ -17,13 +17,14 @@ matrix:
             env: DEPENDENCIES="--prefer-lowest --prefer-stable"
         -   php: 7.1
             env: DEPENDENCIES="--prefer-lowest --prefer-stable"
+        -   php: 7.1
+            env: CHECK_STANDARDS="true"
 
 install:
     - travis_retry composer update $DEPENDENCIES
+    - if [[ "$CHECK_STANDARDS" = "true" ]]; then composer require --dev shopsys/coding-standards:dev-master; fi
 
 script:
     - php vendor/bin/parallel-lint ./src ./tests
-    - php vendor/bin/php-cs-fixer fix --config=vendor/shopsys/coding-standards/build/phpcs-fixer.php_cs --dry-run --verbose --diff ./src ./tests
-    - php vendor/bin/phpcs --standard=vendor/shopsys/coding-standards/rulesetCS.xml --extensions=php --encoding=utf-8 --tab-width=4 -sp ./src ./tests
-    - php vendor/bin/phpmd "./src,./tests" text vendor/shopsys/coding-standards/rulesetMD.xml --extensions=php
     - php vendor/bin/phpunit tests
+    - if [[ "$CHECK_STANDARDS" = "true" ]]; then php vendor/bin/ecs check --verbose ./src ./tests; fi

--- a/packages/http-smoke-testing/.travis.yml
+++ b/packages/http-smoke-testing/.travis.yml
@@ -15,10 +15,10 @@ matrix:
         - { php: 7.3 }
 
 install:
-    - if [[ "$CHECK_STANDARDS" = "true" ]]; then composer require --dev shopsys/coding-standards:dev-master; fi
+    - if [[ "$CHECK_STANDARDS" == "true" ]]; then composer require --dev shopsys/coding-standards:dev-master; fi
     - travis_retry composer update $DEPENDENCIES
 
 script:
     - php vendor/bin/parallel-lint ./src ./tests
     - php vendor/bin/phpunit tests
-    - if [[ "$CHECK_STANDARDS" = "true" ]]; then php vendor/bin/ecs check --verbose ./src ./tests; fi
+    - if [[ "$CHECK_STANDARDS" == "true" ]]; then php vendor/bin/ecs check --verbose ./src ./tests; fi

--- a/packages/http-smoke-testing/.travis.yml
+++ b/packages/http-smoke-testing/.travis.yml
@@ -1,24 +1,18 @@
 language: php
 
-php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
-
 cache:
     directories:
         - ~/.composer/cache
 
 matrix:
     include:
-        -   php: 5.6
-            env: DEPENDENCIES="--prefer-lowest --prefer-stable"
-        -   php: 7.1
-            env: DEPENDENCIES="--prefer-lowest --prefer-stable"
-        -   php: 7.1
-            env: CHECK_STANDARDS="true"
+        - { php: 5.6 }
+        - { php: 5.6, env: DEPENDENCIES="--prefer-lowest --prefer-stable" }
+        - { php: 7.0 }
+        - { php: 7.1, env: CHECK_STANDARDS="true" }
+        - { php: 7.1, env: DEPENDENCIES="--prefer-lowest --prefer-stable" }
+        - { php: 7.2 }
+        - { php: 7.3 }
 
 install:
     - if [[ "$CHECK_STANDARDS" = "true" ]]; then composer require --dev shopsys/coding-standards:dev-master; fi

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4.3|^6.0|^7.0",
-        "shopsys/coding-standards": "^3.0.2"
+        "jakub-onderka/php-parallel-lint": "^0.9"
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16"

--- a/packages/http-smoke-testing/easy-coding-standard.yml
+++ b/packages/http-smoke-testing/easy-coding-standard.yml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+
+services:
+    Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
+
+    Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
+
+parameters:
+    skip:
+        Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:
+            - '*/tests/*'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Travis build failed because of coding standard conflict (it uses legacy 3.0.2 version of shopsys/coding-standards because of support for PHP 5.6, see #194)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No (only dev dependencies were changed) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| finally fixes the stale #194 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

After this PR:
- the shopsys/http-smoke-testing package still supports PHP 5.6
- Travis now runs PHP lint and unit tests in all supported versions
- Travis now runs coding standards check only in PHP 7.1
