### PR TITLE
[shopsys] use autocomplete="new-password" attribute for password inputs

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -68,6 +68,15 @@ There you can find links to upgrade notes for other versions too.
         {% endblock %}
         ```
     - you should prevent indexing by robots using this block on all pages that are secured by an URL hash
+- use `autocomplete="new-password"` attribute for password changing inputs to prevent filling it by browser ([#1121](https://github.com/shopsys/shopsys/pull/1121))
+    - in `shopsys/project-base` repository this change was needed in 3 form classes (`NewPasswordFormType`, `UserFormType` and `RegistrationFormType`):
+        ```diff
+          'type' => PasswordType::class,
+          'options' => [
+        -     'attr' => ['autocomplete' => 'off'],
+        +     'attr' => ['autocomplete' => 'new-password'],
+          ],
+        ```
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -72,7 +72,7 @@ class AdministratorFormType extends AbstractType
                 'type' => PasswordType::class,
                 'required' => $options['scenario'] === self::SCENARIO_CREATE,
                 'options' => [
-                    'attr' => ['autocomplete' => 'off'],
+                    'attr' => ['autocomplete' => 'new-password'],
                 ],
                 'first_options' => [
                     'label' => t('Password'),

--- a/packages/framework/src/Form/Admin/Customer/UserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/UserFormType.php
@@ -159,7 +159,7 @@ class UserFormType extends AbstractType
                 'type' => PasswordType::class,
                 'required' => $options['user'] === null,
                 'options' => [
-                    'attr' => ['autocomplete' => 'off'],
+                    'attr' => ['autocomplete' => 'new-password'],
                 ],
                 'first_options' => [
                     'constraints' => $this->getFirstPasswordConstraints($options['user'] === null),

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/Password/NewPasswordFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/Password/NewPasswordFormType.php
@@ -22,7 +22,7 @@ class NewPasswordFormType extends AbstractType
             ->add('newPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'options' => [
-                    'attr' => ['autocomplete' => 'off'],
+                    'attr' => ['autocomplete' => 'new-password'],
                 ],
                 'first_options' => [
                     'constraints' => [

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/UserFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/UserFormType.php
@@ -52,7 +52,7 @@ class UserFormType extends AbstractType
                 'type' => PasswordType::class,
                 'required' => false,
                 'options' => [
-                    'attr' => ['autocomplete' => 'off'],
+                    'attr' => ['autocomplete' => 'new-password'],
                 ],
                 'first_options' => [
                     'constraints' => [

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php
@@ -52,7 +52,7 @@ class RegistrationFormType extends AbstractType
             ->add('password', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'options' => [
-                    'attr' => ['autocomplete' => 'off'],
+                    'attr' => ['autocomplete' => 'new-password'],
                 ],
                 'first_options' => [
                     'constraints' => [


### PR DESCRIPTION
For browser compatibility, see https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Browser_compatibility

| Q             | A
| ------------- | ---
|Description, reason for the PR| Prevents browsers from filling the input for changing the password.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

When you are registered as a customer, have the password remembered in the browser (and it's the only password remembered on that domain) and visit the *Personal data* page, the input *Changing password > Password* gets filled in automatically, which makes the form invalid (as it doesn't match *Password again* field)
