### PR TITLE
[framework] admin: currency is displayed in the order table header instead of behind every input

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -182,6 +182,33 @@ There you can find links to upgrade notes for other versions too.
     -   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
     +   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain/'
     ```
+- update your usage of `OrderItemsType` and Twig macros from `@ShopsysFramework/Admin/Content/Order/orderItem.html.twig` ([#1229](https://github.com/shopsys/shopsys/pull/1229))
+    - if you haven't customized Twig templates for editing orders in admin or used `OrderItemsType` directly you don't have to do anything
+    - change your usage after the macro signatures were modified (unused parameters were removed):
+        ```diff
+        - {% macro orderItem(orderItemForm, orderItemId, orderItemTotalPricesById, currency, productItem) %}
+        + {% macro orderItem(orderItemForm, orderItemId, productItem) %}
+        ```
+        ```diff
+        - {% macro orderTransport(orderTransportForm, order, transportPricesWithVatByTransportId, transportVatPercentsByTransportId) %}
+        + {% macro orderTransport(orderTransportForm, transportPricesWithVatByTransportId, transportVatPercentsByTransportId) %}
+        ```
+        ```diff
+        - {% macro orderPayment(orderPaymentForm, order, paymentPricesWithVatByPaymentId, paymentVatPercentsByPaymentId) %}
+        + {% macro orderPayment(orderPaymentForm, paymentPricesWithVatByPaymentId, paymentVatPercentsByPaymentId) %}
+        ```
+        ```diff
+        - {% macro priceWithVatWidget(priceWithVatForm, currencySymbol) %}
+        + {% macro priceWithVatWidget(priceWithVatForm) %}
+        ```
+        ```diff
+        - {% macro calculablePriceWidget(calculablePriceForm, currencySymbol) %}
+        + {% macro calculablePriceWidget(calculablePriceForm) %}
+        ```
+    - constructor of `OrderItemsType` no longer accepts `OrderItemPriceCalculation` as third parameter
+        - please change your usage accordingly if you extended this class or call the constructor directly
+    - if you have overridden `{% block order_items_widget %}` you don't have the variable `orderItemTotalPricesById` defined in the block anymore
+        - you can use the totals defined in `OrderItemData::$totalPriceWithVat` and `OrderItemData::$totalPriceWithoutVat` instead
 
 ### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))

--- a/packages/framework/src/Form/OrderItemsType.php
+++ b/packages/framework/src/Form/OrderItemsType.php
@@ -5,7 +5,6 @@ namespace Shopsys\FrameworkBundle\Form;
 use Shopsys\FrameworkBundle\Form\Admin\Order\OrderItemFormType;
 use Shopsys\FrameworkBundle\Form\Admin\Order\OrderPaymentFormType;
 use Shopsys\FrameworkBundle\Form\Admin\Order\OrderTransportFormType;
-use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
@@ -30,23 +29,15 @@ class OrderItemsType extends AbstractType
     private $paymentFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation
-     */
-    private $orderItemPriceCalculation;
-
-    /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
-     * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation $orderItemPriceCalculation
      */
     public function __construct(
         TransportFacade $transportFacade,
-        PaymentFacade $paymentFacade,
-        OrderItemPriceCalculation $orderItemPriceCalculation
+        PaymentFacade $paymentFacade
     ) {
         $this->transportFacade = $transportFacade;
         $this->paymentFacade = $paymentFacade;
-        $this->orderItemPriceCalculation = $orderItemPriceCalculation;
     }
 
     /**
@@ -93,7 +84,6 @@ class OrderItemsType extends AbstractType
         $order = $options['order'];
 
         $view->vars['order'] = $order;
-        $view->vars['orderItemTotalPricesById'] = $this->orderItemPriceCalculation->calculateTotalPricesIndexedById($order->getItems());
         $view->vars['transportPricesWithVatByTransportId'] = $this->transportFacade->getTransportPricesWithVatIndexedByTransportId(
             $order->getCurrency()
         );

--- a/packages/framework/src/Resources/views/Admin/Content/Order/orderItem.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Order/orderItem.html.twig
@@ -16,15 +16,15 @@
             {% endif %}
         </td>
         <td>{{ form_widget(orderItemForm.catnum, {attr: { class: 'input--auto-size text-right'}}) }}</td>
-        <td>{{ self.priceWithVatWidget(orderItemForm.priceWithVat, currencySymbol) }}</td>
+        <td>{{ self.priceWithVatWidget(orderItemForm.priceWithVat) }}</td>
         <td>{{ form_widget(orderItemForm.quantity, {attr: { class: 'input--small text-right input--half-width'}}) }}</td>
         <td>{{ form_widget(orderItemForm.unitName, {attr: { class: 'input--small text-right input--half-width'}}) }}</td>
         <td>{{ form_widget(orderItemForm.vatPercent, {attr: { class: 'input--small text-right input--half-width'}}) }}</td>
         {% set uncheckedByDefault = orderItemForm.vars.data is not null ? orderItemForm.setPricesManually.vars.data : false %}
         <td class="text-center">{{ form_widget(orderItemForm.setPricesManually, {attr: { class: 'js-set-prices-manually'}, checked: uncheckedByDefault}) }}</td>
-        <td>{{ self.calculablePriceWidget(orderItemForm.priceWithoutVat, currencySymbol) }}</td>
-        <td>{{ self.calculablePriceWidget(orderItemForm.totalPriceWithVat, currencySymbol) }}</td>
-        <td>{{ self.calculablePriceWidget(orderItemForm.totalPriceWithoutVat, currencySymbol) }}</td>
+        <td>{{ self.calculablePriceWidget(orderItemForm.priceWithoutVat) }}</td>
+        <td>{{ self.calculablePriceWidget(orderItemForm.totalPriceWithVat) }}</td>
+        <td>{{ self.calculablePriceWidget(orderItemForm.totalPriceWithoutVat) }}</td>
         <td class="table-col-5 table-grid__cell--actions text-center">
             <a href="#" class="js-order-item-remove table-action in-icon in-icon--delete"><i class="svg svg-trash"></i></a>
         </td>
@@ -41,12 +41,12 @@
             >
         <td>{{ form_widget(orderTransportForm.transport, {isSimple: true}) }}</td>
         <td class="text-right">-</td>
-        <td>{{ self.priceWithVatWidget(orderTransportForm.priceWithVat, currencySymbol) }}</td>
+        <td>{{ self.priceWithVatWidget(orderTransportForm.priceWithVat) }}</td>
         <td class="text-right">1</td>
         <td></td>
         <td>{{ form_widget(orderTransportForm.vatPercent, {attr: { class: 'input--small text-right input--half-width'}}) }}</td>
         <td class="text-center">{{ form_widget(orderTransportForm.setPricesManually, {attr: { class: 'js-set-prices-manually'}}) }}</td>
-        <td>{{ self.calculablePriceWidget(orderTransportForm.priceWithoutVat, currencySymbol) }}</td>
+        <td>{{ self.calculablePriceWidget(orderTransportForm.priceWithoutVat) }}</td>
         <td colspan="3"></td>
     </tr>
 {% endmacro %}
@@ -61,12 +61,12 @@
     >
         <td>{{ form_widget(orderPaymentForm.payment, {isSimple: true}) }}</td>
         <td class="text-right">-</td>
-        <td>{{ self.priceWithVatWidget(orderPaymentForm.priceWithVat, currencySymbol) }}</td>
+        <td>{{ self.priceWithVatWidget(orderPaymentForm.priceWithVat) }}</td>
         <td class="text-right">1</td>
         <td></td>
         <td>{{ form_widget(orderPaymentForm.vatPercent, {attr: { class: 'input--small text-right input--half-width'}}) }}</td>
         <td class="text-center">{{ form_widget(orderPaymentForm.setPricesManually, {attr: { class: 'js-set-prices-manually'}}) }}</td>
-        <td>{{ self.calculablePriceWidget(orderPaymentForm.priceWithoutVat, currencySymbol) }}</td>
+        <td>{{ self.calculablePriceWidget(orderPaymentForm.priceWithoutVat) }}</td>
         <td colspan="3"></td>
     </tr>
 {% endmacro %}

--- a/packages/framework/src/Resources/views/Admin/Content/Order/orderItem.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Order/orderItem.html.twig
@@ -1,6 +1,5 @@
-{% macro orderItem(orderItemForm, orderItemId, orderItemTotalPricesById, currency, productItem) %}
+{% macro orderItem(orderItemForm, orderItemId, productItem) %}
     {% import _self as self %}
-    {% set currencySymbol = currency is not null ? currencySymbolByCurrencyId(currency.id) : null %}
     <tr class="js-order-item js-order-item-any" id="{{ orderItemForm.vars.id }}" data-index="{{ orderItemId }}">
         <td class="position-relative">
             {% if productItem and productItem.product %}
@@ -31,9 +30,8 @@
     </tr>
 {% endmacro %}
 
-{% macro orderTransport(orderTransportForm, order, transportPricesWithVatByTransportId, transportVatPercentsByTransportId) %}
+{% macro orderTransport(orderTransportForm, transportPricesWithVatByTransportId, transportVatPercentsByTransportId) %}
     {% import _self as self %}
-    {% set currencySymbol = order is not null ? currencySymbolByCurrencyId(order.currency.id) : null %}
     <tr
             class="js-order-transport-row js-order-item-any"
             data-transport-prices-with-vat-by-transport-id="{{ transportPricesWithVatByTransportId|json_encode() }}"
@@ -51,9 +49,8 @@
     </tr>
 {% endmacro %}
 
-{% macro orderPayment(orderPaymentForm, order, paymentPricesWithVatByPaymentId, paymentVatPercentsByPaymentId) %}
+{% macro orderPayment(orderPaymentForm, paymentPricesWithVatByPaymentId, paymentVatPercentsByPaymentId) %}
     {% import _self as self %}
-    {% set currencySymbol = order is not null ? currencySymbolByCurrencyId(order.currency.id) : null %}
     <tr
             class="js-order-payment-row js-order-item-any"
             data-payment-prices-with-vat-by-payment-id="{{ paymentPricesWithVatByPaymentId|json_encode() }}"
@@ -71,7 +68,7 @@
     </tr>
 {% endmacro %}
 
-{% macro priceWithVatWidget(priceWithVatForm, currencySymbol) %}
+{% macro priceWithVatWidget(priceWithVatForm) %}
     {{ form_errors(priceWithVatForm, {errors_attr: {inline: true}}) }}
     <span class="text-no-wrap">
         <span class="display-inline-block text-normal-wrap">
@@ -82,13 +79,13 @@
                     data-placement="right"
             ></i>
         </span>
-        {{ form_widget(priceWithVatForm, {attr: { class: 'input--small text-right input--half-width'}, symbolAfterInput: currencySymbol}) }}
+        {{ form_widget(priceWithVatForm, {attr: { class: 'input--small text-right input--half-width'}}) }}
     </span>
 {% endmacro %}
 
-{% macro calculablePriceWidget(calculablePriceForm, currencySymbol) %}
+{% macro calculablePriceWidget(calculablePriceForm) %}
     {{ form_errors(calculablePriceForm, {errors_attr: {inline: true}}) }}
     <span class="text-no-wrap">
-        {{ form_widget(calculablePriceForm, {attr: { class: 'input--small text-right input--half-width js-calculable-price'}, symbolAfterInput: currencySymbol}) }}
+        {{ form_widget(calculablePriceForm, {attr: { class: 'input--small text-right input--half-width js-calculable-price'}}) }}
     </span>
 {% endmacro %}

--- a/packages/framework/src/Resources/views/Admin/Form/orderItems.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/orderItems.html.twig
@@ -33,21 +33,21 @@
                         </thead>
                         <tbody
                             id="js-order-items"
-                            data-prototype="{{ orderItemMacro.orderItem(form.itemsWithoutTransportAndPayment.vars.prototype, null, [], order.currency, null)|escape }}"
+                            data-prototype="{{ orderItemMacro.orderItem(form.itemsWithoutTransportAndPayment.vars.prototype, null, null)|escape }}"
                             data-order-product-add-url="{{ url('admin_order_addproduct', { orderId: order.id }) }}"
                         >
                             {% for productItem in order.productItems %}
-                                {{ orderItemMacro.orderItem(form.itemsWithoutTransportAndPayment[productItem.id], productItem.id, orderItemTotalPricesById, order.currency, productItem) }}
+                                {{ orderItemMacro.orderItem(form.itemsWithoutTransportAndPayment[productItem.id], productItem.id, productItem) }}
                             {% endfor %}
 
                             {% for orderItemId, orderItemForm in form.itemsWithoutTransportAndPayment %}
                                 {% if not orderItemForm.rendered %}
-                                    {{ orderItemMacro.orderItem(orderItemForm, orderItemId, orderItemTotalPricesById, order.currency, null) }}
+                                    {{ orderItemMacro.orderItem(orderItemForm, orderItemId, null) }}
                                 {% endif %}
                             {% endfor %}
 
-                            {{ orderItemMacro.orderTransport(form.orderTransport, order, transportPricesWithVatByTransportId, transportVatPercentsByTransportId) }}
-                            {{ orderItemMacro.orderPayment(form.orderPayment, order, paymentPricesWithVatByPaymentId, paymentVatPercentsByPaymentId) }}
+                            {{ orderItemMacro.orderTransport(form.orderTransport, transportPricesWithVatByTransportId, transportVatPercentsByTransportId) }}
+                            {{ orderItemMacro.orderPayment(form.orderPayment, paymentPricesWithVatByPaymentId, paymentVatPercentsByPaymentId) }}
                         </tbody>
                         <tfoot>
                             <tr>

--- a/packages/framework/src/Resources/views/Admin/Form/orderItems.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/orderItems.html.twig
@@ -12,7 +12,7 @@
                             <tr>
                                 <th>{{ 'Name'|trans }}</th>
                                 <th>{{ 'Catalogue number'|trans }}</th>
-                                <th class="text-right">{{ 'Unit price including VAT'|trans }}</th>
+                                <th class="text-right">{{ 'Unit price including VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
                                 <th class="text-right">{{ 'Amount'|trans }}</th>
                                 <th class="text-right">{{ 'Unit'|trans }}</th>
                                 <th class="text-right">{{ 'VAT rate (%)'|trans }}</th>
@@ -25,9 +25,9 @@
                                         ></i>
                                     </span>
                                 </th>
-                                <th class="text-right">{{ 'Unit price excluding VAT'|trans }}</th>
-                                <th class="text-right">{{ 'Total including VAT'|trans }}</th>
-                                <th class="text-right">{{ 'Total excluding VAT'|trans }}</th>
+                                <th class="text-right">{{ 'Unit price excluding VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+                                <th class="text-right">{{ 'Total including VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+                                <th class="text-right">{{ 'Total excluding VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
                                 <th></th>
                         </tr>
                         </thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Having all inputs with currencies behind them was a 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes (simplification of Twig macros) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Before:**
![image](https://user-images.githubusercontent.com/10008612/61537592-d1207800-aa37-11e9-872b-3572bb7d0b53.png)

**After:**
![image](https://user-images.githubusercontent.com/10008612/61537614-dc73a380-aa37-11e9-8fc5-3e832a158c9a.png)
