### PR TITLE
[shopsys] stop using excluded_404s in monolog config for incompatible types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,6 @@
   },
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
-    "symfony/monolog-bundle": ">=3.4.0",
     "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
     "twig/twig": "2.6.1"
   },

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -117,23 +117,23 @@ There you can find links to upgrade notes for other versions too.
     ```
 - unset the incompatible `excluded_404s` configuration from monolog handlers that don't use the `fingers_crossed` type ([#1154](https://github.com/shopsys/shopsys/pull/1154))
     - in `app/config/packages/dev/monolog.yml`:
-    ```diff
-        monolog:
-           handlers:
-               main:
-                   # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
-                   type: group
-                   members: [ nested ]
-    +              excluded_404s: false
-    ```
+        ```diff
+            monolog:
+               handlers:
+                   main:
+                       # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
+                       type: group
+                       members: [ nested ]
+        +              excluded_404s: false
+        ```
     - in `app/config/packages/test/monolog.yml`:
-    ```diff
-        monolog:
-            handlers:
-                main:
-                    type: "null"
-    +               excluded_404s: false
-    ```
+        ```diff
+            monolog:
+                handlers:
+                    main:
+                        type: "null"
+        +               excluded_404s: false
+        ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -115,14 +115,6 @@ There you can find links to upgrade notes for other versions too.
     +           - method: setSqlLoggerFacade
     +           - method: setEntityManager
     ```
-- set `symfony/monolog-bundle` as conflicting in your `composer.json` and run `composer update` command ([#1148](https://github.com/shopsys/shopsys/pull/1148))
-    ```diff
-         "conflict": {
-         "symfony/dependency-injection": "3.4.15|3.4.16",
-    +    "symfony/monolog-bundle": ">=3.4.0",
-         "twig/twig": "2.6.1"
-    },
-    ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -115,6 +115,25 @@ There you can find links to upgrade notes for other versions too.
     +           - method: setSqlLoggerFacade
     +           - method: setEntityManager
     ```
+- unset the incompatible `excluded_404s` configuration from monolog handlers that don't use the `fingers_crossed` type ([#1154](https://github.com/shopsys/shopsys/pull/1154))
+    - in `app/config/packages/dev/monolog.yml`:
+    ```diff
+        monolog:
+           handlers:
+               main:
+                   # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
+                   type: group
+                   members: [ nested ]
+    +              excluded_404s: false
+    ```
+    - in `app/config/packages/test/monolog.yml`:
+    ```diff
+        monolog:
+            handlers:
+                main:
+                    type: "null"
+    +               excluded_404s: false
+    ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -105,7 +105,6 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "symfony/monolog-bundle": ">=3.4.0",
         "twig/twig": "2.6.1"
     }
 }

--- a/project-base/app/config/packages/dev/monolog.yml
+++ b/project-base/app/config/packages/dev/monolog.yml
@@ -4,3 +4,4 @@ monolog:
             # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
             type: group
             members: [ nested ]
+            excluded_404s: false

--- a/project-base/app/config/packages/test/monolog.yml
+++ b/project-base/app/config/packages/test/monolog.yml
@@ -3,6 +3,7 @@ monolog:
     handlers:
         main:
             type: "null"
+            excluded_404s: false
         nested:
             type: "null"
         cron:

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -103,7 +103,6 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "symfony/monolog-bundle": ">=3.4.0",
         "twig/twig": "2.6.1"
     },
     "scripts": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Package `symfony/monolog-bundle` throws an error when using `excluded_404s` or `excluded_http_codes` configuration in types other than `fingers_crossed` since `v3.4.0`, as explained in https://github.com/symfony/monolog-bundle/issues/309 - this PR fixes the configuration on our side. Also, reverts https://github.com/shopsys/shopsys/pull/1148 as it fixes the incompatibility.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
 