### PR TITLE
[shopsys] UpdateChangelogReleaseWorker: add tip about filtering on Github

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
@@ -76,7 +76,7 @@ final class UpdateChangelogReleaseWorker extends AbstractShopsysReleaseWorker
 
         $this->symfonyStyle->note(sprintf('You need to review the file, resolve unclassified entries, remove uninteresting entries, and commit the changes manually with "changelog is now updated for %s release"', $version->getVersionString()));
 
-        $this->symfonyStyle->note('You need to manually remove mentions of pull requests that were not merged into the released version (eg. merged into a branch for next major version) - you can filter pull requests on Github via "base:BRANCH__NAME"');
+        $this->symfonyStyle->note('You need to manually remove mentions of pull requests that were not merged into the released version (eg. merged into a branch for next major version) - you can filter pull requests on Github via "base:BRANCH_NAME"');
 
         $this->confirm('Confirm you have checked CHANGELOG.md and the changes are committed.');
     }

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateChangelogReleaseWorker.php
@@ -76,7 +76,7 @@ final class UpdateChangelogReleaseWorker extends AbstractShopsysReleaseWorker
 
         $this->symfonyStyle->note(sprintf('You need to review the file, resolve unclassified entries, remove uninteresting entries, and commit the changes manually with "changelog is now updated for %s release"', $version->getVersionString()));
 
-        $this->symfonyStyle->note('You need to manually remove mentions of pull requests that were not merged into the released version (eg. merged into a branch for next major version)');
+        $this->symfonyStyle->note('You need to manually remove mentions of pull requests that were not merged into the released version (eg. merged into a branch for next major version) - you can filter pull requests on Github via "base:BRANCH__NAME"');
 
         $this->confirm('Confirm you have checked CHANGELOG.md and the changes are committed.');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Filtering by target branch (base) is very useful when updating the changelog during the release process (see [article Searching issues and pull requests](https://help.github.com/en/articles/searching-issues-and-pull-requests#search-by-branch-name))
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
