### PR TITLE
[framework] AdministratorFacade: fix duplicate user name check

### DIFF
--- a/packages/framework/src/Model/Administrator/AdministratorFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFacade.php
@@ -100,7 +100,7 @@ class AdministratorFacade
     {
         $administratorByUserName = $this->administratorRepository->findByUserName($username);
         if ($administratorByUserName !== null
-            && $administratorByUserName !== $this
+            && $administratorByUserName !== $administrator
             && $administratorByUserName->getUsername() === $username
         ) {
             throw new \Shopsys\FrameworkBundle\Model\Administrator\Exception\DuplicateUserNameException($administrator->getUsername());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1123 the check was moved from `Administrator::edit()` into `AdministratorFacade::checkUsername()` without changing the `$this` reference.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
