### PR TITLE
.travis.yml: overwriting of travis user id by group id in docker-compose is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 -   mkdir -p $CACHE_DIR
 -   cp -f ./docker/conf/docker-compose.yml.dist ./docker-compose.yml
 -   yq write --inplace docker-compose.yml services.php-fpm.build.args.www_data_uid $TRAVIS_USER_ID
--   yq write --inplace docker-compose.yml services.php-fpm.build.args.www_data_uid $TRAVIS_GROUP_ID
+-   yq write --inplace docker-compose.yml services.php-fpm.build.args.www_data_gid $TRAVIS_GROUP_ID
 
 install:
 -   docker load < $CACHE_FILE_IMAGE || true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in travis script was one bug via yq command rewrite where uid was overwriten by gid value and thus gid wasnt intruduced at all into docker-compose php-fpm image build
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
