### PR TITLE
[framework] CountryFormType: removal of duplicate constraint

### DIFF
--- a/packages/framework/src/Form/Admin/Country/CountryFormType.php
+++ b/packages/framework/src/Form/Admin/Country/CountryFormType.php
@@ -57,9 +57,6 @@ class CountryFormType extends AbstractType
         $builder
             ->add('names', LocalizedType::class, [
                 'required' => true,
-                'main_constraints' => [
-                    new Constraints\NotBlank(['message' => 'Please enter country name']),
-                ],
                 'entry_options' => [
                     'required' => true,
                     'constraints' => [


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10008612/61550475-d0e1a600-aa52-11e9-8041-62f868cc3478.png)

| Q             | A
| ------------- | ---
|Description, reason for the PR| The `NotBlank` constraint is duplicate for the default language (defined both in `main_constraints` and `entry_options.constraints`).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
