### PR TITLE
[shopsys] AbstractShopsysReleaseWorker: git identity can be configured if empty

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AbstractShopsysReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractShopsysReleaseWorker.php
@@ -69,6 +69,8 @@ abstract class AbstractShopsysReleaseWorker implements ReleaseWorkerInterface, S
             return;
         }
 
+        $this->configureGitIdentityIfMissing();
+
         $this->processRunner->run('git add .');
         $this->processRunner->run('git commit --message="' . addslashes($message) . '"');
     }
@@ -84,6 +86,26 @@ abstract class AbstractShopsysReleaseWorker implements ReleaseWorkerInterface, S
         $output = $process->getOutput();
 
         return !(bool)empty($output);
+    }
+
+    private function configureGitIdentityIfMissing(): void
+    {
+        $name = $this->getProcessResult(['git', 'config', 'user.name']);
+        $email = $this->getProcessResult(['git', 'config', 'user.email']);
+
+        if ($name === '' || $email === '') {
+            $this->symfonyStyle->warning('Git identity is not configured, unable to create commits...');
+        }
+
+        if ($name === '') {
+            $newName = $this->symfonyStyle->ask('What is your name?');
+            $this->processRunner->run(['git', 'config', 'user.name', $newName]);
+        }
+
+        if ($email === '') {
+            $newEmail = $this->symfonyStyle->ask('What is your email address?');
+            $this->processRunner->run(['git', 'config', 'user.email', $newEmail]);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Release process fails if git identity is not configured as it creates commits. Because release is usually executed within a Docker container, it may be empty if the developer has identity configured globally on the host machine. Now, git identity is checked before making a commit - if it's empty, the user is prompted to configure it (see below).
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Example:
![image](https://user-images.githubusercontent.com/10008612/57777068-3e0a4f80-7721-11e9-8e42-b6dfa01d5803.png)
