### PR TITLE
[framework] changing elasticsearch data structure is safe even in production environment

### DIFF
--- a/docs/cookbook/extending-product-list.md
+++ b/docs/cookbook/extending-product-list.md
@@ -135,7 +135,43 @@ $structure = \array_merge($structure, [
 ]);
 ```
 
-### 4. Extend `ListedProductViewFactory` so it returns the new required data
+### 4. Extend `ProductElasticsearchConverter` to fill empty fields
+
+There are old documents in the Elasticsearch, usually in the production environment.
+Before you reexport all products from the database, there are documents that don't have the new field `brand_name`.
+So you have to provide default values for the case of reading such old documents.
+
+```php
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Product\Search;
+
+use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchConverter as BaseProductElasticsearchConverter;
+
+class ProductElasticsearchConverter extends BaseProductElasticsearchConverter
+{
+    /**
+     * @param array $product
+     * @return array
+     */
+    public function fillEmptyFields(array $product): array
+    {
+        $result = parent::fillEmptyFields($product);
+        $result['brand_name'] = $product['brand_name'] ?? '';
+
+        return $result;
+    }
+}
+```
+
+You need to register your new class in `services.yml` and add it as an alias for the one from the bundle
+
+```yml
+Shopsys\ShopBundle\Model\Product\Search\ProductElasticsearchConverter: ~
+Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFactory: '@Shopsys\ShopBundle\Model\Product\View\ListedProductViewFactory'
+```
+
+### 5. Extend `ListedProductViewFactory` so it returns the new required data
 
 The class is responsible for creating the view object. We need to ensure that the objects is created with proper brand name. We are able to get the brand name from the product entity, so we just need to overwrite `createFromArray()` and `createFromProduct()` methods.  
 
@@ -158,7 +194,7 @@ class ListedProductViewFactory extends BaseListedProductViewFactory
      * @param \Shopsys\ReadModelBundle\Image\ImageView|null $imageView
      * @param \Shopsys\ReadModelBundle\Product\Action\ProductActionView $productActionView
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
-     * @return \Shopsys\ShopBundle\Model\Product\ViewListedProductView
+     * @return \Shopsys\ShopBundle\Model\Product\View\ListedProductView
      */
     public function createFromArray(array $productArray, ?ImageView $imageView, ProductActionView $productActionView, PricingGroup $pricingGroup): BaseListedProductView
     {
@@ -204,7 +240,7 @@ You need to register your new class as an alias for the one from the bundle in `
 Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFactory: '@Shopsys\ShopBundle\Model\Product\View\ListedProductViewFactory'
 ```
 
-### 5. Modify the frontend template for rendering product lists so it displays the new attribute
+### 6. Modify the frontend template for rendering product lists so it displays the new attribute
 
 All product lists are rendered using `productListMacro.html.twig`. You can modify this macro to display product brand name wherever it is suitable for you.
 

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php
@@ -51,4 +51,41 @@ class ProductElasticsearchConverter
     {
         return array_column($data, 'id');
     }
+
+    /**
+     * @param array $product
+     * @return array
+     */
+    public function fillEmptyFields(array $product): array
+    {
+        $result = $product;
+
+        $result['availability'] = $product['availability'] ?? '';
+        $result['catnum'] = $product['catnum'] ?? '';
+        $result['description'] = $product['description'] ?? '';
+        $result['detail_url'] = $product['detail_url'] ?? '';
+        $result['ean'] = $product['ean'] ?? '';
+        $result['name'] = $product['name'] ?? '';
+        $result['partno'] = $product['partno'] ?? '';
+        $result['short_description'] = $product['short_description'] ?? '';
+
+        $result['categories'] = $product['categories'] ?? [];
+        $result['flags'] = $product['flags'] ?? [];
+        $result['parameters'] = $product['parameters'] ?? [];
+        $result['prices'] = $product['prices'] ?? [];
+        $result['visibility'] = $product['visibility'] ?? [];
+
+        $result['ordering_priority'] = $product['ordering_priority'] ?? 0;
+
+        $result['in_stock'] = $product['in_stock'] ?? false;
+        $result['main_variant'] = $product['main_variant'] ?? false;
+
+        $result['calculated_selling_denied'] = $product['calculated_selling_denied'] ?? true;
+        $result['selling_denied'] = $product['selling_denied'] ?? true;
+
+        // unknown default value, used for filtering only
+        $result['brand'] = $product['brand'] ?? null;
+
+        return $result;
+    }
 }

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -205,11 +205,11 @@ class ProductElasticsearchRepository
      */
     protected function extractHits(array $result): array
     {
-        return array_map(static function ($value) {
+        return array_map(function ($value) {
             $data = $value['_source'];
             $data['id'] = (int)$value['_id'];
 
-            return $data;
+            return $this->productElasticsearchConverter->fillEmptyFields($data);
         }, $result['hits']['hits']);
     }
 

--- a/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
@@ -11,8 +11,8 @@ class ProductElasticsearchConverterTest extends TestCase
     {
         $translator = new ProductElasticsearchConverter();
 
-        $data = $this->createData();
-        $expected = $this->createExpected();
+        $data = $this->createConvertBulkData();
+        $expected = $this->createConvertBulkExpected();
 
         $result = $translator->convertBulk('1', $data);
         $this->assertSame($expected, $result);
@@ -21,7 +21,7 @@ class ProductElasticsearchConverterTest extends TestCase
     /**
      * @return array
      */
-    private function createData(): array
+    private function createConvertBulkData(): array
     {
         return [
             3 => [
@@ -46,7 +46,7 @@ class ProductElasticsearchConverterTest extends TestCase
     /**
      * @return array
      */
-    private function createExpected(): array
+    private function createConvertBulkExpected(): array
     {
         return [
             [
@@ -80,5 +80,42 @@ class ProductElasticsearchConverterTest extends TestCase
                 'short_description' => '47 "LG 47LA790V Luxury TV',
             ],
         ];
+    }
+
+    public function testFillEmptyFields(): void
+    {
+        $product = [
+            'name' => '47" LG 47LA790V (FHD)',
+            'catnum' => '5965879P',
+            'partno' => '47LA790V',
+            'ean' => '8845781245928',
+            'description' => 'At first glance its <strong> beautiful design </strong>',
+            'short_description' => '47 "LG 47LA790V Luxury TV from the South Korean company LG bears 47LA790S',
+        ];
+
+        $expected = [
+            'name' => '47" LG 47LA790V (FHD)',
+            'catnum' => '5965879P',
+            'partno' => '47LA790V',
+            'ean' => '8845781245928',
+            'description' => 'At first glance its <strong> beautiful design </strong>',
+            'short_description' => '47 "LG 47LA790V Luxury TV from the South Korean company LG bears 47LA790S',
+            'availability' => '',
+            'detail_url' => '',
+            'categories' => [],
+            'flags' => [],
+            'parameters' => [],
+            'prices' => [],
+            'visibility' => [],
+            'ordering_priority' => 0,
+            'in_stock' => false,
+            'main_variant' => false,
+            'calculated_selling_denied' => true,
+            'selling_denied' => true,
+            'brand' => null,
+        ];
+
+        $converter = new ProductElasticsearchConverter();
+        $this->assertSame($expected, $converter->fillEmptyFields($product));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When a new elasticsearch field is added, old documents (product data) doesn't contain this field and there is no way elasticsearch can provide this field without reindexing from database. This behavior caused problems when a View object (read model) required a new field but data were not reindexed from database. The solution is to fill empty default values for all fields
|New feature| Yes
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

We wanted Elasticsearch provide ["default values"](https://www.elastic.co/guide/en/elasticsearch/reference/current/null-value.html) for all documents, but these default values have restrictions we are unable to evade or hack. Like unable to use for "text", unable to use with empty array `[]` as a default value. And as the Elasticsearch doesn't provide any other solution (there are hack called [script fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-script-fields.html), but too hacky and too fragile - because they are used in query time), we used a programmer solution.

This programmer solution is not ideal. When a programmer forgets to add a default value to the `Converter` the error may occur. On the other if the programmer will use cookbook step by step, the problem will not occur.