### PR TITLE
[shopsys] improve backward compatibility of ProductAvailabilityCalculation patch

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -33,33 +33,8 @@ There you can find links to upgrade notes for other versions too.
 ### Application
 - follow instructions in [the separate article](upgrade-instructions-for-read-model-for-product-lists.md) to introduce read model for frontend product lists into your project ([#1018](https://github.com/shopsys/shopsys/pull/1018))
     - we recommend to read [Introduction to Read Model](/docs/model/introduction-to-read-model.md) article
-- fix up your functional tests because of availability calculation patch in the `shopsys/framework` ([#1113](https://github.com/shopsys/shopsys/pull/1113))
-    - when providing a mock of `EntityManager` to `ProductAvailabilityCalculation` in a test, set its `contains` to always return `true`
-        - it's recommended to extract the mocking into a method, for example see changes in `ProductAvailabilityCalculationTest`:
-            ```diff
-            -     $entityManagerMock = $this->createMock(EntityManager::class);
-            +     $entityManagerMock = $this->createEntityManagerMock();
-            ...
-            -     $entityManagerMock = $this->createMock(EntityManager::class);
-            +     $entityManagerMock = $this->createEntityManagerMock();
-            ...
-            -     $entityManagerMock = $this->createMock(EntityManager::class);
-            +     $entityManagerMock = $this->createEntityManagerMock();
-            ...
-            +
-            + /**
-            +  * @return \PHPUnit\Framework\MockObject\MockObject
-            +  */
-            + protected function createEntityManagerMock(): MockObject
-            + {
-            +     $entityManagerMock = $this->createMock(EntityManager::class);
-            +
-            +     $entityManagerMock->method('contains')->willReturn(true);
-            +
-            +     return $entityManagerMock;
-            + }
-            ```
-    - you can copy-paste a new functional test [`ProductVariantCreationTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` to avoid regression of issues with creating product variants in the future
+- copy a new functional test to avoid regression of issues with creating product variants in the future ([#1113](https://github.com/shopsys/shopsys/pull/1113))
+    - you can copy-paste the class [`ProductVariantCreationTest.php`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` in your project
 - prevent indexing `CustomerPassword:setNewPassword` by robots ([#1119](https://github.com/shopsys/shopsys/pull/1119))
     - add a `meta_robots` Twig block to your `@ShopsysShop/Front/Content/Registration/setNewPassword.html.twig` template:
         ```twig

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -64,7 +64,7 @@ class ProductAvailabilityCalculation
     {
         // If the product is not managed by EntityManager yet, it's not possible to calculate its availability consistently
         // Let's return a default availability for the moment and mark the product for recalculation
-        if (!$this->em->contains($product)) {
+        if ($this->em->contains($product) === false) {
             $product->markForAvailabilityRecalculation();
 
             return $this->availabilityFacade->getDefaultInStockAvailability();

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -3,7 +3,6 @@
 namespace Tests\ShopBundle\Functional\Model\Product\Availability;
 
 use Doctrine\ORM\EntityManager;
-use PHPUnit\Framework\MockObject\MockObject;
 use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityCalculation;
@@ -56,7 +55,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
 
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);
-        $entityManagerMock = $this->createEntityManagerMock();
+        $entityManagerMock = $this->createMock(EntityManager::class);
         $productRepositoryMock = $this->createMock(ProductRepository::class);
 
         $productAvailabilityCalculation = new ProductAvailabilityCalculation(
@@ -147,7 +146,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $availabilityFacadeMock = $this->createMock(AvailabilityFacade::class);
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);
-        $entityManagerMock = $this->createEntityManagerMock();
+        $entityManagerMock = $this->createMock(EntityManager::class);
 
         $productRepositoryMock = $this->createMock(ProductRepository::class);
         $productRepositoryMock
@@ -195,7 +194,7 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
             ->willReturn($defaultInStockAvailability);
         $productSellingDeniedRecalculatorMock = $this->createMock(ProductSellingDeniedRecalculator::class);
         $productVisibilityFacadeMock = $this->createMock(ProductVisibilityFacade::class);
-        $entityManagerMock = $this->createEntityManagerMock();
+        $entityManagerMock = $this->createMock(EntityManager::class);
 
         $productRepositoryMock = $this->createMock(ProductRepository::class);
         $productRepositoryMock
@@ -217,17 +216,5 @@ class ProductAvailabilityCalculationTest extends FunctionalTestCase
         $mainVariantCalculatedAvailability = $productAvailabilityCalculation->calculateAvailability($mainVariant);
 
         $this->assertSame($defaultInStockAvailability, $mainVariantCalculatedAvailability);
-    }
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function createEntityManagerMock(): MockObject
-    {
-        $entityManagerMock = $this->createMock(EntityManager::class);
-
-        $entityManagerMock->method('contains')->willReturn(true);
-
-        return $entityManagerMock;
     }
 }


### PR DESCRIPTION
- the patch in https://github.com/shopsys/shopsys/pull/1113 requried different EntityManager mock creation
- strict comparison of the result of `EntityManager::contains()` with `false` instead of a simple negation removes this requirement (because the mocked method will return `null`)
- tests require no changes to pass successfully after upgrade to a new version of `shopsys/framework` package
- the changes in `ProductAvailabilityCalculationTest` were reverted

| Q             | A
| ------------- | ---
|Description, reason for the PR| All tests should pass in `shopsys/project-base` in `v7.0.0` when upgrading all used `shopsys/*` packages via Composer. This was not true after merging #1113 as the functional tests required minor changes to pass.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
