### PR TITLE
[shopsys] export of logs is not necessary since we use kubernetes dashboard

### DIFF
--- a/.ci/export_logs.sh
+++ b/.ci/export_logs.sh
@@ -4,13 +4,6 @@
 WEBSERVER_PHP_FPM_CONTAINER_NAME="webserver-php-fpm"
 
 for POD_NAME in $(kubectl get pods -n ${JOB_NAME} | grep -v ^NAME | cut -f 1 -d ' '); do
-    # create directory for log files if it does not exist
-    mkdir -p ${WORKSPACE}/logs/
-    # remove already existing log file
-    rm -f ${WORKSPACE}/logs/${POD_NAME}.log || true
-    # print log output to log file
-    kubectl logs ${POD_NAME} -n ${JOB_NAME} --all-containers > ${WORKSPACE}/logs/${POD_NAME}.log
-
     # check if pod name is php-fpm pod because of codeception logs
     if [[ ${POD_NAME} == *${WEBSERVER_PHP_FPM_CONTAINER_NAME}* ]]; then
         # copy codeception logs from php-fpm pod to local


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| We deployed a kubernetes dashboard and now exporting logs using script is not necessary
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
