### PR TITLE
[framework] fixed nullable arguments with default value

### DIFF
--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -285,7 +285,7 @@ class ImageFacade
         string $extension,
         string $entityName,
         ?string $type,
-        string $sizeName = null
+        ?string $sizeName = null
     ): string {
         $imageFilepath = $this->imageLocator->getRelativeImageFilepathFromAttributes($id, $extension, $entityName, $type, $sizeName);
 
@@ -329,7 +329,7 @@ class ImageFacade
         string $extension,
         string $entityName,
         ?string $type,
-        string $sizeName = null
+        ?string $sizeName = null
     ): array {
         $entityConfig = $this->imageConfig->getEntityConfigByEntityName($entityName);
         $sizeConfig = $entityConfig->getSizeConfig($sizeName);

--- a/packages/framework/src/Component/Image/ImageLocator.php
+++ b/packages/framework/src/Component/Image/ImageLocator.php
@@ -77,8 +77,8 @@ class ImageLocator
         string $extension,
         string $entityName,
         ?string $type,
-        string $sizeName = null,
-        int $additionalIndex = null
+        ?string $sizeName = null,
+        ?int $additionalIndex = null
     ): string {
         $path = $this->getRelativeImagePath($entityName, $type, $sizeName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Arguments with default null value have to have nullable typehint. This was violated in recently added methods and fixed in this PR.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No* <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

*not considered BC break even if it changes method declaration as it's changed only in methods that are not yet released (added in #1018).