### PR TITLE
[framework] end of support for helios-ag/fm-elfinder-bundle:^6.2.1

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -57,7 +57,7 @@
         "fzaninotto/faker": "^1.7.1",
         "gedmo/doctrine-extensions": "^2.4.34",
         "guzzlehttp/guzzle": "^6.3",
-        "helios-ag/fm-elfinder-bundle": "^6.2.1|^9.2",
+        "helios-ag/fm-elfinder-bundle": "^9.2",
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/metadata": "^1.6",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| due to the BC reasons there was a need to keep support for old version of package with missing flysystem driver support, but there will be no need, since version 8.x is not backward compatible. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
