### PR TITLE
[shopsys] added Phing target that checks whether there is a project-base/vendor dir

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -206,7 +206,7 @@
         <if>
             <available file="${path.root}/vendor" type="dir" property="dir.Exists"/>
             <then>
-                <echo level="error" message="Composer dependencies are installed in ${path.root} directory which would break the monorepo autoloader. Remove ${path.root}/vendor before re-running the command,"/>
+                <echo level="error" message="Composer dependencies are installed in ${path.root} directory which would break the monorepo autoloader. Remove ${path.root}/vendor before re-running the command."/>
                 <fail message="Directory ${path.root}/vendor found."/>
             </then>
         </if>

--- a/build.xml
+++ b/build.xml
@@ -10,6 +10,8 @@
 
     <import file="${path.framework}/build.xml"/>
 
+    <target name="checks-internal" depends="shopsys_framework.checks-internal,project-base-vendor-check" description="Runs all internal checks for monorepo, eg. availability of services or validity of configuration f." hidden="true"/>
+
     <target name="clean" description="Cleans up directories with cache and scripts which are generated on demand.">
         <phingcall target="shopsys_framework.clean"/>
         <delete failonerror="false" includeemptydirs="true" quiet="true">
@@ -198,6 +200,16 @@
             <arg value="--level=${phpstan.level}"/>
             <arg value="-vvv"/>
         </exec>
+    </target>
+
+    <target name="project-base-vendor-check" description="Check there exists no vendor directory in project-base/ as that would break the autoloader" hidden="true">
+        <if>
+            <available file="${path.root}/vendor" type="dir" property="dir.Exists"/>
+            <then>
+                <echo level="error" message="Composer dependencies are installed in ${path.root} directory which would break the monorepo autoloader. Remove ${path.root}/vendor before re-running the command,"/>
+                <fail message="Directory ${path.root}/vendor found."/>
+            </then>
+        </if>
     </target>
 
     <target name="standards" depends="shopsys_framework.standards,phing-config-check" description="Checks coding standards."/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When someone installs Composer dependencies in project-base directory in monorepo, the autoloader will start failing on duplicate class definitions. I added a check that will fail in such a case and tell the dev what to do. Only added to monorepo build.xml as it is only relevant there.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
