### PR TITLE
[shopsys] remove notes about committing migrations-lock.yml in documentation

### DIFF
--- a/docs/introduction/database-migrations.md
+++ b/docs/introduction/database-migrations.md
@@ -41,7 +41,7 @@ This wouldn't work as well in Shopsys Framework, because you can install a modul
 > If the application would be installed on some other computer the migrations would be executed in a different order and might end up with different structure or data.
 
 This problem is solved by the [MigrationsBundle](https://hithub.com/shopsys/migrations) by generating a `migrations-lock.yml`.
-After the first execution of migrations, the `migrations-lock.yml` file is created in your project's root directory.
+After the execution of migrations, the `migrations-lock.yml` file is updated.
 You should commit this file similarly as you [commit the Composer lock file](https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control).
 It contains the info about all migrations that were executed and it will be used when running the migrations on a different database.
 

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -5,16 +5,6 @@ Here are first steps you should start with.
 
 *Note: If you don't have a working application, [install it](/docs/installation/installation-guide.md) first.*
 
-## Commit `migrations-lock.yml`
-
-Committing lock files is important because the application is then installed in the same way in all environments (most importantly in the production) and also in the same way for all team members.
-Notice that lock files for composer (`composer.lock`) and npm (`package-lock.json`) dependencies are already committed in your project.
-
-```bash
-git add migrations-lock.yml
-git commit -m'locked migrations'
-```
-
 ## Set up domains
 
 A domain can be understood as one instance of the shop.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| after #1323 notes about committing `migrations-lock.yml` will be useless, so they are removed
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
