### PR TITLE
[shopsys] removed BC break in tests

### DIFF
--- a/packages/framework/src/Resources/config/services_test.yml
+++ b/packages/framework/src/Resources/config/services_test.yml
@@ -27,6 +27,8 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade: ~
 
+    Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactory: ~ # @deprecated
+
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactory
 
@@ -41,6 +43,8 @@ services:
     Shopsys\FrameworkBundle\Model\Cart\CartFactory: ~
 
     Shopsys\FrameworkBundle\Model\Category\CategoryFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Category\CategoryFactory: ~ # @deprecated
 
     Shopsys\FrameworkBundle\Model\Category\CategoryFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Category\CategoryFactory
@@ -125,8 +129,12 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository: ~
 
+    Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory: ~ # @deprecated
+
     Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory
+
+    Shopsys\FrameworkBundle\Model\Payment\PaymentFactory: ~ # @deprecated
 
     Shopsys\FrameworkBundle\Model\Payment\PaymentFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Payment\PaymentFactory
@@ -147,10 +155,14 @@ services:
 
     Shopsys\FrameworkBundle\Component\System\PostgresqlLocaleMapper: ~
 
+    Shopsys\FrameworkBundle\Model\Product\ProductDataFactory: ~ # @deprecated
+
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Product\ProductDataFactory
 
     Shopsys\FrameworkBundle\Model\Product\ProductFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductFactory: ~ # @deprecated
 
     Shopsys\FrameworkBundle\Model\Product\ProductFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Product\ProductFactory
@@ -177,10 +189,14 @@ services:
 
     Shopsys\FrameworkBundle\Model\Localization\TranslatableListener: ~
 
+    Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory: ~ # @deprecated
+
     Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory
 
     Shopsys\FrameworkBundle\Model\Transport\TransportFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Transport\TransportFactory: ~ # @deprecated
 
     Shopsys\FrameworkBundle\Model\Transport\TransportFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Transport\TransportFactory
@@ -196,6 +212,8 @@ services:
     Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory: ~
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory: ~ # @deprecated
 
     Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #970 was created BC break in tests that causes errors in tests. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
