### PR TITLE
[framework] admin: added quick menu for product detail

### DIFF
--- a/packages/framework/src/Resources/scripts/admin/product.js
+++ b/packages/framework/src/Resources/scripts/admin/product.js
@@ -39,7 +39,7 @@
             var $titleClone = $title.clone();
 
             $titleClone.find('.js-validation-errors-list').remove();
-            var $navigationItem = $('<li class="anchor-menu__item"><span class="anchor-menu__item__anchor link cursor-pointer">' + $titleClone.text() + '</span></li>');
+            var $navigationItem = $('<li class="side-menu__item"><span class="side-menu__item__link"><span class="side-menu__item__text">' + $titleClone.text() + '</span></span></li>');
             $productDetailNavigation.append($navigationItem);
 
             $navigationItem.click(function () {

--- a/packages/framework/src/Resources/scripts/admin/sideMenu.js
+++ b/packages/framework/src/Resources/scripts/admin/sideMenu.js
@@ -15,10 +15,16 @@
                 $(this).addClass('open');
             });
 
-            var timeout;
+            if ($sideMenu.hasClass('js-side-menu-close-after-mouseleave')) {
+                self.closeMenusAfterMouseleave(500);
+            }
+        };
+
+        this.closeMenusAfterMouseleave = function (timoutMilliseconds) {
+            var timeoutHandle;
             $sideMenu.hover(
-                function () { clearTimeout(timeout); },
-                function () { timeout = setTimeout(self.closeMenus, 500); }
+                function () { clearTimeout(timeoutHandle); },
+                function () { timeoutHandle = setTimeout(self.closeMenus, timoutMilliseconds); }
             );
         };
 

--- a/packages/framework/src/Resources/scripts/admin/sideMenu.js
+++ b/packages/framework/src/Resources/scripts/admin/sideMenu.js
@@ -4,13 +4,27 @@
     Shopsys.sideMenu = Shopsys.sideMenu || {};
 
     Shopsys.sideMenu.SideMenu = function ($sideMenu) {
+        var self = this;
+        var $items;
+
         this.init = function () {
-            var $items = $sideMenu.filterAllNodes('.js-side-menu-item');
+            $items = $sideMenu.filterAllNodes('.js-side-menu-item');
 
             $items.click(function () {
                 $(this).filterAllNodes('.js-side-menu-submenu').show();
                 $(this).addClass('open');
             });
+
+            var timeout;
+            $sideMenu.hover(
+                function () { clearTimeout(timeout); },
+                function () { timeout = setTimeout(self.closeMenus, 500); }
+            );
+        };
+
+        this.closeMenus = function () {
+            $items.filterAllNodes('.js-side-menu-submenu').hide();
+            $items.removeClass('open');
         };
     };
 

--- a/packages/framework/src/Resources/styles/admin/core/variables.less
+++ b/packages/framework/src/Resources/styles/admin/core/variables.less
@@ -27,6 +27,7 @@
 *******************************************************************/
 @width-web: 1200px;
 @width-panel: 210px;
+@width-panel-small: 50px;
 
 @width-content: 100%;
 

--- a/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
+++ b/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
@@ -23,39 +23,17 @@
 
         & .side-menu__item__text {
             display: inline-block;
-            max-width: 0;
             transform: scaleX(0);
             transform-origin: left;
 
-            transition: max-width @side-menu-transition-duration, transform @side-menu-transition-duration;
-        }
-
-        & .side-menu__item__link, & .side-menu__item__label {
-            padding-right: 0;
-
-            transition: padding-right @side-menu-transition-duration;
-
-            .svg {
-                margin-right: 0;
-
-                transition: margin-right @side-menu-transition-duration;
-            }
+            transition: transform @side-menu-transition-duration;
         }
 
         &:hover {
             width: @width-panel;
 
             & .side-menu__item__text {
-                max-width: calc(~"@{width-panel} - @{width-panel-small} - @{side-menu-item-padding}");
                 transform: scaleX(1);
-            }
-
-            & .side-menu__item__link, & .side-menu__item__label {
-                padding-right: @side-menu-item-padding;
-
-                .svg {
-                    margin-right: @side-menu-item-icon-right-gap;
-                }
             }
         }
     }
