### PR TITLE
[project-base] prevent indexing `CustomerPassword:setNewPassword` by robots

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -60,6 +60,14 @@ There you can find links to upgrade notes for other versions too.
             + }
             ```
     - you can copy-paste a new functional test [`ProductVariantCreationTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` to avoid regression of issues with creating product variants in the future
+- prevent indexing `CustomerPassword:setNewPassword` by robots ([#1119](https://github.com/shopsys/shopsys/pull/1119))
+    - add a `meta_robots` Twig block to you `@ShopsysShop/Front/Content/Registration/setNewPassword.html.twig` template:
+        ```twig
+        {% block meta_robots -%}
+            <meta name="robots" content="noindex, follow">
+        {% endblock %}
+        ```
+    - you should prevent indexing by robots using this block on all pages that are secured by an URL hash
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -61,7 +61,7 @@ There you can find links to upgrade notes for other versions too.
             ```
     - you can copy-paste a new functional test [`ProductVariantCreationTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` to avoid regression of issues with creating product variants in the future
 - prevent indexing `CustomerPassword:setNewPassword` by robots ([#1119](https://github.com/shopsys/shopsys/pull/1119))
-    - add a `meta_robots` Twig block to you `@ShopsysShop/Front/Content/Registration/setNewPassword.html.twig` template:
+    - add a `meta_robots` Twig block to your `@ShopsysShop/Front/Content/Registration/setNewPassword.html.twig` template:
         ```twig
         {% block meta_robots -%}
             <meta name="robots" content="noindex, follow">

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Registration/setNewPassword.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Registration/setNewPassword.html.twig
@@ -1,5 +1,9 @@
 {% extends '@ShopsysShop/Front/Layout/layoutWithoutPanel.html.twig' %}
 
+{% block meta_robots -%}
+    <meta name="robots" content="noindex, follow">
+{% endblock %}
+
 {% block title %}
     {{ 'Set new password'|trans }}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| All pages secured by an URL hash should have `noindex` in their robots metadata to prevent indexing them by search engines in case such URL gets leaked.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes