### PR TITLE
[framework] private -> protected in Shopsys\FrameworkBundle\Twig namespace

### DIFF
--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -12,6 +12,7 @@ services:
                     - Shopsys\FrameworkBundle\Model
                     - Shopsys\FrameworkBundle\Component
                     - Shopsys\FrameworkBundle\Controller
+                    - Shopsys\FrameworkBundle\Twig
 
     Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff: ~
 

--- a/packages/framework/src/Twig/CookiesExtension.php
+++ b/packages/framework/src/Twig/CookiesExtension.php
@@ -10,7 +10,7 @@ class CookiesExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Cookies\CookiesFacade
      */
-    private $cookiesFacade;
+    protected $cookiesFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Cookies\CookiesFacade $cookiesFacade

--- a/packages/framework/src/Twig/CssExtension.php
+++ b/packages/framework/src/Twig/CssExtension.php
@@ -10,7 +10,7 @@ class CssExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Component\Css\CssFacade
      */
-    private $cssFacade;
+    protected $cssFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Css\CssFacade $cssFacade

--- a/packages/framework/src/Twig/DateTimeFormatterExtension.php
+++ b/packages/framework/src/Twig/DateTimeFormatterExtension.php
@@ -14,12 +14,12 @@ class DateTimeFormatterExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatter
      */
-    private $dateTimeFormatter;
+    protected $dateTimeFormatter;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
      */
-    private $localization;
+    protected $localization;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Localization\DateTimeFormatter $dateTimeFormatter
@@ -119,7 +119,7 @@ class DateTimeFormatterExtension extends Twig_Extension
      * @param string|null $locale
      * @return string
      */
