### PR TITLE
[shopsys] ProductAvailabilityCalculation: fix calculation of not-yet-persisted products

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -59,7 +59,7 @@ There you can find links to upgrade notes for other versions too.
             +     return $entityManagerMock;
             + }
             ```
-    - you can copy-paste a new functional test [`ProductVariantCreationTest.php`](/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` to avoid regression of issues with creating product variants in the future
+    - you can copy-paste a new functional test [`ProductVariantCreationTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` to avoid regression of issues with creating product variants in the future
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -33,6 +33,33 @@ There you can find links to upgrade notes for other versions too.
 ### Application
 - follow instructions in [the separate article](upgrade-instructions-for-read-model-for-product-lists.md) to introduce read model for frontend product lists into your project ([#1018](https://github.com/shopsys/shopsys/pull/1018))
     - we recommend to read [Introduction to Read Model](/docs/model/introduction-to-read-model.md) article
+- fix up your functional tests because of availability calculation patch in the `shopsys/framework` ([#1113](https://github.com/shopsys/shopsys/pull/1113))
+    - when providing a mock of `EntityManager` to `ProductAvailabilityCalculation` in a test, set its `contains` to always return `true`
+        - it's recommended to extract the mocking into a method, for example see changes in `ProductAvailabilityCalculationTest`:
+            ```diff
+            -     $entityManagerMock = $this->createMock(EntityManager::class);
+            +     $entityManagerMock = $this->createEntityManagerMock();
+            ...
+            -     $entityManagerMock = $this->createMock(EntityManager::class);
+            +     $entityManagerMock = $this->createEntityManagerMock();
+            ...
+            -     $entityManagerMock = $this->createMock(EntityManager::class);
+            +     $entityManagerMock = $this->createEntityManagerMock();
+            ...
+            +
+            + /**
+            +  * @return \PHPUnit\Framework\MockObject\MockObject
+            +  */
+            + protected function createEntityManagerMock(): MockObject
+            + {
+            +     $entityManagerMock = $this->createMock(EntityManager::class);
+            +
+            +     $entityManagerMock->method('contains')->willReturn(true);
+            +
+            +     return $entityManagerMock;
+            + }
+            ```
+    - you can copy-paste a new functional test [`ProductVariantCreationTest.php`](/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` to avoid regression of issues with creating product variants in the future
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -62,6 +62,14 @@ class ProductAvailabilityCalculation
      */
     public function calculateAvailability(Product $product)
     {
+        // If the product is not managed by EntityManager yet, it's not possible to calculate its availability consistently
+        // Let's return a default availability for the moment and mark the product for recalculation
+        if (!$this->em->contains($product)) {
+            $product->markForAvailabilityRecalculation();
+
+            return $this->availabilityFacade->getDefaultInStockAvailability();
+        }
+
         if ($product->isMainVariant()) {
             return $this->calculateMainVariantAvailability($product);
         }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\ShopBundle\Functional\Model\Product\Availability;
 
 use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityCalculation;
@@ -55,7 +56,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
 
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);
-        $entityManagerMock = $this->createMock(EntityManager::class);
+        $entityManagerMock = $this->createEntityManagerMock();
         $productRepositoryMock = $this->createMock(ProductRepository::class);
 
         $productAvailabilityCalculation = new ProductAvailabilityCalculation(
@@ -146,7 +147,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $availabilityFacadeMock = $this->createMock(AvailabilityFacade::class);
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);
-        $entityManagerMock = $this->createMock(EntityManager::class);
+        $entityManagerMock = $this->createEntityManagerMock();
 
         $productRepositoryMock = $this->createMock(ProductRepository::class);
         $productRepositoryMock
@@ -194,7 +195,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
             ->willReturn($defaultInStockAvailability);
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);
-        $entityManagerMock = $this->createMock(EntityManager::class);
+        $entityManagerMock = $this->createEntityManagerMock();
 
         $productRepositoryMock = $this->createMock(ProductRepository::class);
         $productRepositoryMock
@@ -216,5 +217,17 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $mainVariantCalculatedAvailability = $productAvailabilityCalculation->calculateAvailability($mainVariant);
 
         $this->assertSame($defaultInStockAvailability, $mainVariantCalculatedAvailability);
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function createEntityManagerMock(): MockObject
+    {
+        $entityManagerMock = $this->createMock(EntityManager::class);
+
+        $entityManagerMock->method('contains')->willReturn(true);
+
+        return $entityManagerMock;
     }
 }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
@@ -121,7 +121,7 @@ final class ProductVariantCreationTest extends TransactionFunctionalTestCase
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $expectedVariants
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $mainVariant
      */
-    private function assertContainsAllVariants(array $expectedVariants, Product $mainVariant)
+    private function assertContainsAllVariants(array $expectedVariants, Product $mainVariant): void
     {
         $actualVariants = $mainVariant->getVariants();
         $this->assertCount(count($expectedVariants), $actualVariants);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\ShopBundle\Functional\Model\Product;
 
-use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Functional\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory;
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade;
+use Shopsys\ShopBundle\DataFixtures\Demo\AvailabilityDataFixture;
+use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
+
+final class ProductVariantCreationTest extends TransactionFunctionalTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    private $productFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade
+     */
+    private $productVariantFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactory
+     */
+    private $productDataFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = $this->getContainer();
+        $this->productFacade = $container->get(ProductFacade::class);
+        $this->productVariantFacade = $container->get(ProductVariantFacade::class);
+        $this->productDataFactory = $container->get(ProductDataFactory::class);
+    }
+
+    /**
+     * @return array
+     */
+    public function variantsWithAvailabilitiesCanBeCreatedProvider(): array
+    {
+        return [
+            [AvailabilityDataFixture::AVAILABILITY_IN_STOCK],
+            [AvailabilityDataFixture::AVAILABILITY_ON_REQUEST],
+            [AvailabilityDataFixture::AVAILABILITY_OUT_OF_STOCK],
+            [AvailabilityDataFixture::AVAILABILITY_PREPARING],
+        ];
+    }
+
+    /**
+     * @dataProvider variantsWithAvailabilitiesCanBeCreatedProvider
+     * @param string $availabilityReference
+     */
+    public function testVariantsWithAvailabilitiesCanBeCreated(string $availabilityReference): void
+    {
+        $productData = $this->productDataFactory->create();
+        $productData->availability = $this->getReference($availabilityReference);
+
+        $mainProduct = $this->productFacade->create($productData);
+        $secondProduct = $this->productFacade->create($productData);
+        $thirdProduct = $this->productFacade->create($productData);
+
+        $mainVariant = $this->productVariantFacade->createVariant($mainProduct, [$secondProduct, $thirdProduct]);
+
+        $this->assertTrue($mainVariant->isMainVariant());
+        $this->assertContainsAllVariants([$mainProduct, $secondProduct, $thirdProduct], $mainVariant);
+    }
+
+    /**
+     * @return array
+     */
+    public function variantsWithStockCanBeCreatedProvider(): array
+    {
+        return [
+            [0, Product::OUT_OF_STOCK_ACTION_EXCLUDE_FROM_SALE, null],
+            [100, Product::OUT_OF_STOCK_ACTION_EXCLUDE_FROM_SALE, null],
+            [0, Product::OUT_OF_STOCK_ACTION_HIDE, null],
+            [100, Product::OUT_OF_STOCK_ACTION_HIDE, null],
+            [0, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_IN_STOCK],
+            [100, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_IN_STOCK],
+            [0, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_ON_REQUEST],
+            [100, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_ON_REQUEST],
+            [0, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_OUT_OF_STOCK],
+            [100, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_OUT_OF_STOCK],
+            [0, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_PREPARING],
+            [100, Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY, AvailabilityDataFixture::AVAILABILITY_PREPARING],
+        ];
+    }
+
+    /**
+     * @dataProvider variantsWithStockCanBeCreatedProvider
+     * @param int $quantity
+     * @param string $outOfStockAction
+     * @param string|null $outOfStockAvailabilityReference
+     */
+    public function testVariantsWithStockCanBeCreated(int $quantity, string $outOfStockAction, ?string $outOfStockAvailabilityReference): void
+    {
+        $productData = $this->productDataFactory->create();
+        $productData->usingStock = true;
+        $productData->stockQuantity = $quantity;
+        $productData->outOfStockAction = $outOfStockAction;
+        if ($outOfStockAvailabilityReference !== null) {
+            $productData->outOfStockAvailability = $this->getReference($outOfStockAvailabilityReference);
+        }
+
+        $mainProduct = $this->productFacade->create($productData);
+        $secondProduct = $this->productFacade->create($productData);
+        $thirdProduct = $this->productFacade->create($productData);
+
+        $mainVariant = $this->productVariantFacade->createVariant($mainProduct, [$secondProduct, $thirdProduct]);
+
+        $this->assertTrue($mainVariant->isMainVariant());
+        $this->assertContainsAllVariants([$mainProduct, $secondProduct, $thirdProduct], $mainVariant);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $expectedVariants
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $mainVariant
+     */
+    private function assertContainsAllVariants(array $expectedVariants, Product $mainVariant)
+    {
+        $actualVariants = $mainVariant->getVariants();
+        $this->assertCount(count($expectedVariants), $actualVariants);
+        foreach ($expectedVariants as $expectedVariant) {
+            $this->assertContains($expectedVariant, $actualVariants);
+        }
+        foreach ($actualVariants as $actualVariant) {
+            $this->assertTrue($actualVariant->isVariant());
+        }
+    }
+}


### PR DESCRIPTION
- added new functional test for product variant creation to avoid regression (the issue is related to the one mentioned in #581)
- mocks of `EntityManager` that are used in the calculation class have to have the `contains` method return `true` in tests

| Q             | A
| ------------- | ---
|Description, reason for the PR| An unhandled exception was thrown when a variant is created from a product which has no availability set (i.e. newly created product using stock).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1112 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
