### PR TITLE
[shopsys] phpstan.neon: stop excluding coding-standards

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -59,9 +59,6 @@ parameters:
             message: '#Array \(array<.+>\) does not accept object\.#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
         - '#Undefined variable: \$undefined#'
-    excludes_analyse:
-        # Exclude coding standards from packages as it is in incompatible version
-        - %currentWorkingDirectory%/packages/coding-standards/*
 includes:
 	- vendor/phpstan/phpstan-doctrine/extension.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Since #143 (`v7.0.0-alpha3`), the `shopsys/coding-standards` package is no longer in an incompatible version with the rest of the monorepo. This PR suggests to include its code base in the check via PhpStan during `php phing phpstan` (part of `php phing standards`).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
