### PR TITLE
[shopsys] [BC-BREAK] fixed wrong field in exporting products to Elasticsearch

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -39,6 +39,13 @@ There you can find links to upgrade notes for other versions too.
     - if you deploy to the google cloud, copy new [`.ci/deploy-to-google-cloud.sh`](https://github.com/shopsys/project-base/blob/master/.ci/deploy-to-google-cloud.sh) script from `shopsys/project-base` ([#1126](https://github.com/shopsys/shopsys/pull/1126))
 
 ### Application
+- **BC-BREAK** fix inconsistently named field `shortDescription` in Elasticsearch ([#1180](https://github.com/shopsys/shopsys/pull/1180))
+    - in `ProductSearchExportRepositoryTest::getExpectedStructureForRepository()` (the test will fail otherwise)
+        ```diff
+        -   'shortDescription',
+        +   'short_description',
+        ```
+    - in other places you might have used it in your custom code
 - follow instructions in [the separate article](upgrade-instructions-for-read-model-for-product-lists.md) to introduce read model for frontend product lists into your project ([#1018](https://github.com/shopsys/shopsys/pull/1018))
     - we recommend to read [Introduction to Read Model](/docs/model/introduction-to-read-model.md) article
 - copy a new functional test to avoid regression of issues with creating product variants in the future ([#1113](https://github.com/shopsys/shopsys/pull/1113))

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -79,7 +79,7 @@ class ProductSearchExportWithFilterRepository extends ProductSearchExportReposit
             'ean' => $product->getEan(),
             'name' => $product->getName($locale),
             'description' => $product->getDescription($domainId),
-            'shortDescription' => $product->getShortDescription($domainId),
+            'short_description' => $product->getShortDescription($domainId),
             'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
             'flags' => $flagIds,
             'categories' => $categoryIds,

--- a/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
@@ -30,7 +30,7 @@ class ProductElasticsearchConverterTest extends TestCase
                 'partno' => '47LA790V',
                 'ean' => '8845781245928',
                 'description' => 'At first glance its <strong> beautiful design </strong>',
-                'shortDescription' => '47 "LG 47LA790V Luxury TV from the South Korean company LG bears 47LA790S',
+                'short_description' => '47 "LG 47LA790V Luxury TV from the South Korean company LG bears 47LA790S',
             ],
             2 => [
                 'name' => '47" LG 47LA790V',
@@ -38,7 +38,7 @@ class ProductElasticsearchConverterTest extends TestCase
                 'partno' => '47LA',
                 'ean' => '8845781',
                 'description' => 'At first glance its beautiful',
-                'shortDescription' => '47 "LG 47LA790V Luxury TV',
+                'short_description' => '47 "LG 47LA790V Luxury TV',
             ],
         ];
     }
@@ -62,7 +62,7 @@ class ProductElasticsearchConverterTest extends TestCase
                 'partno' => '47LA790V',
                 'ean' => '8845781245928',
                 'description' => 'At first glance its <strong> beautiful design </strong>',
-                'shortDescription' => '47 "LG 47LA790V Luxury TV from the South Korean company LG bears 47LA790S',
+                'short_description' => '47 "LG 47LA790V Luxury TV from the South Korean company LG bears 47LA790S',
             ],
             [
                 'index' => [
@@ -77,7 +77,7 @@ class ProductElasticsearchConverterTest extends TestCase
                 'partno' => '47LA',
                 'ean' => '8845781',
                 'description' => 'At first glance its beautiful',
-                'shortDescription' => '47 "LG 47LA790V Luxury TV',
+                'short_description' => '47 "LG 47LA790V Luxury TV',
             ],
         ];
     }

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportRepositoryTest.php
@@ -54,7 +54,7 @@ class ProductSearchExportRepositoryTest extends TransactionFunctionalTestCase
             'partno',
             'ean',
             'description',
-            'shortDescription',
+            'short_description',
         ];
 
         if ($productSearchExportRepository instanceof ProductSearchExportWithFilterRepository) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Changed `shortDescription` to `short_description` in the export of products. It was already called `short_description` in the structure definition and queries and all other fields use underscore.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes - functional tests will fail after upgrade (the fix is very easy to do and doing this the backward-compatible way would be harder and more confusing for both us and the end users) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| Fixes searching in `Product::$shortDescription` (for this to be fixed, a new product export must be executed) <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
