### PR TITLE
[shopsys] improve upgrade notes for 8.0.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -28,12 +28,14 @@ Follow the instructions in the [monorepo upgrade guide](docs/contributing/upgrad
     * run `docker-compose up -d --force-recreate --remove-orphans` to start the application again
     * update the `shopsys/*` dependencies in `composer.json` to version you are upgrading to
         eg. `"shopsys/framework": "v7.0.0"`
-    * run `composer update`
+    * follow upgrade notes in the *Composer dependencies* section (related with `composer.json`)
+    * run `composer update shopsys/* --with-dependencies`
     * follow all upgrade notes you have not done yet
     * run `php phing clean`
     * run `php phing db-migrations` to run the database migrations
     * test your app locally
     * commit your changes
+    * run `composer update` to update the rest of your dependencies, test the app again and commit `composer.lock`
 * if any of the database migrations does not suit you, there is an option to skip it, see [our Database Migrations docs](https://github.com/shopsys/shopsys/blob/master/docs/introduction/database-migrations.md#reordering-and-skipping-migrations)
 * even we care a lot about these instructions, it is possible we miss something. In case something doesn't work after the upgrade, you'll find more information in the [CHANGELOG](CHANGELOG.md)
 

--- a/docs/contributing/guidelines-for-writing-upgrade.md
+++ b/docs/contributing/guidelines-for-writing-upgrade.md
@@ -58,10 +58,12 @@ Because this section is expected to be the longest, it should contain a finer di
 * Infrastructure
     * related with Docker, Kubernetes, Environment settings, ...
     * instruction to rebuild images must occur only once
+* Composer dependencies
+    * related to composer.json
 * Configuration
     * related with parameters, YML configuration files, ...
 * Tools
-    * Phing, Composer, PHPStan, PHPUnit, ...
+    * Phing, PHPStan, PHPUnit, ...
 * Database migrations
     * Which database changes were introduced in a current version
 * Security

--- a/docs/model/front-end-product-filtering.md
+++ b/docs/model/front-end-product-filtering.md
@@ -32,16 +32,11 @@ Behavior of the filter is defined in the class `Shopsys\FrameworkBundle\Model\Pr
 Each filtering method calls appropriate method in `Shopsys\FrameworkBundle\Model\Product\ProductRepository` class in which a Doctrine `QueryBuilder` object is composed to get proper products with SQL query.
 
 ## Choose an Implementation
-You can choose which one of them will be used by setting one of the previously mentioned implementations in your `services.yml` file:
-```yaml
-    # Elasticsearch filtering
-    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade'
-```
-or
-```yaml
-    # SQL filtering
-    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
-```
+You can choose which one of them will be used by setting one of the previously mentioned implementations in your `services.yml` and `services_test.yml` configuration.
+
+Along with filtering the choice will influence the data source for the product lists for increased performance.
+
+You can find more about this topic in [Introduction to Read Model](/docs/model/introduction-to-read-model.md#read-model-options).
 
 *Note: If you need to extend the implementation of your choice, it is possible you will need to adjust abstract test `Tests\ShopBundle\Functional\Model\Product\ProductOnCurrentDomainFacadeTest` accordingly.
 In that case is perfectly fine to skip or delete implementation of this test for the one you don't use.*

--- a/docs/model/introduction-to-read-model.md
+++ b/docs/model/introduction-to-read-model.md
@@ -21,21 +21,25 @@ The objects in read model are immutable, read-only by definition, and do not hav
 
 The read model is implemented in a separate [`shopsys/read-model`](https://github.com/shopsys/read-model) package.
 
+## Read model options
+
 Currently, you can choose between two implementations of `ListedProductViewFacadeInterface` that represents read model:
 
-## Option 1 - use data from Elasticsearch
+### Option 1 - use data from Elasticsearch
 - use `ListedProductViewElasticFacade` *(default)* implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
     ```yaml
-       Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
+        Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade'
 
-       Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade: ~
+        Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
     ```
 - faster than getting products from SQL
 - to use this implementation you need to use `ProductOnCurrentDomainElasticFacade` as well. You can find more about this topic in [Front-end product filtering](/docs/model/front-end-product-filtering.md)
 
-## Option 2 - use data from SQL database
+### Option 2 - use data from SQL database
 - use `ListedProductViewFacade` implementation of `ListedProductViewFacadeInterface` in `services.yml` and `services_test.yml`
     ```yaml
+        Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface: '@Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade'
+
         Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade'
     ```
 - slower than Elasticsearch, but can be easily used for complex pricing models that calculate prices by SQL function

--- a/docs/upgrade/UPGRADE-v7.3.0.md
+++ b/docs/upgrade/UPGRADE-v7.3.0.md
@@ -211,6 +211,47 @@ There you can find links to upgrade notes for other versions too.
     - stop using the deprecated method `\Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation::getVatCoefficientByPercent()`, use `PriceCalculation::getVatAmountByPriceWithVat()` for VAT calculation instead
     - if you want to customize the VAT calculation (eg. revert it back to the previous implementation), extend the service `@Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation` and override the method `getVatAmountByPriceWithVat()`
     - if you created new tests regarding the price calculation they might start failing after the upgrade - in such case, please see the new VAT calculation and change the tests expectations accordingly
+    - if you have overridden the `orderItems.html.twig` template, you'll need to update it to accommodate the two new columns:
+        ```diff
+          <thead>
+              <tr>
+                  <th>{{ 'Name'|trans }}</th>
+                  <th>{{ 'Catalogue number'|trans }}</th>
+                  <th class="text-right">{{ 'Unit price including VAT'|trans }}</th>
+                  <th class="text-right">{{ 'Amount'|trans }}</th>
+                  <th class="text-right">{{ 'Unit'|trans }}</th>
+                  <th class="text-right">{{ 'VAT rate (%)'|trans }}</th>
+        +         <th class="text-center">
+        +             <span class="display-inline-block" style="width: 80px">
+        +                 {{ 'Set prices manually'|trans }}
+        +                 <i class="svg svg-info cursor-help js-tooltip"
+        +                    data-toggle="tooltip" data-placement="bottom"
+        +                    title="{{ 'All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically.'|trans }}"
+        +                 ></i>
+        +             </span>
+        +         </th>
+        +         <th class="text-right">{{ 'Unit price excluding VAT'|trans }}</th>
+                  <th class="text-right">{{ 'Total including VAT'|trans }}</th>
+                  <th class="text-right">{{ 'Total excluding VAT'|trans }}</th>
+                  <th></th>
+              </tr>
+          </thead>
+        ```
+        ```diff
+          <tfoot>
+              <tr>
+        -         <td colspan="9">
+        +         <td colspan="11">
+                      {# ... #}
+                  </td>
+              </tr>
+              <tr>
+        -         <th colspan="6">{{ 'Total'|trans }}:</th>
+        +         <th colspan="8">{{ 'Total'|trans }}:</th>
+                  {# ... #}
+              </tr>
+          </tfoot>
+        ```
 - use automatic wiring of Redis clients for easier checking and cleaning ([#1161](https://github.com/shopsys/shopsys/pull/1161))
     - if you have redefined the service `@Shopsys\FrameworkBundle\Component\Redis\RedisFacade` or `@Shopsys\FrameworkBundle\Command\CheckRedisCommand` in your project, or you instantiate the classes in your code:
         - instead of instantiating `RedisFacade` with an array of cache clients to be cleaned by `php phing redis-clean`, pass an array of all redis clients and another array of redis clients you don't want to clean (eg. `global` and `session`)

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -7,6 +7,16 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 
+### Infrastructure
+- add the installation of the useful tools to your `docker/php-fpm/Dockerfile` ([#1239](https://github.com/shopsys/shopsys/pull/1239))
+    ```diff
+    libpq-dev \
+    + vim \
+    + nano \
+    + mc \
+    + htop \
+    ```
+
 ### Composer dependencies
 - update the minimal PHP version in your `composer.json` in `require` and `config.platform` section to at least `7.2` because version `7.1` is no longer supported in Shopsys Framework ([#1066](https://github.com/shopsys/shopsys/pull/1066))
     - you can remove the option altogether if all developers working on your project have the same version of PHP installed (eg. using the same Docker image)
@@ -97,14 +107,6 @@ There you can find links to upgrade notes for other versions too.
     ```diff
     -   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
     +   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain/'
-    ```
-- add the installation of the useful tools to your `docker/php-fpm/Dockerfile` ([#1239](https://github.com/shopsys/shopsys/pull/1239))
-    ```diff
-    libpq-dev \
-    + vim \
-    + nano \
-    + mc \
-    + htop \
     ```
 - run [`db-create`](/docs/introduction/console-commands-for-application-management-phing-targets.md#db-create) (this one even on production) and `test-db-create` phing targets to install extension for UUID ([#1055](https://github.com/shopsys/shopsys/pull/1055))
 

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -10,11 +10,19 @@ There you can find links to upgrade notes for other versions too.
 ### Infrastructure
 - add the installation of the useful tools to your `docker/php-fpm/Dockerfile` ([#1239](https://github.com/shopsys/shopsys/pull/1239))
     ```diff
-    libpq-dev \
-    + vim \
-    + nano \
-    + mc \
-    + htop \
+     RUN apt-get install -y \
+         libpng-dev \
+         libjpeg-dev \
+         libfreetype6-dev \
+         libzip-dev \
+         libicu-dev \
+         libpq-dev \
+    +    vim \
+    +    nano \
+    +    mc \
+    +    htop \
+         autoconf && \
+         apt-get clean
     ```
 
 ### Composer dependencies

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -152,47 +152,11 @@ There you can find links to upgrade notes for other versions too.
         - eg. `<property name="yaml-standards.args" value="--exclude-dir=./my-excluded-dir"/>` to exclude `my-excluded-dir/` from the standards
 
 ### Application
+- follow upgrade instructions for entities simplification in the [separate article](./upgrade-instructions-for-entities-simplification.md) ([#1123](https://github.com/shopsys/shopsys/pull/1123))
 - constructors of `FrameworkBundle\Model\Mail\Mailer` and `FrameworkBundle\Component\Cron\CronFacade` classes were changed so if you extend them change them accordingly: ([#875](https://github.com/shopsys/shopsys/pull/875)).
     - `CronFacade::__construct(Logger $logger, CronConfig $cronConfig, CronModuleFacade $cronModuleFacade, Mailer $mailer)`
     - `Mailer::__construct(Swift_Mailer $swiftMailer, Swift_Transport $realSwiftTransport)`
     - find all usages of the constructors and fix them
-- `EntityNameResolver` was added into constructor of these classes: ([#918](https://github.com/shopsys/shopsys/pull/918))
-    - `CronModuleFactory`
-    - `PersistentReferenceFactory`
-    - `ImageFactory`
-    - `FriendlyUrlFactory`
-    - `SettingValueFactory`
-    - `UploadedFileFactory`
-    - `AdministratorGridLimitFactory`
-    - `EnabledModuleFactory`
-    - `ProductCategoryDomainFactory`
-    - `ProductVisibilityFactory`
-    - `ScriptFactory`
-    - `SliderItemFactory`
-
-    In case of extending one of these classes, you should add an `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
-- update your application and tests to correctly handle availabilities and stock ([#1115](https://github.com/shopsys/shopsys/pull/1115))
-    - copy and replace the functional test [`AvailabilityFacadeTest.php`](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php) in `tests/ShopBundle/Functional/Model/Product/Availability/` to test deletion and replacement of availabilities properly
-    - if you have made any custom changes to the test you should merge your changes with the ones described in the pull request linked above
-    - add a test service definition for `AvailabilityDataFactory` in your `src/Shopsys/ShopBundle/Resources/config/services_test.yml` configuration:
-        ```diff
-            Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface: '@Shopsys\ShopBundle\Model\Transport\TransportDataFactory'
-
-        +   Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface: '@Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactory'
-        +
-            Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface: '@Shopsys\ShopBundle\Model\Payment\PaymentDataFactory'
-        ```
-    - check and fix your other tests, they might start failing if they assumed `Product::$availability` is not null when the product is using stock, or that stock quantity is not null when it's not using stock
-- JS functionality connected to `#js-close-without-saving` has been removed, implement your own if you relied on this ([#1168](https://github.com/shopsys/shopsys/pull/1168))
-- update your way of registration of `FriendlyUrlDataProviders` ([#1140](https://github.com/shopsys/shopsys/pull/1140))
-    - the namespace of `FriendlyUrlDataProviderInterface` and `FriendlyUrlDataProviderRegistry` has changed from `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\CompilerPass` to `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl` so change all your usages accordingly
-    - you no longer need to tag your `FriendlyUrlDataProviders` with `shopsys.friendly_url_provider` because it is now done automatically
-    - remove the usages of `RegisterFriendlyUrlDataProviderCompilerPass` class and `FriendlyUrlDataProviderRegistry::registerFriendlyUrlDataProvider` method because they have been removed
-- update your way of registration of `BreadcrumbGenerator` classes ([#1141](https://github.com/shopsys/shopsys/pull/1140))
-    - remove the usages of `FrontBreadcrumbResolverFactory` class as it has been removed.
-    - remove the usages of `BreadcrumbResolver::registerGenerator` method as it has been removed
-    - update your usages of `BreadcrumbResolver::__contruct()` as it now requires a new parameter
-- run `php phing phpstan` in order to check, that you are not using any private, protected or removed constant from Shopsys packages ([#1181](https://github.com/shopsys/shopsys/pull/1181))
 - update your code due to collection entities encapsulation change ([#1047](https://github.com/shopsys/shopsys/pull/1047))
     - when you use values from an entity getter that has returned an `ArrayCollection` before, use the value as an array instead of an object, for example:
         - `src/Shopsys/ShopBundle/Form/Front/Order/TransportAndPaymentFormType.php`
@@ -215,8 +179,46 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Payment\Payment::getPrices`
         - `Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory:getCategories`
     - we recommend encapsulating collections similarly in your own custom entities as well
+- `EntityNameResolver` was added into constructor of these classes: ([#918](https://github.com/shopsys/shopsys/pull/918))
+    - `CronModuleFactory`
+    - `PersistentReferenceFactory`
+    - `ImageFactory`
+    - `FriendlyUrlFactory`
+    - `SettingValueFactory`
+    - `UploadedFileFactory`
+    - `AdministratorGridLimitFactory`
+    - `EnabledModuleFactory`
+    - `ProductCategoryDomainFactory`
+    - `ProductVisibilityFactory`
+    - `ScriptFactory`
+    - `SliderItemFactory`
+
+    In case of extending one of these classes, you should add an `EntityNameResolver` to a constructor and use it in a `create()` method to resolve correct class to return.
+- update your way of registration of `FriendlyUrlDataProviders` ([#1140](https://github.com/shopsys/shopsys/pull/1140))
+    - the namespace of `FriendlyUrlDataProviderInterface` and `FriendlyUrlDataProviderRegistry` has changed from `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\CompilerPass` to `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl` so change all your usages accordingly
+    - you no longer need to tag your `FriendlyUrlDataProviders` with `shopsys.friendly_url_provider` because it is now done automatically
+    - remove the usages of `RegisterFriendlyUrlDataProviderCompilerPass` class and `FriendlyUrlDataProviderRegistry::registerFriendlyUrlDataProvider` method because they have been removed
+- update your way of registration of `BreadcrumbGenerator` classes ([#1141](https://github.com/shopsys/shopsys/pull/1140))
+    - remove the usages of `FrontBreadcrumbResolverFactory` class as it has been removed.
+    - remove the usages of `BreadcrumbResolver::registerGenerator` method as it has been removed
+    - update your usages of `BreadcrumbResolver::__contruct()` as it now requires a new parameter
+- update your application and tests to correctly handle availabilities and stock ([#1115](https://github.com/shopsys/shopsys/pull/1115))
+    - copy and replace the functional test [`AvailabilityFacadeTest.php`](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php) in `tests/ShopBundle/Functional/Model/Product/Availability/` to test deletion and replacement of availabilities properly
+    - if you have made any custom changes to the test you should merge your changes with the ones described in the pull request linked above
+    - add a test service definition for `AvailabilityDataFactory` in your `src/Shopsys/ShopBundle/Resources/config/services_test.yml` configuration:
+        ```diff
+            Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface: '@Shopsys\ShopBundle\Model\Transport\TransportDataFactory'
+
+        +   Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface: '@Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactory'
+        +
+            Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface: '@Shopsys\ShopBundle\Model\Payment\PaymentDataFactory'
+        ```
+    - check and fix your other tests, they might start failing if they assumed `Product::$availability` is not null when the product is using stock, or that stock quantity is not null when it's not using stock
+- follow instructions in the [separate article](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md) to use Elasticsearch to get data into read model ([#1096](https://github.com/shopsys/shopsys/pull/1096))
 - update your `OrderDataFixture` and `UserDataFixture` to create new users and orders in last two weeks instead of one ([#1147](https://github.com/shopsys/shopsys/pull/1147))
     - this is done by changing all occurrences of `$this->faker->dateTimeBetween('-1 week', 'now');` by `$this->faker->dateTimeBetween('-2 week', 'now');`
+- JS functionality connected to `#js-close-without-saving` has been removed, implement your own if you relied on this ([#1168](https://github.com/shopsys/shopsys/pull/1168))
+- run `php phing phpstan` in order to check, that you are not using any private, protected or removed constant from Shopsys packages ([#1181](https://github.com/shopsys/shopsys/pull/1181))
 - get rid of not needed deprecations and BC-promise implementation from 7.x version ([#1193](https://github.com/shopsys/shopsys/pull/1193))
     - remove registration of `productCategoryFilter` filter from `Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig`, `services.yml` and `services_test.yml`
         - in the case, the class contains custom filters, move the filter into the `parent::__construct` as the last parameter
@@ -231,7 +233,7 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Product\ProductFacade`
         - `Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade`
         - `Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager`
-    - check wether you have overwritten methods of `Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository` class and fix their signatures
+    - check whether you have overwritten methods of `Shopsys\FrameworkBundle\Model\Product\Search\Export\ProductSearchExportWithFilterRepository` class and fix their signatures
         - `createQueryBuilder` has less parameters
         - `getProductTotalCountForDomainAndLocale` was renamed to `getProductTotalCountForDomain` and has less parameters
     - rename `ProductSearchExportRepositoryTest` into `ProductSearchExportWithFilterRepositoryTest` and [fix or replace the code](https://github.com/shopsys/shopsys/blob/v8.0.0/project-base/tests/ShopBundle/Functional/Model/Product/Search/ProductSearchExportWithFilterRepositoryTest.php)
@@ -263,6 +265,10 @@ There you can find links to upgrade notes for other versions too.
         POSITION_LEFT_SIDEBAR => 'leftSidebar'
         ```
     - remove the use of `is_plugin_data_group` attribute in form extensions or customized twig templates, the functionality was also removed from `form_row` block in `@FrameworkBundle/src/Resources/views/Admin/Form/theme.html.twig`
+- use getter method instead of property inside `DailyFeedCronModule` ([#1207](https://github.com/shopsys/shopsys/pull/1207))
+    - if you extend `DailyFeedCronModule` in your project use the protected method `getFeedExportCreationDataQueue()` instead of `$this->feedExportCreationDataQueue` (which now might be `null`)
+- check the usage of protected methods of `ParameterFilterRepository` if you've extended it in your project ([#1044](https://github.com/shopsys/shopsys/pull/1044))
+    - the signatures of protected methods changed to remove the need of passing a parameter as a reference
 - update your usage of `OrderItemsType` and Twig macros from `@ShopsysFramework/Admin/Content/Order/orderItem.html.twig` ([#1229](https://github.com/shopsys/shopsys/pull/1229))
     - if you haven't customized Twig templates for editing orders in admin or used `OrderItemsType` directly you don't have to do anything
     - change your usage after the macro signatures were modified (unused parameters were removed):
@@ -290,9 +296,6 @@ There you can find links to upgrade notes for other versions too.
         - please change your usage accordingly if you extended this class or call the constructor directly
     - if you have overridden `{% block order_items_widget %}` you don't have the variable `orderItemTotalPricesById` defined in the block anymore
         - you can use the totals defined in `OrderItemData::$totalPriceWithVat` and `OrderItemData::$totalPriceWithoutVat` instead
-- clean your project repository after administration image assets were moved from `shopsys/project-base` into `shopsys/framework` repository ([#1243](https://github.com/shopsys/shopsys/pull/1243))
-    - remove `bg/`, `flags/`, `logo.svg`, and `preloader.gif` from `web/assets/admin/images/`
-    - if you need to use these assets yourself, you can find them in `web/assets/bundles/shopsysframework/` (they are copied using `php phing assets` which is a part of standard build targets)
 - use new administration selectboxes, checkboxes and radiobuttons ([#1241](https://github.com/shopsys/shopsys/pull/1241))
     - if you have added javascripts in administration relying on `selectize.js` rewrite it to use `Select2` instead
         - the new library has a wider range of functionality, it's now used across all `select` elements, and it's easier to use than `selectize.js`
@@ -330,12 +333,9 @@ There you can find links to upgrade notes for other versions too.
     - use helper classes `AdminCheckbox` and `AdminRadiobutton` instead of directly manipulating `input[type="checkbox"]` and `input[type="radio"]` elements in your administration acceptance tests
         - when you need to work with a particular input, create an instance of the appropriate class via static method `createByCss()` and use its methods to manipulate the input or assert its values
         - run `php phing tests-acceptance` to see that your acceptance test pass
-- use getter method instead of property inside `DailyFeedCronModule` ([#1207](https://github.com/shopsys/shopsys/pull/1207))
-    - if you extend `DailyFeedCronModule` in your project use the protected method `getFeedExportCreationDataQueue()` instead of `$this->feedExportCreationDataQueue` (which now might be `null`)
-- check the usage of protected methods of `ParameterFilterRepository` if you've extended it in your project ([#1044](https://github.com/shopsys/shopsys/pull/1044))
-    - the signatures of protected methods changed to remove the need of passing a parameter as a reference
-- follow instructions in the [separate article](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md) to use Elasticsearch to get data into read model ([#1096](https://github.com/shopsys/shopsys/pull/1096))
-- follow upgrade instructions for entities simplification in the [separate article](./upgrade-instructions-for-entities-simplification.md) ([#1123](https://github.com/shopsys/shopsys/pull/1123))
+- clean your project repository after administration image assets were moved from `shopsys/project-base` into `shopsys/framework` repository ([#1243](https://github.com/shopsys/shopsys/pull/1243))
+    - remove `bg/`, `flags/`, `logo.svg`, and `preloader.gif` from `web/assets/admin/images/`
+    - if you need to use these assets yourself, you can find them in `web/assets/bundles/shopsysframework/` (they are copied using `php phing assets` which is a part of standard build targets)
 - if you want to use our experimental backend API, read [introduction to backend API](/docs/backend-api/introduction-to-backend-api.md) ([#1055](https://github.com/shopsys/shopsys/pull/1055))
 
 ## [shopsys/coding-standards]

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -264,6 +264,8 @@ There you can find links to upgrade notes for other versions too.
         POSITION_PRODUCT_LIST => 'productList'
         POSITION_LEFT_SIDEBAR => 'leftSidebar'
         ```
+        - don't forget uses in Twig, such as `{{ constant('Shopsys\\FrameworkBundle\\Model\\Advert\\Advert::POSITION_HEADER') }}`
+        - don't forget uses in Javascript, such as `Shopsys.constant('\\Shopsys\\FrameworkBundle\\Model\\Advert\\Advert::POSITION_HEADER')`
     - remove the use of `is_plugin_data_group` attribute in form extensions or customized twig templates, the functionality was also removed from `form_row` block in `@FrameworkBundle/src/Resources/views/Admin/Form/theme.html.twig`
 - use getter method instead of property inside `DailyFeedCronModule` ([#1207](https://github.com/shopsys/shopsys/pull/1207))
     - if you extend `DailyFeedCronModule` in your project use the protected method `getFeedExportCreationDataQueue()` instead of `$this->feedExportCreationDataQueue` (which now might be `null`)

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -7,9 +7,63 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 
-### Configuration
+### Composer dependencies
 - update the minimal PHP version in your `composer.json` in `require` and `config.platform` section to at least `7.2` because version `7.1` is no longer supported in Shopsys Framework ([#1066](https://github.com/shopsys/shopsys/pull/1066))
     - you can remove the option altogether if all developers working on your project have the same version of PHP installed (eg. using the same Docker image)
+- upgrade `commerceguys/intl` to `^1.0.0` version ([#1192](https://github.com/shopsys/shopsys/pull/1192))
+    - in your `composer.json`, change the dependency:
+        ```diff
+        - "commerceguys/intl": "0.7.4",
+        + "commerceguys/intl": "^1.0.0",
+        ```
+    - `IntlCurrencyRepository::get()` and `::getAll()` methods no longer accept `$fallbackLocale` as the a parameter
+        - you can set the parameter using the class constructor if necessary
+    - `IntlCurrencyRepository::isSupportedCurrency()` is now strictly type hinted
+    - protected `PriceExtension::getNumberFormatter()` is renamed to `getCurrencyFormatter()` and returns an instance of `CommerceGuys\Intl\Formatter\CurrencyFormatter` now
+        - you need to change your usages accordingly
+- replace `IvoryCKEditorBundle` with `FOSCKEditorBundle` ([#1072](https://github.com/shopsys/shopsys/pull/1072))
+    - replace the registration of the bundle in `app/AppKernel`
+        ```diff
+        - new Ivory\CKEditorBundle\IvoryCKEditorBundle(), // has to be loaded after FrameworkBundle and TwigBundle
+        + new FOS\CKEditorBundle\FOSCKEditorBundle(), // has to be loaded after FrameworkBundle and TwigBundle
+        ```
+    - rename `app/config/packages/ivory_ck_editor.yml` to `app/config/packages/fos_ck_editor.yml` and change the root key in its content
+        ```diff
+        - ivory_ck_editor:
+        + fos_ck_editor:
+        ```
+    - change the package in `composer.json`
+        ```diff
+        - "egeloen/ckeditor-bundle": "^4.0.6",
+        + "friendsofsymfony/ckeditor-bundle": "^2.1",
+        ```
+    - update all usages of the old bundle in
+        - extended twig templates like
+            ```diff
+            - {% use '@IvoryCKEditor/Form/ckeditor_widget.html.twig' with ckeditor_widget as base_ckeditor_widget %}
+            + {% use '@FOSCKEditor/Form/ckeditor_widget.html.twig' with ckeditor_widget as base_ckeditor_widget %}
+            ```
+        - javascripts like
+            ```diff
+            - if (element.type === Shopsys.constant('\\Ivory\\CKEditorBundle\\Form\\Type\\CKEditorType::class')) {
+            + if (element.type === Shopsys.constant('\\FOS\\CKEditorBundle\\Form\\Type\\CKEditorType::class')) {
+            ```
+        - configuration files like
+            ```diff
+            Shopsys\FrameworkBundle\Form\WysiwygTypeExtension:
+                tags:
+            -       - { name: form.type_extension, extended_type: Ivory\CKEditorBundle\Form\Type\CKEditorType }
+            +       - { name: form.type_extension, extended_type: FOS\CKEditorBundle\Form\Type\CKEditorType }
+            ```
+        - php code like
+            ```diff
+            namespace Shopsys\FrameworkBundle\Form\Admin\Transport;
+
+            - use Ivory\CKEditorBundle\Form\Type\CKEditorType;
+            + use FOS\CKEditorBundle\Form\Type\CKEditorType;
+            ```
+
+### Configuration
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))
     - update `app/config/packages/shopsys_shop.yml`
         ```diff
@@ -88,60 +142,6 @@ There you can find links to upgrade notes for other versions too.
         - eg. `<property name="yaml-standards.args" value="--exclude-dir=./my-excluded-dir"/>` to exclude `my-excluded-dir/` from the standards
 
 ### Application
-#### 3rd party dependencies
-- upgrade `commerceguys/intl` to `^1.0.0` version ([#1192](https://github.com/shopsys/shopsys/pull/1192))
-    - in your `composer.json`, change the dependency:
-        ```diff
-        - "commerceguys/intl": "0.7.4",
-        + "commerceguys/intl": "^1.0.0",
-        ```
-    - `IntlCurrencyRepository::get()` and `::getAll()` methods no longer accept `$fallbackLocale` as the a parameter
-        - you can set the parameter using the class constructor if necessary
-    - `IntlCurrencyRepository::isSupportedCurrency()` is now strictly type hinted
-    - protected `PriceExtension::getNumberFormatter()` is renamed to `getCurrencyFormatter()` and returns an instance of `CommerceGuys\Intl\Formatter\CurrencyFormatter` now
-        - you need to change your usages accordingly
-- replace `IvoryCKEditorBundle` with `FOSCKEditorBundle` ([#1072](https://github.com/shopsys/shopsys/pull/1072))
-    - replace the registration of the bundle in `app/AppKernel`
-        ```diff
-        - new Ivory\CKEditorBundle\IvoryCKEditorBundle(), // has to be loaded after FrameworkBundle and TwigBundle
-        + new FOS\CKEditorBundle\FOSCKEditorBundle(), // has to be loaded after FrameworkBundle and TwigBundle
-        ```
-    - rename `app/config/packages/ivory_ck_editor.yml` to `app/config/packages/fos_ck_editor.yml` and change the root key in its content
-        ```diff
-        - ivory_ck_editor:
-        + fos_ck_editor:
-        ```
-    - change the package in `composer.json`
-        ```diff
-        - "egeloen/ckeditor-bundle": "^4.0.6",
-        + "friendsofsymfony/ckeditor-bundle": "^2.1",
-        ```
-    - update all usages of the old bundle in
-        - extended twig templates like
-            ```diff
-            - {% use '@IvoryCKEditor/Form/ckeditor_widget.html.twig' with ckeditor_widget as base_ckeditor_widget %}
-            + {% use '@FOSCKEditor/Form/ckeditor_widget.html.twig' with ckeditor_widget as base_ckeditor_widget %}
-            ```
-        - javascripts like
-            ```diff
-            - if (element.type === Shopsys.constant('\\Ivory\\CKEditorBundle\\Form\\Type\\CKEditorType::class')) {
-            + if (element.type === Shopsys.constant('\\FOS\\CKEditorBundle\\Form\\Type\\CKEditorType::class')) {
-            ```
-        - configuration files like
-            ```diff
-            Shopsys\FrameworkBundle\Form\WysiwygTypeExtension:
-                tags:
-            -       - { name: form.type_extension, extended_type: Ivory\CKEditorBundle\Form\Type\CKEditorType }
-            +       - { name: form.type_extension, extended_type: FOS\CKEditorBundle\Form\Type\CKEditorType }
-            ```
-        - php code like
-            ```diff
-            namespace Shopsys\FrameworkBundle\Form\Admin\Transport;
-
-            - use Ivory\CKEditorBundle\Form\Type\CKEditorType;
-            + use FOS\CKEditorBundle\Form\Type\CKEditorType;
-            ```
-#### Shopsys Framework
 - constructors of `FrameworkBundle\Model\Mail\Mailer` and `FrameworkBundle\Component\Cron\CronFacade` classes were changed so if you extend them change them accordingly: ([#875](https://github.com/shopsys/shopsys/pull/875)).
     - `CronFacade::__construct(Logger $logger, CronConfig $cronConfig, CronModuleFacade $cronModuleFacade, Mailer $mailer)`
     - `Mailer::__construct(Swift_Mailer $swiftMailer, Swift_Transport $realSwiftTransport)`

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -298,6 +298,18 @@ There you can find links to upgrade notes for other versions too.
         - {% macro calculablePriceWidget(calculablePriceForm, currencySymbol) %}
         + {% macro calculablePriceWidget(calculablePriceForm) %}
         ```
+    - if you have overridden the `orderItems.html.twig`, you'll need to add the currency symbols in the table header:
+        ```diff
+        - <th class="text-right">{{ 'Unit price including VAT'|trans }}</th>
+        + <th class="text-right">{{ 'Unit price including VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+          {# ... #}
+        - <th class="text-right">{{ 'Unit price excluding VAT'|trans }}</th>
+        - <th class="text-right">{{ 'Total including VAT'|trans }}</th>
+        - <th class="text-right">{{ 'Total excluding VAT'|trans }}</th>
+        + <th class="text-right">{{ 'Unit price excluding VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+        + <th class="text-right">{{ 'Total including VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+        + <th class="text-right">{{ 'Total excluding VAT'|trans }} ({{ currencySymbolByCurrencyId(order.currency.id) }})</th>
+        ```
     - constructor of `OrderItemsType` no longer accepts `OrderItemPriceCalculation` as third parameter
         - please change your usage accordingly if you extended this class or call the constructor directly
     - if you have overridden `{% block order_items_widget %}` you don't have the variable `orderItemTotalPricesById` defined in the block anymore

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -152,6 +152,10 @@ There you can find links to upgrade notes for other versions too.
         - eg. `<property name="yaml-standards.args" value="--exclude-dir=./my-excluded-dir"/>` to exclude `my-excluded-dir/` from the standards
 
 ### Application
+- **There are BC breaking changes in the `v8.0.0` release, which means that the full build and tests won't pass until you complete a large portion of the upgrade notes.**
+**It is recommended to first resolve incompatible class definitions and method changes by making `phing phpstan` pass using upgrade notes below as a guide.**
+**Then make `phing build-demo-dev-quick` pass as well so you can see the front-end working.**
+**After that, the upgrading will be much easier.**
 - follow upgrade instructions for entities simplification in the [separate article](./upgrade-instructions-for-entities-simplification.md) ([#1123](https://github.com/shopsys/shopsys/pull/1123))
 - constructors of `FrameworkBundle\Model\Mail\Mailer` and `FrameworkBundle\Component\Cron\CronFacade` classes were changed so if you extend them change them accordingly: ([#875](https://github.com/shopsys/shopsys/pull/875)).
     - `CronFacade::__construct(Logger $logger, CronConfig $cronConfig, CronModuleFacade $cronModuleFacade, Mailer $mailer)`

--- a/docs/upgrade/UPGRADE-v8.0.0.md
+++ b/docs/upgrade/UPGRADE-v8.0.0.md
@@ -8,6 +8,8 @@ There you can find links to upgrade notes for other versions too.
 ## [shopsys/framework]
 
 ### Configuration
+- update the minimal PHP version in your `composer.json` in `require` and `config.platform` section to at least `7.2` because version `7.1` is no longer supported in Shopsys Framework ([#1066](https://github.com/shopsys/shopsys/pull/1066))
+    - you can remove the option altogether if all developers working on your project have the same version of PHP installed (eg. using the same Docker image)
 - simplify local configuration ([#1004](https://github.com/shopsys/shopsys/pull/1004))
     - update `app/config/packages/shopsys_shop.yml`
         ```diff
@@ -50,7 +52,6 @@ There you can find links to upgrade notes for other versions too.
     + mc \
     + htop \
     ```
-- update the minimal PHP version in your `composer.json` in `require` and `config.platform` section to `7.2` because version `7.1` is no longer supported in Shopsys Framework ([#1066](https://github.com/shopsys/shopsys/pull/1066))
 - run [`db-create`](/docs/introduction/console-commands-for-application-management-phing-targets.md#db-create) (this one even on production) and `test-db-create` phing targets to install extension for UUID ([#1055](https://github.com/shopsys/shopsys/pull/1055))
 
 ### Tools

--- a/docs/upgrade/upgrade-instructions-for-entities-simplification.md
+++ b/docs/upgrade/upgrade-instructions-for-entities-simplification.md
@@ -137,6 +137,14 @@ The change introduced many [BC breaks](/docs/contributing/backward-compatibility
     - running `php phing phpstan` should help you to discover the problems
 - remove `Tests\ShopBundle\Functional\Model\Cart\CartTest::testMergeWithCartReturnsCartWithSummedProducts()`  
     - add new `Tests\ShopBundle\Functional\Model\Cart\CartMigrationFacadeTest` class, you can copy-paste it from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Cart/CartMigrationFacadeTest.php)
+    - you'll need to skip `FunctionLengthSniff` for this class in your `easy-coding-standard.yml` as it has an excessively long method:
+        ```diff
+          parameters:
+              skip:
+                  ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:
+                      # other skipped classes...
+        +             - '*/tests/ShopBundle/Functional/Model/Cart/CartMigrationFacadeTest.php'
+        ```
 - move some tests from `Tests\ShopBundle\Functional\Model\Cart\CartTest` to `Tests\ShopBundle\Functional\Model\Cart\CartFacadeTest`
 and fix them appropriately (you can copy paste them from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php))
     - `testCannotAddProductFloatQuantityToCart()`

--- a/docs/upgrade/upgrade-instructions-for-entities-simplification.md
+++ b/docs/upgrade/upgrade-instructions-for-entities-simplification.md
@@ -137,7 +137,7 @@ The change introduced many [BC breaks](/docs/contributing/backward-compatibility
     - running `php phing phpstan` should help you to discover the problems
 - remove `Tests\ShopBundle\Functional\Model\Cart\CartTest::testMergeWithCartReturnsCartWithSummedProducts()`  
     - add new `Tests\ShopBundle\Functional\Model\Cart\CartMigrationFacadeTest` class, you can copy-paste it from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Cart/CartMigrationFacadeTest.php)
-- move tests from `Tests\ShopBundle\Functional\Model\Cart\CartTest` to `Tests\ShopBundle\Functional\Model\Cart\CartFacadeTest`
+- move some tests from `Tests\ShopBundle\Functional\Model\Cart\CartTest` to `Tests\ShopBundle\Functional\Model\Cart\CartFacadeTest`
 and fix them appropriately (you can copy paste them from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php))
     - `testCannotAddProductFloatQuantityToCart()`
     - `testCannotAddProductZeroQuantityToCart()`
@@ -146,6 +146,7 @@ and fix them appropriately (you can copy paste them from [Github](https://github
     - `testAddProductToCartMarksRepeatedlyAddedProductAsNotNew()`
     - `testAddProductResultContainsAddedProductQuantity()`
     - `testAddProductResultDoesNotContainPreviouslyAddedProductQuantity()`
+    - test methods `testRemoveItem()` and `testCleanMakesCartEmpty()` should still remain in `CartTest`
 - fix `Tests\ShopBundle\Functional\Model\Order\OrderFacadeTest::testCreate()`:
 ```diff
 - /** @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser $productPriceCalculation */
@@ -155,8 +156,8 @@ and fix them appropriately (you can copy paste them from [Github](https://github
 - $cart->addProduct($product, 1, $productPriceCalculation, $cartItemFactory);
 + $cartFacade->addProductToCart($product->getId(), 1);
 ```
-- move `Tests\FrameworkBundle\Unit\Model\Product\ProductTest::testEditSchedulesPriceRecalculation` to `ProductFacadeTest`
-    - you can copy paste it from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Product/ProductFacadeTest.php#L133)
+- add new test method `testEditSchedulesPriceRecalculation()` to `ProductFacadeTest`
+    - you can copy paste it from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Product/ProductFacadeTest.php#L135-L147)
 - rename `Tests\ShopBundle\Functional\Model\Pricing\ProductManualInputPriceTest` to `Tests\ShopBundle\Functional\Model\Pricing\ProductInputPriceRecalculatorTest` and use instance of `ProductInputPriceRecalculator` for input prices recalculations
     - you can copy paste the class from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Pricing/ProductInputPriceRecalculatorTest.php)
 - rename `Tests\ShopBundle\Functional\Model\Order\OrderEditTest` to `Tests\ShopBundle\Functional\Model\Order\OrderFacadeEditTest`
@@ -170,9 +171,9 @@ and fix them appropriately (you can copy paste them from [Github](https://github
         - add `OrderFacade` from the DIC
         - remove `OrderItemPriceCalculation`, `OrderItemFactoryInterface` and `OrderPriceCalculation`
     - you can see the test class on [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Order/OrderFacadeEditTest.php)
-- remove the following tests from `Tests\FrameworkBundle\Unit\Model\Customer\UserTest` and create new `Tests\ShopBundle\Functional\Model\Customer\CustomerFacadeTest` class that will test the behavior
-(you can copy paste the class from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Customer/CustomerFacadeTest.php))
+- create new `Tests\ShopBundle\Functional\Model\Customer\CustomerFacadeTest` class that will test the behavior of `CustomerFacade`:
     - `testChangeEmailToExistingEmailButDifferentDomainDoNotThrowException()`
     - `testCreateNotDuplicateEmail()`
     - `testCreateDuplicateEmail()`
     - `testCreateDuplicateEmailCaseInsentitive()`
+    - you can copy paste the class from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Customer/CustomerFacadeTest.php)

--- a/docs/upgrade/upgrade-instructions-for-entities-simplification.md
+++ b/docs/upgrade/upgrade-instructions-for-entities-simplification.md
@@ -161,7 +161,7 @@ and fix them appropriately (you can copy paste them from [Github](https://github
 - rename `Tests\ShopBundle\Functional\Model\Pricing\ProductManualInputPriceTest` to `Tests\ShopBundle\Functional\Model\Pricing\ProductInputPriceRecalculatorTest` and use instance of `ProductInputPriceRecalculator` for input prices recalculations
     - you can copy paste the class from [Github](https://github.com/shopsys/project-base/blob/v8.0.0/tests/ShopBundle/Functional/Model/Pricing/ProductInputPriceRecalculatorTest.php)
 - rename `Tests\ShopBundle\Functional\Model\Order\OrderEditTest` to `Tests\ShopBundle\Functional\Model\Order\OrderFacadeEditTest`
-    - change the test to is uses `OrderFacade` to edit the orders instead of calling `Order::edit()` directly
+    - change the test so it uses `OrderFacade` to edit the orders instead of calling `Order::edit()` directly
     - you'll have to modify the *act* phase of the test:
         ```diff
         - $this->order->edit($orderData, $this->orderItemPriceCalculation, $this->orderItemFactory, $this->orderPriceCalculation);

--- a/docs/upgrade/upgrade-instructions-for-entities-simplification.md
+++ b/docs/upgrade/upgrade-instructions-for-entities-simplification.md
@@ -37,6 +37,9 @@ The change introduced many [BC breaks](/docs/contributing/backward-compatibility
     - use `CustomerFacade::setEmail()` instead
 - `User::changePassword()`
     - use `CustomerPasswordFacade::changePassword()` instead
+- `User::resetPassword()`
+    - use `CustomerPasswordFacade::resetPassword()` instead
+    - if you need to reset password without side-effects (such as sending e-mail), instead of `$user->resetPassword($hashGenerator)` use `$user->setResetPasswordHash($hashGenerator->generateHash(CustomerPasswordFacade::RESET_PASSWORD_HASH_LENGTH))`
 - `User::setNewPassword()`
     - use `CustomerPasswordFacade::setNewPassword()` instead
 - `User::editDeliveryAddress()`
@@ -112,10 +115,6 @@ The change introduced many [BC breaks](/docs/contributing/backward-compatibility
 ```diff
 - User::__construct(EntityNameResolver $entityNameResolver, EncoderFactoryInterface $encoderFactory)
 + User::__construct(EntityNameResolver $entityNameResolver, CustomerPasswordFacade $customerPasswordFacade)
-```
-```diff
-- User::resetPassword(HashGenerator $hashGenerator)
-+ User::resetPassword(string $resetPasswordHash)
 ```
 ```diff
 - Administrator::edit(AdministratorData $administratorData, EncoderFactoryInterface $encoderFactory, ?self $administratorByUserName)

--- a/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md
+++ b/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md
@@ -4,6 +4,11 @@ There is a new layer in Shopsys Framework, called [read model](/docs/model/intro
 
 This upgrade requires the [Upgrade Instructions for Read Model for Product Lists](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md) to be applied first.
 
+- if you are using Elasticsearch for filtering, you need to configure it as your data source as well in your `service.yml` and `services_test.yml`:
+    ```diff
+    +    Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade'
+    ```
+    - if in doubt about the configuration, see the [Read Model Options](/docs/model/introduction-to-read-model.md#read-model-options).
 - update Elasticsearch structure in `src/Shopsys/ShopBundle/Resources/definition/product/*.json` like this:
     ```diff
     "mappings": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| During the actual upgrade of demoshop in https://github.com/shopsys/demoshop/pull/56 we gain a lot of insight about the upgrade process. Using this we can tweak the upgrade notes so they are more helpful to developers upgrading their projects.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
