### PR TITLE
docs/index.md: first letters capitalization for all the article names

### DIFF
--- a/docs/frontend/configuring-image-sizes-for-individual-devices-width.md
+++ b/docs/frontend/configuring-image-sizes-for-individual-devices-width.md
@@ -1,4 +1,4 @@
-# Configuring image sizes for individual devices width
+# Configuring Image Sizes for Individual Devices Width
 In Shopsys Framework you can configure image sizes for individual devices width. This is allowed by HTML element [Picture element (see more in Mozilla official documentation)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture).
 
 ## Introduction

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@
 * [Adding an Icon into a Button](./cookbook/adding-an-icon-into-a-button.md)
 * [Modifying a Template in Administration](./cookbook/modifying-a-template-in-administration.md)
 * [Adding Ajax Load More Button into Pagination](./cookbook/adding-ajax-load-more-button-into-pagination.md)
-* [Implementing a basic data import](./cookbook/basic-data-import.md)
+* [Implementing a Basic Data Import](./cookbook/basic-data-import.md)
 * [Creating a Multidomain Design](./cookbook/creating-a-multidomain-design.md)
 * [Working with Multiple Cron Instances](./cookbook/working-with-multiple-cron-instances.md)
 * [Create Basic Grid](./cookbook/create-basic-grid.md)
@@ -68,7 +68,7 @@
 ## Frontend
 * [Design implementation and Customization](./frontend/design-implementation-and-customization.md)
 * [Introduction to LESS](./frontend/introduction-to-less.md)
-* [Configuring image sizes for individual devices width](./frontend/configuring-image-sizes-for-individual-devices-width.md)
+* [Configuring Image Sizes for Individual Devices Width](./frontend/configuring-image-sizes-for-individual-devices-width.md)
 * [Frontend Troubleshooting](./frontend/frontend-troubleshooting.md)
 * [Understanding the Style Directory](./frontend/understanding-the-style-directory.md)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Unification - all the first letters in all the article names should be capitalized (see [Guidelines for Writing Documentation](https://github.com/shopsys/shopsys/blob/v7.2.1/docs/contributing/guidelines-for-writing-documentation.md))
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
