### PR TITLE
[framework] admin: display real name of logged user instead of icon

### DIFF
--- a/packages/framework/src/Resources/styles/admin/components/box/dropdown.less
+++ b/packages/framework/src/Resources/styles/admin/components/box/dropdown.less
@@ -57,13 +57,15 @@
             }
         }
 
-        &--account {
-            color: @color-base;
-
+        &--with-icon {
             .svg {
                 margin-right: 5px;
                 vertical-align: bottom;
             }
+        }
+
+        &--grey {
+            color: @color-grey-middle;
         }
     }
 

--- a/packages/framework/src/Resources/styles/admin/components/box/dropdown.less
+++ b/packages/framework/src/Resources/styles/admin/components/box/dropdown.less
@@ -63,10 +63,6 @@
                 vertical-align: bottom;
             }
         }
-
-        &--grey {
-            color: @color-grey-middle;
-        }
     }
 
     &__options {

--- a/packages/framework/src/Resources/styles/admin/components/box/dropdown.less
+++ b/packages/framework/src/Resources/styles/admin/components/box/dropdown.less
@@ -56,6 +56,15 @@
                 }
             }
         }
+
+        &--account {
+            color: @color-base;
+
+            .svg {
+                margin-right: 5px;
+                vertical-align: bottom;
+            }
+        }
     }
 
     &__options {

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -22,7 +22,7 @@
     <li class="js-toggle-menu-item navig__item">
         <div class="box-dropdown">
             <div
-                    class="box-dropdown__select box-dropdown__select--account"
+                    class="box-dropdown__select box-dropdown__select--with-icon box-dropdown__select--grey"
                     title="{{ 'Account'|trans }}"
             >
                 <i class="svg svg-person-man"></i>

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -22,7 +22,7 @@
     <li class="js-toggle-menu-item navig__item">
         <div class="box-dropdown">
             <div
-                    class="box-dropdown__select box-dropdown__select--with-icon box-dropdown__select--grey"
+                    class="box-dropdown__select box-dropdown__select--with-icon"
                     title="{{ 'Account'|trans }}"
             >
                 <i class="svg svg-person-man"></i>

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -22,9 +22,10 @@
     <li class="js-toggle-menu-item navig__item">
         <div class="box-dropdown">
             <div
-                    class="box-dropdown__select"
+                    class="box-dropdown__select box-dropdown__select--account"
                     title="{{ 'Account'|trans }}"
             >
+                <i class="svg svg-person-man"></i>
                 {{ app.user.realName }}
                 <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
                 <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -25,7 +25,7 @@
                     class="box-dropdown__select"
                     title="{{ 'Account'|trans }}"
             >
-                <i class="svg svg-person-man"></i>
+                {{ app.user.realName }}
                 <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
                 <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
             </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Displaying real name of logged administrator in the account menu (upper right corner) makes much more sense than just displaying an icon.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Before:**
![image](https://user-images.githubusercontent.com/10008612/61438952-e1096080-a940-11e9-9ec3-c361805ca763.png)

**After:**
![image](https://user-images.githubusercontent.com/10008612/61438998-f54d5d80-a940-11e9-9160-d91903243884.png)
