### PR TITLE
[framework] product variants without a price for a pricing group are exportable to elastic

### DIFF
--- a/packages/framework/src/Form/ProductCalculatedPricesType.php
+++ b/packages/framework/src/Form/ProductCalculatedPricesType.php
@@ -52,11 +52,8 @@ class ProductCalculatedPricesType extends AbstractType
         $product = $options['product'];
 
         if ($product !== null) {
-            try {
-                $productSellingPricesIndexedByDomainId = $this->productFacade->getAllProductSellingPricesIndexedByDomainId($product);
-                $view->vars['productSellingPricesIndexedByDomainId'] = $productSellingPricesIndexedByDomainId;
-            } catch (\Shopsys\FrameworkBundle\Model\Product\Pricing\Exception\MainVariantPriceCalculationException $ex) {
-            }
+            $productSellingPricesIndexedByDomainId = $this->productFacade->getAllProductSellingPricesIndexedByDomainId($product);
+            $view->vars['productSellingPricesIndexedByDomainId'] = $productSellingPricesIndexedByDomainId;
         } else {
             $view->vars['pricingGroupsIndexedByDomainId'] = $this->pricingGroupFacade->getAllIndexedByDomainId();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `ProductFacade::getAllProductSellingPricesByDomainId()` now returns zero prices for main variant without a sellable variant instead of throwing an exception.<br>Products with zero prices should not be visible, see [functional docs of Product Visibility](https://github.com/shopsys/shopsys/blob/v7.2.2/docs/functional/product-visibility-and-exclude-from-sale.md#parameters-that-impact-product-visibility) (this currently does not work correctly in Elasticsearch product search/filtering, but at least it's consistent for variants).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1142 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
