### PR TITLE
[coding-standards] explicit visibility is part of the general coding-standards

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -294,7 +294,9 @@ There you can find links to upgrade notes for other versions too.
     - check and get rid of the use of all removed deprecated phing targets from [v7.3.0 release](./UPGRADE-unreleased.md#tools)
 
 ## [shopsys/coding-standards]
-- run `php phing standards-fix` to fix code style as we now disallow Yoda style for comparison in the Shopsys Framework coding standards ([#1209](https://github.com/shopsys/shopsys/pull/1209))
+- run `php phing standards-fix` to fix code style as we check more rules in the Shopsys Framework coding standards:
+    - Yoda style for comparison is disallowed ([#1209](https://github.com/shopsys/shopsys/pull/1209))
+    - visibility must be explicitly set for constants, methods and properties ([#1254](https://github.com/shopsys/shopsys/pull/1254))
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -12,7 +12,3 @@ parameters:
         Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff:
             - '*/src/Shopsys/ShopBundle/*'
             - '*/tests/ShopBundle/*'
-
-        PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-            - '*/src/Shopsys/ShopBundle/*'
-            - '*/tests/ShopBundle/*'

--- a/packages/backend-api/easy-coding-standard.yml
+++ b/packages/backend-api/easy-coding-standard.yml
@@ -11,12 +11,6 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\BackendApiBundle
 
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -158,6 +158,11 @@ services:
         elements:
         - 'property'
         - 'method'
+    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
+        elements:
+        - 'const'
+        - 'method'
+        - 'property'
 
     # Code Metrics
     ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff:

--- a/packages/form-types-bundle/easy-coding-standard.yml
+++ b/packages/form-types-bundle/easy-coding-standard.yml
@@ -2,12 +2,6 @@ imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -14,14 +14,6 @@ services:
                     - Shopsys\FrameworkBundle\Controller
                     - Shopsys\FrameworkBundle\Twig
 
-    SlevomatCodingStandard\Sniffs\Classes\ClassConstantVisibilitySniff: ~
-
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/google-cloud-bundle/easy-coding-standard.yml
+++ b/packages/google-cloud-bundle/easy-coding-standard.yml
@@ -2,12 +2,6 @@ imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/http-smoke-testing/easy-coding-standard.yml
+++ b/packages/http-smoke-testing/easy-coding-standard.yml
@@ -2,12 +2,6 @@ imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/migrations/easy-coding-standard.yml
+++ b/packages/migrations/easy-coding-standard.yml
@@ -2,12 +2,6 @@ imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/plugin-interface/easy-coding-standard.yml
+++ b/packages/plugin-interface/easy-coding-standard.yml
@@ -2,12 +2,6 @@ imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/product-feed-google/easy-coding-standard.yml
+++ b/packages/product-feed-google/easy-coding-standard.yml
@@ -11,12 +11,6 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\GoogleBundle\Model
 
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/product-feed-heureka-delivery/easy-coding-standard.yml
+++ b/packages/product-feed-heureka-delivery/easy-coding-standard.yml
@@ -11,12 +11,6 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\HeurekaDeliveryBundle\Model
 
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -11,12 +11,6 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\HeurekaBundle\Model
 
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/product-feed-zbozi/easy-coding-standard.yml
+++ b/packages/product-feed-zbozi/easy-coding-standard.yml
@@ -11,12 +11,6 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ProductFeed\ZboziBundle\Model
 
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:

--- a/packages/read-model/easy-coding-standard.yml
+++ b/packages/read-model/easy-coding-standard.yml
@@ -11,12 +11,6 @@ services:
                   - analyzed_namespaces:
                         - Shopsys\ReadModelBundle
 
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-        elements:
-            - 'property'
-            - 'method'
-            - 'const'
-
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
 parameters:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Having explicit visibility for `const`, `method`, and `property` is now required even in project repositories. It leads to clearer code which will help our users and there is an automatic fixer for it, so it will not require extra work from them.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Not sure, actually <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
