### PR TITLE
[framework] customers grid in admin has now better "Items per page" text

### DIFF
--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -583,6 +583,9 @@ msgstr "Zákazníci"
 msgid "Customers overview"
 msgstr "Přehled zákazníků"
 
+msgid "Customers per page:"
+msgstr "Zákazníků na stránku:"
+
 msgid "Dashboard"
 msgstr "Nástěnka"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -583,6 +583,9 @@ msgstr ""
 msgid "Customers overview"
 msgstr ""
 
+msgid "Customers per page:"
+msgstr ""
+
 msgid "Dashboard"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Content/Customer/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Customer/listGrid.html.twig
@@ -16,6 +16,10 @@
     {{ 'No customers found.'|trans }}
 {% endblock %}
 
+{% block grid_items_per_page_text %}
+    {{ 'Customers per page:'|trans }}
+{% endblock %}
+
 {% block grid_pager_totalcount %}
     {% set entityName = 'customers'|trans %}
     {{ parent() }}

--- a/packages/framework/src/Resources/views/Admin/Grid/Grid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Grid/Grid.html.twig
@@ -293,7 +293,7 @@
     <div class="in-grid-control__item in-grid-control__item--settings">
         <span class="in-grid-control__item__go">
             <span class="in-grid-control__item__go__text">
-                {{ 'Items per page:'|trans }}
+                {% block grid_items_per_page_text %}{{ 'Items per page:'|trans }}{% endblock %}
             </span>
             <div class="in-grid-control__item__go__block">
                 <select onchange="window.location = '{{ gridView.url({'limit' : '--limit--'}, 'page')|escape('js') }}'.replace('--limit--', this.value);" class="input">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Customers grid had "Items per page" texting in grid. That was changed to "Customers per page".
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
