### PR TITLE
updated UPGRADE.md to include information about need to rebuild docker images without cache

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,11 +21,11 @@ Follow the instructions in the [monorepo upgrade guide](docs/contributing/upgrad
 * check the instructions in all sections, any of them could be relevant for you
 * typical upgrade sequence should be:
     * run `docker-compose down` to turn off your containers
-    * *(MacOS, Windows only)* run `docker-sync stop`
-    * *(MacOS, Windows only)* run `docker-sync clean` so your volumes will be removed
+    * *(MacOS, Windows only)* run `docker-sync clean` so your volumes will be stopped and removed
     * follow upgrade notes in the *Infrastructure* section (related with `docker-compose.yml`, `Dockerfile`, docker containers, `nginx.conf`, `php.ini`, etc.)
     * *(MacOS, Windows only)* run `docker-sync start` to create volumes  
-    * run `docker-compose up -d --build --force-recreate --remove-orphans` to start the application again
+    * run `docker-compose build --no-cache --pull` to build your images without cache and with latest version
+    * run `docker-compose up -d --force-recreate --remove-orphans` to start the application again
     * update the `shopsys/*` dependencies in `composer.json` to version you are upgrading to
         eg. `"shopsys/framework": "v7.0.0"`
     * run `composer update`

--- a/docs/contributing/upgrading-monorepo.md
+++ b/docs/contributing/upgrading-monorepo.md
@@ -1,8 +1,13 @@
 # Upgrading monorepo
 
 Typical upgrade sequence should be:
-* when you update your `docker-compose.yml`, you need to apply the changes by using command `docker-compose up -d`
-* *(Windows, MacOS only)* any changes in `docker-sync.yml` file should follow with `docker-sync stop`, `docker-sync clean` and `docker-sync start` to restart synchronization
+* run `docker-compose down` to turn off your containers
+* *(MacOS, Windows only)* run `docker-sync clean` so your volumes will be stopped and removed
+* update your `docker-compose.yml` by `docker-compose` file specific for your operating system from `docker/conf` folder
+* *(MacOS, Windows only)* update your `docker-sync.yml` by `docker-sync` file specific for your operating system from `docker/conf` folder
+* *(MacOS, Windows only)* run `docker-sync start` to create volumes
+* run `docker-compose build --no-cache --pull` to build your images without cache and with latest version
+* run `docker-compose up -d --force-recreate --remove-orphans` to start the application again
 * run `php phing composer-dev clean db-migrations` in `php-fpm` container
 * if you're experiencing some errors, you can always rebuild application and load demo data with `php phing build-demo-dev`
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There might be situation when Docker build cache prevents to build images well and leads to unexpected errors.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
