### PR TITLE
[framework] LegalConditionsFacade::findArticle() returns null when the Article doesn't exist

### DIFF
--- a/packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
+++ b/packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
@@ -113,7 +113,7 @@ class LegalConditionsFacade
         $articleId = $this->setting->getForDomain($settingKey, $domainId);
 
         if ($articleId !== null) {
-            return $this->articleFacade->getById($articleId);
+            return $this->articleFacade->findById($articleId);
         }
 
         return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Repository and facade methods starting with `find` should return the entity or `null`. Methods starting with `get` should return the entity or throw an exception (see [our Coding Standards that are not checked automatically](https://github.com/shopsys/shopsys/blob/master/docs/contributing/coding-standards.md#standards-that-are-not-checked-automatically)). Here `get` was called from within a `find`, failing with error when the expected `Article` was not found.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
