### PR TITLE
[framework] admin advanced search: reset button will not close the filter

### DIFF
--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
@@ -55,7 +55,8 @@ class AdvancedSearchProductFacade
      */
     public function createAdvancedSearchForm(Request $request)
     {
-        $rulesData = (array)$request->get(static::RULES_FORM_NAME);
+        $rawRulesData = $request->get(static::RULES_FORM_NAME);
+        $rulesData = is_array($rawRulesData) ? $rawRulesData : [];
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(ProductNameFilter::NAME, $rulesData);
 
         return $this->advancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesFormData);

--- a/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
@@ -58,7 +58,8 @@ class AdvancedSearchOrderFacade
      */
     public function createAdvancedSearchOrderForm(Request $request)
     {
-        $rulesData = (array)$request->get(static::RULES_FORM_NAME);
+        $rawRulesData = $request->get(static::RULES_FORM_NAME);
+        $rulesData = is_array($rawRulesData) ? $rawRulesData : [];
         $rulesFormData = $this->ruleFormViewDataFactory->createFromRequestData(OrderPriceFilterWithVatFilter::NAME, $rulesData);
 
         return $this->orderAdvancedSearchFormFactory->createRulesForm(static::RULES_FORM_NAME, $rulesFormData);

--- a/packages/framework/src/Resources/views/Admin/Content/Order/AdvancedSearch/advancedSearch.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Order/AdvancedSearch/advancedSearch.html.twig
@@ -12,7 +12,7 @@
                 {{ 'Add requirement'|trans }}
             </button>
 
-            <a href="{{ url('admin_order_list') }}" class="in-iconic-link">
+            <a href="{{ url('admin_order_list', { as: [{ subject: 'orderTotalPriceWithVat' }] }) }}" class="in-iconic-link">
                 <i class="svg svg-circle-cross"></i>
                 {{ 'Reset filter'|trans }}
             </a>

--- a/packages/framework/src/Resources/views/Admin/Content/Order/AdvancedSearch/advancedSearch.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Order/AdvancedSearch/advancedSearch.html.twig
@@ -12,7 +12,7 @@
                 {{ 'Add requirement'|trans }}
             </button>
 
-            <a href="{{ url('admin_order_list', { as: [{ subject: 'orderTotalPriceWithVat' }] }) }}" class="in-iconic-link">
+            <a href="{{ url('admin_order_list', { as: true }) }}" class="in-iconic-link">
                 <i class="svg svg-circle-cross"></i>
                 {{ 'Reset filter'|trans }}
             </a>

--- a/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/advancedSearch.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/advancedSearch.html.twig
@@ -12,7 +12,7 @@
                 {{ 'Add requirement'|trans }}
             </button>
 
-            <a href="{{ url('admin_product_list', { as: [{ subject: 'productName' }] }) }}" class="in-iconic-link">
+            <a href="{{ url('admin_product_list', { as: true }) }}" class="in-iconic-link">
                 <i class="svg svg-circle-cross"></i>
                 {{ 'Reset filter'|trans }}
             </a>

--- a/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/advancedSearch.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/advancedSearch.html.twig
@@ -12,7 +12,7 @@
                 {{ 'Add requirement'|trans }}
             </button>
 
-            <a href="{{ url('admin_product_list') }}" class="in-iconic-link">
+            <a href="{{ url('admin_product_list', { as: [{ subject: 'productName' }] }) }}" class="in-iconic-link">
                 <i class="svg svg-circle-cross"></i>
                 {{ 'Reset filter'|trans }}
             </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When advanced search is reset (in order list or product list), it should not be closed. This was achieved in a similar way as the link to product AS from dashboard (in `master`).<br>Then I generalized the solution so it's not dependant on knowing the first filter that should be opened (using `{as: true}` instead of eg. `{as: [{subject: 'productName'}]}` to open empty product advanced search)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
