### PR TITLE
[shopsys] Update of community license in packages

### DIFF
--- a/packages/framework/LICENSE
+++ b/packages/framework/LICENSE
@@ -1,4 +1,5 @@
 Shopsys Community License
+version 2018-05-24
 
 Copyright (c) 2014-2019 Shopsys s.r.o., http://www.shopsys.com
 
@@ -16,7 +17,7 @@ subject to the following conditions:
 (1) If the aggregate value (including all taxes such as value-added tax and sales tax) of the orders
 processed by any instance of the Software or any instance of a software created by derivation
 from the Software (each such an instance further referred to as the “Eshop”) used by the Licensee
-exceeds 10,000,000 € or its equivalent in any other currency in any twelve months’ period (“Limit Excess”),
+exceeds 3,000,000 € or its equivalent in any other currency in any three months’ period (“Limit Excess”),
 the license for the use of the Software for such Eshop shall terminate one month after the Limit
 Excess (“License Termination”). From time to time Shopsys may publish on its website or otherwise
 communicate to the licensees of the Software the specification of the type of orders which will not count

--- a/packages/read-model/LICENSE
+++ b/packages/read-model/LICENSE
@@ -1,4 +1,5 @@
 Shopsys Community License
+version 2018-05-24
 
 Copyright (c) 2014-2019 Shopsys s.r.o., http://www.shopsys.com
 
@@ -16,7 +17,7 @@ subject to the following conditions:
 (1) If the aggregate value (including all taxes such as value-added tax and sales tax) of the orders
 processed by any instance of the Software or any instance of a software created by derivation
 from the Software (each such an instance further referred to as the “Eshop”) used by the Licensee
-exceeds 10,000,000 € or its equivalent in any other currency in any twelve months’ period (“Limit Excess”),
+exceeds 3,000,000 € or its equivalent in any other currency in any three months’ period (“Limit Excess”),
 the license for the use of the Software for such Eshop shall terminate one month after the Limit
 Excess (“License Termination”). From time to time Shopsys may publish on its website or otherwise
 communicate to the licensees of the Software the specification of the type of orders which will not count

--- a/project-base/LICENSE
+++ b/project-base/LICENSE
@@ -1,4 +1,5 @@
 Shopsys Community License
+version 2018-05-24
 
 Copyright (c) 2014-2019 Shopsys s.r.o., http://www.shopsys.com
 
@@ -16,7 +17,7 @@ subject to the following conditions:
 (1) If the aggregate value (including all taxes such as value-added tax and sales tax) of the orders
 processed by any instance of the Software or any instance of a software created by derivation
 from the Software (each such an instance further referred to as the “Eshop”) used by the Licensee
-exceeds 10,000,000 € or its equivalent in any other currency in any twelve months’ period (“Limit Excess”),
+exceeds 3,000,000 € or its equivalent in any other currency in any three months’ period (“Limit Excess”),
 the license for the use of the Software for such Eshop shall terminate one month after the Limit
 Excess (“License Termination”). From time to time Shopsys may publish on its website or otherwise
 communicate to the licensees of the Software the specification of the type of orders which will not count


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Community license of shopsys/shopsys was updated 05/2018 but the license in packages was forgotten. The license in read-model, project-base and framework was updated as well.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| no
|Fixes issues| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
