### PR TITLE
[migrations] Configuration::shouldExecuteMigration is fixed

### DIFF
--- a/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
@@ -11,8 +11,8 @@ use Doctrine\DBAL\Migrations\Version;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\Exception\MethodIsNotAllowedException;
 
 /**
- * @see https://github.com/doctrine/migrations/pull/824
  * @method string[] getMigratedVersions()
+ * @see https://github.com/doctrine/migrations/pull/824
  */
 class Configuration extends DoctrineConfiguration
 {

--- a/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
@@ -138,13 +138,7 @@ class Configuration extends DoctrineConfiguration
      */
     private function shouldExecuteMigration(Version $version, array $migratedVersions)
     {
-        foreach ($migratedVersions as $migratedVersion) {
-            if ($version->getVersion() === $migratedVersion) {
-                return false;
-            }
-        }
-
-        return true;
+        return !in_array($version->getVersion(), $migratedVersions, true);
     }
 
     /**

--- a/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
@@ -10,6 +10,10 @@ use Doctrine\DBAL\Migrations\QueryWriter;
 use Doctrine\DBAL\Migrations\Version;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\Exception\MethodIsNotAllowedException;
 
+/**
+ * @see https://github.com/doctrine/migrations/pull/824
+ * @method string[] getMigratedVersions()
+ */
 class Configuration extends DoctrineConfiguration
 {
     /**
@@ -129,13 +133,13 @@ class Configuration extends DoctrineConfiguration
 
     /**
      * @param \Doctrine\DBAL\Migrations\Version $version
-     * @param \Doctrine\DBAL\Migrations\Version[] $migratedVersions
+     * @param string[] $migratedVersions
      * @return bool
      */
     private function shouldExecuteMigration(Version $version, array $migratedVersions)
     {
         foreach ($migratedVersions as $migratedVersion) {
-            if ($version->getVersion() === $migratedVersion->getVersion()) {
+            if ($version->getVersion() === $migratedVersion) {
                 return false;
             }
         }


### PR DESCRIPTION
- wrong return type annotation from doctrine/migrations package was overriden with the correct one
- wrongly implemented call of getVersion method for string instance was fixed

| Q             | A
| ------------- | ---
|Description, reason for the PR| after merge of #1040 phing target db-migrations started to fail because of the wrong return type annotation of method from doctrine/migrations one method was wrongly implemented when we simplifying it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
