### PR TITLE
[shopsys] README.md: add a link to the Travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Shopsys Framework
-![travis-badge](https://travis-ci.org/shopsys/shopsys.svg?branch=master)
+[![Build Status](https://travis-ci.org/shopsys/shopsys.svg?branch=master)](https://travis-ci.org/shopsys/shopsys)
 
 Shopsys Framework is a **fully functional ecommerce platform for businesses transitioning into tech-companies with their own software development team**. 
 It contains the most common B2C and B2B features for online stores, and its infrastructure is prepared for high scalability.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The Travis build badge had no link in the monorepo README.md. Clicking on the badge on the Github web UI opened the badge image in a new tab. It should lead to the build details on Travis (just as in the other readmes of our packages).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Thanks @boris-brtan for mentioning this issue in https://github.com/shopsys/shopsys/pull/1013#issuecomment-491305888