-    private function format($dateTime, $dateType, $timeType, $locale = null)
+    protected function format($dateTime, $dateType, $timeType, $locale = null)
     {
         if ($dateTime === null) {
             return '-';
@@ -137,7 +137,7 @@ class DateTimeFormatterExtension extends Twig_Extension
      * @param string|null $locale
      * @return string
      */
-    private function getLocale($locale = null)
+    protected function getLocale($locale = null)
     {
         if ($locale === null) {
             $locale = $this->localization->getLocale();
@@ -150,7 +150,7 @@ class DateTimeFormatterExtension extends Twig_Extension
      * @param mixed $value
      * @return \DateTime
      */
-    private function convertToDateTime($value)
+    protected function convertToDateTime($value)
     {
         if ($value instanceof DateTime) {
             return $value;

--- a/packages/framework/src/Twig/DomainExtension.php
+++ b/packages/framework/src/Twig/DomainExtension.php
@@ -12,22 +12,22 @@ class DomainExtension extends \Twig_Extension
     /**
      * @var string
      */
-    private $domainImagesUrlPrefix;
+    protected $domainImagesUrlPrefix;
 
     /**
      * @var \Symfony\Component\Asset\Packages
      */
-    private $assetPackages;
+    protected $assetPackages;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\DomainFacade
      */
-    private $domainFacade;
+    protected $domainFacade;
 
     /**
      * @param mixed $domainImagesUrlPrefix

--- a/packages/framework/src/Twig/FileThumbnail/FileThumbnailExtension.php
+++ b/packages/framework/src/Twig/FileThumbnail/FileThumbnailExtension.php
@@ -16,17 +16,17 @@ class FileThumbnailExtension extends Twig_Extension
     /**
      * @var string[]
      */
-    private $iconsByExtension;
+    protected $iconsByExtension;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
      */
-    private $fileUpload;
+    protected $fileUpload;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\Processing\ImageThumbnailFactory
      */
-    private $imageThumbnailFactory;
+    protected $imageThumbnailFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
@@ -98,7 +98,7 @@ class FileThumbnailExtension extends Twig_Extension
      * @param string $filepath
      * @return \Shopsys\FrameworkBundle\Twig\FileThumbnail\FileThumbnailInfo
      */
-    private function getImageThumbnailInfo($filepath)
+    protected function getImageThumbnailInfo($filepath)
     {
         $image = $this->imageThumbnailFactory->getImageThumbnail($filepath);
 
@@ -109,7 +109,7 @@ class FileThumbnailExtension extends Twig_Extension
      * @param string $filepath
      * @return string
      */
-    private function getIconTypeByFilename($filepath)
+    protected function getIconTypeByFilename($filepath)
     {
         $extension = strtolower(pathinfo($filepath, PATHINFO_EXTENSION));
         if (array_key_exists($extension, $this->iconsByExtension)) {

--- a/packages/framework/src/Twig/FileThumbnail/FileThumbnailInfo.php
+++ b/packages/framework/src/Twig/FileThumbnail/FileThumbnailInfo.php
@@ -7,12 +7,12 @@ class FileThumbnailInfo
     /**
      * @var string|null
      */
-    private $iconType;
+    protected $iconType;
 
     /**
      * @var string|null
      */
-    private $imageUri;
+    protected $imageUri;
 
     /**
      * @param string|null $iconType

--- a/packages/framework/src/Twig/FileUploadExtension.php
+++ b/packages/framework/src/Twig/FileUploadExtension.php
@@ -11,7 +11,7 @@ class FileUploadExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
      */
-    private $fileUpload;
+    protected $fileUpload;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload

--- a/packages/framework/src/Twig/FormDetailExtension.php
+++ b/packages/framework/src/Twig/FormDetailExtension.php
@@ -12,7 +12,7 @@ class FormDetailExtension extends Twig_Extension
     /**
      * @var \Twig_Environment
      */
-    private $twigEnvironment;
+    protected $twigEnvironment;
 
     /**
      * @param \Twig_Environment $twigEnvironment

--- a/packages/framework/src/Twig/FormThemeExtension.php
+++ b/packages/framework/src/Twig/FormThemeExtension.php
@@ -54,7 +54,7 @@ class FormThemeExtension extends \Twig_Extension
      * @param string $controller
      * @return bool
      */
-    private function isAdmin(string $controller) : bool
+    protected function isAdmin(string $controller) : bool
     {
         return strpos($controller, 'Shopsys\FrameworkBundle\Controller\Admin') === 0 ||
             strpos($controller, 'Shopsys\ShopBundle\Controller\Admin') === 0;

--- a/packages/framework/src/Twig/HoneyPotExtension.php
+++ b/packages/framework/src/Twig/HoneyPotExtension.php
@@ -48,7 +48,7 @@ class HoneyPotExtension extends Twig_Extension
      * @param \Symfony\Component\Form\FormView $formView
      * @return \Symfony\Component\Form\FormView
      */
-    private function getRootFormView(FormView $formView)
+    protected function getRootFormView(FormView $formView)
     {
         $rootFormView = $formView;
 
@@ -63,7 +63,7 @@ class HoneyPotExtension extends Twig_Extension
      * @param \Symfony\Component\Form\FormView $formView
      * @return bool
      */
-    private function containsNotRenderedPassword(FormView $formView)
+    protected function containsNotRenderedPassword(FormView $formView)
     {
         foreach ($formView->children as $childForm) {
             if (strpos($childForm->vars['name'], static::PASSWORD_FIELD_NAME) !== false && !$childForm->isRendered()) {

--- a/packages/framework/src/Twig/ImageExtension.php
+++ b/packages/framework/src/Twig/ImageExtension.php
@@ -20,7 +20,7 @@ class ImageExtension extends Twig_Extension
     /**
      * @var string
      */
-    private $frontDesignImageUrlPrefix;
+    protected $frontDesignImageUrlPrefix;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
@@ -30,7 +30,7 @@ class ImageExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageLocator
      */
-    private $imageLocator;
+    protected $imageLocator;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
@@ -40,7 +40,7 @@ class ImageExtension extends Twig_Extension
     /**
      * @var \Symfony\Component\Templating\EngineInterface
      */
-    private $templating;
+    protected $templating;
 
     /**
      * @param string $frontDesignImageUrlPrefix
@@ -157,7 +157,7 @@ class ImageExtension extends Twig_Extension
     /**
      * @return string
      */
-    private function getEmptyImageUrl(): string
+    protected function getEmptyImageUrl(): string
     {
         return $this->domain->getUrl() . $this->frontDesignImageUrlPrefix . '/' . static::NOIMAGE_FILENAME;
     }
@@ -168,7 +168,7 @@ class ImageExtension extends Twig_Extension
      * @param string|null $sizeName
      * @return string
      */
-    private function getImageCssClass($entityName, $type, $sizeName)
+    protected function getImageCssClass($entityName, $type, $sizeName)
     {
         $allClassParts = [
             'image',

--- a/packages/framework/src/Twig/InputPriceLabelExtension.php
+++ b/packages/framework/src/Twig/InputPriceLabelExtension.php
@@ -11,7 +11,7 @@ class InputPriceLabelExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting
      */
-    private $pricingSetting;
+    protected $pricingSetting;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting

--- a/packages/framework/src/Twig/Javascript/JavascriptCompiler.php
+++ b/packages/framework/src/Twig/Javascript/JavascriptCompiler.php
@@ -15,47 +15,47 @@ class JavascriptCompiler
     /**
      * @var string
      */
-    private $webPath;
+    protected $webPath;
 
     /**
      * @var string
      */
-    private $jsUrlPrefix;
+    protected $jsUrlPrefix;
 
     /**
      * @var string[]
      */
-    private $allowedDirectories;
+    protected $allowedDirectories;
 
     /**
      * @var string[]
      */
-    private $jsSourcePaths;
+    protected $jsSourcePaths;
 
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
-    private $filesystem;
+    protected $filesystem;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Javascript\Compiler\JsCompiler
      */
-    private $jsCompiler;
+    protected $jsCompiler;
 
     /**
      * @var array
      */
-    private $javascriptLinks = [];
+    protected $javascriptLinks = [];
 
     /**
      * @var \Symfony\Component\Asset\Packages
      */
-    private $assetPackages;
+    protected $assetPackages;
 
     /**
      * @param string $webPath
@@ -105,7 +105,7 @@ class JavascriptCompiler
     /**
      * @param string $javascript
      */
-    private function process($javascript)
+    protected function process($javascript)
     {
         foreach ($this->jsSourcePaths as $jsSourcePath) {
             if ($this->tryToProcessJavascriptFile($jsSourcePath, $javascript)) {
@@ -127,7 +127,7 @@ class JavascriptCompiler
      * @param string $javascript
      * @return bool
      */
-    private function tryToProcessJavascriptFile($jsSourcePath, $javascript)
+    protected function tryToProcessJavascriptFile($jsSourcePath, $javascript)
     {
         $sourcePath = $jsSourcePath . '/' . $javascript;
         $relativeTargetPath = $this->getRelativeTargetPath($javascript);
@@ -152,7 +152,7 @@ class JavascriptCompiler
      * @param string $timestamp
      * @return string
      */
-    private function getPathWithTimestamp($relativePath, $timestamp)
+    protected function getPathWithTimestamp($relativePath, $timestamp)
     {
         $version = '-v' . $timestamp;
 
@@ -163,7 +163,7 @@ class JavascriptCompiler
      * @param string $javascript
      * @return string|null
      */
-    private function getRelativeTargetPath($javascript)
+    protected function getRelativeTargetPath($javascript)
     {
         $relativeTargetPath = null;
         if ($this->isDirectoryAllowed($javascript)) {
@@ -182,7 +182,7 @@ class JavascriptCompiler
      * @param string $javascript
      * @return bool
      */
-    private function isDirectoryAllowed(string $javascript): bool
+    protected function isDirectoryAllowed(string $javascript): bool
     {
         foreach ($this->allowedDirectories as $allowedDirectory) {
             if (strpos($javascript, $allowedDirectory) === 0) {
@@ -196,7 +196,7 @@ class JavascriptCompiler
      * @param string $sourceFilename
      * @param string $relativeTargetPath
      */
-    private function compileJavascriptFile($sourceFilename, $relativeTargetPath)
+    protected function compileJavascriptFile($sourceFilename, $relativeTargetPath)
     {
         $compiledFilename = $this->webPath . '/' . $relativeTargetPath;
 
@@ -219,7 +219,7 @@ class JavascriptCompiler
      * @param string $sourceFilename
      * @return bool
      */
-    private function isCompiledFileFresh($compiledFilename, $sourceFilename)
+    protected function isCompiledFileFresh($compiledFilename, $sourceFilename)
     {
         if (is_file($compiledFilename) && parse_url($sourceFilename, PHP_URL_HOST) === null) {
             $isCompiledFileFresh = filemtime($sourceFilename) < filemtime($compiledFilename);
@@ -234,7 +234,7 @@ class JavascriptCompiler
      * @param string $directoryMask
      * @return bool
      */
-    private function tryToProcessJavascriptDirectoryMask($jsSourcePath, $directoryMask)
+    protected function tryToProcessJavascriptDirectoryMask($jsSourcePath, $directoryMask)
     {
         $parts = explode('/', $directoryMask);
         $mask = array_pop($parts);
@@ -254,7 +254,7 @@ class JavascriptCompiler
      * @param string $filenameMask
      * @return bool
      */
-    private function processJavascriptByMask($jsSourcePath, $path, $filenameMask)
+    protected function processJavascriptByMask($jsSourcePath, $path, $filenameMask)
     {
         $filepaths = (array)glob($jsSourcePath . '/' . $path . '/' . $filenameMask);
         foreach ($filepaths as $filepath) {
@@ -269,7 +269,7 @@ class JavascriptCompiler
      * @param string $filenameMask
      * @return bool
      */
-    private function isMaskValid($filenameMask)
+    protected function isMaskValid($filenameMask)
     {
         return $filenameMask === '' || strpos($filenameMask, '*') !== false;
     }
@@ -277,7 +277,7 @@ class JavascriptCompiler
     /**
      * @param string $javascriptUrl
      */
-    private function processExternalJavascript($javascriptUrl)
+    protected function processExternalJavascript($javascriptUrl)
     {
         $this->javascriptLinks[] = $this->assetPackages->getUrl($javascriptUrl);
     }

--- a/packages/framework/src/Twig/Javascript/JavascriptExtension.php
+++ b/packages/framework/src/Twig/Javascript/JavascriptExtension.php
@@ -11,7 +11,7 @@ class JavascriptExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Twig\Javascript\JavascriptCompiler
      */
-    private $javascriptCompiler;
+    protected $javascriptCompiler;
 
     /**
      * @param \Shopsys\FrameworkBundle\Twig\Javascript\JavascriptCompiler $javascriptCompiler
@@ -48,7 +48,7 @@ class JavascriptExtension extends Twig_Extension
      * @param array $javascriptLinks
      * @return string
      */
-    private function getHtmlJavascriptImports(array $javascriptLinks)
+    protected function getHtmlJavascriptImports(array $javascriptLinks)
     {
         $html = '';
         foreach ($javascriptLinks as $javascriptLink) {

--- a/packages/framework/src/Twig/LocalizationExtension.php
+++ b/packages/framework/src/Twig/LocalizationExtension.php
@@ -11,12 +11,12 @@ class LocalizationExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
      */
-    private $localization;
+    protected $localization;
 
     /**
      * @var \Symfony\Component\Asset\Packages
      */
-    private $assetPackages;
+    protected $assetPackages;
 
     /**
      * @param \Symfony\Component\Asset\Packages $assetPackages
@@ -64,7 +64,7 @@ class LocalizationExtension extends \Twig_Extension
      * @param string $locale
      * @return string
      */
-    private function getTitle($locale)
+    protected function getTitle($locale)
     {
         try {
             $title = $this->localization->getLanguageName($locale);

--- a/packages/framework/src/Twig/MailerSettingExtension.php
+++ b/packages/framework/src/Twig/MailerSettingExtension.php
@@ -12,27 +12,27 @@ class MailerSettingExtension extends Twig_Extension
     /**
      * @var \Symfony\Component\DependencyInjection\ContainerInterface
      */
-    private $container;
+    protected $container;
 
     /**
      * @var bool
      */
-    private $isDeliveryDisabled;
+    protected $isDeliveryDisabled;
 
     /**
      * @var string
      */
-    private $mailerMasterEmailAddress;
+    protected $mailerMasterEmailAddress;
 
     /**
      * @var string[]
      */
-    private $mailerWhitelistExpressions;
+    protected $mailerWhitelistExpressions;
 
     /**
      * @var \Symfony\Component\Templating\EngineInterface
      */
-    private $templating;
+    protected $templating;
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container

--- a/packages/framework/src/Twig/ModuleExtension.php
+++ b/packages/framework/src/Twig/ModuleExtension.php
@@ -11,7 +11,7 @@ class ModuleExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Module\ModuleFacade
      */
-    private $moduleFacade;
+    protected $moduleFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Module\ModuleFacade $moduleFacade

--- a/packages/framework/src/Twig/NumberFormatterExtension.php
+++ b/packages/framework/src/Twig/NumberFormatterExtension.php
@@ -17,12 +17,12 @@ class NumberFormatterExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
      */
-    private $localization;
+    protected $localization;
 
     /**
      * @var \CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface
      */
-    private $numberFormatRepository;
+    protected $numberFormatRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
@@ -107,7 +107,7 @@ class NumberFormatterExtension extends Twig_Extension
      * @param string|null $locale
      * @return string
      */
-    private function getLocale($locale = null)
+    protected function getLocale($locale = null)
     {
         if ($locale === null) {
             $locale = $this->localization->getLocale();

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -26,27 +26,27 @@ class PriceExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade
      */
-    private $currencyFacade;
+    protected $currencyFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
      */
-    private $localization;
+    protected $localization;
 
     /**
      * @var \CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface
      */
-    private $numberFormatRepository;
+    protected $numberFormatRepository;
 
     /**
      * @var \CommerceGuys\Intl\Currency\CurrencyRepositoryInterface
      */
-    private $intlCurrencyRepository;
+    protected $intlCurrencyRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
@@ -231,7 +231,7 @@ class PriceExtension extends Twig_Extension
      * @param string|null $locale
      * @return string
      */
-    private function formatCurrency(Money $price, Currency $currency, string $locale = null): string
+    protected function formatCurrency(Money $price, Currency $currency, string $locale = null): string
     {
         if ($locale === null) {
             $locale = $this->localization->getLocale();
@@ -250,7 +250,7 @@ class PriceExtension extends Twig_Extension
      * @param string $locale
      * @return \CommerceGuys\Intl\Formatter\NumberFormatter
      */
-    private function getNumberFormatter(string $locale): NumberFormatter
+    protected function getNumberFormatter(string $locale): NumberFormatter
     {
         $numberFormat = $this->numberFormatRepository->get($locale);
         $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::CURRENCY);
@@ -287,7 +287,7 @@ class PriceExtension extends Twig_Extension
      * @param string $locale
      * @return string
      */
-    private function getCurrencySymbolByDomainIdAndLocale(int $domainId, string $locale): string
+    protected function getCurrencySymbolByDomainIdAndLocale(int $domainId, string $locale): string
     {
         $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $intlCurrency = $this->intlCurrencyRepository->get($currency->getCode(), $locale);
@@ -309,7 +309,7 @@ class PriceExtension extends Twig_Extension
      * @param string $locale
      * @return string
      */
-    private function getDefaultCurrencySymbolByLocale(string $locale): string
+    protected function getDefaultCurrencySymbolByLocale(string $locale): string
     {
         $currency = $this->currencyFacade->getDefaultCurrency();
         $intlCurrency = $this->intlCurrencyRepository->get($currency->getCode(), $locale);
@@ -333,7 +333,7 @@ class PriceExtension extends Twig_Extension
      * @param string $locale
      * @return string
      */
-    private function getCurrencySymbolByCurrencyIdAndLocale(int $currencyId, string $locale): string
+    protected function getCurrencySymbolByCurrencyIdAndLocale(int $currencyId, string $locale): string
     {
         $currency = $this->currencyFacade->getById($currencyId);
         $intlCurrency = $this->intlCurrencyRepository->get($currency->getCode(), $locale);

--- a/packages/framework/src/Twig/ProductExtension.php
+++ b/packages/framework/src/Twig/ProductExtension.php
@@ -13,12 +13,12 @@ class ProductExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
-    private $categoryFacade;
+    protected $categoryFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade
      */
-    private $productCachedAttributesFacade;
+    protected $productCachedAttributesFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade

--- a/packages/framework/src/Twig/ProductVisibilityExtension.php
+++ b/packages/framework/src/Twig/ProductVisibilityExtension.php
@@ -13,17 +13,17 @@ class ProductVisibilityExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository
      */
-    private $productVisibilityRepository;
+    protected $productVisibilityRepository;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade
      */
-    private $pricingGroupSettingFacade;
+    protected $pricingGroupSettingFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository $productVisibilityRepository

--- a/packages/framework/src/Twig/RequestExtension.php
+++ b/packages/framework/src/Twig/RequestExtension.php
@@ -11,7 +11,7 @@ class RequestExtension extends Twig_Extension
     /**
      * @var \Symfony\Component\HttpFoundation\RequestStack
      */
-    private $requestStack;
+    protected $requestStack;
 
     /**
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
@@ -64,7 +64,7 @@ class RequestExtension extends Twig_Extension
     /**
      * @return array
      */
-    private function getParamsFromRequest()
+    protected function getParamsFromRequest()
     {
         return $this->requestStack->getMasterRequest()->query->all();
     }

--- a/packages/framework/src/Twig/RouterExtension.php
+++ b/packages/framework/src/Twig/RouterExtension.php
@@ -12,7 +12,7 @@ class RouterExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory

--- a/packages/framework/src/Twig/SeoExtension.php
+++ b/packages/framework/src/Twig/SeoExtension.php
@@ -11,12 +11,12 @@ class SeoExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade
      */
-    private $seoSettingFacade;
+    protected $seoSettingFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade

--- a/packages/framework/src/Twig/ShopInfoExtension.php
+++ b/packages/framework/src/Twig/ShopInfoExtension.php
@@ -11,12 +11,12 @@ class ShopInfoExtension extends \Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Model\ShopInfo\ShopInfoSettingFacade
      */
-    private $shopInfoSettingFacade;
+    protected $shopInfoSettingFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\ShopInfo\ShopInfoSettingFacade $shopInfoSettingFacade
@@ -45,7 +45,7 @@ class ShopInfoExtension extends \Twig_Extension
     /**
      * @return \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private function getDomain()
+    protected function getDomain()
     {
         // Twig extensions are loaded during assetic:dump command,
         // so they cannot be dependent on Domain service

--- a/packages/framework/src/Twig/TranslationExtension.php
+++ b/packages/framework/src/Twig/TranslationExtension.php
@@ -82,7 +82,7 @@ class TranslationExtension extends \Twig_Extension
      * @param array $elements
      * @return array
      */
-    private function getEscapedElements(Twig_Environment $twig, array $elements)
+    protected function getEscapedElements(Twig_Environment $twig, array $elements)
     {
         $defaultEscapeFilterCallable = $twig->getFilter('escape')->getCallable();
         $escapedElements = [];

--- a/packages/framework/src/Twig/UploadedFileExtension.php
+++ b/packages/framework/src/Twig/UploadedFileExtension.php
@@ -13,17 +13,17 @@ class UploadedFileExtension extends Twig_Extension
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade
      */
-    private $uploadedFileFacade;
+    protected $uploadedFileFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Twig\FileThumbnail\FileThumbnailExtension
      */
-    private $fileThumbnailExtension;
+    protected $fileThumbnailExtension;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain


### PR DESCRIPTION
- done to allow extensibility by inheritance
- watched by Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer

| Q             | A
| ------------- | ---
|Description, reason for the PR| Twig extensions are not extendable easily
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1098 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
