### PR TITLE
[coding-standards] Yoda style for comparison is now disallowed

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -217,5 +217,8 @@ There you can find links to upgrade notes for other versions too.
 - get rid of not needed deprecations and BC-promise implementation from 7.x version
     - check and get rid of the use of all removed deprecated phing targets from [v7.3.0 release](./UPGRADE-unreleased.md#tools)
 
+## [shopsys/coding-standards]
+- run `php phing standards-fix` to fix code style as we disallow Yoda style for comparison in the Shopsys Framework ([#1209](https://github.com/shopsys/shopsys/pull/1209))
 
 [shopsys/framework]: https://github.com/shopsys/framework
+[shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -218,7 +218,7 @@ There you can find links to upgrade notes for other versions too.
     - check and get rid of the use of all removed deprecated phing targets from [v7.3.0 release](./UPGRADE-unreleased.md#tools)
 
 ## [shopsys/coding-standards]
-- run `php phing standards-fix` to fix code style as we disallow Yoda style for comparison in the Shopsys Framework ([#1209](https://github.com/shopsys/shopsys/pull/1209))
+- run `php phing standards-fix` to fix code style as we now disallow Yoda style for comparison in the Shopsys Framework coding standards ([#1209](https://github.com/shopsys/shopsys/pull/1209))
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -83,6 +83,9 @@ services:
     PhpCsFixer\Fixer\Alias\EregToPregFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
     PhpCsFixer\Fixer\ControlStructure\IncludeFixer: ~
+    PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer:
+        equal: false
+        identical: false
     PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer: ~
     PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer: ~
     PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~

--- a/packages/framework/src/Command/ComposerScriptHandler.php
+++ b/packages/framework/src/Command/ComposerScriptHandler.php
@@ -45,7 +45,7 @@ class ComposerScriptHandler extends ScriptHandler
         $options = self::getOptions($event);
         $consoleDir = self::getConsoleDir($event, $actionName);
 
-        if (null === $consoleDir) {
+        if ($consoleDir === null) {
             $io->writeError(sprintf('Could not locate console dir to %s.', $actionName));
             $io->writeError(sprintf('Commands "%s" not executed.', implode('", "', $commands)));
 

--- a/packages/framework/src/Component/Doctrine/FieldFunction.php
+++ b/packages/framework/src/Component/Doctrine/FieldFunction.php
@@ -31,7 +31,7 @@ class FieldFunction extends FunctionNode
 
         $lexer = $parser->getLexer();
         $this->nextArgumentExpressions = [];
-        while (Lexer::T_COMMA === $lexer->lookahead['type']) {
+        while ($lexer->lookahead['type'] === Lexer::T_COMMA) {
             $parser->match(Lexer::T_COMMA);
             $this->nextArgumentExpressions[] = $parser->ArithmeticPrimary();
         }

--- a/packages/framework/src/Component/Form/ResizeFormListener.php
+++ b/packages/framework/src/Component/Form/ResizeFormListener.php
@@ -200,7 +200,7 @@ class ResizeFormListener implements EventSubscriberInterface
             );
         }
 
-        if (null === $previousViewData) {
+        if ($previousViewData === null) {
             $previousViewData = [];
         }
         if (!is_array($previousViewData) && !($previousViewData instanceof Traversable && $previousViewData instanceof ArrayAccess)) {

--- a/packages/framework/src/Component/Translation/JsFileExtractor.php
+++ b/packages/framework/src/Component/Translation/JsFileExtractor.php
@@ -43,7 +43,7 @@ class JsFileExtractor implements FileVisitorInterface
      */
     public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
     {
-        if ('.js' !== substr($file, -3)) {
+        if (substr($file, -3) !== '.js') {
             return;
         }
 

--- a/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorUserProvider.php
@@ -104,6 +104,6 @@ class AdministratorUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return Administrator::class === $class || is_subclass_of($class, Administrator::class);
+        return $class === Administrator::class || is_subclass_of($class, Administrator::class);
     }
 }

--- a/packages/framework/src/Model/Customer/FrontendUserProvider.php
+++ b/packages/framework/src/Model/Customer/FrontendUserProvider.php
@@ -91,6 +91,6 @@ class FrontendUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return User::class === $class || is_subclass_of($class, User::class);
+        return $class === User::class || is_subclass_of($class, User::class);
     }
 }

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -186,7 +186,7 @@ class ErrorController extends FrontBaseController
         $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
         $content = sprintf("You are trying to access an unknown domain '%s'.", $url);
 
-        if (EnvironmentType::TEST === Environment::getEnvironment(false)) {
+        if (Environment::getEnvironment(false) === EnvironmentType::TEST) {
             $overwriteDomainUrl = $this->getParameter('overwrite_domain_url');
             $content .= sprintf(" TEST environment is active, current domain url is '%s'.", $overwriteDomainUrl);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In SSFW we don't use Yoda style for comparison. This is now automatically checked with coding standards.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
