### PR TITLE
[shopsys] UpdateUpgradeReleaseWorker: added note about checking upgrade instructions from lower versions

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -97,7 +97,8 @@ final class UpdateUpgradeReleaseWorker extends AbstractShopsysReleaseWorker
             'Typically, you need to:
             - check the correctness of the order of Shopsys packages and sections, 
             - check whether there are no duplicated instructions for modifying docker related files, 
-            - change the links from master to the %1$s version in UPGRADE-%1$s.md file.',
+            - change the links from master to the %1$s version in UPGRADE-%1$s.md file.
+            - check whether the upgrade instructions from the lower versions (i.e. from the supported branches that were merged into the current one) are included in the UPGRADE-%1$s.md file',
             $versionString
         ));
         $this->symfonyStyle->note(sprintf('You need to commit the upgrade files manually with commit message "upgrade files are now updated for %s release" commit message.', $versionString));


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| We need to ensure that upgrade instructions for patch versions are included in the all relevant `UPGRADE` files
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
