### PR TITLE
[framework] replace constant from other classes for value

### DIFF
--- a/packages/framework/src/Migrations/MultidomainMigrationTrait.php
+++ b/packages/framework/src/Migrations/MultidomainMigrationTrait.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use PDO;
-use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
 /**
  * This trait can be used in classes
@@ -17,7 +16,7 @@ trait MultidomainMigrationTrait
     protected function getAllDomainIds()
     {
         return $this
-            ->sql('SELECT domain_id FROM setting_values WHERE name = :baseUrl', ['baseUrl' => Setting::BASE_URL])
+            ->sql('SELECT domain_id FROM setting_values WHERE name = :baseUrl', ['baseUrl' => 'baseUrl'])
             ->fetchAll(PDO::FETCH_COLUMN, 'domain_id');
     }
 

--- a/packages/framework/src/Migrations/Version20160129122637.php
+++ b/packages/framework/src/Migrations/Version20160129122637.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20160129122637 extends AbstractMigration
@@ -14,7 +13,7 @@ class Version20160129122637 extends AbstractMigration
     public function up(Schema $schema)
     {
         $sql = 'INSERT INTO setting_values (name, domain_id, value, type) VALUES
-            (\'' . Setting::BASE_URL . '\', 1, \'http://localhost:8080\', \'string\')
+            (\'baseUrl\', 1, \'http://localhost:8080\', \'string\')
         ';
         $this->sql($sql);
 

--- a/packages/framework/src/Migrations/Version20160531080553.php
+++ b/packages/framework/src/Migrations/Version20160531080553.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20160531080553 extends AbstractMigration
@@ -14,9 +13,9 @@ class Version20160531080553 extends AbstractMigration
     public function up(Schema $schema)
     {
         $this->sql('INSERT INTO setting_values (name, domain_id, value, type) VALUES
-            (\'' . Setting::FEED_DOMAIN_ID_TO_CONTINUE . '\', 0, NULL, \'string\'),
-            (\'' . Setting::FEED_ITEM_ID_TO_CONTINUE . '\', 0, NULL, \'string\'),
-            (\'' . Setting::FEED_NAME_TO_CONTINUE . '\', 0, NULL, \'string\')
+            (\'feedDomainIdToContinue\', 0, NULL, \'string\'),
+            (\'feedItemIdToContinue\', 0, NULL, \'string\'),
+            (\'feedNameToContinue\', 0, NULL, \'string\')
         ');
     }
 

--- a/packages/framework/src/Migrations/Version20180409100239.php
+++ b/packages/framework/src/Migrations/Version20180409100239.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequest;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20180409100239 extends AbstractMigration
@@ -14,7 +13,7 @@ class Version20180409100239 extends AbstractMigration
     public function up(Schema $schema)
     {
         $this->sql('ALTER TABLE personal_data_access_request ADD type VARCHAR(50)');
-        $this->sql('UPDATE personal_data_access_request SET type = :type', ['type' => PersonalDataAccessRequest::TYPE_DISPLAY]);
+        $this->sql('UPDATE personal_data_access_request SET type = :type', ['type' => 'display']);
         $this->sql('ALTER TABLE personal_data_access_request ALTER COLUMN type SET NOT NULL');
     }
 

--- a/packages/framework/src/Migrations/Version20181008000001.php
+++ b/packages/framework/src/Migrations/Version20181008000001.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20181008000001 extends AbstractMigration
@@ -13,8 +12,8 @@ class Version20181008000001 extends AbstractMigration
      */
     public function up(Schema $schema)
     {
-        $this->sql('UPDATE setting_values SET value = 0 WHERE value IS NULL AND type = \'integer\' AND  name = \'' . Setting::DEFAULT_AVAILABILITY_IN_STOCK . '\'');
-        $this->sql('UPDATE setting_values SET value = 0 WHERE value IS NULL AND type = \'integer\' AND  name = \'' . Setting::DEFAULT_UNIT . '\'');
+        $this->sql('UPDATE setting_values SET value = 0 WHERE value IS NULL AND type = \'integer\' AND  name = \'defaultAvailabilityInStockId\'');
+        $this->sql('UPDATE setting_values SET value = 0 WHERE value IS NULL AND type = \'integer\' AND  name = \'defaultUnitId\'');
         $this->sql('UPDATE setting_values SET type = \'none\' where value IS NULL');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| What I know it's not good to use constants which can be changed in time and migrations must not adjust over time, right? So I changed these constants to their value.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

P.S.: I didn't change classes with which I was not sure:

- [here](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Migrations/Version20190121094400.php#L107) is used `Doctrine\DBAL\Connection\Connection::PARAM_INT_ARRAY` constant and I don't know that is ok
- [I am not sure about using this constant](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Migrations/MultidomainMigrationTrait.php#L20)

P.P.S.: after consultation with @pk16011990 I heard PHP class constant is OK because this constant/classes should be changed only in major version (e.c. from PHP 7 to PHP 8). If it's true then I am ok with PDO constant and other PHP constants.