### PR TITLE
[project-base] app folder is now included in coding standards checks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -68,6 +68,7 @@
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
             <arg value="--clear-cache"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -86,6 +87,7 @@
     <target name="ecs-diff" description="Checks coding standards in changed files in the whole monorepo by PHP easy coding standards." hidden="true">
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -106,6 +108,7 @@
             <arg value="check"/>
             <arg value="--clear-cache"/>
             <arg value="--fix"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -125,6 +128,7 @@
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
             <arg value="--fix"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -198,6 +202,7 @@
 
     <target name="phplint" description="Checks syntax of PHP files in the whole monorepo." hidden="true">
         <exec executable="${path.phplint.executable}" logoutput="true" passthru="true" checkreturn="true">
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.packages}/*/src"/>
@@ -220,6 +225,7 @@
             <arg path="./phpstan.neon"/>
             <arg path="${path.packages}/*/src"/>
             <arg path="${path.packages}/*/tests"/>
+            <arg path="${path.app}"/>
             <arg path="${path.root}/src"/>
             <arg path="${path.root}/tests"/>
             <arg path="${path.utils}/*/src"/>

--- a/docs/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/docs/upgrade/UPGRADE-v9.0.0-dev.md
@@ -24,4 +24,19 @@ There you can find links to upgrade notes for other versions too.
         - `src/Resources/views/Admin/Content/Category/detail.html.twig`
         - `src/Resources/views/Admin/Content/Product/detail.html.twig`
 
+### Tools
+
+- apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))
+    - add `app/router.php` to skipped files for two rules in your `easy-coding-standard.yml`:
+        ```diff
+          Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff:
+              - '*/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php'
+              - '*/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php'
+        +     - '*/app/router.php'
+
+        + Shopsys\CodingStandards\Sniffs\ForbiddenSuperGlobalSniff:
+        +     - '*/app/router.php'
+        ```
+  - run `php phing standards-fix` and fix possible violations that need to be fixed manually
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -296,6 +296,7 @@
             <arg value="--name-only"/>
             <arg value="--diff-filter=ACMR"/>
             <arg value="${git.merge.base}"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
         </exec>
@@ -304,6 +305,7 @@
             <arg value="ls-files"/>
             <arg value="--others"/>
             <arg value="--exclude-standard"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
         </exec>
@@ -422,6 +424,7 @@
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
             <arg value="--clear-cache"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -432,6 +435,7 @@
     <target name="ecs-diff" description="Checks coding standards in changed files by PHP easy coding standards." hidden="true">
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -444,6 +448,7 @@
             <arg value="check"/>
             <arg value="--clear-cache"/>
             <arg value="--fix"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -455,6 +460,7 @@
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
             <arg value="--fix"/>
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
             <arg path="${path.root}/*.md"/>
@@ -575,6 +581,7 @@
 
     <target name="phplint" description="Checks syntax of PHP files." hidden="true">
         <exec executable="${path.phplint.executable}" logoutput="true" passthru="true" checkreturn="true">
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
         </exec>
@@ -600,6 +607,7 @@
             <arg value="-c"/>
             <arg path="${path.phpstan.config}"/>
 
+            <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
 

--- a/project-base/app/AppCache.php
+++ b/project-base/app/AppCache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 
 class AppCache extends HttpCache

--- a/project-base/app/AppKernel.php
+++ b/project-base/app/AppKernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;

--- a/project-base/app/Bootstrap.php
+++ b/project-base/app/Bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys;
 
 use AppKernel;
@@ -78,7 +80,7 @@ class Bootstrap
     private function configurePhp()
     {
         error_reporting(E_ALL);
-        ini_set('display_errors', 0);
+        ini_set('display_errors', '0');
     }
 
     private function initDoctrine()

--- a/project-base/app/Environment.php
+++ b/project-base/app/Environment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys;
 
 use Composer\IO\IOInterface;

--- a/project-base/app/autoload.php
+++ b/project-base/app/autoload.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../vendor/autoload.php';

--- a/project-base/app/maintenance.php
+++ b/project-base/app/maintenance.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
     header('HTTP/1.1 503 Service Temporarily Unavailable');
     header('Status: 503 Service Temporarily Unavailable');
     header('Retry-after: 300');

--- a/project-base/app/router.php
+++ b/project-base/app/router.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file implements rewrite rules for PHP built-in web server.
  *

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -34,6 +34,7 @@ parameters:
         Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff:
             - '*/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php'
             - '*/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php'
+            - '*/app/router.php'
 
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:
             - '*/tests/*'
@@ -44,3 +45,6 @@ parameters:
         Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff:
             - '*/src/Shopsys/ShopBundle/*'
             - '*/tests/ShopBundle/*'
+
+        Shopsys\CodingStandards\Sniffs\ForbiddenSuperGlobalSniff:
+            - '*/app/router.php'


### PR DESCRIPTION
- fixed all the violations
- router.php is skipped for ValidVariableNameSniff and ForbiddenSuperGlobalSniff as it needs to use superglobals

| Q             | A
| ------------- | ---
|Description, reason for the PR| I see no reason why the folder should be excluded from the checks :slightly_smiling_face: I believe it just have been forgotten
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
