### PR TITLE
[framework] administration: quicksearch for products via dashboard

### DIFF
--- a/packages/framework/src/Controller/Admin/DefaultController.php
+++ b/packages/framework/src/Controller/Admin/DefaultController.php
@@ -4,6 +4,8 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData;
+use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormType;
 use Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
@@ -68,6 +70,7 @@ class DefaultController extends AdminBaseController
 
     /**
      * @Route("/dashboard/")
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function dashboardAction()
     {
@@ -78,6 +81,11 @@ class DefaultController extends AdminBaseController
         $newOrdersInLastTwoWeeksDates = $this->statisticsProcessingFacade->getDateTimesFormattedToLocaleFormat($newOrdersCountByDayInLastTwoWeeks);
         $newOrdersInLastTwoWeeksCounts = $this->statisticsProcessingFacade->getCounts($newOrdersCountByDayInLastTwoWeeks);
 
+        $quickProductSearchData = new QuickSearchFormData();
+        $quickProductSearchForm = $this->createForm(QuickSearchFormType::class, $quickProductSearchData, [
+            'action' => $this->generateUrl('admin_product_list'),
+        ]);
+
         $this->addWarningMessagesOnDashboard();
 
         return $this->render(
@@ -87,6 +95,7 @@ class DefaultController extends AdminBaseController
                 'registeredInLastTwoWeeksValues' => $registeredInLastTwoWeeksCounts,
                 'newOrdersInLastTwoWeeksLabels' => $newOrdersInLastTwoWeeksDates,
                 'newOrdersInLastTwoWeeksValues' => $newOrdersInLastTwoWeeksCounts,
+                'quickProductSearchForm' => $quickProductSearchForm->createView(),
             ]
         );
     }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1720,6 +1720,9 @@ msgstr "Slevové kupóny"
 msgid "Published data"
 msgstr "Zveřejněné údaje"
 
+msgid "Quick product search"
+msgstr "Rychlé vyhledávání v produktech"
+
 msgid "Quick search"
 msgstr "Rychlé vyhledávání"
 
@@ -1797,6 +1800,9 @@ msgstr "Hledání"
 
 msgid "Search [verb]"
 msgstr "Vyhledat"
+
+msgid "Search by name, catalogue number, or product part number..."
+msgstr "Vyhledat dle názvu, katalogového čísla nebo partno produktu..."
 
 msgid "Searching in all currencies"
 msgstr "Vyhledává se ve všech měnách"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1720,6 +1720,9 @@ msgstr ""
 msgid "Published data"
 msgstr ""
 
+msgid "Quick product search"
+msgstr ""
+
 msgid "Quick search"
 msgstr ""
 
@@ -1797,6 +1800,9 @@ msgstr "Search"
 
 msgid "Search [verb]"
 msgstr "Search"
+
+msgid "Search by name, catalogue number, or product part number..."
+msgstr ""
 
 msgid "Searching in all currencies"
 msgstr ""

--- a/packages/framework/src/Resources/views/Admin/Content/Default/index.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Default/index.html.twig
@@ -4,20 +4,33 @@
 {% block h1 %}{{ 'Dashboard'|trans }}{% endblock %}
 
 {% block main_content %}
-	<div class="width-50-percent float-left">
-		<canvas
-			class="js-line-chart"
-			data-chart-labels="{{ newOrdersInLastTwoWeeksLabels|json_encode }}"
-			data-chart-values="{{ newOrdersInLastTwoWeeksValues|json_encode }}"
-			data-chart-title="{{ 'New orders'|trans }}"
-		></canvas>
-	</div>
-	<div class="width-50-percent float-left">
-		<canvas
-			class="js-line-chart"
-			data-chart-labels="{{ registeredInLastTwoWeeksLabels|json_encode }}"
-			data-chart-values="{{ registeredInLastTwoWeeksValues|json_encode }}"
-			data-chart-title="{{ 'New registered customers'|trans }}"
-		></canvas>
-	</div>
+    <div class="margin-bottom-20">
+        <div class="width-50-percent float-left">
+            <h2>{{ 'Quick product search'|trans }}</h2>
+        </div>
+        <div class="width-50-percent float-left text-right padding-top-10">
+            <a href="{{ url('admin_product_list', { as: [{ subject: 'productName' }] }) }}">
+                {{ 'Advanced search'|trans }}
+            </a>
+        </div>
+        <div class="in-tab__content clear">
+            {% include '@ShopsysFramework/Admin/Content/Product/quickSearchFormContent.html.twig' with {quickSearchForm: quickProductSearchForm} %}
+        </div>
+    </div>
+    <div class="width-50-percent float-left">
+        <canvas
+            class="js-line-chart"
+            data-chart-labels="{{ newOrdersInLastTwoWeeksLabels|json_encode }}"
+            data-chart-values="{{ newOrdersInLastTwoWeeksValues|json_encode }}"
+            data-chart-title="{{ 'New orders'|trans }}"
+        ></canvas>
+    </div>
+    <div class="width-50-percent float-left">
+        <canvas
+            class="js-line-chart"
+            data-chart-labels="{{ registeredInLastTwoWeeksLabels|json_encode }}"
+            data-chart-values="{{ registeredInLastTwoWeeksValues|json_encode }}"
+            data-chart-title="{{ 'New registered customers'|trans }}"
+        ></canvas>
+    </div>
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Product/quickSearchFormContent.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/quickSearchFormContent.html.twig
@@ -1,6 +1,11 @@
 {{ form_start(quickSearchForm) }}
     <div class="box-quick-search">
-        {{ form_widget(quickSearchForm.text, { attr: { class: 'box-quick-search__input'}} ) }}
+        {{ form_widget(quickSearchForm.text, { attr:
+            {
+                class: 'box-quick-search__input',
+                placeholder: 'Search by name, catalogue number, or product part number...'|trans
+            }
+        })}}
         {{ form_widget(quickSearchForm.submit, { label: 'Search [verb]'|trans, attr: { class: 'box-quick-search__btn'}, full_name: '' }) }}
         <i class="svg svg-info cursor-help js-tooltip box-quick-search__icon in-icon in-icon--info"
          data-toggle="tooltip" data-placement="left"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| for the speed purposes and better UX we would like to have direct connection between products and dashboard (default page after administrator is logged in)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
