### PR TITLE
[project-base] fix typo in twig template

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -14,5 +14,7 @@ There you can find links to upgrade notes for other versions too.
         - if ($form->isValid() && $form->isSubmitted()) {
         + if ($form->isSubmitted() && $form->isValid()) {
         ```
+- fix the typo in Twig template `@ShopsysShop/Front/Content/Category/panel.html.twig` ([#1043](https://github.com/shopsys/shopsys/pull/1043))
+    - `categoriyWithLazyLoadedVisibleChildren` ⟶ `categoryWithLazyLoadedVisibleChildren`
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Category/panel.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Category/panel.html.twig
@@ -1,16 +1,16 @@
 {% if categoriesWithLazyLoadedVisibleChildren|length > 0 %}
     <ul class="js-category-list list-menu dont-print {% if isFirstLevel %}list-menu--root{% endif %}" {% if isFirstLevel %}id="js-categories"{% endif %}>
-        {% for categoriyWithLazyLoadedVisibleChildren in categoriesWithLazyLoadedVisibleChildren %}
-            {% set isCurrentCategory = (currentCategory is not null and currentCategory == categoriyWithLazyLoadedVisibleChildren.category) %}
+        {% for categoryWithLazyLoadedVisibleChildren in categoriesWithLazyLoadedVisibleChildren %}
+            {% set isCurrentCategory = (currentCategory is not null and currentCategory == categoryWithLazyLoadedVisibleChildren.category) %}
             <li class="list-menu__item js-category-item">
-                <a href="{{ url('front_product_list', { id: categoriyWithLazyLoadedVisibleChildren.category.id }) }}" class="list-menu__item__link list-menu__item__link--level-{{ categoriyWithLazyLoadedVisibleChildren.category.level }} {% if isCurrentCategory %}current{% endif %}">
-                    {{ categoriyWithLazyLoadedVisibleChildren.category.name }}
-                    {% if categoriyWithLazyLoadedVisibleChildren.hasChildren %}
-                        <i class="list-menu__item__control svg svg-arrow js-category-collapse-control {% if categoriyWithLazyLoadedVisibleChildren.category in openCategories %}open{% endif %}" data-url="{{ url('front_category_branch', { parentCategoryId: categoriyWithLazyLoadedVisibleChildren.category.id }) }}"></i>
+                <a href="{{ url('front_product_list', { id: categoryWithLazyLoadedVisibleChildren.category.id }) }}" class="list-menu__item__link list-menu__item__link--level-{{ categoryWithLazyLoadedVisibleChildren.category.level }} {% if isCurrentCategory %}current{% endif %}">
+                    {{ categoryWithLazyLoadedVisibleChildren.category.name }}
+                    {% if categoryWithLazyLoadedVisibleChildren.hasChildren %}
+                        <i class="list-menu__item__control svg svg-arrow js-category-collapse-control {% if categoryWithLazyLoadedVisibleChildren.category in openCategories %}open{% endif %}" data-url="{{ url('front_category_branch', { parentCategoryId: categoryWithLazyLoadedVisibleChildren.category.id }) }}"></i>
                     {% endif %}
                 </a>
-                {% if categoriyWithLazyLoadedVisibleChildren.category in openCategories %}
-                    {% set categoriesWithLazyLoadedVisibleChildren = categoriyWithLazyLoadedVisibleChildren.children %}
+                {% if categoryWithLazyLoadedVisibleChildren.category in openCategories %}
+                    {% set categoriesWithLazyLoadedVisibleChildren = categoryWithLazyLoadedVisibleChildren.children %}
                     {% set isFirstLevel = false %}
 
                     {% include _self %}


### PR DESCRIPTION
rename variable `categoriyWithLazyLoadedVisibleChildren` to `categoryWithLazyLoadedVisibleChildren` in 
`Front/Content/Category/panel.html.twig`

| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
