### PR TITLE
[framework] composer.json: added missing PHP extension dom

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "ext-bcmath": "*",
     "ext-ctype": "*",
     "ext-curl": "*",
+    "ext-dom": "*",
     "ext-filter": "*",
     "ext-gd": "*",
     "ext-iconv": "*",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -24,6 +24,7 @@
         "ext-bcmath": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
+        "ext-dom": "*",
         "ext-gd": "*",
         "ext-iconv": "*",
         "ext-intl": "*",


### PR DESCRIPTION
- it is required by XmlNormalizer class

| Q             | A
| ------------- | ---
|Description, reason for the PR| This fix is extracted from https://github.com/shopsys/shopsys/pull/1289, see https://github.com/shopsys/shopsys/pull/1289#issuecomment-519443668
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
