### PR TITLE
[framework] dashboard statistics display zero trend when there are no data in previous week

### DIFF
--- a/packages/framework/src/Controller/Admin/DefaultController.php
+++ b/packages/framework/src/Controller/Admin/DefaultController.php
@@ -190,7 +190,9 @@ class DefaultController extends AdminBaseController
      */
     protected function getTrendDifference(int $previous, int $current): int
     {
-        if ($previous === 0) {
+        if ($previous === 0 && $current === 0) {
+            $trend = 0;
+        } elseif ($previous === 0) {
             $trend = 100;
         } else {
             $trend = (int)round(($current / $previous - 1) * 100);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Admin dashboard was displaying wrong trend when no data were present for calculation
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
