### PR TITLE
[shopsys] updated documentation and upgrade notes for v7.3.0 release

### DIFF
--- a/docs/installation/installation-using-docker-on-production-server.md
+++ b/docs/installation/installation-using-docker-on-production-server.md
@@ -196,6 +196,10 @@ We will also make elasticsearch server listen on 192.168.0.1 subnet by modifying
 ```
 network.host: 0.0.0.0
 ```
+
+To [sort properly in different locales](/docs/introduction/how-to-set-up-domains-and-locales.md#37-sorting-in-different-locales) we need to [install ICU analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html)
+which ensures that alphabetical sorting is correct for every language and its set of rules.
+
 We also need to restart service so the new configuration is applied.
 ```
 service elasticsearch restart

--- a/docs/model/introduction-to-read-model.md
+++ b/docs/model/introduction-to-read-model.md
@@ -22,11 +22,21 @@ The objects in read model are immutable, read-only by definition, and do not hav
 The read model is implemented in a separate [`shopsys/read-model`](https://github.com/shopsys/read-model) package.
 
 Currently, you can choose between two implementations of `ListedProductViewFacadeInterface` that represents read model:
- - `ListedProductViewElasticFacade` *(default)*
-    - data from Elasticsearch
-    - faster than getting products from SQL
-    - to use this implementation you need to use `ProductOnCurrentDomainElasticFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)
- - `ListedProductViewFacade`
-    - data from SQL
-    - slower than Elasticsearch, but can be easily used for complex pricing models that calculate prices by SQL function
-    - to use this implementation you need to use `ProductOnCurrentDomainFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)
+
+## Option 1 - use data from Elasticsearch
+- use `ListedProductViewElasticFacade` *(default)* implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
+    ```yaml
+       Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
+
+       Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade: ~
+    ```
+- faster than getting products from SQL
+- to use this implementation you need to use `ProductOnCurrentDomainElasticFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)
+
+## Option 2 - use data from SQL database
+- use `ListedProductViewFacade` implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
+    ```yaml
+        Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade'
+    ```
+- slower than Elasticsearch, but can be easily used for complex pricing models that calculate prices by SQL function
+- to use this implementation you need to use `ProductOnCurrentDomainFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -176,6 +176,7 @@ There you can find links to upgrade notes for other versions too.
         POSITION_LEFT_SIDEBAR => 'leftSidebar'
         ```
     - remove the use of `is_plugin_data_group` attribute in form extensions or customized twig templates, the functionality was also removed from `form_row` block in `@FrameworkBundle/src/Resources/views/Admin/Form/theme.html.twig`
+- follow instructions in [the separate article](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md) to use Elasticsearch to get data into read model ([#1096](https://github.com/shopsys/shopsys/pull/1096))
 
 ### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))

--- a/docs/upgrade/UPGRADE-v7.0.1.md
+++ b/docs/upgrade/UPGRADE-v7.0.1.md
@@ -20,7 +20,25 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher ([#1148](https://github.com/shopsys/shopsys/pull/1148)) or fix the bundle configuration, see [#1154](https://github.com/shopsys/shopsys/pull/1154)
+    - in `app/config/packages/dev/monolog.yml`:
+        ```diff
+            monolog:
+               handlers:
+                   main:
+                       # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
+                       type: group
+                       members: [ nested ]
+        +              excluded_404s: false
+        ```
+    - in `app/config/packages/test/monolog.yml`:
+        ```diff
+            monolog:
+                handlers:
+                    main:
+                        type: "null"
+        +               excluded_404s: false
+        ```
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [Upgrade from v7.0.0 to v7.0.1]: https://github.com/shopsys/shopsys/compare/v7.0.0...v7.0.1

--- a/docs/upgrade/UPGRADE-v7.1.1.md
+++ b/docs/upgrade/UPGRADE-v7.1.1.md
@@ -20,6 +20,24 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher ([#1148](https://github.com/shopsys/shopsys/pull/1148)) or fix the bundle configuration, see [#1154](https://github.com/shopsys/shopsys/pull/1154)
+    - in `app/config/packages/dev/monolog.yml`:
+        ```diff
+            monolog:
+               handlers:
+                   main:
+                       # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
+                       type: group
+                       members: [ nested ]
+        +              excluded_404s: false
+        ```
+    - in `app/config/packages/test/monolog.yml`:
+        ```diff
+            monolog:
+                handlers:
+                    main:
+                        type: "null"
+        +               excluded_404s: false
+        ```
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-v7.2.2.md
+++ b/docs/upgrade/UPGRADE-v7.2.2.md
@@ -20,6 +20,24 @@ There you can find links to upgrade notes for other versions too.
     - if you have customized e-mailing on your project (eg. by implementing Twig templates for mail content), you should check your code to avoid double escaping (eg. execute `htmlspecialchars_decode($value, ENT_QUOTES)` before passing the variables replacements to you implementation)
 
 ### Configuration
-- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher before [symfony/monolog-bundle#309](https://github.com/symfony/monolog-bundle/issues/309) is resolved ([#1148](https://github.com/shopsys/shopsys/pull/1148))
+- do not update `symfony/monolog-bundle` to the version `3.4.0` and higher ([#1148](https://github.com/shopsys/shopsys/pull/1148)) or fix the bundle configuration, see [#1154](https://github.com/shopsys/shopsys/pull/1154)
+    - in `app/config/packages/dev/monolog.yml`:
+        ```diff
+            monolog:
+               handlers:
+                   main:
+                       # change "fingers_crossed" handler to "group" that works as a passthrough to "nested"
+                       type: group
+                       members: [ nested ]
+        +              excluded_404s: false
+        ```
+    - in `app/config/packages/test/monolog.yml`:
+        ```diff
+            monolog:
+                handlers:
+                    main:
+                        type: "null"
+        +               excluded_404s: false
+        ```
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/phpstan-level-4.md
+++ b/docs/upgrade/phpstan-level-4.md
@@ -106,8 +106,3 @@ To upgrade level of PHPStan you need to:
     +   $form['product_form[displayAvailabilityGroup][unit]']->setValue($unit->getId());
     +   $form['product_form[displayAvailabilityGroup][availability]']->setValue($availability->getId());
     ```
-- fix typo in `OrderDataFixture::getRandomCountryFromFirstDomain()`
-    ```diff
-    -   $randomPaymentReferenceName = $this->faker->randomElement([
-    +   $randomCountryReferenceName = $this->faker->randomElement([
-    ```

--- a/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md
+++ b/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md
@@ -1,0 +1,89 @@
+# Upgrade Instructions for Read Model for Product Lists from Elasticsearch
+
+There is a new layer in Shopsys Framework, called [read model](/docs/model/introduction-to-read-model.md), separating the templates and application model.
+
+This upgrade requires the [Upgrade Instructions for Read Model for Product Lists](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md) to be applied first.
+
+- update Elasticsearch structure in `src/Shopsys/ShopBundle/Resources/definition/product/*.json` like this:
+    ```diff
+    "mappings": {
+      "_doc": {
+        "properties": {
+
+           //...
+
+          "prices": {
+            "type": "nested",
+            "properties": {
+              "pricing_group_id": {
+                "type": "integer"
+              },
+    -         "amount": {
+    +         "price_with_vat": {
+                "type": "float"
+    -         }
+    +         },
+    +         "price_without_vat": {
+    +           "type": "float"
+    +         },
+    +         "vat": {
+    +           "type": "float"
+    +         },
+    +         "price_from": {
+    +           "type": "boolean"
+    +         }
+            }
+          },
+
+          //...
+
+    +     "selling_denied": {
+    +       "type": "boolean"
+    +     },
+    +     "availability": {
+    +       "type": "text"
+    +     },
+    +     "main_variant": {
+    +       "type": "boolean"
+    +     },
+    +     "detail_url": {
+    +       "type": "text"
+    +     },
+    +     "visibility": {
+    +       "type": "nested",
+    +       "properties": {
+    +         "pricing_group_id": {
+    +           "type": "integer"
+    +         },
+    +         "visible": {
+    +           "type": "boolean"
+    +         }
+    +       }
+    +     }
+        }
+    ```
+- fix test `ProductSearchExportRepositoryTest::getExpectedStructureForRepository()` by adding new Elasticsearch fields to it
+    ```diff
+        if ($productSearchExportRepository instanceof ProductSearchExportWithFilterRepository) {
+            $structure = \array_merge($structure, [
+    +           'availability',
+                'brand',
+                'flags',
+                'categories',
+    +           'detail_url',
+                'in_stock',
+                'prices',
+                'parameters',
+                'ordering_priority',
+                'calculated_selling_denied',
+    +           'selling_denied',
+    +           'main_variant',
+    +           'visibility',
+            ]);
+        }
+    ```
+- fix tests in `ListedProductViewFacadeTest` by changing `ListedProductViewFacade` to `ListedProductViewFacadeInterface`
+    ```diff
+    -   $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
+    +   $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
+    ```

--- a/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
+++ b/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
@@ -5,11 +5,7 @@ Besides better logical separation of the application, it is a first step towards
 The read model package is marked as *experimental* at the moment so there is a possibility we might introduce some BC breaking changes there.
 You do not need to perform the upgrade instantly, however, if you do so, you will be better prepared for the upcoming changes.
 
-There are two implementations of read model facades right now as we want to provide you possibilities that suits you the best.
-You can choose between SQL or Elasticsearch implementation, you can learn more in [Front-end product filtering](/docs/model/front-end-product-filtering.md).
-
-<!-- TODO change link to PR to the split merge commit in project-base -->
-To start using the read model, follow the instructions (you can also find inspiration in [#1018](https://github.com/shopsys/shopsys/pull/1018) where the read model was introduced to `project-base`):
+To start using the read model, follow the instructions (you can also find inspiration in [read model for FE product lists (#1018)](https://github.com/shopsys/project-base/commit/68261ea2732e9dbc90cc4c96925ac86daafcde53) where the read model was introduced to `project-base`):
 - add dependency on `shopsys/read-model` to your `composer.json`
 - register the bundle in your `app/AppKernel.php`:
     ```php
@@ -79,6 +75,8 @@ To start using the read model, follow the instructions (you can also find inspir
             - $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForSearch(
             + $paginationResult = $this->listedProductViewFacade->getFilteredPaginatedForSearch(
             ```
+            - _Note: `getFilteredPaginatedForSearch` does not accept null value as $searchText.
+            Be sure you have default value set if you're getting search text from query parameter._
         - in `ProductController::listByBrandAction`:
             ```diff
             - $paginationResult = $this->productOnCurrentDomainFacade->getPaginatedProductsForBrand(
@@ -138,116 +136,21 @@ To start using the read model, follow the instructions (you can also find inspir
     ```
 - edit your `productListMacro.html.twig` so it now works with instances of `ListedProductView` instead of `Product` entities. You can see the complete diff of the template [here](https://github.com/shopsys/shopsys/pull/1018/files#diff-0f5d7197a48555d8902a9391ea330e6f)
     - in the macro, you now need to render product flags by their ids using `renderFlagsByIds` function:
-        - copy `FlagsExtension` class from [here](/project-base/src/Shopsys/ShopBundle/Twig/FlagsExtension.php) and put it to your new `src/Shopsys/ShopBundle/Twig/FlagsExtension.php`
-        - copy `twig.yml` services configuration [here](/project-base/src/Shopsys/ShopBundle/Resources/config/services/twig.yml) and put it in your new `src/Shopsys/ShopBundle/Resources/config/services/twig.yml` so the Twig extension is registered as Symfony service
-        - copy `productFlags.html.twig` template from [here](/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Product/productFlags.html.twig) and put it to your new `src/Shopsys/ShopBundle/Resources/views/Front/Inline/Product/productFlags.html.twig`
+        - copy [`FlagsExtension` class](/project-base/src/Shopsys/ShopBundle/Twig/FlagsExtension.php) and put it to your new `src/Shopsys/ShopBundle/Twig/FlagsExtension.php`
+        - copy [`twig.yml` services configuration](/project-base/src/Shopsys/ShopBundle/Resources/config/services/twig.yml) and put it in your new `src/Shopsys/ShopBundle/Resources/config/services/twig.yml` so the Twig extension is registered as Symfony service
+            - _Note: any previously aliased extensions from `Shopsys\ShopBundle\Twig` namespace have to be removed from `services.yml` file_
+        - copy [`productFlags.html.twig` template](/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Product/productFlags.html.twig) and put it to your new `src/Shopsys/ShopBundle/Resources/views/Front/Inline/Product/productFlags.html.twig`
+        - copy [`productAction.html.twig` template](/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Inline/Cart/productAction.html.twig) and put it to your new `src/Shopsys/ShopBundle/Resources/views/Front/Inline/Cart/productAction.html.twig`
     - in the macro, to render "add to cart" form, use the new `CartController::productActionAction` instead of `addProductFormAction`
         ```diff
-         - {% if not product.isMainVariant %}
-         -    {{ render(controller('ShopsysShopBundle:Front/Cart:addProductForm',{
-         -        product: product
-         -    }
+        - {% if not product.isMainVariant %}
+        -    {{ render(controller('ShopsysShopBundle:Front/Cart:addProductForm',{
+        -        product: product
+        -    }
 
-         -    )) }}
+        -    )) }}
         - {% else %}
         -     <a href="{{ url('front_product_detail', { id: product.id }) }}" class="btn btn--success">{{ 'Choose variant'|trans }}</a>
         - {% endif %}
         + {{ render(controller('ShopsysShopBundle:Front/Cart:productAction', { productActionView: productView.action } )) }}
         ```
-    - update Elasticsearch structure in `src/Shopsys/ShopBundle/Resources/definition/product/*.json` like this:
-        ```diff
-        "mappings": {
-          "_doc": {
-            "properties": {
-
-               //...
-
-              "prices": {
-                "type": "nested",
-                "properties": {
-                  "pricing_group_id": {
-                    "type": "integer"
-                  },
-        -         "amount": {
-        +         "price_with_vat": {
-                    "type": "float"
-        -         }
-        +         },
-        +         "price_without_vat": {
-        +           "type": "float"
-        +         },
-        +         "vat": {
-        +           "type": "float"
-        +         },
-        +         "price_from": {
-        +           "type": "boolean"
-        +         }
-                }
-              },
-
-              //...
-
-        +     "selling_denied": {
-        +       "type": "boolean"
-        +     },
-        +     "availability": {
-        +       "type": "text"
-        +     },
-        +     "main_variant": {
-        +       "type": "boolean"
-        +     },
-        +     "detail_url": {
-        +       "type": "text"
-        +     },
-        +     "visibility": {
-        +       "type": "nested",
-        +       "properties": {
-        +         "pricing_group_id": {
-        +           "type": "integer"
-        +         },
-        +         "visible": {
-        +           "type": "boolean"
-        +         }
-        +       }
-        +     }
-            }
-        ```
-    - fix test `ProductSearchExportRepositoryTest::getExpectedStructureForRepository()` by adding new Elasticsearch fields to it
-        ```diff
-            if ($productSearchExportRepository instanceof ProductSearchExportWithFilterRepository) {
-                $structure = \array_merge($structure, [
-        +           'availability',
-                    'brand',
-                    'flags',
-                    'categories',
-        +           'detail_url',
-                    'in_stock',
-                    'prices',
-                    'parameters',
-                    'ordering_priority',
-                    'calculated_selling_denied',
-        +           'selling_denied',
-        +           'main_variant',
-        +           'visibility',
-                ]);
-            }
-        ```
-    - fix tests in `ListedProductViewFacadeTest` by changing `ListedProductViewFacade` to `ListedProductViewFacadeInterface`
-        ```diff
-        -   $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacade::class);
-        +   $listedProductViewFacade = $this->getContainer()->get(ListedProductViewFacadeInterface::class);
-        ```
-    ### Use SQL read model facade
-    - use `ListedProductViewFacade` implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
-        ```yaml
-            Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade'
-        ```
-    - to use this implementation you need to use `ProductOnCurrentDomainFacade` as well. You can find more about it [Front-end product filtering](/docs/model/front-end-product-filtering.md)
-    ### Use Elasticsearch read model facade
-    - use `ListedProductViewElasticFacade` implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
-        ```yaml
-            Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
-
-            Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade: ~  
-        ```
-     - to use this implementation you need to use `ProductOnCurrentDomainElasticFacade` as well. You can find more about it [Front-end product filtering](/docs/model/front-end-product-filtering.md)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Upgrade notes to upgrade from v7.2.2 to v7.3.0 has been updated with experience from upgrading. Documentation updated along.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

- PHPStan instructions are part of another PR – #1199 as there are more things to consider
- Read Model instructions separated into multiple files because the introduction of the read model is a part of 7.3.0 release, but data from Elasticsearch into Read Model will take place in 8.0.0 release and this was now very confusing during the upgrade
- instructions about excluded_404s (`symfony/monolog-bundle`) moved higher and reworded because of its one of the first things that are needed to do to be able to continue with upgrading
- instruction about `src/Shopsys/ShopBundle/Resources/config/services/twig.yml` file removed because it's introduced in read model article and there is currently the correct version of this file (no need to do this step at all) 
- instruction fix typo in `OrderDataFixture::getRandomCountryFromFirstDomain()` moved from article about PHPStan update to main upgrade as it's not related to the PHPStan checks
- updated production installation guide with information about the need to install ICU Analysis plugin for Elasticsearch
- information about a way how to use SQL or Elastic read model facade moved from upgrade notes into the documentation as it makes more sense there (upgrade files for read model and elastic read model are separated)
- upgrade instructions for `7.0.1`, `7.1.1`, and `7.2.2` about conflicting `symfony/monolog-bundle` are now updated as we know the proper solution so it is not necessary to mark the bundle as conflicting anymore