### PR TITLE
[framework] configure VarDumperExtension in all environments

### DIFF
--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -4,6 +4,8 @@ namespace Shopsys\FrameworkBundle\DependencyInjection;
 
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface;
+use Shopsys\FrameworkBundle\Twig\NoVarDumperExtension;
+use Shopsys\FrameworkBundle\Twig\VarDumperExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -25,7 +27,22 @@ class ShopsysFrameworkExtension extends Extension
             $loader->load('services_test.yml');
         }
 
+        $this->configureVarDumperTwigExtension($container);
+
         $container->registerForAutoconfiguration(GridInlineEditInterface::class)
             ->addTag('shopsys.grid_inline_edit');
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    protected function configureVarDumperTwigExtension(ContainerBuilder $container): void
+    {
+        $isDev = $container->getParameter('kernel.environment') === EnvironmentType::DEVELOPMENT;
+
+        $varDumperExtensionService = $isDev ? VarDumperExtension::class : NoVarDumperExtension::class;
+
+        $container->getDefinition($varDumperExtensionService)
+            ->addTag('twig.extension');
     }
 }

--- a/packages/framework/src/Resources/config/services/twig.yml
+++ b/packages/framework/src/Resources/config/services/twig.yml
@@ -17,3 +17,9 @@ services:
 
     Shopsys\FrameworkBundle\Twig\ImageExtension:
         arguments: ['%shopsys.front_design_image_url_prefix%']
+
+    Shopsys\FrameworkBundle\Twig\NoVarDumperExtension:
+        autoconfigure: false
+
+    Shopsys\FrameworkBundle\Twig\VarDumperExtension:
+        autoconfigure: false

--- a/packages/framework/src/Twig/NoVarDumperExtension.php
+++ b/packages/framework/src/Twig/NoVarDumperExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Twig;
 
 use Twig\Extension\AbstractExtension;
@@ -8,9 +10,9 @@ use Twig\TwigFunction;
 class NoVarDumperExtension extends AbstractExtension
 {
     /**
-     * @return array
+     * @return Twig\TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('d', function () {}),
@@ -18,7 +20,10 @@ class NoVarDumperExtension extends AbstractExtension
         ];
     }
 
-    public function getName()
+    /**
+     * @return string
+     */
+    public function getName(): string
     {
         return 'no_var_dumper_extension';
     }

--- a/packages/framework/src/Twig/NoVarDumperExtension.php
+++ b/packages/framework/src/Twig/NoVarDumperExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class NoVarDumperExtension extends AbstractExtension
+{
+    /**
+     * @return array
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('d', function () {}),
+            new TwigFunction('dump', function () {}),
+        ];
+    }
+
+    public function getName()
+    {
+        return 'no_var_dumper_extension';
+    }
+}

--- a/packages/framework/src/Twig/NoVarDumperExtension.php
+++ b/packages/framework/src/Twig/NoVarDumperExtension.php
@@ -10,13 +10,15 @@ use Twig\TwigFunction;
 class NoVarDumperExtension extends AbstractExtension
 {
     /**
-     * @return Twig\TwigFunction[]
+     * @return \Twig\TwigFunction[]
      */
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('d', function () {}),
-            new TwigFunction('dump', function () {}),
+            new TwigFunction('d', function () {
+            }),
+            new TwigFunction('dump', function () {
+            }),
         ];
     }
 


### PR DESCRIPTION
- twig functions `d()` and `dump()` are now defined in all environments
- `d()` and `dump()` now do nothing in prod and test environments

| Q             | A
| ------------- | ---
|Description, reason for the PR| Phing target `twig-lint` fails if the application is in `prod` environemnt with a confusing message (see below) after #1068 because it now checks more Twig templates. Also, using `dump()` Twig function causes a 500 error in `prod` environment.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Output of target `twig-lint` executed in morepo in `prod` application environement:

```
Shopsys Framework > twig-lint:


Shopsys Framework > shopsys_framework.twig-lint:


 [OK] All 79 Twig files contain valid syntax.                                                                           


  ERROR  in /var/www/html/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDumpFixer/wrong/wrong.html.twig (line -1)
      1      123456

 [WARNING] 185 Twig files have valid syntax and 1 contain errors.                                                       

12:55:40 ERROR     [app] Command `lint:twig` exited with status code 1

BUILD FAILED
/var/www/html/build.xml:321:85: Task exited with code 1

Total time: 3.4647 seconds
```