### PR TITLE
[framework] design - hacky solution of advanced form

### DIFF
--- a/packages/framework/src/Resources/scripts/admin/advancedSearch.js
+++ b/packages/framework/src/Resources/scripts/admin/advancedSearch.js
@@ -54,10 +54,13 @@
 
     Shopsys.advancedSearch.addRule = function ($rulesContainer, $ruleTemplate, newIndex) {
         var ruleHtml = $ruleTemplate.clone().wrap('<div>').parent().html().replace(/__template__/g, newIndex);
+        ruleHtml = ruleHtml.replace("no-init", "");
+        ruleHtml = ruleHtml.replace("no-init", "");
+        ruleHtml = ruleHtml.replace("no-init", "");
         var $rule = $($.parseHTML(ruleHtml));
         $rule.appendTo($rulesContainer);
-
         Shopsys.register.registerNewContent($rule);
+        Shopsys.select2.init($rulesContainer);
     };
 
     Shopsys.advancedSearch.updateAllValuesByOperator = function ($rulesContainer) {

--- a/packages/framework/src/Resources/scripts/admin/components/select2.js
+++ b/packages/framework/src/Resources/scripts/admin/components/select2.js
@@ -1,12 +1,14 @@
 (function ($) {
-
     Shopsys = window.Shopsys || {};
+    Shopsys.select2 = Shopsys.flashMessage || {};
 
-    Shopsys.register.registerCallback(function ($container) {
-        $container.filterAllNodes('select').select2({
+    Shopsys.select2.init = function ($container) {
+        $container.filterAllNodes('select:not(.no-init)').select2({
             minimumResultsForSearch: 5,
             width: 'computedstyle'
         });
-    });
+    };
+
+    Shopsys.register.registerCallback(Shopsys.select2.init);
 
 })(jQuery);

--- a/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/ruleForm.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/ruleForm.html.twig
@@ -2,16 +2,21 @@
 {% for key, ruleForm in rulesForm %}
     {% set isTemplate = key is same as('__template__') %}
 
+    {% if isTemplate %}
+        {% set templateClassContainer = "display-none" %}
+        {% set templateClassSelect = "no-init" %}
+    {% endif %}
+
     <div
-        class="box-advanced-search__item js-advanced-search-rule{{ isTemplate ? ' display-none' : '' }}"
+        class="box-advanced-search__item js-advanced-search-rule {{ templateClassContainer|default('') }}"
         {{- isTemplate ? ' id="js-advanced-search-rule-template"' : '' -}}
     >
         <div class="box-advanced-search__item__content">
-            {{ form_widget(ruleForm.subject, { attr: { class: 'js-advanced-search-rule-subject' }, isSimple: true} ) }}
+            {{ form_widget(ruleForm.subject, { attr: { class: templateClassSelect|default('') ~ ' js-advanced-search-rule-subject' }, isSimple: true} ) }}
         </div>
 
         <div class="box-advanced-search__item__content">
-            {{ form_widget(ruleForm.operator, { attr: { class: 'js-advanced-search-rule-operator' }, isSimple: true} ) }}
+            {{ form_widget(ruleForm.operator, { attr: { class: templateClassSelect|default('') ~ ' js-advanced-search-rule-operator' }, isSimple: true} ) }}
         </div>
 
         <div class="box-advanced-search__item__content">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| My hypothesis was, that problem in initialization of select2 on hidden (template row). So I bring this hacky solution to show way how to fix it. I have changed select2 init function to enable call it globaly and disabled initialization to select with class .no-init. So in template row should be only not initializated select, and we should init them after appending to DOM on new line. When select2 is already initialized original select element is hidden and according original is created new html structure with all functionality and JS events - thats why it is not good to duplicate initialized select2.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1279 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
