### PR TITLE
[framework] admin: consistency in separators in setting form

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Content/Availability/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Availability/list.html.twig
@@ -3,9 +3,10 @@
 {% block title %}- {{ 'Availabilities overview'|trans }}{% endblock %}
 {% block h1 %}{{ 'Availabilities overview'|trans }}{% endblock %}
 
-
 {% block main_content %}
-    {{ render(controller('ShopsysFrameworkBundle:Admin/Availability:setting')) }}
+    <div class="wrap-divider wrap-divider--bottom">
+        {{ render(controller('ShopsysFrameworkBundle:Admin/Availability:setting')) }}
+    </div>
 
     {{ gridView.render() }}
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/currencySettings.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/currencySettings.html.twig
@@ -1,14 +1,12 @@
 {{ form_start(form) }}
-    <div class="wrap-divider wrap-divider--bottom">
-        <div class="form-group">
-            <div class="form-group__title">
-                {{ 'Settings'|trans }}
-            </div>
-            {{ form_row(form.defaultCurrency, { label: 'Default administration currency'|trans, icon: { title: 'When changing the default currency there is no recalculation of prices'|trans } }) }}
-            {% for item in form.domainDefaultCurrencies %}
-                {{ form_row(item, { label: 'Basic frontend currency %domainName%'|trans({'%domainName%': domainNames[item.vars.name]})}) }}
-            {% endfor %}
+    <div class="form-group">
+        <div class="form-group__title">
+            {{ 'Settings'|trans }}
         </div>
+        {{ form_row(form.defaultCurrency, { label: 'Default administration currency'|trans, icon: { title: 'When changing the default currency there is no recalculation of prices'|trans } }) }}
+        {% for item in form.domainDefaultCurrencies %}
+            {{ form_row(item, { label: 'Basic frontend currency %domainName%'|trans({'%domainName%': domainNames[item.vars.name]})}) }}
+        {% endfor %}
     </div>
 
     {% embed '@ShopsysFramework/Admin/Inline/FixedBar/fixedBar.html.twig' %}

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/list.html.twig
@@ -4,9 +4,9 @@
 {% block h1 %}{{ 'Currencies'|trans }}{% endblock %}
 
 {% block main_content %}
-
-    {{ render(controller('ShopsysFrameworkBundle:Admin/Currency:settings')) }}
+    <div class="wrap-divider wrap-divider--bottom">
+        {{ render(controller('ShopsysFrameworkBundle:Admin/Currency:settings')) }}
+    </div>
 
     {{ gridView.render() }}
-
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Pricing/Groups/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Pricing/Groups/list.html.twig
@@ -6,7 +6,9 @@
 {% block main_content %}
     {{ render(controller('ShopsysFrameworkBundle:Admin/Domain:domainTabs')) }}
 
-    {{ render(controller('ShopsysFrameworkBundle:Admin/PricingGroup:settings')) }}
+    <div class="wrap-divider wrap-divider--bottom">
+        {{ render(controller('ShopsysFrameworkBundle:Admin/PricingGroup:settings')) }}
+    </div>
 
     {{ gridView.render() }}
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Pricing/Groups/pricingGroupSettings.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Pricing/Groups/pricingGroupSettings.html.twig
@@ -1,11 +1,9 @@
 {{ form_start(form) }}
-    <div class="wrap-divider wrap-divider--bottom">
-        <div class="form-group">
-            <div class="form-group__title">
-                {{ 'Settings'|trans }}
-            </div>
-            {{ form_row(form.defaultPricingGroup, { 'label': 'Default pricing group'|trans }) }}
+    <div class="form-group">
+        <div class="form-group__title">
+            {{ 'Settings'|trans }}
         </div>
+        {{ form_row(form.defaultPricingGroup, { 'label': 'Default pricing group'|trans }) }}
     </div>
 
     {% embed '@ShopsysFramework/Admin/Inline/FixedBar/fixedBar.html.twig' %}

--- a/packages/framework/src/Resources/views/Admin/Content/Unit/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Unit/list.html.twig
@@ -4,7 +4,9 @@
 {% block h1 %}{{ 'Units overview'|trans }}{% endblock %}
 
 {% block main_content %}
-    {{ render(controller('ShopsysFrameworkBundle:Admin/Unit:setting')) }}
+    <div class="wrap-divider wrap-divider--bottom">
+        {{ render(controller('ShopsysFrameworkBundle:Admin/Unit:setting')) }}
+    </div>
 
     {{ gridView.render() }}
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Vat/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Vat/list.html.twig
@@ -4,8 +4,9 @@
 {% block h1 %}{{ 'VAT and rounding'|trans }}{% endblock %}
 
 {% block main_content %}
-
-    {{ render(controller('ShopsysFrameworkBundle:Admin/Vat:settings')) }}
+    <div class="wrap-divider wrap-divider--bottom">
+        {{ render(controller('ShopsysFrameworkBundle:Admin/Vat:settings')) }}
+    </div>
 
     {{ gridView.render() }}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were inconsistencies among different pages with inline editation and some setting at the same time (eg. units, currencies, pricing group)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

- all setting form with grid below are contained in `.wrap-divider`
- the `.wrap-divider` div is never defined inside the settings template
    - it is created because of the grid below it, so it should be in the same template as the grid (`list.html.twig`)
- whitespace normalized