### PR TITLE
[shopsys] UPGRADE-v7.x.x tweak because of conflict with symfony/monolog-bundle:3.4.0

### DIFF
--- a/docs/upgrade/UPGRADE-v7.0.1.md
+++ b/docs/upgrade/UPGRADE-v7.0.1.md
@@ -20,7 +20,7 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the version than `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [Upgrade from v7.0.0 to v7.0.1]: https://github.com/shopsys/shopsys/compare/v7.0.0...v7.0.1

--- a/docs/upgrade/UPGRADE-v7.0.1.md
+++ b/docs/upgrade/UPGRADE-v7.0.1.md
@@ -20,7 +20,7 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version than `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [Upgrade from v7.0.0 to v7.0.1]: https://github.com/shopsys/shopsys/compare/v7.0.0...v7.0.1

--- a/docs/upgrade/UPGRADE-v7.0.1.md
+++ b/docs/upgrade/UPGRADE-v7.0.1.md
@@ -19,5 +19,8 @@ There you can find links to upgrade notes for other versions too.
     - if you haven't extended any of these methods and haven't called `new MessageData(...)` in your code, you should be protected by the upgrade alone
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
+### Configuration
+- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+
 [shopsys/framework]: https://github.com/shopsys/framework
 [Upgrade from v7.0.0 to v7.0.1]: https://github.com/shopsys/shopsys/compare/v7.0.0...v7.0.1

--- a/docs/upgrade/UPGRADE-v7.0.1.md
+++ b/docs/upgrade/UPGRADE-v7.0.1.md
@@ -20,7 +20,7 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [Upgrade from v7.0.0 to v7.0.1]: https://github.com/shopsys/shopsys/compare/v7.0.0...v7.0.1

--- a/docs/upgrade/UPGRADE-v7.1.1.md
+++ b/docs/upgrade/UPGRADE-v7.1.1.md
@@ -20,6 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version than `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.1.1.md
+++ b/docs/upgrade/UPGRADE-v7.1.1.md
@@ -19,4 +19,7 @@ There you can find links to upgrade notes for other versions too.
     - if you haven't extended any of these methods and haven't called `new MessageData(...)` in your code, you should be protected by the upgrade alone
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
+### Configuration
+- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.1.1.md
+++ b/docs/upgrade/UPGRADE-v7.1.1.md
@@ -20,6 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the version than `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.1.1.md
+++ b/docs/upgrade/UPGRADE-v7.1.1.md
@@ -20,6 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.2.2.md
+++ b/docs/upgrade/UPGRADE-v7.2.2.md
@@ -20,6 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version than `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.2.2.md
+++ b/docs/upgrade/UPGRADE-v7.2.2.md
@@ -19,4 +19,7 @@ There you can find links to upgrade notes for other versions too.
     - if you haven't extended any of these methods and haven't called `new MessageData(...)` in your code, you should be protected by the upgrade alone
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
+### Configuration
+- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.2.2.md
+++ b/docs/upgrade/UPGRADE-v7.2.2.md
@@ -20,6 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the version than `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.2.2.md
+++ b/docs/upgrade/UPGRADE-v7.2.2.md
@@ -20,6 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the higher version than `3.3.1` before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
 
 [shopsys/framework]: https://github.com/shopsys/framework


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| hotfix of problem with BC of project using newest monolog-bundle version 3.4.0
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
