### PR TITLE
[project-base] fixed FilterQueryTest to properly use Elasticsearch index

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -17,6 +17,22 @@ There you can find links to upgrade notes for other versions too.
 - fix the typo in Twig template `@ShopsysShop/Front/Content/Category/panel.html.twig` ([#1043](https://github.com/shopsys/shopsys/pull/1043))
     - `categoriyWithLazyLoadedVisibleChildren` ⟶ `categoryWithLazyLoadedVisibleChildren`
 - create an empty file `app/Resources/.gitkeep` to prepare a folder for [your overwritten templates](/docs/cookbook/modifying-a-template-in-administration.md) ([#1073](https://github.com/shopsys/shopsys/pull/1073))
+- fix `FilterQueryTest` to use ElasticSearch index prefix properly ([#1082](https://github.com/shopsys/shopsys/pull/1082))
+    ```diff
+    - 16:   private const ELASTICSEARCH_INDEX = 'product1';
+    + 16:   private const ELASTICSEARCH_INDEX = 'product';
+    ...
+             /** @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory */
+             $filterQueryFactory = $this->getContainer()->get(FilterQueryFactory::class);
+    - 169:       $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
+    + 169:
+    + 170:       /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
+    + 171:       $elasticSearchStructureManager = $elasticSearchIndexName = $this->getContainer()->get(ElasticsearchStructureManager::class);
+    + 172:
+    + 173:       $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
+    + 174:
+    + 175:       $filter = $filterQueryFactory->create($elasticSearchIndexName);
+    ```
 
 ### Infrastructure
 - replace url part in `infrastructure/google-cloud/nginx-ingress.tf` to use released version of this nginx-ingress configuration ([#1077](https://github.com/shopsys/shopsys/pull/1043))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -26,9 +26,9 @@ There you can find links to upgrade notes for other versions too.
     - $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
     + /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
     + $elasticSearchStructureManager = $elasticSearchIndexName = $this->getContainer()->get(ElasticsearchStructureManager::class);
-    + 
+    +
     + $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
-    + 
+    +
     + $filter = $filterQueryFactory->create($elasticSearchIndexName);
     ```
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -17,21 +17,19 @@ There you can find links to upgrade notes for other versions too.
 - fix the typo in Twig template `@ShopsysShop/Front/Content/Category/panel.html.twig` ([#1043](https://github.com/shopsys/shopsys/pull/1043))
     - `categoriyWithLazyLoadedVisibleChildren` ⟶ `categoryWithLazyLoadedVisibleChildren`
 - create an empty file `app/Resources/.gitkeep` to prepare a folder for [your overwritten templates](/docs/cookbook/modifying-a-template-in-administration.md) ([#1073](https://github.com/shopsys/shopsys/pull/1073))
-- fix `FilterQueryTest` to use ElasticSearch index prefix properly ([#1082](https://github.com/shopsys/shopsys/pull/1082))
+- fix `FilterQueryTest` to use ElasticSearch index prefix properly via `ElasticsearchStructureManager` ([#1082](https://github.com/shopsys/shopsys/pull/1082))
     ```diff
-    - 16:   private const ELASTICSEARCH_INDEX = 'product1';
-    + 16:   private const ELASTICSEARCH_INDEX = 'product';
-    ...
-             /** @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory */
-             $filterQueryFactory = $this->getContainer()->get(FilterQueryFactory::class);
-    - 169:       $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
-    + 169:
-    + 170:       /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
-    + 171:       $elasticSearchStructureManager = $elasticSearchIndexName = $this->getContainer()->get(ElasticsearchStructureManager::class);
-    + 172:
-    + 173:       $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
-    + 174:
-    + 175:       $filter = $filterQueryFactory->create($elasticSearchIndexName);
+    - private const ELASTICSEARCH_INDEX = 'product1';
+    + private const ELASTICSEARCH_INDEX = 'product';
+    ```
+    ```diff
+    - $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
+    + /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
+    + $elasticSearchStructureManager = $elasticSearchIndexName = $this->getContainer()->get(ElasticsearchStructureManager::class);
+    + 
+    + $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
+    + 
+    + $filter = $filterQueryFactory->create($elasticSearchIndexName);
     ```
 
 ### Infrastructure

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -25,7 +25,7 @@ There you can find links to upgrade notes for other versions too.
     ```diff
     - $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
     + /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
-    + $elasticSearchStructureManager = $elasticSearchIndexName = $this->getContainer()->get(ElasticsearchStructureManager::class);
+    + $elasticSearchStructureManager = $this->getContainer()->get(ElasticsearchStructureManager::class);
     +
     + $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
     +

--- a/docs/upgrade/interchangeable-filtering.md
+++ b/docs/upgrade/interchangeable-filtering.md
@@ -31,7 +31,7 @@ Even then, you should make some upgrade steps to have your code tested properly 
     - `Filter/BrandFilterChoiceRepositoryTest.php`
     - `Filter/FlagFilterChoiceRepositoryTest.php`
     - `Filter/ParameterFilterChoiceRepositoryTest.php`
-    - `Search/FilterQueryTest.php`
+    - `Search/FilterQueryTest.php` ([view fixed in v7.2.1](https://github.com/shopsys/project-base/raw/v7.2.1/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php))
 - skip the path `'*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'` for following coding standard sniffs in your `easy-coding-standard.yml` file
     `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff`
     `ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff`
@@ -72,7 +72,7 @@ To start filtering products via Elasticsearch you have to do these steps.
     - `Filter/BrandFilterChoiceRepositoryTest.php`
     - `Filter/FlagFilterChoiceRepositoryTest.php`
     - `Filter/ParameterFilterChoiceRepositoryTest.php`
-    - `Search/FilterQueryTest.php`
+    - `Search/FilterQueryTest.php` ([view fixed in v7.2.1](https://github.com/shopsys/project-base/raw/v7.2.1/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php))
 - skip the path `'*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'` for the following coding standard sniffs in your `easy-coding-standard.yml` file
     `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff`
     `ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff`

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Product\Search;
 
 use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 use Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery;
@@ -12,7 +13,7 @@ use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
 class FilterQueryTest extends TransactionFunctionalTestCase
 {
-    private const ELASTICSEARCH_INDEX = 'product1';
+    private const ELASTICSEARCH_INDEX = 'product';
 
     public function testBrand(): void
     {
@@ -165,7 +166,13 @@ class FilterQueryTest extends TransactionFunctionalTestCase
     {
         /** @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory */
         $filterQueryFactory = $this->getContainer()->get(FilterQueryFactory::class);
-        $filter = $filterQueryFactory->create(self::ELASTICSEARCH_INDEX);
+
+        /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
+        $elasticSearchStructureManager = $this->getContainer()->get(ElasticsearchStructureManager::class);
+
+        $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
+
+        $filter = $filterQueryFactory->create($elasticSearchIndexName);
 
         return $filter->filterOnlySellable();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `FilterQueryTest` was not using Elasticsearch index prefix if specified, resulting in possible failing tests. This is fixed now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
