### PR TITLE
[framework] DailyFeedCronModule: use getter for queue to eliminate side effects in constructor

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -249,6 +249,8 @@ There you can find links to upgrade notes for other versions too.
     - use helper classes `AdminCheckbox` and `AdminRadiobutton` instead of directly manipulating `input[type="checkbox"]` and `input[type="radio"]` elements in your administration acceptance tests
         - when you need to work with a particular input, create an instance of the appropriate class via static method `createByCss()` and use its methods to manipulate the input or assert its values
         - run `php phing tests-acceptance` to see that your acceptance test pass
+- use getter method instead of property inside `DailyFeedCronModule` ([#1207](https://github.com/shopsys/shopsys/pull/1207))
+    - if you extend `DailyFeedCronModule` in your project use the protected method `getFeedExportCreationDataQueue()` instead of `$this->feedExportCreationDataQueue` (which now might be `null`)
 
 ### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))

--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -49,10 +49,6 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
         $this->feedFacade = $feedFacade;
         $this->domain = $domain;
         $this->setting = $setting;
-        $this->feedExportCreationDataQueue = new FeedExportCreationDataQueue(
-            $this->feedFacade->getFeedNames('daily'),
-            $this->domain->getAll()
-        );
     }
 
     /**
@@ -68,7 +64,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
      */
     public function iterate(): bool
     {
-        if ($this->feedExportCreationDataQueue->isEmpty()) {
+        if ($this->getFeedExportCreationDataQueue()->isEmpty()) {
             $this->logger->addDebug('Queue is empty, no feeds to process.');
 
             return false;
@@ -93,7 +89,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
 
             $this->currentFeedExport = null;
 
-            return $this->feedExportCreationDataQueue->next();
+            return $this->getFeedExportCreationDataQueue()->next();
         }
 
         return true;
@@ -105,8 +101,8 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
     public function sleep(): void
     {
         $this->currentFeedExport->sleep();
-        $currentFeedName = $this->feedExportCreationDataQueue->getCurrentFeedName();
-        $currentDomain = $this->feedExportCreationDataQueue->getCurrentDomain();
+        $currentFeedName = $this->getFeedExportCreationDataQueue()->getCurrentFeedName();
+        $currentDomain = $this->getFeedExportCreationDataQueue()->getCurrentDomain();
         $lastSeekId = $this->currentFeedExport !== null ? $this->currentFeedExport->getLastSeekId() : null;
 
         $this->setting->set(Setting::FEED_NAME_TO_CONTINUE, $currentFeedName);
@@ -129,7 +125,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
         $feedNameToContinue = $this->setting->get(Setting::FEED_NAME_TO_CONTINUE);
         $domainIdToContinue = $this->setting->get(Setting::FEED_DOMAIN_ID_TO_CONTINUE);
         if ($feedNameToContinue !== null && $domainIdToContinue !== null) {
-            $queue = $this->feedExportCreationDataQueue;
+            $queue = $this->getFeedExportCreationDataQueue();
             while ($feedNameToContinue !== $queue->getCurrentFeedName() || $domainIdToContinue !== $queue->getCurrentDomain()->getId()) {
                 $queue->next();
             }
@@ -141,8 +137,8 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
 
         $this->logger->addDebug(sprintf(
             'Waking up... Continuing with feed "%s" on "%s", processing from ID %d.',
-            $this->feedExportCreationDataQueue->getCurrentFeedName(),
-            $this->feedExportCreationDataQueue->getCurrentDomain()->getName(),
+            $this->getFeedExportCreationDataQueue()->getCurrentFeedName(),
+            $this->getFeedExportCreationDataQueue()->getCurrentDomain()->getName(),
             $this->currentFeedExport->getLastSeekId()
         ));
     }
@@ -154,9 +150,21 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
     protected function createCurrentFeedExport(?int $lastSeekId = null): FeedExport
     {
         return $this->feedFacade->createFeedExport(
-            $this->feedExportCreationDataQueue->getCurrentFeedName(),
-            $this->feedExportCreationDataQueue->getCurrentDomain(),
+            $this->getFeedExportCreationDataQueue()->getCurrentFeedName(),
+            $this->getFeedExportCreationDataQueue()->getCurrentDomain(),
             $lastSeekId
         );
+    }
+
+    protected function getFeedExportCreationDataQueue(): FeedExportCreationDataQueue
+    {
+        if (null === $this->feedExportCreationDataQueue) {
+            $this->feedExportCreationDataQueue = new FeedExportCreationDataQueue(
+                $this->feedFacade->getFeedNames('daily'),
+                $this->domain->getAll()
+            );
+        }
+
+        return $this->feedExportCreationDataQueue;
     }
 }

--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -30,7 +30,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
     protected $logger;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Feed\FeedExportCreationDataQueue
+     * @var \Shopsys\FrameworkBundle\Model\Feed\FeedExportCreationDataQueue|null
      */
     protected $feedExportCreationDataQueue;
 
@@ -156,9 +156,12 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
         );
     }
 
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Feed\FeedExportCreationDataQueue
+     */
     protected function getFeedExportCreationDataQueue(): FeedExportCreationDataQueue
     {
-        if (null === $this->feedExportCreationDataQueue) {
+        if ($this->feedExportCreationDataQueue === null) {
             $this->feedExportCreationDataQueue = new FeedExportCreationDataQueue(
                 $this->feedFacade->getFeedNames('daily'),
                 $this->domain->getAll()

--- a/packages/framework/src/Resources/config/services/cron.yml
+++ b/packages/framework/src/Resources/config/services/cron.yml
@@ -35,7 +35,6 @@ services:
     Shopsys\FrameworkBundle\Model\Feed\DailyFeedCronModule:
         tags:
             - { name: shopsys.cron, hours: '*/6', minutes: '0' }
-        lazy: true
 
     Shopsys\FrameworkBundle\Model\Feed\HourlyFeedCronModule:
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| I want to run `bin/console` to list all commands even if the database schema is not yet created.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes
|Fixes issues| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
