### PR TITLE
[framework] GridView: remove .form-line__side before rendering

### DIFF
--- a/packages/framework/src/Component/Grid/GridView.php
+++ b/packages/framework/src/Component/Grid/GridView.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Twig\TemplateWrapper;
 use Twig_Environment;
 
 class GridView
@@ -106,15 +107,31 @@ class GridView
                 $templateParameters = $this->twig->mergeGlobals($parameters);
 
                 if ($echo) {
-                    echo $template->renderBlock($name, $templateParameters);
+                    echo $this->renderBlockFromTemplate($template, $name, $templateParameters);
                     return;
                 } else {
-                    return $template->renderBlock($name, $templateParameters);
+                    return $this->renderBlockFromTemplate($template, $name, $templateParameters);
                 }
             }
         }
 
         throw new \InvalidArgumentException(sprintf('Block "%s" doesn\'t exist in grid template "%s".', $name, $this->theme));
+    }
+
+    /**
+     * @param \Twig\TemplateWrapper $template
+     * @param string $name
+     * @param array $parameters
+     * @return string
+     */
+    protected function renderBlockFromTemplate(TemplateWrapper $template, string $name, array $parameters): string
+    {
+        $renderedBlock = $template->renderBlock($name, $parameters);
+
+        // CSS class "form-line__side" breaks forms in inline edit
+        $renderedBlockWithoutForbiddenClass = str_replace('form-line__side', '', $renderedBlock);
+
+        return $renderedBlockWithoutForbiddenClass;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Forms that appear in inline edit are not displayed well. Problems arise from the fact that `form_row` is used to render the form and the `theme.html.twig` assumes it will be rendered in a standard full-page form. Fixing it properly would require an overhaul of the form rendering and of the current theme. I thought of adding a one more boolean parameter (`display_side`) that could toggle rendering of the `.form-line__side` but that would be probably also pretty brittle. Furthermore, the `.form-line > .form-line__side > .form-line__item` HTML structure that appears in our forms is a violation of BEM.<br>In the end, I propose a kind of a dirty solution - just filtering all occurrences of `form-line__side` from the rendered output in `GridView`. There will probably never be a case where this element would make sense in a grid and the string is unambiguous so I'm not afraid it will ever remove something it shouldn't.<br>I cannot honestly say I'm proud of this solution, but in the end, I think it will get the job done.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Before:**
![image](https://user-images.githubusercontent.com/10008612/61549395-2ff1eb80-aa50-11e9-9dfb-006f2aa7dc14.png)


**After:**
![image](https://user-images.githubusercontent.com/10008612/61549377-26688380-aa50-11e9-9870-4836506c3f43.png)

