### PR TITLE
[framework] admin: logo is now a link to dashboard

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Layout/layout.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/layout.html.twig
@@ -17,9 +17,9 @@
             <header class="web__header">
                 <div class="web__header__in">
                     <div class="web__header__logo">
-
-                        <img class="web__header__logo__svg" src="{{ asset('assets/admin/images/logo.svg') }}" alt="Shopsys Framework">
-
+                        <a href="{{ url('admin_default_dashboard') }}">
+                            <img class="web__header__logo__svg" src="{{ asset('assets/admin/images/logo.svg') }}" alt="Shopsys Framework">
+                        </a>
                     </div>
                     {{ render(controller('ShopsysFrameworkBundle:Admin/Menu:menu')) }}
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Webpage logos usually link to the homepage. In admin, it should link to the dashboard.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
