### PR TITLE
[shopsys] all services injected in order to prevent BC breaks are now injected same way

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -127,14 +127,6 @@ There you can find links to upgrade notes for other versions too.
         +    Shopsys\ShopBundle\Twig\:
         +        resource: '../../Twig/'
         ```
-- if you have `Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter` re-registered in your `services.yml`, add proper setter calls ([#1122](https://github.com/shopsys/shopsys/pull/1122))
-    ```diff
-        Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter
-    +       calls:
-    +           - method: setProgressBarFactory
-    +           - method: setSqlLoggerFacade
-    +           - method: setEntityManager
-    ```
 - unset the incompatible `excluded_404s` configuration from monolog handlers that don't use the `fingers_crossed` type ([#1154](https://github.com/shopsys/shopsys/pull/1154))
     - in `app/config/packages/dev/monolog.yml`:
         ```diff

--- a/packages/framework/src/Component/Router/DomainRouterFactory.php
+++ b/packages/framework/src/Component/Router/DomainRouterFactory.php
@@ -53,27 +53,37 @@ class DomainRouterFactory
      * @param \Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory $localizedRouterFactory
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory $friendlyUrlRouterFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Symfony\Component\HttpFoundation\RequestStack|null $requestStack
      */
     public function __construct(
         $routerConfiguration,
         LoaderInterface $configLoader,
         LocalizedRouterFactory $localizedRouterFactory,
         FriendlyUrlRouterFactory $friendlyUrlRouterFactory,
-        Domain $domain
+        Domain $domain,
+        ?RequestStack $requestStack = null
     ) {
         $this->routerConfiguration = $routerConfiguration;
         $this->configLoader = $configLoader;
         $this->localizedRouterFactory = $localizedRouterFactory;
         $this->domain = $domain;
         $this->friendlyUrlRouterFactory = $friendlyUrlRouterFactory;
+        $this->requestStack = $requestStack;
     }
 
     /**
+     * @required
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     public function setRequestStack(RequestStack $requestStack)
     {
-        $this->requestStack = $requestStack;
+        if ($this->requestStack === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->requestStack = $requestStack;
+        }
     }
 
     /**

--- a/packages/framework/src/Component/Router/DomainRouterFactory.php
+++ b/packages/framework/src/Component/Router/DomainRouterFactory.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Router;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory;
@@ -74,11 +75,14 @@ class DomainRouterFactory
     /**
      * @required
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     public function setRequestStack(RequestStack $requestStack)
     {
+        if ($this->requestStack !== null && $this->requestStack !== $requestStack) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
         if ($this->requestStack === null) {
             @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 

--- a/packages/framework/src/Model/Mail/MailTemplateFacade.php
+++ b/packages/framework/src/Model/Mail/MailTemplateFacade.php
@@ -84,12 +84,15 @@ class MailTemplateFacade
     /**
      * @required
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateAttachmentFilepathProvider $mailTemplateAttachmentFilepathProvider
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     public function setMailTemplateAttachmentFilepathProvider(MailTemplateAttachmentFilepathProvider $mailTemplateAttachmentFilepathProvider): void
     {
-        if ($this->mailTemplateAttachmentFilepathProvider !== null) {
+        if ($this->mailTemplateAttachmentFilepathProvider !== null && $this->mailTemplateAttachmentFilepathProvider !== $mailTemplateAttachmentFilepathProvider) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
+        if ($this->mailTemplateAttachmentFilepathProvider === null) {
             @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
             $this->mailTemplateAttachmentFilepathProvider = $mailTemplateAttachmentFilepathProvider;

--- a/packages/framework/src/Model/Mail/MailTemplateFacade.php
+++ b/packages/framework/src/Model/Mail/MailTemplateFacade.php
@@ -59,6 +59,7 @@ class MailTemplateFacade
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactoryInterface $mailTemplateFactory
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateDataFactoryInterface $mailTemplateDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateAttachmentFilepathProvider|null $mailTemplateAttachmentFilepathProvider
      */
     public function __construct(
         EntityManagerInterface $em,
@@ -67,7 +68,8 @@ class MailTemplateFacade
         Domain $domain,
         UploadedFileFacade $uploadedFileFacade,
         MailTemplateFactoryInterface $mailTemplateFactory,
-        MailTemplateDataFactoryInterface $mailTemplateDataFactory
+        MailTemplateDataFactoryInterface $mailTemplateDataFactory,
+        ?MailTemplateAttachmentFilepathProvider $mailTemplateAttachmentFilepathProvider = null
     ) {
         $this->em = $em;
         $this->mailTemplateRepository = $mailTemplateRepository;
@@ -76,19 +78,22 @@ class MailTemplateFacade
         $this->uploadedFileFacade = $uploadedFileFacade;
         $this->mailTemplateFactory = $mailTemplateFactory;
         $this->mailTemplateDataFactory = $mailTemplateDataFactory;
+        $this->mailTemplateAttachmentFilepathProvider = $mailTemplateAttachmentFilepathProvider;
     }
 
     /**
+     * @required
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateAttachmentFilepathProvider $mailTemplateAttachmentFilepathProvider
-     * @deprecated Will be changed to constructor injection in 8.0
+     * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     public function setMailTemplateAttachmentFilepathProvider(MailTemplateAttachmentFilepathProvider $mailTemplateAttachmentFilepathProvider): void
     {
         if ($this->mailTemplateAttachmentFilepathProvider !== null) {
-            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
-        }
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->mailTemplateAttachmentFilepathProvider = $mailTemplateAttachmentFilepathProvider;
+            $this->mailTemplateAttachmentFilepathProvider = $mailTemplateAttachmentFilepathProvider;
+        }
     }
 
     /**

--- a/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
@@ -13,13 +13,26 @@ class OrderItemDataFactory implements OrderItemDataFactoryInterface
     protected $orderItemPriceCalculation;
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation|null $orderItemPriceCalculation
+     */
+    public function __construct(?OrderItemPriceCalculation $orderItemPriceCalculation = null)
+    {
+        $this->orderItemPriceCalculation = $orderItemPriceCalculation;
+    }
+
+    /**
      * @required
-     * @internal Will be replaced with constructor injection in the next major release
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation $orderItemPriceCalculation
+     * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     public function setOrderItemPriceCalculation(OrderItemPriceCalculation $orderItemPriceCalculation)
     {
-        $this->orderItemPriceCalculation = $orderItemPriceCalculation;
+        if ($this->orderItemPriceCalculation === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->orderItemPriceCalculation = $orderItemPriceCalculation;
+        }
     }
 
     /**

--- a/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Model\Order\Item;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\OrderItemPriceCalculationNotInjectedException;
 use Shopsys\FrameworkBundle\Model\Order\Item\Exception\OrderItemUnitPricesAreInconsistentButTotalsAreNotForcedException;
 
@@ -23,11 +24,14 @@ class OrderItemDataFactory implements OrderItemDataFactoryInterface
     /**
      * @required
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation $orderItemPriceCalculation
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     public function setOrderItemPriceCalculation(OrderItemPriceCalculation $orderItemPriceCalculation)
     {
+        if ($this->orderItemPriceCalculation !== null && $this->orderItemPriceCalculation !== $orderItemPriceCalculation) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
         if ($this->orderItemPriceCalculation === null) {
             @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 
-use BadMethodCallException;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory;
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade;
@@ -51,54 +50,69 @@ class ProductSearchExporter
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportRepository $productSearchExportRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter $productElasticsearchConverter
+     * @param \Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory|null $progressBarFactory
+     * @param \Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade|null $sqlLoggerFacade
+     * @param \Doctrine\ORM\EntityManagerInterface|null $entityManager
      */
     public function __construct(
         ProductSearchExportRepository $productSearchExportRepository,
         ProductElasticsearchRepository $productElasticsearchRepository,
-        ProductElasticsearchConverter $productElasticsearchConverter
+        ProductElasticsearchConverter $productElasticsearchConverter,
+        ?ProgressBarFactory $progressBarFactory = null,
+        ?SqlLoggerFacade $sqlLoggerFacade = null,
+        ?EntityManagerInterface $entityManager = null
     ) {
         $this->productSearchExportRepository = $productSearchExportRepository;
         $this->productElasticsearchRepository = $productElasticsearchRepository;
         $this->productElasticsearchConverter = $productElasticsearchConverter;
+        $this->progressBarFactory = $progressBarFactory;
+        $this->sqlLoggerFacade = $sqlLoggerFacade;
+        $this->entityManager = $entityManager;
     }
 
     /**
+     * @required
      * @param \Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory $progressBarFactory
      * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     public function setProgressBarFactory(ProgressBarFactory $progressBarFactory): void
     {
-        if ($this->progressBarFactory !== null) {
-            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
-        }
+        if ($this->progressBarFactory === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->progressBarFactory = $progressBarFactory;
+            $this->progressBarFactory = $progressBarFactory;
+        }
     }
 
     /**
+     * @required
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade $sqlLoggerFacade
      * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     public function setSqlLoggerFacade(SqlLoggerFacade $sqlLoggerFacade): void
     {
-        if ($this->sqlLoggerFacade !== null) {
-            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
-        }
+        if ($this->sqlLoggerFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->sqlLoggerFacade = $sqlLoggerFacade;
+            $this->sqlLoggerFacade = $sqlLoggerFacade;
+        }
     }
 
     /**
+     * @required
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
      * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     public function setEntityManager(EntityManagerInterface $entityManager): void
     {
-        if ($this->entityManager !== null) {
-            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
-        }
+        if ($this->entityManager === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
-        $this->entityManager = $entityManager;
+            $this->entityManager = $entityManager;
+        }
     }
 
     /**
@@ -125,8 +139,6 @@ class ProductSearchExporter
      */
     public function exportWithOutput(int $domainId, string $locale, SymfonyStyle $symfonyStyleIo): void
     {
-        $this->validateInjectedDependencies();
-
         $this->sqlLoggerFacade->temporarilyDisableLogging();
 
         $startFrom = 0;
@@ -179,23 +191,5 @@ class ProductSearchExporter
     protected function removeNotUpdated(int $domainId, array $exportedIds): void
     {
         $this->productElasticsearchRepository->deleteNotPresent($domainId, $exportedIds);
-    }
-
-    /**
-     * @internal Will be removed in the next major release
-     */
-    protected function validateInjectedDependencies(): void
-    {
-        if (!$this->progressBarFactory instanceof ProgressBarFactory) {
-            throw new BadMethodCallException(sprintf('Method "%s::setProgressBarFactory()" has to be called in "services.yml" definition.', __CLASS__));
-        }
-
-        if (!$this->sqlLoggerFacade instanceof SqlLoggerFacade) {
-            throw new BadMethodCallException(sprintf('Method "%s::setSqlLoggerFacade()" has to be called in "services.yml" definition.', __CLASS__));
-        }
-
-        if (!$this->entityManager instanceof EntityManagerInterface) {
-            throw new BadMethodCallException(sprintf('Method "%s::setEntityManager()" has to be called in "services.yml" definition.', __CLASS__));
-        }
     }
 }

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 
+use BadMethodCallException;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory;
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade;
@@ -73,11 +74,14 @@ class ProductSearchExporter
     /**
      * @required
      * @param \Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory $progressBarFactory
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     public function setProgressBarFactory(ProgressBarFactory $progressBarFactory): void
     {
+        if ($this->progressBarFactory !== null && $this->progressBarFactory !== $progressBarFactory) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
         if ($this->progressBarFactory === null) {
             @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
@@ -88,11 +92,14 @@ class ProductSearchExporter
     /**
      * @required
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade $sqlLoggerFacade
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     public function setSqlLoggerFacade(SqlLoggerFacade $sqlLoggerFacade): void
     {
+        if ($this->sqlLoggerFacade !== null && $this->sqlLoggerFacade !== $sqlLoggerFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
         if ($this->sqlLoggerFacade === null) {
             @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
@@ -103,11 +110,14 @@ class ProductSearchExporter
     /**
      * @required
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     public function setEntityManager(EntityManagerInterface $entityManager): void
     {
+        if ($this->entityManager !== null && $this->entityManager !== $entityManager) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+
         if ($this->entityManager === null) {
             @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -60,22 +60,18 @@ class ProductElasticsearchRepository
         $this->client = $client;
         $this->productElasticsearchConverter = $productElasticsearchConverter;
         $this->elasticsearchStructureManager = $elasticsearchStructureManager;
-        $this->filterQueryFactory = $filterQueryFactory;
+        $this->filterQueryFactory = $filterQueryFactory ?? $this->createFilterQueryFactory();
     }
 
     /**
-     * @required
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
-     * @internal Will be replaced with constructor injection in the next major release
-     * @deprecated
+     * @deprecated Will be replaced with constructor injection in the next major release
      */
     protected function createFilterQueryFactory(): FilterQueryFactory
     {
-        if ($this->filterQueryFactory === null) {
-            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
 
-            $this->filterQueryFactory = new FilterQueryFactory();
-        }
+        return new FilterQueryFactory();
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -47,27 +47,35 @@ class ProductElasticsearchRepository
      * @param \Elasticsearch\Client $client
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter $productElasticsearchConverter
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager $elasticsearchStructureManager
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory|null $filterQueryFactory
      */
     public function __construct(
         string $indexPrefix,
         Client $client,
         ProductElasticsearchConverter $productElasticsearchConverter,
-        ElasticsearchStructureManager $elasticsearchStructureManager
+        ElasticsearchStructureManager $elasticsearchStructureManager,
+        ?FilterQueryFactory $filterQueryFactory = null
     ) {
         $this->indexPrefix = $indexPrefix;
         $this->client = $client;
         $this->productElasticsearchConverter = $productElasticsearchConverter;
         $this->elasticsearchStructureManager = $elasticsearchStructureManager;
-        $this->filterQueryFactory = $this->createFilterQueryFactory();
+        $this->filterQueryFactory = $filterQueryFactory;
     }
 
     /**
+     * @required
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
-     * @deprecated Will be replaced with constructor injection in the next major release
+     * @internal Will be replaced with constructor injection in the next major release
+     * @deprecated
      */
     protected function createFilterQueryFactory(): FilterQueryFactory
     {
-        return new FilterQueryFactory();
+        if ($this->filterQueryFactory === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+
+            $this->filterQueryFactory = new FilterQueryFactory();
+        }
     }
 
     /**

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -465,10 +465,6 @@ services:
         arguments:
             - '@logger'
 
-    Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade:
-        calls:
-            - method: setMailTemplateAttachmentFilepathProvider
-
     Shopsys\FrameworkBundle\Model\Pricing\DelayedPricingSetting: ~
 
     Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler:
@@ -523,8 +519,6 @@ services:
 
     Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory:
         arguments: ['%router.resource%']
-        calls:
-            - method: setRequestStack
 
     Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory:
         arguments: ['%shopsys.router.friendly_url_router_filepath%']
@@ -1007,11 +1001,7 @@ services:
             - '%shopsys.elasticsearch.structure_dir%'
             - '%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
 
-    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter:
-        calls:
-            - method: setProgressBarFactory
-            - method: setSqlLoggerFacade
-            - method: setEntityManager
+    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExporter: ~
 
     Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter: ~
 


### PR DESCRIPTION
- all services has been added to constructors but might be nullable and set via setters

| Q             | A
| ------------- | ---
|Description, reason for the PR| Service injections are now all solved same way. There are understandable deprecation errors triggered when services are injected via setter injection and users now can use constructor injection and avoid this deprecation errors.  Note: the removed method validateInjectedDependencies() does not cause a violation of a BC promise as the method was not yet part of any released version
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes