### PR TITLE
[framework] custom extension of FlysystemVolumeDriver is loaded via files instead of classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
       "Shopsys\\FrameworkBundle\\": "packages/framework/src/"
     },
     "classmap": [
-      "packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php",
       "project-base/app/AppCache.php",
       "project-base/app/AppKernel.php",
       "project-base/app/Bootstrap.php",
       "project-base/app/Environment.php"
     ],
     "files": [
+      "packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php",
       "packages/framework/src/Component/Translation/functions.php",
       "packages/framework/src/Component/VarDumper/functions.php"
     ]

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -8,10 +8,8 @@
             "Shopsys\\FrameworkBundle\\": "src/",
             "Tests\\FrameworkBundle\\Test\\": "tests/Test/"
         },
-        "classmap": [
-            "src/Component/Filesystem/Flysystem/VolumeDriver.php"
-        ],
         "files": [
+            "src/Component/Filesystem/Flysystem/VolumeDriver.php",
             "src/Component/Translation/functions.php",
             "src/Component/VarDumper/functions.php"
         ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| class-map autoloader property refuses to load extended FlysystemVolumeDriver (introduced in #932) so the autoloading is fixed by files property of autoloader in composer.json.<br/>This fixes generation of thumbnails inside the file manager and URLs of the contents.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Before:**
![image](https://user-images.githubusercontent.com/10008612/58474046-73b02f00-814a-11e9-932c-6698c4863ac7.png)

**After:**
![image](https://user-images.githubusercontent.com/10008612/58474118-9d695600-814a-11e9-8a0a-5f1b04fb00c8.png)
