### PR TITLE
[framework] FrontOrderDataMapper::prefillTransportAndPaymentFromOrder prefills methods that are not deleted

### DIFF
--- a/packages/framework/src/Model/Order/FrontOrderDataMapper.php
+++ b/packages/framework/src/Model/Order/FrontOrderDataMapper.php
@@ -25,8 +25,8 @@ class FrontOrderDataMapper
      */
     protected function prefillTransportAndPaymentFromOrder(FrontOrderData $frontOrderData, Order $order)
     {
-        $frontOrderData->transport = $order->getTransport();
-        $frontOrderData->payment = $order->getPayment();
+        $frontOrderData->transport = $order->getTransport()->isDeleted() ? null : $order->getTransport();
+        $frontOrderData->payment = $order->getPayment()->isDeleted() ? null : $order->getPayment();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| if user is logged-in and order frontend of the last order of customer contains deleted shipping of payment method prefill functionality for new order fails on error about non existent payment/shipping method item. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1101  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
