### PR TITLE
[shopsys] commerceguys/intl is now upgraded to ^1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "barryvdh/elfinder-flysystem-driver": "^0.2",
     "bmatzner/jquery-bundle": "^2.2.2",
     "bmatzner/jquery-ui-bundle": "^1.10.3",
-    "commerceguys/intl": "0.7.4",
+    "commerceguys/intl": "^1.0.0",
     "composer/composer": "^1.6.0",
     "craue/formflow-bundle": "^3.0.3",
     "defuse/php-encryption": "^2.2.1",

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -119,6 +119,17 @@ There you can find links to upgrade notes for other versions too.
     - we recommend encapsulating collections similarly in your own custom entities as well
 - update your `OrderDataFixture` and `UserDataFixture` to create new users and orders in last two weeks instead of one ([#1147](https://github.com/shopsys/shopsys/pull/1147))
     - this is done by changing all occurrences of `$this->faker->dateTimeBetween('-1 week', 'now');` by `$this->faker->dateTimeBetween('-2 week', 'now');`
+- upgrade `commerceguys/intl` to `^1.0.0` version ([#1192](https://github.com/shopsys/shopsys/pull/1192))
+    - in your `composer.json`, change the dependency:
+        ```diff
+        - "commerceguys/intl": "0.7.4",
+        + "commerceguys/intl": "^1.0.0",
+        ```
+    - `IntlCurrencyRepository::get()` and `::getAll()` methods no longer accept `$fallbackLocale` as the a parameter
+        - you can set the parameter using the class constructor if necessary
+    - `IntlCurrencyRepository::isSupportedCurrency()` is now strictly type hinted
+    - protected `PriceExtension::getNumberFormatter()` is renamed to `getCurrencyFormatter()` and returns an instance of `CommerceGuys\Intl\Formatter\CurrencyFormatter` now
+        - you need to change your usages accordingly
 
 ### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -39,7 +39,7 @@
         "barryvdh/elfinder-flysystem-driver": "^0.2",
         "bmatzner/jquery-bundle": "^2.2.2",
         "bmatzner/jquery-ui-bundle": "^1.10.3",
-        "commerceguys/intl": "0.7.4",
+        "commerceguys/intl": "^1.0.0",
         "composer/composer": "^1.6.0",
         "craue/formflow-bundle": "^3.0.3",
         "defuse/php-encryption": "^2.2.1",

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -42,8 +42,8 @@ class CurrencyFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        /** @var \CommerceGuys\Intl\Currency\Currency[] $intlCurrencies */
         $intlCurrencies = $this->intlCurrencyRepository->getAll($this->localization->getLocale());
-        /* @var $intlCurrencies \CommerceGuys\Intl\Currency\CurrencyInterface[] */
 
         $possibleCurrencyCodes = [];
         foreach ($intlCurrencies as $intlCurrency) {

--- a/packages/framework/src/Model/Localization/Exception/UndefinedLegacyCurrencyException.php
+++ b/packages/framework/src/Model/Localization/Exception/UndefinedLegacyCurrencyException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Localization\Exception;
+
+use Exception;
+
+class UndefinedLegacyCurrencyException extends Exception implements LocalizationException
+{
+    /**
+     * @param string $currencyCode
+     * @param \Exception|null $previous
+     */
+    public function __construct(string $currencyCode, ?Exception $previous = null)
+    {
+        $message = sprintf('Legacy currency for code %s is not defined', $currencyCode);
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Twig/NumberFormatterExtension.php
+++ b/packages/framework/src/Twig/NumberFormatterExtension.php
@@ -62,10 +62,12 @@ class NumberFormatterExtension extends Twig_Extension
      */
     public function formatNumber($number, $locale = null)
     {
-        $numberFormat = $this->numberFormatRepository->get($this->getLocale($locale));
-        $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::DECIMAL);
-        $numberFormatter->setMinimumFractionDigits(static::MINIMUM_FRACTION_DIGITS);
-        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter = new NumberFormatter($this->numberFormatRepository, [
+            'locale' => $this->getLocale($locale),
+            'style' => 'decimal',
+            'minimum_fraction_digits' => static::MINIMUM_FRACTION_DIGITS,
+            'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
+        ]);
 
         return $numberFormatter->format($number);
     }
@@ -78,10 +80,12 @@ class NumberFormatterExtension extends Twig_Extension
      */
     public function formatDecimalNumber($number, $minimumFractionDigits, $locale = null)
     {
-        $numberFormat = $this->numberFormatRepository->get($this->getLocale($locale));
-        $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::DECIMAL);
-        $numberFormatter->setMinimumFractionDigits($minimumFractionDigits);
-        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter = new NumberFormatter($this->numberFormatRepository, [
+            'locale' => $this->getLocale($locale),
+            'style' => 'decimal',
+            'minimum_fraction_digits' => $minimumFractionDigits,
+            'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
+        ]);
 
         return $numberFormatter->format($number);
     }
@@ -93,12 +97,14 @@ class NumberFormatterExtension extends Twig_Extension
      */
     public function formatPercent($number, $locale = null)
     {
-        $numberFormat = $this->numberFormatRepository->get($this->getLocale($locale));
-        $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::PERCENT);
-        $numberFormatter->setMinimumFractionDigits(static::MINIMUM_FRACTION_DIGITS);
-        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
+        $numberFormatter = new NumberFormatter($this->numberFormatRepository, [
+            'locale' => $this->getLocale($locale),
+            'style' => 'percent',
+            'minimum_fraction_digits' => static::MINIMUM_FRACTION_DIGITS,
+            'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
+        ]);
 
-        return $numberFormatter->format($number);
+        return $numberFormatter->format($number / 100);
     }
 
     /**

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Twig;
 
 use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
-use CommerceGuys\Intl\Formatter\NumberFormatter;
+use CommerceGuys\Intl\Formatter\CurrencyFormatter;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
@@ -235,27 +235,33 @@ class PriceExtension extends Twig_Extension
             $locale = $this->localization->getLocale();
         }
 
-        $numberFormatter = $this->getNumberFormatter($locale);
+        $currencyFormatter = $this->getCurrencyFormatter($locale);
         $intlCurrency = $this->intlCurrencyRepository->get(
             $currency->getCode(),
             $locale
         );
 
-        return $numberFormatter->formatCurrency($price->getAmount(), $intlCurrency);
+        return $currencyFormatter->format($price->getAmount(), $intlCurrency->getCurrencyCode());
     }
 
     /**
      * @param string $locale
-     * @return \CommerceGuys\Intl\Formatter\NumberFormatter
+     * @return \CommerceGuys\Intl\Formatter\CurrencyFormatter
      */
-    protected function getNumberFormatter(string $locale): NumberFormatter
+    protected function getCurrencyFormatter(string $locale): CurrencyFormatter
     {
-        $numberFormat = $this->numberFormatRepository->get($locale);
-        $numberFormatter = new NumberFormatter($numberFormat, NumberFormatter::CURRENCY);
-        $numberFormatter->setMinimumFractionDigits(static::MINIMUM_FRACTION_DIGITS);
-        $numberFormatter->setMaximumFractionDigits(static::MAXIMUM_FRACTION_DIGITS);
+        $currencyFormatter = new CurrencyFormatter(
+            $this->numberFormatRepository,
+            $this->intlCurrencyRepository,
+            [
+                'locale' => $locale,
+                'style' => 'standard',
+                'minimum_fraction_digits' => static::MINIMUM_FRACTION_DIGITS,
+                'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
+            ]
+        );
 
-        return $numberFormatter;
+        return $currencyFormatter;
     }
 
     /**

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -40,7 +40,7 @@
         "arvenil/ninja-mutex": "^0.4.1",
         "bmatzner/jquery-bundle": "^2.2.2",
         "bmatzner/jquery-ui-bundle": "^1.10.3",
-        "commerceguys/intl": "0.7.4",
+        "commerceguys/intl": "^1.0.0",
         "composer/composer": "^1.6.0",
         "craue/formflow-bundle": "^3.0.3",
         "doctrine/annotations": "^1.6.0",


### PR DESCRIPTION
- the library dropped support for a few currencies (BYR, MRO, STD, VEF)
- the legacy currencies are now provided by Shopsys implementation of
IntlCurrencyRepository to keep BC
- the library usages modified in accordance with the changes in the new
version
- see https://github.com/commerceguys/intl/compare/v0.7.4...v1.0.4

| Q             | A
| ------------- | ---
|Description, reason for the PR| https://github.com/shopsys/shopsys/issues/164
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #164  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
