### PR TITLE
[shopsys] php configuration is not mounted anymore via docker-compose using Windows

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -11,7 +11,7 @@ services:
         container_name: shopsys-framework-postgres
         volumes:
             - ./project-base/docker/postgres/postgres.conf:/var/lib/postgresql/data/postgresql.conf:delegated
-            - ./project-base/var/postgres-data:/var/lib/postgresql/data:cached
+            - postgres-data:/var/lib/postgresql/data
         environment:
             - PGDATA=/var/lib/postgresql/data/pgdata
             - POSTGRES_USER=root

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -46,7 +46,6 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/project-base/web
-            - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         ports:
             - "35729:35729"
 

--- a/docs/contributing/upgrading-monorepo.md
+++ b/docs/contributing/upgrading-monorepo.md
@@ -28,6 +28,10 @@ Typical upgrade sequence should be:
     +       - config_file=/var/lib/postgresql/data/postgresql.conf
     ```
 - remove `database_server_version` parameter from `parameters.yml` and `parameters.yml.dist` ([#1001](https://github.com/shopsys/shopsys/pull/1001))
+- *(Windows only)* remove mounting of `docker/php-fpm/php-ini-overrides.ini` via `docker-compose.yml` using Windows OS ([#1017](https://github.com/shopsys/shopsys/pull/1017))
+    ```diff
+    -            - ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
+    ```
 
 ## [From v7.0.0 to v7.1.0]
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -217,6 +217,11 @@ There you can find links to upgrade notes for other versions too.
         +   database_server_version: 10.5
         ...
         ```
+- *(Windows only)* remove mounting of `docker/php-fpm/php-ini-overrides.ini` via `docker-compose.yml` using Windows OS ([#1017](https://github.com/shopsys/shopsys/pull/1017))
+    ```diff
+    -            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
+    ```
+
 ### Tools
 - add path for tests folder into `ecs-fix` phing target of `build-dev.xml` file to be able to fix files that were found by `ecs` phing target ([#980](https://github.com/shopsys/shopsys/pull/980))
     ```diff

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -40,7 +40,6 @@ services:
             - shopsys-framework-sync:/var/www/html
             - shopsys-framework-vendor-sync:/var/www/html/vendor
             - shopsys-framework-web-sync:/var/www/html/web
-            - ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         ports:
             - "35729:35729"
 


### PR DESCRIPTION
- mounting of php-ini-overrides was removed from docker-compose config for win since it is copied during php-fpm image build

| Q             | A
| ------------- | ---
|Description, reason for the PR| php configuration is burned into php-fpm image during docker build so there is no need to overwrite it. And it will be consistent with docker-compose confs for mac and linux 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
