### PR TITLE
[framework] RedisFacade: unification of used clients

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -78,6 +78,17 @@ There you can find links to upgrade notes for other versions too.
 - use automatic wiring of Redis clients for easier checking and cleaning ([#1161](https://github.com/shopsys/shopsys/pull/1161))
     - if you have redefined the service `@Shopsys\FrameworkBundle\Component\Redis\RedisFacade` or `@Shopsys\FrameworkBundle\Command\CheckRedisCommand` in your project, or you instantiate the classes in your code:
         - instead of instantiating `RedisFacade` with an array of cache clients to be cleaned by `php phing redis-clean`, pass an array of all redis clients and another array of redis clients you don't want to clean (eg. `global` and `session`)
+            ```diff
+                Shopsys\FrameworkBundle\Component\Redis\RedisFacade:
+                    arguments:
+            -           - '@snc_redis.doctrine_metadata'
+            -           - '@snc_redis.doctrine_query'
+            -           - '@snc_redis.my_custom_cache'
+            +           $allClients: !tagged snc_redis.client
+            +           $persistentClients:
+            +               - '@snc_redis.global'
+            +               - '@snc_redis.session'
+            ```
             - this allows you to use `!tagged snc_redis.client` in your DIC config for the first argument, ensuring that newly created clients will be registered by the facade
         - instead of instantiating `CheckRedisCommand` with an array of redis clients, pass an instance of `RedisFacade` instead
     - modify the functional test `\Tests\ShopBundle\Functional\Component\Redis\RedisFacadeTest` so it creates `RedisFacade` using the two arrays and add a new test case `testNotCleaningPersistentClient`

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -75,6 +75,13 @@ There you can find links to upgrade notes for other versions too.
     - stop using the deprecated method `\Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation::getVatCoefficientByPercent()`, use `PriceCalculation::getVatAmountByPriceWithVat()` for VAT calculation instead
     - if you want to customize the VAT calculation (eg. revert it back to the previous implementation), extend the service `@Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation` and override the method `getVatAmountByPriceWithVat()`
     - if you created new tests regarding the price calculation they might start failing after the upgrade - in such case, please see the new VAT calculation and change the tests expectations accordingly
+- use automatic wiring of Redis clients for easier checking and cleaning ([#1161](https://github.com/shopsys/shopsys/pull/1161))
+    - if you have redefined the service `@Shopsys\FrameworkBundle\Component\Redis\RedisFacade` or `@Shopsys\FrameworkBundle\Command\CheckRedisCommand` in your project, or you instantiate the classes in your code:
+        - instead of instantiating `RedisFacade` with an array of cache clients to be cleaned by `php phing redis-clean`, pass an array of all redis clients and another array of redis clients you don't want to clean (eg. `global` and `session`)
+            - this allows you to use `!tagged snc_redis.client` in your DIC config for the first argument, ensuring that newly created clients will be registered by the facade
+        - instead of instantiating `CheckRedisCommand` with an array of redis clients, pass an instance of `RedisFacade` instead
+    - modify the functional test `\Tests\ShopBundle\Functional\Component\Redis\RedisFacadeTest` so it creates `RedisFacade` using the two arrays and add a new test case `testNotCleaningPersistentClient`
+        - you can copy-paste the [`RedisFacadeTest`](https://github.com/shopsys/project-base/blob/master/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php) from `shopsys/project-base`
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/packages/framework/src/Command/CheckRedisCommand.php
+++ b/packages/framework/src/Command/CheckRedisCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Command;
 
+use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,18 +15,18 @@ class CheckRedisCommand extends Command
     protected static $defaultName = 'shopsys:redis:check-availability';
 
     /**
-     * @var \Redis[]
+     * @var \Shopsys\FrameworkBundle\Component\Redis\RedisFacade
      */
-    protected $cacheClients;
+    protected $redisFacade;
 
     /**
-     * @param \Redis[] $cacheClients
+     * @param \Shopsys\FrameworkBundle\Component\Redis\RedisFacade $redisFacade
      */
-    public function __construct(array $cacheClients)
+    public function __construct(RedisFacade $redisFacade)
     {
-        $this->cacheClients = $cacheClients;
-
         parent::__construct();
+
+        $this->redisFacade = $redisFacade;
     }
 
     protected function configure()
@@ -41,13 +42,11 @@ class CheckRedisCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Checks availability of Redis...');
-        foreach ($this->cacheClients as $cacheClient) {
-            try {
-                $cacheClient->ping();
-            } catch (\RedisException $e) {
-                throw new \Shopsys\FrameworkBundle\Command\Exception\RedisNotRunningException('Redis is not available.');
-            }
+        try {
+            $this->redisFacade->pingAllClients();
+            $output->writeln('Redis is available');
+        } catch (\RedisException $e) {
+            throw new \Shopsys\FrameworkBundle\Command\Exception\RedisNotRunningException('Redis is not available.', 0, $e);
         }
-        $output->writeln('Redis is available');
     }
 }

--- a/packages/framework/src/Command/CheckRedisCommand.php
+++ b/packages/framework/src/Command/CheckRedisCommand.php
@@ -21,9 +21,15 @@ class CheckRedisCommand extends Command
     protected static $defaultName = 'shopsys:redis:check-availability';
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Redis\RedisFacade|\Redis[]
+     * @deprecated This property is deprecated since SSFW 7.3
+     * @var \Redis[]
      */
-    protected $redisFacadeOrClients;
+    protected $cacheClients;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Redis\RedisFacade|null
+     */
+    protected $redisFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Redis\RedisFacade|\Redis[] $redisFacadeOrClients
@@ -39,8 +45,12 @@ class CheckRedisCommand extends Command
                 sprintf('Passing instances of "%s" directly into constructor of "%s" is deprecated since SSFW 7.3, pass "%s" instead', Redis::class, __CLASS__, RedisFacade::class),
                 E_USER_DEPRECATED
             );
+
+            $this->cacheClients = $redisFacadeOrClients;
+        } else {
+            $this->cacheClients = [];
+            $this->redisFacade = $redisFacadeOrClients;
         }
-        $this->redisFacadeOrClients = $redisFacadeOrClients;
     }
 
     protected function configure()
@@ -76,10 +86,10 @@ class CheckRedisCommand extends Command
      */
     protected function pingAllClients(): void
     {
-        if ($this->redisFacadeOrClients instanceof RedisFacade) {
-            $this->redisFacadeOrClients->pingAllClients();
+        if ($this->redisFacade !== null) {
+            $this->redisFacade->pingAllClients();
         } else {
-            foreach ($this->redisFacadeOrClients as $redisClient) {
+            foreach ($this->cacheClients as $redisClient) {
                 $redisClient->ping();
             }
         }

--- a/packages/framework/src/Command/CheckRedisCommand.php
+++ b/packages/framework/src/Command/CheckRedisCommand.php
@@ -38,7 +38,10 @@ class CheckRedisCommand extends Command
     {
         parent::__construct();
 
-        if (!$redisFacadeOrClients instanceof RedisFacade) {
+        if ($redisFacadeOrClients instanceof RedisFacade) {
+            $this->redisFacade = $redisFacadeOrClients;
+            $this->cacheClients = [];
+        } else {
             Assert::allIsInstanceOf($redisFacadeOrClients, Redis::class);
 
             @trigger_error(
@@ -47,9 +50,6 @@ class CheckRedisCommand extends Command
             );
 
             $this->cacheClients = $redisFacadeOrClients;
-        } else {
-            $this->cacheClients = [];
-            $this->redisFacade = $redisFacadeOrClients;
         }
     }
 

--- a/packages/framework/src/Command/Exception/RedisNotRunningException.php
+++ b/packages/framework/src/Command/Exception/RedisNotRunningException.php
@@ -5,6 +5,9 @@ namespace Shopsys\FrameworkBundle\Command\Exception;
 use Exception;
 use Throwable;
 
+/**
+ * @deprecated This exception is deprecated since SSFW 7.3
+ */
 class RedisNotRunningException extends Exception
 {
     /**

--- a/packages/framework/src/Component/Redis/RedisFacade.php
+++ b/packages/framework/src/Component/Redis/RedisFacade.php
@@ -19,6 +19,12 @@ class RedisFacade
     protected $persistentClients;
 
     /**
+     * @deprecated This property is deprecated since SSFW 7.3
+     * @var \Redis[]
+     */
+    protected $cacheClients;
+
+    /**
      * @param \Redis[] $allClients
      * @param \Redis[] $persistentClients
      */
@@ -26,6 +32,7 @@ class RedisFacade
     {
         $this->allClients = $allClients;
         $this->persistentClients = $persistentClients;
+        $this->cacheClients = $this->getCacheClients();
     }
 
     /**

--- a/packages/framework/src/Component/Redis/RedisFacade.php
+++ b/packages/framework/src/Component/Redis/RedisFacade.php
@@ -22,7 +22,7 @@ class RedisFacade
      * @param \Redis[] $allClients
      * @param \Redis[] $persistentClients
      */
-    public function __construct(iterable $allClients, iterable $persistentClients)
+    public function __construct(iterable $allClients, iterable $persistentClients = [])
     {
         $this->allClients = $allClients;
         $this->persistentClients = $persistentClients;

--- a/packages/framework/src/DependencyInjection/Compiler/RedisFacadeClientFilterCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RedisFacadeClientFilterCompilerPass.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
+
+use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Filter clients wired into RedisFacade so only defined services are passed (because of BC)
+ * @deprecated This class is deprecated since SSFW 7.3
+ */
+class RedisFacadeClientFilterCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $redisFacadeDefinition = $container->getDefinition(RedisFacade::class);
+        $filteredArguments = $this->getFilteredArguments($redisFacadeDefinition, $container);
+        $redisFacadeDefinition->setArguments($filteredArguments);
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\Definition $redisFacadeDefinition
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @return array
+     */
+    protected function getFilteredArguments(Definition $redisFacadeDefinition, ContainerBuilder $container): array
+    {
+        return array_map(
+            function ($argument) use ($container) {
+                return is_array($argument) ? $this->removeMissingReferences($argument, $container) : $argument;
+            },
+            $redisFacadeDefinition->getArguments()
+        );
+    }
+
+    /**
+     * @param array $array
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @return array
+     */
+    protected function removeMissingReferences(array $array, ContainerBuilder $container): array
+    {
+        return array_filter($array, function ($item) use ($container) {
+            if ($item instanceof Reference && !$container->hasDefinition((string)$item)) {
+                $message = sprintf('A missing service definition "%s" has been removed by "%s".', $item, __CLASS__);
+                $message .= ' This compiler pass is deprecated since SSFW 7.3, you should define the missing service or remove the reference from the arguments.';
+                @trigger_error($message, E_USER_DEPRECATED);
+
+                return false;
+            }
+
+            return true;
+        });
+    }
+}

--- a/packages/framework/src/DependencyInjection/Compiler/RedisFacadeClientFilterCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RedisFacadeClientFilterCompilerPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
 
 use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -154,6 +154,10 @@ services:
             # must be ran before ProductVisibilityFacade
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 20 }
 
+    Shopsys\FrameworkBundle\Command\CheckRedisCommand:
+        arguments:
+            - '@Shopsys\FrameworkBundle\Component\Redis\RedisFacade'
+
     Shopsys\FrameworkBundle\Component\Cron\CronFacade:
         arguments:
             - '@monolog.logger.cron'

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -154,6 +154,7 @@ services:
             # must be ran before ProductVisibilityFacade
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 20 }
 
+    # this explicit definition will not be needed when the @deprecated argument type is removed
     Shopsys\FrameworkBundle\Command\CheckRedisCommand:
         arguments:
             - '@Shopsys\FrameworkBundle\Component\Redis\RedisFacade'

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -973,11 +973,10 @@ services:
 
     Shopsys\FrameworkBundle\Component\Redis\RedisFacade:
         arguments:
-            $cacheClients:
-            - '@snc_redis.bestselling_products'
-            - '@snc_redis.doctrine_metadata'
-            - '@snc_redis.doctrine_query'
-            - '@snc_redis.framework_annotations'
+            $allClients: !tagged snc_redis.client
+            $persistentClients:
+                - '@snc_redis.global'
+                - '@snc_redis.session'
 
     Shopsys\FrameworkBundle\Component\Redis\RedisVersionsFacade:
         arguments:
@@ -1014,12 +1013,3 @@ services:
             - method: setEntityManager
 
     Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter: ~
-
-    Shopsys\FrameworkBundle\Command\CheckRedisCommand:
-        arguments:
-            $cacheClients:
-            - '@snc_redis.bestselling_products'
-            - '@snc_redis.doctrine_metadata'
-            - '@snc_redis.doctrine_query'
-            - '@snc_redis.framework_annotations'
-            - '@snc_redis.session'

--- a/packages/framework/src/Resources/config/services/commands.yml
+++ b/packages/framework/src/Resources/config/services/commands.yml
@@ -38,5 +38,7 @@ services:
         arguments:
             - '%shopsys.vendor_dir%'
 
+    # RedisCleanCacheOldCommand is not being autoconfigured because of BC (see #886) @deprecated
+    # It must have been configured manually in src/Shopsys/ShopBundle/Resources/config/services/commands.yml
     Shopsys\FrameworkBundle\Command\RedisCleanCacheOldCommand:
         autoconfigure: false

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -4,10 +4,12 @@ namespace Shopsys\FrameworkBundle;
 
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\CompilerPass\RegisterFriendlyUrlDataProviderCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\LazyRedisCompilerPass;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RedisFacadeClientFilterCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterCronModulesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExtensionsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProductFeedConfigsCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -26,5 +28,6 @@ class ShopsysFrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterPluginDataFixturesCompilerPass());
         $container->addCompilerPass(new RegisterProductFeedConfigsCompilerPass());
         $container->addCompilerPass(new LazyRedisCompilerPass());
+        $container->addCompilerPass(new RedisFacadeClientFilterCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }

--- a/packages/framework/tests/Unit/Command/CheckRedisCommandTest.php
+++ b/packages/framework/tests/Unit/Command/CheckRedisCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Command;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Redis;
+use Shopsys\FrameworkBundle\Command\CheckRedisCommand;
+use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class CheckRedisCommandTest extends TestCase
+{
+    /**
+     * @return iterable
+     */
+    public function pingAllRedisClientsProvider(): iterable
+    {
+        yield [true, new RedisFacade([])];
+        yield [true, new RedisFacade([$this->createRedisMockExpectingPing()])];
+        yield [true, new RedisFacade([$this->createRedisMockExpectingPing(), $this->createRedisMockExpectingPing(), $this->createRedisMockExpectingPing()])];
+        yield [false, new RedisFacade([$this->createRedisMockThrowingException()])];
+        yield [false, new RedisFacade([$this->createRedisMockExpectingPing(), $this->createRedisMockThrowingException()])];
+        yield [true, []];
+        yield [true, [$this->createRedisMockExpectingPing()]];
+        yield [true, [$this->createRedisMockExpectingPing(), $this->createRedisMockExpectingPing(), $this->createRedisMockExpectingPing()]];
+        yield [false, [$this->createRedisMockThrowingException()]];
+        yield [false, [$this->createRedisMockExpectingPing(), $this->createRedisMockThrowingException()]];
+    }
+
+    /**
+     * @dataProvider pingAllRedisClientsProvider
+     * @param bool $expectSuccess
+     * @param \Shopsys\FrameworkBundle\Component\Redis\RedisFacade|\Redis[] $redisFacadeOrClients
+     */
+    public function testPingAllRedisClients(bool $expectSuccess, $redisFacadeOrClients): void
+    {
+        $checkRedisCommand = new CheckRedisCommand($redisFacadeOrClients);
+
+        $output = new BufferedOutput();
+        $returnCode = $checkRedisCommand->run(new StringInput(''), $output);
+
+        $this->assertSame($expectSuccess ? 0 : 1, $returnCode);
+        $this->assertStringContainsString($expectSuccess ? 'Redis is available' : 'Redis is not available', $output->fetch());
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createRedisMockExpectingPing(): MockObject
+    {
+        $redisMock = $this->createMock(Redis::class);
+        $redisMock->expects($this->once())->method('ping');
+
+        return $redisMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createRedisMockThrowingException(): MockObject
+    {
+        $redisMock = $this->createMock(Redis::class);
+        $redisMock->method('ping')->willThrowException(new \RedisException());
+
+        return $redisMock;
+    }
+}

--- a/project-base/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php
@@ -14,7 +14,7 @@ class RedisFacadeTest extends FunctionalTestCase
      */
     private $redisClient;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->redisClient = $this->getContainer()->get('snc_redis.test');
     }

--- a/project-base/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Redis/RedisFacadeTest.php
@@ -9,23 +9,42 @@ use Tests\ShopBundle\Test\FunctionalTestCase;
 
 class RedisFacadeTest extends FunctionalTestCase
 {
+    /**
+     * @var \Redis
+     */
+    private $redisClient;
+
+    protected function setUp()
+    {
+        $this->redisClient = $this->getContainer()->get('snc_redis.test');
+    }
+
     public function testCleanCache(): void
     {
-        $redisClient = $this->getContainer()->get('snc_redis.test');
-        $redisClient->set('test', 'test');
-        $facade = new RedisFacade([$redisClient]);
+        $this->redisClient->set('test', 'test');
+        $facade = new RedisFacade([$this->redisClient], []);
 
         $facade->cleanCache();
-        $this->assertSame(0, $redisClient->exists('test'));
+
+        $this->assertFalse((bool)$this->redisClient->exists('test'));
     }
 
     public function testCleanCacheNoErrorOnEmpty(): void
     {
-        $redisClient = $this->getContainer()->get('snc_redis.test');
-        $facade = new RedisFacade([$redisClient]);
+        $facade = new RedisFacade([$this->redisClient], []);
 
         $facade->cleanCache();
-        $lastError = $redisClient->getLastError();
-        $this->assertSame(null, $lastError);
+
+        $this->assertNull($this->redisClient->getLastError());
+    }
+
+    public function testNotCleaningPersistentClient(): void
+    {
+        $this->redisClient->set('test', 'test');
+        $facade = new RedisFacade([$this->redisClient], [$this->redisClient]);
+
+        $facade->cleanCache();
+
+        $this->assertTrue((bool)$this->redisClient->exists('test'));
     }
 }


### PR DESCRIPTION
- all `Redis` clients are injected into the facade via service tag
- clients that should not be cleaned are injected via manual service configuration, minimizing errors
- `CheckRedisCommand` uses `RedisFacade` for the pinging
- mentioning a Redis client that was not defined in previous versions (`@snc_redis.global` or `@snc_redis.framework_annotations`) explicitly in arguments would cause a BC break - this issue has been resolved by `RedisFacadeClientFilterCompilerPass` that removes such undefined services from `RedisFacade`

| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR tries to resolve the same issue as in #1158, but tries to do so without expecting users to hard-code everything, making the solution less error-prone (hopefully).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| just partially #1108 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
