### PR TITLE
[framework] trailing comma in function call is now removed

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureUpdateChecker.php
+++ b/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureUpdateChecker.php
@@ -79,7 +79,7 @@ class ElasticsearchStructureUpdateChecker
             $definition['settings']['index']['creation_date'],
             $definition['settings']['index']['provided_name'],
             $definition['settings']['index']['uuid'],
-            $definition['settings']['index']['version'],
+            $definition['settings']['index']['version']
         );
 
         $this->recursiveArraySorter->recursiveArrayKsort($definition);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In PHP 7.1 and PHP 7.2 trailing comma in function calls is invalid syntax.  Problem was introduced in #1133. This trailing comma is removed now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes