### PR TITLE
[framework] Fix error for less>=3.0.1

### DIFF
--- a/packages/framework/src/Resources/styles/admin/core/variables.less
+++ b/packages/framework/src/Resources/styles/admin/core/variables.less
@@ -13,7 +13,7 @@
 /*******************************************************************
 // FONTS
 *******************************************************************/
-@import url('https://fonts.googleapis.com/css?family=Roboto:400,500&subset=latin-ext');
+@import (css) url('https://fonts.googleapis.com/css?family=Roboto:400,500&subset=latin-ext');
 
 @font: "Roboto", Arial, Helvetica, sans-serif;
 


### PR DESCRIPTION
https://github.com/less/less.js/issues/3188

| Q             | A
| ------------- | ---
|Description, reason for the PR| less.js < 3.0 automaticaly detects if imported file is less or css. But from 3.0.1 it should be defined by `(css)` before url to avoid errors during build, see https://github.com/less/less.js/issues/3188
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
