### PR TITLE
[backend-api] backend-api installer is now updated with latest changes in build.xml file

### DIFF
--- a/packages/backend-api/install/build.xml.patch
+++ b/packages/backend-api/install/build.xml.patch
@@ -1,15 +1,16 @@
-@@ -5,10 +5,16 @@
- 
+@@ -5,10 +5,17 @@
+
      <property name="path.root" value="${project.basedir}"/>
      <property name="path.vendor" value="${path.root}/vendor"/>
 +    <property name="path.backend-api" value="${path.vendor}/shopsys/backend-api"/>
      <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
- 
+
+     <property name="is-multidomain" value="true"/>
+     <property name="phpstan.level" value="1"/>
+
      <import file="${path.framework}/build.xml"/>
 +    <import file="${path.backend-api}/build.xml"/>
- 
-     <property name="is-multidomain" value="true"/>
-
++
 +    <target name="composer-dev" depends="shopsys_framework.composer-dev,backend-api-oauth-keys-generate" description="Installs dependencies for development and generate OAuth keys."/>
 +
 +    <target name="composer-prod" depends="shopsys_framework.composer-prod,backend-api-oauth-keys-generate" description="Installs dependencies for production and generate OAuth keys."/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1199 was updated build.xml file causing backend-api installation to fail. This change is now applied in backend-api installer, so it's now possible to install backend-api again without problem 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
