### PR TITLE
[shopsys] php-fpm Dockerfile: update repository before install `libpg-dev`

### DIFF
--- a/docs/upgrade/UPGRADE-v7.3.2-dev.md
+++ b/docs/upgrade/UPGRADE-v7.3.2-dev.md
@@ -7,6 +7,20 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 
+### Infrastructure
+- update your `docker/php-fpm/Dockerfile` like this ([#1282](https://github.com/shopsys/shopsys/pull/1282)):
+    ```diff
+        # libicu-dev for intl extension
+            # libpg-dev for connection to postgres database
+            # autoconf needed by "redis" extension
+    -       RUN apt-get install -y \
+    +       RUN apt-get update && \
+    +           apt-get install -y \
+                libpng-dev \
+                libjpeg-dev \
+                libfreetype6-dev \
+    ```
+
 ### Configuration
 - update your `app/config/packages/doctrine.yml` ([#1273](https://github.com/shopsys/shopsys/pull/1273))
     ```diff

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -30,7 +30,8 @@ RUN chmod +x /usr/local/bin/docker-install-composer && \
 # libicu-dev for intl extension
 # libpg-dev for connection to postgres database
 # autoconf needed by "redis" extension
-RUN apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Docker compose failed on install `libpg-dev` without update package repository. The console output is attached below.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Run `docker-compose up -d --build --force-recreate` failed on:

```bash
E: Failed to fetch http://cdn-fastly.deb.debian.org/debian/pool/main/p/postgresql-9.6/libpq5_9.6.11-0+deb9u1_amd64.deb  404  Not Found
E: Failed to fetch http://cdn-fastly.deb.debian.org/debian/pool/main/p/postgresql-9.6/libpq-dev_9.6.11-0+deb9u1_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 34.0 MB in 1min 40s (338 kB/s)
ERROR: Service 'php-fpm' failed to build: The command '/bin/sh -c apt-get install -y     libpng-dev     libjpeg-dev     libfreetype6-dev     libzip-dev     libicu-dev     libpq-dev     vim     nano     mc     htop     autoconf &&     apt-get clean' returned a non-zero code: 100
```

Full output:
```bash
$ docker-compose up -d --build --force-recreate
Building php-fpm
Step 1/33 : FROM php:7.3-fpm-stretch as base
 ---> 56e680f0448d
Step 2/33 : ARG project_root=.
 ---> Using cache
 ---> 2e7e54698d4e
Step 3/33 : ENV REDIS_PREFIX=''
 ---> Using cache
 ---> 622c88022a28
Step 4/33 : ENV ELASTIC_SEARCH_INDEX_PREFIX=''
 ---> Using cache
 ---> 7e74436b42ff
Step 5/33 : RUN apt-get update && apt-get install -y wget gnupg g++ locales unzip dialog apt-utils git && apt-get clean
 ---> Using cache
 ---> 72f081345828
Step 6/33 : RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
 ---> Using cache
 ---> 481efa260e08
Step 7/33 : RUN apt-get update && apt-get install -y nodejs && apt-get clean
 ---> Using cache
 ---> 95fa7392d1fa
Step 8/33 : COPY ${project_root}/docker/php-fpm/docker-install-composer /usr/local/bin/docker-install-composer
 ---> Using cache
 ---> 6e912d770973
Step 9/33 : RUN chmod +x /usr/local/bin/docker-install-composer &&     docker-install-composer
 ---> Using cache
 ---> d10ad8bf4c6e
Step 10/33 : RUN apt-get install -y     libpng-dev     libjpeg-dev     libfreetype6-dev     libzip-dev     libicu-dev     libpq-dev     vim     nano     mc     htop     autoconf &&     apt-get clean
 ---> Running in 0184018be32e
Reading package lists...
Building dependency tree...
Reading state information...
autoconf is already the newest version (2.69-10).
The following additional packages will be installed:
  icu-devtools libfreetype6 libgpm2 libjpeg62-turbo libjpeg62-turbo-dev
  libpng-tools libpng16-16 libpq5 libslang2 libzip4 mc-data vim-common
  vim-runtime xxd zlib1g-dev
Suggested packages:
  lsof strace gpm icu-doc postgresql-doc-9.6 arj catdvi | texlive-binaries
  dbview djvulibre-bin genisoimage gv imagemagick libaspell-dev links | w3m
  | lynx odt2txt poppler-utils python-boto python-tz xpdf | pdf-viewer zip
  spell ctags vim-doc vim-scripts
The following NEW packages will be installed:
  htop icu-devtools libfreetype6 libfreetype6-dev libgpm2 libicu-dev
  libjpeg-dev libjpeg62-turbo libjpeg62-turbo-dev libpng-dev libpng-tools
  libpng16-16 libpq-dev libpq5 libslang2 libzip-dev libzip4 mc mc-data nano
  vim vim-common vim-runtime xxd zlib1g-dev
0 upgraded, 25 newly installed, 0 to remove and 3 not upgraded.
Need to get 34.3 MB of archives.
After this operation, 151 MB of additional disk space will be used.
Get:1 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libslang2 amd64 2.3.1-5 [503 kB]
Get:2 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 nano amd64 2.7.4-1 [485 kB]
Get:3 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 xxd amd64 2:8.0.0197-4+deb9u1 [132 kB]
Get:4 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 vim-common all 2:8.0.0197-4+deb9u1 [159 kB]
Get:5 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libgpm2 amd64 1.20.4-6.2+b1 [34.2 kB]
Get:6 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 htop amd64 2.0.2-1 [88.2 kB]
Get:7 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 icu-devtools amd64 57.1-6+deb9u2 [178 kB]
Get:8 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpng16-16 amd64 1.6.28-1 [280 kB]
Get:9 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libfreetype6 amd64 2.6.3-3.2 [438 kB]
Get:10 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 zlib1g-dev amd64 1:1.2.8.dfsg-5 [205 kB]
Get:11 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpng-dev amd64 1.6.28-1 [250 kB]
Get:12 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libfreetype6-dev amd64 2.6.3-3.2 [5815 kB]
Get:13 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libicu-dev amd64 57.1-6+deb9u2 [16.5 MB]
Get:14 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libjpeg62-turbo amd64 1:1.5.1-2 [134 kB]
Get:15 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libjpeg62-turbo-dev amd64 1:1.5.1-2 [210 kB]
Get:16 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libjpeg-dev all 1:1.5.1-2 [56.1 kB]
Get:17 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpng-tools amd64 1.6.28-1 [133 kB]
Err:18 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpq5 amd64 9.6.11-0+deb9u1
  404  Not Found
Err:19 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libpq-dev amd64 9.6.11-0+deb9u1
  404  Not Found
Get:20 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libzip4 amd64 1.1.2-1.1+b1 [40.6 kB]
Get:21 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 libzip-dev amd64 1.1.2-1.1+b1 [117 kB]
Get:22 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 mc-data all 3:4.8.18-1 [1267 kB]
Get:23 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 mc amd64 3:4.8.18-1 [513 kB]
Get:24 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 vim-runtime all 2:8.0.0197-4+deb9u1 [5407 kB]
Get:25 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 vim amd64 2:8.0.0197-4+deb9u1 [1034 kB]
E: Failed to fetch http://cdn-fastly.deb.debian.org/debian/pool/main/p/postgresql-9.6/libpq5_9.6.11-0+deb9u1_amd64.deb  404  Not Found
E: Failed to fetch http://cdn-fastly.deb.debian.org/debian/pool/main/p/postgresql-9.6/libpq-dev_9.6.11-0+deb9u1_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 34.0 MB in 1min 40s (338 kB/s)
ERROR: Service 'php-fpm' failed to build: The command '/bin/sh -c apt-get install -y     libpng-dev     libjpeg-dev     libfreetype6-dev     libzip-dev     libicu-dev     libpq-dev     vim     nano     mc     htop     autoconf &&     apt-get clean' returned a non-zero code: 100
```