### PR TITLE
[framework] changed variant abbreviation to a translation in administration

### DIFF
--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1237,6 +1237,9 @@ msgstr "Zboží na titulní stránce"
 msgid "Main variant"
 msgstr "Hlavní varianta"
 
+msgid "Main variant [abbreviation]"
+msgstr "H"
+
 msgid "Make modification"
 msgstr "Provést úpravu"
 
@@ -2223,6 +2226,9 @@ msgstr "Varianta"
 
 msgid "Variant <strong>{{ productVariant|productDisplayName }}</strong> successfully created."
 msgstr "Varianta <strong>{{ productVariant|productDisplayName }}</strong> byla úspěšně vytvořena."
+
+msgid "Variant [abbreviation]"
+msgstr "V"
 
 msgid "Variant alias"
 msgstr "Alias varianty"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1237,6 +1237,9 @@ msgstr ""
 msgid "Main variant"
 msgstr ""
 
+msgid "Main variant [abbreviation]"
+msgstr "M"
+
 msgid "Make modification"
 msgstr ""
 
@@ -2223,6 +2226,9 @@ msgstr ""
 
 msgid "Variant <strong>{{ productVariant|productDisplayName }}</strong> successfully created."
 msgstr ""
+
+msgid "Variant [abbreviation]"
+msgstr "V"
 
 msgid "Variant alias"
 msgstr ""

--- a/packages/framework/src/Resources/views/Admin/Content/Product/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/listGrid.html.twig
@@ -15,10 +15,10 @@
 
 {% block grid_value_cell_id_name %}
     {% if row.p.variantType == VARIANT_TYPE_MAIN %}
-        <span class="in-letter cursor-help js-tooltip" title="{{ 'Main variant'|trans }}">H</span>
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Main variant'|trans }}">{{ 'Main variant [abbreviation]'|trans }}</span>
     {% endif %}
     {% if row.p.variantType == VARIANT_TYPE_VARIANT %}
-        <span class="in-letter cursor-help js-tooltip" title="{{ 'Variant'|trans }}">V</span>
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Variant'|trans }}">{{ 'Variant [abbreviation]'|trans }}</span>
     {% endif %}
     <a href="{{ url('admin_product_edit', { id: row.p.id }) }}" target="_blank">{{ row.product|productListDisplayName }}</a>
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/ProductPicker/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/ProductPicker/listGrid.html.twig
@@ -6,10 +6,10 @@
 
 {% block grid_value_cell_id_name %}
     {% if row.p.variantType == VARIANT_TYPE_MAIN %}
-        <span class="in-letter cursor-help js-tooltip" title="{{ 'Main variant'|trans }}">H</span>
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Main variant'|trans }}">{{ 'Main variant [abbreviation]'|trans }}</span>
     {% endif %}
     {% if row.p.variantType == VARIANT_TYPE_VARIANT %}
-        <span class="in-letter cursor-help js-tooltip" title="{{ 'Variant'|trans }}">V</span>
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Variant'|trans }}">{{ 'Variant [abbreviation]'|trans }}</span>
     {% endif %}
     {{ row.product|productListDisplayName }}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Variant abbreviation should be a translation so you can change it if you want to
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
