### PR TITLE
[framework] show information about project in debug toolbar

### DIFF
--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Collector;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\ShopsysFrameworkBundle;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+
+final class ShopsysFrameworkDataCollector extends DataCollector
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        Domain $domain
+    ) {
+        $this->domain = $domain;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null): void
+    {
+        $this->data = [
+            'version' => ShopsysFrameworkBundle::VERSION,
+            'docsVersion' => $this->resolveDocsVersion(ShopsysFrameworkBundle::VERSION),
+            'domains' => $this->domain->getAll(),
+            'currentDomainId' => $this->domain->getId(),
+            'currentDomainName' => $this->domain->getName(),
+            'currentDomainLocale' => $this->domain->getLocale(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion(): string
+    {
+        return $this->data['version'];
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
+     */
+    public function getDomains(): array
+    {
+        return $this->data['domains'];
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentDomainId(): int
+    {
+        return $this->data['currentDomainId'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentDomainName(): string
+    {
+        return $this->data['currentDomainName'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentDomainLocale(): string
+    {
+        return $this->data['currentDomainLocale'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'shopsys_framework_core';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocsVersion(): string
+    {
+        return $this->data['docsVersion'];
+    }
+
+    /**
+     * @param string $versionString
+     * @return string
+     */
+    protected function resolveDocsVersion(string $versionString): string
+    {
+        if (strpos($versionString, '-dev') !== false) {
+            return 'master';
+        }
+
+        return 'v' . $versionString;
+    }
+}

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -57,6 +57,10 @@ services:
             - '@request_stack'
             - '%kernel.debug%'
 
+    Shopsys\FrameworkBundle\Component\Collector\ShopsysFrameworkDataCollector:
+        tags:
+            - { name: data_collector, id: shopsys_framework_core, template: '@ShopsysFramework/Components/Collector/shopsysFramework.html.twig', priority: -300 }
+
     Symfony\Component\Translation\MessageSelector: '@translator.selector'
 
     Doctrine\Common\Annotations\DocParser: '@jms_translation.doc_parser'

--- a/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
+++ b/packages/framework/src/Resources/views/Components/Collector/shopsysFramework.html.twig
@@ -1,0 +1,46 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% set icon %}
+        <img width="24" height="24" alt="Shopsys" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAMAAADXqc3KAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAXFQTFRFAAAA////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////iIJ5mQAAAHt0Uk5TAAnGsIhGFAEO//zbdQwHe5O5+P7aNGlyE3Hh9mQEWezmYAVKvUUK8v2nJBK8zzflNaBssmP7HVXYA15qyxYPfKGij/mUAlbvX3jE87OL+u7wgFepF6qX05mlwI6SuEyuGXm0hy2twtIfnWvDPVj0Wm0aS8rZqH9dYZvJigjPOQAAAVJJREFUeJxtUmdXwkAQPCzgBkRNFKMRghEJgliioQgCirGLLfaGgl2w119v7hIkPJwPt5O5ncztvUOoCktDY1Oz1Ybq0AIAlN3RWrfhbGvvoIHp7KpRXd1OXNieXuD63FXdw3v7CREGfOAdrMh+jxgYChofoWEIj1T6RyEc/HOP0dS4ziQRJiymvElZjuAa5ZmY0W+L4zVihylcExyTnCZ6SkoLeDsDM+Qgs1mYUzCbX+AWsWcJlhFr9SPFsQKr2MOuQS6tzRNdT6INZhMh91YWtlXs2QF6l+SgPdjXVsXB8S4yeYbOkRx0AIck5+g4RBrZE9BzTuWcar6z1BlkJWzJx+DcrF8AJRGmFALeYlW/BL4g6Dx4Bdc3hq7egnwnVLqKItw/6LRU1v9v4LEM8tMzHt1dkswHib+8ytTb+8enRgVUg3yC0x6CiP6B+vXt+zELv8X1L+4rtB6IAAAAAElFTkSuQmCC" />
+        <span class="sf-toolbar-value">{{ collector.version }}</span>
+    {% endset %}
+    {% set text %}
+        <div class="sf-toolbar-info-group">
+            <div class="sf-toolbar-info-piece">
+                <b>Version</b>
+                <span>{{ collector.version }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Current domain</b>
+                <span>{{ collector.currentDomainName }}</span>
+            </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Locale</b>
+                <span class="sf-toolbar-status">{{ collector.currentDomainLocale }}</span>
+            </div>
+        </div>
+        <div class="sf-toolbar-info-group">
+            {% for domain in collector.domains %}
+                <div class="sf-toolbar-info-piece">
+                    <b>{{ domain.name }}</b>
+                    <span>
+                        {% if domain.id is same as(collector.currentDomainId) %}
+                            {{ domain.url }}
+                        {% else %}
+                            <a href="{{ domain.url }}">{{ domain.url }}</a>
+                        {% endif %}
+                    </span>
+                </div>
+            {% endfor %}
+        </div>
+        <div class="sf-toolbar-info-group">
+            <div class="sf-toolbar-info-piece">
+                <b>Resources</b>
+                <span><a href="https://github.com/shopsys/shopsys/blob/{{collector.docsVersion}}/docs/index.md" target="_blank" rel="help">Documentation</a></span>
+            </div>
+        </div>
+    {% endset %}
+
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with {'link': false, additional_classes: 'sf-toolbar-block-right'} %}
+{% endblock %}

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -16,6 +16,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class ShopsysFrameworkBundle extends Bundle
 {
     /**
+     * @var string
+     */
+    public const VERSION = '7.3.0-dev';
+
+    /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
     public function build(ContainerBuilder $container)

--- a/utils/releaser/src/FileManipulator/FrameworkBundleVersionFileManipulator.php
+++ b/utils/releaser/src/FileManipulator/FrameworkBundleVersionFileManipulator.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\FileManipulator;
+
+use Nette\Utils\Strings;
+use PharIo\Version\Version;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class FrameworkBundleVersionFileManipulator
+{
+    /**
+     * @var string
+     */
+    public const FRAMEWORK_BUNDLE_VERSION_FILE_PATH = '/packages/framework/src/ShopsysFrameworkBundle.php';
+
+    /**
+     * @var string
+     */
+    private const FRAMEWORK_BUNDLE_VERSION_PATTERN = "/public const VERSION = '(.+)';/";
+
+    /**
+     * @param \Symfony\Component\Finder\SplFileInfo $splFileInfo
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function updateFrameworkBundleVersion(SplFileInfo $splFileInfo, Version $version): string
+    {
+        return Strings::replace(
+            $splFileInfo->getContents(),
+            self::FRAMEWORK_BUNDLE_VERSION_PATTERN,
+            function ($match) use ($version) {
+                return str_replace($match[1], $this->getVersionWithoutPrefix($version), $match[0]);
+            }
+        );
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    private function getVersionWithoutPrefix(Version $version): string
+    {
+        return ltrim($version->getVersionString(), 'v');
+    }
+}

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/SetFrameworkBundleVersionToDevReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/SetFrameworkBundleVersionToDevReleaseWorker.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\AfterRelease;
+
+use Nette\Utils\FileSystem;
+use PharIo\Version\Version;
+use RuntimeException;
+use Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+use Symfony\Component\Console\Question\Question;
+use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
+
+final class SetFrameworkBundleVersionToDevReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @var \Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator
+     */
+    private $frameworkBundleVersionFileManipulator;
+
+    /**
+     * @param \Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator $frameworkBundleVersionFileManipulator
+     */
+    public function __construct(FrameworkBundleVersionFileManipulator $frameworkBundleVersionFileManipulator)
+    {
+        $this->frameworkBundleVersionFileManipulator = $frameworkBundleVersionFileManipulator;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return 'Set ShopsysFrameworkBundle version to next dev version and commit it.';
+    }
+
+    /**
+     * Higher first
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 170;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $developmentVersion = $this->askForNextDevelopmentVersion($version);
+        $this->updateFrameworkBundleVersion($developmentVersion);
+
+        $this->commit(sprintf(
+            'ShopsysFrameworkBundle: version updated to "%s"',
+            $developmentVersion->getVersionString()
+        ));
+
+        $this->symfonyStyle->note('You need to push the master branch manually, however, you have to wait until the previous (tagged) master build is finished on Heimdall. Otherwise, master-project-base would have never been built from the source codes where there are dependencies on the tagged versions of shopsys packages.');
+        $this->confirm('Confirm you have waited long enough and then pushed the master branch.');
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::AFTER_RELEASE;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return \PharIo\Version\Version
+     */
+    private function askForNextDevelopmentVersion(Version $version): Version
+    {
+        $suggestedDevelopmentVersion = $this->suggestDevelopmentVersion($version);
+
+        $question = new Question('Enter next development version for ShopsysFrameworkBundle', $suggestedDevelopmentVersion->getVersionString());
+        $question->setValidator(static function ($answer) {
+            $version = new Version($answer);
+
+            if (!$version->hasPreReleaseSuffix()) {
+                throw new RuntimeException(
+                    'Development version must be suffixed (with \'-dev\', \'-alpha1\', ...)'
+                );
+            }
+
+            return $version;
+        });
+
+        return $this->symfonyStyle->askQuestion($question);
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    private function updateFrameworkBundleVersion(Version $version): void
+    {
+        $upgradeFilePath = getcwd() . FrameworkBundleVersionFileManipulator::FRAMEWORK_BUNDLE_VERSION_FILE_PATH;
+        $upgradeFileInfo = new SmartFileInfo($upgradeFilePath);
+
+        $newUpgradeContent = $this->frameworkBundleVersionFileManipulator->updateFrameworkBundleVersion($upgradeFileInfo, $version);
+
+        FileSystem::write($upgradeFilePath, $newUpgradeContent);
+    }
+
+    /**
+     * Return new development version (e.g. from 7.1.0 to 7.2.0-dev)
+     * @param \PharIo\Version\Version $version
+     * @return \PharIo\Version\Version
+     */
+    private function suggestDevelopmentVersion(Version $version): Version
+    {
+        $newVersionString = $version->getMajor()->getValue() . '.' . ($version->getMinor()->getValue() + 1) . '.0-dev';
+        return new Version($newVersionString);
+    }
+}

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/SetMutualDependenciesToDevMasterReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/SetMutualDependenciesToDevMasterReleaseWorker.php
@@ -75,8 +75,7 @@ final class SetMutualDependenciesToDevMasterReleaseWorker extends AbstractShopsy
         );
 
         $this->commit('composer.json in all packages now use latest shopsys version');
-        $this->symfonyStyle->note('You need to push the master branch manually, however, you have to wait until the previous (tagged) master build is finished on Heimdall. Otherwise, master-project-base would have never been built from the source codes where there are dependencies on the tagged versions of shopsys packages.');
-        $this->confirm('Confirm you have waited long enough and then pushed the master branch.');
+        $this->confirm('Confirm you have pushed the new commit into the master branch');
     }
 
     /**

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetFrameworkBundleVersionReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetFrameworkBundleVersionReleaseWorker.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
+
+use Nette\Utils\FileSystem;
+use PharIo\Version\Version;
+use Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+use Symplify\MonorepoBuilder\Release\Message;
+use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
+
+final class SetFrameworkBundleVersionReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @var \Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator
+     */
+    private $frameworkBundleVersionFileManipulator;
+
+    /**
+     * @param \Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator $frameworkBundleVersionFileManipulator
+     */
+    public function __construct(
+        FrameworkBundleVersionFileManipulator $frameworkBundleVersionFileManipulator
+    ) {
+        $this->frameworkBundleVersionFileManipulator = $frameworkBundleVersionFileManipulator;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return 'Set ShopsysFrameworkBundle version to released version and commit it.';
+    }
+
+    /**
+     * Higher first
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 845;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $this->updateFrameworkBundleVersion($version);
+
+        $this->commit(sprintf(
+            'ShopsysFrameworkBundle: version updated to "%s"',
+            $version->getVersionString()
+        ));
+
+        $this->symfonyStyle->success(Message::SUCCESS);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::RELEASE_CANDIDATE;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    private function updateFrameworkBundleVersion(Version $version): void
+    {
+        $upgradeFilePath = getcwd() . FrameworkBundleVersionFileManipulator::FRAMEWORK_BUNDLE_VERSION_FILE_PATH;
+        $upgradeFileInfo = new SmartFileInfo($upgradeFilePath);
+
+        $newUpgradeContent = $this->frameworkBundleVersionFileManipulator->updateFrameworkBundleVersion($upgradeFileInfo, $version);
+
+        FileSystem::write($upgradeFilePath, $newUpgradeContent);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After I started work with more projects, I was asking my colleagues to tell me which version of framework project has. So I created toolbar with version and basic information about project. I also upgraded releaser which will update version automatically.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

<img width="387" alt="Screenshot 2019-05-11 at 23 50 44" src="https://user-images.githubusercontent.com/1482966/57575463-c0a5bd00-744a-11e9-91f9-5af84b108c01.png">