### PR TITLE
[framework] AdvancedSearch respects current route on reset form

### DIFF
--- a/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
+++ b/packages/framework/src/Model/AdvancedSearch/AdvancedSearchProductFacade.php
@@ -8,8 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AdvancedSearchProductFacade
 {
-    /** @access protected */
-    const RULES_FORM_NAME = 'as';
+    public const RULES_FORM_NAME = 'as';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchFormFactory

--- a/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/AdvancedSearchOrderFacade.php
@@ -11,8 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class AdvancedSearchOrderFacade
 {
-    /** @access protected */
-    const RULES_FORM_NAME = 'as';
+    public const RULES_FORM_NAME = 'as';
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchFormFactory

--- a/packages/framework/src/Resources/views/Admin/Content/Order/AdvancedSearch/advancedSearch.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Order/AdvancedSearch/advancedSearch.html.twig
@@ -12,7 +12,9 @@
                 {{ 'Add requirement'|trans }}
             </button>
 
-            <a href="{{ url('admin_order_list', { as: true }) }}" class="in-iconic-link">
+            {% set RULES_FORM_NAME = constant('Shopsys\\FrameworkBundle\\Model\\AdvancedSearchOrder\\AdvancedSearchOrderFacade::RULES_FORM_NAME') %}
+            {% set routeParams =  getRouteParams()|merge({ (RULES_FORM_NAME): true }) %}
+            <a href="{{ url(getRoute(), routeParams) }}" class="in-iconic-link">
                 <i class="svg svg-circle-cross"></i>
                 {{ 'Reset filter'|trans }}
             </a>

--- a/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/advancedSearch.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/AdvancedSearch/advancedSearch.html.twig
@@ -12,7 +12,9 @@
                 {{ 'Add requirement'|trans }}
             </button>
 
-            <a href="{{ url('admin_product_list', { as: true }) }}" class="in-iconic-link">
+            {% set RULES_FORM_NAME = constant('Shopsys\\FrameworkBundle\\Model\\AdvancedSearch\\AdvancedSearchProductFacade::RULES_FORM_NAME') %}
+            {% set routeParams =  getRouteParams()|merge({ (RULES_FORM_NAME): true }) %}
+            <a href="{{ url(getRoute(), routeParams) }}" class="in-iconic-link">
                 <i class="svg svg-circle-cross"></i>
                 {{ 'Reset filter'|trans }}
             </a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Administration > Product > Product Detail I am trying to add new accessories. I click to "Add Products", open "Advanced Filter" and click "Reset Filter". Then the content of popup window reloads and standard product overview appears in the popup so I am not allowed to finish assigning accessories.
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| closes #1274
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
