### PR TITLE
[framework] remove redundant service definitions

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -415,11 +415,6 @@ services:
 
     Shopsys\FrameworkBundle\Model\PersonalData\Mail\PersonalDataExportMail: ~
 
-    Shopsys\FrameworkBundle\Model\Feed\FeedConfigFacade:
-        arguments:
-            - '%shopsys.feed_url_prefix%'
-            - '%shopsys.feed_dir%'
-
     Shopsys\FrameworkBundle\Model\Feed\FeedPathProvider:
         arguments:
             $feedUrlPrefix: '%shopsys.feed_url_prefix%'
@@ -705,8 +700,6 @@ services:
     Shopsys\FrameworkBundle\Model\Product\Flag\FlagFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Product\Flag\FlagFactory
 
-    Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\CompilerPass\FriendlyUrlDataProviderConfig: ~
-
     Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactoryInterface:
         alias: Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactory
 
@@ -913,8 +906,6 @@ services:
 
     Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory
-
-    Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportDataConverter: ~
 
     Shopsys\FrameworkBundle\Model\Sitemap\SitemapFilePrefixer: ~
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -176,8 +176,6 @@ services:
             - '%shopsys.domain_urls_config_filepath%'
         lazy: true
 
-    Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassProvider: ~
-
     Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassProviderInterface:
         alias: Shopsys\FrameworkBundle\Model\MultidomainEntityClassProvider
 
@@ -405,13 +403,9 @@ services:
         tags:
             - { name: validator.constraint_validator, alias: Shopsys\FrameworkBundle\Form\Constraints\UniqueSlugsOnDomainsValidator }
 
-    Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorUserProvider: ~
-
     Shopsys\FrameworkBundle\Model\Cookies\CookiesFacade:
         arguments:
             - '%kernel.environment%'
-
-    Shopsys\FrameworkBundle\Model\Customer\FrontendUserProvider: ~
 
     Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer: ~
 
@@ -937,8 +931,6 @@ services:
     Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender: ~
 
     Shopsys\FrameworkBundle\Component\Domain\DomainUrlReplacer: ~
-
-    Shopsys\FrameworkBundle\Component\Image\Processing\ImageGenerator: ~
 
     Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor: ~
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In our `services.yml` there were either redundantly defined services or services referring to a missing class. Such service definitions can be safely removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
