### PR TITLE
[project-base] enforce strict typing in project repository

### DIFF
--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -300,6 +300,31 @@ There you can find links to upgrade notes for other versions too.
     - Yoda style for comparison is disallowed ([#1209](https://github.com/shopsys/shopsys/pull/1209))
     - visibility must be explicitly set for constants, methods and properties ([#1254](https://github.com/shopsys/shopsys/pull/1254))
     - there must be no space before and one space after a colon when hinting a return value ([#1255](https://github.com/shopsys/shopsys/pull/1255))
+- we recommend using `DeclareStrictTypesFixer` to enforce [strict typing](https://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict) in your project ([#1256](https://github.com/shopsys/shopsys/pull/1256))
+    - add the fixer to your `easy-coding-standard.yml` config:
+        ```diff
+          imports:
+              - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+
+        + services:
+        +     PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~
+        +
+          parameters:
+        ```
+    - run the fixer via `php phing standards-fix` to add `declare(strict_type=1);` to your PHP files
+    - run static analysis check and tests via `php phing phpstan tests tests-acceptance`
+    - fix the types that are passed in your code
+        - in `shopsys/project-base` there was only one problem in `\Tests\ShopBundle\Functional\PersonalData\PersonalDataExportXmlTest`:
+            ```diff
+            - $order = new Order($orderData, 1523596513, 'hash');
+            + $order = new Order($orderData, '1523596513', 'hash');
+            ```
+        - you can always ignore the rule for a particular file by adding a `skip` parameter to your `easy-coding-standard.yml` config:
+            ```diff
+              skip:
+            +     PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer:
+            +         - 'src/Shopsys/ShopBundle/Model/MyCustomModel/ClassWithoutStrictTypes.php'
+            ```
 
 [shopsys/framework]: https://github.com/shopsys/framework
 [shopsys/coding-standards]: https://github.com/shopsys/coding-standards

--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -5,6 +5,10 @@ imports:
 
 parameters:
     skip:
+        PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer:
+            - 'packages/*'
+            - 'utils/*'
+
         Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff:
             - '*/src/Shopsys/ShopBundle/*'
             - '*/tests/ShopBundle/*'

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
+services:
+    PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~
+
 parameters:
     exclude_files:
         - '*/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php'

--- a/project-base/src/Shopsys/ShopBundle/Command/PerformanceDataCommand.php
+++ b/project-base/src/Shopsys/ShopBundle/Command/PerformanceDataCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Command;
 
 use Shopsys\ShopBundle\DataFixtures\Performance\CategoryDataFixture;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/AdvertController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/AdvertController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Advert\AdvertFacade;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ArticleController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ArticleController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Article\Article;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/BestsellingProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/BestsellingProductController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/BrandController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/BrandController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/BreadcrumbController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/BreadcrumbController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbResolver;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CartController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CartController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CategoryController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CategoryController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ContactFormController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ContactFormController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerPasswordController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerPasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Exception;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/FlashMessageController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/FlashMessageController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 class FlashMessageController extends FrontBaseController

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/FrontBaseController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/FrontBaseController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/HeurekaController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/HeurekaController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/HomepageController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/HomepageController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ImageController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ImageController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use League\Flysystem\FilesystemInterface;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/LoginController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/LoginController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Security\Authenticator;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/NewsletterController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/NewsletterController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/PersonalDataController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/PromoCodeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Order\PromoCode\CurrentPromoCodeFacade;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/RegistrationController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/RegistrationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/RobotsController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/RobotsController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ScriptController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ScriptController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/SearchController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/SearchController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Test/ErrorHandlerController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Test/ErrorHandlerController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Test;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Test/ExpectedTestException.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Test/ExpectedTestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Controller\Test;
 
 use Exception;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AdministratorDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AdministratorDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AdvertDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AdvertDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ArticleDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ArticleDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AvailabilityDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/AvailabilityDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BestsellingProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BestsellingProductDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BrandDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BrandDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CountryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CountryDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/FlagDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/FlagDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/NewsletterSubscriberDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/NewsletterSubscriberDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderStatusDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderStatusDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PaymentDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PersonalDataAccessRequestDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PricingGroupDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PricingGroupDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductAccessoriesDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductAccessoriesDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureCsvReader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureCsvReader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Shopsys\FrameworkBundle\Component\Csv\CsvReader;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use DateTime;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductParametersFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductParametersFixtureLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PromoCodeDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PromoCodeDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ScriptDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ScriptDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueShopInfoDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueShopInfoDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SliderItemDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SliderItemDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TopCategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TopCategoryDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TopProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TopProductDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TransportDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TransportDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UnitDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UnitDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixtureLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Shopsys\FrameworkBundle\Component\Csv\CsvReader;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/VatDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/VatDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Demo;
 
 use Doctrine\Common\Persistence\ObjectManager;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Performance;
 
 use Faker\Generator as Faker;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/Exception/PerformanceException.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/Exception/PerformanceException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Performance\Exception;
 
 use Throwable;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/Exception/UndefinedArrayKeyException.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/Exception/UndefinedArrayKeyException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Performance\Exception;
 
 use Exception;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Performance;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Performance;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures\Performance;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/ProductDataFixtureReferenceInjector.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/ProductDataFixtureReferenceInjector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DataFixtures;
 
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;

--- a/project-base/src/Shopsys/ShopBundle/DependencyInjection/Configuration.php
+++ b/project-base/src/Shopsys/ShopBundle/DependencyInjection/Configuration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;

--- a/project-base/src/Shopsys/ShopBundle/DependencyInjection/ShopsysShopExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/DependencyInjection/ShopsysShopExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\DependencyInjection;
 
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/AdministratorFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/AdministratorFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Administrator\AdministratorFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/ArticleFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/ArticleFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Article\ArticleFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/BrandFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/BrandFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Product\Brand\BrandFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/CategoryFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/CategoryFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Category\CategoryFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/OrderFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/OrderFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Order\OrderFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/PaymentFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/PaymentFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Payment\PaymentFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/ProductFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Product\ProductFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/TransportFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/TransportFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Transport\TransportFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Admin/UserFormTypeExtension.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Admin/UserFormTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Admin;
 
 use Shopsys\FrameworkBundle\Form\Admin\Customer\UserFormType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Cart/AddProductFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Cart/AddProductFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Cart;
 
 use Symfony\Component\Form\AbstractType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Cart/CartFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Cart/CartFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Cart;
 
 use Shopsys\FrameworkBundle\Form\Constraints\ConstraintValue;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Contact/ContactFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Contact/ContactFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Contact;
 
 use Shopsys\FrameworkBundle\Component\Form\TimedFormTypeExtension;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/BillingAddressFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/BillingAddressFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Customer;
 
 use Shopsys\FrameworkBundle\Form\ValidationGroup;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/CustomerFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/CustomerFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Customer;
 
 use Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/DeliveryAddressFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/DeliveryAddressFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Customer;
 
 use Shopsys\FrameworkBundle\Form\ValidationGroup;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/Password/NewPasswordFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/Password/NewPasswordFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Customer\Password;
 
 use Symfony\Component\Form\AbstractType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/Password/ResetPasswordFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/Password/ResetPasswordFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Customer\Password;
 
 use Shopsys\FrameworkBundle\Form\Constraints\Email;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/UserFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Customer/UserFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Customer;
 
 use Shopsys\FrameworkBundle\Form\Constraints\FieldsAreNotIdentical;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Login/LoginFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Login/LoginFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Login;
 
 use Shopsys\FrameworkBundle\Form\Constraints\Email;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Newsletter/SubscriptionFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Newsletter/SubscriptionFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Newsletter;
 
 use Shopsys\FrameworkBundle\Component\Form\TimedFormTypeExtension;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/DomainAwareOrderFlowFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/DomainAwareOrderFlowFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Order;
 
 use Craue\FormFlowBundle\Storage\DataManager;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/OrderFlow.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/OrderFlow.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Order;
 
 use Craue\FormFlowBundle\Form\FormFlow;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Order;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/TransportAndPaymentFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/TransportAndPaymentFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Order;
 
 use Shopsys\FrameworkBundle\Form\SingleCheckboxChoiceType;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/PersonalData/PersonalDataFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/PersonalData/PersonalDataFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\PersonalData;
 
 use Shopsys\FrameworkBundle\Component\Form\TimedFormTypeExtension;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ParameterFilterFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ParameterFilterFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Product;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Registration/RegistrationFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Form\Front\Registration;
 
 use Shopsys\FrameworkBundle\Component\Form\TimedFormTypeExtension;

--- a/project-base/src/Shopsys/ShopBundle/Migrations/Version20180425143739.php
+++ b/project-base/src/Shopsys/ShopBundle/Migrations/Version20180425143739.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/project-base/src/Shopsys/ShopBundle/Model/Administrator/Administrator.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Administrator/Administrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Administrator;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Administrator/AdministratorData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Administrator/AdministratorData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Administrator;
 
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorData as BaseAdministratorData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Administrator/AdministratorDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Administrator/AdministratorDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Administrator;
 
 use Shopsys\FrameworkBundle\Model\Administrator\Administrator as BaseAdministrator;

--- a/project-base/src/Shopsys/ShopBundle/Model/Article/Article.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Article/Article.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Article;
 
 use DateTime;

--- a/project-base/src/Shopsys/ShopBundle/Model/Article/ArticleData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Article/ArticleData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Article;
 
 use DateTime;

--- a/project-base/src/Shopsys/ShopBundle/Model/Article/ArticleDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Article/ArticleDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Article;
 
 use DateTime;

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/Category.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/Category.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Category;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/CategoryData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/CategoryData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/CategoryDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/CategoryDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\Category as BaseCategory;

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/CurrentCategoryResolver.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/CurrentCategoryResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;

--- a/project-base/src/Shopsys/ShopBundle/Model/Customer/User.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Customer/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Customer;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Customer/UserData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Customer/UserData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Customer;
 
 use Shopsys\FrameworkBundle\Model\Customer\UserData as BaseUserData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Customer/UserDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Customer/UserDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Customer;
 
 use Shopsys\FrameworkBundle\Model\Customer\User as BaseUser;

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/FrontOrderData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/FrontOrderData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\FrontOrderData as BaseFrontOrderData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Order.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Order.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Order;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/OrderData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/OrderData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\OrderData as BaseOrderData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/OrderDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/OrderDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\Order as BaseOrder;

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/OrderDataMapper.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/OrderDataMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\FrontOrderData as BaseFrontOrderData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/Payment.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/Payment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Payment;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/Brand.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/Brand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Product\Brand;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/BrandData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/BrandData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Product\Brand;
 
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandData as BaseBrandData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/BrandDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/BrandDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Product\Brand;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Product;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/ProductData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/ProductData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/ProductDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/ProductDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;

--- a/project-base/src/Shopsys/ShopBundle/Model/Transport/Transport.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Transport/Transport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Transport;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/src/Shopsys/ShopBundle/Model/Transport/TransportData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Transport/TransportData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Transport;
 
 use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;

--- a/project-base/src/Shopsys/ShopBundle/Model/Transport/TransportDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Transport/TransportDataFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle\Model\Transport;
 
 use Shopsys\FrameworkBundle\Model\Transport\Transport as BaseTransport;

--- a/project-base/src/Shopsys/ShopBundle/ShopsysShopBundle.php
+++ b/project-base/src/Shopsys/ShopBundle/ShopsysShopBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\ShopBundle;
 
 use Shopsys\FrameworkBundle\Component\Translation\Translator;

--- a/project-base/tests/ReadModelBundle/Functional/Product/Listed/ListedProductViewFacadeTest.php
+++ b/project-base/tests/ReadModelBundle/Functional/Product/Listed/ListedProductViewFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ReadModelBundle\Functional\Product\Listed;
 
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/AdminProductAdvancedSearchCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/AdminProductAdvancedSearchCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\LoginPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/AdministratorLoginCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/AdministratorLoginCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\LoginPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/CartCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/CartCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Front\CartBoxPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerLoginCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerLoginCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Front\LayoutPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerRegistrationCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/CustomerRegistrationCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Front\LayoutPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Test\Codeception\AcceptanceTester;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/LoginAsCustomerCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/LoginAsCustomerCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\LoginPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/OrderCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/OrderCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/AbstractPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/AbstractPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject;
 
 use Tests\ShopBundle\Test\Codeception\AcceptanceTester;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/EntityEditPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/EntityEditPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/InlineEditPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/InlineEditPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/LoginPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/LoginPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/ProductAdvancedSearchPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Admin/ProductAdvancedSearchPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartBoxPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartBoxPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/FloatingWindowPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/FloatingWindowPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/HomepagePage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/HomepagePage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/LayoutPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/LayoutPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/LoginPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/LoginPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/OrderPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/OrderPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductDetailPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductDetailPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductFilterPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductFilterPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductListComponent.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductListComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductListPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/ProductListPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Facebook\WebDriver\WebDriverBy;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/RegistrationPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/RegistrationPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance\PageObject\Front;
 
 use Shopsys\FrameworkBundle\Component\Form\TimedFormTypeExtension;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PaymentImageUploadCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PaymentImageUploadCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\EntityEditPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/ProductFilterCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/ProductFilterCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Front\ProductFilterPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/ProductImageUploadCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/ProductImageUploadCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\EntityEditPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PromoCodeInlineEditCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PromoCodeInlineEditCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\InlineEditPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/TransportImageUploadCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/TransportImageUploadCest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
 use Tests\ShopBundle\Acceptance\acceptance\PageObject\Admin\EntityEditPage;

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/_bootstrap.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/_bootstrap.php
@@ -1,3 +1,5 @@
 <?php
 
+declare(strict_types=1);
+
 // Here you can initialize variables that will be available to your tests

--- a/project-base/tests/ShopBundle/Functional/Component/Doctrine/GroupedScalarHydratorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Doctrine/GroupedScalarHydratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Doctrine;
 
 use Doctrine\ORM\Query\Expr\Join;

--- a/project-base/tests/ShopBundle/Functional/Component/Doctrine/SortableNullsWalkerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Doctrine/SortableNullsWalkerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Doctrine;
 
 use Doctrine\ORM\Query;

--- a/project-base/tests/ShopBundle/Functional/Component/Domain/Config/DomainsConfigLoaderTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Domain/Config/DomainsConfigLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Domain\Config;
 
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;

--- a/project-base/tests/ShopBundle/Functional/Component/Domain/Multidomain/MultidomainEntityDataCreatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Domain/Multidomain/MultidomainEntityDataCreatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Domain\Multidomain;
 
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlQuoter;

--- a/project-base/tests/ShopBundle/Functional/Component/FlashMessage/BagTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/FlashMessage/BagTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\FlashMessage;
 
 use Tests\ShopBundle\Test\FunctionalTestCase;

--- a/project-base/tests/ShopBundle/Functional/Component/Grid/Ordering/GridOrderingFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Grid/Ordering/GridOrderingFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Grid\Ordering;
 
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\GridOrderingFacade;

--- a/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderDataSourceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderDataSourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Grid;
 
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;

--- a/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderWithRowManipulatorDataSourceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Grid/QueryBuilderWithRowManipulatorDataSourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Grid;
 
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderWithRowManipulatorDataSource;

--- a/project-base/tests/ShopBundle/Functional/Component/HttpFoundation/FragmentHandlerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/HttpFoundation/FragmentHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\Request;

--- a/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Constant/JsConstantCompilerPassTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Constant/JsConstantCompilerPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Javascript\Compiler\Constant;
 
 use Shopsys\FrameworkBundle\Component\Javascript\Compiler\Constant\JsConstantCompilerPass;

--- a/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Constant/Testclass.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Constant/Testclass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Javascript\Compiler\Constant;
 
 class Testclass

--- a/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Translator/JsTranslatorCompilerPassTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Javascript/Compiler/Translator/JsTranslatorCompilerPassTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Component\Javascript\Compiler\Translator;
 
 use Shopsys\FrameworkBundle\Component\Javascript\Compiler\JsCompiler;

--- a/project-base/tests/ShopBundle/Functional/Controller/ContainerControllerResolverTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/ContainerControllerResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;

--- a/project-base/tests/ShopBundle/Functional/Controller/HomepageControllerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/HomepageControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Controller;
 
 use Tests\ShopBundle\Test\FunctionalTestCase;

--- a/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Controller;
 
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension;
 
 use Doctrine\Common\Annotations\AnnotationReader;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryManyToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryManyToManyBidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryOneToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryOneToManyBidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryOneToOneBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/CategoryOneToOneBidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedCategory.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedCategory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedOrderItem.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedOrderItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductManyToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductManyToManyBidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductOneToManyBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductOneToManyBidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductOneToOneBidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ProductOneToOneBidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/UnidirectionalEntity.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/UnidirectionalEntity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension\Model;
 
 use Doctrine\ORM\Mapping as ORM;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/OverwritableEntityNameResolver.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/OverwritableEntityNameResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension;
 
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/OverwritableLoadORMMetadataSubscriber.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/OverwritableLoadORMMetadataSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\EntityExtension;
 
 use Joschi127\DoctrineEntityOverrideBundle\EventListener\LoadORMMetadataSubscriber;

--- a/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOperatorTranslationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOperatorTranslationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Form\Admin\AdvancedSearch;
 
 use Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOperatorTranslation;

--- a/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOrderFilterTranslationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchOrderFilterTranslationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Form\Admin\AdvancedSearch;
 
 use Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOrderFilterTranslation;

--- a/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchProductFilterTranslationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/Admin/AdvancedSearch/AdvancedSearchProductFilterTranslationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Form\Admin\AdvancedSearch;
 
 use Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchProductFilterTranslation;

--- a/project-base/tests/ShopBundle/Functional/Form/YesNoTypeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Form/YesNoTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Form;
 
 use Shopsys\FormTypesBundle\YesNoType;

--- a/project-base/tests/ShopBundle/Functional/Model/Administrator/AdministratorRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Administrator/AdministratorRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Administrator;
 
 use DateTime;

--- a/project-base/tests/ShopBundle/Functional/Model/Administrator/Security/AdministratorFrontSecurityFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Administrator/Security/AdministratorFrontSecurityFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Administrator\Security;
 
 use Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Article/ArticleTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Article/ArticleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Article;
 
 use DateTime;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
 use DateTime;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartMigrationFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartMigrationFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
 use Doctrine\ORM\EntityManager;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Cart;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Cart\Watcher;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryDomainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Newsletter\NewsletterRepository;
 
 use Doctrine\ORM\Internal\Hydration\IterableResult;

--- a/project-base/tests/ShopBundle/Functional/Model/Newsletter/Subscriber/NewsletterSubscriberPersistenceTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Newsletter/Subscriber/NewsletterSubscriberPersistenceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Newsletter\Subscriber;
 
 use DateTimeImmutable;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Mail/OrderMailTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Mail/OrderMailTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Order\Mail;
 
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Order;
 
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderNumberSequenceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderNumberSequenceRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\OrderNumberSequenceRepository;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderTransportAndPaymentTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderTransportAndPaymentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Order\Preview;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Status/OrderStatusFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Status/OrderStatusFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Order\Status;
 
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation;

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentDomainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Payment/PaymentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Pricing\Group;
 
 use Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Pricing;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;

--- a/project-base/tests/ShopBundle/Functional/Model/Pricing/ProductInputPriceRecalculatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Pricing/ProductInputPriceRecalculatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Pricing;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Availability;
 
 use Doctrine\ORM\EntityManager;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityRecalculatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/ProductAvailabilityRecalculatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Availability;
 
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Brand/BrandDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Brand/BrandDomainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Brand;
 
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Filter;
 
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Filter;
 
 use Shopsys\FrameworkBundle\Model\Product\Filter\FlagFilterChoiceRepository;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Filter;
 
 use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductDomainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use ReflectionClass;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainSqlFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainSqlFacadeCountDataTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product;
 
 use DateTime;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/FilterQueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Search;
 
 use Elasticsearch\Client;

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportWithFilterRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportWithFilterRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Product\Search;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Model/Security/AuthenticatorTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Security/AuthenticatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Security;
 
 use Shopsys\FrameworkBundle\Model\Customer\CustomerFacade;

--- a/project-base/tests/ShopBundle/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Transport;
 
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;

--- a/project-base/tests/ShopBundle/Functional/Model/Transport/TransportDomainTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Transport/TransportDomainTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Transport;
 
 use Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Unit/UnitFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Unit/UnitFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Unit;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/Model/Vat/VatFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Vat/VatFacadeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Model\Vat;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface;

--- a/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
+++ b/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
@@ -164,7 +164,7 @@ class PersonalDataExportXmlTest extends TransactionFunctionalTestCase
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->country = $country;
 
-        $order = new Order($orderData, 1523596513, 'hash');
+        $order = new Order($orderData, '1523596513', 'hash');
 
         return $order;
     }

--- a/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
+++ b/project-base/tests/ShopBundle/Functional/PersonalData/PersonalDataExportXmlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\PersonalData;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Functional/Twig/DateTimeFormatterExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/DateTimeFormatterExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Twig;
 
 use DateTime;

--- a/project-base/tests/ShopBundle/Functional/Twig/NumberFormatterExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/NumberFormatterExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Twig;
 
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;

--- a/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Twig;
 
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;

--- a/project-base/tests/ShopBundle/Functional/Twig/TwigEnvironmentTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/TwigEnvironmentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Functional\Twig;
 
 use Tests\ShopBundle\Test\FunctionalTestCase;

--- a/project-base/tests/ShopBundle/Performance/Feed/AllFeedsTest.php
+++ b/project-base/tests/ShopBundle/Performance/Feed/AllFeedsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Feed;
 
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;

--- a/project-base/tests/ShopBundle/Performance/Feed/PerformanceResultsCsvExporter.php
+++ b/project-base/tests/ShopBundle/Performance/Feed/PerformanceResultsCsvExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Feed;
 
 use Tests\ShopBundle\Performance\JmeterCsvReporter;

--- a/project-base/tests/ShopBundle/Performance/Feed/PerformanceTestSample.php
+++ b/project-base/tests/ShopBundle/Performance/Feed/PerformanceTestSample.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Feed;
 
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;

--- a/project-base/tests/ShopBundle/Performance/JmeterCsvReporter.php
+++ b/project-base/tests/ShopBundle/Performance/JmeterCsvReporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance;
 
 class JmeterCsvReporter

--- a/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
+++ b/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 use Doctrine\DBAL\Logging\LoggerChain;

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceResultsCsvExporter.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceResultsCsvExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 use Tests\ShopBundle\Performance\JmeterCsvReporter;

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSample.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSample.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 class PerformanceTestSample

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQualifier.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQualifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 class PerformanceTestSampleQualifier

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQueryCounter.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSampleQueryCounter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 use Doctrine\DBAL\Logging\SQLLogger;

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSamplesAggregator.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSamplesAggregator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 class PerformanceTestSamplesAggregator

--- a/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSummaryPrinter.php
+++ b/project-base/tests/ShopBundle/Performance/Page/PerformanceTestSummaryPrinter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Performance\Page;
 
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/project-base/tests/ShopBundle/Smoke/AllFeedsTest.php
+++ b/project-base/tests/ShopBundle/Smoke/AllFeedsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Smoke;
 
 use League\Flysystem\FilesystemInterface;

--- a/project-base/tests/ShopBundle/Smoke/Http/HttpSmokeTest.php
+++ b/project-base/tests/ShopBundle/Smoke/Http/HttpSmokeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Smoke\Http;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Smoke\Http;
 
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;

--- a/project-base/tests/ShopBundle/Smoke/LocalizationListenerTest.php
+++ b/project-base/tests/ShopBundle/Smoke/LocalizationListenerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Smoke;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Smoke/NewProductTest.php
+++ b/project-base/tests/ShopBundle/Smoke/NewProductTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Smoke;
 
 use Shopsys\FrameworkBundle\Form\Admin\Product\ProductFormType;

--- a/project-base/tests/ShopBundle/Test/Codeception/AcceptanceTester.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/AcceptanceTester.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception;
 
 use Codeception\Actor;

--- a/project-base/tests/ShopBundle/Test/Codeception/Exception/DeprecatedMethodException.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Exception/DeprecatedMethodException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Exception;
 
 use Exception;

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Helper;
 
 use Codeception\Module;

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/DatabaseHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/DatabaseHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Helper;
 
 use Codeception\Module;

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/DomainHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/DomainHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Helper;
 
 use Codeception\Module;

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/SymfonyHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/SymfonyHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Helper;
 
 use AppKernel;

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/WebDriverHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/WebDriverHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Helper;
 
 use Codeception\Module;

--- a/project-base/tests/ShopBundle/Test/Codeception/Module/Db.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Module/Db.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Module;
 
 use Codeception\Module\Db as BaseDb;

--- a/project-base/tests/ShopBundle/Test/Codeception/Module/StrictWebDriver.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Module/StrictWebDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test\Codeception\Module;
 
 use Codeception\Module\WebDriver;

--- a/project-base/tests/ShopBundle/Test/Codeception/_bootstrap.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/_bootstrap.php
@@ -1,3 +1,5 @@
 <?php
 
+declare(strict_types=1);
+
 // This is global bootstrap for autoloading

--- a/project-base/tests/ShopBundle/Test/FunctionalTestCase.php
+++ b/project-base/tests/ShopBundle/Test/FunctionalTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test;
 
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;

--- a/project-base/tests/ShopBundle/Test/TransactionFunctionalTestCase.php
+++ b/project-base/tests/ShopBundle/Test/TransactionFunctionalTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Test;
 
 abstract class TransactionFunctionalTestCase extends FunctionalTestCase

--- a/project-base/tests/ShopBundle/Unit/Form/Front/Newsletter/SubscriptionFormTypeTest.php
+++ b/project-base/tests/ShopBundle/Unit/Form/Front/Newsletter/SubscriptionFormTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Unit\Form\Front\Newsletter;
 
 use PHPUnit\Framework\Assert;

--- a/project-base/tests/ShopBundle/Unit/Form/Front/Order/PersonalInfoFormTypeTest.php
+++ b/project-base/tests/ShopBundle/Unit/Form/Front/Order/PersonalInfoFormTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Unit\Form\Front\Order;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;

--- a/project-base/tests/ShopBundle/Unit/Model/Article/ArticleTest.php
+++ b/project-base/tests/ShopBundle/Unit/Model/Article/ArticleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Unit\Model\Article;
 
 use DateTime;

--- a/project-base/tests/ShopBundle/Unit/Tests/Performance/Page/PerformanceResultsCsvExporterTest.php
+++ b/project-base/tests/ShopBundle/Unit/Tests/Performance/Page/PerformanceResultsCsvExporterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\ShopBundle\Unit\Tests\Performance\Page;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Using [strict typing](https://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.strict) is a general best-practice in PHP. It leads to safer code which will help our users and there is an automatic fixer for it, so it will not require extra work from them, except for fixing wrongly typed variables. <br>Even though there is a lot to do for complete switch to strict typing across the whole codebase (there are few problems in our typing and the change could have serious backward-compatibility implications), we can recommend our users to enable the `declare(strict_types=1)` in their project.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
