### PR TITLE
[framework] BreadcrumbResolver is created by GenericBreadcrumbResolverFactory

### DIFF
--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\DependencyInjection;
 
+use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\GridInlineEditInterface;
 use Shopsys\FrameworkBundle\Twig\NoVarDumperExtension;
@@ -31,6 +32,8 @@ class ShopsysFrameworkExtension extends Extension
 
         $container->registerForAutoconfiguration(GridInlineEditInterface::class)
             ->addTag('shopsys.grid_inline_edit');
+        $container->registerForAutoconfiguration(BreadcrumbGeneratorInterface::class)
+            ->addTag('shopsys.breadcrumb_generator');
     }
 
     /**

--- a/packages/framework/src/Model/Breadcrumb/FrontBreadcrumbResolverFactory.php
+++ b/packages/framework/src/Model/Breadcrumb/FrontBreadcrumbResolverFactory.php
@@ -9,6 +9,9 @@ use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataBreadcrumbGenerator;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandBreadcrumbGenerator;
 use Shopsys\FrameworkBundle\Model\Product\ProductBreadcrumbGenerator;
 
+/**
+ * @deprecated Using this class is deprecated since SSFW 7.3, use GenericBreadcrumbResolverFactory instead which is easier to use
+ */
 class FrontBreadcrumbResolverFactory
 {
     /**
@@ -34,6 +37,11 @@ class FrontBreadcrumbResolverFactory
         ErrorPageBreadcrumbGenerator $errorPageBreadcrumbGenerator,
         PersonalDataBreadcrumbGenerator $personalDataBreadcrumbGenerator
     ) {
+        @trigger_error(
+            sprintf('Using "%s" is deprecated since SSFW 7.3, use "%s" instead which is easier to use', self::class, GenericBreadcrumbResolverFactory::class),
+            E_USER_DEPRECATED
+        );
+
         $this->breadcrumbGenerators = [
             $articleBreadcrumbGenerator,
             $categoryBreadcrumbGenerator,

--- a/packages/framework/src/Model/Breadcrumb/GenericBreadcrumbResolverFactory.php
+++ b/packages/framework/src/Model/Breadcrumb/GenericBreadcrumbResolverFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Model\Breadcrumb;
+
+use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbResolver;
+
+class GenericBreadcrumbResolverFactory
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface[]
+     */
+    protected $breadcrumbGenerators;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface[] $breadcrumbGenerators
+     */
+    public function __construct(iterable $breadcrumbGenerators) {
+        $this->breadcrumbGenerators = $breadcrumbGenerators;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbResolver
+     */
+    public function create()
+    {
+        $frontBreadcrumbResolver = new BreadcrumbResolver();
+        foreach ($this->breadcrumbGenerators as $breadcrumbGenerator) {
+            $frontBreadcrumbResolver->registerGenerator($breadcrumbGenerator);
+        }
+
+        return $frontBreadcrumbResolver;
+    }
+}

--- a/packages/framework/src/Model/Breadcrumb/GenericBreadcrumbResolverFactory.php
+++ b/packages/framework/src/Model/Breadcrumb/GenericBreadcrumbResolverFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Breadcrumb;
 
 use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbResolver;
@@ -14,14 +16,15 @@ class GenericBreadcrumbResolverFactory
     /**
      * @param \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface[] $breadcrumbGenerators
      */
-    public function __construct(iterable $breadcrumbGenerators) {
+    public function __construct(iterable $breadcrumbGenerators)
+    {
         $this->breadcrumbGenerators = $breadcrumbGenerators;
     }
 
     /**
      * @return \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbResolver
      */
-    public function create()
+    public function create(): BreadcrumbResolver
     {
         $frontBreadcrumbResolver = new BreadcrumbResolver();
         foreach ($this->breadcrumbGenerators as $breadcrumbGenerator) {

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -128,10 +128,13 @@ services:
 
     Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~
 
+    Shopsys\FrameworkBundle\Model\Breadcrumb\GenericBreadcrumbResolverFactory:
+        arguments: [!tagged shopsys.breadcrumb_generator]
+
     Shopsys\FrameworkBundle\Model\Module\ModuleList: ~
 
     Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbResolver:
-        factory: ['@Shopsys\FrameworkBundle\Model\Breadcrumb\FrontBreadcrumbResolverFactory', create]
+        factory: ['@Shopsys\FrameworkBundle\Model\Breadcrumb\GenericBreadcrumbResolverFactory', create]
 
     Shopsys\FrameworkBundle\Model\Cart\CartMigrationFacade:
         tags:


### PR DESCRIPTION
- breadcrumb generators have been autoconfigured to be tagged as `shopsys.breadcrumb_generator`
- all services tagged as `shopsys.breadcrumb_generator` are passed to the factory
  - this allows users to add breadcrumb generators much more easily
- the use of `FrontBreadcrumbResolverFactory` with hard-coded dependecies was deprecated

**TODO**
* [ ] adding upgrade notes
* [ ] testing of BC from project repository with an added breadcrumb generator
* [ ] revision of docs (maybe addressing #919)

| Q             | A
| ------------- | ---
|Description, reason for the PR| registering of BreadcrumbGenerators should be much easier for our users (#1090)
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #1090 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
