### PR TITLE
[shopsys] fixed path for domain icons directory

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -177,6 +177,11 @@ There you can find links to upgrade notes for other versions too.
         ```
     - remove the use of `is_plugin_data_group` attribute in form extensions or customized twig templates, the functionality was also removed from `form_row` block in `@FrameworkBundle/src/Resources/views/Admin/Form/theme.html.twig`
 - follow instructions in [the separate article](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md) to use Elasticsearch to get data into read model ([#1096](https://github.com/shopsys/shopsys/pull/1096))
+- fix `shopsys.domain_images_url_prefix` parameter in your `paths.yml` file to properly load domain icons in images data fixtures ([#1183](https://github.com/shopsys/shopsys/pull/1183))
+    ```diff
+    -   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
+    +   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain/'
+    ```
 
 ### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))

--- a/packages/framework/src/Component/Domain/DomainIconResizer.php
+++ b/packages/framework/src/Component/Domain/DomainIconResizer.php
@@ -8,8 +8,8 @@ use Symfony\Bridge\Monolog\Logger;
 
 class DomainIconResizer
 {
-    protected const DOMAIN_ICON_WIDTH = 48;
-    protected const DOMAIN_ICON_HEIGHT = 33;
+    protected const DOMAIN_ICON_WIDTH = 46;
+    protected const DOMAIN_ICON_HEIGHT = 26;
     protected const DOMAIN_ICON_CROP = false;
 
     /**

--- a/packages/framework/src/Controller/Admin/DomainController.php
+++ b/packages/framework/src/Controller/Admin/DomainController.php
@@ -125,17 +125,19 @@ class DomainController extends AdminBaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             try {
-                $files = $form->getData()[DomainFormType::FIELD_ICON]->uploadedFiles;
+                /** @var \Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadData|null $iconData */
+                $iconData = $form->getData()[DomainFormType::FIELD_ICON];
+                $files = $iconData !== null ? $iconData->uploadedFiles : [];
                 if (count($files) !== 0) {
                     $iconName = reset($files);
 
                     $this->domainFacade->editIcon($id, $iconName);
-                }
 
-                $this->getFlashMessageSender()->addSuccessFlashTwig(
-                    t('Domain <strong>{{ name }}</strong> modified'),
-                    ['name' => $domain->getName()]
-                );
+                    $this->getFlashMessageSender()->addSuccessFlashTwig(
+                        t('Domain <strong>{{ name }}</strong> modified'),
+                        ['name' => $domain->getName()]
+                    );
+                }
 
                 return new JsonResponse(['result' => 'valid']);
             } catch (\Shopsys\FrameworkBundle\Component\Image\Processing\Exception\FileIsNotSupportedImageException $ex) {

--- a/packages/framework/src/Controller/Admin/DomainController.php
+++ b/packages/framework/src/Controller/Admin/DomainController.php
@@ -134,7 +134,7 @@ class DomainController extends AdminBaseController
                     $this->domainFacade->editIcon($id, $iconName);
 
                     $this->getFlashMessageSender()->addSuccessFlashTwig(
-                        t('Domain <strong>{{ name }}</strong> modified'),
+                        t('Domain <strong>{{ name }}</strong> modified. Try clearing your browser cache (CTRL+F5) if you can\'t see the new icon.'),
                         ['name' => $domain->getName()]
                     );
                 }

--- a/packages/framework/src/Resources/styles/admin/components/form/line-box.less
+++ b/packages/framework/src/Resources/styles/admin/components/form/line-box.less
@@ -21,7 +21,6 @@
                 margin-right: 10px;
 
                 text-align: center;
-                background: @color-f;
 
                 img {
                     .center-image();

--- a/packages/framework/src/Resources/styles/admin/components/form/line.less
+++ b/packages/framework/src/Resources/styles/admin/components/form/line.less
@@ -244,7 +244,6 @@
             margin-right: 10px;
 
             text-align: center;
-            background: @color-f;
 
             img {
                 .center-image();

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -739,8 +739,8 @@ msgstr "Doména"
 msgid "Domain %domainName%"
 msgstr "Doména %domainName%"
 
-msgid "Domain <strong>{{ name }}</strong> modified"
-msgstr "Byla upravena doména <strong>{{ name }}</strong>"
+msgid "Domain <strong>{{ name }}</strong> modified. Try clearing your browser cache (CTRL+F5) if you can't see the new icon."
+msgstr "Byla upravena doména <strong>{{ name }}</strong>. Nevidíte-li novou ikonu, zkuste smazat cache vašeho prohlížeče (CTRL+F5)."
 
 msgid "Domain name"
 msgstr "Název domény"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Domain %domainName%"
 msgstr ""
 
-msgid "Domain <strong>{{ name }}</strong> modified"
+msgid "Domain <strong>{{ name }}</strong> modified. Try clearing your browser cache (CTRL+F5) if you can't see the new icon."
 msgstr ""
 
 msgid "Domain name"

--- a/project-base/app/config/paths.yml
+++ b/project-base/app/config/paths.yml
@@ -7,7 +7,7 @@ parameters:
     shopsys.default_db_schema_filepath: '%shopsys.framework.resources_dir%/database/schema.sql'
     shopsys.domain_config_filepath: '%kernel.root_dir%/config/domains.yml'
     shopsys.domain_images_dir: '/web%shopsys.domain_images_url_prefix%'
-    shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
+    shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain/'
     shopsys.domain_urls_config_filepath: '%kernel.root_dir%/config/domains_urls.yml'
     shopsys.error_pages_dir: '%shopsys.root_dir%/var/errorPages/'
     shopsys.feed_dir: '/web%shopsys.feed_url_prefix%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Icons for domains were not loaded as part of demo data fixtures. This is fixed now
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
