### PR TITLE
[shopsys] added note about recreating structure during deployment in upgrade guide for v7.2.0

### DIFF
--- a/docs/upgrade/interchangeable-filtering.md
+++ b/docs/upgrade/interchangeable-filtering.md
@@ -46,7 +46,7 @@ Even then, you should make some upgrade steps to have your code tested properly 
     - update the test of the export repository `tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php` to match the new Elasticsearch structure
         - you can copy [`ProductSearchExportRepositoryTest.php`](https://github.com/shopsys/project-base/blob/v7.2.0/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php) from `shopsys/project-base`
         - the test is written in such a way that supports both the SQL and Elasticsearch filtering (depending on the service in your DIC)
-    - recreate the structure and export products to Elasticsearch with `php phing product-search-recreate-structure product-search-export-products`
+    - recreate the structure and export products to Elasticsearch with `php phing product-search-recreate-structure product-search-export-products` on your machine, and also later during deployment of your application
 
 ## Use new Elasticsearch Filtering
 To start filtering products via Elasticsearch you have to do these steps.
@@ -79,4 +79,4 @@ To start filtering products via Elasticsearch you have to do these steps.
 - skip the path `'*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'` for the following coding standard sniffs in your `easy-coding-standard.yml` file
     `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff`
     `ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff`
-- don't forget to recreate the structure and export products to Elasticsearch with `php phing product-search-recreate-structure product-search-export-products`
+- don't forget to recreate the structure and export products to Elasticsearch with `php phing product-search-recreate-structure product-search-export-products`, especially later during deployment of your application


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| during the upgrade of `shopsys/demoshop` I recreated the structure locally, but I forgot to recreate it during the deployment (as it is not a standard part of the deployment process). This lead to a *500 Internal Server Error* on the product list page.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
