### PR TITLE
[shopsys] BC promise: added info about Twig macros

### DIFF
--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -113,7 +113,7 @@ The changes should always be described in [upgrade notes](/UPGRADE.md) (in the *
 Changes of Twig functions and filters in `MINOR` and `PATCH` releases must be backward-compatible.
 This means only a new optional argument or a support for new data type of existing argument may be added.
 
-Twig blocks, functions, filters and the templates themselves can be removed or renamed only in a `MAJOR` release.
+Twig blocks, functions, filters, macros, imports of macros in templates, and the templates themselves can be removed or renamed only in a `MAJOR` release.
 
 ### HTML
 Backward-compatible changes and additions to the HTML structure may be introduced in any release.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In https://github.com/shopsys/shopsys/pull/1284, we were discussing whether removal of imports of Twig macros from templates should be considered a BC breaking change. It was not explicitly mentioned in our BC promise, however, I believe it should be. Imagine a situation when a project developer extends a template and uses the imported macro from the parent in his child template. Then if we remove the import in the parent template, it causes an error in the child template.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
