### PR TITLE
[framework] admin: new order items have "Set prices manually" unchecked by default

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Content/Order/orderItem.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Order/orderItem.html.twig
@@ -20,7 +20,7 @@
         <td>{{ form_widget(orderItemForm.quantity, {attr: { class: 'text-right input--half-width'}}) }}</td>
         <td>{{ form_widget(orderItemForm.unitName, {attr: { class: 'text-right input--half-width'}}) }}</td>
         <td>{{ form_widget(orderItemForm.vatPercent, {attr: { class: 'text-right input--half-width'}}) }}</td>
-        {% set uncheckedByDefault = orderItemForm.vars.data is not null ? orderItemForm.setPricesManually.vars.data : true %}
+        {% set uncheckedByDefault = orderItemForm.vars.data is not null ? orderItemForm.setPricesManually.vars.data : false %}
         <td class="text-center">{{ form_widget(orderItemForm.setPricesManually, {attr: { class: 'js-set-prices-manually'}, checked: uncheckedByDefault}) }}</td>
         <td>{{ self.calculablePriceWidget(orderItemForm.priceWithoutVat, currencySymbol) }}</td>
         <td>{{ self.calculablePriceWidget(orderItemForm.totalPriceWithVat, currencySymbol) }}</td>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was a bug introduced during #1129 when the checkbox was inverted - the default value wasn't inverted (see https://github.com/shopsys/shopsys/pull/1129/commits/801b88ccb9b1a1a3615561668388ee9244b48f30#diff-8f6c88d8ce48d96fe646f558e7e66726).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
