### PR TITLE
[project-base] use the monolog config option "excluded_http_codes" instead of "excluded_404s"

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -115,7 +115,18 @@ There you can find links to upgrade notes for other versions too.
     +           - method: setSqlLoggerFacade
     +           - method: setEntityManager
     ```
-- unset the incompatible `excluded_404s` configuration from monolog handlers that don't use the `fingers_crossed` type ([#1154](https://github.com/shopsys/shopsys/pull/1154))
+- use the monolog configuration option `excluded_http_codes` instead of deprecated `excluded_404s` ([#1163](https://github.com/shopsys/shopsys/pull/1163))
+    - in `app/config/packages/monolog.yml`, in the `main` handler:
+        ```diff
+          type: fingers_crossed
+          buffer_size: 1000
+          action_level: warning
+          handler: nested
+        - excluded_404s:
+        -     - ^/
+        + excluded_http_codes: [404]
+        ```
+- unset the incompatible `excluded_404s`/`excluded_http_codes` configuration from monolog handlers that don't use the `fingers_crossed` type ([#1154](https://github.com/shopsys/shopsys/pull/1154))
     - in `app/config/packages/dev/monolog.yml`:
         ```diff
             monolog:
@@ -124,7 +135,7 @@ There you can find links to upgrade notes for other versions too.
                        # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
                        type: group
                        members: [ nested ]
-        +              excluded_404s: false
+        +              excluded_http_codes: false
         ```
     - in `app/config/packages/test/monolog.yml`:
         ```diff
@@ -132,7 +143,7 @@ There you can find links to upgrade notes for other versions too.
                 handlers:
                     main:
                         type: "null"
-        +               excluded_404s: false
+        +               excluded_http_codes: false
         ```
 
 ### Tools

--- a/project-base/app/config/packages/dev/monolog.yml
+++ b/project-base/app/config/packages/dev/monolog.yml
@@ -4,4 +4,4 @@ monolog:
             # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
             type: group
             members: [ nested ]
-            excluded_404s: false
+            excluded_http_codes: false

--- a/project-base/app/config/packages/monolog.yml
+++ b/project-base/app/config/packages/monolog.yml
@@ -6,8 +6,7 @@ monolog:
             buffer_size: 1000
             action_level: warning
             handler: nested
-            excluded_404s:
-                - ^/
+            excluded_http_codes: [404]
         nested:
             type: stream
             path: "%shopsys.log_stream%"

--- a/project-base/app/config/packages/test/monolog.yml
+++ b/project-base/app/config/packages/test/monolog.yml
@@ -3,7 +3,7 @@ monolog:
     handlers:
         main:
             type: "null"
-            excluded_404s: false
+            excluded_http_codes: false
         nested:
             type: "null"
         cron:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The `excluded_404s` option is deprecated since `symfony/monolog-bundle v3.4`.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
