### PR TITLE
[shopsys] domain configuration is autoloaded in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -297,7 +297,7 @@
         </exec>
     </target>
 
-    <target name="translations-dump" description="Extracts translatable messages in the whole monorepo.">
+    <target name="translations-dump" depends="domains-info-load" description="Extracts translatable messages in the whole monorepo.">
         <phingcall target="shopsys_framework.translations-dump"/>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -306,7 +306,7 @@
             <arg value="--dir=${path.packages}/form-types-bundle/src"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/form-types-bundle/src/Resources/translations"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -319,7 +319,7 @@
             <arg value="--exclude-name=*AnnotatedRouteControllerLoader.php"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.framework}/src/Resources/translations"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -328,7 +328,7 @@
             <arg value="--dir=${path.packages}/product-feed-google/src"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-google/src/Resources/translations"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -337,7 +337,7 @@
             <arg value="--dir=${path.packages}/product-feed-heureka/src"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-heureka/src/Resources/translations"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -346,7 +346,7 @@
             <arg value="--dir=${path.packages}/product-feed-heureka-delivery/src"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-heureka-delivery/src/Resources/translations"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -355,7 +355,7 @@
             <arg value="--dir=${path.packages}/product-feed-zbozi/src"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-zbozi/src/Resources/translations"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
     </target>
 

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -16,14 +16,10 @@ This configuration file contains information about the domain ID, the domain ide
 #### 1.2 Set up the url address
 Set the url address for the domain in `app/config/domains_urls.yml`.
 
-#### 1.3 Set up the application as "singledomain"
-Modify the value of the parameter `is-multidomain` in `build.xml` to `false`.
-Based on this parameter, smoke and functional tests are run for a single domain, or multiple domains, respectively.
-
-#### 1.4 Locale settings
+#### 1.3 Locale settings
 Set up the locale of the domain according to the instructions in the section [Locale settings](#3-locale-settings)
 
-#### 1.5 Build
+#### 1.4 Build
 Start the build, for example using a phing target
 ```
 php phing build-demo-dev
@@ -35,10 +31,13 @@ More information about what Phing targets are and how they work can be found in 
 
 After the build is completed, a singledomain application is created.
 
-#### 1.6 Tests
+#### 1.5 Tests
 Some tests are prepared for the configuration with the first domain with `en` locale.
 For example `Tests\ShopBundle\Functional\Twig\PriceExtensionTest` is expecting the specific format of displayed currency.
 If you want to use already created tests for your specific configuration, you may need to modify these tests to be able to test your specific configuration of the domain.
+
+*Note: Some smoke and functional tests are only executed for a single domain or a multiple domain configuration.*
+*Search for `@group singledomain` or `@group multidomain` in your test methods' annotations respectively.*
 
 ### 2. How to add a new domain
 
@@ -51,11 +50,7 @@ Set the url address for the domain in `app/config/domains_urls.yml`.
 
 *Note: When you add a domain with the new url address on the MacOS platform, you need to enable this url address also in the network interface, see [Installation Using Docker for MacOS](https://github.com/shopsys/shopsys/blob/master/docs/installation/installation-using-docker-macos.md#11-enable-second-domain-optional)*
 
-#### 2.3 Set up the application as "multidomain"
-Modify the value of the parameter `is-multidomain` in `build.xml` to `true` (this is the default value).
-Based on this parameter, smoke and functional tests are run for a single domain, or multiple domains, respectively.
-
-#### 2.4 Locale settings
+#### 2.3 Locale settings
 Set up the locale of the domain according to the instructions in the section [Locale settings](#3-locale-settings)
 
 #### 2.5 Create multidomains data
@@ -104,15 +99,11 @@ Create a file with the frontend routes for the added locale if this file is not 
 Create this file in the directory `src/Shopsys/ShopBundle/Resources/config/` with the name `routing_front_xx.yml` where `xx` replace for the code of added locale.
 
 #### 3.3 Translations and messages
-In order to correctly display the labels like *Registration*, *Cart*, ..., create a file with translations of messages in `src/Shopsys/ShopBundle/Resources/translations/`.
-Override the Phing property `translations.dump.locales` in the `build.xml` and set a space-separated list of locales you want to dump.
-For example, if you want to add `xx` to the locales, add `<property name="translations.dump.locales" value="cs en xx"/>` to your `build.xml`.
-
-Then run
+You can extract all translatable messages from the source codes and templates for all your configured locales by running a phing target
 ```
 php phing translations-dump
 ```
-There will be created files for translations of messages for the new locale in `src/Shopsys/ShopBundle/Resources/translations/`.
+There will be created files for translations of messages for the new locale in `src/Shopsys/ShopBundle/Resources/translations/`, which you'll need to translate.
 
 For more information about translations, see [the separate article](/docs/introduction/translations.md).
 

--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -17,5 +17,26 @@ There you can find links to upgrade notes for other versions too.
     -     -   ./docker/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/php.ini
       ports:
     ```
+ 
+### Tools
+- let Phing properties `is-multidomain` and `translations.dump.locales` be auto-detected ([#1308](https://github.com/shopsys/shopsys/pull/1308))
+    - stop overriding the Phing properties `is-multidomain` and `translations.dump.locales` in your `build.xml`, these properties should not be used anymore
+        ```diff
+          <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
+
+        - <property name="is-multidomain" value="true"/>
+        - <property name="translations.dump.locales" value="cs en xx"/>
+          <property name="phpstan.level" value="1"/>
+        ```
+    - if you use the deprecated properties in your `build.xml` yourself, make the particular Phing target dependent on `domains-info-load` and use new auto-detected properties `domains-info.is-multidomain` and `domains-info.locales` instead
+        ```diff
+        - <target name="my-custom-localization-target">
+        + <target name="my-custom-localization-target" depends="domains-info-load">
+              <exec executable="${path.custom-localization.executable}" passthru="true" checkreturn="true">
+        -         <arg line="${translations.dump.locales}"/>
+        +         <arg line="${domains-info.locales}"/>
+              </exec>
+          </target>
+        ```
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/backend-api/install/build.xml.patch
+++ b/packages/backend-api/install/build.xml.patch
@@ -1,11 +1,10 @@
-@@ -5,10 +5,17 @@
+@@ -5,9 +5,16 @@
 
      <property name="path.root" value="${project.basedir}"/>
      <property name="path.vendor" value="${path.root}/vendor"/>
 +    <property name="path.backend-api" value="${path.vendor}/shopsys/backend-api"/>
      <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
 
-     <property name="is-multidomain" value="true"/>
      <property name="phpstan.level" value="1"/>
 
      <import file="${path.framework}/build.xml"/>

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="shopsys_framework" default="list">
 
-    <property name="is-multidomain" value="true"/>
+    <property name="is-multidomain" value="true" description="This property is @deprecated, see 'domains-info-load' target instead."/>
     <property name="path.app" value="${path.root}/app"/>
     <property name="path.bin" value="${path.vendor}/bin"/>
     <property name="path.bin-console" value="${path.root}/bin/console"/>
@@ -37,7 +37,7 @@
     <property name="path.web.styles.front" value="${path.web}/assets/frontend/styles"/>
     <property name="path.yaml-standards.executable" value="${path.bin}/yaml-standards"/>
     <property name="phpstan.level" value="4"/>
-    <property name="translations.dump.locales" value="en cs"/>
+    <property name="translations.dump.locales" value="en cs" description="This property is @deprecated, see 'domains-info-load' target instead."/>
     <property name="translations.dump.flags" value="--keep"/>
     <property name="yaml-standards.indent-count" value="4"/>
     <property name="yaml-standards.args" value=""/>
@@ -267,6 +267,31 @@
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:schema:create"/>
         </exec>
+    </target>
+
+    <target name="domains-info-load" description="Load info about domains configuration into Phing properties." hidden="true">
+        <exec executable="${path.php.executable}" outputProperty="domains-info.ids">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:domains:info"/>
+        </exec>
+
+        <exec executable="${path.php.executable}" outputProperty="domains-info.locales">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:domains:info"/>
+            <arg value="locale"/>
+        </exec>
+
+        <if>
+            <matches string="${domains-info.ids}" pattern="\d+\s+\d+"/>
+            <then>
+                <echo>y</echo>
+                <property name="domains-info.is-multidomain" value="true"/>
+            </then>
+            <else>
+                <echo>f</echo>
+                <property name="domains-info.is-multidomain" value="false"/>
+            </else>
+        </if>
     </target>
 
     <target name="diff-files" description="Finds changed files (against origin/master) and saves them into properties." hidden="true">
@@ -875,9 +900,9 @@
         </exec>
     </target>
 
-    <target name="tests-functional" depends="clean,clean-redis" description="Runs functional tests.">
+    <target name="tests-functional" depends="clean,clean-redis,domains-info-load" description="Runs functional tests.">
         <if>
-            <istrue value="${is-multidomain}"/>
+            <istrue value="${domains-info.is-multidomain}"/>
             <then>
                 <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="true">
                     <arg value="--colors=always"/>
@@ -929,9 +954,9 @@
         </exec>
     </target>
 
-    <target name="tests-smoke" depends="clean,clean-redis" description="Runs smoke tests.">
+    <target name="tests-smoke" depends="clean,clean-redis,domains-info-load" description="Runs smoke tests.">
         <if>
-            <istrue value="${is-multidomain}"/>
+            <istrue value="${domains-info.is-multidomain}"/>
             <then>
                 <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="true">
                     <arg value="--colors=always"/>
@@ -974,7 +999,7 @@
         </exec>
     </target>
 
-    <target name="translations-dump" description="Extracts translatable messages from all source files in your project.">
+    <target name="translations-dump" depends="domains-info-load" description="Extracts translatable messages from all source files in your project.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="translation:extract"/>
@@ -985,7 +1010,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.src}/Shopsys/ShopBundle/Resources/translations"/>
             <arg line="${translations.dump.flags}"/>
-            <arg line="${translations.dump.locales}"/>
+            <arg line="${domains-info.locales}"/>
         </exec>
     </target>
 

--- a/packages/framework/src/Command/DomainInfoCommand.php
+++ b/packages/framework/src/Command/DomainInfoCommand.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+
+class DomainInfoCommand extends Command
+{
+    protected const ARG_PROPERTY_NAME = 'propertyName';
+    protected const ARG_ID = 'username';
+
+    protected const OPTION_ALL = 'all';
+
+    protected const RETURN_CODE_OK = 0;
+    protected const RETURN_CODE_ERROR = 1;
+
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'shopsys:domains:info';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    public function __construct(Domain $domain) {
+        parent::__construct();
+
+        $this->domain = $domain;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Loads and displays domain info.')
+            ->addArgument(self::ARG_PROPERTY_NAME, InputArgument::OPTIONAL, 'Property that should be loaded', 'id')
+            ->addArgument(self::ARG_ID, InputArgument::OPTIONAL, 'Domain ID (if omitted, the command will output all distinct values)')
+            ->addOption(self::OPTION_ALL, 'a', InputOption::VALUE_NONE, 'Display all property values (without sorting and deduplication)');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        try {
+            $domainConfigs = $this->getDomainConfigs($input);
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return self::RETURN_CODE_ERROR;
+        }
+
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $propertyName = $input->getArgument(self::ARG_PROPERTY_NAME);
+        $propertyValues = [];
+        foreach ($domainConfigs as $domainConfig) {
+            if (!$propertyAccessor->isReadable($domainConfig, $propertyName)) {
+                $this->outputPropertyNotAccessible($io, $domainConfig, $propertyName);
+
+                return self::RETURN_CODE_ERROR;
+            }
+
+            $propertyValues[] = $propertyAccessor->getValue($domainConfig, $propertyName);
+        }
+
+        if (!$input->getOption(self::OPTION_ALL)) {
+            sort($propertyValues);
+            $propertyValues = array_unique($propertyValues);
+        }
+        $io->writeln(implode("\t", $this->formatPropertyValues($propertyValues)));
+
+        return self::RETURN_CODE_OK;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
+     */
+    protected function getDomainConfigs(InputInterface $input): array
+    {
+        $domainConfigs = $this->domain->getAllIncludingDomainConfigsWithoutDataCreated();
+
+        $domainId = $input->getArgument(self::ARG_ID);
+        if ($domainId !== null) {
+            foreach ($domainConfigs as $domainConfig) {
+                if ($domainId === (string)$domainConfig->getId()) {
+                    return [$domainConfig];
+                }
+            }
+
+            throw new \InvalidArgumentException(sprintf('Domain with ID "%s" not found.', $domainId));
+        }
+
+        return $domainConfigs;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $io
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string $propertyName
+     */
+    protected function outputPropertyNotAccessible(SymfonyStyle $io, DomainConfig $domainConfig, string $propertyName): void
+    {
+        $io->error(sprintf('Property "%s" of DomainConfig is not accessible.', $propertyName));
+
+        $propertyExtractor = new ReflectionExtractor();
+        $io->writeln('You can access these properties:');
+        $io->listing($propertyExtractor->getProperties($domainConfig));
+    }
+
+    /**
+     * @param mixed[] $propertyValues
+     * @return string[]
+     */
+    protected function formatPropertyValues(array $propertyValues): array
+    {
+        return array_map(function ($propertyValue) {
+            if ($propertyValue === null) {
+                return '<options=bold;fg=cyan>NULL</options=bold;fg=cyan>';
+            } elseif ($propertyValue === true) {
+                return '<options=bold;fg=green>YES</options=bold;fg=green>';
+            } elseif ($propertyValue === false) {
+                return '<options=bold;fg=red>NO</options=bold;fg=red>';
+            } else {
+                return $propertyValue;
+            }
+        }, $propertyValues);
+    }
+}

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -7,7 +7,6 @@
     <property name="path.vendor" value="${path.root}/vendor"/>
     <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
 
-    <property name="is-multidomain" value="true"/>
     <property name="phpstan.level" value="1"/>
 
     <import file="${path.framework}/build.xml"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The `is-multidomain` and `translations.dump.locales` properties are now loaded automatically using a new Symfony command `shopsys:domains:info` instead of having developers set them up manually. Simplifies configuration of domains and locales. Also provides a way to show info about domains via CLI.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #941
 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
