### PR TITLE
[framework] phing targets redis-check and clean-redis clean also items of framework_annotations client

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -975,9 +975,9 @@ services:
         arguments:
             $cacheClients:
             - '@snc_redis.bestselling_products'
-            - '@snc_redis.framework_annotations'
             - '@snc_redis.doctrine_metadata'
             - '@snc_redis.doctrine_query'
+            - '@snc_redis.framework_annotations'
 
     Shopsys\FrameworkBundle\Component\Redis\RedisVersionsFacade:
         arguments:
@@ -1019,7 +1019,7 @@ services:
         arguments:
             $cacheClients:
             - '@snc_redis.bestselling_products'
-            - '@snc_redis.framework_annotations'
             - '@snc_redis.doctrine_metadata'
             - '@snc_redis.doctrine_query'
+            - '@snc_redis.framework_annotations'
             - '@snc_redis.session'

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -975,6 +975,7 @@ services:
         arguments:
             $cacheClients:
             - '@snc_redis.bestselling_products'
+            - '@snc_redis.framework_annotations'
             - '@snc_redis.doctrine_metadata'
             - '@snc_redis.doctrine_query'
 
@@ -1018,6 +1019,7 @@ services:
         arguments:
             $cacheClients:
             - '@snc_redis.bestselling_products'
+            - '@snc_redis.framework_annotations'
             - '@snc_redis.doctrine_metadata'
             - '@snc_redis.doctrine_query'
             - '@snc_redis.session'


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| clean-redis and redis-check phing targets should use also framework_annotations snc_redis client
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| just partially #1108 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
