### PR TITLE
[coding-standards] added return type hint spacing fixer

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -299,6 +299,7 @@ There you can find links to upgrade notes for other versions too.
 - run `php phing standards-fix` to fix code style as we check more rules in the Shopsys Framework coding standards:
     - Yoda style for comparison is disallowed ([#1209](https://github.com/shopsys/shopsys/pull/1209))
     - visibility must be explicitly set for constants, methods and properties ([#1254](https://github.com/shopsys/shopsys/pull/1254))
+    - there must be no space before and one space after a colon when hinting a return value ([#1255](https://github.com/shopsys/shopsys/pull/1255))
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -19,6 +19,7 @@ services:
     # Slevomat Checkers
     SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff: ~
     SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff: ~
+    SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff: ~
 
     # Shopsys Checkers
     Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer: ~

--- a/packages/framework/src/Migrations/Version20180724060204.php
+++ b/packages/framework/src/Migrations/Version20180724060204.php
@@ -10,7 +10,7 @@ class Version20180724060204 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->sql('
             CREATE OR REPLACE FUNCTION set_product_catnum_tsvector() RETURNS trigger AS $$
@@ -156,7 +156,7 @@ class Version20180724060204 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
     }
 }

--- a/packages/framework/src/Migrations/Version20181114102106.php
+++ b/packages/framework/src/Migrations/Version20181114102106.php
@@ -12,7 +12,7 @@ final class Version20181114102106 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE pricing_groups ALTER COLUMN coefficient DROP NOT NULL');
     }
@@ -20,7 +20,7 @@ final class Version20181114102106 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
     }
 }

--- a/packages/framework/src/Migrations/Version20181114120915.php
+++ b/packages/framework/src/Migrations/Version20181114120915.php
@@ -12,7 +12,7 @@ final class Version20181114120915 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE products ALTER COLUMN price_calculation_type DROP NOT NULL');
     }
@@ -20,7 +20,7 @@ final class Version20181114120915 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
     }
 }

--- a/packages/framework/src/Migrations/Version20181114134959.php
+++ b/packages/framework/src/Migrations/Version20181114134959.php
@@ -12,7 +12,7 @@ final class Version20181114134959 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         /**
          * for each price group find matching currency on price group domain
@@ -41,7 +41,7 @@ final class Version20181114134959 extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
     }
 }

--- a/packages/framework/src/Twig/FormThemeExtension.php
+++ b/packages/framework/src/Twig/FormThemeExtension.php
@@ -52,7 +52,7 @@ class FormThemeExtension extends \Twig_Extension
      * @param string $controller
      * @return bool
      */
-    protected function isAdmin(string $controller) : bool
+    protected function isAdmin(string $controller): bool
     {
         return strpos($controller, 'Shopsys\FrameworkBundle\Controller\Admin') === 0 ||
             strpos($controller, 'Shopsys\ShopBundle\Controller\Admin') === 0;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeEditTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeEditTest.php
@@ -42,7 +42,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
      */
     private $orderItemDataFactory;
 
-    protected function setUp():void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Having a standard way of writing return type hints (`): int`) makes work easier for developers. It leads to more consistent code which will help our users and there is an automatic fixer for it, so it will not require extra work from them.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Not sure, actually <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
