### PR TITLE
[shopsys] docker-compose-win.yml.dist: remove php.ini volume mount

### DIFF
--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -46,7 +46,6 @@ services:
             -   shopsys-framework-sync:/var/www/html
             -   shopsys-framework-vendor-sync:/var/www/html/vendor
             -   shopsys-framework-web-sync:/var/www/html/project-base/web
-            -   ./project-base/docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         ports:
             - "35729:35729"
 

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -4,3 +4,19 @@ This guide contains instructions to upgrade from version v8.0.0 to Unreleased.
 
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+
+## [shopsys/framework]
+
+### Infrastructure
+- remove the unnecessary volume mount of `php.ini` from your `docker/conf/docker-compose-win.yml.dist` and possibly `docker-compose.yml` ([#1276](https://github.com/shopsys/shopsys/pull/1276))
+    ```diff
+      volumes:
+          -   shopsys-framework-sync:/var/www/html
+          -   shopsys-framework-vendor-sync:/var/www/html/vendor
+          -   shopsys-framework-web-sync:/var/www/html/web
+    -     -   ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
+      ports:
+    ```
+  
+[shopsys/framework]: https://github.com/shopsys/framework

--- a/docs/upgrade/UPGRADE-unreleased.md
+++ b/docs/upgrade/UPGRADE-unreleased.md
@@ -18,5 +18,5 @@ There you can find links to upgrade notes for other versions too.
     -     -   ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
       ports:
     ```
-  
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -40,7 +40,6 @@ services:
             -   shopsys-framework-sync:/var/www/html
             -   shopsys-framework-vendor-sync:/var/www/html/vendor
             -   shopsys-framework-web-sync:/var/www/html/web
-            -   ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
         ports:
             - "35729:35729"
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The mounting of `php.ini` is not necessary as it is copied into the Docker image during build (the mounting was removed in #497 but reappeared 3 weeks later in #499 - possibly during a rebase?).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
