### PR TITLE
[framework] convert DOMAIN environment variable to integer

### DIFF
--- a/packages/framework/src/Component/Domain/DomainFactory.php
+++ b/packages/framework/src/Component/Domain/DomainFactory.php
@@ -39,7 +39,7 @@ class DomainFactory
 
         $domainId = getenv('DOMAIN');
         if ($domainId !== false) {
-            $domain->switchDomainById($domainId);
+            $domain->switchDomainById((int)$domainId);
         }
 
         return $domain;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| getenv returns only a string
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
