### PR TITLE
[shopsys] merging to master is enabled after all changes are pushed during release

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AfterRelease/EnableMergingToMasterReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/EnableMergingToMasterReleaseWorker.php
@@ -25,7 +25,7 @@ final class EnableMergingToMasterReleaseWorker extends AbstractShopsysReleaseWor
      */
     public function getPriority(): int
     {
-        return 155;
+        return 145;
     }
 
     /**

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/SetUnreleasedNoteInInstallationGuidesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/SetUnreleasedNoteInInstallationGuidesReleaseWorker.php
@@ -10,7 +10,6 @@ use Shopsys\Releaser\FileManipulator\InstallationGuideFileManipulator;
 use Shopsys\Releaser\FilesProvider\InstallationGuideFilesProvider;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class SetUnreleasedNoteInInstallationGuidesReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/SetUnreleasedNoteInInstallationGuidesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/SetUnreleasedNoteInInstallationGuidesReleaseWorker.php
@@ -66,7 +66,7 @@ final class SetUnreleasedNoteInInstallationGuidesReleaseWorker extends AbstractS
             FileSystem::write($fileInfo->getPathname(), $newContent);
         }
         $this->commit('docker installation guides: updated note about the unreleased version');
-        $this->symfonyStyle->success(Message::SUCCESS);
+        $this->confirm('Confirm you have pushed the new commit into the master branch');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Releaser during its `after-release` stage tells you to enable merging to `master` and in the following release worker (`SetUnreleasedNoteInInstallationGuidesReleaseWorker`) makes some changes and commits them. This commit can be easily forgotten without being pushed. I've switched the order of the two release workers and added a prompt for pushing the changes.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
