### PR TITLE
[shopsys] guidelines-for-pull-request.md: added note about proper PR targeting

### DIFF
--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -22,6 +22,8 @@ Once created, a git tag marking a release will never be removed or edited.
 Pre-release version format is `MAJOR.MINOR.PATCH-<alpha|beta|rc><n>`, eg. `7.0.0-beta5`.*
 
 ### Current Release Plan
+Currently, `7.3`, and `8.0` versions are supported, i.e. we are releasing patch versions for them on a regular basis.
+
 To be able to develop and improve Shopsys Framework we plan to release `MAJOR` versions almost quarterly, aiming to release a new `MAJOR` every 3-4 months.
 We expect this period to increase in the future to yearly releases.
 

--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -22,7 +22,7 @@ Once created, a git tag marking a release will never be removed or edited.
 Pre-release version format is `MAJOR.MINOR.PATCH-<alpha|beta|rc><n>`, eg. `7.0.0-beta5`.*
 
 ### Current Release Plan
-Currently, `7.3`, and `8.0` versions are supported, i.e. we are releasing patch versions for them on a regular basis.
+Currently, `7.3` and `8.0` versions are supported, i.e. we are releasing patch versions for them on a regular basis.
 
 To be able to develop and improve Shopsys Framework we plan to release `MAJOR` versions almost quarterly, aiming to release a new `MAJOR` every 3-4 months.
 We expect this period to increase in the future to yearly releases.

--- a/docs/contributing/guidelines-for-pull-request.md
+++ b/docs/contributing/guidelines-for-pull-request.md
@@ -41,7 +41,9 @@ If your pull request:
 * **fixes a bug and does not contain any BC break**, it should be targeted to the oldest supported version where the bug occurs.
 * **does not contain any BC break**, it should be targeted to `master`.
 * **contains any BC break**, it should be targeted to a branch where the next major release is being prepared.
-    * E.g., if the latest release is `v7.1.0` and you want to introduce a breaking change, you need to rebase your branch on `8.0` branch and target your PR against it. If no such a branch exists, you need to create one.
+    * E.g., if the latest release is `v7.1.0` and you want to introduce a breaking change, you need to rebase your branch on `8.0` branch and target your PR against it.
+
+*Note: Always rebase your branch onto the base branch before retargeting, otherwise your PR might contain more commits than you'd want to merge.*
 
 ## 2. Changes after review
 During the review, reviewer will write comments how to improve the solution or fix bugs. CR can end in `Approved` or `RequestChanges` status when further edits are needed. After completing the CR, it is necessary to correct errors encountered by the reviewer.

--- a/docs/contributing/guidelines-for-pull-request.md
+++ b/docs/contributing/guidelines-for-pull-request.md
@@ -24,10 +24,6 @@ git fetch
 git rebase origin/master
 ```
 
-**Important note:**
-If your pull request contains any BC breaks (see [Backward Compatibility Promise](/docs/contributing/backward-compatibility-promise.md)), it should not be targeted against the current master but against a branch where the next major release is being prepared.
-E.g., if the latest release is `v7.1.0` and you want to introduce a breaking change, you need to rebase your branch on `8.0` branch and target your PR against it. If no such a branch exists, you need to create one.
-
 * You have to check your change using the command `php phing standards tests tests-acceptance` as it’s mentioned in [contributing](../../project-base/CONTRIBUTING.md).
 
     *Note: In this step you were using multiple Phing targets.
@@ -37,6 +33,15 @@ E.g., if the latest release is `v7.1.0` and you want to introduce a breaking cha
 * [Create a PR](https://github.com/shopsys/shopsys/compare?expand=1) with essential information to make our code review easier.
     * you do not have to update `CHANGELOG.md` at all as it is generated automatically using [symplify/changelog-linker](https://github.com/symplify/changeloglinker) during our release process.
 * Now just wait for review of your change.
+
+### Note about targeting pull requests
+As we [support multiple versions](./backward-compatibility-promise.md#current-release-plan) of Shopsys Framework while keeping [Backward Compatibility Promise](/docs/contributing/backward-compatibility-promise.md), it is important to think about proper targeting of your pull request.
+
+If your pull request:
+* **fixes a bug and does not contain any BC break**, it should be targeted to the oldest supported version where the bug occurs.
+* **does not contain any BC break**, it should be targeted to `master`.
+* **contains any BC break**, it should be targeted to a branch where the next major release is being prepared.
+    * E.g., if the latest release is `v7.1.0` and you want to introduce a breaking change, you need to rebase your branch on `8.0` branch and target your PR against it. If no such a branch exists, you need to create one.
 
 ## 2. Changes after review
 During the review, reviewer will write comments how to improve the solution or fix bugs. CR can end in `Approved` or `RequestChanges` status when further edits are needed. After completing the CR, it is necessary to correct errors encountered by the reviewer.

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateListOfSupportedVersionsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateListOfSupportedVersionsReleaseWorker.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
+
+use PharIo\Version\Version;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+
+final class UpdateListOfSupportedVersionsReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return '[Manually] Update the list of currently supported versions mentioned in BC promise (if necessary).';
+    }
+
+    /**
+     * Higher first
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 843;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $this->symfonyStyle->note('When releasing a new MINOR or MAJOR version, make sure the list of currently supported versions in BC promise (https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md#current-release-plan) is up to date.');
+        $this->symfonyStyle->note('If necessary, update the list and commit the change with "backward-compatibility-promise.md: updated list of currently supported versions" commit message.');
+
+        $this->confirm('Confirm the list is up to date');
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::RELEASE_CANDIDATE;
+    }
+}


### PR DESCRIPTION
- backward-compatibility-promise.md: added information about currently supported versions

| Q             | A
| ------------- | ---
|Description, reason for the PR| We were missing information about proper PR tergeting and currently supported versions in our docs. This PR should help developers of Shopsys Framework, as well as the external contributors to avoid confusion.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
