### PR TITLE
[shopsys] ignoring of phpstan rule is updated after release of phpstan/phpdoc-parser:0.3.4

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -11,6 +11,16 @@ There you can find links to upgrade notes for other versions too.
 - follow instructions in [the separate article](upgrade-instructions-for-read-model-for-product-lists.md) to introduce read model for frontend product lists into your project ([#1018](https://github.com/shopsys/shopsys/pull/1018))
     - we recommend to read [Introduction to Read Model](/docs/model/introduction-to-read-model.md) article
 
+### Configuration
+- update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))
+    ```diff
+     #ignore annotations in generated code#
+     -
+    -    message: '#(PHPDoc tag @(param|return) has invalid value .+ expected TOKEN_IDENTIFIER at offset \d+)#'
+    +    message: '#(PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+)#'
+         path: %currentWorkingDirectory%/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
+    ```
+
 ### Tools
 - we recommend upgrading PHPStan to level 4 [#1040](https://github.com/shopsys/shopsys/pull/1040)
     - you'll find detailed instructions in separate article [Upgrade Instructions for Upgrading PHPStan to Level 4](/docs/upgrade/phpstan-level-4.md)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,7 +35,7 @@ parameters:
             path: %currentWorkingDirectory%/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
         #Shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base
         -
-            message: '#(PHPDoc tag @(param|return) has invalid value .+ expected TOKEN_IDENTIFIER at offset \d+)#'
+            message: '#(PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+)#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
         -
             message: '#(PHPDoc tag @throws with type .+ is not subtype of Throwable)#'

--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
         - '#Undefined variable: \$undefined#'
         #ignore annotations in generated code#
         -
-            message: '#(PHPDoc tag @(param|return) has invalid value .+ expected TOKEN_IDENTIFIER at offset \d+)#'
+            message: '#(PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+)#'
             path: %currentWorkingDirectory%/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
         -
             message: '#(PHPDoc tag @throws with type .+ is not subtype of Throwable)#'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| after small change in package phpstan/phpdoc-parser in version 0.3.4 phpstan/phpdoc-parser#26 parsing of docblock was changed so we need to update our ingoreError section of phpstan.neon
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
