### PR TITLE
[project-base] Form::isValid() should be called after Form::isSubmitted()

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -8,7 +8,7 @@ There you can find links to upgrade notes for other versions too.
 ## [shopsys/framework]
 
 ### Application
-- call `Form::isSubmitted()` before `Form::isValid()` (#1041)
+- call `Form::isSubmitted()` before `Form::isValid()` ([#1041](https://github.com/shopsys/shopsys/pull/1041))
     - search for `$form->isValid() && $form->isSubmitted()` and fix the order of calls (in `shopsys/project-base` the wrong order could have been found in `src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php`):
         ```diff
         - if ($form->isValid() && $form->isSubmitted()) {

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -4,3 +4,15 @@ This guide contains instructions to upgrade from version v7.2.0 to Unreleased.
 
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+## [shopsys/framework]
+
+### Application
+- call `Form::isSubmitted()` before `Form::isValid()` (#1041)
+    - search for `$form->isValid() && $form->isSubmitted()` and fix the order of calls (in `shopsys/project-base` the wrong order could have been found in `src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php`):
+        ```diff
+        - if ($form->isValid() && $form->isSubmitted()) {
+        + if ($form->isSubmitted() && $form->isValid()) {
+        ```
+
+[shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php
@@ -108,7 +108,7 @@ class PersonalDataController extends FrontBaseController
 
         $form->handleRequest($request);
 
-        if ($form->isValid() && $form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $personalData = $this->personalDataAccessRequestFacade->createPersonalDataAccessRequest(
                 $form->getData(),
                 $this->domain->getId()
@@ -138,7 +138,7 @@ class PersonalDataController extends FrontBaseController
 
         $form->handleRequest($request);
 
-        if ($form->isValid() && $form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $personalData = $this->personalDataAccessRequestFacade->createPersonalDataAccessRequest(
                 $form->getData(),
                 $this->domain->getId()


### PR DESCRIPTION
If the form is not submitted, method Form::isValid() will throw an exception in Symfony 4.0

| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes