### PR TITLE
[framework] AbstractMigration: removed deprecation annotation

### DIFF
--- a/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
@@ -9,7 +9,6 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
 {
     /**
      * {@inheritDoc}
-     * @deprecated use "sql" method instead
      */
     protected function addSql($sql, array $params = [], array $types = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The method is not in fact deprecated, it's rather forbidden as explained in https://github.com/shopsys/shopsys/issues/1213#issuecomment-512242620
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ~resolves~ *helps with* #1213 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
