### PR TITLE
[framework] DomainController: fix non-existing route

### DIFF
--- a/packages/framework/src/Controller/Admin/DomainController.php
+++ b/packages/framework/src/Controller/Admin/DomainController.php
@@ -82,7 +82,7 @@ class DomainController extends AdminBaseController
 
         $referer = $request->server->get('HTTP_REFERER');
         if ($referer === null) {
-            return $this->redirectToRoute('admin_dashboard');
+            return $this->redirectToRoute('admin_default_dashboard');
         } else {
             return $this->redirect($referer);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The route `admin_dashboard` does not exist, changed to `admin_default_dashboard`. The domain switcher didn't work in some edge cases. Thanks for noticing @PatrikBajer!
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
