### PR TITLE
[framework] defining empty services of Redis clients for BC

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -115,6 +115,16 @@ services:
         arguments:
             - '@snc_redis.framework_annotations'
 
+    # empty instance of a Redis client that can be provided as a service, will be removed in 8.0 (@deprecated)
+    # the client was added in shopsys/project-base in v7.2.0 via configuration
+    snc_redis.framework_annotations:
+        class: Redis
+
+    # empty instance of a Redis client that can be provided as a service, will be removed in 8.0 (@deprecated)
+    # the client was added in shopsys/project-base in v7.1.0 via configuration
+    snc_redis.global:
+        class: Redis
+
     Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider: ~
 
     Shopsys\FrameworkBundle\Model\AdminNavigation\SideMenuBuilder:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Some Redis clients were added via configration in `shopsys/project-base` in previous versions (in #886 and #930). Projects may fail after upgrading on undefined services when generating the DIC. This PR avoids this problem by defining an empty service. Some work might still be needed to make those empty services behave correctly when called without Redis client configuration.<br>The backward compatibility should be tested thoroughly and the consequences of the missing clients should be explored.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
