### PR TITLE
[project-base] initialization of php-fpm container via kubernetes is now done via www-data user

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -19,10 +19,24 @@ There you can find links to upgrade notes for other versions too.
 - create an empty file `app/Resources/.gitkeep` to prepare a folder for [your overwritten templates](/docs/cookbook/modifying-a-template-in-administration.md) ([#1073](https://github.com/shopsys/shopsys/pull/1073))
 
 ### Infrastructure
-- replace url part in `infrastructure/google-cloud/nginx-ingress.tf` to use released version of this nginx-ingress configuration ([#1077](https://github.com/shopsys/shopsys/pull/1043))
+- replace url part in `infrastructure/google-cloud/nginx-ingress.tf` to use released version of this nginx-ingress configuration ([#1077](https://github.com/shopsys/shopsys/pull/1077))
     ```diff
     - command     = "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml"
     + command     = "kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.24.1/deploy/mandatory.yaml"
+- add configuration into `kubernetes/deployments/webserver-php-fpm.yml` to run initialization process of php-fpm container as user www-data(33) ([#1078](https://github.com/shopsys/shopsys/pull/1078))
+    ```diff
+      -   name: copy-source-codes-to-volume
+          image: ~
+    +     securityContext:
+    +         runAsUser: 33
+          command: ["sh", "-c", "cp -r /var/www/html/. /tmp/source-codes"]
+    ```
+    ```diff
+      -   name: initialize-database
+          image: ~
+    +     securityContext:
+    +         runAsUser: 33
+          command: ["sh", "-c", "cd /var/www/html && ./phing db-create dirs-create db-demo product-search-recreate-structure product-search-export-products grunt error-pages-generate warmup"]
     ```
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/kubernetes/deployments/webserver-php-fpm.yml
+++ b/project-base/kubernetes/deployments/webserver-php-fpm.yml
@@ -43,6 +43,8 @@ spec:
             initContainers:
             -   name: copy-source-codes-to-volume
                 image: ~
+                securityContext:
+                    runAsUser: 33
                 command: ["sh", "-c", "cp -r /var/www/html/. /tmp/source-codes"]
                 volumeMounts:
                 -   name: source-codes
@@ -55,6 +57,8 @@ spec:
                     subPath: parameters.yml
             -   name: initialize-database
                 image: ~
+                securityContext:
+                    runAsUser: 33
                 command: ["sh", "-c", "cd /var/www/html && ./phing db-create dirs-create db-demo product-search-recreate-structure product-search-export-products grunt error-pages-generate warmup"]
                 volumeMounts:
                 -   name: source-codes


### PR DESCRIPTION
- creating or recreating of folders and files duting initialization phase was changed to run via www-data(33) user

| Q             | A
| ------------- | ---
|Description, reason for the PR| after last check of the deploy script onto google-cloud we encountered a problem with non-functional administration. The problem occurred during initialization of php-fpm container where the assets, Doctrine migrations and other folders were under root ownership. So we needed to add chroot to www-data or user id 33 also for other phases of the php-fpm container build in webserver-php-fpm POD.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
