### PR TITLE
[framework] ProductSearchExportWithFilterRepository: get product selling prices only for certain domain

### DIFF
--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -353,9 +353,8 @@ class ProductFacade
     {
         $productSellingPrices = [];
 
-        foreach ($this->pricingGroupRepository->getAll() as $pricingGroup) {
-            $productSellingPrices[$pricingGroup->getDomainId()] =
-                $this->getAllProductSellingPricesByDomainId($product, $pricingGroup->getDomainId());
+        foreach ($this->domain->getAllIds() as $domainId) {
+            $productSellingPrices[$domainId] = $this->getAllProductSellingPricesByDomainId($product, $domainId);
         }
 
         return $productSellingPrices;
@@ -366,7 +365,7 @@ class ProductFacade
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice[]
      */
-    public function getAllProductSellingPricesByDomainId(Product $product, $domainId)
+    public function getAllProductSellingPricesByDomainId(Product $product, int $domainId): array
     {
         $productSellingPrices = [];
 

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -354,9 +354,26 @@ class ProductFacade
         $productSellingPrices = [];
 
         foreach ($this->pricingGroupRepository->getAll() as $pricingGroup) {
-            $productSellingPrices[$pricingGroup->getDomainId()][$pricingGroup->getId()] = new ProductSellingPrice(
+            $productSellingPrices[$pricingGroup->getDomainId()] =
+                $this->getAllProductSellingPricesByDomainId($product, $pricingGroup->getDomainId());
+        }
+
+        return $productSellingPrices;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice[]
+     */
+    public function getAllProductSellingPricesByDomainId(Product $product, $domainId)
+    {
+        $productSellingPrices = [];
+
+        foreach ($this->pricingGroupRepository->getPricingGroupsByDomainId($domainId) as $pricingGroup) {
+            $productSellingPrices[$pricingGroup->getId()] = new ProductSellingPrice(
                 $pricingGroup,
-                $this->productPriceCalculation->calculatePrice($product, $pricingGroup->getDomainId(), $pricingGroup)
+                $this->productPriceCalculation->calculatePrice($product, $domainId, $pricingGroup)
             );
         }
 

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -163,8 +163,8 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
     protected function extractPrices(int $domainId, Product $product): array
     {
         $prices = [];
-        $productSellingPrices = $this->productFacade->getAllProductSellingPricesIndexedByDomainId($product)[$domainId];
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice $productSellingPrice */
+        $productSellingPrices = $this->productFacade->getAllProductSellingPricesByDomainId($product, $domainId);
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice[] $productSellingPrices */
         foreach ($productSellingPrices as $productSellingPrice) {
             $prices[] = [
                 'pricing_group_id' => $productSellingPrice->getPricingGroup()->getId(),

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -163,6 +163,7 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
     protected function extractPrices(int $domainId, Product $product): array
     {
         $prices = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice[] $productSellingPrices */
         $productSellingPrices = $this->productFacade->getAllProductSellingPricesByDomainId($product, $domainId);
         foreach ($productSellingPrices as $productSellingPrice) {
             $prices[] = [

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -164,7 +164,6 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
     {
         $prices = [];
         $productSellingPrices = $this->productFacade->getAllProductSellingPricesByDomainId($product, $domainId);
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice[] $productSellingPrices */
         foreach ($productSellingPrices as $productSellingPrice) {
             $prices[] = [
                 'pricing_group_id' => $productSellingPrice->getPricingGroup()->getId(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If main variant was not sellable on certain domain, export products to Elastic failed (`MainVariantPriceCalculationException`). `ProductSearchExportWithFilterRepository` extracted prices for products on all domains, even on domains where they were not sellable.  
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
