### PR TITLE
[shopsys] composer.json: symfony/monolog-bundle >= 3.4.0 is set as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,6 +156,7 @@
   },
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
+    "symfony/monolog-bundle": ">=3.4.0",
     "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
     "twig/twig": "2.6.1"
   },

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -115,6 +115,14 @@ There you can find links to upgrade notes for other versions too.
     +           - method: setSqlLoggerFacade
     +           - method: setEntityManager
     ```
+- set `symfony/monolog-bundle` as conflicting in your `composer.json` and run `composer update` command ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+    ```diff
+         "conflict": {
+         "symfony/dependency-injection": "3.4.15|3.4.16",
+    +    "symfony/monolog-bundle": ">=3.4.0",
+         "twig/twig": "2.6.1"
+    },
+    ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -105,6 +105,7 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
+        "symfony/monolog-bundle": ">=3.4.0",
         "twig/twig": "2.6.1"
     }
 }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -103,6 +103,7 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
+        "symfony/monolog-bundle": ">=3.4.0",
         "twig/twig": "2.6.1"
     },
     "scripts": {


### PR DESCRIPTION
- see https://github.com/symfony/monolog-bundle/issues/309

| Q             | A
| ------------- | ---
|Description, reason for the PR| new minor release of monolog-bundle
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| should fix bc breaking of all versions <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
