### PR TITLE
[framework] rewrite of shopsys:phing-targets:sort command

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -147,10 +147,10 @@
         <phingcall target="eslint-fix"/>
     </target>
 
-    <target name="phing-targets-sorting-check" description="Checks the sorting of phing targets." hidden="true">
+    <target name="phing-config-check" description="Checks the syntax of Phing configuration." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
-            <arg value="shopsys:phing-targets:sort"/>
+            <arg value="shopsys:phing-config:fix"/>
             <arg value="--check"/>
             <arg path="${project.basedir}/build.xml"/>
             <arg path="${path.root}/build.xml"/>
@@ -158,10 +158,10 @@
         </exec>
     </target>
 
-    <target name="phing-targets-sorting-fix" description="Sorts the phing targets automatically." hidden="true">
+    <target name="phing-config-fix" description="Fixes the syntax of Phing configuration." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
-            <arg value="shopsys:phing-targets:sort"/>
+            <arg value="shopsys:phing-config:fix"/>
             <arg path="${project.basedir}/build.xml"/>
             <arg path="${path.root}/build.xml"/>
             <arg path="${path.framework}/build.xml"/>
@@ -200,13 +200,13 @@
         </exec>
     </target>
 
-    <target name="standards" depends="shopsys_framework.standards,phing-targets-sorting-check" description="Checks coding standards."/>
+    <target name="standards" depends="shopsys_framework.standards,phing-config-check" description="Checks coding standards."/>
 
-    <target name="standards-diff" depends="shopsys_framework.standards-diff,phing-targets-sorting-check" description="Checks coding standards in changed files."/>
+    <target name="standards-diff" depends="shopsys_framework.standards-diff,phing-config-check" description="Checks coding standards in changed files."/>
 
-    <target name="standards-fix" depends="shopsys_framework.standards-fix,phing-targets-sorting-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix" depends="shopsys_framework.standards-fix,phing-config-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
 
-    <target name="standards-fix-diff" depends="shopsys_framework.standards-fix-diff,phing-targets-sorting-fix" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix-diff" depends="shopsys_framework.standards-fix-diff,phing-config-fix" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
 
     <target name="tests-unit" description="Runs unit tests in the whole monorepo.">
         <phingcall target="shopsys_framework.tests-unit"/>

