### PR TITLE
[shopsys] .travis.yml: run unit tests in packages and utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ jobs:
         script: docker-compose exec php-fpm ./phing db-create test-db-create build-demo-dev-quick error-pages-generate checks-ci
 
     -   name: "Standards, Unit Tests"
-        script: docker-compose exec php-fpm ./phing standards tests-unit
+        script: docker-compose exec php-fpm ./phing standards tests-static


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `tests-unit` only executes unit tests of project-base, missing `tests-packages` and `tests-utils` - using `tests-static` which depends on all three
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

related to #969 