### PR TITLE
[framework] generating of multidomain sitemaps

### DIFF
--- a/packages/framework/src/Model/Sitemap/SitemapDumper.php
+++ b/packages/framework/src/Model/Sitemap/SitemapDumper.php
@@ -57,7 +57,12 @@ class SitemapDumper extends Dumper
         $this->deleteExistingSitemaps($targetDir);
 
         $finder = new Finder();
-        foreach ($finder->files()->in($this->tmpFolder)->getIterator() as $file) {
+        $sitemapFileFinder = $finder
+            ->files()
+            ->name(sprintf('%s*.xml', $this->sitemapFilePrefix))
+            ->in($this->tmpFolder);
+
+        foreach ($sitemapFileFinder->getIterator() as $file) {
             $this->mountManager->move(
                 'local://' . TransformString::removeDriveLetterFromPath($file->getPathname()),
                 'main://' . $targetDir . '/' . $file->getBasename()
@@ -74,7 +79,10 @@ class SitemapDumper extends Dumper
      */
     protected function deleteExistingSitemaps($targetDir)
     {
-        $files = $this->abstractFilesystem->listContents($targetDir);
+        $files = array_filter($this->abstractFilesystem->listContents($targetDir), function ($file)
+        {
+            return strpos($file['filename'], $this->sitemapFilePrefix) === 0;
+        });
         foreach ($files as $file) {
             $this->abstractFilesystem->delete($file['path']);
         }

--- a/packages/framework/src/Model/Sitemap/SitemapDumper.php
+++ b/packages/framework/src/Model/Sitemap/SitemapDumper.php
@@ -79,8 +79,7 @@ class SitemapDumper extends Dumper
      */
     protected function deleteExistingSitemaps($targetDir)
     {
-        $files = array_filter($this->abstractFilesystem->listContents($targetDir), function ($file)
-        {
+        $files = array_filter($this->abstractFilesystem->listContents($targetDir), function ($file) {
             return strpos($file['filename'], $this->sitemapFilePrefix) === 0;
         });
         foreach ($files as $file) {


### PR DESCRIPTION
- removing of old sitemap files was separated for each domain
- copying of newly generated files from tmp to mainfilesystem was limited for sitemap domain prefix

| Q             | A
| ------------- | ---
|Description, reason for the PR| during generating sitemaps for multidomain shop, previous domain sitemaps were removed from mainfilesystem. Now there are just removed only those that are processed in the current item from cycle of domains list and also uploaded based on their prefix that contains unique name with domain id.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
