### PR TITLE
Fixed link to elasticsearch license file

### DIFF
--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -100,7 +100,7 @@ https://github.com/vrana/adminer/blob/master/readme.txt
 ### Elasticsearch
 Image: `Docker.elastic.co/elasticsearch/elasticsearch-oss`  
 License: Apache License 2.0  
-https://github.com/elastic/elasticsearch/blob/66b5ed86f7adede8102cd4d979b9f4924e5bd837/LICENSE.txt  
+https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt
 Copyright 2009-2018 Elasticsearch
 
 ### Php

--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -100,7 +100,7 @@ https://github.com/vrana/adminer/blob/master/readme.txt
 ### Elasticsearch
 Image: `Docker.elastic.co/elasticsearch/elasticsearch-oss`  
 License: Apache License 2.0  
-https://github.com/elastic/elasticsearch/blob/master/LICENSE.txt
+https://github.com/elastic/elasticsearch/blob/v6.3.2/LICENSE.txt  
 Copyright 2009-2018 Elasticsearch
 
 ### Php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In 3rd part SW overview there was link to obsolete version of elastic license. Now it is fixed to elasticserach/master/license.txt
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
