### PR TITLE
[shopsys] added note about option to skip test for one of two implementations …

### DIFF
--- a/docs/model/front-end-product-filtering.md
+++ b/docs/model/front-end-product-filtering.md
@@ -42,3 +42,6 @@ or
     # SQL filtering
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
 ```
+
+*Note: If you need to extend the implementation of your choice, it is possible you will need to adjust abstract test `Tests\ShopBundle\Functional\Model\Product\ProductOnCurrentDomainFacadeTest` accordingly.
+In that case is perfectly fine to skip or delete implementation of this test for the one you don't use.*


### PR DESCRIPTION
… of ProductOnCurrentDomainFacadeInterface

| Q             | A
| ------------- | ---
|Description, reason for the PR| Now it's clear what to do if you extend one of implementations `ProductOnCurrentDomainFacadeInterface`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
