### PR TITLE
[framework] CurrentPromoCodeFacadeTest: fixed call of getMockForAbstractClass

### DIFF
--- a/packages/framework/tests/Unit/Model/Order/PromoCode/CurrentPromoCodeFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/PromoCode/CurrentPromoCodeFacadeTest.php
@@ -21,7 +21,7 @@ class CurrentPromoCodeFacadeTest extends TestCase
         $validPromoCodeData->code = 'validCode';
         $validPromoCodeData->percent = 10.0;
         $validPromoCode = new PromoCode($validPromoCodeData);
-        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class, ['get']);
+        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class);
         $sessionMock->expects($this->atLeastOnce())->method('get')->willReturn($validPromoCode->getCode());
         $emMock = $this->createMock(EntityManager::class);
         $promoCodeRepositoryMock = $this->getMockBuilder(PromoCodeRepository::class)
@@ -42,7 +42,7 @@ class CurrentPromoCodeFacadeTest extends TestCase
         $validPromoCodeData->code = 'validCode';
         $validPromoCodeData->percent = 10.0;
         $validPromoCode = new PromoCode($validPromoCodeData);
-        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class, ['get']);
+        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class);
         $sessionMock->expects($this->atLeastOnce())->method('get')->willReturn($validPromoCode->getCode());
         $emMock = $this->createMock(EntityManager::class);
         $promoCodeRepositoryMock = $this->getMockBuilder(PromoCodeRepository::class)
@@ -64,7 +64,7 @@ class CurrentPromoCodeFacadeTest extends TestCase
         $validPromoCodeData->code = 'validCode';
         $validPromoCodeData->percent = 10.0;
         $validPromoCode = new PromoCode($validPromoCodeData);
-        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class, ['get']);
+        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class);
         $sessionMock->expects($this->atLeastOnce())->method('set')->with(
             $this->anything(),
             $this->equalTo($enteredCode)
@@ -85,7 +85,7 @@ class CurrentPromoCodeFacadeTest extends TestCase
     public function testSetEnteredPromoCodeInvalid()
     {
         $enteredCode = 'invalidCode';
-        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class, ['get']);
+        $sessionMock = $this->getMockForAbstractClass(SessionInterface::class);
         $sessionMock->expects($this->never())->method('set');
 
         $emMock = $this->createMock(EntityManager::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The second parameter of `TestCase::getMockForAbstractClass()` is `$arguments`, not `$methods` - the $arguments parameter is used to instantiate the mock class (which does not have a constructor and that makes our unit tests fail, seemingly since upgrade to `phpunit/phpunit: 7.5.12` from `7.5.11`).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes