### PR TITLE
[framework] advancedSearch.js: destroy Select2 control in rule template during initialization

### DIFF
--- a/packages/framework/src/Resources/scripts/admin/advancedSearch.js
+++ b/packages/framework/src/Resources/scripts/admin/advancedSearch.js
@@ -5,6 +5,7 @@
 
     Shopsys.advancedSearch.init = function ($addRuleButton, $rulesContainer, $ruleTemplate) {
         $ruleTemplate.detach().removeClass('display-none').removeAttr('id').find('*[id]').removeAttr('id');
+        $ruleTemplate.find('select.select2-hidden-accessible').select2('destroy');
 
         var newRuleIndexCounter = 0;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If not destroyed, the control elements would get duplicated during `Shopsys.advancedSearch.addRule()` (see #1279).<br><br>Now, the template contains only pure `<select>` tags and can be copied freely - the Select2 will initialize with the correct data during execution of `Shopsys.register.registerNewContent()`.<br><br>See [Select2 docs](https://select2.org/programmatic-control/methods) for details on the implementation.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1279, closes #1301  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