--- a/packages/framework/src/Command/PhingConfigFixerCommand.php
+++ b/packages/framework/src/Command/PhingConfigFixerCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use Exception;
+use RuntimeException;
 use SimpleXMLElement;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -48,7 +48,7 @@ class PhingConfigFixerCommand extends Command
         foreach ($paths as $path) {
             $content = file_get_contents($path);
 
-            $sortedContent = $this->fixConfiguration($content, $io);
+            $sortedContent = $this->fixConfiguration($content);
 
             $isContentChanged = $content !== $sortedContent;
             if ($checkOnly && $isContentChanged) {
@@ -152,7 +152,7 @@ class PhingConfigFixerCommand extends Command
             $replacedContent = str_replace($targetBlock, $targetPlaceholder, $content);
 
             if ($content === $replacedContent) {
-                throw new Exception("This block was not found in the XML content and could not be replaced:\n\n" . $targetBlock);
+                throw new RuntimeException("This block was not found in the XML content and could not be replaced:\n\n" . $targetBlock);
             }
 
             $content = $replacedContent;
@@ -175,7 +175,7 @@ class PhingConfigFixerCommand extends Command
             $replacedContent = str_replace($targetPlaceholder, $targetBlock, $content);
 
             if ($content === $replacedContent) {
-                throw new Exception(sprintf('The placeholder for target #%d was not found in the XML content and could not be replaced.', $position));
+                throw new RuntimeException(sprintf('The placeholder for target #%d was not found in the XML content and could not be replaced.', $position));
             }
 
             $content = $replacedContent;

--- a/packages/framework/src/Command/SortPhingTargetsCommand.php
+++ b/packages/framework/src/Command/SortPhingTargetsCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Command;
 
 use SimpleXMLElement;
@@ -22,7 +24,7 @@ class SortPhingTargetsCommand extends Command
      */
     protected static $defaultName = 'shopsys:phing-targets:sort';
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDescription('Sort Phing targets alphabetically')

--- a/packages/framework/src/Command/SortPhingTargetsCommand.php
+++ b/packages/framework/src/Command/SortPhingTargetsCommand.php
@@ -2,16 +2,18 @@
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use Exception;
 use SimpleXMLElement;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class SortPhingTargetsCommand extends Command
 {
+    protected const RETURN_CODE_OK = 0;
+    protected const RETURN_CODE_ERROR = 1;
     protected const ARG_XML_PATH = 'xml';
     protected const OPTION_ONLY_CHECK = 'check';
 
@@ -31,31 +33,52 @@ class SortPhingTargetsCommand extends Command
     /**
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $returnCode = static::RETURN_CODE_OK;
+        $io = new SymfonyStyle($input, $output);
+
+        $checkOnly = $input->getOption(static::OPTION_ONLY_CHECK);
         $paths = $input->getArgument(static::ARG_XML_PATH);
         foreach ($paths as $path) {
             $content = file_get_contents($path);
 
-            $sortedContent = $this->sortTargetBlocks($content);
+            $sortedContent = $this->sortTargetBlocks($content, $io);
 
-            if (!$input->getOption(static::OPTION_ONLY_CHECK)) {
+            $isContentChanged = $content !== $sortedContent;
+            if ($checkOnly && $isContentChanged) {
+                $returnCode = static::RETURN_CODE_ERROR;
+
+                $io->error(sprintf('The targets in "%s" are not alphabetically sorted.', $path));
+            } elseif ($isContentChanged) {
                 file_put_contents($path, $sortedContent);
-            } elseif ($content !== $sortedContent) {
-                throw new Exception('The targets are not alphabetically sorted. Re-run the command without the "' . static::OPTION_ONLY_CHECK . '" option to fix it.');
+
+                $io->success(sprintf('The targets in "%s" were alphabetically sorted.', $path));
             }
         }
+
+        if ($returnCode === static::RETURN_CODE_OK) {
+            $io->success('All targets are alphabetically sorted.');
+        } elseif ($returnCode === static::RETURN_CODE_ERROR) {
+            $io->error('Some targets are not alphabetically sorted.');
+
+            $io->comment(sprintf('Re-run the command without the "%s" option to fix it automatically.', static::OPTION_ONLY_CHECK));
+        }
+
+        return $returnCode;
     }
 
     /**
      * @param string $content
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
      * @return string
      */
-    protected function sortTargetBlocks(string $content): string
+    protected function sortTargetBlocks(string $content, SymfonyStyle $io): string
     {
         $targetBlocks = $this->extractTargetBlocksIndexedByName($content);
-        $content = $this->replaceTargetsByPlaceholders($content, $targetBlocks);
+        $content = $this->replaceTargetsByPlaceholders($content, $targetBlocks, $io);
         $content = $this->normalizeWhitespaceBetweenPlaceholders($content);
 
         ksort($targetBlocks);
@@ -104,9 +127,10 @@ class SortPhingTargetsCommand extends Command
     /**
      * @param string $content
      * @param string[] $targetBlocks
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
      * @return string
      */
-    protected function replaceTargetsByPlaceholders(string $content, array $targetBlocks): string
+    protected function replaceTargetsByPlaceholders(string $content, array $targetBlocks, SymfonyStyle $io): string
     {
         $position = 1;
         foreach ($targetBlocks as $targetBlock) {
@@ -115,7 +139,9 @@ class SortPhingTargetsCommand extends Command
             $replacedContent = str_replace($targetBlock, $targetPlaceholder, $content);
 
             if ($content === $replacedContent) {
-                throw new Exception("Target block was not found in the original XML, probably because of unexpected formatting:\n\n" . $targetBlock);
+                $io->warning("This target block was not found in the original XML:\n\n" . $targetBlock);
+
+                $io->warning('This is probably because of unexpected formatting (eg. excessive whitespace). Position of this target will not be checked nor fixed.');
             }
 
             $content = $replacedContent;


### PR DESCRIPTION
- renamed to `shopsys:phing-config:fix`
- the class was renamed to `PhingConfigFixerCommand`
- `SymfonyStyle` is used for input / output
- return codes are used instead of throwing Exceptions (Exceptions are still thrown for actual errors)
- messages were tweaked for better understandability
- the command also normalizes the whitespace in XML

| Q             | A
| ------------- | ---
|Description, reason for the PR| Usage of shopsys:phing-targets:sort introduced in #1104 was clumsy and caused a lot of hard-to-find errors.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No (the class was not released yet) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
