### PR TITLE
[shopsys] use inline links in upgrade note headings

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -1,8 +1,6 @@
-# [Upgrade from v7.2.0 to Unreleased]
+# [Upgrade from v7.2.0 to Unreleased](https://github.com/shopsys/shopsys/compare/v7.2.0...HEAD)
 
 This guide contains instructions to upgrade from version v7.2.0 to Unreleased.
 
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
-
-[Upgrade from v7.2.0 to Unreleased]: https://github.com/shopsys/shopsys/compare/v7.2.0...HEAD

--- a/docs/upgrade/UPGRADE-v7.0.0-beta6.md
+++ b/docs/upgrade/UPGRADE-v7.0.0-beta6.md
@@ -1,4 +1,4 @@
-# [Upgrade from v7.0.0-beta5 to v7.0.0-beta6]
+# [Upgrade from v7.0.0-beta5 to v7.0.0-beta6](https://github.com/shopsys/shopsys/compare/v7.0.0-beta5...v7.0.0-beta6)
 
 This guide contains instructions to upgrade from version v7.0.0-beta5 to v7.0.0-beta6.
 
@@ -283,6 +283,5 @@ for instance:
     - you need to adjust already extended methods and fields to `protected` visibility because all `private` visibilities from these namespaces were changed to `protected`
     - you can delete methods that you just copied due to inability to inherit
 
-[Upgrade from v7.0.0-beta5 to v7.0.0-beta6]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta5...v7.0.0-beta6
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/product-feed-heureka]: https://github.com/shopsys/product-feed-heureka

--- a/docs/upgrade/UPGRADE-v7.0.0.md
+++ b/docs/upgrade/UPGRADE-v7.0.0.md
@@ -1,4 +1,4 @@
-# [Upgrade from v7.0.0-beta6 to v7.0.0]
+# [Upgrade from v7.0.0-beta6 to v7.0.0](https://github.com/shopsys/shopsys/compare/v7.0.0-beta6...v7.0.0)
 
 This guide contains instructions to upgrade from version v7.0.0-beta6 to v7.0.0.
 
@@ -94,6 +94,5 @@ if you want to have products data exported to Elasticsearch after `build-demo` t
         - `web/content/images/product/list`
         - `web/content/images/sliderItem/default`
 
-[Upgrade from v7.0.0-beta6 to v7.0.0]: https://github.com/shopsys/shopsys/compare/v7.0.0-beta6...v7.0.0
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/project-base]: https://github.com/shopsys/project-base

--- a/docs/upgrade/UPGRADE-v7.1.0.md
+++ b/docs/upgrade/UPGRADE-v7.1.0.md
@@ -1,4 +1,4 @@
-# [Upgrade from v7.0.0 to v7.1.0]
+# [Upgrade from v7.0.0 to v7.1.0](https://github.com/shopsys/shopsys/compare/v7.0.0...v7.1.0)
 
 This guide contains instructions to upgrade from version v7.0.0 to v7.1.0.
 
@@ -194,6 +194,5 @@ There you can find links to upgrade notes for other versions too.
   because it causes problems during entity extension. Such problem with `OrderItem` was resolved during [making OrderItem extendable #715](https://github.com/shopsys/shopsys/pull/715)  
   If you want to use Doctrine inheritance mapping anyway, please skip `Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff` ([#848](https://github.com/shopsys/shopsys/pull/848))
 
-[Upgrade from v7.0.0 to v7.1.0]: https://github.com/shopsys/shopsys/compare/v7.0.0...v7.1.0
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/docs/upgrade/UPGRADE-v7.2.0.md
+++ b/docs/upgrade/UPGRADE-v7.2.0.md
@@ -1,4 +1,4 @@
-# [Upgrade from v7.1.0 to v7.2.0]
+# [Upgrade from v7.1.0 to v7.2.0](https://github.com/shopsys/shopsys/compare/v7.1.0...v7.2.0)
 
 This guide contains instructions to upgrade from version v7.1.0 to v7.2.0.
 
@@ -281,5 +281,4 @@ There you can find links to upgrade notes for other versions too.
     + <arg path="${path.tests}" />
     ```
 
-[Upgrade from v7.1.0 to v7.2.0]: https://github.com/shopsys/shopsys/compare/v7.1.0...v7.2.0
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/template/UPGRADE-unreleased.md.twig
+++ b/docs/upgrade/template/UPGRADE-unreleased.md.twig
@@ -1,8 +1,6 @@
-# [Upgrade from {{ versionString }} to Unreleased]
+# [Upgrade from {{ versionString }} to Unreleased](https://github.com/shopsys/shopsys/compare/{{ versionString }}...HEAD)
 
 This guide contains instructions to upgrade from version {{ versionString }} to Unreleased.
 
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
-
-[Upgrade from {{ versionString }} to Unreleased]: https://github.com/shopsys/shopsys/compare/{{ versionString }}...HEAD


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This format is easier to work with during automated release process (see [VersionUpgradeFileManipulator](https://github.com/shopsys/shopsys/blob/v7.2.0/utils/releaser/src/FileManipulator/VersionUpgradeFileManipulator.php) and [its unit test](https://github.com/shopsys/shopsys/blob/v7.2.0/utils/releaser/tests/FileManipulator/UpgradeFileManipulator/VersionUpgradeFileManipulatorTest.php)).<br />Otherwise the headings are not properly updated by releaser.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
