### PR TITLE
[shopsys] unused macros has been removed from multiple twig templates

### DIFF
--- a/docs/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/docs/upgrade/UPGRADE-v9.0.0-dev.md
@@ -4,3 +4,24 @@ This guide contains instructions to upgrade from version v8.1.0-dev to v9.0.0-de
 
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+## [shopsys/framework]
+
+### Application
+
+- update your twig files ([#1284](https://github.com/shopsys/shopsys/pull/1284/)):
+    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/list.html.twig`
+        - remove: `{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}`
+    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/listByBrand.html.twig`
+        - remove: `{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}`
+    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/productListMacro.html.twig`
+        - remove: `{% import '@ShopsysShop/Front/Inline/Product/productFlagsMacro.html.twig' as productFlags %}`
+    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/search.html.twig`
+        - remove: `{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}`
+    - check your templates if you are extending or importing any of the following templates as imports of unused macros were removed from them:
+        - `src/Resources/views/Admin/Content/Article/detail.html.twig`
+        - `src/Resources/views/Admin/Content/Brand/detail.html.twig`
+        - `src/Resources/views/Admin/Content/Category/detail.html.twig`
+        - `src/Resources/views/Admin/Content/Product/detail.html.twig`
+
+[shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/src/Resources/views/Admin/Content/Article/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Article/detail.html.twig
@@ -1,7 +1,5 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
 
-{% import '@ShopsysFramework/Admin/Form/seoFormRowMacros.html.twig' as seoFormRowMacros %}
-
 {% block title %}- {{ 'Article'|trans }}{% endblock %}
 {% block h1 %}{{ 'Article'|trans }}{% endblock %}
 

--- a/packages/framework/src/Resources/views/Admin/Content/Brand/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Brand/detail.html.twig
@@ -1,5 +1,5 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
-{% import '@ShopsysFramework/Admin/Form/seoFormRowMacros.html.twig' as seoFormRowMacros %}
+
 {% block title %}- {{ 'Brand'|trans }}{% endblock %}
 {% block h1 %}{{ 'Brand'|trans }}{% endblock %}
 

--- a/packages/framework/src/Resources/views/Admin/Content/Category/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Category/detail.html.twig
@@ -1,5 +1,4 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
-{% import '@ShopsysFramework/Admin/Form/seoFormRowMacros.html.twig' as seoFormRowMacros %}
 
 {% block title %}- {{ 'Category'|trans }}{% endblock %}
 {% block h1 %}{{ 'Category'|trans }}{% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Product/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/detail.html.twig
@@ -1,5 +1,4 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
-{% import '@ShopsysFramework/Admin/Form/seoFormRowMacros.html.twig' as seoFormRowMacros %}
 {% import _self as self %}
 
 {% block title %}- {{ 'Product'|trans }}{% endblock %}

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/list.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/list.html.twig
@@ -1,7 +1,6 @@
 {% extends '@ShopsysShop/Front/Layout/layoutWithPanel.html.twig' %}
 {% import '@ShopsysShop/Front/Inline/Paginator/paginator.html.twig' as paginator %}
 {% import '@ShopsysShop/Front/Content/Product/filterFormMacro.html.twig' as productFilterForm %}
-{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}
 
 {% set domain = getDomain() %}
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/listByBrand.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/listByBrand.html.twig
@@ -1,6 +1,5 @@
 {% extends '@ShopsysShop/Front/Layout/layoutWithPanel.html.twig' %}
 {% import '@ShopsysShop/Front/Inline/Paginator/paginator.html.twig' as paginator %}
-{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}
 
 {% set domain = getDomain() %}
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/productListMacro.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/productListMacro.html.twig
@@ -1,5 +1,4 @@
 {% macro list(productViews, listCssClass, productHeadingTagName) %}
-    {% import '@ShopsysShop/Front/Inline/Product/productFlagsMacro.html.twig' as productFlags %}
 
     <ul class="list-products js-list js-product-list {{ listCssClass|default('') }}">
         {% for productView in productViews %}

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/search.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/search.html.twig
@@ -1,7 +1,6 @@
 {% extends '@ShopsysShop/Front/Layout/layoutWithPanel.html.twig' %}
 {% import '@ShopsysShop/Front/Inline/Paginator/paginator.html.twig' as paginator %}
 {% import '@ShopsysShop/Front/Content/Product/filterFormMacro.html.twig' as productFilterForm %}
-{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}
 
 {% block title %}
     {{ 'Search results for "%searchText%"'|trans({ '%searchText%': searchText }) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were some legacy parts of code that imported no longer necessary macros.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes
|Fixes issues| #561 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
