### PR TITLE
[shopsys] use ElasticSearch to get data to readmodel

### DIFF
--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -3,7 +3,7 @@ In the following example, we will add `extId` (alias "external ID") field to the
 It is a common modification when you need your e-commerce application and ERP system to co-work smoothly.
 
 *Note: if you want to display your new attribute on the frontend product list, you need to extend the [read model layer](/docs/model/introduction-to-read-model.md) as well.
-You can find instructions in [Extending Product List](./cookbook/extending-product-list.md).*
+You can find instructions in [Extending Product List](./extending-product-list.md).*
 
 ## Extend framework `Product` entity
 

--- a/docs/cookbook/extending-product-list.md
+++ b/docs/cookbook/extending-product-list.md
@@ -87,60 +87,22 @@ declare(strict_types=1);
 
 namespace Shopsys\ShopBundle\Model\Product\Search\Export;
 
+use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
 use Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository as BaseProductSearchExportWithFilterRepository;
 
 class ProductSearchExportWithFilterRepository extends BaseProductSearchExportWithFilterRepository
 {
-    /**
-     * @param int $domainId
-     * @param string $locale
-     * @param int $startFrom
-     * @param int $batchSize
-     * @return array
-     */
-    public function getProductsData(int $domainId, string $locale, int $startFrom, int $batchSize): array
+   /**
+    * @param \Shopsys\ShopBundle\Model\Product\Product $product
+    * @param int $domainId
+    * @param string $locale
+    * @return array
+    */
+    protected function extractResult(BaseProduct $product, int $domainId, string $locale): array
     {
-        $queryBuilder = $this->createQueryBuilder($domainId, $locale)
-            ->setFirstResult($startFrom)
-            ->setMaxResults($batchSize);
+        $result = parent::extractResult($product, $domainId, $locale);
 
-        $query = $queryBuilder->getQuery();
-
-        $result = [];
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
-        foreach ($query->getResult() as $product) {
-            $flagIds = $this->extractFlags($product);
-            $categoryIds = $this->extractCategories($domainId, $product);
-            $parameters = $this->extractParameters($locale, $product);
-            $prices = $this->extractPrices($domainId, $product);
-            $visibility = $this->extractVisibility($domainId, $product);
-
-            $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl($domainId, 'front_product_detail', $product->getId());
-
-            $result[] = [
-                'id' => $product->getId(),
-                'catnum' => $product->getCatnum(),
-                'partno' => $product->getPartno(),
-                'ean' => $product->getEan(),
-                'name' => $product->getName($locale),
-                'description' => $product->getDescription($domainId),
-                'shortDescription' => $product->getShortDescription($domainId),
-                'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
-                'brand_name' => $product->getBrand() ? $product->getBrand()->getName() : '',
-                'flags' => $flagIds,
-                'categories' => $categoryIds,
-                'in_stock' => $product->getCalculatedAvailability()->getDispatchTime() === 0,
-                'prices' => $prices,
-                'parameters' => $parameters,
-                'ordering_priority' => $product->getOrderingPriority(),
-                'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
-                'selling_denied' => $product->isSellingDenied(),
-                'availability' => $product->getAvailability()->getName($locale),
-                'main_variant' => $product->isMainVariant(),
-                'detail_url' => $friendlyUrl->getAbsoluteUrl($this->domain),
-                'visibility' => $visibility,
-            ];
-        }
+        $result['brand_name'] = $product->getBrand() ? $product->getBrand()->getName() : '';
 
         return $result;
     }

--- a/docs/cookbook/extending-product-list.md
+++ b/docs/cookbook/extending-product-list.md
@@ -66,15 +66,123 @@ class ListedProductView extends BaseListedProductView
 }
 ```
 
-### 2. Extend `ListedProductViewFactory` so it returns the new required data
+### 2. Add new attribute to Elasticsearch
 
-The class is responsible for creating the view object. We need to ensure that the objects is created with proper brand name. We are able to get the brand name from the product entity, so we just need to overwrite `createFromProduct()` method.  
+In order to add new attribute to Elasticsearch you need to add it to the structure first.
+You can do that by adding it to `mappings` in all `src/Shopsys/ShopBundle/Resources/definition/product/*.json` files like this:
+```diff
+  "mappings": {
+    "_doc": {
+      "properties": {
++       "brand_name": {
++         "type": "text"
++       },
+```
+
+### 3. Export new attribute to Elasticsearch
+
+The class responsible for exporting products to Elasticsearch is `ProductSearchExportWithFilterRepository` so we need to extend it and add the attribute to method `getProductsData`.
+```php
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Product\Search\Export;
+
+use Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository as BaseProductSearchExportWithFilterRepository;
+
+class ProductSearchExportWithFilterRepository extends BaseProductSearchExportWithFilterRepository
+{
+    /**
+     * @param int $domainId
+     * @param string $locale
+     * @param int $startFrom
+     * @param int $batchSize
+     * @return array
+     */
+    public function getProductsData(int $domainId, string $locale, int $startFrom, int $batchSize): array
+    {
+        $queryBuilder = $this->createQueryBuilder($domainId, $locale)
+            ->setFirstResult($startFrom)
+            ->setMaxResults($batchSize);
+
+        $query = $queryBuilder->getQuery();
+
+        $result = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
+        foreach ($query->getResult() as $product) {
+            $flagIds = $this->extractFlags($product);
+            $categoryIds = $this->extractCategories($domainId, $product);
+            $parameters = $this->extractParameters($locale, $product);
+            $prices = $this->extractPrices($domainId, $product);
+            $visibility = $this->extractVisibility($domainId, $product);
+
+            $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl($domainId, 'front_product_detail', $product->getId());
+
+            $result[] = [
+                'id' => $product->getId(),
+                'catnum' => $product->getCatnum(),
+                'partno' => $product->getPartno(),
+                'ean' => $product->getEan(),
+                'name' => $product->getName($locale),
+                'description' => $product->getDescription($domainId),
+                'shortDescription' => $product->getShortDescription($domainId),
+                'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
+                'brand_name' => $product->getBrand() ? $product->getBrand()->getName() : '',
+                'flags' => $flagIds,
+                'categories' => $categoryIds,
+                'in_stock' => $product->getCalculatedAvailability()->getDispatchTime() === 0,
+                'prices' => $prices,
+                'parameters' => $parameters,
+                'ordering_priority' => $product->getOrderingPriority(),
+                'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
+                'selling_denied' => $product->isSellingDenied(),
+                'availability' => $product->getAvailability()->getName($locale),
+                'main_variant' => $product->isMainVariant(),
+                'detail_url' => $friendlyUrl->getAbsoluteUrl($this->domain),
+                'visibility' => $visibility,
+            ];
+        }
+
+        return $result;
+    }
+}
+```
+
+You need to register your new class as an alias for the one from the FrameworkBundle in `services.yml` and `services_test.yml`:
+
+```yml
+Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository: '@Shopsys\ShopBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository'
+```
+
+Then you need to fix `ProductSearchExportRepositoryTest::getExpectedStructureForRepository` (because this test check if your structure is correct) by adding new attribute:
+```diff
+$structure = \array_merge($structure, [
+    'availability',
+    'brand',
+    'flags',
+    'categories',
+    'detail_url',
+    'in_stock',
+    'prices',
+    'parameters',
+    'ordering_priority',
+    'calculated_selling_denied',
+    'selling_denied',
+    'main_variant',
+    'visibility',
++   'brand_name',
+]);
+```
+
+### 4. Extend `ListedProductViewFactory` so it returns the new required data
+
+The class is responsible for creating the view object. We need to ensure that the objects is created with proper brand name. We are able to get the brand name from the product entity, so we just need to overwrite `createFromArray()` and `createFromProduct()` methods.  
 
 ```php
 declare(strict_types=1);
 
 namespace Shopsys\ShopBundle\Model\Product\View;
 
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\ReadModelBundle\Image\ImageView;
 use Shopsys\ReadModelBundle\Product\Action\ProductActionView;
