### PR TITLE
[migrations] add missing strict types and return types into template

### DIFF
--- a/packages/migrations/src/Resources/views/Migration/migration.php.twig
+++ b/packages/migrations/src/Resources/views/Migration/migration.php.twig
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 
 use Doctrine\DBAL\Schema\Schema;
@@ -10,7 +12,7 @@ class {{ migrationClassName }} extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
 {% for sqlCommand in sqlCommands %}
         $this->sql('{{ sqlCommand|raw }}');
@@ -20,7 +22,7 @@ class {{ migrationClassName }} extends AbstractMigration
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Add missing strict types and return types for migration template.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

I know it's a little stupid thing because it doesn't bring anything new, but I like the order in the code 😄 If you don't want this PR, I will accept it.