### PR TITLE
[framework] DailyFeedCronModule set as lazy to avoid side-effects in constructor

### DIFF
--- a/packages/framework/src/Resources/config/services/cron.yml
+++ b/packages/framework/src/Resources/config/services/cron.yml
@@ -35,6 +35,7 @@ services:
     Shopsys\FrameworkBundle\Model\Feed\DailyFeedCronModule:
         tags:
             - { name: shopsys.cron, hours: '*/6', minutes: '0' }
+        lazy: true
 
     Shopsys\FrameworkBundle\Model\Feed\HourlyFeedCronModule:
         tags:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| As explained in https://github.com/shopsys/shopsys/pull/1207#issuecomment-511810553, this allows to list all commands using `bin/console` without connection to DB in a BC manner.<br>Thanks @hason for bringing this issue up in #1207!
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
