### PR TITLE
read-model package is now listed in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ There is a list of all the repositories maintained by monorepo:
 * [shopsys/product-feed-heureka-delivery]
 * [shopsys/product-feed-zbozi]
 * [shopsys/google-cloud-bundle]
+* [shopsys/read-model]
 
 Packages are formatted by release version. You can see all the changes done to package that you carry about with this tree.
 
@@ -2056,6 +2057,7 @@ That's why is this section formatted differently.
 [shopsys/migrations]: https://github.com/shopsys/migrations
 [shopsys/monorepo-tools]: https://github.com/shopsys/monorepo-tools
 [shopsys/google-cloud-bundle]: https://github.com/shopsys/google-cloud-bundle
+[shopsys/read-model]: https://github.com/shopsys/read-model
 
 [@pk16011990]: https://github.com/pk16011990
 [@stanoMilan]: https://github.com/stanoMilan


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in CHANGELOG, there should be listed all packages maintined by monorepo
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
