### PR TITLE
[shopsys] docker-sync now does not exclude project-base/docs in monorepo

### DIFF
--- a/docker/conf/docker-sync-win.yml.dist
+++ b/docker/conf/docker-sync-win.yml.dist
@@ -17,7 +17,6 @@ syncs:
             'docker',
             'nbproject',
             'project-base/docker',
-            'project-base/docs',
             'project-base/kubernetes',
             'project-base/node_modules',
             'project-base/var/cache',

--- a/docker/conf/docker-sync.yml.dist
+++ b/docker/conf/docker-sync.yml.dist
@@ -13,7 +13,6 @@ syncs:
             'docker',
             'nbproject',
             'project-base/docker',
-            'project-base/docs',
             'project-base/kubernetes',
             'project-base/node_modules',
             'project-base/var/cache',

--- a/docs/contributing/upgrading-monorepo.md
+++ b/docs/contributing/upgrading-monorepo.md
@@ -38,6 +38,7 @@ Typical upgrade sequence should be:
         - eg. you can use `tests-unit` to run unit tests in the whole monorepo instead of running `tests-unit`, `tests-packages` and `tests-utils`
         - you can even use coding standards subtargets in the whole monorepo, such as `ecs`, `eslint-fix`, etc.
     - read [the new guidelines for phing targets](/docs/contributing/guidelines-for-phing-targets.md) before suggesting changes via pull requests
+- remove `'project-base/docs',` line from your `docker-sync.yml` ([#1172](https://github.com/shopsys/shopsys/pull/1172))
 
 ## [From v7.2.0 to v7.2.1]
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Running any `ecs` phing target was failing on missing `project-base/docs` folder.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