@@ -84,10 +192,32 @@ use Shopsys\ReadModelBundle\Product\Listed\ListedProductView as BaseListedProduc
 class ListedProductViewFactory extends BaseListedProductViewFactory
 {
     /**
+     * @param array $productArray
+     * @param \Shopsys\ReadModelBundle\Image\ImageView|null $imageView
+     * @param \Shopsys\ReadModelBundle\Product\Action\ProductActionView $productActionView
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\ShopBundle\Model\Product\ViewListedProductView
+     */
+    public function createFromArray(array $productArray, ?ImageView $imageView, ProductActionView $productActionView, PricingGroup $pricingGroup): BaseListedProductView
+    {
+        return new ListedProductView(
+            $productArray['id'],
+            $productArray['name'],
+            $productArray['shortDescription'],
+            $productArray['availability'],
+            $this->getProductPriceFromArrayByPricingGroup($productArray['prices'], $pricingGroup),
+            $productArray['flags'],
+            $productActionView,
+            $imageView,
+            $productArray['brand_name']
+        );
+    }
+
+    /**
      * @param \Shopsys\ShopBundle\Model\Product\Product $product
      * @param \Shopsys\ReadModelBundle\Image\ImageView|null $imageView
      * @param \Shopsys\ReadModelBundle\Product\Action\ProductActionView $productActionView
-     * @return \Shopsys\ReadModelBundle\Product\Listed\ListedProductView
+     * @return \Shopsys\ShopBundle\Model\Product\View\ListedProductView
      */
     public function createFromProduct(Product $product, ?ImageView $imageView, ProductActionView $productActionView): BaseListedProductView
     {
@@ -100,7 +230,7 @@ class ListedProductViewFactory extends BaseListedProductViewFactory
             $this->getFlagIdsForProduct($product),
             $productActionView,
             $imageView,
-            $product->getBrand() ? $product->getBrand()->getName() : null
+            $product->getBrand() !== null ? $product->getBrand()->getName() : null
         );
     }
 }
@@ -112,7 +242,7 @@ You need to register your new class as an alias for the one from the bundle in `
 Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFactory: '@Shopsys\ShopBundle\Model\Product\View\ListedProductViewFactory'
 ```
 
