### PR TITLE
ProductSearchCreateStructureCommand exits on error

### DIFF
--- a/packages/framework/src/Command/ProductSearchCreateStructureCommand.php
+++ b/packages/framework/src/Command/ProductSearchCreateStructureCommand.php
@@ -2,7 +2,6 @@
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchStructureException;
 use Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportStructureFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -44,11 +43,7 @@ class ProductSearchCreateStructureCommand extends Command
     {
         $symfonyStyleIo = new SymfonyStyle($input, $output);
         $output->writeln('Creating structure');
-        try {
-            $this->productSearchExportStructureFacade->createIndexes($output);
-            $symfonyStyleIo->success('Structure created successfully!');
-        } catch (ElasticsearchStructureException $e) {
-            $symfonyStyleIo->error($e->getMessage());
-        }
+        $this->productSearchExportStructureFacade->createIndexes($output);
+        $symfonyStyleIo->success('Structure created successfully!');
     }
 }

--- a/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureManager.php
+++ b/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureManager.php
@@ -85,7 +85,13 @@ class ElasticsearchStructureManager
     {
         $file = sprintf('%s/%s/%s.json', $this->definitionDirectory, $index, $domainId);
         if (!is_file($file)) {
-            throw new ElasticsearchStructureException(sprintf('File %s not found', $file));
+            throw new ElasticsearchStructureException(
+                sprintf(
+                    'Definition file %d.json, for domain ID %1$d, not found in definition folder "%s".' . PHP_EOL . 'Please make sure that for each domain exists a definition json file named by the corresponding domain ID.',
+                    $domainId,
+                    $this->definitionDirectory
+                )
+            );
         }
         $json = file_get_contents($file);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ProductSearchCreateStructureCommand was outputting successful exit codes even if it failed. This PR makes sure that developer will not overlook errors that this command can output.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No 
|Fixes issues| fixes #936 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
