### PR TITLE
[project-base] gke-cluster.tf: remove 'google_container_engine_versions' data source

### DIFF
--- a/project-base/infrastructure/google-cloud/gke-cluster.tf
+++ b/project-base/infrastructure/google-cloud/gke-cluster.tf
@@ -5,7 +5,6 @@ data "google_container_engine_versions" "primary" {
 resource "google_container_cluster" "primary" {
   name               = "primary"
   zone               = "${data.google_container_engine_versions.primary.zone}"
-  min_master_version = "${data.google_container_engine_versions.primary.latest_master_version}"
   node_version       = "${data.google_container_engine_versions.primary.latest_node_version}"
   initial_node_count = 3
 

--- a/project-base/infrastructure/google-cloud/gke-cluster.tf
+++ b/project-base/infrastructure/google-cloud/gke-cluster.tf
@@ -1,11 +1,6 @@
-data "google_container_engine_versions" "primary" {
-  zone = "${var.GOOGLE_CLOUD_REGION}-a"
-}
-
 resource "google_container_cluster" "primary" {
   name               = "primary"
-  zone               = "${data.google_container_engine_versions.primary.zone}"
-  node_version       = "${data.google_container_engine_versions.primary.latest_node_version}"
+  zone               = "${var.GOOGLE_CLOUD_REGION}-a"
   initial_node_count = 3
 
   node_config {

--- a/upgrade/UPGRADE-v7.3.2-dev.md
+++ b/upgrade/UPGRADE-v7.3.2-dev.md
@@ -20,6 +20,15 @@ There you can find links to upgrade notes for other versions too.
                 libjpeg-dev \
                 libfreetype6-dev \
     ```
+- remove `min_master_version` option from `gce-cluster.tf` config to make it set automatically and consistent with [documentation](https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_version) ([#1198](https://github.com/shopsys/shopsys/pull/1198))
+    ```diff
+     resource "google_container_cluster" "primary" {
+       name               = "primary"
+       zone               = "${data.google_container_engine_versions.primary.zone}"
+    -  min_master_version = "${data.google_container_engine_versions.primary.latest_master_version}"
+       node_version       = "${data.google_container_engine_versions.primary.latest_node_version}"
+       initial_node_count = 3
+    ```
 
 ### Application
 - fix the typos in translation messages and demo data ([#1335](https://github.com/shopsys/shopsys/pull/1335))

--- a/upgrade/UPGRADE-v7.3.2-dev.md
+++ b/upgrade/UPGRADE-v7.3.2-dev.md
@@ -20,14 +20,19 @@ There you can find links to upgrade notes for other versions too.
                 libjpeg-dev \
                 libfreetype6-dev \
     ```
-- remove `min_master_version` option from `gce-cluster.tf` config to make it set automatically and consistent with [documentation](https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_version) ([#1198](https://github.com/shopsys/shopsys/pull/1198))
+- remove `google_container_engine_versions` data source from `gce-cluster.tf` config to make it set automatically by GKE ([#1198](https://github.com/shopsys/shopsys/pull/1198))
     ```diff
-     resource "google_container_cluster" "primary" {
-       name               = "primary"
-       zone               = "${data.google_container_engine_versions.primary.zone}"
-    -  min_master_version = "${data.google_container_engine_versions.primary.latest_master_version}"
-       node_version       = "${data.google_container_engine_versions.primary.latest_node_version}"
-       initial_node_count = 3
+    - data "google_container_engine_versions" "primary" {
+    -   zone = "${var.GOOGLE_CLOUD_REGION}-a"
+    - }
+    -
+      resource "google_container_cluster" "primary" {
+        name               = "primary"
+    -   zone               = "${data.google_container_engine_versions.primary.zone}"
+    -   min_master_version = "${data.google_container_engine_versions.primary.latest_master_version}"
+    -   node_version       = "${data.google_container_engine_versions.primary.latest_node_version}"
+    +   zone               = "${var.GOOGLE_CLOUD_REGION}-a"
+        initial_node_count = 3
     ```
 
 ### Application


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Avoids error during `terraform apply`: `google_container_cluster.primary: node_version and min_master_version must be set to equivalent values on create`, for details, see [the docs](https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_version).<br>As we don't really need running on the latest version of Kubernetes, it's safer to omit the whole data source and let GKE resolve version automatically.<br>Also, it makes the config simpler, which is nice.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
