### PR TITLE
[coding-standards] symplify extension is simplified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,7 +569,7 @@ The changelog is generated during the release process using [ChangelogLinker](ht
         - javascript validation and tests were bound to the new paths of the form elements
         - docs were updated
 - [#401 - Microservice Product Search](https://github.com/shopsys/shopsys/pull/401)
-    - added [Microservice Product Search](https://github.com/shopsys/microservice-product-search), microservice is used for the searching of products on Shopsys Framework 
+    - added [Microservice Product Search](https://github.com/shopsys/microservice-product-search), microservice is used for the searching of products on Shopsys Framework
     - added MicroserviceClient component
 
 #### Changed
@@ -589,7 +589,7 @@ The changelog is generated during the release process using [ChangelogLinker](ht
 ### [shopsys/project-base]
 #### Changed
 - [#401 - Microservice Product Search](https://github.com/shopsys/shopsys/pull/401)
-    - added [Microservice Product Search](https://github.com/shopsys/microservice-product-search), microservice is used for the searching of products on Shopsys Framework 
+    - added [Microservice Product Search](https://github.com/shopsys/microservice-product-search), microservice is used for the searching of products on Shopsys Framework
     - now the following phing targets are also triggered over the microservice
         - standards
         - standards-diff
@@ -652,7 +652,7 @@ The changelog is generated during the release process using [ChangelogLinker](ht
   - FeedExport is responsible for the actual generation of a file in batches on a specific domain
   - FeedRenderer is responsible for rendering the feed from Twig template
   - FeedPathProvider is responsible for providing the correct filepath and url to the specified feed on a domain
-  - ProductUrlsBatchLoader and ProductParametersBatchLoader are responsible for loading product data in batches 
+  - ProductUrlsBatchLoader and ProductParametersBatchLoader are responsible for loading product data in batches
   - cron modules use the logger for debug information
   - DailyFeedCronModule is responsible for continuation of the correct feed after waking up
 - [#182 - Cart: flush() is called only if there are really some changes in cart items](https://github.com/shopsys/shopsys/pull/182)
@@ -801,7 +801,7 @@ It was only important with [the original open-box architecture](https://blog.sho
     - modified [travis script](./packages/framework/project-base/.travis.yml)
         - removed check for php 7.0
         - php-cs-fixer, phpcs, phpmd binaries replaced by ecs binaries
-        - inline code skips moved to [autoload-easy-coding-standard.yml](./packages/framework/autoload-easy-coding-standard.yml) 
+        - inline code skips moved to [autoload-easy-coding-standard.yml](./packages/framework/autoload-easy-coding-standard.yml)
 - [#171 - Update to twig 2.x](https://github.com/shopsys/shopsys/pull/171):
     - updated to Twig 2.4.8
     - all depracated calls has been fixed
@@ -809,7 +809,7 @@ It was only important with [the original open-box architecture](https://blog.sho
     - all occurrences of netdevelo were changed to shopsys
 - [#257 - Admin: reset.less: disable scrollbar normalization in order to fix problems with jQuery UI drag&drop]( https://github.com/shopsys/shopsys/pull/257)
     - dragged item is now at correct position
-        -scrollbar normalization was disabled for sortable components 
+        -scrollbar normalization was disabled for sortable components
 - [#261 - Sending personal data to Heureka can be disabled](https://github.com/shopsys/shopsys/pull/261)
     - the last step of cart contains opt-out checkbox to disable sending personal data to Heureka (if Heureka Verified by Customers is enabled on the domain)
 - [#206 clearing Setting's cache is now done via DoctrineEventListener](https://github.com/shopsys/shopsys/pull/206)
@@ -818,9 +818,9 @@ It was only important with [the original open-box architecture](https://blog.sho
 - [#254 - Removal of EntityDetail classes](https://github.com/shopsys/shopsys/pull/276)
     - `TransportDetail` and `TransportDetailFactory` were removed - `TransportFacade` is now able to provide transport base prices
     - `PaymentDetail` and `PaymentDetailFactory` were removed - `PaymentFacade` is now able to provide payment base prices
-    - `ProductDetail` and `ProductDetailFactory` were removed - new `ProductCachedAttributesFacade` is now responsible for caching of products selling prices and parameters 
-    - `CategoryDetail` was renamed to `CategoryWithPreloadedChildren` and methods for it's creation were moved from `CategoryDetailFactory` to new `CategoryWithPreloadedChildrenFactory` 
-    - `LazyLoadedCategoryDetail` was renamed to `CategoryWithLazyLoadedVisibleChildren` and methods for it's creation were moved from deleted `CategoryDetailFactory` to new `CategoryWithLazyLoadedVisibleChildrenFactory` 
+    - `ProductDetail` and `ProductDetailFactory` were removed - new `ProductCachedAttributesFacade` is now responsible for caching of products selling prices and parameters
+    - `CategoryDetail` was renamed to `CategoryWithPreloadedChildren` and methods for it's creation were moved from `CategoryDetailFactory` to new `CategoryWithPreloadedChildrenFactory`
+    - `LazyLoadedCategoryDetail` was renamed to `CategoryWithLazyLoadedVisibleChildren` and methods for it's creation were moved from deleted `CategoryDetailFactory` to new `CategoryWithLazyLoadedVisibleChildrenFactory`
 - [#274 grid: drag&drop is supported with enabled gridInlineEdit](https://github.com/shopsys/shopsys/pull/274)
 - [#165 Different approach to multidomain entities](https://github.com/shopsys/shopsys/pull/165)
     - multi-domain entities were changed so they are used similarly to translations
@@ -852,11 +852,11 @@ It was only important with [the original open-box architecture](https://blog.sho
 - [#176 - Admin: Validation for free shipping is inconsistent](https://github.com/shopsys/shopsys/pull/176)
     - `Resources/views/Admin/Content/TransportAndPayment/freeTransportAndPaymentLimitSetting.html.twig`: `form_errors` was included for `form_widget` for consistency of admin forms
 - [#228 - show selectbox options](https://github.com/shopsys/shopsys/pull/228)
-    - the use of jQuery plugin for selectboxes was modified on Shopsys Framework side so options will now be seen 
+    - the use of jQuery plugin for selectboxes was modified on Shopsys Framework side so options will now be seen
 - [#243 - Admin: changed domain icon in e-shop domain administration can be saved](https://github.com/shopsys/shopsys/pull/243)
     - changed domain icon in e-shop domain administration can be saved
 - copying of localized entities
-    - detection of new locale is now done before multidomain data are created 
+    - detection of new locale is now done before multidomain data are created
 
 ### [shopsys/project-base]
 #### Changed
@@ -895,7 +895,7 @@ It was only important with [the original open-box architecture](https://blog.sho
 #### Changed
 - [#143](https://github.com/shopsys/shopsys/pull/143) [Shopsys Coding Standards dev-master](./packages/coding-standards/) is now used
     - php-cs-fixer, phpcs, phpmd binaries replaced by ecs binaries
-    - build scripts were modified to work with new easy-coding-standard checker 
+    - build scripts were modified to work with new easy-coding-standard checker
 - [#230 - composer-dev updates dependencies if composer.json was changed](https://github.com/shopsys/shopsys/pull/230)
 
 #### Fixed
@@ -964,7 +964,7 @@ It was only important with [the original open-box architecture](https://blog.sho
 #### Changed
 - [#143 - Shopsys framework now uses latest version of Shopsys coding standards](https://github.com/shopsys/shopsys/pull/143) [Shopsys Coding Standards dev-master](./packages/coding-standards/) is now used
     - version of coding-standards package was updated to dev-master in [composer.json](./packages/product-feed-heureka/composer.json)
-    - inline code skips moved to [autoload-easy-coding-standard.yml](./packages/product-feed-heureka/autoload-easy-coding-standard.yml) 
+    - inline code skips moved to [autoload-easy-coding-standard.yml](./packages/product-feed-heureka/autoload-easy-coding-standard.yml)
     - modified [travis script](./packages/product-feed-heureka/.travis.yml)
         - removed check for php 7.0 due to compatibility with ecs
         - php-cs-fixer, phpcs, phpmd binaries replaced by ecs binary
@@ -995,7 +995,7 @@ It was only important with [the original open-box architecture](https://blog.sho
 #### Changed
 - [#143 - Shopsys framework now uses latest version of Shopsys coding standards](https://github.com/shopsys/shopsys/pull/143) [Shopsys Coding Standards dev-master](./packages/coding-standards/) is now used
     - version of coding-standards package was updated to dev-master in [composer.json](./packages/product-feed-zbozi/composer.json)
-    - inline code skips moved to [autoload-easy-coding-standard.yml](./packages/product-feed-zbozi/autoload-easy-coding-standard.yml) 
+    - inline code skips moved to [autoload-easy-coding-standard.yml](./packages/product-feed-zbozi/autoload-easy-coding-standard.yml)
     - modified [travis script](./packages/product-feed-zbozi/.travis.yml)
         - removed check for php 7.0 due to compatibility with ecs
         - php-cs-fixer, phpcs, phpmd binaries replaced by ecs binary
@@ -1007,33 +1007,33 @@ It was only important with [the original open-box architecture](https://blog.sho
 ### [shopsys/framework]
 #### Added
 - [#74 - Export personal information](https://github.com/shopsys/shopsys/pull/74):
-    - Countries have code in ISO 3166-1 alpha-2 
-    - admin: added site content and email template for personal data export 
+    - Countries have code in ISO 3166-1 alpha-2
+    - admin: added site content and email template for personal data export
 - [#95 - Entity name resolving in EntityManager, QueryBuilders and Repositories](https://github.com/shopsys/shopsys/pull/95):
-    - extended glass-box model entities are now used instead of their parent entities in EntityManager and QueryBuilders 
+    - extended glass-box model entities are now used instead of their parent entities in EntityManager and QueryBuilders
         - this removes the need to manually override all repositories that work with extended entities
         - the functionality is automatically tested in [shopsys/project-base](https://github.com/shopsys/project-base)
             - see `\Tests\ShopBundle\Database\EntityExtension\EntityExtensionTest`
 - [#107 - Entities by factories](https://github.com/shopsys/shopsys/pull/107):
-    - entities are created by factories 
+    - entities are created by factories
         - allowing override factory that creates extended entities in project-base
 
 #### Changed
 - [#102 - Protected visibility of all private properties and methods of facades](https://github.com/shopsys/shopsys/pull/102):
-    - visibility of all private properties and methods of repositories of entities was changed to protected 
+    - visibility of all private properties and methods of repositories of entities was changed to protected
         - there are changed only repositories of entities because currently there was no need for extendibility of other repositories
         - protected visibility allows overriding of behavior from projects
 - [#116 - Visibility of properties and methods of DataFactories and Repositories is protected](https://github.com/shopsys/shopsys/pull/116)
-    - visibility of all private properties and methods of DataFactories was changed to protected 
+    - visibility of all private properties and methods of DataFactories was changed to protected
         - protected visibility allows overriding of behavior from projects
 - [#113 - terminology: expression "indexes" is used now instead of "indices"](https://github.com/shopsys/shopsys/pull/113)
-    - unification of terminology - indices and indexes 
+    - unification of terminology - indices and indexes
         - there is only "indexes" expression used now
 - [#103 - Defaultly rendered form types](https://github.com/shopsys/shopsys/pull/103):
     - `CustomerFormType`, `PaymentFormType` and `TransportFormType` are now all rendered using FormType classes and they
         are ready for extension from `project-base` side.
 - [#70 - extraction of project-independent part of Shopsys\Environment](https://github.com/shopsys/shopsys/pull/70):
-    - moved constants with types of environment from [shopsys/project-base](https://github.com/shopsys/project-base) 
+    - moved constants with types of environment from [shopsys/project-base](https://github.com/shopsys/project-base)
         - moved from `\Shopsys\Environment` to `\Shopsys\FrameworkBundle\Component\Environment\EnvironmentType`
 - [#87 - service deprecations](https://github.com/shopsys/shopsys/pull/87):
     - service definition follows Symfony 4 autowiring standards (@EdoBarnas)
@@ -1043,33 +1043,33 @@ It was only important with [the original open-box architecture](https://blog.sho
         - services with common suffixes (`*Facade`, `*Repository` etc.) are auto-discovered
         - see `services.yml` for details
 - [#91 - all exception interfaces are now Throwable](https://github.com/shopsys/shopsys/pull/91):
-    - all exception interfaces are now Throwable 
-    - visibility of all private properties and methods of facades was changed to protected 
+    - all exception interfaces are now Throwable
+    - visibility of all private properties and methods of facades was changed to protected
         - protected visibility allows overriding of behavior from projects
 - [#130 - License condition for turnover changed from 12 to 3 months](https://github.com/shopsys/shopsys/pull/130)
 
 #### Fixed
-- [#89 - choiceList values are prepared for js ChoiceToBooleanArrayTransformer](https://github.com/shopsys/shopsys/pull/89) 
-    - choiceList values are prepared for js Choice(s)ToBooleanArrayTransformer 
+- [#89 - choiceList values are prepared for js ChoiceToBooleanArrayTransformer](https://github.com/shopsys/shopsys/pull/89)
+    - choiceList values are prepared for js Choice(s)ToBooleanArrayTransformer
         - fixed "The choices were not found" console js error in the params filter
 - [relevant CHANGELOG.md files updated](https://github.com/shopsys/shopsys/commit/68d730ac9eed9f8cf29c843f89718194ad51b1da):
     - command `shopsys:server:run` for running PHP built-in web server for a chosen domain
 - [#108 - demo entity extension](https://github.com/shopsys/shopsys/pull/108)
-    - db indices for product name are now created for translations in all locales 
+    - db indices for product name are now created for translations in all locales
     - `LoadDataFixturesCommand` - fixed the `--fixtures` option description
 
 ### [shopsys/project-base]
 #### Added
-- [#74 - Export personal information](https://github.com/shopsys/shopsys/pull/74): 
+- [#74 - Export personal information](https://github.com/shopsys/shopsys/pull/74):
     - frontend: added site for requesting personal data export [@stanoMilan]
-- [#94 - Installation guide update](https://github.com/shopsys/shopsys/pull/94): 
+- [#94 - Installation guide update](https://github.com/shopsys/shopsys/pull/94):
     - support for [native installation](https://github.com/shopsys/shopsys/blob/master/docs/installation/native-installation.md) of the application
 
 #### Changed
 - [#70 - extraction of project-independent part of Shopsys\Environment](https://github.com/shopsys/shopsys/pull/70):
     - moved constants with types of environment into [shopsys/framework](https://github.com/shopsys/framework)
     - moved from `\Shopsys\Environment` to `\Shopsys\FrameworkBundle\Component\Environment\EnvironmentType`
-- [Dependency Injection strict mode is now enabled](https://github.com/shopsys/shopsys/commit/cdcb51268d56770ae460fe22b41cc09f51c4aab6) [@EdoBarnas]: 
+- [Dependency Injection strict mode is now enabled](https://github.com/shopsys/shopsys/commit/cdcb51268d56770ae460fe22b41cc09f51c4aab6) [@EdoBarnas]:
     - disables autowiring features that were removed in Symfony 4
 
 #### Fixed
@@ -1078,16 +1078,16 @@ It was only important with [the original open-box architecture](https://blog.sho
         - see https://github.com/symfony/swiftmailer-bundle/commit/5edfbd39eaefb176922a346c16b0ae3aaeec87e0
         - the new setting requires array instead of string so the parameter `mailer_master_email_address` is wrapped into array in config
 - [`FpJsFormValidator` error in console on FE order pages](https://github.com/shopsys/shopsys/commit/fbadde0966e92941dd470591d6a8a4924a798aa8)
-- [failure during Docker image build triggered by `E: Unable to locate package postgresql-client-9.5`](https://github.com/shopsys/shopsys/pull/110) 
+- [failure during Docker image build triggered by `E: Unable to locate package postgresql-client-9.5`](https://github.com/shopsys/shopsys/pull/110)
 
 #### Removed
-- [#94 - Installation guide update](https://github.com/shopsys/shopsys/pull/94): 
+- [#94 - Installation guide update](https://github.com/shopsys/shopsys/pull/94):
     - support of installation using Docker for Windows 10 Home and lower
     - virtualization is extremely slow, native installation has much better results in such case
 
 ### [shopsys/shopsys]
 #### Added
-- [#108 - demo entity extension](https://github.com/shopsys/shopsys/pull/108): 
+- [#108 - demo entity extension](https://github.com/shopsys/shopsys/pull/108):
     - [cookbook](docs/cookbook/adding-new-attribute-to-an-entity.md) for adding new attribute to an entity
 
 #### Changed
@@ -1109,7 +1109,7 @@ It was only important with [the original open-box architecture](https://blog.sho
 
 #### Fixed
 - [#117 - documentation: missing redis extension in required php extensions](https://github.com/shopsys/shopsys/pull/117) [@pk16011990]
-- [#124 - Admin: Customer cannot be saved + fixed js error from administration console](https://github.com/shopsys/shopsys/pull/124): 
+- [#124 - Admin: Customer cannot be saved + fixed js error from administration console](https://github.com/shopsys/shopsys/pull/124):
     - admin: e-mail validation in customer editation is working correctly now
 
 ### [shopsys/http-smoke-testing]
@@ -1128,17 +1128,17 @@ It was only important with [the original open-box architecture](https://blog.sho
     - visibility of all private properties and methods of facades was changed to protected
         - protected visibility allows overriding of behavior from projects
 
-### [shopsys/product-feed-heureka] 
-#### Changed 
-- [#116 - Visibility of properties and methods of DataFactories and Repositories is protected](https://github.com/shopsys/shopsys/pull/116): 
-    - visibility of all private properties and methods of repositories of entities was changed to protected 
-        - there are changed only repositories of entities because currently there was no need for extendibility of other repositories 
-        - protected visibility allows overriding of behavior from projects 
-- [Doctrine entities are used for storing data instead of using `DataStorageProviderInterface`](https://github.com/shopsys/shopsys/commit/3f32f513276f112d8ef4bdf854e413829bcf80f8) 
-    - previously saved data will be migrated 
-- [#102 - Protected visibility of all private properties and methods of facades](https://github.com/shopsys/shopsys/pull/102): 
-    - visibility of all private properties and methods of facades was changed to protected 
-        - protected visibility allows overriding of behavior from projects 
+### [shopsys/product-feed-heureka]
+#### Changed
+- [#116 - Visibility of properties and methods of DataFactories and Repositories is protected](https://github.com/shopsys/shopsys/pull/116):
+    - visibility of all private properties and methods of repositories of entities was changed to protected
+        - there are changed only repositories of entities because currently there was no need for extendibility of other repositories
+        - protected visibility allows overriding of behavior from projects
+- [Doctrine entities are used for storing data instead of using `DataStorageProviderInterface`](https://github.com/shopsys/shopsys/commit/3f32f513276f112d8ef4bdf854e413829bcf80f8)
+    - previously saved data will be migrated
+- [#102 - Protected visibility of all private properties and methods of facades](https://github.com/shopsys/shopsys/pull/102):
+    - visibility of all private properties and methods of facades was changed to protected
+        - protected visibility allows overriding of behavior from projects
 
 ### [shopsys/product-feed-zbozi]
 #### Changed
@@ -1244,10 +1244,10 @@ from its open-box repository [shopsys/project-base](https://github.com/shopsys/p
 ### [shopsys/project-base]
 #### Added
 - Sessions are now stored in Redis
-- Admin - Legal conditions: added personal data settings 
+- Admin - Legal conditions: added personal data settings
 - Frontend site for requesting personal data information
     - Admin - added email template for personal data request
-    - Frontend send email with link to personal data access site 
+    - Frontend send email with link to personal data access site
 - docs: new WIP documentation about working with glassbox
 - docker: [`php-fpm/Dockerfile`](./project-base/docker/php-fpm/Dockerfile) added installation of `grunt-cli` to be able to run `grunt watch`
     - [`docker-compose.yml.dist`](docker/conf/docker-compose.yml.dist) and [`docker-compose-mac.yml.dist`](docker/conf/docker-compose-mac.yml.dist): opened port 35729 for livereload, that is used by `grunt watch`
@@ -1271,8 +1271,8 @@ from its open-box repository [shopsys/project-base](https://github.com/shopsys/p
     - this will allow styles to be upgraded via `composer update` in project implementations
 - grunt now compiles less files also from [shopsys/framework](https://github.com/shopsys/framework) package
 - updated phpunit/phpunit to version 7
-- phing target dump-translations does not delete messages, that are not found in translated directories 
-- docs updated in order to provide up-to-date information about the current project state 
+- phing target dump-translations does not delete messages, that are not found in translated directories
+- docs updated in order to provide up-to-date information about the current project state
 - installation guides: updated instructions for creating new project from Shopsys Framework sources
 - basics-about-package-architecture.md updated to reflect current architecture state
 - updated doctrine/doctrine-fixtures-bundle
@@ -1292,22 +1292,22 @@ Before we managed to implement monorepo for our packages, we had slightly differ
 That's why is this section formatted differently.
 
 ### [shopsys/http-smoke-testing]
-#### [1.1.0](https://github.com/shopsys/http-smoke-testing/compare/v1.0.0...v1.1.0) - 2017-11-01 
+#### [1.1.0](https://github.com/shopsys/http-smoke-testing/compare/v1.0.0...v1.1.0) - 2017-11-01
 ##### Added
 - [CONTRIBUTING.md](https://github.com/shopsys/http-smoke-testing/blob/master/CONTRIBUTING.md)
- 
-##### Changed 
+
+##### Changed
 - Improved IDE auto-completion when customizing test cases via [`RouteConfig`](https://github.com/shopsys/http-smoke-testing/blob/master/src/RouteConfig.php)
-    - Methods `changeDefaultRequestDataSet()` and `addExtraRequestDataSet()` now return new interface [`RequestDataSetInterface`](https://github.com/shopsys/http-smoke-testing/blob/master/src/RequestDataSetConfig.php). 
-    - This new interface includes only a subset of methods in [`RequestDataSet`](https://github.com/shopsys/http-smoke-testing/blob/master/src/RequestDataSet.php) that is relevant to test case customization. 
- 
-#### [1.0.1](https://github.com/shopsys/http-smoke-testing/compare/v1.0.0...v1.0.1) - 2017-07-03 
-##### Added 
+    - Methods `changeDefaultRequestDataSet()` and `addExtraRequestDataSet()` now return new interface [`RequestDataSetInterface`](https://github.com/shopsys/http-smoke-testing/blob/master/src/RequestDataSetConfig.php).
+    - This new interface includes only a subset of methods in [`RequestDataSet`](https://github.com/shopsys/http-smoke-testing/blob/master/src/RequestDataSet.php) that is relevant to test case customization.
+
+#### [1.0.1](https://github.com/shopsys/http-smoke-testing/compare/v1.0.0...v1.0.1) - 2017-07-03
+##### Added
 - Unit test for RequestDataSetGenerator class
 - This Changelog
- 
-#### 1.0.0 - 2017-05-23 
-##### Added 
+
+#### 1.0.0 - 2017-05-23
+##### Added
 - Extracted HTTP smoke testing functionality from [Shopsys Framework](http://www.shopsys-framework.com/)
 - `.travis.yml` file with Travis CI configuration
 
@@ -1348,24 +1348,24 @@ That's why is this section formatted differently.
 
 #### [0.5.0](https://github.com/shopsys/product-feed-heureka/compare/v0.4.2...v0.5.0) - 2017-10-05
 ##### Added
-- logic of Heureka categorization moved from [Shopsys Framework](https://www.shopsys-framework.com/) core repository 
+- logic of Heureka categorization moved from [Shopsys Framework](https://www.shopsys-framework.com/) core repository
     - Heureka categories are downloaded everyday via CRON module
     - extends CRUD of categories for assigning Heureka categories to categories on your online store
     - contains demo data fixtures
 
 #### [0.4.2](https://github.com/shopsys/product-feed-heureka/compare/v0.4.1...v0.4.2) - 2017-10-05
 ##### Added
-- support for shopsys/plugin-interface 0.3.0 
-- support for shopsys/product-feed-interface 0.5.0 
+- support for shopsys/plugin-interface 0.3.0
+- support for shopsys/product-feed-interface 0.5.0
 
 #### [0.4.1](https://github.com/shopsys/product-feed-heureka/compare/v0.4.0...v0.4.1) - 2017-09-25
 ##### Added
 - [CONTRIBUTING.md](https://github.com/shopsys/product-feed-heureka/blob/master/CONTRIBUTING.md)
 ##### Changed
 - Dependency [product-feed-interface](https://github.com/shopsys/product-feed-interface) upgraded from ~0.3.0 to ~0.4.0
-- [`HeurekaFeedConfig`](https://github.com/shopsys/product-feed-heureka/blob/master/src/HeurekaFeedConfig.php) now filters not sellable products 
-- [`HeurekaFeedConfig`](https://github.com/shopsys/product-feed-heureka/blob/master/src/HeurekaFeedConfig.php) implemented method `getAdditionalData()` 
-- [`TestStandardFeedItem`](https://github.com/shopsys/product-feed-heureka/blob/master/tests/TestStandardFeedItem.php) implemented method `getCurrencyCode()` 
+- [`HeurekaFeedConfig`](https://github.com/shopsys/product-feed-heureka/blob/master/src/HeurekaFeedConfig.php) now filters not sellable products
+- [`HeurekaFeedConfig`](https://github.com/shopsys/product-feed-heureka/blob/master/src/HeurekaFeedConfig.php) implemented method `getAdditionalData()`
+- [`TestStandardFeedItem`](https://github.com/shopsys/product-feed-heureka/blob/master/tests/TestStandardFeedItem.php) implemented method `getCurrencyCode()`
 
 #### [0.4.0](https://github.com/shopsys/product-feed-heureka/compare/v0.3.0...v0.4.0) - 2017-09-12
 ##### Added
@@ -1374,94 +1374,94 @@ That's why is this section formatted differently.
     - twig/twig 1.34.0
     - twig/extensions 1.3.0
 - New automatic test that is controlling right behavior of plugin
-- Added travis build icon into [README.md](https://github.com/shopsys/product-feed-heureka/blob/master/README.md) 
+- Added travis build icon into [README.md](https://github.com/shopsys/product-feed-heureka/blob/master/README.md)
 ##### Changed
-- Dependency [shopsys/product-feed-interface] upgraded from ~0.2.0 to ~0.3.0 
+- Dependency [shopsys/product-feed-interface] upgraded from ~0.2.0 to ~0.3.0
 ##### Removed
-- `HeurekaFeedConfig::getFeedItemRepository()` 
+- `HeurekaFeedConfig::getFeedItemRepository()`
 
 #### [0.3.0](https://github.com/shopsys/product-feed-heureka/compare/v0.2.0...v0.3.0) - 2017-08-09
 ##### Added
-- This Changelog 
-- UPGRADE.md 
-- Plugin demo data (cpc for 2 domains) 
+- This Changelog
+- UPGRADE.md
+- Plugin demo data (cpc for 2 domains)
 ##### Changed
-- Dependency [shopsys/plugin-interface] upgraded from ~0.1.0 to ~0.2.0 
+- Dependency [shopsys/plugin-interface] upgraded from ~0.1.0 to ~0.2.0
 
 #### [0.2.0](https://github.com/shopsys/product-feed-heureka/compare/v0.1.0...v0.2.0) - 2017-08-02
 ##### Added
-- Retrieving custom plugin data 
+- Retrieving custom plugin data
     - Heureka category names
     - MAX_CPC (Maximum price per click)
-- Extension of product form with custom field for MAX_CPC 
-- New dependencies 
+- Extension of product form with custom field for MAX_CPC
+- New dependencies
     - [shopsys/plugin-interface ~0.1.0](https://github.com/shopsys/plugin-interface)
     - [shopsys/form-types-bundle ~0.1.0](https://github.com/shopsys/form-types-bundle)
     - [symfony/form ^3.0](https://github.com/symfony/form)
     - [symfony/translation ^3.0](https://github.com/symfony/translation)
     - [symfony/validator ^3.0](https://github.com/symfony/validator)
 ##### Changed
-- Dependency [shopsys/product-feed-interface] upgraded from ~0.1.0 to ~0.2.0 
+- Dependency [shopsys/product-feed-interface] upgraded from ~0.1.0 to ~0.2.0
 
 ### [shopsys/product-feed-zbozi]
 #### [0.5.0](https://github.com/shopsys/product-feed-zbozi/compare/v0.4.2...v0.5.0) - 2018-02-19
 ##### Changed
-- services.yml updated to Symfony 3.4 best practices 
-- updated shopsys/form-types-bundle to version 0.2.0 
+- services.yml updated to Symfony 3.4 best practices
+- updated shopsys/form-types-bundle to version 0.2.0
 
 #### [0.4.2](https://github.com/shopsys/product-feed-zbozi/compare/v0.4.1...v0.4.2) - 2017-10-04
 ##### Added
-- support for shopsys/plugin-interface 0.3.0 
-- support for shopsys/product-feed-interface 0.5.0 
+- support for shopsys/plugin-interface 0.3.0
+- support for shopsys/product-feed-interface 0.5.0
 
 #### [0.4.1](https://github.com/shopsys/product-feed-zbozi/compare/v0.4.0...v0.4.1) - 2017-09-25
 ##### Added
 - [CONTRIBUTING.md](https://github.com/shopsys/product-feed-zbozi/blob/master/CONTRIBUTING.md)
 ##### Changed
-- Dependency [shopsys/product-feed-interface] upgraded from ~0.3.0 to ~0.4.0 
-- [`ZboziFeedConfig`](https://github.com/shopsys/product-feed-zbozi/blob/master/src/ZboziFeedConfig.php) now filters not sellable products 
-- [`ZboziFeedConfig`](https://github.com/shopsys/product-feed-zbozi/blob/master/src/ZboziFeedConfig.php) implemented method `getAdditionalData()` 
-- [`TestStandardFeedItem`](https://github.com/shopsys/product-feed-zbozi/blob/master/tests/TestStandardFeedItem.php) implemented method `getCurrencyCode()` 
+- Dependency [shopsys/product-feed-interface] upgraded from ~0.3.0 to ~0.4.0
+- [`ZboziFeedConfig`](https://github.com/shopsys/product-feed-zbozi/blob/master/src/ZboziFeedConfig.php) now filters not sellable products
+- [`ZboziFeedConfig`](https://github.com/shopsys/product-feed-zbozi/blob/master/src/ZboziFeedConfig.php) implemented method `getAdditionalData()`
+- [`TestStandardFeedItem`](https://github.com/shopsys/product-feed-zbozi/blob/master/tests/TestStandardFeedItem.php) implemented method `getCurrencyCode()`
 
 #### [0.4.0](https://github.com/shopsys/product-feed-zbozi/compare/v0.3.0...v0.4.0) - 2017-09-12
 ##### Added
-- New dependencies for dev 
+- New dependencies for dev
     - phpunit/phpunit >=5.0.0,<6.0
     - twig/twig 1.34.0
     - twig/extensions 1.3.0
 - New automatic test that is controlling right behavior of plugin
-- Added travis build icon into [README.md](https://github.com/shopsys/product-feed-zbozi/blob/master/README.md) 
+- Added travis build icon into [README.md](https://github.com/shopsys/product-feed-zbozi/blob/master/README.md)
 ##### Changed
-- Dependency [product-feed-interface](https://github.com/shopsys/product-feed-zbozi/blob/master/shopsys/product-feed-interface) upgraded from ~0.2.0 to ~0.3.0 
+- Dependency [product-feed-interface](https://github.com/shopsys/product-feed-zbozi/blob/master/shopsys/product-feed-interface) upgraded from ~0.2.0 to ~0.3.0
 ##### Removed
-- `ZboziFeedConfig::getFeedItemRepository()` 
+- `ZboziFeedConfig::getFeedItemRepository()`
 
 #### [0.3.0](https://github.com/shopsys/product-feed-zbozi/compare/v0.2.0...v0.3.0) - 2017-09-06
 ##### Added
-- This Changelog 
-- UPGRADE.md 
-- Plugin demo data (cpc, cpc_search and show for 2 domains) 
+- This Changelog
+- UPGRADE.md
+- Plugin demo data (cpc, cpc_search and show for 2 domains)
 ##### Changed
-- Dependency [plugin-interface](https://github.com/shopsys/plugin-interface) upgraded from ~0.1.0 to ~0.2.0 
+- Dependency [plugin-interface](https://github.com/shopsys/plugin-interface) upgraded from ~0.1.0 to ~0.2.0
 
 #### [0.2.0](https://github.com/shopsys/product-feed-zbozi/compare/v0.1.0...v0.2.0) - 2017-08-08
 ##### Added
-- Retrieving custom plugin data and extension of product form with custom fields 
+- Retrieving custom plugin data and extension of product form with custom fields
     - show (offer in feeds)
     - cpc (maximum price per click)
     - cpc_search (maximum price per click in offers)
-- New dependencies 
+- New dependencies
     - [shopsys/plugin-interface ~0.1.0](https://github.com/shopsys/plugin-interface)
     - [shopsys/form-types-bundle ~0.1.0](https://github.com/shopsys/form-types-bundle)
     - [symfony/form ^3.0](https://github.com/symfony/form)
     - [symfony/translation ^3.0](https://github.com/symfony/translation)
     - [symfony/validator ^3.0](https://github.com/symfony/validator)
 ##### Changed
-- Dependency [product-feed-interface](https://github.com/shopsys/product-feed-zbozi/blob/master/shopsys/product-feed-interface) upgraded from ~0.1.0 to ~0.2.0 
+- Dependency [product-feed-interface](https://github.com/shopsys/product-feed-zbozi/blob/master/shopsys/product-feed-interface) upgraded from ~0.1.0 to ~0.2.0
 
 #### 0.1.0 - 2017-07-13
 ##### Added
-- Extracted Zboží.cz product feed plugin from [Shopsys Framework](http://www.shopsys-framework.com/) 
+- Extracted Zboží.cz product feed plugin from [Shopsys Framework](http://www.shopsys-framework.com/)
 - `.travis.yml` file with Travis CI configuration
 
 ### [shopsys/product-feed-heureka-delivery]
@@ -1517,15 +1517,15 @@ That's why is this section formatted differently.
 
 ### [shopsys/product-feed-interface]
 #### [0.5.0](https://github.com/shopsys/product-feed-interface/compare/v0.4.0...v0.5.0) - 2017-10-04
-- [`StandardFeedItemInterface`](src/StandardFeedItemInterface.php) contains ID of its main category 
+- [`StandardFeedItemInterface`](src/StandardFeedItemInterface.php) contains ID of its main category
 
 #### [0.4.0](https://github.com/shopsys/product-feed-interface/compare/v0.3.0...v0.4.0) - 2017-09-25
 ##### Added
-- [CONTRIBUTING.md](CONTRIBUTING.md) 
-- [template for github pull requests](docs/PULL_REQUEST_TEMPLATE.md) 
-- [`StandardFeedItemInterface`](./packages/product-feed-interface/src/StandardFeedItemInterface.php) has new method `isSellingDenied()` 
-- [`FeedConfigInterface`](./packages/product-feed-interface/src/FeedConfigInterface.php) has new method `getAdditionalInformation()` 
-- [`StandardFeedItemInterface`](./packages/product-feed-interface/src/StandardFeedItemInterface.php) has new method `getCurrencyShortcut()` 
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [template for github pull requests](docs/PULL_REQUEST_TEMPLATE.md)
+- [`StandardFeedItemInterface`](./packages/product-feed-interface/src/StandardFeedItemInterface.php) has new method `isSellingDenied()`
+- [`FeedConfigInterface`](./packages/product-feed-interface/src/FeedConfigInterface.php) has new method `getAdditionalInformation()`
+- [`StandardFeedItemInterface`](./packages/product-feed-interface/src/StandardFeedItemInterface.php) has new method `getCurrencyShortcut()`
 
 #### [0.3.0](https://github.com/shopsys/product-feed-interface/compare/v0.2.1...v0.3.0) - 2017-09-12
 ##### Added
@@ -1558,13 +1558,13 @@ That's why is this section formatted differently.
  - [CONTRIBUTING.md](https://github.com/shopsys/plugin-interface/blob/master/CONTRIBUTING.md)
  - `DataStorageInterface` can return all saved data via `getAll()`
  - `IteratedCronModuleInterface` and `SimpleCronModuleInterface`
- 
+
 #### [0.2.0](https://github.com/shopsys/plugin-interface/compare/v0.1.0...v0.2.0) - 2017-09-06
 ##### Added
  - This Changelog
  - interface for loading plugin's demo data
      - `PluginDataFixtureInterface`
- 
+
 #### 0.1.0 - 2017-08-04
 ##### Added
  - Package of interfaces providing compatibility between [Shopsys Framework](https://www.shopsys-framework.com) and plugins
@@ -1581,7 +1581,7 @@ That's why is this section formatted differently.
 ##### Added
 - PHPStan support (@mhujer)
     - currently analysing source code by level 0
-- PHP 7.2 support 
+- PHP 7.2 support
 - Uniformity of PHP and Postgres timezones is checked during the build
 - in `TEST` environment `Domain` is created with all instances of `DomainConfig` having URL set to `%overwrite_domain_url%`
     - parameter is set only in `parameters_test.yml` as it is only relevant in `TEST` environment
@@ -1589,35 +1589,35 @@ That's why is this section formatted differently.
     - overwriting the domain URL is necessary for Selenium acceptance tests running in Docker
 - LegalConditionsSetting: added privacy policy article selection
     - customers need to agree with privacy policy while registring, sending contact form and completing order process
-- SubscriptionFormType: added required privacy policy agreement checkbox 
-- subscription form: added link to privacy policy agreement article 
-- NewsletterController now exports date of subscription to newsletter 
-- `services_command.yml` to set Commands as services 
+- SubscriptionFormType: added required privacy policy agreement checkbox
+- subscription form: added link to privacy policy agreement article
+- NewsletterController now exports date of subscription to newsletter
+- `services_command.yml` to set Commands as services
 - [docker-troubleshooting.md](https://github.com/shopsys/shopsys/blob/master/docs/docker/docker-troubleshooting.md): added to help developers with common problems that occurs using docker for development
 - Newsletter subscriber is distinguished by domain
     - Admin: E-mail newsletter now exports e-mails to csv for each domain separatedly
-- DatabaseSearching: added getFullTextLikeSearchString() 
+- DatabaseSearching: added getFullTextLikeSearchString()
 - admin: E-mail newsletter: now contains list of registered e-mails with ability to delete them
 
 ##### Changed
-- cache is cleared before PHPUnit tests only when run via [Console Commands for Application Management (Phing Targets)](https://github.com/shopsys/shopsys/blob/master/docs/introduction/console-commands-for-application-management-phing-targets.md), not when run using `phpunit` directly 
-- PHPUnit tests now fail on warning 
-- end of support of PHP 7.0 
-- renamed TermsAndCondition to LegalCondition to avoid multiple classes for legal conditions agreements 
+- cache is cleared before PHPUnit tests only when run via [Console Commands for Application Management (Phing Targets)](https://github.com/shopsys/shopsys/blob/master/docs/introduction/console-commands-for-application-management-phing-targets.md), not when run using `phpunit` directly
+- PHPUnit tests now fail on warning
+- end of support of PHP 7.0
+- renamed TermsAndCondition to LegalCondition to avoid multiple classes for legal conditions agreements
 - emails with empty subject or body are no longer sent
-- postgresql-client is installed in [php-fpm/dockerfile](./project-base/docker/php-fpm/Dockerfile) for `pg_dump` function 
+- postgresql-client is installed in [php-fpm/dockerfile](./project-base/docker/php-fpm/Dockerfile) for `pg_dump` function
     - postgresql was downgraded to 9.5 because of compatibility with postgresql-client
-- docker-compose: added container_name to smtp-server and adminer 
-- configuration of Docker Compose tweaked for easier development 
+- docker-compose: added container_name to smtp-server and adminer
+- configuration of Docker Compose tweaked for easier development
     - `docker-compose.yml` is added to `.gitignore` for everyone to be able to make individual changes
     - the predefined templates are now in `/docker/conf` directory
     - `adminer` container uses port 1100 by default (as 1000 is often already in use)
     - Docker Sync is used only in configuration for MacOS as only there it is needed
     - `postgres` container is created with a volume for data persistence (in `var/postgres-data`)
     - see documentation of [Installation Using Docker](https://github.com/shopsys/shopsys/blob/master/docs/installation/installation-using-docker.md) for details
-- default parameters in `parameters.yml.dist` and `parameters_test.yml.dist` are for Docker installation (instead of native) 
-- Front/NewsletterController: extracted duplicit rendering and add return typehints 
-- Symfony updated to version 3.4 
+- default parameters in `parameters.yml.dist` and `parameters_test.yml.dist` are for Docker installation (instead of native)
+- Front/NewsletterController: extracted duplicit rendering and add return typehints
+- Symfony updated to version 3.4
     - autowiring is now done via Symfony PSR-4
     - services now use FQN as naming convention
     - services are private by default
@@ -1626,40 +1626,40 @@ That's why is this section formatted differently.
     - all inline calls of services changed to use FQN
     - services no longer required in services.yml have been removed
     - services instanced after DI container creation are set as synthetic
-- users and administrators are logged out of all the sessions except the current one on password change (this is required in Symfony 4) 
-- running Phing without parameter now shows list of available targets instead of building application 
-- updated presta/sitemap-bundle to version 1.5.2 in order to avoid deprecated calls 
+- users and administrators are logged out of all the sessions except the current one on password change (this is required in Symfony 4)
+- running Phing without parameter now shows list of available targets instead of building application
+- updated presta/sitemap-bundle to version 1.5.2 in order to avoid deprecated calls
  - updated SitemapListener to avoid using of deprecated SitemapListenerInterface
-- updated symfony/swiftmailer-bundle to version 3.2.0 in order to fix deprecated calls 
-- all calls of Form::isValid() are called only on submitted forms in order to prevent deprecated call 
+- updated symfony/swiftmailer-bundle to version 3.2.0 in order to fix deprecated calls
+- all calls of Form::isValid() are called only on submitted forms in order to prevent deprecated call
 - symlink so root/bin acts like root/project-base/bin
 - all commands are now services, that are lazy loaded with autowired dependencies
-- NewsletterFacadeTest: renamed properties to match class name 
+- NewsletterFacadeTest: renamed properties to match class name
 
 ##### Fixed
 - `BrandFacade::create()` now generates friendly URL for all domains (@sspooky13)
 - `Admin/HeurekaController::embedWidgetAction()` moved to new `Front/HeurekaController` as the action is called in FE template
 - PHPUnit tests do not fail on Windows machine with PHP 7.0 because of excessively long file paths
-- customizeBundle.js: on-submit actions are no longer triggered when form validation error occurs 
-- fixed google product feed availability values by updating it to v0.1.2 
+- customizeBundle.js: on-submit actions are no longer triggered when form validation error occurs
+- fixed google product feed availability values by updating it to v0.1.2
 - reloading of order preview now calls `Shopsys.register.registerNewContent()` (@petr.kadlec)
 - CurrentPromoCodeFacace: promo code is not searched in database if code is empty (@petr.kadlec)
 - CategoryRepository::getCategoriesWithVisibleChildren() checks visibility of children (@petr.kadlec)
-- added missing migration for privacy policy article 
-- OrderStatusFilter: show names in labels instead of ids 
+- added missing migration for privacy policy article
+- OrderStatusFilter: show names in labels instead of ids
 - legal conditions text in order 3rd step is not HTML escaped anymore
 - product search now does not cause 500 error when the search string ends with backslash
 
 ##### Removed
-- PHPStorm Inspect is no longer used for static analysis of source code 
-- Phing targets standards-ci and standards-ci-diff because they were redundant to standards and standards-diff targets 
-- deprecated packages `symplify/controller-autowire` and `symplify/default-autowire` 
+- PHPStorm Inspect is no longer used for static analysis of source code
+- Phing targets standards-ci and standards-ci-diff because they were redundant to standards and standards-diff targets
+- deprecated packages `symplify/controller-autowire` and `symplify/default-autowire`
 
 #### 6.0.0-beta20 - 2017-12-11
 - released only in closed beta
 
 ##### Changed
-- Docker `nginx.conf` has been upgraded with better performance settings 
+- Docker `nginx.conf` has been upgraded with better performance settings
     - JavaScript and CSS files are compressed with GZip
     - static content has cache headers set in order to leverage browser cache
 ##### Fixed
@@ -1673,7 +1673,7 @@ That's why is this section formatted differently.
 - released only in closed beta
 
 ##### Fixed
-- updated symfony/symfony to v3.2.14 in order to avoid known security vulnerabilities 
+- updated symfony/symfony to v3.2.14 in order to avoid known security vulnerabilities
 
 #### 6.0.0-beta19.1 - 2017-11-21
 - released only in closed beta
@@ -1685,13 +1685,13 @@ That's why is this section formatted differently.
 - released only in closed beta
 
 ##### Added
-- size of performance data fixtures and limits for performance testing are now configurable via parameters defined in [`parameters_common.yml`](./project-base/app/config/parameters_common.yml) 
-- performance tests report database query counts 
+- size of performance data fixtures and limits for performance testing are now configurable via parameters defined in [`parameters_common.yml`](./project-base/app/config/parameters_common.yml)
+- performance tests report database query counts
 - UserDataFixture: alias for SettingValueDataFixture to fix [PHP bug #66862](https://bugs.php.net/bug.php?id=66862)
 
 ##### Changed
-- parameters that are in `parameters.yml` or `parameters_test.yml` that are not in their `.dist` templates are not removed during `composer install` anymore 
-- customer creating controllers are not catching exception for duplicate email, it is not necessary since it is done by UniqueEmail constraint now 
+- parameters that are in `parameters.yml` or `parameters_test.yml` that are not in their `.dist` templates are not removed during `composer install` anymore
+- customer creating controllers are not catching exception for duplicate email, it is not necessary since it is done by UniqueEmail constraint now
 - input "remember me" in login form is encapsulated by its label for better UX
 
 #### 6.0.0-beta18 - 2017-10-19
@@ -1700,21 +1700,21 @@ That's why is this section formatted differently.
 ##### Added
 - [coding standards documentation](https://github.com/shopsys/shopsys/blob/master/docs/contributing/coding-standards.md)
 - acceptance tests asserting successful image upload in admin for product, transport and payment
-- Docker based server stack for easier installation and development 
+- Docker based server stack for easier installation and development
     - see [Installation Using Docker](https://github.com/shopsys/shopsys/blob/master/docs/installation/installation-using-docker.md) for details
-- plugins can now extend the CRUD of categories (using `CategoryFormType`) 
+- plugins can now extend the CRUD of categories (using `CategoryFormType`)
 
 ##### Changed
-- cache deletion before running unit tests is now done using `Symfony\Filesystem` instead of using console command 
+- cache deletion before running unit tests is now done using `Symfony\Filesystem` instead of using console command
     - deleting via console command `cache:clear` is slow, because it creates whole application container first and then deletes all cache created in process
 - Windows locales list: use more tolerant name for Czech locale
     - in Windows 2017 Fall Creators Update the locale name was changed from "Czech_Czech Republic" to "Czech_Czechia"
     - name "Czech" is acceptable in all Windows versions
-- interfaces for CRON modules moved to [shopsys/plugin-interface](https://github.com/shopsys/plugin-interface) 
+- interfaces for CRON modules moved to [shopsys/plugin-interface](https://github.com/shopsys/plugin-interface)
 - `ImageDemoCommand` now prompts to truncate "images" db table when it is not empty before new demo images are loaded
 
 ##### Deleted
-- logic of Heureka categorization moved to [shopsys/product-feed-heureka](https://github.com/shopsys/product-feed-heureka) 
+- logic of Heureka categorization moved to [shopsys/product-feed-heureka](https://github.com/shopsys/product-feed-heureka)
     - all your current Heureka category data will be migrated into the new structure
 
 ##### Fixed
@@ -1724,44 +1724,44 @@ That's why is this section formatted differently.
 - released only in closed beta
 
 ##### Added
-- MIT license 
+- MIT license
 - phing targets `eslint-check`, `eslint-check-diff`, `eslint-fix` and `eslint-fix-diff` to check and fix coding standards in JS files (@sspooky13)
     - executed as a part of targets `standards`, `standards-diff`, `standards-fix` and `standards-fix-diff`
-- [product feed plugin for Google](https://github.com/shopsys/product-feed-google/) 
+- [product feed plugin for Google](https://github.com/shopsys/product-feed-google/)
 - new article explaining [Basics About Package Architecture](https://github.com/shopsys/shopsys/blob/master/docs/introduction/basics-about-package-architecture.md)
 
 ##### Changed
-- `StandardFeedItemRepository`: now selects available products instead of sellable, filtering of not sellable products is made in product plugins 
+- `StandardFeedItemRepository`: now selects available products instead of sellable, filtering of not sellable products is made in product plugins
 - implementations of `StandardFeedItemInterface` now must have implemented methods `isSellingDenied()` and `getCurrencyCode()`
-- implementations of `FeedConfigInterface` now must have implemented method `getAdditionalInformation()` 
+- implementations of `FeedConfigInterface` now must have implemented method `getAdditionalInformation()`
 
 #### 6.0.0-beta16 - 2017-09-19
 - released only in closed beta
 
 ##### Added
-- new command `shopsys:plugin-data-fixtures:load` for loading demo data from plugins 
+- new command `shopsys:plugin-data-fixtures:load` for loading demo data from plugins
     - called during build of demo database
-- new documentation about Shopsys Framework model architecture 
+- new documentation about Shopsys Framework model architecture
 - `FeedItemRepositoryInterface`
     - moved from [shopsys/product-feed-interface](https://github.com/shopsys/product-feed-interface/)
 - [template for github pull requests](https://github.com/shopsys/shopsys/blob/master/docs/PULL_REQUEST_TEMPLATE.md)
 
 ##### Changed
-- dependency [shopsys/plugin-interface](https://github.com/shopsys/plugin-interface/) upgraded from 0.1.0 to 0.2.0 
-- dependency [shopsys/product-feed-heureka](https://github.com/shopsys/product-feed-heureka/) upgraded from 0.2.0 to 0.4.0 
-- dependency [shopsys/product-feed-zbozi](https://github.com/shopsys/product-feed-zbozi/) upgraded from 0.2.0 to 0.4.0 
+- dependency [shopsys/plugin-interface](https://github.com/shopsys/plugin-interface/) upgraded from 0.1.0 to 0.2.0
+- dependency [shopsys/product-feed-heureka](https://github.com/shopsys/product-feed-heureka/) upgraded from 0.2.0 to 0.4.0
+- dependency [shopsys/product-feed-zbozi](https://github.com/shopsys/product-feed-zbozi/) upgraded from 0.2.0 to 0.4.0
 - dependency [shopsys/product-feed-heureka-delivery](https://github.com/shopsys/product-feed-heureka-delivery/) upgraded from 0.1.1 to 0.2.0
 - dependency [shopsys/product-feed-interface](https://github.com/shopsys/product-feed-interface/) upgraded from 0.2.1 to 0.3.0
 - it is no longer needed to redeclare feed plugin's implementations of `FeedConfigInterface` in `services.yml`
     - decision about providing proper instance of `FeedItemRepositoryInterface` is made in `FeedConfigFacade`
-- FeedConfigRepository renamed to `FeedConfigRegistry` 
+- FeedConfigRepository renamed to `FeedConfigRegistry`
     - it is not fetching data from Doctrine as other repositories, it only serves as a container for registering services of specific type
     - similar to `PluginDataFixtureRegistry` or `PluginCrudExtensionRegistry`
-- `UknownPluginDataFixtureException` renamed to `UnknownPluginCrudExtensionTypeException` because of a typo 
+- `UknownPluginDataFixtureException` renamed to `UnknownPluginCrudExtensionTypeException` because of a typo
 - `FeedConfigRegistry` now contains all FeedConfigs in one array (indexed by type)
     - definition and assertion of known feed configs types moved from [`RegisterProductFeedConfigsCompilerPass`](./src/Shopsys/ShopBundle/DependencyInjection/Compiler/RegisterProductFeedConfigsCompilerPass.php) to `FeedConfigRegistry`
     - changed message and arguments of `UnknownFeedConfigTypeException`
-- renamed methods working with standard feeds only to be more expressive 
+- renamed methods working with standard feeds only to be more expressive
     - renamed `FeedConfigFacade::getFeedConfigs()` to `getStandardFeedConfigs()`
     - renamed `FeedFacade::generateFeedsIteratively()` to `generateStandardFeedsIteratively()`
     - renamed `FeedGenerationConfigFactory::createAll()` to `createAllForStandardFeeds()`
@@ -1771,19 +1771,19 @@ That's why is this section formatted differently.
     - it now extends `CollectionType` instead of `ChoiceType`
     - it loads only those categories that are needed to show all selected categories in a tree, not all of them
     - collapsed categories can be loaded via AJAX
-- `CategoryRepository::findById()` now uses `find()` method of Doctrine repository instead of query builder so it can use cached results 
-- it is possible to mention occurrences of an image size in [`images.yml`](./project-base/src/Shopsys/ShopBundle/Resources/config/images.yml) 
+- `CategoryRepository::findById()` now uses `find()` method of Doctrine repository instead of query builder so it can use cached results
+- it is possible to mention occurrences of an image size in [`images.yml`](./project-base/src/Shopsys/ShopBundle/Resources/config/images.yml)
     - previously they were directly in `ImageController`
     - they are not translatable anymore (too hard to maintain)
 
 ##### Removed
 - email for error reporting removed from [`parameters_test.yml.dist`](./project-base/app/config/parameters_test.yml.dist)
-- removed unused private properties from classes 
-- removed `CategoriesTypeTransformerFactory` 
+- removed unused private properties from classes
+- removed `CategoriesTypeTransformerFactory`
     - the `CategoriesTypeTransformer` can be fully autowired after deletion of `$domainId`
 
 ##### Fixed
-- [`InlineEditPage::createNewRow()`](./project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/InlineEditPage.php) now waits for AJAX to complete 
+- [`InlineEditPage::createNewRow()`](./project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/InlineEditPage.php) now waits for AJAX to complete
     - fixes false negatives of acceptance test [`PromoCodeInlineEditCest::testPromoCodeCreate()`](./project-base/tests/ShopBundle/Acceptance/acceptance/PromoCodeInlineEditCest.php)
 
 #### 6.0.0-beta15 - 2017-08-31
@@ -1847,9 +1847,9 @@ That's why is this section formatted differently.
 
 ##### Changed
 - `OrmJoinColumnRequireNullableFixer` marked as *risky* (@sustmi)
-- [#11](https://github.com/shopsys/coding-standards/pull/11) dropped support of PHP 7.0 
+- [#11](https://github.com/shopsys/coding-standards/pull/11) dropped support of PHP 7.0
 - [#12](https://github.com/shopsys/coding-standards/pull/12/) [EasyCodingStandard](https://github.com/Symplify/EasyCodingStandard) is now used (@TomasVotruba)
-    - the tool encapsulates PHP-CS-Fixer and PHP_CodeSniffer 
+    - the tool encapsulates PHP-CS-Fixer and PHP_CodeSniffer
     - rules configuration is now unified in single file - [`easy-coding-standard.neon`](./packages/coding-standards/easy-coding-standard.neon)
     - the option `ignore-whitespace` for rules checking method and class length is not available anymore
         - the limits were increased to 550 (class length) and 60 (method length)
@@ -1864,8 +1864,8 @@ That's why is this section formatted differently.
 
 #### [3.1.0](https://github.com/shopsys/coding-standards/compare/v3.0.2...v3.1.0) - 2017-10-12
 ##### Added
-- This changelog 
-- [Description of used coding standards rules](./packages/coding-standards/docs/description-of-used-coding-standards-rules.md) 
+- This changelog
+- [Description of used coding standards rules](./packages/coding-standards/docs/description-of-used-coding-standards-rules.md)
 - New rules in [phpcs-fixer ruleset](./packages/coding-standards/build/phpcs-fixer.php_cs):
     - combine_consecutive_unsets
     - function_typehint_space
@@ -1890,8 +1890,8 @@ That's why is this section formatted differently.
     - whitespace_after_comma_in_array
 
 ##### Changed
-- friendsofphp/php-cs-fixer upgraded from version 2.1 to version 2.3 
-- [phpcs-fixer ruleset](./build/phpcs-fixer.php_cs) 
+- friendsofphp/php-cs-fixer upgraded from version 2.1 to version 2.3
+- [phpcs-fixer ruleset](./build/phpcs-fixer.php_cs)
     - replaced deprecated "hash_to_slash_comment" rule with "single_line_comment_style" rule
     - custom NoUnusedImportsFixer replaced with standard "no_unused_imports" rule
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Shopsys Framework
 [![Build Status](https://travis-ci.org/shopsys/shopsys.svg?branch=master)](https://travis-ci.org/shopsys/shopsys)
 
-Shopsys Framework is a **fully functional ecommerce platform for businesses transitioning into tech-companies with their own software development team**. 
+Shopsys Framework is a **fully functional ecommerce platform for businesses transitioning into tech-companies with their own software development team**.
 It contains the most common B2C and B2B features for online stores, and its infrastructure is prepared for high scalability.
 
-Shopsys Framework is **the fruit of our 15 years of experience in creating custom-made online stores and it’s dedicated to best in-house devs teams who work with online stores with tens of millions of Euros of turnover per year**. 
+Shopsys Framework is **the fruit of our 15 years of experience in creating custom-made online stores and it’s dedicated to best in-house devs teams who work with online stores with tens of millions of Euros of turnover per year**.
 
-Our platform’s **architecture is modern and corresponds to the latest trends in the production of software for leading ecommerce solutions**. 
-Deployment and scaling of our system are comfortable thanks to the use of the containerization and orchestration concepts (**Docker, Kubernetes**). 
+Our platform’s **architecture is modern and corresponds to the latest trends in the production of software for leading ecommerce solutions**.
+Deployment and scaling of our system are comfortable thanks to the use of the containerization and orchestration concepts (**Docker, Kubernetes**).
 The platform is based on one of the best PHP frameworks on the market - **Symfony**.
 
 ## Shopsys Framework Infrastructure
@@ -38,7 +38,7 @@ Shopsys Framework is fully functional e-commerce platform with all basic functio
 * Full core upgradability
 * GDPR compliance
 * Preparation for scalability
-* Manifest for orchestration via [Kubernetes](./docs/kubernetes/introduction-to-kubernetes.md) 
+* Manifest for orchestration via [Kubernetes](./docs/kubernetes/introduction-to-kubernetes.md)
 * Support to easier [deployment to Google Cloud via Terraform](./docs/kubernetes/how-to-deploy-ssfw-to-google-cloud-platform.md)
 
 ### Plans for next releases
@@ -80,7 +80,7 @@ If you have some ideas or you want to help to improve Shopsys Framework, let us 
 We are looking forward to your insights, feedback, and improvements.
 Thank you for helping us making Shopsys Framework better.
 
-You can find all the necessary information in our [Contribution Guide](./CONTRIBUTING.md). 
+You can find all the necessary information in our [Contribution Guide](./CONTRIBUTING.md).
 
 ## Support
 What to do when you are in troubles or need some help?
@@ -94,14 +94,14 @@ Or ultimately, just [report an issue](https://github.com/shopsys/shopsys/issues/
 ## License
 We distribute our main parts of Shopsys Framework
 [shopsys/project-base](https://github.com/shopsys/project-base) and
-[shopsys/framework](https://github.com/shopsys/framework) under two different licenses: 
+[shopsys/framework](https://github.com/shopsys/framework) under two different licenses:
 
 * [Community License](./LICENSE) in MIT style for growing small to mid-size e-commerce sites with total online sales less than 12.000.000 EUR / year (3.000.000 EUR / quarter)
 * Commercial License
 
 Learn the principles on which we distribute our product on our website at [Licenses and Pricing section](https://www.shopsys.com/licensing).
 
-The rest of modules of Shopsys Framework including [HTTP smoke testing](https://github.com/shopsys/http-smoke-testing) are distributed under standard MIT license. 
+The rest of modules of Shopsys Framework including [HTTP smoke testing](https://github.com/shopsys/http-smoke-testing) are distributed under standard MIT license.
 
 Shopsys Framework also uses some third-party components and images which are licensed under their own respective licenses.
 The list of these licenses is summarized in [Open Source License Acknowledgements and Third Party Copyrights](./open-source-license-acknowledgements-and-third-party-copyrights.md).

--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,7 @@
     </target>
 
     <target name="standards" depends="phplint,ecs,phpstan-packages,twig-lint,yaml-lint,eslint-check,standards-packages,standards-utils" description="Checks coding standards in the project-base, packages and utils folder."/>
-    <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan-packages,twig-lint-diff,yaml-lint,eslint-check-diff,standards-packages, standards-utils" description="Checks coding standards on changed files in the project-base, packages and utils folder."/>
+    <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan-packages,twig-lint-diff,yaml-lint,eslint-check-diff,standards-packages,standards-utils" description="Checks coding standards on changed files in the project-base, packages and utils folder."/>
 
     <target name="clean" description="Cleans up directories with cache and scripts which are generated on demand.">
         <delete failonerror="false" includeemptydirs="true">
@@ -71,11 +71,9 @@
         </exec>
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check" />
-            <arg path="./packages/*/src"/>
-            <arg path="./packages/*/tests" />
-            <arg path="./packages/*/*.md"/>
-            <arg path="./*.md"/>
+            <arg path="./packages"/>
             <arg path="./docs"/>
+            <arg path="./*.md"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
@@ -103,11 +101,9 @@
             <arg value="check" />
             <arg value="--clear-cache" />
             <arg value="--fix" />
-            <arg path="./packages/*/src"/>
-            <arg path="./packages/*/tests" />
-            <arg path="./packages/*/*.md"/>
-            <arg path="./*.md"/>
+            <arg path="./packages"/>
             <arg path="./docs"/>
+            <arg path="./*.md"/>
         </exec>
         <exec executable="${path.eslint.executable}" passthru="true" checkreturn="true">
             <arg value="--color" />
@@ -124,11 +120,9 @@
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check" />
             <arg value="--fix" />
-            <arg path="./packages/*/src"/>
-            <arg path="./packages/*/tests" />
-            <arg path="./packages/*/*.md"/>
-            <arg path="./*.md"/>
+            <arg path="./packages"/>
             <arg path="./docs"/>
+            <arg path="./*.md"/>
         </exec>
         <exec executable="${path.eslint.executable}" passthru="true" checkreturn="true">
             <arg value="--color" />
@@ -148,8 +142,7 @@
         </exec>
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check" />
-            <arg path="./utils/*/src"/>
-            <arg path="./utils/*/tests"/>
+            <arg path="./utils"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}" />
@@ -170,8 +163,7 @@
             <arg value="check" />
             <arg value="--clear-cache" />
             <arg value="--fix" />
-            <arg path="./utils/*/src"/>
-            <arg path="./utils/*/tests"/>
+            <arg path="./utils"/>
         </exec>
     </target>
 

--- a/packages/coding-standards/src/Finder/FileFinder.php
+++ b/packages/coding-standards/src/Finder/FileFinder.php
@@ -23,18 +23,22 @@ final class FileFinder implements CustomSourceProviderInterface
         foreach ($source as $singleSource) {
             if (is_file($singleSource)) {
                 $fileInfo = new SplFileInfo($singleSource);
-                $files[$fileInfo->getPath()] = new SymfonySplFileInfo($singleSource, $fileInfo->getPath(), $fileInfo->getPathname());
+                $files[] = new SymfonySplFileInfo($singleSource, $fileInfo->getPath(), $fileInfo->getPathname());
             } else {
                 $directories[] = $singleSource;
             }
         }
 
         $finder = Finder::create()->files()
+            ->ignoreUnreadableDirs(true)
+            ->notPath('app/')
+            ->notPath('node_modules/')
+            ->notPath('var/')
+            ->notPath('vendor/')
+            ->notPath('web/')
             ->name('#\.(twig|html(\.twig)?|php|md)$#')
-            ->in($directories);
-
-        // ArrayIterator will be fixed in new release
-        $finder->append(new \ArrayIterator($files));
+            ->in($directories)
+            ->append($files);
 
         return $finder;
     }

--- a/packages/coding-standards/src/Finder/FileFinder.php
+++ b/packages/coding-standards/src/Finder/FileFinder.php
@@ -23,7 +23,7 @@ final class FileFinder implements CustomSourceProviderInterface
         foreach ($source as $singleSource) {
             if (is_file($singleSource)) {
                 $fileInfo = new SplFileInfo($singleSource);
-                $files[] = new SymfonySplFileInfo($singleSource, $fileInfo->getPath(), $fileInfo->getPathname());
+                $files[$fileInfo->getPathName()] = new SymfonySplFileInfo($singleSource, $fileInfo->getPath(), $fileInfo->getPathname());
             } else {
                 $directories[] = $singleSource;
             }


### PR DESCRIPTION
- wrong processing of files checked via input argument and their contents were fixed
- skip paths were added to be able to use ecs command via `vendor/bin/ecs check .`
- phing configuration for monorepo `build.xml` was simplified

| Q             | A
| ------------- | ---
|Description, reason for the PR| i noticed that we have implementation of file founder somehow corrupted, and also it was possible little simplify symplify and maybe match some requests like #383 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Standards and tests pass| Yes
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
