### PR TITLE
[shopsys] Product: availability cannot be set when using stock (and vice versa)

### DIFF
--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -73,6 +73,18 @@ There you can find links to upgrade notes for other versions too.
 - if you want to use our experimental API follow these instructions in [the separate article](upgrade-instructions-for-backend-api.md) to introduce backend API into your project ([#1055](https://github.com/shopsys/shopsys/pull/1055))
     - we recommend to read [introduction to backend API](/docs/backend-api/introduction-to-backend-api.md) article as well
 - run [db-create](/docs/introduction/console-commands-for-application-management-phing-targets.md#db-create) (this one even on production) and `test-db-create` phing targets to install extension for UUID
+- update your application and tests to correctly handle availabilities and stock ([#1115](https://github.com/shopsys/shopsys/pull/1115))
+    - copy and replace the functional test [AvailabilityFacadeTest.php](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php) in `tests/ShopBundle/Functional/Model/Product/Availability/` to test deletion and replacement of availabilities properly
+    - if you have made any custom changes to the test you should merge your changes with the ones described in the pull request linked above
+    - add a test service definition for `AvailabilityDataFactory` in your `src/Shopsys/ShopBundle/Resources/config/services_test.yml` configuration:
+        ```diff
+            Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface: '@Shopsys\ShopBundle\Model\Transport\TransportDataFactory'
+
+        +   Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface: '@Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactory'
+        +
+            Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface: '@Shopsys\ShopBundle\Model\Payment\PaymentDataFactory'
+        ```
+    - check and fix your other tests, they might start failing if they assumed `Product::$availability` is not null when the product is using stock, or that stock quantity is not null when it's not using stock
 
 ### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -301,12 +301,8 @@ class Product extends AbstractTranslatableEntity
         $this->sellingTo = $productData->sellingTo;
         $this->sellingDenied = $productData->sellingDenied;
         $this->hidden = $productData->hidden;
-        $this->usingStock = $productData->usingStock;
-        $this->stockQuantity = $productData->stockQuantity;
         $this->unit = $productData->unit;
-        $this->outOfStockAction = $productData->outOfStockAction;
-        $this->availability = $productData->availability;
-        $this->outOfStockAvailability = $productData->outOfStockAvailability;
+        $this->setAvailabilityAndStock($productData);
         $this->calculatedAvailability = $this->availability;
         $this->recalculateAvailability = true;
         $this->calculatedVisibility = false;
@@ -379,11 +375,7 @@ class Product extends AbstractTranslatableEntity
             $this->setCategories($productCategoryDomainFactory, $productData->categoriesByDomainId);
         }
         if (!$this->isMainVariant()) {
-            $this->usingStock = $productData->usingStock;
-            $this->stockQuantity = $productData->stockQuantity;
-            $this->outOfStockAction = $productData->outOfStockAction;
-            $this->availability = $productData->availability;
-            $this->outOfStockAvailability = $productData->outOfStockAvailability;
+            $this->setAvailabilityAndStock($productData);
             $this->catnum = $productData->catnum;
             $this->partno = $productData->partno;
             $this->ean = $productData->ean;
@@ -403,6 +395,25 @@ class Product extends AbstractTranslatableEntity
         $this->flags->clear();
         foreach ($flags as $flag) {
             $this->flags->add($flag);
+        }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     */
+    protected function setAvailabilityAndStock(ProductData $productData): void
+    {
+        $this->usingStock = $productData->usingStock;
+        if ($this->usingStock) {
+            $this->stockQuantity = $productData->stockQuantity;
+            $this->outOfStockAction = $productData->outOfStockAction;
+            $this->outOfStockAvailability = $productData->outOfStockAvailability;
+            $this->availability = null;
+        } else {
+            $this->stockQuantity = null;
+            $this->outOfStockAction = null;
+            $this->outOfStockAvailability = null;
+            $this->availability = $productData->availability;
         }
     }
 

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -123,7 +123,7 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
             'ordering_priority' => $product->getOrderingPriority(),
             'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
             'selling_denied' => $product->isSellingDenied(),
-            'availability' => $product->getAvailability()->getName($locale),
+            'availability' => $product->getCalculatedAvailability()->getName($locale),
             'main_variant' => $product->isMainVariant(),
             'detail_url' => $detailUrl,
             'visibility' => $visibility,

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
@@ -47,12 +47,25 @@ final class OrderProductFacadeTest extends TestCase
         );
     }
 
-    public function testSubtractOrderProductsFromStockUsingStock(): void
+    /**
+     * @return iterable
+     */
+    public function subtractOrderProductsFromStockUsingStockProvider(): iterable
     {
-        $stockQuantity = 15;
-        $orderedQuantity = 10;
-        $expectedStockQuantity = 5;
+        yield [15, 10, 5];
+        yield [10, 10, 0];
+        yield [5, 0, 5];
+        yield [0, 5, -5];
+    }
 
+    /**
+     * @dataProvider subtractOrderProductsFromStockUsingStockProvider
+     * @param int $stockQuantity
+     * @param int $orderedQuantity
+     * @param int $expectedStockQuantity
+     */
+    public function testSubtractOrderProductsFromStockUsingStock(int $stockQuantity, int $orderedQuantity, int $expectedStockQuantity): void
+    {
         $product = $this->createProductWithStockQuantity($stockQuantity);
         $orderProduct = $this->createOrderItem($product, $orderedQuantity);
 
@@ -61,12 +74,25 @@ final class OrderProductFacadeTest extends TestCase
         $this->assertSame($expectedStockQuantity, $product->getStockQuantity());
     }
 
-    public function testAddOrderProductsToStockUsingStock(): void
+    /**
+     * @return iterable
+     */
+    public function addOrderProductsFromStockUsingStockProvider(): iterable
     {
-        $stockQuantity = 15;
-        $orderedQuantity = 10;
-        $expectedStockQuantity = 25;
+        yield [15, 10, 25];
+        yield [10, 10, 20];
+        yield [5, 0, 5];
+        yield [0, 5, 5];
+    }
 
+    /**
+     * @dataProvider addOrderProductsFromStockUsingStockProvider
+     * @param int $stockQuantity
+     * @param int $orderedQuantity
+     * @param int $expectedStockQuantity
+     */
+    public function testAddOrderProductsToStockUsingStock(int $stockQuantity, int $orderedQuantity, int $expectedStockQuantity): void
+    {
         $product = $this->createProductWithStockQuantity($stockQuantity);
         $orderProduct = $this->createOrderItem($product, $orderedQuantity);
 

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\FrameworkBundle\Unit\Model\Order\Item;
 
 use Doctrine\ORM\EntityManager;
@@ -18,64 +20,24 @@ use Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 
-class OrderProductFacadeTest extends TestCase
+final class OrderProductFacadeTest extends TestCase
 {
-    public function testSubtractOrderProductsFromStockUsingStock()
-    {
-        $productStockQuantity = 15;
-        $orderProductQuantity = 10;
-
-        $orderMock = $this->createMock(Order::class);
-
-        $productData = new ProductData();
-        $productData->usingStock = true;
-        $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
-        $productPrice = Price::zero();
-
-        $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
-        $orderProduct->setProduct($product);
-
-        $orderProductFacade = $this->createOrderProductFacade();
-        $orderProductFacade->subtractOrderProductsFromStock([$orderProduct]);
-
-        $this->assertSame($productStockQuantity - $orderProductQuantity, $product->getStockQuantity());
-    }
-
-    public function testAddOrderProductsToStockUsingStock()
-    {
-        $productStockQuantity = 15;
-        $orderProductQuantity = 10;
-
-        $orderMock = $this->createMock(Order::class);
-
-        $productData = new ProductData();
-        $productData->usingStock = true;
-        $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
-        $productPrice = Price::zero();
-
-        $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
-        $orderProduct->setProduct($product);
-
-        $orderProductFacade = $this->createOrderProductFacade();
-        $orderProductFacade->addOrderProductsToStock([$orderProduct]);
-
-        $this->assertSame($productStockQuantity + $orderProductQuantity, $product->getStockQuantity());
-    }
-
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderProductFacade
+     * @var \Shopsys\FrameworkBundle\Model\Order\Item\OrderProductFacade
      */
-    private function createOrderProductFacade()
+    private $orderProductFacade;
+
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $moduleFacadeMock = $this->getMockBuilder(ModuleFacade::class)
             ->setMethods(['isEnabled'])
             ->disableOriginalConstructor()
             ->getMock();
         $moduleFacadeMock->expects($this->any())->method('isEnabled')->willReturn(true);
 
-        return new OrderProductFacade(
+        $this->orderProductFacade = new OrderProductFacade(
             $this->createMock(EntityManager::class),
             $this->createMock(ProductHiddenRecalculator::class),
             $this->createMock(ProductSellingDeniedRecalculator::class),
@@ -83,5 +45,69 @@ class OrderProductFacadeTest extends TestCase
             $this->createMock(ProductVisibilityFacade::class),
             $moduleFacadeMock
         );
+    }
+
+    public function testSubtractOrderProductsFromStockUsingStock(): void
+    {
+        $stockQuantity = 15;
+        $orderedQuantity = 10;
+        $expectedStockQuantity = 5;
+
+        $product = $this->createProductWithStockQuantity($stockQuantity);
+        $orderProduct = $this->createOrderItem($product, $orderedQuantity);
+
+        $this->orderProductFacade->subtractOrderProductsFromStock([$orderProduct]);
+
+        $this->assertSame($expectedStockQuantity, $product->getStockQuantity());
+    }
+
+    public function testAddOrderProductsToStockUsingStock(): void
+    {
+        $stockQuantity = 15;
+        $orderedQuantity = 10;
+        $expectedStockQuantity = 25;
+
+        $product = $this->createProductWithStockQuantity($stockQuantity);
+        $orderProduct = $this->createOrderItem($product, $orderedQuantity);
+
+        $this->orderProductFacade->addOrderProductsToStock([$orderProduct]);
+
+        $this->assertSame($expectedStockQuantity, $product->getStockQuantity());
+    }
+
+    /**
+     * @param int $productStockQuantity
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     */
+    private function createProductWithStockQuantity(int $productStockQuantity): Product
+    {
+        $productData = new ProductData();
+        $productData->usingStock = true;
+        $productData->stockQuantity = $productStockQuantity;
+        $productData->outOfStockAction = Product::OUT_OF_STOCK_ACTION_HIDE;
+
+        return Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param int $orderProductQuantity
+     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItem
+     */
+    private function createOrderItem(Product $product, int $orderProductQuantity): OrderItem
+    {
+        $orderProduct = new OrderItem(
+            $this->createMock(Order::class),
+            'productName',
+            Price::zero(),
+            '0',
+            $orderProductQuantity,
+            OrderItem::TYPE_PRODUCT,
+            null,
+            null
+        );
+        $orderProduct->setProduct($product);
+
+        return $orderProduct;
     }
 }

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
@@ -42,28 +42,6 @@ class OrderProductFacadeTest extends TestCase
         $this->assertSame($productStockQuantity - $orderProductQuantity, $product->getStockQuantity());
     }
 
-    public function testSubtractOrderProductsFromStockNotUsingStock()
-    {
-        $productStockQuantity = 15;
-        $orderProductQuantity = 10;
-
-        $orderMock = $this->createMock(Order::class);
-
-        $productData = new ProductData();
-        $productData->usingStock = false;
-        $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
-        $productPrice = Price::zero();
-
-        $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
-        $orderProduct->setProduct($product);
-
-        $orderProductFacade = $this->createOrderProductFacade();
-        $orderProductFacade->subtractOrderProductsFromStock([$orderProduct]);
-
-        $this->assertSame($productStockQuantity, $product->getStockQuantity());
-    }
-
     public function testAddOrderProductsToStockUsingStock()
     {
         $productStockQuantity = 15;
@@ -84,28 +62,6 @@ class OrderProductFacadeTest extends TestCase
         $orderProductFacade->addOrderProductsToStock([$orderProduct]);
 
         $this->assertSame($productStockQuantity + $orderProductQuantity, $product->getStockQuantity());
-    }
-
-    public function testAddOrderProductsToStockNotUsingStock()
-    {
-        $productStockQuantity = 15;
-        $orderProductQuantity = 10;
-
-        $orderMock = $this->createMock(Order::class);
-
-        $productData = new ProductData();
-        $productData->usingStock = false;
-        $productData->stockQuantity = $productStockQuantity;
-        $product = Product::create($productData, new ProductCategoryDomainFactory(new EntityNameResolver([])));
-        $productPrice = Price::zero();
-
-        $orderProduct = new OrderItem($orderMock, 'productName', $productPrice, 0, $orderProductQuantity, OrderItem::TYPE_PRODUCT, null, null);
-        $orderProduct->setProduct($product);
-
-        $orderProductFacade = $this->createOrderProductFacade();
-        $orderProductFacade->addOrderProductsToStock([$orderProduct]);
-
-        $this->assertSame($productStockQuantity, $product->getStockQuantity());
     }
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services_test.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services_test.yml
@@ -42,6 +42,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface: '@Shopsys\ShopBundle\Model\Transport\TransportDataFactory'
 
+    Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface: '@Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactory'
+
     Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface: '@Shopsys\ShopBundle\Model\Payment\PaymentDataFactory'
 
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\ProductDataFactory'

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php
@@ -1,47 +1,109 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Availability;
 
-use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData;
+use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
+use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
+use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
-use Shopsys\ShopBundle\DataFixtures\Demo\AvailabilityDataFixture;
 use Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixture;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
-class AvailabilityFacadeTest extends TransactionFunctionalTestCase
+final class AvailabilityFacadeTest extends TransactionFunctionalTestCase
 {
-    public function testDeleteByIdAndReplace()
-    {
-        $em = $this->getEntityManager();
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade */
-        $availabilityFacade = $this->getContainer()->get(AvailabilityFacade::class);
-        /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory */
-        $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
-        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
-        $productFacade = $this->getContainer()->get(ProductFacade::class);
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator
+     */
+    private $em;
 
-        $availabilityData = new AvailabilityData();
-        $availabilityData->name = ['cs' => 'name'];
-        $availabilityToDelete = $availabilityFacade->create($availabilityData);
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability $availabilityToReplaceWith */
-        $availabilityToReplaceWith = $this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK);
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface
+     */
+    private $availabilityDataFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade
+     */
+    private $availabilityFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface
+     */
+    private $productDataFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    private $productFacade;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->em = $this->getEntityManager();
+        $this->availabilityFacade = $this->getContainer()->get(AvailabilityFacade::class);
+        $this->availabilityDataFactory = $this->getContainer()->get(AvailabilityDataFactoryInterface::class);
+        $this->productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
+        $this->productFacade = $this->getContainer()->get(ProductFacade::class);
+    }
+
+    public function testDeleteByIdAndReplaceProductAvailability(): void
+    {
         /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductData $productData */
-        $productData = $productDataFactory->createFromProduct($product);
+        $productData = $this->productDataFactory->createFromProduct($product);
 
+        $availabilityToDelete = $this->createNewAvailability();
+        $productData->usingStock = false;
         $productData->availability = $availabilityToDelete;
+
+        $this->productFacade->edit($product->getId(), $productData);
+
+        $availabilityToReplaceWith = $this->createNewAvailability();
+        $this->availabilityFacade->deleteById($availabilityToDelete->getId(), $availabilityToReplaceWith->getId());
+
+        $this->em->refresh($product);
+
+        $this->assertSame($availabilityToReplaceWith, $product->getAvailability());
+    }
+
+    public function testDeleteByIdAndReplaceProductOutOfStockAvailability(): void
+    {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
+        $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
+        $productData = $this->productDataFactory->createFromProduct($product);
+
+        $availabilityToDelete = $this->createNewAvailability();
+        $productData->usingStock = true;
+        $productData->stockQuantity = 1;
+        $productData->outOfStockAction = Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY;
         $productData->outOfStockAvailability = $availabilityToDelete;
 
-        $productFacade->edit($product->getId(), $productData);
+        $this->productFacade->edit($product->getId(), $productData);
 
-        $availabilityFacade->deleteById($availabilityToDelete->getId(), $availabilityToReplaceWith->getId());
+        $availabilityToReplaceWith = $this->createNewAvailability();
+        $this->availabilityFacade->deleteById($availabilityToDelete->getId(), $availabilityToReplaceWith->getId());
 
-        $em->refresh($product);
+        $this->em->refresh($product);
 
-        $this->assertEquals($availabilityToReplaceWith, $product->getAvailability());
-        $this->assertEquals($availabilityToReplaceWith, $product->getOutOfStockAvailability());
+        $this->assertSame($availabilityToReplaceWith, $product->getOutOfStockAvailability());
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
+     */
+    private function createNewAvailability(): Availability
+    {
+        $availabilityData = $this->availabilityDataFactory->create();
+
+        foreach (array_keys($availabilityData->name) as $locale) {
+            $availabilityData->name[$locale] = 'new availability';
+        }
+
+        return $this->availabilityFacade->create($availabilityData);
     }
 }


### PR DESCRIPTION
- this behavior is consistent with the actual product creation and editting via adminsitration
- having availability set even when using stock can hide issues and cause inconsistencies
- ~this PR will fail during loading data fixures and tests because of #1112 until #1113 is merged~

| Q             | A
| ------------- | ---
|Description, reason for the PR| Products were created and edited inconsistently.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
