### PR TITLE
[framework] fixed memory leak on shopsys:product-search:export-products command

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -129,6 +129,14 @@ There you can find links to upgrade notes for other versions too.
         +    Shopsys\ShopBundle\Twig\:
         +        resource: '../../Twig/'
         ```
+- if you have `Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter` re-registered in your `services.yml`, add proper setter calls ([#1122](https://github.com/shopsys/shopsys/pull/1122))
+    ```diff
+        Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter
+    +       calls:
+    +           - method: setProgressBarFactory
+    +           - method: setSqlLoggerFacade
+    +           - method: setEntityManager
+    ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/packages/framework/src/Command/ProductSearchExportProductsCommand.php
+++ b/packages/framework/src/Command/ProductSearchExportProductsCommand.php
@@ -26,13 +26,13 @@ class ProductSearchExportProductsCommand extends Command
     public function __construct(ProductSearchExportFacade $productSearchExportFacade)
     {
         parent::__construct();
+
         $this->productSearchExportFacade = $productSearchExportFacade;
     }
 
     protected function configure()
     {
-        $this
-            ->setDescription('Exports all products to Elasticsearch for searching ');
+        $this->setDescription('Exports all products to Elasticsearch for searching ');
     }
 
     /**
@@ -43,7 +43,9 @@ class ProductSearchExportProductsCommand extends Command
     {
         $symfonyStyleIo = new SymfonyStyle($input, $output);
         $output->writeln('Exporting products to Elasticsearch');
-        $this->productSearchExportFacade->exportAll();
+
+        $this->productSearchExportFacade->exportAllWithOutput($symfonyStyleIo);
+
         $symfonyStyleIo->success('All products successfully exported');
     }
 }

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportFacade.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportFacade.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ProductSearchExportFacade
 {
@@ -26,12 +27,30 @@ class ProductSearchExportFacade
         $this->exporter = $exporter;
     }
 
+    /**
+     * @deprecated Use `exportAllWithOutput` instead
+     */
     public function exportAll(): void
     {
         foreach ($this->domain->getAll() as $domain) {
             $id = $domain->getId();
             $locale = $domain->getLocale();
             $this->exporter->export($id, $locale);
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyleIo
+     */
+    public function exportAllWithOutput(SymfonyStyle $symfonyStyleIo): void
+    {
+        foreach ($this->domain->getAll() as $domain) {
+            $domainId = $domain->getId();
+            $locale = $domain->getLocale();
+
+            $symfonyStyleIo->section('Exporting data for domain ' . $domainId);
+
+            $this->exporter->exportWithOutput($domainId, $locale, $symfonyStyleIo);
         }
     }
 }

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportRepository.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibility;
 
@@ -70,5 +71,17 @@ class ProductSearchExportRepository
             ->setParameter('variantTypeVariant', Product::VARIANT_TYPE_VARIANT);
 
         return $queryBuilder;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $locale
+     * @return int
+     */
+    public function getProductTotalCountForDomainAndLocale(int $domainId, string $locale): int
+    {
+        $result = new QueryPaginator($this->createQueryBuilder($domainId, $locale));
+
+        return $result->getTotalCount();
     }
 }

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -1006,7 +1006,11 @@ services:
             - '%shopsys.elasticsearch.structure_dir%'
             - '%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
 
-    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter: ~
+    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter:
+        calls:
+            - method: setProgressBarFactory
+            - method: setSqlLoggerFacade
+            - method: setEntityManager
 
     Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter: ~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Exporting products to Elasticsearch needed more memory, the more products was present. Now the memory usage is stable and low enough (< 100MB). Progressbar representing the number of exported products was added.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1021 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Disabling SQL logging is in our documentation as [best practice for working with many records](https://github.com/shopsys/shopsys/blob/master/docs/cookbook/basic-data-import.md#best-practices) and it can be found as a known solution – for example https://janhapke.com/blog/optimizing-doctrine-in-long-running-jobs/

Also, the identity map of Doctrine EntityManager is cleared after each batch to prevent memory leaks.