### PR TITLE
[project-base] Dockerfile: error demonstration resulting in unbuildable image

### DIFF
--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -25,24 +25,8 @@ COPY ${project_root}/docker/php-fpm/docker-install-composer /usr/local/bin/docke
 RUN chmod +x /usr/local/bin/docker-install-composer && \
     docker-install-composer
 
-# libpng-dev needed by "gd" extension
-# libzip-dev needed by "zip" extension
-# libicu-dev for intl extension
-# libpg-dev for connection to postgres database
-# autoconf needed by "redis" extension
-RUN apt-get install -y \
-    libpng-dev \
-    libjpeg-dev \
-    libfreetype6-dev \
-    libzip-dev \
-    libicu-dev \
-    libpq-dev \
-    vim \
-    nano \
-    mc \
-    htop \
-    autoconf && \
-    apt-get clean
+# fail instead of installing required PHP extensions
+RUN exit 1
 
 # "gd" extension needs to have specified jpeg and freetype dir for jpg/jpeg images support
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This is a demonstration of a problem I've noticed in https://github.com/shopsys/demoshop/pull/59#issuecomment-519141095 - the Docker image for `php-fpm` doesn't get rebuilt as it is loaded from cache (cache from `master` build is used for new PRs).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes (it's actually just a general break of the application) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
