### PR TITLE
[framework] fixed memory leak in cron ProductSearchExportCronModule

### DIFF
--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportCronModule.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportCronModule.php
@@ -4,6 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Search\Export;
 
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 use Symfony\Bridge\Monolog\Logger;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class ProductSearchExportCronModule implements SimpleCronModuleInterface
 {
@@ -29,6 +32,7 @@ class ProductSearchExportCronModule implements SimpleCronModuleInterface
 
     public function run()
     {
-        $this->productSearchExportFacade->exportAll();
+        $symfonyStyle = new SymfonyStyle(new ArrayInput([]), new NullOutput());
+        $this->productSearchExportFacade->exportAllWithOutput($symfonyStyle);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Exporting products to Elasticsearch needed more memory, the more products were present. Now the memory usage is stable and low enough (< 100MB). This solves the same problem as #1122 does but for export with cron module.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes