### PR TITLE
[shopsys] UpdateUpgradeReleaseWorker adds the changed files to staging area automatically

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -131,6 +131,8 @@ final class UpdateUpgradeReleaseWorker extends AbstractShopsysReleaseWorker
 
         FileSystem::write($upgradeFilePath, $newUpgradeContent);
         FileSystem::rename($upgradeFilePath, getcwd() . '/docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md');
+
+        $this->processRunner->run('git add docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md');
     }
 
     /**

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -127,12 +127,13 @@ final class UpdateUpgradeReleaseWorker extends AbstractShopsysReleaseWorker
         $upgradeFilePath = getcwd() . '/docs/upgrade/UPGRADE-unreleased.md';
         $upgradeFileInfo = new SmartFileInfo($upgradeFilePath);
 
+        $newUpgradeFilePath = getcwd() . '/docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md';
         $newUpgradeContent = $this->versionUpgradeFileManipulator->processFileToString($upgradeFileInfo, $version);
 
         FileSystem::write($upgradeFilePath, $newUpgradeContent);
-        FileSystem::rename($upgradeFilePath, getcwd() . '/docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md');
+        FileSystem::rename($upgradeFilePath, $newUpgradeFilePath);
 
-        $this->processRunner->run('git add docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md');
+        $this->processRunner->run('git add ' . $newUpgradeFilePath);
     }
 
     /**

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -127,13 +127,12 @@ final class UpdateUpgradeReleaseWorker extends AbstractShopsysReleaseWorker
         $upgradeFilePath = getcwd() . '/docs/upgrade/UPGRADE-unreleased.md';
         $upgradeFileInfo = new SmartFileInfo($upgradeFilePath);
 
-        $newUpgradeFilePath = getcwd() . '/docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md';
         $newUpgradeContent = $this->versionUpgradeFileManipulator->processFileToString($upgradeFileInfo, $version);
 
         FileSystem::write($upgradeFilePath, $newUpgradeContent);
-        FileSystem::rename($upgradeFilePath, $newUpgradeFilePath);
+        FileSystem::rename($upgradeFilePath, getcwd() . '/docs/upgrade/UPGRADE-' . $version->getVersionString() . '.md');
 
-        $this->processRunner->run('git add ' . $newUpgradeFilePath);
+        $this->processRunner->run('git add .');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The release worker creates a file but doesn't add it to the staging area, which might be confusing for the developer. All changed files are added to the staging area automatically now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
