### PR TITLE
[shopsys] build.xml: build-deploy-* are fixed

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -8,6 +8,13 @@ There you can find links to upgrade notes for other versions too.
 ## [shopsys/framework]
 
 ### Infrastructure
+- update your `docker/php-fpm/Dockerfile` production stage build ([#1177](https://github.com/shopsys/shopsys/pull/1177))
+    ```diff
+    RUN composer install --optimize-autoloader --no-interaction --no-progress --no-dev
+
+    -RUN php phing composer-prod npm dirs-create assets
+    +RUN php phing build-deploy-part-1-db-independent
+    ```
 - update Elasticsearch build configuration ([#1069](https://github.com/shopsys/shopsys/pull/1069))
     - copy new [Dockerfile from shopsys/project-base](https://github.com/shopsys/project-base/blob/master/docker/elasticsearch/Dockerfile)
     - update `docker-compose.yml` and `docker-compose.yml.dist`

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -82,9 +82,9 @@
 
     <target name="build-demo-dev-quick" depends="build-version-generate,wipe-excluding-logs,composer-dev,npm,dirs-create,test-dirs-create,assets,db-demo,product-search-recreate-structure,product-search-export-products,grunt,clean-redis-old" description="Builds application for development with clean demo DB while skipping nonessential steps."/>
 
-    <target name="build-deploy-part-1-db-independent" depends="build-version-generate,clean,composer-prod,redis-check,npm,dirs-create,assets" description="First part of application build for production preserving your DB (can be run without maintenance page)."/>
+    <target name="build-deploy-part-1-db-independent" depends="build-version-generate,clean,composer-prod,npm,dirs-create,assets" description="First part of application build for production preserving your DB (can be run without maintenance page)."/>
 
-    <target name="build-deploy-part-2-db-dependent" depends="db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,grunt,error-pages-generate,warmup,clean-redis-old" description="Second part of application build for production preserving your DB (must be run with maintenance page when containing DB migrations)."/>
+    <target name="build-deploy-part-2-db-dependent" depends="redis-check,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,grunt,error-pages-generate,warmup,clean-redis-old" description="Second part of application build for production preserving your DB (must be run with maintenance page when containing DB migrations)."/>
 
     <target name="build-dev" depends="build-version-generate,clean,composer-dev,npm,timezones-check,dirs-create,test-dirs-create,assets,db-migrations,domains-data-create,friendly-urls-generate,domains-urls-replace,product-search-recreate-structure,product-search-export-products,grunt,error-pages-generate,tests-acceptance-build,clean-redis-old,checks-diff" description="Builds application for development preserving your DB and runs checks on changed files."/>
 

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -120,7 +120,7 @@ COPY --chown=www-data:www-data / /var/www/html
 
 RUN composer install --optimize-autoloader --no-interaction --no-progress --no-dev
 
-RUN php phing composer-prod npm dirs-create assets
+RUN php phing build-deploy-part-1-db-independent
 
 ########################################################################################################################
 


### PR DESCRIPTION
- redis-check was moved from part-1-db-independet into part-2-db-dependent
- part-1-db-independent was used in production stage build in Dockerfile for php-fpm image so installation guide now make sense and build-version-generate is contained

| Q             | A
| ------------- | ---
|Description, reason for the PR| installation guide for production was not accurate since build-version was introduced and other thins were bound to it. Also production stage build is now simplified, since it is dependent on the things that were removed from old version of installation guide for production. phing target `build-deploy-part-1-db-independent` was fixed since redis-check is db-dependent target.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
