### PR TITLE
[project-base] force locale for number formatting

### DIFF
--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -146,4 +146,7 @@ There you can find links to upgrade notes for other versions too.
         +       arguments:
         +           $useInlineEditation: false
         ```
+- add `setlocale(LC_NUMERIC, 'en_US.utf8');` in your `Bootstrap.php` right behind `setlocale(LC_CTYPE, 'en_US.utf8');` ([#1313](https://github.com/shopsys/shopsys/pull/1313/))
+    - add [`\Tests\ShopBundle\Unit\NumberFormattingTest`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Unit/NumberFormattingTest.php)
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/app/Bootstrap.php
+++ b/project-base/app/Bootstrap.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 require_once __DIR__ . '/autoload.php';
 
 setlocale(LC_CTYPE, 'en_US.utf8');
+setlocale(LC_NUMERIC, 'en_US.utf8');
 
 class Bootstrap
 {

--- a/project-base/tests/ShopBundle/Unit/NumberFormattingTest.php
+++ b/project-base/tests/ShopBundle/Unit/NumberFormattingTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class NumberFormattingTest extends TestCase
+{
+    public function testNumberFormatting()
+    {
+        $formattedNumber = sprintf('%01.2f', 123456.789);
+        $expectedResult = '123456.79';
+
+        $this->assertSame($expectedResult, $formattedNumber);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When server has "wrong" locale, `Money` or sitemap does not work properly. For more info see #1184
|New feature| No
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| closes #1184
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