-### 3. Modify the frontend template for rendering product lists so it displays the new attribute
+### 5. Modify the frontend template for rendering product lists so it displays the new attribute
 
 All product lists are rendered using `productListMacro.html.twig`. You can modify this macro to display product brand name wherever it is suitable for you.
 

--- a/docs/model/elasticsearch.md
+++ b/docs/model/elasticsearch.md
@@ -43,7 +43,7 @@ Following product attributes are exported into Elasticsearch (i.e. the search or
 * ordering_priority (priority number)
 * calculated_selling_denied (true/false value whether the product is already sold out)
 
-Data of all products are exported into Elasticsearch by CRON module (`ProductSearchExportCronModule.php`) once an hour.
+Data of all products are exported into Elasticsearch by CRON module (`ProductSearchExportCronModule.php`) every 5 minutes.
 Alternatively, you can force the export manually using `product-search-export-products` Phing target.
 
 ## Use of Elasticsearch

--- a/docs/model/elasticsearch.md
+++ b/docs/model/elasticsearch.md
@@ -41,13 +41,18 @@ Following product attributes are exported into Elasticsearch (i.e. the search or
 * in_stock (true/false value whether the product is in stock)
 * parameters (pairs of parameter IDs and parameter value IDs)
 * ordering_priority (priority number)
-* calculated_selling_denied (true/false value whether the product is already sold out)
+* calculated_selling_denied (calculated true/false value whether the product is already sold out)
+* selling_denied (true/false value whether the product can be sold)
+* availability (translation of product availability)
+* main_variant (true/false value whether the product is main variant or not. You can find more about behaviour of variants [here](/docs/functional/behavior-of-product-variants.md))
+* detail_url (absolute url to page with products detail)
+* visibility (all visibilities for all pricing groups and domains)
 
 Data of all products are exported into Elasticsearch by CRON module (`ProductSearchExportCronModule.php`) every 5 minutes.
 Alternatively, you can force the export manually using `product-search-export-products` Phing target.
 
 ## Use of Elasticsearch
-Elasticsearch is used to search, filter and sort products on the frontend.
+Elasticsearch is used to search, filter and sort products on the frontend and to display products in listing via [Read Model](/docs/model/introduction-to-read-model.md).
 You can learn more about [Product searching](/docs/model/front-end-product-searching.md) and [Product filtering](/docs/model/front-end-product-filtering.md) in particular articles.
 [Sorting](/docs/introduction/how-to-set-up-domains-and-locales.md#37-sorting-in-different-locales) is done with the help of [ICU analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html)
 which ensures that alphabetical sorting is correct for every language and its set of rules.

--- a/docs/model/introduction-to-read-model.md
+++ b/docs/model/introduction-to-read-model.md
@@ -20,3 +20,13 @@ Read model is a view on the model from a specific perspective - from the reading
 The objects in read model are immutable, read-only by definition, and do not have any behavior.
 
 The read model is implemented in a separate [`shopsys/read-model`](https://github.com/shopsys/read-model) package.
+
+Currently, you can choose between two implementations of `ListedProductViewFacadeInterface` that represents read model:
+ - `ListedProductViewElasticFacade` *(default)*
+    - data from Elasticsearch
+    - faster than getting products from SQL
+    - to use this implementation you need to use `ProductOnCurrentDomainElasticFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)
+ - `ListedProductViewFacade`
+    - data from SQL
+    - slower than Elasticsearch, but can be easily used for complex pricing models that calculate prices by SQL function
+    - to use this implementation you need to use `ProductOnCurrentDomainFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)

--- a/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
+++ b/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
@@ -151,3 +151,81 @@ To start using the read model, follow the instructions (you can also find inspir
         - {% endif %}
         + {{ render(controller('ShopsysShopBundle:Front/Cart:productAction', { productActionView: productView.action } )) }}
         ```
+    - update Elasticsearch structure in `src/Shopsys/ShopBundle/Resources/definition/product/*.json` like this:
+        ```diff
+        "mappings": {
+          "_doc": {
+            "properties": {
+
+               //...
+
+              "prices": {
+                "type": "nested",
+                "properties": {
+                  "pricing_group_id": {
+                    "type": "integer"
+                  },
+        -         "amount": {
+        +         "price_with_vat": {
+                    "type": "float"
+        -         }
+        +         },
+        +         "price_without_vat": {
+        +           "type": "float"
+        +         },
+        +         "vat": {
+        +           "type": "float"
+        +         },
+        +         "price_from": {
+        +           "type": "boolean"
+        +         }
+                }
+              },
+
+              //...
+
+        +     "selling_denied": {
+        +       "type": "boolean"
+        +     },
+        +     "availability": {
+        +       "type": "text"
+        +     },
+        +     "main_variant": {
+        +       "type": "boolean"
+        +     },
+        +     "detail_url": {
+        +       "type": "text"
+        +     },
+        +     "visibility": {
+        +       "type": "nested",
+        +       "properties": {
+        +         "pricing_group_id": {
+        +           "type": "integer"
+        +         },
+        +         "visible": {
+        +           "type": "boolean"
+        +         }
+        +       }
+        +     }
+            }
+        ```
+    - fix test `ProductSearchExportRepositoryTest::getExpectedStructureForRepository()` by adding new Elasticsearch fields to it
+        ```diff
+            if ($productSearchExportRepository instanceof ProductSearchExportWithFilterRepository) {
+                $structure = \array_merge($structure, [
+        +           'availability',
+                    'brand',
+                    'flags',
+                    'categories',
+        +           'detail_url',
+                    'in_stock',
+                    'prices',
+                    'parameters',
+                    'ordering_priority',
+                    'calculated_selling_denied',
+        +           'selling_denied',
+        +           'main_variant',
+        +           'visibility',
+                ]);
+            }
+        ```

--- a/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
+++ b/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
@@ -5,6 +5,9 @@ Besides better logical separation of the application, it is a first step towards
 The read model package is marked as *experimental* at the moment so there is a possibility we might introduce some BC breaking changes there.
 You do not need to perform the upgrade instantly, however, if you do so, you will be better prepared for the upcoming changes.
 
+There are two implementations of read model facades right now as we want to provide you possibilities that suits you the best.
+You can choose between SQL or Elasticsearch implementation, you can learn more in [Front-end product filtering](/docs/model/front-end-product-filtering.md).
+
 <!-- TODO change link to PR to the split merge commit in project-base -->
 To start using the read model, follow the instructions (you can also find inspiration in [#1018](https://github.com/shopsys/shopsys/pull/1018) where the read model was introduced to `project-base`):
 - add dependency on `shopsys/read-model` to your `composer.json`
@@ -229,3 +232,22 @@ To start using the read model, follow the instructions (you can also find inspir
                 ]);
             }
         ```
+    - fix tests in `ListedProductViewFacadeTest` by changing `ListedProductViewFacade` to `ListedProductViewFacadeInterface`
+        ```diff
+        -   $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+        +   $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
+        ```
+    ### Use SQL read model facade
+    - use `ListedProductViewFacade` implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
+        ```yaml
+            Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade'
+        ```
+    - to use this implementation you need to use `ProductOnCurrentDomainFacade` as well. You can find more about it [Front-end product filtering](/docs/model/front-end-product-filtering.md)
+    ### Use Elasticsearch read model facade
+    - use `ListedProductViewElasticFacade` implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
+        ```yaml
+            Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
+
+            Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade: ~  
+        ```
+     - to use this implementation you need to use `ProductOnCurrentDomainElasticFacade` as well. You can find more about it [Front-end product filtering](/docs/model/front-end-product-filtering.md)

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -168,13 +168,11 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     {
         $emptyProductFilterData = new ProductFilterData();
 
-        $filterQuery = $this->createProductsForBrandFilterQuery($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
+        $filterQuery = $this->createListableProductsForBrandFilterQuery($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
 
-        $productIds = $this->productElasticsearchRepository->getSortedProductIdsByFilterQuery($filterQuery);
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
-        $listableProductsByIds = $this->productRepository->getListableByIds($this->domain->getId(), $this->currentCustomer->getPricingGroup(), $productIds->getIds());
-
-        return new PaginationResult($page, $limit, $productIds->getTotal(), $listableProductsByIds);
+        return new PaginationResult($page, $limit, $productsResult->getTotal(), $productsResult->getHits());
     }
 
     /**
@@ -185,7 +183,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    protected function createProductsForBrandFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $brandId): FilterQuery
+    protected function createListableProductsForBrandFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $brandId): FilterQuery
     {
         return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->filterByBrands([$brandId]);

--- a/packages/framework/src/Model/Product/ProductVisibility.php
+++ b/packages/framework/src/Model/Product/ProductVisibility.php
@@ -64,4 +64,12 @@ class ProductVisibility
     {
         return $this->visible;
     }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup
+     */
+    public function getPricingGroup(): PricingGroup
+    {
+        return $this->pricingGroup;
+    }
 }

--- a/packages/framework/src/Model/Product/ProductVisibilityRepository.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityRepository.php
@@ -154,6 +154,19 @@ class ProductVisibilityRepository
         return $productVisibility;
     }
 
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductVisibility[]
+     */
+    public function findProductVisibilitiesByDomainIdAndProduct($domainId, Product $product): array
+    {
+        return $this->getProductVisibilityRepository()->findBy([
+            'product' => $product->getId(),
+            'domainId' => $domainId,
+        ]);
+    }
+
     protected function markAllProductsVisibilityAsRecalculated()
     {
         $this->em->createNativeQuery(

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -5,10 +5,14 @@ namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
+use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibility;
+use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository;
 
 class ProductSearchExportWithFilterRepository extends ProductSearchExportRepository
 {
@@ -23,16 +27,44 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
     protected $productFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository
+     */
+    protected $friendlyUrlRepository;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository
+     */
+    protected $productVisibilityRepository;
+
+    /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository $parameterRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
+     * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository
      */
-    public function __construct(EntityManagerInterface $em, ParameterRepository $parameterRepository, ProductFacade $productFacade)
-    {
+    public function __construct(
+        EntityManagerInterface $em,
+        ParameterRepository $parameterRepository,
+        ProductFacade $productFacade,
+        FriendlyUrlRepository $friendlyUrlRepository,
+        Domain $domain,
+        ProductVisibilityRepository $productVisibilityRepository
+    ) {
         parent::__construct($em);
 
         $this->parameterRepository = $parameterRepository;
         $this->productFacade = $productFacade;
+        $this->em = $em;
+        $this->friendlyUrlRepository = $friendlyUrlRepository;
+        $this->domain = $domain;
+        $this->productVisibilityRepository = $productVisibilityRepository;
     }
 
     /**
@@ -57,6 +89,9 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
             $categoryIds = $this->extractCategories($domainId, $product);
             $parameters = $this->extractParameters($locale, $product);
             $prices = $this->extractPrices($domainId, $product);
+            $visibility = $this->extractVisibility($domainId, $product);
+
+            $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl($domainId, 'front_product_detail', $product->getId());
 
             $result[] = [
                 'id' => $product->getId(),
@@ -74,6 +109,11 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
                 'parameters' => $parameters,
                 'ordering_priority' => $product->getOrderingPriority(),
                 'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
+                'selling_denied' => $product->isSellingDenied(),
+                'availability' => $product->getAvailability()->getName($locale),
+                'main_variant' => $product->isMainVariant(),
+                'detail_url' => $friendlyUrl->getAbsoluteUrl($this->domain),
+                'visibility' => $visibility,
             ];
         }
 
@@ -166,12 +206,40 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
         /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice[] $productSellingPrices */
         $productSellingPrices = $this->productFacade->getAllProductSellingPricesByDomainId($product, $domainId);
         foreach ($productSellingPrices as $productSellingPrice) {
+            $sellingPrice = $productSellingPrice->getSellingPrice();
+            $priceFrom = false;
+            if ($sellingPrice instanceof ProductPrice) {
+                $priceFrom = $sellingPrice->isPriceFrom();
+            }
+
             $prices[] = [
                 'pricing_group_id' => $productSellingPrice->getPricingGroup()->getId(),
-                'amount' => (float)$productSellingPrice->getSellingPrice()->getPriceWithVat()->getAmount(),
+                'price_with_vat' => (float)$sellingPrice->getPriceWithVat()->getAmount(),
+                'price_without_vat' => (float)$sellingPrice->getPriceWithoutVat()->getAmount(),
+                'vat' => (float)$sellingPrice->getVatAmount()->getAmount(),
+                'price_from' => $priceFrom,
             ];
         }
 
         return $prices;
+    }
+
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return array
+     */
+    protected function extractVisibility(int $domainId, Product $product): array
+    {
+        $visibility = [];
+
+        foreach ($this->productVisibilityRepository->findProductVisibilitiesByDomainIdAndProduct($domainId, $product) as $productVisibility) {
+            $visibility[] = [
+                'pricing_group_id' => $productVisibility->getPricingGroup()->getId(),
+                'visible' => $productVisibility->isVisible(),
+            ];
+        }
+
+        return $visibility;
     }
 }

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -82,42 +82,64 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
 
         $query = $queryBuilder->getQuery();
 
-        $result = [];
+        $results = [];
         /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
         foreach ($query->getResult() as $product) {
-            $flagIds = $this->extractFlags($product);
-            $categoryIds = $this->extractCategories($domainId, $product);
-            $parameters = $this->extractParameters($locale, $product);
-            $prices = $this->extractPrices($domainId, $product);
-            $visibility = $this->extractVisibility($domainId, $product);
-
-            $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl($domainId, 'front_product_detail', $product->getId());
-
-            $result[] = [
-                'id' => $product->getId(),
-                'catnum' => $product->getCatnum(),
-                'partno' => $product->getPartno(),
-                'ean' => $product->getEan(),
-                'name' => $product->getName($locale),
-                'description' => $product->getDescription($domainId),
-                'shortDescription' => $product->getShortDescription($domainId),
-                'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
-                'flags' => $flagIds,
-                'categories' => $categoryIds,
-                'in_stock' => $product->getCalculatedAvailability()->getDispatchTime() === 0,
-                'prices' => $prices,
-                'parameters' => $parameters,
-                'ordering_priority' => $product->getOrderingPriority(),
-                'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
-                'selling_denied' => $product->isSellingDenied(),
-                'availability' => $product->getAvailability()->getName($locale),
-                'main_variant' => $product->isMainVariant(),
-                'detail_url' => $friendlyUrl->getAbsoluteUrl($this->domain),
-                'visibility' => $visibility,
-            ];
+            $results[] = $this->extractResult($product, $domainId, $locale);
         }
 
-        return $result;
+        return $results;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param int $domainId
+     * @param string $locale
+     * @return array
+     */
+    protected function extractResult(Product $product, int $domainId, string $locale): array
+    {
+        $flagIds = $this->extractFlags($product);
+        $categoryIds = $this->extractCategories($domainId, $product);
+        $parameters = $this->extractParameters($locale, $product);
+        $prices = $this->extractPrices($domainId, $product);
+        $visibility = $this->extractVisibility($domainId, $product);
+        $detailUrl = $this->extractDetailUrl($domainId, $product);
+
+        return [
+            'id' => $product->getId(),
+            'catnum' => $product->getCatnum(),
+            'partno' => $product->getPartno(),
+            'ean' => $product->getEan(),
+            'name' => $product->getName($locale),
+            'description' => $product->getDescription($domainId),
+            'shortDescription' => $product->getShortDescription($domainId),
+            'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
+            'flags' => $flagIds,
+            'categories' => $categoryIds,
+            'in_stock' => $product->getCalculatedAvailability()->getDispatchTime() === 0,
+            'prices' => $prices,
+            'parameters' => $parameters,
+            'ordering_priority' => $product->getOrderingPriority(),
+            'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
+            'selling_denied' => $product->isSellingDenied(),
+            'availability' => $product->getAvailability()->getName($locale),
+            'main_variant' => $product->isMainVariant(),
+            'detail_url' => $detailUrl,
+            'visibility' => $visibility,
+        ];
+    }
+
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return string
+     */
+    protected function extractDetailUrl(int $domainId, Product $product): string
+    {
+        $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl($domainId, 'front_product_detail', $product->getId());
+
+        return $friendlyUrl->getAbsoluteUrl($this->domain);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -75,7 +75,7 @@ class FilterQuery
 
         if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_PRICE_ASC) {
             $clone->sorting = [
-                'prices.amount' => [
+                'prices.price_with_vat' => [
                     'order' => 'asc',
                     'nested' => [
                         'path' => 'prices',
@@ -95,7 +95,7 @@ class FilterQuery
 
         if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_PRICE_DESC) {
             $clone->sorting = [
-                'prices.amount' => [
+                'prices.price_with_vat' => [
                     'order' => 'desc',
                     'nested' => [
                         'path' => 'prices',
@@ -203,7 +203,7 @@ class FilterQuery
                             ],
                             [
                                 'range' => [
-                                    'prices.amount' => $prices,
+                                    'prices.price_with_vat' => $prices,
                                 ],
                             ],
                         ],

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -299,6 +299,42 @@ class FilterQuery
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterOnlyVisible(PricingGroup $pricingGroup): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'nested' => [
+                'path' => 'visibility',
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            'match_all' => new \stdClass(),
+                        ],
+                        'filter' => [
+                            [
+                                'term' => [
+                                    'visibility.pricing_group_id' => $pricingGroup->getId(),
+                                ],
+                            ],
+                            [
+                                'term' => [
+                                    'visibility.visible' => true,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
      * @param string $text
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -155,6 +155,17 @@ class ProductElasticsearchRepository
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\ProductsResult
+     */
+    public function getSortedProductsResultByFilterQuery(FilterQuery $filterQuery): ProductsResult
+    {
+        $result = $this->client->search($filterQuery->getQuery());
+
+        return new ProductsResult($this->extractTotalCount($result), $this->extractHits($result));
+    }
+
+    /**
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
      * @param string $indexName
      * @param string $searchText
@@ -177,6 +188,20 @@ class ProductElasticsearchRepository
     {
         $hits = $result['hits']['hits'];
         return array_column($hits, '_id');
+    }
+
+    /**
+     * @param array $result
+     * @return array
+     */
+    protected function extractHits(array $result): array
+    {
+        return array_map(static function ($value) {
+            $data = $value['_source'];
+            $data['id'] = (int)$value['_id'];
+
+            return $data;
+        }, $result['hits']['hits']);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/ProductsResult.php
+++ b/packages/framework/src/Model/Product/Search/ProductsResult.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Search;
+
+class ProductsResult
+{
+    /**
+     * @var int
+     */
+    protected $total;
+
+    /**
+     * @var array
+     */
+    protected $hits;
+
+    /**
+     * @param int $total
+     * @param array $hits
+     */
+    public function __construct(int $total, array $hits)
+    {
+        $this->total = $total;
+        $this->hits = $hits;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHits(): array
+    {
+        return $this->hits;
+    }
+}

--- a/packages/framework/src/Resources/config/services/cron.yml
+++ b/packages/framework/src/Resources/config/services/cron.yml
@@ -6,7 +6,7 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportCronModule:
         tags:
-            - { name: shopsys.cron, hours: '*', minutes: '0' }
+            - { name: shopsys.cron, hours: '*', minutes: '*' }
 
     Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule:
         tags:

--- a/packages/read-model/src/Product/Action/ProductActionViewFacade.php
+++ b/packages/read-model/src/Product/Action/ProductActionViewFacade.php
@@ -59,4 +59,13 @@ class ProductActionViewFacade
 
         return $productActionViews;
     }
+
+    /**
+     * @param array $productArray
+     * @return \Shopsys\ReadModelBundle\Product\Action\ProductActionView
+     */
+    public function getForArray(array $productArray): ProductActionView
+    {
+        return $this->productActionViewFactory->createFromArray($productArray);
+    }
 }

--- a/packages/read-model/src/Product/Action/ProductActionViewFactory.php
+++ b/packages/read-model/src/Product/Action/ProductActionViewFactory.php
@@ -25,4 +25,18 @@ class ProductActionViewFactory
             $absoluteUrl
         );
     }
+
+    /**
+     * @param array $productArray
+     * @return \Shopsys\ReadModelBundle\Product\Action\ProductActionView
+     */
+    public function createFromArray(array $productArray): ProductActionView
+    {
+        return new ProductActionView(
+            $productArray['id'],
+            $productArray['selling_denied'],
+            $productArray['main_variant'],
+            $productArray['detail_url']
+        );
+    }
 }

--- a/packages/read-model/src/Product/Listed/ListedProductViewFacade.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFacade.php
@@ -192,7 +192,7 @@ class ListedProductViewFacade implements ListedProductViewFacadeInterface
     {
         $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForSearch($searchText, $filterData, $orderingModeId, $page, $limit);
 
-        return $this->createPaginationResultWithData($paginationResult);
+        return $this->createPaginationResultWithArray($paginationResult);
     }
 
     /**

--- a/packages/read-model/src/Product/Listed/ListedProductViewFacade.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFacade.php
@@ -177,7 +177,7 @@ class ListedProductViewFacade implements ListedProductViewFacadeInterface
     {
         $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsInCategory($filterData, $orderingModeId, $page, $limit, $categoryId);
 
-        return $this->createPaginationResultWithData($paginationResult);
+        return $this->createPaginationResultWithArray($paginationResult);
     }
 
     /**
@@ -221,6 +221,42 @@ class ListedProductViewFacade implements ListedProductViewFacadeInterface
             $paginationResult->getTotalCount(),
             $this->createFromProducts($paginationResult->getResults())
         );
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult $paginationResult
+     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
+     */
+    protected function createPaginationResultWithArray(PaginationResult $paginationResult): PaginationResult
+    {
+        return new PaginationResult(
+            $paginationResult->getPage(),
+            $paginationResult->getPageSize(),
+            $paginationResult->getTotalCount(),
+            $this->createFromArray($paginationResult->getResults())
+        );
+    }
+
+    /**
+     * @param array $productsArray
+     * @return \Shopsys\ReadModelBundle\Product\Listed\ListedProductView[]
+     */
+    protected function createFromArray(array $productsArray): array
+    {
+        $imageViews = $this->imageViewFacade->getForEntityIds(Product::class, array_column($productsArray, 'id'));
+
+        $listedProductViews = [];
+        foreach ($productsArray as $productArray) {
+            $productId = $productArray['id'];
+            $listedProductViews[$productId] = $this->listedProductViewFactory->createFromArray(
+                $productArray,
+                $imageViews[$productId],
+                $this->productActionViewFacade->getForArray($productArray),
+                $this->currentCustomer->getPricingGroup()
+            );
+        }
+
+        return $listedProductViews;
     }
 
     /**

--- a/packages/read-model/src/Product/Listed/ListedProductViewFacade.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFacade.php
@@ -206,21 +206,7 @@ class ListedProductViewFacade implements ListedProductViewFacadeInterface
     {
         $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForBrand($orderingModeId, $page, $limit, $brandId);
 
-        return $this->createPaginationResultWithData($paginationResult);
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult $paginationResult
-     * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
-     */
-    protected function createPaginationResultWithData(PaginationResult $paginationResult): PaginationResult
-    {
-        return new PaginationResult(
-            $paginationResult->getPage(),
-            $paginationResult->getPageSize(),
-            $paginationResult->getTotalCount(),
-            $this->createFromProducts($paginationResult->getResults())
-        );
+        return $this->createPaginationResultWithArray($paginationResult);
     }
 
     /**

--- a/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\ReadModelBundle\Product\Listed;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Pricing\Price;
+use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade;
 use Shopsys\ReadModelBundle\Image\ImageView;
@@ -55,6 +59,46 @@ class ListedProductViewFactory
             $productActionView,
             $imageView
         );
+    }
+
+    /**
+     * @param array $productArray
+     * @param \Shopsys\ReadModelBundle\Image\ImageView|null $imageView
+     * @param \Shopsys\ReadModelBundle\Product\Action\ProductActionView $productActionView
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\ReadModelBundle\Product\Listed\ListedProductView
+     */
+    public function createFromArray(array $productArray, ?ImageView $imageView, ProductActionView $productActionView, PricingGroup $pricingGroup): ListedProductView
+    {
+        return new ListedProductView(
+            $productArray['id'],
+            $productArray['name'],
+            $productArray['shortDescription'],
+            $productArray['availability'],
+            $this->getProductPriceFromArrayByPricingGroup($productArray['prices'], $pricingGroup),
+            $productArray['flags'],
+            $productActionView,
+            $imageView
+        );
+    }
+
+    /**
+     * @param array $pricesArray
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice|null
+     */
+    protected function getProductPriceFromArrayByPricingGroup(array $pricesArray, PricingGroup $pricingGroup): ?ProductPrice
+    {
+        foreach ($pricesArray as $priceArray) {
+            if ($priceArray['pricing_group_id'] === $pricingGroup->getId()) {
+                $priceWithoutVat = Money::create((string)$priceArray['price_without_vat']);
+                $priceWithVat = Money::create((string)$priceArray['price_with_vat']);
+                $price = new Price($priceWithoutVat, $priceWithVat);
+                return new ProductPrice($price, $priceArray['price_from']);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -55,6 +55,10 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade'
 
+    Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
+
+    Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade: ~
+
     Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository:
         alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services_test.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services_test.yml
@@ -60,3 +60,5 @@ services:
     Shopsys\ReadModelBundle\Product\Action\ProductActionViewFacade: ~
 
     Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade: ~
+
+    Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'

--- a/project-base/src/Shopsys/ShopBundle/Resources/definition/product/1.json
+++ b/project-base/src/Shopsys/ShopBundle/Resources/definition/product/1.json
@@ -168,8 +168,17 @@
             "pricing_group_id": {
               "type": "integer"
             },
-            "amount": {
+            "price_with_vat": {
               "type": "float"
+            },
+            "price_without_vat": {
+              "type": "float"
+            },
+            "vat": {
+              "type": "float"
+            },
+            "price_from": {
+              "type": "boolean"
             }
           }
         },
@@ -192,6 +201,29 @@
         },
         "calculated_selling_denied": {
           "type": "boolean"
+        },
+        "selling_denied": {
+          "type": "boolean"
+        },
+        "availability": {
+          "type": "text"
+        },
+        "main_variant": {
+          "type": "boolean"
+        },
+        "detail_url": {
+          "type": "text"
+        },
+        "visibility": {
+          "type": "nested",
+          "properties": {
+            "pricing_group_id": {
+              "type": "integer"
+            },
+            "visible": {
+              "type": "boolean"
+            }
+          }
         }
       }
     }

--- a/project-base/src/Shopsys/ShopBundle/Resources/definition/product/2.json
+++ b/project-base/src/Shopsys/ShopBundle/Resources/definition/product/2.json
@@ -168,8 +168,17 @@
             "pricing_group_id": {
               "type": "integer"
             },
-            "amount": {
+            "price_with_vat": {
               "type": "float"
+            },
+            "price_without_vat": {
+              "type": "float"
+            },
+            "vat": {
+              "type": "float"
+            },
+            "price_from": {
+              "type": "boolean"
             }
           }
         },
@@ -192,6 +201,29 @@
         },
         "calculated_selling_denied": {
           "type": "boolean"
+        },
+        "selling_denied": {
+          "type": "boolean"
+        },
+        "availability": {
+          "type": "text"
+        },
+        "main_variant": {
+          "type": "boolean"
+        },
+        "detail_url": {
+          "type": "text"
+        },
+        "visibility": {
+          "type": "nested",
+          "properties": {
+            "pricing_group_id": {
+              "type": "integer"
+            },
+            "visible": {
+              "type": "boolean"
+            }
+          }
         }
       }
     }

--- a/project-base/tests/ReadModelBundle/Functional/Product/Listed/ListedProductViewFacadeTest.php
+++ b/project-base/tests/ReadModelBundle/Functional/Product/Listed/ListedProductViewFacadeTest.php
@@ -5,15 +5,15 @@ namespace Tests\ReadModelBundle\Functional\Product\Listed;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 use Shopsys\ReadModelBundle\Product\Listed\ListedProductView;
-use Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade;
+use Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface;
 use Tests\ShopBundle\Test\FunctionalTestCase;
 
 class ListedProductViewFacadeTest extends FunctionalTestCase
 {
     public function testGetAllAccessories(): void
     {
-        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade $listedProductViewFacade */
-        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade */
+        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
 
         $productId1 = 24;
         $productId2 = 13;
@@ -34,8 +34,8 @@ class ListedProductViewFacadeTest extends FunctionalTestCase
 
     public function testGetPaginatedForBrand(): void
     {
-        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade $listedProductViewFacade */
-        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade */
+        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
 
         $brandId = 1;
         $foundProductId = 5;
@@ -50,8 +50,8 @@ class ListedProductViewFacadeTest extends FunctionalTestCase
 
     public function testGetFilteredPaginatedForSearch(): void
     {
-        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade $listedProductViewFacade */
-        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade */
+        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
         $emptyFilterData = new ProductFilterData();
 
         $paginationResults = $listedProductViewFacade->getFilteredPaginatedForSearch('kitty', $emptyFilterData, ProductListOrderingConfig::ORDER_BY_NAME_ASC, 1, 10);
@@ -64,8 +64,8 @@ class ListedProductViewFacadeTest extends FunctionalTestCase
 
     public function testGetTop(): void
     {
-        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade $listedProductViewFacade */
-        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade */
+        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
 
         $firstTopProductId = 1;
 
@@ -80,8 +80,8 @@ class ListedProductViewFacadeTest extends FunctionalTestCase
     public function testGetFilteredPaginatedInCategory(): void
     {
 
-        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade $listedProductViewFacade */
-        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+        /** @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade */
+        $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
         $emptyFilterData = new ProductFilterData();
 
         $categoryId = 9;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php
@@ -59,14 +59,19 @@ class ProductSearchExportRepositoryTest extends TransactionFunctionalTestCase
 
         if ($productSearchExportRepository instanceof ProductSearchExportWithFilterRepository) {
             $structure = \array_merge($structure, [
+                'availability',
                 'brand',
                 'flags',
                 'categories',
+                'detail_url',
                 'in_stock',
                 'prices',
                 'parameters',
                 'ordering_priority',
                 'calculated_selling_denied',
+                'selling_denied',
+                'main_variant',
+                'visibility',
             ]);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to ensure fastest load time on product lists so the data in readmodel is loaded from Elasticsearch and not database
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
