### PR TITLE
DI parameter %build-version% is always string now

### DIFF
--- a/project-base/app/config/parameters_version.yml.dist
+++ b/project-base/app/config/parameters_version.yml.dist
@@ -1,2 +1,2 @@
 parameters:
-    build-version: %%version%%
+    build-version: '%%version%%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The parameter `%build-version%` is sometimes string and sometimes can be cast to integer, which might be problematic.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
