### PR TITLE
[project-base] ingress-nginx deployment config loads now tagged version instead of master branch version

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -18,4 +18,11 @@ There you can find links to upgrade notes for other versions too.
     - `categoriyWithLazyLoadedVisibleChildren` ⟶ `categoryWithLazyLoadedVisibleChildren`
 - create an empty file `app/Resources/.gitkeep` to prepare a folder for [your overwritten templates](/docs/cookbook/modifying-a-template-in-administration.md) ([#1073](https://github.com/shopsys/shopsys/pull/1073))
 
+### Infrastructure
+- replace url part in `infrastructure/google-cloud/nginx-ingress.tf` to use released version of this nginx-ingress configuration ([#1077](https://github.com/shopsys/shopsys/pull/1043))
+    ```diff
+    - command     = "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml"
+    + command     = "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.24.1/deploy/mandatory.yaml"
+    ```
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/infrastructure/google-cloud/nginx-ingress.tf
+++ b/project-base/infrastructure/google-cloud/nginx-ingress.tf
@@ -6,7 +6,7 @@ resource "kubernetes_namespace" "ingress-nginx" {
   }
 
   provisioner "local-exec" {
-    command     = "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml"
+    command     = "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.24.1/deploy/mandatory.yaml"
     interpreter = ["/bin/bash", "-c"]
   }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| when https://github.com/kubernetes/ingress-nginx/tree/master/deploy changed the structure of its configs after the merge of this kubernetes/ingress-nginx#4055 PR we encountered that our project contains link onto master branch, thus we changed the URL of the mandatory.yaml config into last released stable version where the config is functional with our terraform configuration scripts.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
