### PR TITLE
[shopsys] added Elasticsearch structure migration via reindexing for easier deployment

### DIFF
--- a/docs/installation/installation-using-docker-on-production-server.md
+++ b/docs/installation/installation-using-docker-on-production-server.md
@@ -348,6 +348,9 @@ docker-compose -p production up -d --force-recreate webserver
 # remove container for building the application image
 docker rm -f build-php-fpm-container
 ```
+***Note:** During `build-deploy-part-2-db-dependent` phing target `product-search-migrate-structure` is called and can cause error when you change the type of field to another (eg. you change it from `bool` to `integer`). If you need to make this change, please add new field with the correct type and delete the old field instead*
+
+***Note:** If you need to have freshly exported products in Elasticsearch after deploy, you can call phing target `product-search-export-products` during `build-deploy-part-2-db-dependent`.*
 
 ## Logging
 If you need to inspect your application logs, use `docker-compose logs` command.

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -140,6 +140,20 @@ Consists of two subtasks that can be run independently:
 * `product-search-delete-structure` - deletes existing indexes structure
 * `product-search-create-structure` - creates new indexes structure by json definitions stored in [the resources directory](/project-base/src/Shopsys/ShopBundle/Resources/definition).
 
+#### product-search-migrate-structure
+Migrates Elasticsearch indexes if there is change between currently used structure and the one in `*.json`.
+Especially useful when you need to change the structure and don't need to have fresh data in Elasticsearch
+* creates new index without alias
+* reindexes data from old index to the new one
+* deletes old index
+* creates alias for the new index
+
+*Note: If you add field/s to the structure and reindex they won't be available until `product-search-export-products` is called.*
+*You application must handle the properties not being filled correctly until all products are exported.*
+
+*Note: Using this phing target after changing the type of field to another in structure (eg. changing it from `bool` to `integer`) will cause an error.*
+*If you need to make this change, please add new field with the correct type and delete the old field instead.*
+
 #### product-search-export-products
 Exports all visible products to Elasticsearch.
 

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -149,7 +149,7 @@ Especially useful when you need to change the structure and don't need to have f
 * creates alias for the new index
 
 *Note: If you add field/s to the structure and reindex they won't be available until `product-search-export-products` is called.*
-*You application must handle the properties not being filled correctly until all products are exported.*
+*Your application must handle the properties not being filled correctly until all products are exported.*
 
 *Note: Using this phing target after changing the type of field to another in structure (eg. changing it from `bool` to `integer`) will cause an error.*
 *If you need to make this change, please add new field with the correct type and delete the old field instead.*

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -84,11 +84,11 @@
 
     <target name="build-deploy-part-1-db-independent" depends="build-version-generate,clean,composer-prod,npm,dirs-create,assets" description="First part of application build for production preserving your DB (can be run without maintenance page)."/>
 
-    <target name="build-deploy-part-2-db-dependent" depends="redis-check,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,grunt,error-pages-generate,warmup,clean-redis-old" description="Second part of application build for production preserving your DB (must be run with maintenance page when containing DB migrations)."/>
+    <target name="build-deploy-part-2-db-dependent" depends="product-search-migrate-structure,redis-check,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,grunt,error-pages-generate,warmup,clean-redis-old" description="Second part of application build for production preserving your DB (must be run with maintenance page when containing DB migrations)."/>
 
     <target name="build-dev" depends="build-version-generate,clean,composer-dev,npm,timezones-check,dirs-create,test-dirs-create,assets,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,product-search-recreate-structure,product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,clean-redis-old,checks-diff" description="Builds application for development preserving your DB and runs checks on changed files."/>
 
-    <target name="build-dev-quick" depends="build-version-generate,clean,composer-dev,npm,dirs-create,test-dirs-create,assets,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,grunt,clean-redis-old" description="Builds application for development preserving your DB while skipping nonessential steps."/>
+    <target name="build-dev-quick" depends="build-version-generate,clean,composer-dev,npm,dirs-create,test-dirs-create,assets,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,product-search-migrate-structure,grunt,clean-redis-old" description="Builds application for development preserving your DB while skipping nonessential steps."/>
 
     <target name="build-new" depends="wipe,build-version-generate,composer-prod,redis-check,npm,dirs-create,assets,db-rebuild,grunt,error-pages-generate,warmup,product-search-recreate-structure,clean-redis-old" description="Builds application for production with clean DB (with base data only)."/>
 
@@ -688,6 +688,13 @@
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:product-search:export-products"/>
+        </exec>
+    </target>
+
+    <target name="product-search-migrate-structure" description="Creates new structure, reindexes it from old one, deletes old structure and add alias to new structure.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:product-search:migrate-if-necessary"/>
         </exec>
     </target>
 

--- a/packages/framework/src/Command/ProductSearchMigrateIfNecessaryCommand.php
+++ b/packages/framework/src/Command/ProductSearchMigrateIfNecessaryCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportStructureFacade;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class ProductSearchMigrateIfNecessaryCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'shopsys:product-search:migrate-if-necessary';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportStructureFacade
+     */
+    protected $productSearchExportStructureFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportStructureFacade $productSearchExportStructureFacade
+     */
+    public function __construct(ProductSearchExportStructureFacade $productSearchExportStructureFacade)
+    {
+        $this->productSearchExportStructureFacade = $productSearchExportStructureFacade;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Creates new structure, reindexes it from old one, deletes old structure and adds alias to new structure');
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $symfonyStyleIo = new SymfonyStyle($input, $output);
+        $output->writeln('Migrating indexes');
+        $this->productSearchExportStructureFacade->migrateIndexesIfNecessary($output);
+        $symfonyStyleIo->success('Indexes migrated successfully!');
+    }
+}

--- a/packages/framework/src/Component/ArrayUtils/RecursiveArraySorter.php
+++ b/packages/framework/src/Component/ArrayUtils/RecursiveArraySorter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ArrayUtils;
+
+class RecursiveArraySorter
+{
+    /**
+     * @param array $array
+     * @return bool
+     */
+    public function recursiveArrayKsort(array &$array): bool
+    {
+        $return = true;
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $return = $this->recursiveArrayKsort($value) && $return;
+            }
+        }
+        return ksort($array) && $return;
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureManager.php
+++ b/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureManager.php
@@ -2,7 +2,10 @@
 
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 
+use BadMethodCallException;
 use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchMoreThanOneCurrentIndexException;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchNoCurrentIndexException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchStructureException;
 
 class ElasticsearchStructureManager
@@ -23,15 +26,50 @@ class ElasticsearchStructureManager
     protected $client;
 
     /**
+     * @var string|null
+     */
+    protected $buildVersion;
+
+    /**
      * @param string $definitionDirectory
      * @param string $indexPrefix
      * @param \Elasticsearch\Client $client
+     * @param string|null $buildVersion
      */
-    public function __construct(string $definitionDirectory, string $indexPrefix, Client $client)
+    public function __construct(string $definitionDirectory, string $indexPrefix, Client $client, ?string $buildVersion = null)
     {
         $this->definitionDirectory = $definitionDirectory;
         $this->indexPrefix = $indexPrefix;
         $this->client = $client;
+        $this->buildVersion = $buildVersion;
+    }
+
+    /**
+     * @param string $buildVersion
+     * @internal Will be replaced with constructor injection in the next major release
+     */
+    public function setBuildVersion(string $buildVersion): void
+    {
+        if ($this->buildVersion !== null) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
+        $this->buildVersion = $buildVersion;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @return string
+     * @deprecated Getting index name without a version using this method is deprecated since SSFW 7.3, use getVersionedIndexName or getAliasName instead
+     */
+    public function getIndexName(int $domainId, string $index): string
+    {
+        @trigger_error(
+            sprintf('Getting index name without a version using method "%s" is deprecated since SSFW 7.3, use %s or %s instead', __METHOD__, 'getVersionedIndexName', 'getAliasName'),
+            E_USER_DEPRECATED
+        );
+        return $this->getAliasName($domainId, $index);
     }
 
     /**
@@ -39,7 +77,69 @@ class ElasticsearchStructureManager
      * @param string $index
      * @return string
      */
-    public function getIndexName(int $domainId, string $index): string
+    public function getVersionedIndexName(int $domainId, string $index): string
+    {
+        return $this->indexPrefix . ($this->buildVersion ?? 'null') . $index . $domainId;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @return string
+     */
+    public function getCurrentIndexName(int $domainId, string $index): string
+    {
+        $aliasName = $this->getAliasName($domainId, $index);
+
+        $indexes = $this->client->indices();
+        if (!$indexes->existsAlias(['name' => $aliasName]) && $indexes->exists(['index' => $aliasName])) {
+            @trigger_error(
+                sprintf('Passing index name instead of alias name to method %s is deprecated since SSFW 7.3', __METHOD__),
+                E_USER_DEPRECATED
+            );
+            return $aliasName;
+        }
+
+        $indexNames = $this->getExistingIndexNamesForAlias($aliasName);
+
+        if (count($indexNames) > 1) {
+            throw new ElasticsearchMoreThanOneCurrentIndexException($aliasName);
+        } elseif (count($indexNames) === 0) {
+            throw new ElasticsearchNoCurrentIndexException($aliasName);
+        }
+
+        return reset($indexNames);
+    }
+
+    /**
+     * @param string $aliasName
+     * @return array
+     */
+    protected function getExistingIndexNamesForAlias(string $aliasName): array
+    {
+        $existingIndexNames = [];
+        $indexes = $this->client->indices();
+
+        if ($indexes->existsAlias(['name' => $aliasName])) {
+            $aliases = $indexes->getAlias([
+                'name' => $aliasName,
+            ]);
+            foreach (array_keys($aliases) as $indexName) {
+                if ($indexes->exists(['index' => $indexName])) {
+                    $existingIndexNames[] = $indexName;
+                }
+            }
+        }
+
+        return $existingIndexNames;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @return string
+     */
+    public function getAliasName(int $domainId, string $index): string
     {
         return $this->indexPrefix . $index . $domainId;
     }
@@ -50,11 +150,17 @@ class ElasticsearchStructureManager
      */
     public function createIndex(int $domainId, string $index)
     {
-        $definition = $this->getDefinition($domainId, $index);
+        $definition = $this->getStructureDefinition($domainId, $index);
         $indexes = $this->client->indices();
-        $indexName = $this->getIndexName($domainId, $index);
+        $indexName = $this->getVersionedIndexName($domainId, $index);
         if ($indexes->exists(['index' => $indexName])) {
-            throw new ElasticsearchStructureException(sprintf('Index %s already exists', $indexName));
+            $message = sprintf('Index %s already exists', $indexName);
+            if ($this->buildVersion === '0000000000000000' || $this->buildVersion === null) {
+                $message .= ' Please start using build version or delete current index before creating a new one.';
+            } else {
+                $message .= ' Maybe you forgot to execute "php phing generate-build-version" before creating new index?';
+            }
+            throw new ElasticsearchStructureException($message);
         }
 
         $indexes->create([
@@ -67,8 +173,26 @@ class ElasticsearchStructureManager
      * @param int $domainId
      * @param string $index
      */
+    public function migrateIndex(int $domainId, string $index)
+    {
+        $this->createIndex($domainId, $index);
+        $this->reindexFromCurrentIndexToNewIndex($domainId, $index);
+        $this->deleteCurrentIndex($domainId, $index);
+        $this->createAliasForIndex($domainId, $index);
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @deprecated Deleting index using this method is deprecated since SSFW 7.3, use deleteIndexesOfCurrentAlias instead
+     */
     public function deleteIndex(int $domainId, string $index)
     {
+        @trigger_error(
+            sprintf('Deleting index using method "%s" is deprecated since SSFW 7.3, use %s instead', __METHOD__, 'deleteIndexesOfCurrentAlias'),
+            E_USER_DEPRECATED
+        );
+
         $indexes = $this->client->indices();
         $indexName = $this->getIndexName($domainId, $index);
         if ($indexes->exists(['index' => $indexName])) {
@@ -79,9 +203,78 @@ class ElasticsearchStructureManager
     /**
      * @param int $domainId
      * @param string $index
+     */
+    protected function reindexFromCurrentIndexToNewIndex(int $domainId, string $index)
+    {
+        $indexes = $this->client->indices();
+        $indexName = $this->getVersionedIndexName($domainId, $index);
+        $currentIndexName = $this->getCurrentIndexName($domainId, $index);
+        if ($indexes->exists(['index' => $currentIndexName]) && $indexes->exists(['index' => $indexName])) {
+            $body = [
+                'source' => [
+                    'index' => $currentIndexName,
+                ],
+                'dest' => [
+                    'index' => $indexName,
+                ],
+            ];
+
+            $this->client->reindex([
+                'body' => $body,
+            ]);
+        }
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     */
+    public function createAliasForIndex(int $domainId, string $index)
+    {
+        $indexes = $this->client->indices();
+        $aliasName = $this->getAliasName($domainId, $index);
+        $indexName = $this->getVersionedIndexName($domainId, $index);
+
+        if (!$indexes->existsAlias(['name' => $aliasName, 'index' => $indexName]) && $indexes->exists(['index' => $indexName])) {
+            $indexes->putAlias([
+                'index' => $indexName,
+                'name' => $aliasName,
+            ]);
+        }
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     */
+    public function deleteCurrentIndex(int $domainId, string $index): void
+    {
+        try {
+            $indexName = $this->getCurrentIndexName($domainId, $index);
+        } catch (ElasticsearchNoCurrentIndexException $e) {
+            return;
+        }
+
+        $this->client->indices()->delete(['index' => $indexName]);
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
      * @return array
+     * @deprecated using method getDefinition is deprecated since SSFW 7.3. Use public method getStructureDefinition instead
      */
     protected function getDefinition(int $domainId, string $index): array
+    {
+        $this->getStructureDefinition($domainId, $index);
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @return array
+     */
+    public function getStructureDefinition(int $domainId, string $index): array
     {
         $file = sprintf('%s/%s/%s.json', $this->definitionDirectory, $index, $domainId);
         if (!is_file($file)) {

--- a/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureUpdateChecker.php
+++ b/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureUpdateChecker.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
+
+use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Component\ArrayUtils\RecursiveArraySorter;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchNoCurrentIndexException;
+
+class ElasticsearchStructureUpdateChecker
+{
+    /**
+     * @var \Elasticsearch\Client
+     */
+    protected $client;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager
+     */
+    protected $elasticsearchStructureManager;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ArrayUtils\RecursiveArraySorter
+     */
+    protected $recursiveArraySorter;
+
+    /**
+     * @param \Elasticsearch\Client $client
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticsearchStructureManager
+     * @param \Shopsys\FrameworkBundle\Component\ArrayUtils\RecursiveArraySorter $recursiveArraySorter
+     */
+    public function __construct(
+        Client $client,
+        ElasticsearchStructureManager $elasticsearchStructureManager,
+        RecursiveArraySorter $recursiveArraySorter
+    ) {
+        $this->client = $client;
+        $this->elasticsearchStructureManager = $elasticsearchStructureManager;
+        $this->recursiveArraySorter = $recursiveArraySorter;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @return bool
+     */
+    public function isNecessaryToUpdateStructure(int $domainId, string $index): bool
+    {
+        $definition = $this->elasticsearchStructureManager->getStructureDefinition($domainId, $index);
+
+        try {
+            $indexName = $this->elasticsearchStructureManager->getCurrentIndexName($domainId, $index);
+        } catch (ElasticsearchNoCurrentIndexException $e) {
+            return true;
+        }
+
+        $currentIndex = $this->client->indices()->get(['index' => $indexName]);
+
+        $currentIndexDefinition = $this->prepareDefinitionForComparing(reset($currentIndex));
+        $definition = $this->prepareDefinitionForComparing($definition);
+
+        return $currentIndexDefinition !== $definition;
+    }
+
+    /**
+     * @param array $definition
+     * @return array
+     */
+    protected function prepareDefinitionForComparing(array $definition): array
+    {
+        if (array_key_exists('analysis', $definition['settings'])) {
+            $definition['settings']['index']['analysis'] = $definition['settings']['analysis'];
+            unset($definition['settings']['analysis']);
+        }
+
+        unset(
+            $definition['aliases'],
+            $definition['settings']['index']['creation_date'],
+            $definition['settings']['index']['provided_name'],
+            $definition['settings']['index']['uuid'],
+            $definition['settings']['index']['version'],
+        );
+
+        $this->recursiveArraySorter->recursiveArrayKsort($definition);
+
+        return $this->castAllIntegersToStrings($definition);
+    }
+
+    /**
+     * @param array $structureDefinition
+     * @return array
+     */
+    protected function castAllIntegersToStrings(array $structureDefinition): array
+    {
+        return array_map(
+            function ($item) {
+                if (is_array($item)) {
+                    return $this->castAllIntegersToStrings($item);
+                }
+                return is_int($item) ? (string)$item : $item;
+            },
+            $structureDefinition
+        );
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchException.php
+++ b/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Exception;
+
+use Throwable;
+
+interface ElasticsearchException extends Throwable
+{
+}

--- a/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchMoreThanOneCurrentIndexException.php
+++ b/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchMoreThanOneCurrentIndexException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Exception;
+
+use RuntimeException;
+use Throwable;
+
+class ElasticsearchMoreThanOneCurrentIndexException extends RuntimeException implements ElasticsearchException
+{
+    /**
+     * @param string $aliasName
+     * @param \Throwable|null $previous
+     */
+    public function __construct(string $aliasName, ?Throwable $previous = null)
+    {
+        $message = sprintf('There is more than one index aliased "%s". Please delete all non current ones.', $aliasName);
+
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchNoCurrentIndexException.php
+++ b/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchNoCurrentIndexException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Exception;
+
+use RuntimeException;
+use Throwable;
+
+class ElasticsearchNoCurrentIndexException extends RuntimeException implements ElasticsearchException
+{
+    /**
+     * @param string $aliasName
+     * @param \Throwable|null $previous
+     */
+    public function __construct(string $aliasName, ?Throwable $previous = null)
+    {
+        $message = sprintf('There is no current index for alias "%s".', $aliasName);
+
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchStructureException.php
+++ b/packages/framework/src/Component/Elasticsearch/Exception/ElasticsearchStructureException.php
@@ -4,6 +4,6 @@ namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Exception;
 
 use Exception;
 
-class ElasticsearchStructureException extends Exception
+class ElasticsearchStructureException extends Exception implements ElasticsearchException
 {
 }

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -302,7 +302,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     protected function getIndexName(): string
     {
-        return $this->elasticsearchStructureManager->getIndexName(
+        return $this->elasticsearchStructureManager->getAliasName(
             $this->domain->getId(),
             ProductElasticsearchRepository::ELASTICSEARCH_INDEX
         );

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportStructureFacade.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportStructureFacade.php
@@ -1,9 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker;
 use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -20,13 +24,60 @@ class ProductSearchExportStructureFacade
     protected $elasticsearchStructureManager;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker
+     */
+    protected $elasticsearchStructureUpdateChecker;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticsearchStructureManager
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker|null $elasticsearchStructureUpdateChecker
      */
-    public function __construct(Domain $domain, ElasticsearchStructureManager $elasticsearchStructureManager)
-    {
+    public function __construct(
+        Domain $domain,
+        ElasticsearchStructureManager $elasticsearchStructureManager,
+        ?ElasticsearchStructureUpdateChecker $elasticsearchStructureUpdateChecker
+    ) {
         $this->domain = $domain;
         $this->elasticsearchStructureManager = $elasticsearchStructureManager;
+        $this->elasticsearchStructureUpdateChecker = $elasticsearchStructureUpdateChecker;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker $elasticsearchStructureUpdateChecker
+     * @internal Will be replaced with constructor injection in the next major release
+     */
+    public function setElasticsearchStructureUpdateChecker(ElasticsearchStructureUpdateChecker $elasticsearchStructureUpdateChecker): void
+    {
+        if ($this->elasticsearchStructureUpdateChecker !== null && $this->elasticsearchStructureUpdateChecker !== $elasticsearchStructureUpdateChecker) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
+        if ($this->elasticsearchStructureUpdateChecker === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major version. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->elasticsearchStructureUpdateChecker = $elasticsearchStructureUpdateChecker;
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    public function migrateIndexesIfNecessary(OutputInterface $output)
+    {
+        foreach ($this->domain->getAllIds() as $domainId) {
+            $output->writeln(sprintf('Migrating index for domain with ID %s', $domainId));
+
+            $index = ProductElasticsearchRepository::ELASTICSEARCH_INDEX;
+
+            if ($this->elasticsearchStructureUpdateChecker->isNecessaryToUpdateStructure($domainId, $index)) {
+                $this->elasticsearchStructureManager->migrateIndex($domainId, $index);
+                $output->writeln(sprintf('Migration done for domain with ID %s', $domainId));
+            } else {
+                $output->writeln(sprintf('Migrating is not necessary as there were no changes in the definition'));
+            }
+        }
     }
 
     /**
@@ -35,14 +86,39 @@ class ProductSearchExportStructureFacade
     public function createIndexes(OutputInterface $output)
     {
         foreach ($this->domain->getAllIds() as $domainId) {
-            $output->writeln(sprintf('Creating index for id %s', $domainId));
+            $this->createIndexIfNecessary($output, $domainId);
+            $this->createAlias($output, $domainId);
+        }
+    }
 
-            $this->elasticsearchStructureManager->createIndex(
-                $domainId,
-                ProductElasticsearchRepository::ELASTICSEARCH_INDEX
-            );
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param int $domainId
+     */
+    protected function createAlias(OutputInterface $output, int $domainId)
+    {
+        $output->writeln(sprintf('Creating alias for domain with ID %s', $domainId));
 
+        $this->elasticsearchStructureManager->createAliasForIndex(
+            $domainId,
+            ProductElasticsearchRepository::ELASTICSEARCH_INDEX
+        );
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param int $domainId
+     */
+    protected function createIndexIfNecessary(OutputInterface $output, int $domainId)
+    {
+        $output->writeln(sprintf('Creating index for domain with ID %s', $domainId));
+
+        $index = ProductElasticsearchRepository::ELASTICSEARCH_INDEX;
+        if ($this->elasticsearchStructureUpdateChecker->isNecessaryToUpdateStructure($domainId, $index)) {
+            $this->elasticsearchStructureManager->createIndex($domainId, $index);
             $output->writeln('Index created');
+        } else {
+            $output->writeln('Creating index was not necessary as the structure did not change');
         }
     }
 
@@ -52,8 +128,8 @@ class ProductSearchExportStructureFacade
     public function deleteIndexes(OutputInterface $output)
     {
         foreach ($this->domain->getAllIds() as $domainId) {
-            $output->writeln(sprintf('Deleting index for id %s', $domainId));
-            $this->elasticsearchStructureManager->deleteIndex(
+            $output->writeln(sprintf('Deleting index for domain with ID %s', $domainId));
+            $this->elasticsearchStructureManager->deleteCurrentIndex(
                 $domainId,
                 ProductElasticsearchRepository::ELASTICSEARCH_INDEX
             );

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -125,9 +125,14 @@ class ProductElasticsearchRepository
     /**
      * @param int $domainId
      * @return string
+     * @deprecated Getting index name using this method is deprecated since SSFW 7.3, use ElasticsearchStructureManager::getCurrentIndexName or ElasticsearchStructureManager::getAliasName instead
      */
     protected function getIndexName(int $domainId): string
     {
+        @trigger_error(
+            sprintf('Getting index name using method "%s" is deprecated since SSFW 7.3, use %s or %s instead', __METHOD__, 'ElasticsearchStructureManager::getCurrentIndexName', 'ElasticsearchStructureManager::getAliasName'),
+            E_USER_DEPRECATED
+        );
         return $this->indexPrefix . self::ELASTICSEARCH_INDEX . $domainId;
     }
 
@@ -142,7 +147,7 @@ class ProductElasticsearchRepository
             return [];
         }
 
-        $parameters = $this->createQuery($this->getIndexName($domainId), $searchText);
+        $parameters = $this->createQuery($this->elasticsearchStructureManager->getAliasName($domainId, self::ELASTICSEARCH_INDEX), $searchText);
         $result = $this->client->search($parameters);
         return $this->extractIds($result);
     }
@@ -199,7 +204,7 @@ class ProductElasticsearchRepository
     public function bulkUpdate(int $domainId, array $data): void
     {
         $body = $this->productElasticsearchConverter->convertBulk(
-            $this->elasticsearchStructureManager->getIndexName($domainId, self::ELASTICSEARCH_INDEX),
+            $this->elasticsearchStructureManager->getCurrentIndexName($domainId, self::ELASTICSEARCH_INDEX),
             $data
         );
 
@@ -216,7 +221,7 @@ class ProductElasticsearchRepository
     public function deleteNotPresent(int $domainId, array $keepIds): void
     {
         $this->client->deleteByQuery([
-            'index' => $this->elasticsearchStructureManager->getIndexName($domainId, self::ELASTICSEARCH_INDEX),
+            'index' => $this->elasticsearchStructureManager->getCurrentIndexName($domainId, self::ELASTICSEARCH_INDEX),
             'type' => '_doc',
             'body' => [
                 'query' => [

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -991,9 +991,14 @@ services:
 
     Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager:
         arguments:
-            - '%shopsys.elasticsearch.structure_dir%'
-            - '%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
+            $definitionDirectory: '%shopsys.elasticsearch.structure_dir%'
+            $indexPrefix: '%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
+            $buildVersion: '%build-version%'
 
     Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter: ~
 
     Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter: ~
+
+    Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker: ~
+
+    Shopsys\FrameworkBundle\Component\ArrayUtils\RecursiveArraySorter: ~

--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -11,6 +11,8 @@ services:
         arguments:
             - '%overwrite_domain_url%'
 
+    Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker: ~
+
     Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade: ~
 
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository: ~

--- a/packages/framework/tests/Unit/Component/Elasticsearch/ElasticsearchStructureManagerTest.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/ElasticsearchStructureManagerTest.php
@@ -33,13 +33,13 @@ class ElasticsearchStructureManagerTest extends TestCase
         $this->client = $this->createMock(Client::class);
         $this->indices = $this->createMock(IndicesNamespace::class);
         $this->client->method('indices')->willReturn($this->indices);
-        $this->structureManager = new ElasticsearchStructureManager($definitionDirectory, '', $this->client);
+        $this->structureManager = new ElasticsearchStructureManager($definitionDirectory, '', $this->client, '12345');
     }
 
-    public function testCreateSuccessIndex(): void
+    public function testCreateSuccessIndexWithAlias(): void
     {
         $expected = [
-            'index' => 'test-product1',
+            'index' => '12345test-product1',
             'body' => [
                 'settings' => [
                     'index' => [
@@ -51,6 +51,7 @@ class ElasticsearchStructureManagerTest extends TestCase
         $this->indices->expects($this->once())->method('create')->with($expected);
 
         $this->structureManager->createIndex(1, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->createAliasForIndex(1, static::ELASTICSEARCH_INDEX);
     }
 
     public function testCreateWhileJsonNotExistsFails(): void
@@ -72,7 +73,7 @@ class ElasticsearchStructureManagerTest extends TestCase
         $expectedDelete = ['index' => 'test-product1'];
         $this->indices->expects($this->once())->method('delete')->with($expectedDelete);
 
-        $this->structureManager->deleteIndex(1, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->deleteCurrentIndex(1, static::ELASTICSEARCH_INDEX);
     }
 
     public function testDeleteNotExisting(): void
@@ -81,6 +82,6 @@ class ElasticsearchStructureManagerTest extends TestCase
 
         $this->indices->expects($this->never())->method('delete');
 
-        $this->structureManager->deleteIndex(1, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->deleteCurrentIndex(1, static::ELASTICSEARCH_INDEX);
     }
 }

--- a/project-base/tests/ShopBundle/Functional/Component/Elasticsearch/ElasticsearchStructureUpdateCheckerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Elasticsearch/ElasticsearchStructureUpdateCheckerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Functional\Component\Elasticsearch;
+
+use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker;
+use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository;
+use Tests\ShopBundle\Test\FunctionalTestCase;
+
+final class ElasticsearchStructureUpdateCheckerTest extends FunctionalTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker
+     */
+    private $elasticsearchStructureUpdateChecker;
+
+    /**
+     * @var \Elasticsearch\Client
+     */
+    private $elasticsearchClient;
+
+    /**
+     * @var \Elasticsearch\Namespaces\IndicesNamespace
+     */
+    private $elasticsearchIndexes;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager
+     */
+    private $elasticsearchStructureManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->elasticsearchStructureUpdateChecker = $this->getContainer()->get(ElasticsearchStructureUpdateChecker::class);
+
+        $this->elasticsearchClient = $this->getContainer()->get(Client::class);
+        $this->elasticsearchIndexes = $this->elasticsearchClient->indices();
+        $this->elasticsearchStructureManager = $this->getContainer()->get(ElasticsearchStructureManager::class);
+    }
+
+    /**
+     * @return iterable
+     */
+    public function elasticseachIndexesParametersProvider(): iterable
+    {
+        /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
+        $domain = $this->getContainer()->get(Domain::class);
+
+        foreach ($domain->getAllIds() as $domainId) {
+            yield [$domainId, ProductElasticsearchRepository::ELASTICSEARCH_INDEX];
+        }
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @dataProvider elasticseachIndexesParametersProvider
+     */
+    public function testUpdateIsNotNecessaryWhenNothingIsChanged(int $domainId, string $index): void
+    {
+        $definition = $this->elasticsearchStructureManager->getStructureDefinition($domainId, $index);
+        $aliasName = $this->elasticsearchStructureManager->getAliasName($domainId, $index);
+        $indexName = $this->elasticsearchStructureManager->getCurrentIndexName($domainId, $index);
+
+        $this->createNewStructureAndMakeBackup($definition, $definition, $indexName, $aliasName);
+
+        try {
+            $this->assertFalse($this->elasticsearchStructureUpdateChecker->isNecessaryToUpdateStructure($domainId, $index));
+        } finally {
+            $this->revertStructureFromBackup($definition, $indexName, $aliasName);
+        }
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $index
+     * @dataProvider elasticseachIndexesParametersProvider
+     */
+    public function testUpdateIsNecessaryWhenStructureHasAdditionalProperty(int $domainId, string $index): void
+    {
+        $oldDefinition = $this->elasticsearchStructureManager->getStructureDefinition($domainId, $index);
+        $aliasName = $this->elasticsearchStructureManager->getAliasName($domainId, $index);
+        $indexName = $this->elasticsearchStructureManager->getCurrentIndexName($domainId, $index);
+
+        $newDefinition = $oldDefinition;
+        $newDefinition['mappings']['_doc']['properties']['new_property'] = ['type' => 'text'];
+
+        $this->createNewStructureAndMakeBackup($oldDefinition, $newDefinition, $indexName, $aliasName);
+
+        try {
+            $this->assertTrue($this->elasticsearchStructureUpdateChecker->isNecessaryToUpdateStructure($domainId, $index));
+        } finally {
+            $this->revertStructureFromBackup($oldDefinition, $indexName, $aliasName);
+        }
+    }
+
+    /**
+     * @param array $oldDefinition
+     * @param array $newDefinition
+     * @param string $indexName
+     * @param string $aliasName
+     */
+    private function createNewStructureAndMakeBackup(array $oldDefinition, array $newDefinition, string $indexName, string $aliasName): void
+    {
+        $backupIndexName = $indexName . '_backup';
+        $this->moveStructureByReindexing($indexName, $backupIndexName, $oldDefinition);
+        $this->elasticsearchIndexes->create(['index' => $indexName, 'body' => $newDefinition]);
+        $this->elasticsearchIndexes->putAlias(['index' => $indexName, 'name' => $aliasName]);
+    }
+
+    /**
+     * @param array $oldDefinition
+     * @param string $indexName
+     * @param string $aliasName
+     */
+    private function revertStructureFromBackup(array $oldDefinition, string $indexName, string $aliasName): void
+    {
+        $backupIndexName = $indexName . '_backup';
+        $this->elasticsearchIndexes->delete(['index' => $indexName]);
+        $this->moveStructureByReindexing($backupIndexName, $indexName, $oldDefinition);
+        $this->elasticsearchIndexes->putAlias(['index' => $indexName, 'name' => $aliasName]);
+    }
+
+    /**
+     * @param string $oldName
+     * @param string $newName
+     * @param array $definition
+     */
+    private function moveStructureByReindexing(string $oldName, string $newName, array $definition): void
+    {
+        $this->elasticsearchIndexes->create([
+            'index' => $newName,
+            'body' => $definition,
+        ]);
+        $this->elasticsearchClient->reindex([
+            'body' => [
+                'source' => ['index' => $oldName],
+                'dest' => ['index' => $newName],
+            ],
+            'refresh' => true,
+            'wait_for_completion' => true,
+        ]);
+
+        $this->elasticsearchIndexes->delete(['index' => $oldName]);
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
@@ -170,7 +170,7 @@ class FilterQueryTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticSearchStructureManager */
         $elasticSearchStructureManager = $this->getContainer()->get(ElasticsearchStructureManager::class);
 
-        $elasticSearchIndexName = $elasticSearchStructureManager->getIndexName(1, self::ELASTICSEARCH_INDEX);
+        $elasticSearchIndexName = $elasticSearchStructureManager->getAliasName(1, self::ELASTICSEARCH_INDEX);
 
         $filter = $filterQueryFactory->create($elasticSearchIndexName);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| this PR lowers the downtime of eshop when deploying by reindexing to a new index elasticsearch that is created only if the structure has changed
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
