### PR TITLE
[framework] fixed ordering cutomers by telephone in administration

### DIFF
--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -196,7 +196,7 @@ class CustomerController extends AdminBaseController
 
         $grid->addColumn('name', 'name', t('Full name'), true);
         $grid->addColumn('city', 'city', t('City'), true);
-        $grid->addColumn('telephone', 'telephone', t('Telephone'), true);
+        $grid->addColumn('telephone', 'u.telephone', t('Telephone'), true);
         $grid->addColumn('email', 'u.email', t('E-mail'), true);
         $grid->addColumn('pricingGroup', 'pricingGroup', t('Pricing group'), true);
         $grid->addColumn('orders_count', 'ordersCount', t('Number of orders'), true)->setClassAttribute('text-right');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Customers in administration could not be sorted by the phone. This is fixed now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
