### PR TITLE
[project-base] consistency of  service configs in FrameworkBundle and ShopBundle

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -196,6 +196,27 @@ There you can find links to upgrade notes for other versions too.
         -   - { resource: forms.yml }
             - { resource: services/*.yml }
         ```
+    - exclude loading of DataFixtures folder from services.yml
+        ```diff
+        -        exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
+        +        exclude: '../../{Command,Controller,DataFixtures,DependencyInjection,Form,Migrations,Resources,Twig}'
+        ```
+    - move all services based on `DataFixtures` namespace into `src/Shopsys/ShopBundle/Resources/config/services/data_fixtures.yml` configuration
+    - update `src/Shopsys/ShopBundle/Resources/config/services/data_fixtures.yml` config file
+        ```diff
+        services:
+            _defaults:
+        -        tags: ['doctrine.fixture.orm']
+                autowire: true
+
+            Shopsys\ShopBundle\DataFixtures\:
+        -        resource: '../../../DataFixtures/**/*DataFixture.php'
+        +        tags: ['doctrine.fixture.orm']
+        +        resource: '../../../DataFixtures/**/*{DataFixture,Loader}.php'
+
+        -   Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureLoader: ~
+        -   Shopsys\ShopBundle\DataFixtures\Demo\ProductParametersFixtureLoader: ~
+        ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -181,6 +181,21 @@ There you can find links to upgrade notes for other versions too.
         ```
 - remove the useless route `front_category_panel` from your `routing_front.yml` ([#1042](https://github.com/shopsys/shopsys/pull/1042))
     - you'll find the configuration file in `src/Shopsys/ShopBundle/Resources/config/`
+- update your services configuration tree ([#1182](https://github.com/shopsys/shopsys/pull/1182))
+    - move your `src/Shopsys/ShopBundle/Resources/config/forms.yml` into `src/Shopsys/ShopBundle/Resources/config/services/forms.yml` and update it
+        ```diff
+        Shopsys\ShopBundle\Form\:
+        -    resource: '../../Form/'
+        +    resource: '../../../Form/'
+
+        Shopsys\ShopBundle\Form\Admin\ArticleFormTypeExtension:
+        ```
+    - remove loading of forms.yml config from services.yml
+        ```diff
+        imports:
+        -   - { resource: forms.yml }
+            - { resource: services/*.yml }
+        ```
 
 ### Tools
 - use the `build.xml` [Phing configuration](/docs/introduction/console-commands-for-application-management-phing-targets.md) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     Shopsys\ShopBundle\:
         resource: '../../**/*{Calculation,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer}.php'
-        exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
+        exclude: '../../{Command,Controller,DataFixtures,DependencyInjection,Form,Migrations,Resources,Twig}'
 
     League\Flysystem\MountManager:
         arguments:
@@ -58,44 +58,6 @@ services:
         alias: Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository
 
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface: '@Shopsys\ShopBundle\Model\Product\Brand\BrandDataFactory'
-
-    Shopsys\ShopBundle\DataFixtures\ProductDataFixtureReferenceInjector: ~
-
-    Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureLoader: ~
-
-    Shopsys\ShopBundle\DataFixtures\Demo\ProductParametersFixtureLoader: ~
-
-    Shopsys\ShopBundle\DataFixtures\Performance\CategoryDataFixture:
-        arguments:
-            - "%shopsys.performance_data.category.counts_by_level%"
-
-    Shopsys\ShopBundle\DataFixtures\Performance\OrderDataFixture:
-        arguments:
-            - "%shopsys.performance_data.order.total_count%"
-            - "%shopsys.performance_data.order.item_count_per_order%"
-
-    Shopsys\ShopBundle\DataFixtures\Performance\ProductDataFixture:
-        arguments:
-            - "%shopsys.performance_data.product.total_count%"
-
-    Shopsys\ShopBundle\DataFixtures\Performance\UserDataFixture:
-        arguments:
-            - "%shopsys.performance_data.user.count_per_domain%"
-
-    Shopsys\ShopBundle\DataFixtures\Demo\ImageDataFixture:
-        arguments:
-            - '%shopsys.data_fixtures_images.resources_dir%'
-            - '%shopsys.image_dir%'
-            - '%shopsys.domain_images_dir%'
-        tags: ['doctrine.fixture.orm']
-
-    Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureCsvReader:
-        arguments:
-            - '%shopsys.data_fixtures.resource_products_filepath%'
-
-    Shopsys\ShopBundle\DataFixtures\Demo\UserDataFixtureLoader:
-        arguments:
-            - '%shopsys.data_fixtures.resource_customers_filepath%'
 
     Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: forms.yml }
     - { resource: services/*.yml }
 
 services:

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services/data_fixtures.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services/data_fixtures.yml
@@ -1,7 +1,45 @@
 services:
     _defaults:
-        tags: ['doctrine.fixture.orm']
         autowire: true
 
     Shopsys\ShopBundle\DataFixtures\:
-        resource: '../../../DataFixtures/**/*DataFixture.php'
+        tags: ['doctrine.fixture.orm']
+        resource: '../../../DataFixtures/**/*{DataFixture,Loader}.php'
+
+    Shopsys\ShopBundle\DataFixtures\ProductDataFixtureReferenceInjector: ~
+
+    Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureLoader: ~
+
+    Shopsys\ShopBundle\DataFixtures\Demo\ProductParametersFixtureLoader: ~
+
+    Shopsys\ShopBundle\DataFixtures\Performance\CategoryDataFixture:
+        arguments:
+            - "%shopsys.performance_data.category.counts_by_level%"
+
+    Shopsys\ShopBundle\DataFixtures\Performance\OrderDataFixture:
+        arguments:
+            - "%shopsys.performance_data.order.total_count%"
+            - "%shopsys.performance_data.order.item_count_per_order%"
+
+    Shopsys\ShopBundle\DataFixtures\Performance\ProductDataFixture:
+        arguments:
+            - "%shopsys.performance_data.product.total_count%"
+
+    Shopsys\ShopBundle\DataFixtures\Performance\UserDataFixture:
+        arguments:
+            - "%shopsys.performance_data.user.count_per_domain%"
+
+    Shopsys\ShopBundle\DataFixtures\Demo\ImageDataFixture:
+        arguments:
+            - '%shopsys.data_fixtures_images.resources_dir%'
+            - '%shopsys.image_dir%'
+            - '%shopsys.domain_images_dir%'
+        tags: ['doctrine.fixture.orm']
+
+    Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureCsvReader:
+        arguments:
+            - '%shopsys.data_fixtures.resource_products_filepath%'
+
+    Shopsys\ShopBundle\DataFixtures\Demo\UserDataFixtureLoader:
+        arguments:
+            - '%shopsys.data_fixtures.resource_customers_filepath%'

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services/forms.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services/forms.yml
@@ -5,7 +5,7 @@ services:
         public: false
 
     Shopsys\ShopBundle\Form\:
-            resource: '../../Form/'
+            resource: '../../../Form/'
 
     Shopsys\ShopBundle\Form\Admin\ArticleFormTypeExtension:
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| there is some inconsistency of ShopBundle in the face of FrameworkBundle were forms.yml are contained in different tree path.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| veeeery partially #1048  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
