### PR TITLE
prezent/doctrine-translatable-bundle in version 1.0.6 is now marked as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
     "phpstan/phpstan-phpunit": "^0.11.2"
   },
   "conflict": {
+    "prezent/doctrine-translatable-bundle": "1.0.6",
     "symfony/dependency-injection": "3.4.15|3.4.16",
     "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
     "twig/twig": "2.6.1"

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -122,5 +122,10 @@ There you can find links to upgrade notes for other versions too.
         - don't forget to update your Dockerfiles, Kubernetes manifests, scripts and other files that might reference the phing targets above
 - we recommend upgrading PHPStan to level 4 [#1040](https://github.com/shopsys/shopsys/pull/1040)
     - you'll find detailed instructions in separate article [Upgrade Instructions for Upgrading PHPStan to Level 4](/docs/upgrade/phpstan-level-4.md)
+- add conflict with `prezent/doctrine-translatable-bundle` in version `1.0.6` to your `composer.json` [#1107](https://github.com/shopsys/shopsys/pull/1107)
+    ```diff
+    "conflict": {
+    +     "prezent/doctrine-translatable-bundle": "1.0.6",
+    ```
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -104,6 +104,7 @@
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"
     },
     "conflict": {
+        "prezent/doctrine-translatable-bundle": "1.0.6",
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
     }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -102,6 +102,7 @@
         "phpstan/phpstan-phpunit": "^0.11.2"
     },
     "conflict": {
+        "prezent/doctrine-translatable-bundle": "1.0.6",
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| https://github.com/Prezent/doctrine-translatable-bundle/issues/25
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
