### PR TITLE
[framework] products with zero price are now not returned from Elasticsearch

### DIFF
--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -234,6 +234,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     {
         $filterQuery = $this->filterQueryFactory->create($this->getIndexName())
             ->filterOnlySellable()
+            ->filterOnlyVisible($this->currentCustomer->getPricingGroup())
             ->setPage($page)
             ->setLimit($limit)
             ->applyOrdering($orderingModeId, $this->currentCustomer->getPricingGroup());
@@ -264,8 +265,9 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
     {
         $baseFilterQuery = $this->filterQueryFactory->create($this->getIndexName())
-            ->filterByCategory([$categoryId])
-            ->filterOnlySellable();
+            ->filterOnlySellable()
+            ->filterOnlyVisible($this->currentCustomer->getPricingGroup())
+            ->filterByCategory([$categoryId]);
         $baseFilterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $baseFilterQuery, $this->currentCustomer->getPricingGroup());
         $baseFilterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $baseFilterQuery);
 
@@ -283,8 +285,9 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         $searchText = $searchText ?? '';
 
         $baseFilterQuery = $this->filterQueryFactory->create($this->getIndexName())
-            ->search($searchText)
-            ->filterOnlySellable();
+            ->filterOnlySellable()
+            ->filterOnlyVisible($this->currentCustomer->getPricingGroup())
+            ->search($searchText);
         $baseFilterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $baseFilterQuery, $this->currentCustomer->getPricingGroup());
         $baseFilterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $baseFilterQuery);
 

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -216,6 +216,44 @@ class FilterQuery
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function filterOnlyVisible(PricingGroup $pricingGroup): self
+    {
+        $clone = clone $this;
+
+        $clone->filters[] = [
+            'nested' => [
+                'path' => 'prices',
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            'match_all' => new \stdClass(),
+                        ],
+                        'filter' => [
+                            [
+                                'term' => [
+                                    'prices.pricing_group_id' => $pricingGroup->getId(),
+                                ],
+                            ],
+                            [
+                                'range' => [
+                                    'prices.amount' => [
+                                        'gt' => 0,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        return $clone;
+    }
+
+    /**
      * @param int[] $categoryIds
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| product with zero price for pricing group was returned from Elasticsearch and that for that "Total number of products" was not consistent with shown products. This is fixed now – products with zero price for current pricing group are not returned from Elasticsearch anymore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
