### PR TITLE
[shopsys] set @returnv annotation as ignored by doctrine/annotations

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -75,6 +75,18 @@ There you can find links to upgrade notes for other versions too.
     - stop using the deprecated method `\Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation::getVatCoefficientByPercent()`, use `PriceCalculation::getVatAmountByPriceWithVat()` for VAT calculation instead
     - if you want to customize the VAT calculation (eg. revert it back to the previous implementation), extend the service `@Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation` and override the method `getVatAmountByPriceWithVat()`
     - if you created new tests regarding the price calculation they might start failing after the upgrade - in such case, please see the new VAT calculation and change the tests expectations accordingly
+- to fix problem with dumping translations ([#1169](https://github.com/shopsys/shopsys/pull/1169))
+    - update your `autoload.php` file accordingly:
+    ```diff
+    +   use Doctrine\Common\Annotations\AnnotationReader;
+        use Doctrine\Common\Annotations\AnnotationRegistry;
+
+        $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../vendor/autoload.php';
+        /* @var $loader \Composer\Autoload\ClassLoader */
+
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    +   AnnotationReader::addGlobalIgnoredName('returnv');
+    ```
 
 ### Configuration
 - update `phpstan.neon` with following change to skip phpstan error ([#1086](https://github.com/shopsys/shopsys/pull/1086))

--- a/project-base/app/autoload.php
+++ b/project-base/app/autoload.php
@@ -1,10 +1,12 @@
 <?php
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../vendor/autoload.php';
 /* @var $loader \Composer\Autoload\ClassLoader */
 
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+AnnotationReader::addGlobalIgnoredName('returnv');
 
 return $loader;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This versions caused phing target `translations-dump` to fail. Interval of versions is closed because this problem is already solved in their master branch.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
