### PR TITLE
[project-base] unification of URL paths

### DIFF
--- a/project-base/config/shopsys-routing/routing_front_cs.yml
+++ b/project-base/config/shopsys-routing/routing_front_cs.yml
@@ -39,7 +39,7 @@ front_order_sent:
     defaults: { _controller: App\Controller\Front\OrderController:sentAction }
 
 front_product_search:
-    path: /hledani
+    path: /hledani/
     defaults: { _controller: App\Controller\Front\ProductController:searchAction }
 
 front_registration_register:

--- a/project-base/config/shopsys-routing/routing_front_en.yml
+++ b/project-base/config/shopsys-routing/routing_front_en.yml
@@ -39,7 +39,7 @@ front_order_sent:
     defaults: { _controller: App\Controller\Front\OrderController:sentAction }
 
 front_product_search:
-    path: /search
+    path: /search/
     defaults: { _controller: App\Controller\Front\ProductController:searchAction }
 
 front_registration_register:

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -38,6 +38,11 @@ There you can find links to upgrade notes for other versions too.
         -   RUN npm install -g npm@6.13.2
         ```
 
+### Configuration
+- add trailing slash to all your localized paths for `front_product_search` route ([#1067](https://github.com/shopsys/shopsys/pull/1067))
+    - be aware, if you already have such paths (`hledani/`, `search/`) in your application
+    - the change might cause problems with your SEO as well
+
 ### Application
 
 - update your twig files ([#1284](https://github.com/shopsys/shopsys/pull/1284/)):


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| paths for localized routes `front_product_search` are missing trailing slash - this is inconsistent with the other paths in the application and might cause potential troubles, see https://shopsysframework.slack.com/archives/C5Q2MM677/p1558522300005100 for more information
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Possibly - there might be a problem if a project already contains `hledani/`, or `search/` paths, e.g. when there is a product with such a name (and friendly URL). The change might also cause problems with SEO <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
