### PR TITLE
[framework] restrict access to currency settings to superadmin

### DIFF
--- a/packages/framework/src/Controller/Admin/CurrencyController.php
+++ b/packages/framework/src/Controller/Admin/CurrencyController.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Shopsys\FrameworkBundle\Component\ConfirmDelete\ConfirmDeleteResponseFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
@@ -12,6 +13,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
+/**
+ * @Security("has_role('ROLE_SUPER_ADMIN')")
+ */
 class CurrencyController extends AdminBaseController
 {
     /**

--- a/packages/framework/src/Controller/Admin/CurrencyController.php
+++ b/packages/framework/src/Controller/Admin/CurrencyController.php
@@ -2,7 +2,6 @@
 
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Shopsys\FrameworkBundle\Component\ConfirmDelete\ConfirmDeleteResponseFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
@@ -13,9 +12,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Security("has_role('ROLE_SUPER_ADMIN')")
- */
 class CurrencyController extends AdminBaseController
 {
     /**

--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -147,7 +147,10 @@ class SideMenuBuilder
         $menu->addChild('pricing_groups', ['route' => 'admin_pricinggroup_list', 'label' => t('Pricing groups')]);
         $menu->addChild('vat', ['route' => 'admin_vat_list', 'label' => t('VAT')]);
         $menu->addChild('free_transport_and_payment', ['route' => 'admin_transportandpayment_freetransportandpaymentlimit', 'label' => t('Free shipping and payment')]);
-        $menu->addChild('currencies', ['route' => 'admin_currency_list', 'label' => t('Currencies and rounding')]);
+        if ($this->authorizationChecker->isGranted(Roles::ROLE_SUPER_ADMIN)) {
+            $currenciesMenuItem = $menu->addChild('currencies', ['route' => 'admin_currency_list', 'label' => t('Currencies')]);
+            $currenciesMenuItem->setExtra('superadmin', true);
+        }
         $promoCodesMenu = $menu->addChild('promo_codes', ['route' => 'admin_promocode_list', 'label' => t('Promo codes')]);
         $promoCodesMenu->addChild('new', ['route' => 'admin_promocode_new', 'label' => t('New promo code'), 'display' => false]);
         $promoCodesMenu->addChild('edit', ['route' => 'admin_promocode_edit', 'label' => t('Editing promo code'), 'display' => false]);

--- a/project-base/config/packages/security.yaml
+++ b/project-base/config/packages/security.yaml
@@ -80,6 +80,7 @@ security:
         - { path: ^/login-as-remembered-user/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/admin/superadmin/, roles: ROLE_SUPER_ADMIN }
         - { path: ^/admin/cron/*, roles: ROLE_SUPER_ADMIN }
+        - { path: ^/admin/currency/, roles: ROLE_SUPER_ADMIN }
         - { path: ^/admin/translation/list/$, roles: ROLE_SUPER_ADMIN }
         - { path: ^/admin/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/admin/authorization/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }

--- a/project-base/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -260,6 +260,20 @@ class RouteConfigCustomization
                 $config->changeDefaultRequestDataSet($debugNote)
                     ->setParameter('id', $vat->getId())
                     ->setParameter('newId', $newVat->getId());
+            })
+            ->customizeByRouteName('admin_currency_list', function (RouteConfig $config) {
+                $config->changeDefaultRequestDataSet('Currency setting is available only to superadmin.')
+                    ->setExpectedStatusCode(302);
+                $config->addExtraRequestDataSet('Should be OK when logged in as "superadmin".')
+                    ->setAuth(new BasicHttpAuth('superadmin', 'admin123'))
+                    ->setExpectedStatusCode(200);
+            })
+            ->customizeByRouteName('admin_currency_deleteconfirm', function (RouteConfig $config) {
+                $config->changeDefaultRequestDataSet('Currency setting is available only to superadmin.')
+                    ->setExpectedStatusCode(302);
+                $config->addExtraRequestDataSet('Should be OK when logged in as "superadmin".')
+                    ->setAuth(new BasicHttpAuth('superadmin', 'admin123'))
+                    ->setExpectedStatusCode(200);
             });
     }
 

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -27,3 +27,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fix 500 error during logout when the user is already logged out ([#1909](https://github.com/shopsys/shopsys/pull/1909))
     - you might want to update your translations, because new translation message has been added for Czech and English language only
+
+- restrict access to Admin > Pricing > Currencies only to superadmin ([#1338](https://github.com/shopsys/shopsys/pull/1338))
+    - see #project-base-diff to upgrade your project 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When changing a basic frontend currency on a domain in administration, the product prices are not recalculated or changed in any way. They remain the same, but in a different currency. This may happen without any warning or prompt. Because of this, I suggest restricting the access to currency setting to superadmin only.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md --><br> ~~(for this reason, I've used `@Security` annotation instead of a record in `security.yml`, which is used for restricting access to other pages)~~<br>Record in security.yml is necessaary as it is project-base thing same as upgrading smoke tests. The app will not break when upgrade (except missing link to affected page). 
|Fixes issues| resolves #791 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