@@ -74,10 +52,15 @@
         .side-menu--collapsed:hover ~ & {
             opacity: 0;
         }
+
+        & .side-menu__item {
+            white-space: normal;
+        }
     }
 
     &__item {
         display: block;
+        white-space: nowrap;
 
         border-bottom: @side-menu-item-border;
 
@@ -178,6 +161,7 @@
         .reset-ul();
 
         width: @width-panel;
+        white-space: normal;
 
         .side-menu:not(.side-menu--collapsed) > .side-menu__item--active > & {
             display: block !important;

--- a/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
+++ b/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
@@ -3,9 +3,78 @@
 @side-menu-item-padding: 18px;
 @side-menu-item-icon-size: 16px;
 @side-menu-item-icon-right-gap: 15px;
+@side-menu-menu-border-width: 1px;
+@side-menu-menu-border: @side-menu-menu-border-width solid @bg-web;
+@side-menu-transition-duration: 250ms 150ms;
 
 .side-menu {
     .reset-ul();
+    width: @width-panel;
+
+    transition: width @side-menu-transition-duration;
+
+    &--collapsed {
+        position: relative;
+        overflow: hidden;
+        z-index: 1;
+        width: @width-panel-small;
+
+        border-right: @side-menu-menu-border;
+
+        & .side-menu__item__text {
+            display: inline-block;
+            max-width: 0;
+            transform: scaleX(0);
+            transform-origin: left;
+
+            transition: max-width @side-menu-transition-duration, transform @side-menu-transition-duration;
+        }
+
+        & .side-menu__item__link, & .side-menu__item__label {
+            padding-right: 0;
+
+            transition: padding-right @side-menu-transition-duration;
+
+            .svg {
+                margin-right: 0;
+
+                transition: margin-right @side-menu-transition-duration;
+            }
+        }
+
+        &:hover {
+            width: @width-panel;
+
+            & .side-menu__item__text {
+                max-width: calc(~"@{width-panel} - @{width-panel-small} - @{side-menu-item-padding}");
+                transform: scaleX(1);
+            }
+
+            & .side-menu__item__link, & .side-menu__item__label {
+                padding-right: @side-menu-item-padding;
+
+                .svg {
+                    margin-right: @side-menu-item-icon-right-gap;
+                }
+            }
+        }
+    }
+
+    &--detail {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: calc(~"@{width-panel-small} - @{side-menu-menu-border-width}");
+        width: calc(~"@{width-panel} - @{width-panel-small}");
+        opacity: 1;
+
+        border-left: @side-menu-menu-border;
+        transition: opacity @side-menu-transition-duration;
+
+        .side-menu--collapsed:hover ~ & {
+            opacity: 0;
+        }
+    }
 
     &__item {
         display: block;
@@ -25,6 +94,7 @@
             position: relative;
             padding: 15px 18px;
 
+            background-color: @color-f;
             color: @color-base;
             font-family: @font-medium;
             font-size: 14px;
@@ -49,7 +119,7 @@
             }
 
             .side-menu__item--active & {
-                padding: calc(~"@{side-menu-item-padding} - @{side-menu-item-active-border-width}");
+                padding-left: calc(~"@{side-menu-item-padding} - @{side-menu-item-active-border-width}");
 
                 background-color: @color-grey-light;
                 border-left: @side-menu-item-active-border-width solid @color-blue;
@@ -107,11 +177,13 @@
     &__submenu {
         .reset-ul();
 
-        .side-menu__item--active > & {
+        width: @width-panel;
+
+        .side-menu__item--active:not(.side-menu--collapsed &) > & {
             display: block !important;
         }
 
-        .open:not(.side-menu__item--active) & {
+        .open:not(.side-menu__item--active) &, .side-menu--collapsed .side-menu__item--active > & {
             .animated(0.1s, 0s);
             .fadeIn-scale-topLeft;
         }

--- a/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
+++ b/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
@@ -3,7 +3,7 @@
 @side-menu-item-padding: 18px;
 @side-menu-item-icon-size: 16px;
 @side-menu-item-icon-right-gap: 15px;
-@side-menu-menu-border-width: 1px;
+@side-menu-menu-border-width: 2px;
 @side-menu-menu-border: @side-menu-menu-border-width solid @bg-web;
 @side-menu-transition-duration: 250ms 150ms;
 
@@ -55,6 +55,10 @@
 
         & .side-menu__item {
             white-space: normal;
+
+            &__link {
+                padding: 10px;
+            }
         }
     }
 

--- a/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
+++ b/packages/framework/src/Resources/styles/admin/layout/panel/side-menu.less
@@ -179,7 +179,7 @@
 
         width: @width-panel;
 
-        .side-menu__item--active:not(.side-menu--collapsed &) > & {
+        .side-menu:not(.side-menu--collapsed) > .side-menu__item--active > & {
             display: block !important;
         }
 

--- a/packages/framework/src/Resources/views/Admin/Content/Product/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/detail.html.twig
@@ -23,7 +23,7 @@
 
 {% block menu_panel %}
     <nav class="panel">
-        {{ knp_menu_render('admin_side_menu', {template: 'ShopsysFrameworkBundle:Admin/Menu:side_menu.html.twig', renderNavElement: false, rootListClass: 'side-menu--collapsed'}) }}
+        {{ knp_menu_render('admin_side_menu', {template: 'ShopsysFrameworkBundle:Admin/Menu:side_menu.html.twig', renderNavElement: false, rootListClass: 'side-menu--collapsed js-side-menu-close-after-mouseleave'}) }}
         <ul class="side-menu side-menu--detail js-product-detail-navigation"></ul>
     </nav>
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Product/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/detail.html.twig
@@ -20,3 +20,10 @@
     {{ form_end(form) }}
 
 {% endblock %}
+
+{% block menu_panel %}
+    <nav class="panel">
+        {{ knp_menu_render('admin_side_menu', {template: 'ShopsysFrameworkBundle:Admin/Menu:side_menu.html.twig', renderNavElement: false, rootListClass: 'side-menu--collapsed'}) }}
+        <ul class="side-menu side-menu--detail js-product-detail-navigation"></ul>
+    </nav>
+{% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Menu/side_menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Menu/side_menu.html.twig
@@ -22,14 +22,20 @@
 {% endblock %}
 
 {% block root %}
-    <nav class="panel">
-        {{ block('list') -}}
-    </nav>
+    {% if options.renderNavElement is defined and options.renderNavElement %}
+        <nav class="panel">
+    {% endif %}
+
+    {{ block('list') -}}
+
+    {% if options.renderNavElement is defined and options.renderNavElement %}
+        </nav>
+    {% endif %}
 {% endblock %}
 
 {% block list %}
     {%- if item.level == 0 -%}
-        {%- set classes = ['side-menu', 'js-side-menu'] -%}
+        {%- set classes = ['side-menu', 'js-side-menu', options.rootListClass|default('')] -%}
     {%- else -%}
         {%- set classes = ['side-menu__submenu', 'side-menu__submenu--level' ~ item.level] -%}
         {%- if item.level == 1 -%}
@@ -106,12 +112,13 @@
     {%- if icon is not null -%}
         <i class="svg svg-{{ icon }}"></i>
     {%- endif -%}
-    {%- if options.allow_safe_labels and item.getExtra('safe_label', false) -%}
-        {{ item.label|raw }}
-    {%- else -%}
-        {{ item.label }}
-    {%- endif -%}
-
-    <i class="side-menu__item__arrow side-menu__item__arrow--down"></i>
-
+    {%- set class = item.level == 1 ? 'side-menu__item__text' : 'side-menu__submenu__item__text' -%}
+    <span{{ self.attributes(item.labelAttributes, [class]) }}>
+        {%- if options.allow_safe_labels and item.getExtra('safe_label', false) -%}
+            {{ item.label|raw }}
+        {%- else -%}
+            {{ item.label }}
+        {%- endif -%}
+        <i class="side-menu__item__arrow side-menu__item__arrow--down"></i>
+    </span>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Quick menu for product detail was removed in #1168, now it can be returned back. Side menu navigation is collapsed by default (showing only icons) and will appear on mouse hover. After menu is collapsed again, all submenus are closed.
|New feature| Yes<!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

![image](https://user-images.githubusercontent.com/10008612/60895587-34a2ec80-a265-11e9-8058-6cce8be328ac.png)

