### PR TITLE
[shopsys] automated fixes and additions of annotations for extended classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
         "prezent/doctrine-translatable-bundle": "^1.0.3",
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8",
+        "roave/better-reflection": "^3.5",
         "sensio/distribution-bundle": "^5.0.21",
         "sensio/framework-extra-bundle": "^3.0.29",
         "sensio/generator-bundle": "^3.1.7",

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -166,6 +166,17 @@ Exports all visible products to Elasticsearch.
 
 ### Coding standards
 
+#### annotations-check
+Checks whether annotations of extended classes in the project match the actual types according to [`ClassExtensionRegistry`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php).
+Reported problems can be fixed using [`annotations-fix` phing target](#annotations-fix).
+
+#### annotations-fix
+Makes static analysis tools understand the extended code in your project by changing annotations and adding `@property` and `@method` annotations to relevant classes.
+
+You can read more in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
+
+You can read more about the topic in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
+
 #### standards / standards-diff
 Checks coding standards in source files. Checking all files may take a few minutes, `standards-diff` is much quicker as it checks only files changed against `origin/master`.
 
@@ -196,12 +207,6 @@ The size of performance data to be generated and asserted limits can be configur
 You can easily override the default values in your `parameters.yml` or `parameters_test.yml` configuration files.
 
 ### Other
-
-#### annotations-check
-Checks whether annotations of extended classes in the project match the actual types according to [`ClassExtensionRegistry`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php).
-Reported problems can be fixed using [`annotations-fix` phing target](#annotations-fix).
-
-You can read more about the topic in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
 
 #### cron
 Runs background jobs. Should be executed periodically by system Cron every 5 minutes.
@@ -234,11 +239,6 @@ For more information, see [Working with Multiple Cron Instances](/docs/cookbook/
 Lists all available background jobs. If there is more than one cron instance registered, jobs are grouped by instance.
 
 For more information, see [Working with Multiple Cron Instances](/docs/cookbook/working-with-multiple-cron-instances.md) cookbook or you can read about [Cron in general](/docs/introduction/cron.md).
-
-#### annotations-fix
-Makes static analysis tools understand the extended code in your project by changing annotations and adding `@property` and `@method` annotations to relevant classes.
-
-You can read more in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
 
 #### grunt
 Builds CSS from LESS via Grunt.

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -197,9 +197,9 @@ You can easily override the default values in your `parameters.yml` or `paramete
 
 ### Other
 
-#### check-annotations
+#### annotations-check
 Checks whether annotations of extended classes in the project match the actual types according to [`ClassExtensionRegistry`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php).
-Reported problems can be fixed using [`fix-annotations` phing target](#fix-annotations).
+Reported problems can be fixed using [`annotations-fix` phing target](#annotations-fix).
 
 You can read more about the topic in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
 
@@ -235,7 +235,7 @@ Lists all available background jobs. If there is more than one cron instance reg
 
 For more information, see [Working with Multiple Cron Instances](/docs/cookbook/working-with-multiple-cron-instances.md) cookbook or you can read about [Cron in general](/docs/introduction/cron.md).
 
-#### fix-annotations
+#### annotations-fix
 Makes static analysis tools understand the extended code in your project by changing annotations and adding `@property` and `@method` annotations to relevant classes.
 
 You can read more in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -197,6 +197,12 @@ You can easily override the default values in your `parameters.yml` or `paramete
 
 ### Other
 
+#### check-annotations
+Checks whether annotations of extended classes in the project match the actual types according to [`ClassExtensionRegistry`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php).
+Reported problems can be fixed using [`fix-annotations` phing target](#fix-annotations).
+
+You can read more about the topic in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
+
 #### cron
 Runs background jobs. Should be executed periodically by system Cron every 5 minutes.
 

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -229,6 +229,11 @@ Lists all available background jobs. If there is more than one cron instance reg
 
 For more information, see [Working with Multiple Cron Instances](/docs/cookbook/working-with-multiple-cron-instances.md) cookbook or you can read about [Cron in general](/docs/introduction/cron.md).
 
+#### fix-annotations
+Makes static analysis tools understand the extended code in your project by changing annotations and adding `@property` and `@method` annotations to relevant classes.
+
+You can read more in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).
+
 #### grunt
 Builds CSS from LESS via Grunt.
 

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -27,6 +27,7 @@ For more detailed information about the Shopsys Framework, please see [Shopsys F
 - [Do you have any tips how to debug emails during development in Docker?](#do-you-have-any-tips-how-to-debug-emails-during-development-in-docker)
 - [Can I see what is really happening in the Codeception acceptance tests when using Docker?](#can-i-see-what-is-really-happening-in-the-codeception-acceptance-tests-when-using-docker)
 - [Why is there a faked PHP 7.2 platform in the Composer config?](#why-is-there-a-faked-php-72-platform-in-the-composer-config)
+- [How to make PHPStorm and PHPStan understand that I use extended classes?](#how-to-make-phpstorm-and-phpstan-understand-that-i-use-extended-classes)
 
 ## What are the phing targets?
 Every phing target is a task that can be executed simply by `php phing <target-name>` command.
@@ -162,3 +163,7 @@ See [Composer docs](https://getcomposer.org/doc/01-basic-usage.md#installing-wit
 Without this forced platform version, you could encounter issues when working on your project with developers that use a different version of PHP.
 For example, your `composer.lock` could contain dependencies that not all developers can install.
 If that's not your case, you can safely remove the `config.platform.php` option from your `composer.json` and run `composer update` to use higher versions of your dependencies.
+
+## How to make PHPStorm and PHPStan understand that I use extended classes?
+There is a phing target that automatically fixes all relevant `@var` and `@param` annotations, and adds proper `@method` and `@property` annotations to your classes so the static analysis understands the class extensions properly.
+You can read more in the ["Framework extensibility" article](./framework-extensibility.md#making-the-static-analysis-understand-the-extended-code).

--- a/docs/introduction/framework-extensibility.md
+++ b/docs/introduction/framework-extensibility.md
@@ -146,7 +146,7 @@ class ProductController
       }
 }
 ```
-**Luckily, you do need to fix the annotations manually, there is the [Phing target `fix-annotations`](./console-commands-for-application-management-phing-targets.md#fix-annotations), that handles everything for you.**
+**Luckily, you do need to fix the annotations manually, there is the [Phing target `annotations-fix`](./console-commands-for-application-management-phing-targets.md#annotations-fix), that handles everything for you.**
 
 ### Problem 2
 There might be yet another problem with static analysis when extending framework classes.
@@ -203,7 +203,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
   class ProductFacade extends BaseProductFacade
   {
 ```
-**Even this scenario is covered by `fix-annotations` phing target.**
+**Even this scenario is covered by `annotations-fix` phing target.**
 
 ### Problem 3
 There is one kind of problem that is not fixed automatically and needs to be addressed manually.
@@ -282,7 +282,7 @@ private function myAwesomeMethod($id)
 }
 ```
 
-As a workaround for this, you can create an empty class extending the one from the framework, register the extension in your `services.yml`, and then use `php phing fix-annotations` to fix appropriate annotations for you.
+As a workaround for this, you can create an empty class extending the one from the framework, register the extension in your `services.yml`, and then use `php phing annotations-fix` to fix appropriate annotations for you.
 
 Which way to go really depends on your situation. If you are likely to extend the given framework class sooner or later, or the same problem with the class is reported in many places, it would be better to create the empty extended class right away.
 Otherwise, it might be better just extracting and annotating the variable manually (like in [this commit in monorepo](https://github.com/shopsys/shopsys/commit/efd008b8d))

--- a/docs/introduction/framework-extensibility.md
+++ b/docs/introduction/framework-extensibility.md
@@ -78,3 +78,216 @@ as well as a list of customizations that are not (and will not be) possible at a
     * separate users login credentials
     * share company attributes
     * change association from 1:1 to 1:N
+
+## Making the static analysis understand the extended code
+### Problem 1
+When extending framework classes, it may happen that tools for static analysis (e.g. PHPStan, PHPStorm) will not understand your code properly.
+Imagine this situation:
+
+- You have a controller that is dependent on a framework service:
+```php
+namespace Shopsys\ShopBundle\Controller\Front;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+
+class ProductController
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    protected $productFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
+     */
+    public function __construct(ProductFacade $productFacade)
+    {
+        $this->productFacade = $productFacade;
+    }
+}
+```
+- In your project, you extend the framework's `ProductFacade` service:
+```php
+namespace Shopsys\ShopBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
+
+class ProductFacade extends BaseProductFacade
+{
+    public function myCustomAwesomeFunction()
+    {
+        return 42;
+    }
+}
+```
+- You register your extension in DI services configuration and thanks to that, your class is used in `ProductController` instead of the one from `FrameworkBundle`, so far so good:
+```yaml
+Shopsys\FrameworkBundle\Model\Product\ProductFacade: '@Shopsys\ShopBundle\Model\Product\ProductFacade'
+```
+**However, when you want to use your `myCustomAwesomeFunction()` in `ProductController`, the static analysis is not aware of that function.**
+#### Solution
+To fix this, you need to change the annotations properly:
+```diff
+class ProductController
+{
+      /**
+-      * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
++      * @var \Shopsys\ShopBundle\Model\Product\ProductFacade
+       */
+      protected $productFacade;
+
+      /**
+-      * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
++      * @param \Shopsys\ShopBundle\Model\Product\ProductFacade $productFacade
+       */
+      public function __construct(ProductFacade $productFacade)
+      {
+          $this->productFacade = $productFacade;
+      }
+}
+```
+**Luckily, you do need to fix the annotations manually, there is the [Phing target `fix-annotations`](./console-commands-for-application-management-phing-targets.md#fix-annotations), that handles everything for you.**
+
+### Problem 2
+There might be yet another problem with static analysis when extending framework classes.
+Imagine the following situation:
+
+- In framework, there is `ProductFacade` that has `ProductRepository` property
+```php
+namespace Shopsys\FrameworkBundle\Model\Product;
+
+class ProductFacade
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+     */
+    public function getProductRepository()
+    {
+        retrun $this->productRepository;
+    }
+}
+```
+- In your project, you extend `ProductRepository` and `ProductFacade` as well.
+- Then, in your extended facade, you want to access the repository (generally speaking, you want to access the parent's property that has a type that is extended in your project, or you want to access a method that returns a type that is already extended):
+```php
+namespace Shopsys\ShopBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
+
+class ProductFacade extends BaseProductFacade
+{
+    public function myCustomAwesomeFunction()
+    {
+        $this->productRepository; // static analysis thinks this is of type \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+        $this->getProductRepository(); // static analysis thinks this is of type \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+    }
+}
+```
+- **Once again, static analysis is not aware of the extension.**
+#### Solution
+To fix this, you don't need to override the method or property, you just need to add proper `@method` and `@property` annotations to your class:
+```diff
+namespace Shopsys\ShopBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade as BaseProductFacade;
+
++ /**
++  * @method \Shopsys\ShopBundle\Model\Product\ProductRepository getProductRepository()
++  * @property \Shopsys\ShopBundle\Model\Product\ProductRepository $productRepository
++  */
+  class ProductFacade extends BaseProductFacade
+  {
+```
+**Even this scenario is covered by `fix-annotations` phing target.**
+
+### Problem 3
+There is one kind of problem that is not fixed automatically and needs to be addressed manually.
+Shopsys Framework uses a kind of magic for working with extended entities (see [`EntityNameResolver` class](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/EntityExtension/EntityNameResolver.php)),
+and static analysis tools are not aware of that fact.
+Imagine the following situation:
+- You have extended `Product` entity in your project
+- In the framework, there is `ProductFacade` class that is not extended in your project, and it has a method that returns instances of `Product` entity (in fact, it returns instances of your child `Product` entity thanks to the mentioned `EntityNameResolver` magic).
+```php
+namespace Shopsys\FrameworkBundle\Model\Product;
+
+// the class has no extension in your project
+class ProductFacade
+{
+
+    /**
+     * This class is not extended in the project either
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     */
+    public function getById($id)
+    {
+        // despite the annotation, extended Product entity from your project is returned
+        return $this->productRepository->getById($id);
+    }
+}
+```
+- You have a controller that is dependent on the framework service:
+```php
+namespace Shopsys\ShopBundle\Controller\Front;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+
+class ProductController
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    protected $productFacade;
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    public function __construct(ProductFacade $productFacade)
+    {
+        return $this->productFacade = $productFacade;
+    }
+
+    /**
+     * @param int $id
+     * Your Product instance is returned indeed, but static analysis is confused
+     * @return \Shopsys\ShopBundle\Model\Product\Product
+     */
+    private function myAwesomeMethod($id)
+    {
+        return $this->productFacade->getById($id);
+    }
+}
+```
+**In such a case, static analysis does not understand that the extended `Product` entity is returned.**
+#### Solution
+This needs to be fixed manually using a local variable with an inline annotation:
+```diff
+private function myAwesomeMethod($id)
+{
++    /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
++    $product = $this->productFacade->getById($id);
+
+
+-    return $this->productFacade->getById($id);
++    return $product;
+}
+```
+
+As a workaround for this, you can create an empty class extending the one from the framework, register the extension in your `services.yml`, and then use `php phing fix-annotations` to fix appropriate annotations for you.
+
+Which way to go really depends on your situation. If you are likely to extend the given framework class sooner or later, or the same problem with the class is reported in many places, it would be better to create the empty extended class right away.
+Otherwise, it might be better just extracting and annotating the variable manually (like in [this commit in monorepo](https://github.com/shopsys/shopsys/commit/efd008b8d))
+as it is quicker and you can avoid having an unused empty class in your project.
+
+### Tip
+If you are a fan of an automation and PHPStorm user at the same time, you can simplify things even more and set your IDE to automatically run the phing target every time you e.g. change something in your project.
+This can be achieved by setting up a custom "[File watcher](https://www.jetbrains.com/help/phpstorm/using-file-watchers.html)".

--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -125,7 +125,16 @@ There you can find links to upgrade notes for other versions too.
         + docker-compose exec -T php-fpm composer install
         + docker-compose exec -T php-fpm ./phing db-create test-db-create build-demo-dev-quick error-pages-generate
         ```
+- run `php phing fix-annotations` to fix or add all the relevant annotations for your extended classes ([#1344](https://github.com/shopsys/shopsys/pull/1344))
+    - thanks to the fixes, your IDE (PHPStorm) will understand your code better
+    - you can read more about the whole topic in the ["Framework extensibility" article](../introduction/framework-extensibility.md#making-the-static-analysis-understand-the-extended-code)
+    - the checks and fixes of the proper annotations are now included in all `standards-*` phing targets, if you want to turn this feature off, add the following line into your `build.xml`:
+    ```diff
+      <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
+    + <property name="check-and-fix-annotations" value="false"/>
 
+      <import file="${path.framework}/build.xml"/>
+    ```
 ### Database migrations
 - run database migrations so products will use a DateTime type for columns for "Selling start date" (selling_from) and "Selling end date" (selling_to) ([#1343](https://github.com/shopsys/shopsys/pull/1343))
     - please check [`Version20190823110846`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Migrations/Version20190823110846.php)

--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -135,6 +135,14 @@ There you can find links to upgrade notes for other versions too.
 
       <import file="${path.framework}/build.xml"/>
     ```
+- increase your PHPStan level to 4 in your `build.xml` ([#1040](https://github.com/shopsys/shopsys/pull/1040))
+    ```diff
+  - <property name="phpstan.level" value="1"/>
+  + <property name="phpstan.level" value="4"/>
+    ```
+    - a lot of the possible issues should be already resolved if you followed the previous instruction and ran the `php phing fix-annotations` phing command
+    - some of the issues related to class extension need to be addressed manually nevertheless (see the ["Framework extensibility" article](../introduction/framework-extensibility.md#problem-3)) for more information
+    - you need to resolve all the other reported problems (any of them can be ignored in your `phpstan.neon`). You can find inspiration in [#1040](https://github.com/shopsys/shopsys/pull/1040)
 ### Database migrations
 - run database migrations so products will use a DateTime type for columns for "Selling start date" (selling_from) and "Selling end date" (selling_to) ([#1343](https://github.com/shopsys/shopsys/pull/1343))
     - please check [`Version20190823110846`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Migrations/Version20190823110846.php)

--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -125,7 +125,7 @@ There you can find links to upgrade notes for other versions too.
         + docker-compose exec -T php-fpm composer install
         + docker-compose exec -T php-fpm ./phing db-create test-db-create build-demo-dev-quick error-pages-generate
         ```
-- run `php phing fix-annotations` to fix or add all the relevant annotations for your extended classes ([#1344](https://github.com/shopsys/shopsys/pull/1344))
+- run `php phing annotations-fix` to fix or add all the relevant annotations for your extended classes ([#1344](https://github.com/shopsys/shopsys/pull/1344))
     - thanks to the fixes, your IDE (PHPStorm) will understand your code better
     - you can read more about the whole topic in the ["Framework extensibility" article](../introduction/framework-extensibility.md#making-the-static-analysis-understand-the-extended-code)
     - the checks and fixes of the proper annotations are now included in all `standards-*` phing targets, if you want to turn this feature off, add the following line into your `build.xml`:
@@ -140,7 +140,7 @@ There you can find links to upgrade notes for other versions too.
   - <property name="phpstan.level" value="1"/>
   + <property name="phpstan.level" value="4"/>
     ```
-    - a lot of the possible issues should be already resolved if you followed the previous instruction and ran the `php phing fix-annotations` phing command
+    - a lot of the possible issues should be already resolved if you followed the previous instruction and ran the `php phing annotations-fix` phing command
     - some of the issues related to class extension need to be addressed manually nevertheless (see the ["Framework extensibility" article](../introduction/framework-extensibility.md#problem-3)) for more information
     - you need to resolve all the other reported problems (any of them can be ignored in your `phpstan.neon`). You can find inspiration in [#1040](https://github.com/shopsys/shopsys/pull/1040)
 ### Database migrations

--- a/packages/backend-api/install/build.xml.patch
+++ b/packages/backend-api/install/build.xml.patch
@@ -5,7 +5,7 @@
 +    <property name="path.backend-api" value="${path.vendor}/shopsys/backend-api"/>
      <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
 
-     <property name="phpstan.level" value="1"/>
+     <property name="phpstan.level" value="4"/>
 
      <import file="${path.framework}/build.xml"/>
 +    <import file="${path.backend-api}/build.xml"/>

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -2,6 +2,7 @@
 <project name="shopsys_framework" default="list">
 
     <property name="is-multidomain" value="true" description="This property is @deprecated, see 'domains-info-load' target instead."/>
+    <property name="check-and-fix-annotations" value="true"/>
     <property name="path.app" value="${path.root}/app"/>
     <property name="path.bin" value="${path.vendor}/bin"/>
     <property name="path.bin-console" value="${path.root}/bin/console"/>
@@ -105,11 +106,22 @@
     </target>
 
     <target name="check-annotations" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'fix-annotations' phing target">
-        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
-            <arg value="${path.bin-console}"/>
-            <arg value="shopsys:extended-classes:annotations"/>
-            <arg value="--dry-run"/>
-        </exec>
+        <if>
+            <istrue value="${check-and-fix-annotations}"/>
+            <then>
+                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                    <arg value="${path.bin-console}"/>
+                    <arg value="shopsys:extended-classes:annotations"/>
+                    <arg value="--dry-run"/>
+                </exec>
+            </then>
+            <else>
+                <echo>
+                    Annotations checks are turned off by configuration, see "check-and-fix-annotations" build property.
+                    You are still able to run "shopsys:extended-classes:annotations" Symfony command directly.
+                </echo>
+            </else>
+        </if>
     </target>
 
     <target name="checks" depends="checks-internal,standards,tests" description="Runs internal checks, coding standards and runs unit, DB and smoke tests."/>
@@ -564,10 +576,21 @@
     </target>
 
     <target name="fix-annotations" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
-        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
-            <arg value="${path.bin-console}"/>
-            <arg value="shopsys:extended-classes:annotations"/>
-        </exec>
+        <if>
+            <istrue value="${check-and-fix-annotations}"/>
+            <then>
+                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                    <arg value="${path.bin-console}"/>
+                    <arg value="shopsys:extended-classes:annotations"/>
+                </exec>
+            </then>
+            <else>
+                <echo>
+                    Annotations fixes are turned off by configuration, see "check-and-fix-annotations" build property.
+                    You are still able to run "shopsys:extended-classes:annotations" Symfony command directly.
+                </echo>
+            </else>
+        </if>
     </target>
 
     <target name="friendly-urls-generate" description="Generates friendly urls for supported entities when missing.">
@@ -715,13 +738,13 @@
         </exec>
     </target>
 
-    <target name="standards" depends="phplint,ecs,phpstan,twig-lint,yaml-standards,eslint-check" description="Checks coding standards."/>
+    <target name="standards" depends="phplint,ecs,check-annotations,phpstan,twig-lint,yaml-standards,eslint-check" description="Checks coding standards."/>
 
-    <target name="standards-diff" depends="phplint-diff,ecs-diff,phpstan,twig-lint-diff,yaml-standards,eslint-check-diff" description="Checks coding standards in changed files."/>
+    <target name="standards-diff" depends="phplint-diff,ecs-diff,check-annotations,phpstan,twig-lint-diff,yaml-standards,eslint-check-diff" description="Checks coding standards in changed files."/>
 
-    <target name="standards-fix" depends="ecs-fix,yaml-standards-fix,eslint-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix" depends="ecs-fix,fix-annotations,yaml-standards-fix,eslint-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
 
-    <target name="standards-fix-diff" depends="ecs-fix-diff,yaml-standards-fix,eslint-fix-diff" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix-diff" depends="ecs-fix-diff,fix-annotations,yaml-standards-fix,eslint-fix-diff" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
 
     <target name="test-db-create" description="Creates test database for application with required configuration.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -53,6 +53,43 @@
         </else>
     </if>
 
+    <target name="annotations-check" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'annotations-fix' phing target">
+        <if>
+            <istrue value="${check-and-fix-annotations}"/>
+            <then>
+                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                    <arg value="${path.bin-console}"/>
+                    <arg value="shopsys:extended-classes:annotations"/>
+                    <arg value="--dry-run"/>
+                </exec>
+            </then>
+            <else>
+                <echo>
+                    Annotations checks are turned off by configuration, see "check-and-fix-annotations" build property.
+                    You are still able to run "shopsys:extended-classes:annotations" Symfony command directly.
+                </echo>
+            </else>
+        </if>
+    </target>
+
+    <target name="annotations-fix" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
+        <if>
+            <istrue value="${check-and-fix-annotations}"/>
+            <then>
+                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                    <arg value="${path.bin-console}"/>
+                    <arg value="shopsys:extended-classes:annotations"/>
+                </exec>
+            </then>
+            <else>
+                <echo>
+                    Annotations fixes are turned off by configuration, see "check-and-fix-annotations" build property.
+                    You are still able to run "shopsys:extended-classes:annotations" Symfony command directly.
+                </echo>
+            </else>
+        </if>
+    </target>
+
     <target name="assets" description="Installs web assets from external bundles into a public web directory.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true" output="${dev.null}">
             <arg value="${path.bin-console}"/>
@@ -103,25 +140,6 @@
                 </replacetokens>
             </filterchain>
         </copy>
-    </target>
-
-    <target name="check-annotations" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'fix-annotations' phing target">
-        <if>
-            <istrue value="${check-and-fix-annotations}"/>
-            <then>
-                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
-                    <arg value="${path.bin-console}"/>
-                    <arg value="shopsys:extended-classes:annotations"/>
-                    <arg value="--dry-run"/>
-                </exec>
-            </then>
-            <else>
-                <echo>
-                    Annotations checks are turned off by configuration, see "check-and-fix-annotations" build property.
-                    You are still able to run "shopsys:extended-classes:annotations" Symfony command directly.
-                </echo>
-            </else>
-        </if>
     </target>
 
     <target name="checks" depends="checks-internal,standards,tests" description="Runs internal checks, coding standards and runs unit, DB and smoke tests."/>
@@ -575,24 +593,6 @@
         </if>
     </target>
 
-    <target name="fix-annotations" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
-        <if>
-            <istrue value="${check-and-fix-annotations}"/>
-            <then>
-                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
-                    <arg value="${path.bin-console}"/>
-                    <arg value="shopsys:extended-classes:annotations"/>
-                </exec>
-            </then>
-            <else>
-                <echo>
-                    Annotations fixes are turned off by configuration, see "check-and-fix-annotations" build property.
-                    You are still able to run "shopsys:extended-classes:annotations" Symfony command directly.
-                </echo>
-            </else>
-        </if>
-    </target>
-
     <target name="friendly-urls-generate" description="Generates friendly urls for supported entities when missing.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -738,13 +738,13 @@
         </exec>
     </target>
 
-    <target name="standards" depends="phplint,ecs,check-annotations,phpstan,twig-lint,yaml-standards,eslint-check" description="Checks coding standards."/>
+    <target name="standards" depends="phplint,ecs,annotations-check,phpstan,twig-lint,yaml-standards,eslint-check" description="Checks coding standards."/>
 
-    <target name="standards-diff" depends="phplint-diff,ecs-diff,check-annotations,phpstan,twig-lint-diff,yaml-standards,eslint-check-diff" description="Checks coding standards in changed files."/>
+    <target name="standards-diff" depends="phplint-diff,ecs-diff,annotations-check,phpstan,twig-lint-diff,yaml-standards,eslint-check-diff" description="Checks coding standards in changed files."/>
 
-    <target name="standards-fix" depends="ecs-fix,fix-annotations,yaml-standards-fix,eslint-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix" depends="ecs-fix,annotations-fix,yaml-standards-fix,eslint-fix" description="Automatically fixes *some* coding standards violations in all files. Always run 'standards' to be sure there are no further violations."/>
 
-    <target name="standards-fix-diff" depends="ecs-fix-diff,fix-annotations,yaml-standards-fix,eslint-fix-diff" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
+    <target name="standards-fix-diff" depends="ecs-fix-diff,annotations-fix,yaml-standards-fix,eslint-fix-diff" description="Automatically fixes *some* coding standards violations in changed files. Always run 'standards' to be sure there are no further violations."/>
 
     <target name="test-db-create" description="Creates test database for application with required configuration.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -104,6 +104,14 @@
         </copy>
     </target>
 
+    <target name="check-annotations" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'fix-annotations' phing target">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:extended-classes:annotations"/>
+            <arg value="--dry-run"/>
+        </exec>
+    </target>
+
     <target name="checks" depends="checks-internal,standards,tests" description="Runs internal checks, coding standards and runs unit, DB and smoke tests."/>
 
     <target name="checks-ci" depends="checks-internal,test-db-demo,test-product-search-recreate-structure,test-product-search-export-products,tests-functional,tests-smoke,tests-acceptance" description="Runs internal checks and runs DB, smoke and acceptance tests."/>
@@ -558,7 +566,7 @@
     <target name="fix-annotations" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
-            <arg value="shopsys:extended-classes:fix-annotations"/>
+            <arg value="shopsys:extended-classes:annotations"/>
         </exec>
     </target>
 

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -555,6 +555,13 @@
         </if>
     </target>
 
+    <target name="fix-annotations" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:extended-classes:fix-annotations"/>
+        </exec>
+    </target>
+
     <target name="friendly-urls-generate" description="Generates friendly urls for supported entities when missing.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -74,6 +74,7 @@
         "prezent/doctrine-translatable-bundle": "^1.0.3",
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8",
+        "roave/better-reflection": "^3.5",
         "sensio/distribution-bundle": "^5.0.21",
         "sensio/framework-extra-bundle": "^3.0.29",
         "shopsys/doctrine-orm": "^2.6.2",

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -41,6 +41,9 @@ parameters:
         -
             message: '#Access to an undefined property PhpParser\\Node::\$name\.#'
             path: %currentWorkingDirectory%/src/Component/Translation/ConstraintViolationExtractor.php
+    excludes_analyses:
+        # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:fix-annotations" command
+        - %currentWorkingDirectory%/tests/Unit/Component/ClassExtension/Source/*
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -42,7 +42,7 @@ parameters:
             message: '#Access to an undefined property PhpParser\\Node::\$name\.#'
             path: %currentWorkingDirectory%/src/Component/Translation/ConstraintViolationExtractor.php
     excludes_analyses:
-        # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:fix-annotations" command
+        # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:annotations" command
         - %currentWorkingDirectory%/tests/Unit/Component/ClassExtension/Source/*
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon

--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -73,7 +73,7 @@ class ExtendedClassesAnnotationsCommand extends Command
             ->setHelp('What does the command do exactly?
 - Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.
 - Adds @property annotations to project classes when there exists a property in parent class that is extended in the project.
-- Adds @method annotations to project classes when there exists a method in parent class that returns an instance of a class that is extended in the project.');
+- Adds @method annotations to project classes when there exists a method in parent class that accepts as a parameter or returns an instance of a class that is extended in the project.');
     }
 
     /**

--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -133,7 +133,7 @@ class ExtendedClassesAnnotationsCommand extends Command
             $symfonyStyle->success('All good!');
             return 0;
         } elseif ($isDryRun) {
-            $symfonyStyle->note('You can fix the annotations using "fix-annotations" phing command.');
+            $symfonyStyle->note('You can fix the annotations using "annotations-fix" phing command.');
             return 1;
         }
     }

--- a/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -33,7 +36,10 @@ class FixExtendedClassesAnnotationsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.');
+            ->setDescription('
+                Fixes and adds annotations in project classes to improve static analysis and DX with extended classes:
+                - Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.
+                - Adds @property annotations to project classes when there exists a property in parent class that is extended in the project.');
     }
 
     /**
@@ -53,6 +59,7 @@ class FixExtendedClassesAnnotationsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->replaceFrameworkWithProjectAnnotations();
+        $this->addPropertyAnnotationsToProjectClasses();
         $output->writeln('Annotations fixed successfully');
     }
 
@@ -110,16 +117,190 @@ class FixExtendedClassesAnnotationsCommand extends Command
     {
         $annotationsReplacementsMap = [];
         foreach ($classExtensionMap as $frameworkClass => $projectClass) {
-            /**
-             * We want to match the FQCN followed by space or an array declaration but want to exclude the substrings.
-             * E.g. for "\Shopsys\FrameworkBundle\Model\Product\Product" we do not want to match "\Shopsys\FrameworkBundle\Model\Product\ProductFacade"
-             * but we want to match "\Shopsys\FrameworkBundle\Model\Product\Product[]"
-             */
-            $index = '/(?P<fqcn>\\\\' . preg_quote($frameworkClass, '/') . ')(?!\w)(?P<brackets>(\[\])*)/';
+            $index = $this->getEscapedFqcnWithLeadingSlashPattern($frameworkClass);
             $value = '$1$2|\\' . $projectClass . '$2';
             $annotationsReplacementsMap[$index] = $value;
         }
 
         return $annotationsReplacementsMap;
+    }
+
+    protected function addPropertyAnnotationsToProjectClasses(): void
+    {
+        $classExtensionMap = $this->classExtensionRegistry->getClassExtensionMap();
+        foreach ($classExtensionMap as $frameworkClass => $projectClass) {
+            $frameworkClassBetterReflection = $this->getBetterReflectionClass($frameworkClass);
+            foreach ($frameworkClassBetterReflection->getProperties() as $property) {
+                $this->addPropertyAnnotationToProjectClassIfNecessary($property, $projectClass, array_keys($classExtensionMap));
+            }
+        }
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @param string $projectClass
+     * @param string[] $extendedFrameworkClasses
+     */
+    protected function addPropertyAnnotationToProjectClassIfNecessary(
+        ReflectionProperty $reflectionProperty,
+        string $projectClass,
+        array $extendedFrameworkClasses
+    ): void {
+        $projectClassBetterReflection = $this->getBetterReflectionClass($projectClass);
+        foreach ($extendedFrameworkClasses as $extendedFrameworkClass) {
+            $isPropertyOfTypeThatIsExtendedInProject = preg_match(
+                $this->getEscapedFqcnWithLeadingSlashPattern($extendedFrameworkClass),
+                $reflectionProperty->getDocComment()
+            );
+            if (!$this->isPropertyDeclaredInClass($reflectionProperty->getName(), $projectClassBetterReflection)
+                && $isPropertyOfTypeThatIsExtendedInProject
+            ) {
+                $this->addPropertyAnnotationToClass($reflectionProperty, $projectClassBetterReflection);
+            }
+        }
+    }
+
+    /**
+     * We want to match the FQCN followed by space or an array declaration but want to exclude the substrings.
+     * E.g. for "\Shopsys\FrameworkBundle\Model\Product\Product" we do not want to match "\Shopsys\FrameworkBundle\Model\Product\ProductFacade"
+     * but we want to match "\Shopsys\FrameworkBundle\Model\Product\Product[]"
+     *
+     * @param string $fullyQualifiedClassName
+     * @return string
+     */
+    protected function getEscapedFqcnWithLeadingSlashPattern(string $fullyQualifiedClassName): string
+    {
+        return '/(?P<fqcn>\\\\' . preg_quote($fullyQualifiedClassName, '/') . ')(?!\w)(?P<brackets>(\[\])*)/';
+    }
+
+    /**
+     * @param string $fullyQualifiedClassName
+     * @return \Roave\BetterReflection\Reflection\ReflectionClass
+     */
+    protected function getBetterReflectionClass(string $fullyQualifiedClassName): ReflectionClass
+    {
+        $projectClassBetterReflection = (new BetterReflection())
+            ->classReflector()
+            ->reflect($fullyQualifiedClassName);
+
+        return $projectClassBetterReflection;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectClassBetterReflection
+     */
+    protected function addPropertyAnnotationToClass(ReflectionProperty $reflectionProperty, ReflectionClass $projectClassBetterReflection): void
+    {
+        $replacedTypeForProperty = $this->getReplacedTypeForProperty($reflectionProperty);
+        $projectClassName = $projectClassBetterReflection->getShortName();
+        $projectClassFileName = $projectClassBetterReflection->getFileName();
+        $projectClassDocBlock = $projectClassBetterReflection->getDocComment();
+        if ($projectClassDocBlock !== '') {
+            $this->updateClassAnnotationWithProperty(
+                $reflectionProperty,
+                $replacedTypeForProperty,
+                $projectClassDocBlock,
+                $projectClassFileName
+            );
+        } else {
+            $this->addClassAnnotationWithProperty(
+                $reflectionProperty,
+                $replacedTypeForProperty,
+                $projectClassName,
+                $projectClassFileName
+            );
+        }
+    }
+
+    /**
+     * @param string $propertyName
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $reflectionClass
+     * @return bool
+     */
+    protected function isPropertyDeclaredInClass(string $propertyName, ReflectionClass $reflectionClass)
+    {
+        $reflectionProperty = $reflectionClass->getProperty($propertyName);
+        if ($reflectionProperty === null) {
+            return false;
+        }
+
+        return $reflectionProperty->getDeclaringClass()->getName() === $reflectionClass->getName();
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @return string
+     */
+    protected function getReplacedTypeForProperty(ReflectionProperty $reflectionProperty): string
+    {
+        $propertyType = implode('|', $reflectionProperty->getDocBlockTypeStrings());
+
+        $annotationsReplacementsMap = $this->getAnnotationsReplacementsMap($this->classExtensionRegistry->getClassExtensionMap());
+        $replacedPropertyType = preg_replace(
+            array_keys($annotationsReplacementsMap),
+            $annotationsReplacementsMap,
+            $propertyType
+        );
+
+        return $replacedPropertyType;
+    }
+
+    /**
+     * @param string $fileName
+     * @param string $search
+     * @param string $replace
+     */
+    protected function replaceInFile(string $fileName, string $search, string $replace): void
+    {
+        $fileContent = file_get_contents($fileName);
+        $replacedContent = str_replace($search, $replace, $fileContent);
+        file_put_contents($fileName, $replacedContent);
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @param string $replacedTypeForProperty
+     * @param string $projectClassDocBlock
+     * @param string $projectClassFileName
+     */
+    protected function updateClassAnnotationWithProperty(
+        ReflectionProperty $reflectionProperty,
+        string $replacedTypeForProperty,
+        string $projectClassDocBlock,
+        string $projectClassFileName
+    ): void {
+        $propertyAnnotationNewLine = sprintf(
+            "* @property %s%s $%s\n",
+            $reflectionProperty->isStatic() ? 'static ' : '',
+            $replacedTypeForProperty,
+            $reflectionProperty->getName()
+        );
+        if (strpos($projectClassDocBlock, $propertyAnnotationNewLine) === false) {
+            $extendedDocBlock = str_replace('*/', $propertyAnnotationNewLine . ' */', $projectClassDocBlock);
+            $this->replaceInFile($projectClassFileName, $projectClassDocBlock, $extendedDocBlock);
+        }
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @param string $replacedTypeForProperty
+     * @param string $projectClassShortName
+     * @param string $projectClassFileName
+     */
+    protected function addClassAnnotationWithProperty(
+        ReflectionProperty $reflectionProperty,
+        string $replacedTypeForProperty,
+        string $projectClassShortName,
+        string $projectClassFileName
+    ): void {
+        $replacement = sprintf(
+            "/**\n * @property %s%s $%s\n */\nclass %s",
+            $reflectionProperty->isStatic() ? 'static ' : '',
+            $replacedTypeForProperty,
+            $reflectionProperty->getName(),
+            $projectClassShortName
+        );
+        $this->replaceInFile($projectClassFileName, 'class ' . $projectClassShortName, $replacement);
     }
 }

--- a/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+
+class FixExtendedClassesAnnotationsCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'shopsys:extended-classes:fix-annotations';
+
+    /**
+     * @var string
+     */
+    protected $projectRootDirectory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry
+     */
+    protected $classExtensionRegistry;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.');
+    }
+
+    /**
+     * @param string $projectRootDirectory
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry $classExtensionRegistry
+     */
+    public function __construct(string $projectRootDirectory, ClassExtensionRegistry $classExtensionRegistry)
+    {
+        parent::__construct();
+        $this->projectRootDirectory = $projectRootDirectory;
+        $this->classExtensionRegistry = $classExtensionRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->replaceFrameworkWithProjectAnnotations();
+        $output->writeln('Annotations fixed successfully');
+    }
+
+    protected function replaceFrameworkWithProjectAnnotations(): void
+    {
+        $finder = $this->getFinderForReplacingAnnotations();
+        $annotationsReplacementsMap = $this->getAnnotationsReplacementsMap($this->classExtensionRegistry->getClassExtensionMap());
+        foreach ($finder as $fileWithFrameworkAnnotationsToReplace) {
+            $pathname = $fileWithFrameworkAnnotationsToReplace->getPathname();
+            $content = file_get_contents($pathname);
+            $replacedContent = preg_replace(
+                array_keys($annotationsReplacementsMap),
+                $annotationsReplacementsMap,
+                $content
+            );
+            file_put_contents($pathname, $replacedContent);
+        }
+    }
+
+    /**
+     * @return \Symfony\Component\Finder\Finder
+     */
+    protected function getFinderForReplacingAnnotations(): Finder
+    {
+        $finder = Finder::create()
+            ->files()
+            ->ignoreUnreadableDirs()
+            ->in([
+                $this->projectRootDirectory . '/app',
+                $this->projectRootDirectory . '/src',
+                $this->projectRootDirectory . '/tests',
+            ])
+            ->name('*.php')
+            ->contains($this->getRelevantFrameworkAnnotationsPattern());
+
+        return $finder;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getRelevantFrameworkAnnotationsPattern(): string
+    {
+        $frameworkClasses = array_keys($this->classExtensionRegistry->getClassExtensionMap());
+        $unescapedRegular = sprintf('/(@var|@param|@return) (\\%s)/', implode('|\\', $frameworkClasses));
+
+        return preg_quote($unescapedRegular, '/');
+    }
+
+    /**
+     * @param string[] $classExtensionMap
+     * @return string[]
+     */
+    protected function getAnnotationsReplacementsMap(array $classExtensionMap): array
+    {
+        $annotationsReplacementsMap = [];
+        foreach ($classExtensionMap as $frameworkClass => $projectClass) {
+            /**
+             * We want to match the FQCN followed by space or an array declaration but want to exclude the substrings.
+             * E.g. for "\Shopsys\FrameworkBundle\Model\Product\Product" we do not want to match "\Shopsys\FrameworkBundle\Model\Product\ProductFacade"
+             * but we want to match "\Shopsys\FrameworkBundle\Model\Product\Product[]"
+             */
+            $index = '/(?P<fqcn>\\\\' . preg_quote($frameworkClass, '/') . ')(?!\w)(?P<brackets>(\[\])*)/';
+            $value = '$1$2|\\' . $projectClass . '$2';
+            $annotationsReplacementsMap[$index] = $value;
+        }
+
+        return $annotationsReplacementsMap;
+    }
+}

--- a/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
@@ -37,11 +37,11 @@ class FixExtendedClassesAnnotationsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setDescription('
-                Fixes and adds annotations in project classes to improve static analysis and DX with extended classes:
-                - Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.
-                - Adds @property annotations to project classes when there exists a property in parent class that is extended in the project.
-                - Adds @method annotations to project classes when there exists a method in parent class that returns an instance of a class that is extended in the project.');
+            ->setDescription('Fixes and adds annotations in project classes to improve static analysis and DX with extended classes. See "help" for more information')
+            ->setHelp('What does the command do exactly?
+- Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.
+- Adds @property annotations to project classes when there exists a property in parent class that is extended in the project.
+- Adds @method annotations to project classes when there exists a method in parent class that returns an instance of a class that is extended in the project.');
     }
 
     /**

--- a/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/FixExtendedClassesAnnotationsCommand.php
@@ -96,20 +96,9 @@ class FixExtendedClassesAnnotationsCommand extends Command
                 $this->projectRootDirectory . '/tests',
             ])
             ->name('*.php')
-            ->contains($this->getRelevantFrameworkAnnotationsPattern());
+            ->contains($this->classExtensionRegistry->getAnnotationsReplacementsMap()->getPatternForAny());
 
         return $finder;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getRelevantFrameworkAnnotationsPattern(): string
-    {
-        $frameworkClasses = array_keys($this->classExtensionRegistry->getClassExtensionMap());
-        $unescapedRegular = sprintf('/(@var|@param|@return) (\\%s)/', implode('|\\', $frameworkClasses));
-
-        return preg_quote($unescapedRegular, '/');
     }
 
     protected function addPropertyAndMethodAnnotationsToProjectClasses(): void

--- a/packages/framework/src/Component/ClassExtension/AnnotationsAdder.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsAdder.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+use Roave\BetterReflection\Reflection\ReflectionClass;
+
+class AnnotationsAdder
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer
+     */
+    protected $fileContentReplacer;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer $fileContentReplacer
+     */
+    public function __construct(FileContentsReplacer $fileContentReplacer)
+    {
+        $this->fileContentReplacer = $fileContentReplacer;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $betterReflectionClass
+     * @param string $propertyAndMethodAnnotationsLines
+     */
+    public function addAnnotationToClass(ReflectionClass $betterReflectionClass, string $propertyAndMethodAnnotationsLines): void
+    {
+        $projectClassDocComment = $betterReflectionClass->getDocComment();
+        $projectClassFileName = $betterReflectionClass->getFileName();
+        if ($propertyAndMethodAnnotationsLines === '') {
+            return;
+        }
+        if ($projectClassDocComment === '') {
+            $classKeywordWithName = 'class ' . $betterReflectionClass->getShortName();
+            $this->fileContentReplacer->replaceInFile(
+                $projectClassFileName,
+                $classKeywordWithName,
+                "/**\n" . $propertyAndMethodAnnotationsLines . " */\n" . $classKeywordWithName
+            );
+        } else {
+            $replacedClassDocBlock = str_replace(' */', $propertyAndMethodAnnotationsLines . ' */', $projectClassDocComment);
+            $this->fileContentReplacer->replaceInFile($projectClassFileName, $projectClassDocComment, $replacedClassDocBlock);
+        }
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacementsMap.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacementsMap.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+class AnnotationsReplacementsMap
+{
+    /**
+     * @var string[]
+     */
+    protected $classExtensionMap;
+
+    /**
+     * @param string[] $classExtensionMap
+     */
+    public function __construct(array $classExtensionMap)
+    {
+        $this->classExtensionMap = $classExtensionMap;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPatterns(): array
+    {
+        $patterns = [];
+        foreach (array_keys($this->classExtensionMap) as $frameworkClass) {
+            $patterns[] = '/\\\\' . preg_quote(ltrim($frameworkClass, '\\'), '/') . '(?!\w)/';
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getReplacements(): array
+    {
+        $replacements = [];
+        foreach (array_values($this->classExtensionMap) as $projectClass) {
+            $replacements[] = '\\' . ltrim($projectClass, '\\');
+        }
+
+        return $replacements;
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacementsMap.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacementsMap.php
@@ -44,4 +44,19 @@ class AnnotationsReplacementsMap
 
         return $replacements;
     }
+
+    /**
+     * This method assumes that {@see AnnotationsReplacementsMap::getPatterns()} doesn't use modifiers after delimiter
+     *
+     * @return string
+     */
+    public function getPatternForAny(): string
+    {
+        $patternsWithoutDelimiters = [];
+        foreach ($this->getPatterns() as $pattern) {
+            $patternsWithoutDelimiters[] = substr($pattern, 1, -1);
+        }
+
+        return '/' . implode('|', $patternsWithoutDelimiters) . '/';
+    }
 }

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\ClassExtension;
 
+use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+
 class AnnotationsReplacer
 {
     /**
@@ -30,5 +33,31 @@ class AnnotationsReplacer
             $this->annotationsReplacementsMap->getReplacements(),
             $string
         );
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionMethod $reflectionMethod
+     * @return string
+     */
+    public function replaceInMethodReturnType(ReflectionMethod $reflectionMethod): string
+    {
+        $methodReturnTypes = $reflectionMethod->getDocBlockReturnTypes();
+        $replacedReturnTypes = [];
+        foreach ($methodReturnTypes as $methodReturnType) {
+            $replacedReturnTypes[] = $this->replaceIn((string)$methodReturnType);
+        }
+
+        return implode('|', $replacedReturnTypes);
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @return string
+     */
+    public function replaceInPropertyType(ReflectionProperty $reflectionProperty): string
+    {
+        $propertyType = implode('|', $reflectionProperty->getDocBlockTypeStrings());
+
+        return $this->replaceIn($propertyType);
     }
 }

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+class AnnotationsReplacer
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap
+     */
+    protected $annotationsReplacementsMap;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap $annotationsReplacementsMap
+     */
+    public function __construct(AnnotationsReplacementsMap $annotationsReplacementsMap)
+    {
+        $this->annotationsReplacementsMap = $annotationsReplacementsMap;
+    }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    public function replaceIn(string $string): string
+    {
+        return preg_replace(
+            $this->annotationsReplacementsMap->getPatterns(),
+            $this->annotationsReplacementsMap->getReplacements(),
+            $string
+        );
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\ClassExtension;
 
 use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 class AnnotationsReplacer
@@ -59,5 +60,20 @@ class AnnotationsReplacer
         $propertyType = implode('|', $reflectionProperty->getDocBlockTypeStrings());
 
         return $this->replaceIn($propertyType);
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionParameter $reflectionParameter
+     * @return string
+     */
+    public function replaceInParameterType(ReflectionParameter $reflectionParameter): string
+    {
+        $parameterTypes = $reflectionParameter->getDocBlockTypeStrings();
+        $replacedTypes = [];
+        foreach ($parameterTypes as $parameterType) {
+            $replacedTypes[] = $this->replaceIn((string)$parameterType);
+        }
+
+        return implode('|', $replacedTypes);
     }
 }

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -85,4 +85,12 @@ class ClassExtensionRegistry
         $reflector = new ClassReflector(new SingleFileSourceLocator($pathname, $astLocator));
         return $reflector->getAllClasses()[0]->getName();
     }
+
+    /**
+     * @return string[]
+     */
+    public function getClassExtensionMap(): array
+    {
+        return $this->serviceExtensionMap + $this->entityExtensionMap + $this->dataObjectExtensionMap;
+    }
 }

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -24,7 +24,7 @@ class ClassExtensionRegistry
     /**
      * @var string[]
      */
-    protected $dataObjectExtensionMap = [];
+    protected $otherClassesExtensionMap = [];
 
     /**
      * @var string
@@ -39,7 +39,7 @@ class ClassExtensionRegistry
     {
         $this->entityExtensionMap = $entityExtensionMap;
         $this->frameworkRootDir = $frameworkRootDir;
-        $this->dataObjectExtensionMap = $this->getDataObjectExtensionMap();
+        $this->otherClassesExtensionMap = $this->getOtherClassesExtensionMap();
     }
 
     /**
@@ -52,27 +52,30 @@ class ClassExtensionRegistry
     }
 
     /**
+     * Other classes that are not entities or registered in service extension map
+     * I.e. data objects and controllers (other class types can by added by modifying the finder if necessary)
+     *
      * @return string[]
      */
-    protected function getDataObjectExtensionMap(): array
+    protected function getOtherClassesExtensionMap(): array
     {
         $finder = Finder::create()
             ->files()
             ->ignoreUnreadableDirs()
-            ->in($this->frameworkRootDir)
-            ->name('/.*Data\.php/');
+            ->in($this->frameworkRootDir . '/src')
+            ->name('/.*(Data|Controller)\.php/');
 
-        $dataObjectsMap = [];
+        $otherClassesMap = [];
         foreach ($finder as $file) {
             /** @var \Symfony\Component\Finder\SplFileInfo $file */
             $frameworkClassFqcn = $this->getFqcn($file->getPathname());
             $projectClassFqcn = str_replace('Shopsys\FrameworkBundle', 'Shopsys\ShopBundle', $frameworkClassFqcn);
             if (class_exists($projectClassFqcn)) {
-                $dataObjectsMap[$frameworkClassFqcn] = $projectClassFqcn;
+                $otherClassesMap[$frameworkClassFqcn] = $projectClassFqcn;
             }
         }
 
-        return $dataObjectsMap;
+        return $otherClassesMap;
     }
 
     /**
@@ -91,6 +94,6 @@ class ClassExtensionRegistry
      */
     public function getClassExtensionMap(): array
     {
-        return $this->serviceExtensionMap + $this->entityExtensionMap + $this->dataObjectExtensionMap;
+        return $this->serviceExtensionMap + $this->entityExtensionMap + $this->otherClassesExtensionMap;
     }
 }

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -93,4 +93,12 @@ class ClassExtensionRegistry
     {
         return $this->serviceExtensionMap + $this->entityExtensionMap + $this->dataObjectExtensionMap;
     }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap
+     */
+    public function getAnnotationsReplacementsMap(): AnnotationsReplacementsMap
+    {
+        return new AnnotationsReplacementsMap($this->getClassExtensionMap());
+    }
 }

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+use Symfony\Component\Finder\Finder;
+
+class ClassExtensionRegistry
+{
+    /**
+     * @var string[]
+     */
+    protected $entityExtensionMap = [];
+
+    /**
+     * @var string[]
+     */
+    protected $serviceExtensionMap = [];
+
+    /**
+     * @var string[]
+     */
+    protected $dataObjectExtensionMap = [];
+
+    /**
+     * @var string
+     */
+    protected $frameworkRootDir;
+
+    /**
+     * @param string[] $entityExtensionMap
+     * @param string $frameworkRootDir
+     */
+    public function __construct(array $entityExtensionMap, string $frameworkRootDir)
+    {
+        $this->entityExtensionMap = $entityExtensionMap;
+        $this->frameworkRootDir = $frameworkRootDir;
+        $this->dataObjectExtensionMap = $this->getDataObjectExtensionMap();
+    }
+
+    /**
+     * @param string $parentClassName
+     * @param string $childClassName
+     */
+    public function addExtendedService(string $parentClassName, string $childClassName): void
+    {
+        $this->serviceExtensionMap[$parentClassName] = $childClassName;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getDataObjectExtensionMap(): array
+    {
+        $finder = Finder::create()
+            ->files()
+            ->ignoreUnreadableDirs()
+            ->in($this->frameworkRootDir)
+            ->name('/.*Data\.php/');
+
+        $dataObjectsMap = [];
+        foreach ($finder as $file) {
+            /** @var \Symfony\Component\Finder\SplFileInfo $file */
+            $frameworkClassFqcn = $this->getFqcn($file->getPathname());
+            $projectClassFqcn = str_replace('Shopsys\FrameworkBundle', 'Shopsys\ShopBundle', $frameworkClassFqcn);
+            if (class_exists($projectClassFqcn)) {
+                $dataObjectsMap[$frameworkClassFqcn] = $projectClassFqcn;
+            }
+        }
+
+        return $dataObjectsMap;
+    }
+
+    /**
+     * @param string $pathname
+     * @return string
+     */
+    protected function getFqcn(string $pathname): string
+    {
+        $astLocator = (new BetterReflection())->astLocator();
+        $reflector = new ClassReflector(new SingleFileSourceLocator($pathname, $astLocator));
+        return $reflector->getAllClasses()[0]->getName();
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -93,12 +93,4 @@ class ClassExtensionRegistry
     {
         return $this->serviceExtensionMap + $this->entityExtensionMap + $this->dataObjectExtensionMap;
     }
-
-    /**
-     * @return \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap
-     */
-    public function getAnnotationsReplacementsMap(): AnnotationsReplacementsMap
-    {
-        return new AnnotationsReplacementsMap($this->getClassExtensionMap());
-    }
 }

--- a/packages/framework/src/Component/ClassExtension/FileContentsReplacer.php
+++ b/packages/framework/src/Component/ClassExtension/FileContentsReplacer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+class FileContentsReplacer
+{
+    /**
+     * @param string $fileName
+     * @param string $search
+     * @param string $replace
+     */
+    public function replaceInFile(string $fileName, string $search, string $replace): void
+    {
+        $fileContent = file_get_contents($fileName);
+        $replacedContent = str_replace($search, $replace, $fileContent);
+        file_put_contents($fileName, $replacedContent);
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+use phpDocumentor\Reflection\Type;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
+
+class MethodAnnotationsFactory
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap
+     */
+    protected $annotationsReplacementsMap;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer
+     */
+    protected $annotationsReplacer;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap $annotationsReplacementsMap
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer $annotationsReplacer
+     */
+    public function __construct(
+        AnnotationsReplacementsMap $annotationsReplacementsMap,
+        AnnotationsReplacer $annotationsReplacer
+    ) {
+        $this->annotationsReplacementsMap = $annotationsReplacementsMap;
+        $this->annotationsReplacer = $annotationsReplacer;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkClassBetterReflection
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectClassBetterReflection
+     * @return string
+     */
+    public function getProjectClassNecessaryMethodAnnotationsLines(
+        ReflectionClass $frameworkClassBetterReflection,
+        ReflectionClass $projectClassBetterReflection
+    ): string {
+        $projectClassDocBlock = $projectClassBetterReflection->getDocComment();
+        $methodAnnotationsLines = '';
+        foreach ($frameworkClassBetterReflection->getMethods() as $method) {
+            $methodAnnotationLine = $this->getMethodAnnotationLine($method, $projectClassBetterReflection);
+            if ($methodAnnotationLine !== '' && strpos($projectClassDocBlock, $methodAnnotationLine) === false) {
+                $methodAnnotationsLines .= $methodAnnotationLine;
+            }
+        }
+
+        return $methodAnnotationsLines;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionMethod $reflectionMethodFromFrameworkClass
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectClassBetterReflection
+     * @return string
+     */
+    public function getMethodAnnotationLine(
+        ReflectionMethod $reflectionMethodFromFrameworkClass,
+        ReflectionClass $projectClassBetterReflection
+    ): string {
+        foreach ($this->annotationsReplacementsMap->getPatterns() as $frameworkClassPattern) {
+            foreach ($reflectionMethodFromFrameworkClass->getDocBlockReturnTypes() as $docBlockReturnType) {
+                if (!$this->isMethodImplementedInClass($reflectionMethodFromFrameworkClass->getName(), $projectClassBetterReflection)
+                    && $this->isMethodReturningTypeThatIsExtendedInProject($frameworkClassPattern, $docBlockReturnType)
+                ) {
+                    return sprintf(
+                        " * @method %s%s %s(%s)\n",
+                        $reflectionMethodFromFrameworkClass->isStatic() ? 'static ' : '',
+                        $this->annotationsReplacer->replaceInMethodReturnType($reflectionMethodFromFrameworkClass),
+                        $reflectionMethodFromFrameworkClass->getName(),
+                        $this->getMethodParameterNames($reflectionMethodFromFrameworkClass)
+                    );
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $methodName
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $reflectionClass
+     * @return bool
+     */
+    protected function isMethodImplementedInClass(string $methodName, ReflectionClass $reflectionClass): bool
+    {
+        try {
+            $reflectionMethod = $reflectionClass->getMethod($methodName);
+            return $reflectionMethod->getDeclaringClass()->getName() === $reflectionClass->getName();
+        } catch (\OutOfBoundsException $ex) {
+            return false;
+        }
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionMethod $reflectionMethod
+     * @return string
+     */
+    protected function getMethodParameterNames(ReflectionMethod $reflectionMethod): string
+    {
+        $methodParameterNames = [];
+        foreach ($reflectionMethod->getParameters() as $methodParameter) {
+            $methodParameterNames[] = '$' . $methodParameter->getName();
+        }
+
+        return implode(', ', $methodParameterNames);
+    }
+
+    /**
+     * @param string $frameworkClassPattern
+     * @param \phpDocumentor\Reflection\Type $docBlockReturnType
+     * @return bool
+     */
+    protected function isMethodReturningTypeThatIsExtendedInProject(
+        string $frameworkClassPattern,
+        Type $docBlockReturnType
+    ): bool {
+        return (bool)preg_match($frameworkClassPattern, (string)$docBlockReturnType);
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/PropertyAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/PropertyAnnotationsFactory.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+
+class PropertyAnnotationsFactory
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap
+     */
+    protected $annotationsReplacementsMap;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer
+     */
+    protected $annotationsReplacer;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap $annotationsReplacementsMap
+     * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer $annotationsReplacer
+     */
+    public function __construct(
+        AnnotationsReplacementsMap $annotationsReplacementsMap,
+        AnnotationsReplacer $annotationsReplacer
+    ) {
+        $this->annotationsReplacementsMap = $annotationsReplacementsMap;
+        $this->annotationsReplacer = $annotationsReplacer;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkClassBetterReflection
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectClassBetterReflection
+     * @return string
+     */
+    public function getProjectClassNecessaryPropertyAnnotationsLines(
+        ReflectionClass $frameworkClassBetterReflection,
+        ReflectionClass $projectClassBetterReflection
+    ): string {
+        $projectClassDocBlock = $projectClassBetterReflection->getDocComment();
+        $propertyAnnotationsLines = '';
+        foreach ($frameworkClassBetterReflection->getProperties() as $property) {
+            $propertyAnnotationLine = $this->getPropertyAnnotationLine($property, $projectClassBetterReflection);
+            if ($propertyAnnotationLine !== '' && strpos($projectClassDocBlock, $propertyAnnotationLine) === false) {
+                $propertyAnnotationsLines .= $propertyAnnotationLine;
+            }
+        }
+
+        return $propertyAnnotationsLines;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionPropertyFromFrameworkClass
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectClassBetterReflection
+     * @return string
+     */
+    protected function getPropertyAnnotationLine(
+        ReflectionProperty $reflectionPropertyFromFrameworkClass,
+        ReflectionClass $projectClassBetterReflection
+    ): string {
+        foreach ($this->annotationsReplacementsMap->getPatterns() as $frameworkClassPattern) {
+            if (!$this->isPropertyDeclaredInClass($reflectionPropertyFromFrameworkClass->getName(), $projectClassBetterReflection)
+                && $this->isPropertyOfTypeThatIsExtendedInProject($reflectionPropertyFromFrameworkClass, $frameworkClassPattern)
+            ) {
+                $replacedTypeForProperty = $this->annotationsReplacer->replaceInPropertyType($reflectionPropertyFromFrameworkClass);
+
+                return sprintf(
+                    " * @property %s%s $%s\n",
+                    $reflectionPropertyFromFrameworkClass->isStatic() ? 'static ' : '',
+                    $replacedTypeForProperty,
+                    $reflectionPropertyFromFrameworkClass->getName()
+                );
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $propertyName
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $reflectionClass
+     * @return bool
+     */
+    protected function isPropertyDeclaredInClass(string $propertyName, ReflectionClass $reflectionClass): bool
+    {
+        $reflectionProperty = $reflectionClass->getProperty($propertyName);
+        if ($reflectionProperty === null) {
+            return false;
+        }
+
+        return $reflectionProperty->getDeclaringClass()->getName() === $reflectionClass->getName();
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @param string $frameworkClassPattern
+     * @return bool
+     */
+    protected function isPropertyOfTypeThatIsExtendedInProject(ReflectionProperty $reflectionProperty, string $frameworkClassPattern): bool
+    {
+        $isPropertyOfTypeThatIsExtendedInProject = (bool)preg_match(
+            $frameworkClassPattern,
+            $reflectionProperty->getDocComment()
+        );
+
+        return $isPropertyOfTypeThatIsExtendedInProject;
+    }
+}

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
+
+use Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $classExtensionRegistryDefinition = $container->findDefinition(ClassExtensionRegistry::class);
+        foreach ($container->getServiceIds() as $serviceId) {
+            if ($this->isFrameworkClassWithAlias($container, $serviceId)) {
+                $aliasId = (string)$container->getAlias($serviceId);
+                if ($this->isProjectClass($aliasId)) {
+                    $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$serviceId, $aliasId]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param string $serviceId
+     * @return bool
+     */
+    private function isFrameworkClassWithAlias(ContainerBuilder $container, string $serviceId): bool
+    {
+        return strpos($serviceId, 'Shopsys\FrameworkBundle') !== false && $container->hasAlias($serviceId);
+    }
+
+    /**
+     * @param string $serviceId
+     * @return bool
+     */
+    private function isProjectClass(string $serviceId): bool
+    {
+        return strpos($serviceId, 'Shopsys\ShopBundle') !== false;
+    }
+}

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -997,3 +997,8 @@ services:
     Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureUpdateChecker: ~
 
     Shopsys\FrameworkBundle\Component\ArrayUtils\RecursiveArraySorter: ~
+
+    Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap:
+        arguments: ["@=service('Shopsys\\\\FrameworkBundle\\\\Component\\\\ClassExtension\\\\ClassExtensionRegistry').getClassExtensionMap()"]
+
+    Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer: ~

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -1002,3 +1002,7 @@ services:
         arguments: ["@=service('Shopsys\\\\FrameworkBundle\\\\Component\\\\ClassExtension\\\\ClassExtensionRegistry').getClassExtensionMap()"]
 
     Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer: ~
+
+    Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsAdder: ~
+
+    Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer: ~

--- a/packages/framework/src/Resources/config/services/commands.yml
+++ b/packages/framework/src/Resources/config/services/commands.yml
@@ -39,5 +39,5 @@ services:
             - '%shopsys.vendor_dir%'
 
     # the command is supposed to be used in DEV environment only so it is configured in services_dev.yml
-    Shopsys\FrameworkBundle\Command\FixExtendedClassesAnnotationsCommand:
+    Shopsys\FrameworkBundle\Command\ExtendedClassesAnnotationsCommand:
         autoconfigure: false

--- a/packages/framework/src/Resources/config/services/commands.yml
+++ b/packages/framework/src/Resources/config/services/commands.yml
@@ -37,3 +37,7 @@ services:
     Shopsys\MigrationBundle\Command\GenerateMigrationCommand:
         arguments:
             - '%shopsys.vendor_dir%'
+
+    # the command is supposed to be used in DEV environment only so it is configured in services_dev.yml
+    Shopsys\FrameworkBundle\Command\FixExtendedClassesAnnotationsCommand:
+        autoconfigure: false

--- a/packages/framework/src/Resources/config/services_dev.yml
+++ b/packages/framework/src/Resources/config/services_dev.yml
@@ -13,3 +13,8 @@ services:
             - { name: 'data_collector', template: '@ShopsysFramework/Debug/Elasticsearch/template.html.twig', id: 'shopsys.elasticsearch_collector' }
 
     Shopsys\FrameworkBundle\Component\Elasticsearch\Debug\ElasticsearchRequestCollection:
+
+    Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry:
+        arguments:
+            - '%shopsys.entity_extension.map%'
+            - '%shopsys.framework.root_dir%'

--- a/packages/framework/src/Resources/config/services_dev.yml
+++ b/packages/framework/src/Resources/config/services_dev.yml
@@ -19,6 +19,6 @@ services:
             - '%shopsys.entity_extension.map%'
             - '%shopsys.framework.root_dir%'
 
-    Shopsys\FrameworkBundle\Command\FixExtendedClassesAnnotationsCommand:
+    Shopsys\FrameworkBundle\Command\ExtendedClassesAnnotationsCommand:
         arguments:
             - '%shopsys.root_dir%'

--- a/packages/framework/src/Resources/config/services_dev.yml
+++ b/packages/framework/src/Resources/config/services_dev.yml
@@ -18,3 +18,7 @@ services:
         arguments:
             - '%shopsys.entity_extension.map%'
             - '%shopsys.framework.root_dir%'
+
+    Shopsys\FrameworkBundle\Command\FixExtendedClassesAnnotationsCommand:
+        arguments:
+            - '%shopsys.root_dir%'

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -2,11 +2,13 @@
 
 namespace Shopsys\FrameworkBundle;
 
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\LazyRedisCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterCronModulesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExtensionsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProductFeedConfigsCompilerPass;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProjectFrameworkClassExtensionsCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,5 +31,9 @@ class ShopsysFrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterPluginDataFixturesCompilerPass());
         $container->addCompilerPass(new RegisterProductFeedConfigsCompilerPass());
         $container->addCompilerPass(new LazyRedisCompilerPass());
+        $environment = $container->getParameter('kernel.environment');
+        if ($environment === EnvironmentType::DEVELOPMENT) {
+            $container->addCompilerPass(new RegisterProjectFrameworkClassExtensionsCompilerPass());
+        }
     }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsAdderTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsAdderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\ReflectionObject;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsAdder;
+use Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest\DummyClassWithAnAnnotation;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest\DummyClassWithNoAnnotation;
+
+class AnnotationsAdderTest extends TestCase
+{
+    public function testAddAnnotationToClassThatHasNoAnnotationYet(): void
+    {
+        $betterReflectionClass = ReflectionObject::createFromName(DummyClassWithNoAnnotation::class);
+        /** @var \Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer|\PHPUnit\Framework\MockObject\MockObject $fileContentsReplacerMock */
+        $fileContentsReplacerMock = $this->getMockBuilder(FileContentsReplacer::class)
+            ->setMethods(['replaceInFile'])
+            ->getMock();
+        $classKeywordWithName = 'class ' . $betterReflectionClass->getShortName();
+        $propertyAndMethodAnnotationsLines = "@property CategoryFacade \$categoryFacade\n@method CategoryFacade getCategoryFacade()\n";
+        $fileContentsReplacerMock->expects($this->once())->method('replaceInFile')->with(
+            $betterReflectionClass->getFileName(),
+            $classKeywordWithName,
+            "/**\n" . $propertyAndMethodAnnotationsLines . " */\n" . $classKeywordWithName
+        );
+
+        $annotationsAdder = new AnnotationsAdder($fileContentsReplacerMock);
+        $annotationsAdder->addAnnotationToClass(
+            $betterReflectionClass,
+            $propertyAndMethodAnnotationsLines
+        );
+    }
+
+    public function testAddAnnotationToClassThatHasAlreadyAnAnnotation(): void
+    {
+        $betterReflectionClass = ReflectionObject::createFromName(DummyClassWithAnAnnotation::class);
+        /** @var \Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer|\PHPUnit\Framework\MockObject\MockObject $fileContentsReplacerMock */
+        $fileContentsReplacerMock = $this->getMockBuilder(FileContentsReplacer::class)
+            ->setMethods(['replaceInFile'])
+            ->getMock();
+        $propertyAndMethodAnnotationsLines = "@property CategoryFacade \$categoryFacade\n@method CategoryFacade getCategoryFacade()\n";
+        $docComment = $betterReflectionClass->getDocComment();
+        $fileContentsReplacerMock->expects($this->once())->method('replaceInFile')->with(
+            $betterReflectionClass->getFileName(),
+            $docComment,
+            str_replace(' */', $propertyAndMethodAnnotationsLines . ' */', $docComment)
+        );
+
+        $annotationsAdder = new AnnotationsAdder($fileContentsReplacerMock);
+        $annotationsAdder->addAnnotationToClass(
+            $betterReflectionClass,
+            $propertyAndMethodAnnotationsLines
+        );
+    }
+
+    public function testAddAnnotationToClassEmptyAnnotation(): void
+    {
+        $betterReflectionClass = ReflectionObject::createFromName(DummyClassWithAnAnnotation::class);
+        /** @var \Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer|\PHPUnit\Framework\MockObject\MockObject $fileContentsReplacerMock */
+        $fileContentsReplacerMock = $this->getMockBuilder(FileContentsReplacer::class)
+            ->setMethods(['replaceInFile'])
+            ->getMock();
+        $fileContentsReplacerMock->expects($this->never())->method('replaceInFile');
+
+        $annotationsAdder = new AnnotationsAdder($fileContentsReplacerMock);
+        $annotationsAdder->addAnnotationToClass($betterReflectionClass, '');
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
+
+class AnnotationsReplacerTest extends TestCase
+{
+    /**
+     * @return array
+     */
+    public function getTestReplaceAnnotationsDataProvider(): array
+    {
+        return [
+            [
+                'input' => '@var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade',
+                'output' => '@var \Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            ],
+            [
+                'input' => '@var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface',
+                'output' => '@var \Shopsys\ShopBundle\Model\MyProduct\ProductDataFactory',
+            ],
+            [
+                'input' => '@var \Shopsys\FrameworkBundle\Model\Article\ArticleData',
+                'output' => '@var \Shopsys\ShopBundle\Model\Article\ArticleData',
+            ],
+            [
+                'input' => '@var \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory',
+                'output' => '@var \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory',
+            ],
+            [
+                'input' => '@var \Shopsys\FrameworkBundle\Model\Article\ArticleDataInterface',
+                'output' => '@var \Shopsys\FrameworkBundle\Model\Article\ArticleDataInterface',
+            ],
+            [
+                'input' => '@param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade',
+                'output' => '@param \Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            ],
+            [
+                'input' => '@return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade',
+                'output' => '@return \Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            ],
+            [
+                'input' => '@return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade[]',
+                'output' => '@return \Shopsys\ShopBundle\Model\Category\CategoryFacade[]',
+            ],
+            [
+                'input' => '@return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null',
+                'output' => '@return \Shopsys\ShopBundle\Model\Category\CategoryFacade|null',
+            ],
+            [
+                'input' => '@return int',
+                'output' => '@return int',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestReplaceAnnotationsDataProvider
+     * @param string $input
+     * @param string $output
+     */
+    public function testReplaceIn(string $input, string $output): void
+    {
+        $replacementMap = new AnnotationsReplacementsMap([
+            'Shopsys\FrameworkBundle\Model\Category\CategoryFacade' => 'Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            'Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface' => 'Shopsys\ShopBundle\Model\MyProduct\ProductDataFactory',
+            'Shopsys\FrameworkBundle\Model\Article\ArticleData' => 'Shopsys\ShopBundle\Model\Article\ArticleData',
+        ]);
+
+        $propertyReplacer = new AnnotationsReplacer($replacementMap);
+
+        $this->assertEquals($output, $propertyReplacer->replaceIn($input));
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
@@ -7,6 +7,7 @@ namespace Tests\FrameworkBundle\Unit\Component\ClassExtension;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionObject;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
@@ -136,5 +137,31 @@ class AnnotationsReplacerTest extends TestCase
     public function testReplaceInPropertyType(ReflectionProperty $reflectionProperty, string $output): void
     {
         $this->assertEquals($output, $this->annotationsReplacer->replaceInPropertyType($reflectionProperty));
+    }
+
+    /**
+     * @return array
+     */
+    public function testReplaceInParameterTypeDataProvider(): array
+    {
+        $reflectionClass = ReflectionObject::createFromName(DummyClassForAnnotationsReplacerTest::class);
+        $reflectionMethod = $reflectionClass->getMethod('acceptsVariousParameters');
+
+        return [
+            [$reflectionMethod->getParameter('categoryFacade'), '\Shopsys\ShopBundle\Model\Category\CategoryFacade'],
+            [$reflectionMethod->getParameter('categoryFacadeOrNull'), '\Shopsys\ShopBundle\Model\Category\CategoryFacade|null'],
+            [$reflectionMethod->getParameter('array'), '\Shopsys\ShopBundle\Model\Article\ArticleData[]'],
+            [$reflectionMethod->getParameter('integer'), 'int'],
+        ];
+    }
+
+    /**
+     * @dataProvider testReplaceInParameterTypeDataProvider
+     * @param \Roave\BetterReflection\Reflection\ReflectionParameter $reflectionParameter
+     * @param string $output
+     */
+    public function testReplaceInParameterType(ReflectionParameter $reflectionParameter, string $output): void
+    {
+        $this->assertEquals($output, $this->annotationsReplacer->replaceInParameterType($reflectionParameter));
     }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
@@ -30,6 +30,7 @@ class MethodAnnotationsFactoryTest extends TestCase
     {
         $replacementMap = new AnnotationsReplacementsMap([
             'Shopsys\FrameworkBundle\Model\Category\CategoryFacade' => 'Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            'Shopsys\FrameworkBundle\Model\Category\Category' => 'Shopsys\ShopBundle\Model\Category\Category',
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass',
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass2' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass2',
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass3' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass3',
@@ -76,5 +77,6 @@ class MethodAnnotationsFactoryTest extends TestCase
         );
 
         $this->assertContains('@method \Shopsys\ShopBundle\Model\Category\CategoryFacade getCategoryFacade()', $annotationLines);
+        $this->assertContains('@method setCategory(\Shopsys\ShopBundle\Model\Category\Category $category)', $annotationLines);
     }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionObject;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
+use Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass2;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass3;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass4;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass2;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass3;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass4;
+
+class MethodAnnotationsFactoryTest extends TestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory
+     */
+    private $methodAnnotationsFactory;
+
+    protected function setUp(): void
+    {
+        $replacementMap = new AnnotationsReplacementsMap([
+            'Shopsys\FrameworkBundle\Model\Category\CategoryFacade' => 'Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass2' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass2',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass3' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass3',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass4' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass4',
+        ]);
+
+        $this->methodAnnotationsFactory = new MethodAnnotationsFactory($replacementMap, new AnnotationsReplacer($replacementMap));
+    }
+
+    /**
+     * @return array
+     */
+    public function testGetProjectClassNecessaryMethodAnnotationsLinesEmptyResultDataProvider(): array
+    {
+        return [
+            'method redeclared in the child using annotation' => [ReflectionObject::createFromName(BaseClass::class), ReflectionObject::createFromName(ChildClass::class)],
+            'method not included in the extension map' => [ReflectionObject::createFromName(BaseClass2::class), ReflectionObject::createFromName(ChildClass2::class)],
+            'method redeclared in the child\'s source code' => [ReflectionObject::createFromName(BaseClass3::class), ReflectionObject::createFromName(ChildClass3::class)],
+        ];
+    }
+
+    /**
+     * @dataProvider testGetProjectClassNecessaryMethodAnnotationsLinesEmptyResultDataProvider
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkReflectionClass
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectReflectionClass
+     */
+    public function testGetProjectClassNecessaryMethodAnnotationsLinesEmptyResult(
+        ReflectionClass $frameworkReflectionClass,
+        ReflectionClass $projectReflectionClass
+    ): void {
+        $annotationLines = $this->methodAnnotationsFactory->getProjectClassNecessaryMethodAnnotationsLines(
+            $frameworkReflectionClass,
+            $projectReflectionClass
+        );
+
+        $this->assertEmpty($annotationLines);
+    }
+
+    public function testGetProjectClassNecessaryMethodAnnotationsLines(): void
+    {
+        $annotationLines = $this->methodAnnotationsFactory->getProjectClassNecessaryMethodAnnotationsLines(
+            ReflectionObject::createFromName(BaseClass4::class),
+            ReflectionObject::createFromName(ChildClass4::class)
+        );
+
+        $this->assertContains('@method \Shopsys\ShopBundle\Model\Category\CategoryFacade getCategoryFacade()', $annotationLines);
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/PropertyAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/PropertyAnnotationsFactoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionObject;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
+use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
+use Shopsys\FrameworkBundle\Component\ClassExtension\PropertyAnnotationsFactory;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass2;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass3;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass4;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass2;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass3;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass4;
+
+class PropertyAnnotationsFactoryTest extends TestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\PropertyAnnotationsFactory
+     */
+    private $propertyAnnotationsFactory;
+
+    protected function setUp(): void
+    {
+        $replacementMap = new AnnotationsReplacementsMap([
+            'Shopsys\FrameworkBundle\Model\Category\CategoryFacade' => 'Shopsys\ShopBundle\Model\Category\CategoryFacade',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass2' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass2',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass3' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass3',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass4' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass4',
+        ]);
+
+        $this->propertyAnnotationsFactory = new PropertyAnnotationsFactory($replacementMap, new AnnotationsReplacer($replacementMap));
+    }
+
+    /**
+     * @return array
+     */
+    public function testGetProjectClassNecessaryPropertyAnnotationsLinesEmptyResultDataProvider(): array
+    {
+        return [
+            'property redeclared in the child using annotation' => [ReflectionObject::createFromName(BaseClass::class), ReflectionObject::createFromName(ChildClass::class)],
+            'property not included in the extension map' => [ReflectionObject::createFromName(BaseClass2::class), ReflectionObject::createFromName(ChildClass2::class)],
+            'property redeclared in the child\'s source code' => [ReflectionObject::createFromName(BaseClass3::class), ReflectionObject::createFromName(ChildClass3::class)],
+        ];
+    }
+
+    /**
+     * @dataProvider testGetProjectClassNecessaryPropertyAnnotationsLinesEmptyResultDataProvider
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkReflectionClass
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectReflectionClass
+     */
+    public function testGetProjectClassNecessaryPropertyAnnotationsLinesEmptyResult(
+        ReflectionClass $frameworkReflectionClass,
+        ReflectionClass $projectReflectionClass
+    ): void {
+        $annotationLines = $this->propertyAnnotationsFactory->getProjectClassNecessaryPropertyAnnotationsLines(
+            $frameworkReflectionClass,
+            $projectReflectionClass
+        );
+
+        $this->assertEmpty($annotationLines);
+    }
+
+    public function testGetProjectClassNecessaryPropertyAnnotationsLines(): void
+    {
+        $annotationLines = $this->propertyAnnotationsFactory->getProjectClassNecessaryPropertyAnnotationsLines(
+            ReflectionObject::createFromName(BaseClass4::class),
+            ReflectionObject::createFromName(ChildClass4::class)
+        );
+
+        $this->assertContains('@property \Shopsys\ShopBundle\Model\Category\CategoryFacade $categoryFacade', $annotationLines);
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithAnAnnotation.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithAnAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest;
+
+/**
+ * Class DummyClassWithAnAnnotation
+ */
+class DummyClassWithAnAnnotation
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithNoAnnotation.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithNoAnnotation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest;
+
+class DummyClassWithNoAnnotation
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacerTest.php
@@ -48,4 +48,14 @@ class DummyClassForAnnotationsReplacerTest
     public function returnsInt()
     {
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null $categoryFacadeOrNull
+     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData[] $array
+     * @param int $integer
+     */
+    public function acceptsVariousParameters($categoryFacade, $categoryFacadeOrNull, $array, $integer)
+    {
+    }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source;
+
+class DummyClassForAnnotationsReplacerTest
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null
+     */
+    public $categoryFacadeOrNull;
+
+    /**
+     * @var int
+     */
+    public $integer;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleData[]
+     */
+    public $articleDataArray;
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public function returnsFrameworkCategoryFacade()
+    {
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null
+     */
+    public function returnsFrameworkCategoryFacadeOrNull()
+    {
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Article\ArticleData[]
+     */
+    public function returnsFrameworkArticleDataArray()
+    {
+    }
+
+    /**
+     * @return int
+     */
+    public function returnsInt()
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class BaseClass
+{
+    /**
+     * This method is redeclared in the child class using the method annotation
+     *
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public function getCategoryFacade()
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass2.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass2.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class BaseClass2
+{
+    /**
+     * This method returns a type that is not extended in the project
+     *
+     * @return \Shopsys\FrameworkBundle\Model\Article\ArticleData
+     */
+    public function getArticleData()
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass3.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass3.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class BaseClass3
+{
+    /**
+     * This method is redeclared in the child class
+     *
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public function getCategoryFacade()
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass4.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass4.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class BaseClass4
+{
+    /**
+     * This method return a type that is registered in the class extension map and hence the "@method" annotation must be added to the child class
+     *
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public function getCategoryFacade()
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass4.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass4.php
@@ -7,11 +7,20 @@ namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnot
 class BaseClass4
 {
     /**
-     * This method return a type that is registered in the class extension map and hence the "@method" annotation must be added to the child class
+     * This method returns a type that is registered in the class extension map and hence the "@method" annotation must be added to the child class
      *
      * @return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
     public function getCategoryFacade()
+    {
+    }
+
+    /**
+     * This method accepts parameter with type that is registered in the class extension map and hence the "@method" annotation must be added to the child class
+     *
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     */
+    public function setCategory($category)
     {
     }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+/**
+ * @method \Shopsys\ShopBundle\Model\Category\CategoryFacade getCategoryFacade()
+ */
+class ChildClass extends BaseClass
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass2.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass2.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class ChildClass2 extends BaseClass2
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass3.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass3.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class ChildClass3 extends BaseClass3
+{
+    /**
+     * @return \Shopsys\ShopBundle\Model\Category\CategoryFacade
+     */
+    public function getCategoryFacade()
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass4.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass4.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class ChildClass4 extends BaseClass4
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class BaseClass
+{
+    /**
+     * This property is redeclared in the child class using the property annotation
+     *
+     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public $categoryFacade;
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass2.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass2.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class BaseClass2
+{
+    /**
+     * This property is not of a type that is extended in the project
+     *
+     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleData
+     */
+    public $articleData;
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass3.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass3.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class BaseClass3
+{
+    /**
+     * This property is redeclared in the child class
+     *
+     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public $categoryFacade;
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass4.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass4.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class BaseClass4
+{
+    /**
+     * This property is of a type that is registered in the class extension map and hence the "@property" annotation must be added to the child class
+     *
+     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    public $categoryFacade;
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+/**
+ * @property \Shopsys\ShopBundle\Model\Category\CategoryFacade $categoryFacade
+ */
+class ChildClass extends BaseClass
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass2.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass2.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class ChildClass2 extends BaseClass2
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass3.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass3.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class ChildClass3 extends BaseClass3
+{
+    /**
+     * @var \Shopsys\ShopBundle\Model\Category\CategoryFacade
+     */
+    public $categoryFacade;
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass4.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/ChildClass4.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest;
+
+class ChildClass4 extends BaseClass4
+{
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -68,6 +68,8 @@ parameters:
     excludes_analyse:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*
+        # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:fix-annotations" command
+        - %currentWorkingDirectory%/packages/framework/tests/Unit/Component/ClassExtension/Source/*
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -68,7 +68,7 @@ parameters:
     excludes_analyse:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*
-        # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:fix-annotations" command
+        # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:annotations" command
         - %currentWorkingDirectory%/packages/framework/tests/Unit/Component/ClassExtension/Source/*
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -7,7 +7,7 @@
     <property name="path.vendor" value="${path.root}/vendor"/>
     <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
 
-    <property name="phpstan.level" value="1"/>
+    <property name="phpstan.level" value="4"/>
 
     <import file="${path.framework}/build.xml"/>
 </project>

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/BestsellingProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/BestsellingProductController.php
@@ -43,7 +43,7 @@ class BestsellingProductController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\ShopBundle\Model\Category\Category $category
      */
     public function listAction(Category $category)
     {

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CartController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CartController.php
@@ -149,7 +149,7 @@ class CartController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param \Shopsys\ShopBundle\Model\Product\Product $product
      * @param string $type
      * @deprecated This action is deprecated since 7.3.0, use ShopsysShopBundle:Front/Cart:productAction instead
      */

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CategoryController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CategoryController.php
@@ -115,7 +115,7 @@ class CategoryController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category[] $categories
+     * @param \Shopsys\ShopBundle\Model\Category\Category[] $categories
      * @param bool $showProductsCountByCategory
      */
     public function categoryListAction(array $categories, $showProductsCountByCategory = true)

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/CustomerController.php
@@ -113,7 +113,7 @@ class CustomerController extends FrontBaseController
             return $this->redirectToRoute('front_login');
         }
 
-        /** @var \Shopsys\FrameworkBundle\Model\Customer\User $user */
+        /** @var \Shopsys\ShopBundle\Model\Customer\User $user */
         $user = $this->getUser();
 
         $orders = $this->orderFacade->getCustomerOrderList($user);
@@ -152,14 +152,14 @@ class CustomerController extends FrontBaseController
 
             $user = $this->getUser();
             try {
-                /** @var \Shopsys\FrameworkBundle\Model\Order\Order $order */
+                /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
                 $order = $this->orderFacade->getByOrderNumberAndUser($orderNumber, $user);
             } catch (\Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException $ex) {
                 $this->getFlashMessageSender()->addErrorFlash(t('Order not found'));
                 return $this->redirectToRoute('front_customer_orders');
             }
         } else {
-            /** @var \Shopsys\FrameworkBundle\Model\Order\Order $order */
+            /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
             $order = $this->orderFacade->getByUrlHashAndDomain($urlHash, $this->domain->getId());
         }
 

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -54,7 +54,7 @@ class OrderController extends FrontBaseController
     private $orderMailFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataMapper
+     * @var \Shopsys\ShopBundle\Model\Order\OrderDataMapper
      */
     private $orderDataMapper;
 
@@ -296,8 +296,8 @@ class OrderController extends FrontBaseController
     /**
      * @param \Shopsys\ShopBundle\Model\Order\OrderData $orderData
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreview $orderPreview
-     * @param \Shopsys\FrameworkBundle\Model\Transport\Transport[] $transports
-     * @param \Shopsys\FrameworkBundle\Model\Payment\Payment[] $payments
+     * @param \Shopsys\ShopBundle\Model\Transport\Transport[] $transports
+     * @param \Shopsys\ShopBundle\Model\Payment\Payment[] $payments
      */
     private function checkTransportAndPaymentChanges(
         OrderData $orderData,
@@ -381,7 +381,7 @@ class OrderController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param \Shopsys\ShopBundle\Model\Order\Order $order
      */
     private function sendMail($order)
     {

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -333,11 +333,14 @@ class ProductController extends FrontBaseController
      */
     private function searchCategories($searchText)
     {
-        return $this->categoryFacade->getVisibleByDomainAndSearchText(
+        /** @var \Shopsys\ShopBundle\Model\Category\Category[] $categories */
+        $categories = $this->categoryFacade->getVisibleByDomainAndSearchText(
             $this->domain->getId(),
             $this->domain->getLocale(),
             $searchText
         );
+
+        return $categories;
     }
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ProductController.php
@@ -302,7 +302,7 @@ class ProductController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\ShopBundle\Model\Category\Category $category
      * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig
      */
     private function createProductFilterConfigForCategory(Category $category)
@@ -329,7 +329,7 @@ class ProductController extends FrontBaseController
 
     /**
      * @param string|null $searchText
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @return \Shopsys\ShopBundle\Model\Category\Category[]
      */
     private function searchCategories($searchText)
     {

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/RegistrationController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/RegistrationController.php
@@ -22,7 +22,7 @@ class RegistrationController extends FrontBaseController
     private $customerFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Customer\UserDataFactory
      */
     private $userDataFactory;
 
@@ -43,7 +43,7 @@ class RegistrationController extends FrontBaseController
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface $userDataFactory
+     * @param \Shopsys\ShopBundle\Model\Customer\UserDataFactory $userDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade
      * @param \Shopsys\FrameworkBundle\Model\Security\Authenticator $authenticator
      * @param \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ScriptController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ScriptController.php
@@ -52,7 +52,7 @@ class ScriptController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param \Shopsys\ShopBundle\Model\Order\Order $order
      */
     public function embedOrderSentPageScriptsAction(Order $order)
     {
@@ -62,7 +62,7 @@ class ScriptController extends FrontBaseController
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param \Shopsys\ShopBundle\Model\Order\Order $order
      */
     public function embedOrderSentPageGoogleAnalyticsScriptAction(Order $order)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ArticleDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ArticleDataFixture.php
@@ -24,13 +24,13 @@ class ArticleDataFixture extends AbstractReferenceFixture
     protected $articleFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Article\ArticleDataFactory
      */
     protected $articleDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
-     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface $articleDataFactory
+     * @param \Shopsys\ShopBundle\Model\Article\ArticleDataFactory $articleDataFactory
      */
     public function __construct(ArticleFacade $articleFacade, ArticleDataFactoryInterface $articleDataFactory)
     {
@@ -79,7 +79,7 @@ class ArticleDataFixture extends AbstractReferenceFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
+     * @param \Shopsys\ShopBundle\Model\Article\ArticleData $articleData
      * @param string|null $referenceName
      */
     protected function createArticle(ArticleData $articleData, $referenceName = null)

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BrandDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/BrandDataFixture.php
@@ -39,12 +39,12 @@ class BrandDataFixture extends AbstractReferenceFixture
     /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade */
     protected $brandFacade;
 
-    /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface */
+    /** @var \Shopsys\ShopBundle\Model\Product\Brand\BrandDataFactory */
     protected $brandDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface $brandDataFactory
+     * @param \Shopsys\ShopBundle\Model\Product\Brand\BrandDataFactory $brandDataFactory
      */
     public function __construct(BrandFacade $brandFacade, BrandDataFactoryInterface $brandDataFactory)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
@@ -63,6 +63,7 @@ class CategoryDataFixture extends AbstractReferenceFixture
         /**
          * Root category is created in database migration.
          * @see \Shopsys\FrameworkBundle\Migrations\Version20180603135345
+         * @var \Shopsys\ShopBundle\Model\Category\Category
          */
         $rootCategory = $this->categoryFacade->getRootCategory();
         $categoryData = $this->categoryDataFactory->create();
@@ -245,6 +246,7 @@ class CategoryDataFixture extends AbstractReferenceFixture
      */
     protected function createCategory(CategoryData $categoryData, $referenceName = null)
     {
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
         $category = $this->categoryFacade->create($categoryData);
         if ($referenceName !== null) {
             $this->addReference($referenceName, $category);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CategoryDataFixture.php
@@ -31,7 +31,7 @@ class CategoryDataFixture extends AbstractReferenceFixture
     protected $categoryFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Category\CategoryDataFactory
      */
     protected $categoryDataFactory;
 
@@ -42,7 +42,7 @@ class CategoryDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
-     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface $categoryDataFactory
+     * @param \Shopsys\ShopBundle\Model\Category\CategoryDataFactory $categoryDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
@@ -239,9 +239,9 @@ class CategoryDataFixture extends AbstractReferenceFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryData $categoryData
+     * @param \Shopsys\ShopBundle\Model\Category\CategoryData $categoryData
      * @param string|null $referenceName
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category
+     * @return \Shopsys\ShopBundle\Model\Category\Category
      */
     protected function createCategory(CategoryData $categoryData, $referenceName = null)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
@@ -138,8 +138,8 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         ];
 
         foreach ($brandsImagesData as $imageId => $brandName) {
+            /** @var \Shopsys\ShopBundle\Model\Product\Brand\Brand $brand */
             $brand = $this->getReference($brandName);
-            /* @var $brand \Shopsys\ShopBundle\Model\Product\Brand\Brand */
 
             $this->saveImageIntoDb($brand->getId(), 'brand', $imageId);
         }
@@ -162,8 +162,8 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         ];
 
         foreach ($categoriesImagesData as $imageId => $categoryName) {
+            /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
             $category = $this->getReference($categoryName);
-            /* @var $category \Shopsys\ShopBundle\Model\Category\Category */
 
             $this->saveImageIntoDb($category->getId(), 'category', $imageId);
         }
@@ -178,8 +178,8 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         ];
 
         foreach ($paymentsImagesData as $imageId => $paymentName) {
+            /** @var \Shopsys\ShopBundle\Model\Payment\Payment $payment */
             $payment = $this->getReference($paymentName);
-            /* @var $payment \Shopsys\ShopBundle\Model\Payment\Payment */
 
             $this->saveImageIntoDb($payment->getId(), 'payment', $imageId);
         }
@@ -194,8 +194,8 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         ];
 
         foreach ($transportsImagesData as $imageId => $transportName) {
+            /** @var \Shopsys\ShopBundle\Model\Transport\Transport $transport */
             $transport = $this->getReference($transportName);
-            /* @var $transport \Shopsys\ShopBundle\Model\Transport\Transport */
 
             $this->saveImageIntoDb($transport->getId(), 'transport', $imageId);
         }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ImageDataFixture.php
@@ -139,7 +139,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
 
         foreach ($brandsImagesData as $imageId => $brandName) {
             $brand = $this->getReference($brandName);
-            /* @var $brand \Shopsys\FrameworkBundle\Model\Product\Brand\Brand */
+            /* @var $brand \Shopsys\ShopBundle\Model\Product\Brand\Brand */
 
             $this->saveImageIntoDb($brand->getId(), 'brand', $imageId);
         }
@@ -163,7 +163,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
 
         foreach ($categoriesImagesData as $imageId => $categoryName) {
             $category = $this->getReference($categoryName);
-            /* @var $category \Shopsys\FrameworkBundle\Model\Category\Category */
+            /* @var $category \Shopsys\ShopBundle\Model\Category\Category */
 
             $this->saveImageIntoDb($category->getId(), 'category', $imageId);
         }
@@ -179,7 +179,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
 
         foreach ($paymentsImagesData as $imageId => $paymentName) {
             $payment = $this->getReference($paymentName);
-            /* @var $payment \Shopsys\FrameworkBundle\Model\Payment\Payment */
+            /* @var $payment \Shopsys\ShopBundle\Model\Payment\Payment */
 
             $this->saveImageIntoDb($payment->getId(), 'payment', $imageId);
         }
@@ -195,7 +195,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
 
         foreach ($transportsImagesData as $imageId => $transportName) {
             $transport = $this->getReference($transportName);
-            /* @var $transport \Shopsys\FrameworkBundle\Model\Transport\Transport */
+            /* @var $transport \Shopsys\ShopBundle\Model\Transport\Transport */
 
             $this->saveImageIntoDb($transport->getId(), 'transport', $imageId);
         }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainArticleDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainArticleDataFixture.php
@@ -25,7 +25,7 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
     protected $articleFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Article\ArticleDataFactory
      */
     protected $articleDataFactory;
 
@@ -36,7 +36,7 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
-     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface $articleDataFactory
+     * @param \Shopsys\ShopBundle\Model\Article\ArticleDataFactory $articleDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
@@ -99,7 +99,7 @@ class MultidomainArticleDataFixture extends AbstractReferenceFixture implements 
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
+     * @param \Shopsys\ShopBundle\Model\Article\ArticleData $articleData
      * @param string|null $referenceName
      */
     protected function createArticle(ArticleData $articleData, ?string $referenceName = null)

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainCategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainCategoryDataFixture.php
@@ -160,8 +160,8 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
      */
     protected function editCategoryOnDomain(string $referenceName, int $domainId, string $description)
     {
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
         $category = $this->getReference($referenceName);
-        /* @var $category \Shopsys\ShopBundle\Model\Category\Category */
         $categoryData = $this->categoryDataFacade->createFromCategory($category);
         $categoryData->descriptions[$domainId] = $description;
         $this->categoryFacade->edit($category->getId(), $categoryData);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainCategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainCategoryDataFixture.php
@@ -20,7 +20,7 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
     protected $categoryFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Category\CategoryDataFactory
      */
     protected $categoryDataFacade;
 
@@ -31,7 +31,7 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
-     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface $categoryDataFacade
+     * @param \Shopsys\ShopBundle\Model\Category\CategoryDataFactory $categoryDataFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
@@ -161,7 +161,7 @@ class MultidomainCategoryDataFixture extends AbstractReferenceFixture implements
     protected function editCategoryOnDomain(string $referenceName, int $domainId, string $description)
     {
         $category = $this->getReference($referenceName);
-        /* @var $category \Shopsys\FrameworkBundle\Model\Category\Category */
+        /* @var $category \Shopsys\ShopBundle\Model\Category\Category */
         $categoryData = $this->categoryDataFacade->createFromCategory($category);
         $categoryData->descriptions[$domainId] = $description;
         $this->categoryFacade->edit($category->getId(), $categoryData);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.php
@@ -227,8 +227,8 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
             null
         );
 
+        /** @var \Shopsys\ShopBundle\Model\Order\Order $order */
         $order = $this->orderFacade->createOrder($orderData, $orderPreview, $user);
-        /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
 
         $referenceName = OrderDataFixture::ORDER_PREFIX . $order->getId();
         $this->addReference($referenceName, $order);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainOrderDataFixture.php
@@ -43,7 +43,7 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
     protected $orderPreviewFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Order\OrderDataFactory
      */
     protected $orderDataFactory;
 
@@ -57,7 +57,7 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
      * @param \Faker\Generator $faker
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface $orderDataFactory
+     * @param \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
@@ -203,9 +203,9 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
+     * @param \Shopsys\ShopBundle\Model\Order\OrderData $orderData
      * @param array $products
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
+     * @param \Shopsys\ShopBundle\Model\Customer\User $user
      */
     protected function createOrder(
         OrderData $orderData,
@@ -228,7 +228,7 @@ class MultidomainOrderDataFixture extends AbstractReferenceFixture implements De
         );
 
         $order = $this->orderFacade->createOrder($orderData, $orderPreview, $user);
-        /* @var $order \Shopsys\FrameworkBundle\Model\Order\Order */
+        /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
 
         $referenceName = OrderDataFixture::ORDER_PREFIX . $order->getId();
         $this->addReference($referenceName, $order);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainProductDataFixture.php
@@ -42,7 +42,7 @@ class MultidomainProductDataFixture extends AbstractReferenceFixture implements 
     protected $productFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory
      */
     protected $productDataFactory;
 
@@ -57,7 +57,7 @@ class MultidomainProductDataFixture extends AbstractReferenceFixture implements 
      * @param \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade
      * @param \Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureCsvReader $productDataFixtureCsvReader
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface $productDataFactory
+     * @param \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
@@ -108,7 +108,7 @@ class MultidomainProductDataFixture extends AbstractReferenceFixture implements 
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param \Shopsys\ShopBundle\Model\Product\Product $product
      * @param array $row
      */
     protected function editProduct(Product $product, array $row)

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainSettingValueDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainSettingValueDataFixture.php
@@ -49,19 +49,19 @@ class MultidomainSettingValueDataFixture extends AbstractReferenceFixture implem
      */
     protected function loadForDomain(int $domainId)
     {
+        /** @var \Shopsys\ShopBundle\Model\Article\Article $termsAndConditionsDomain */
         $termsAndConditionsDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_TERMS_AND_CONDITIONS, $domainId);
-        /* @var $termsAndConditionsDomain \Shopsys\ShopBundle\Model\Article\Article */
         $this->setting->setForDomain(Setting::TERMS_AND_CONDITIONS_ARTICLE_ID, $termsAndConditionsDomain->getId(), $domainId);
 
+        /** @var \Shopsys\ShopBundle\Model\Article\Article $privacyPolicyDomain */
         $privacyPolicyDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_PRIVACY_POLICY, $domainId);
-        /* @var $privacyPolicyDomain \Shopsys\ShopBundle\Model\Article\Article */
         $this->setting->setForDomain(Setting::PRIVACY_POLICY_ARTICLE_ID, $privacyPolicyDomain->getId(), $domainId);
 
+        /** @var \Shopsys\ShopBundle\Model\Article\Article $cookiesDomain */
         $cookiesDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_COOKIES, $domainId);
-        /* @var $cookiesDomain \Shopsys\ShopBundle\Model\Article\Article */
         $this->setting->setForDomain(Setting::COOKIES_ARTICLE_ID, $cookiesDomain->getId(), $domainId);
 
-        /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReferenceForDomain(MultidomainPricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN, $domainId);
         $this->setting->setForDomain(Setting::DEFAULT_PRICING_GROUP, $pricingGroup->getId(), $domainId);
 
@@ -76,7 +76,7 @@ class MultidomainSettingValueDataFixture extends AbstractReferenceFixture implem
         ';
         $this->setting->setForDomain(Setting::ORDER_SENT_PAGE_CONTENT, $orderSentText, $domainId);
 
-        /* @var $defaultCurrency \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency */
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $defaultCurrency */
         $defaultCurrency = $this->getReference(CurrencyDataFixture::CURRENCY_EUR);
         $this->setting->setForDomain(PricingSetting::DEFAULT_DOMAIN_CURRENCY, $defaultCurrency->getId(), $domainId);
 

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainSettingValueDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MultidomainSettingValueDataFixture.php
@@ -50,15 +50,15 @@ class MultidomainSettingValueDataFixture extends AbstractReferenceFixture implem
     protected function loadForDomain(int $domainId)
     {
         $termsAndConditionsDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_TERMS_AND_CONDITIONS, $domainId);
-        /* @var $termsAndConditionsDomain \Shopsys\FrameworkBundle\Model\Article\Article */
+        /* @var $termsAndConditionsDomain \Shopsys\ShopBundle\Model\Article\Article */
         $this->setting->setForDomain(Setting::TERMS_AND_CONDITIONS_ARTICLE_ID, $termsAndConditionsDomain->getId(), $domainId);
 
         $privacyPolicyDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_PRIVACY_POLICY, $domainId);
-        /* @var $privacyPolicyDomain \Shopsys\FrameworkBundle\Model\Article\Article */
+        /* @var $privacyPolicyDomain \Shopsys\ShopBundle\Model\Article\Article */
         $this->setting->setForDomain(Setting::PRIVACY_POLICY_ARTICLE_ID, $privacyPolicyDomain->getId(), $domainId);
 
         $cookiesDomain = $this->getReferenceForDomain(MultidomainArticleDataFixture::ARTICLE_COOKIES, $domainId);
-        /* @var $cookiesDomain \Shopsys\FrameworkBundle\Model\Article\Article */
+        /* @var $cookiesDomain \Shopsys\ShopBundle\Model\Article\Article */
         $this->setting->setForDomain(Setting::COOKIES_ARTICLE_ID, $cookiesDomain->getId(), $domainId);
 
         /* @var $pricingGroup \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup */

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/OrderDataFixture.php
@@ -42,7 +42,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
     protected $orderPreviewFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Order\OrderDataFactory
      */
     protected $orderDataFactory;
 
@@ -51,7 +51,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
      * @param \Faker\Generator $faker
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface $orderDataFactory
+     * @param \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory
      */
     public function __construct(
         UserRepository $userRepository,
@@ -565,9 +565,9 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
+     * @param \Shopsys\ShopBundle\Model\Order\OrderData $orderData
      * @param array $products
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
+     * @param \Shopsys\ShopBundle\Model\Customer\User $user
      */
     protected function createOrder(
         OrderData $orderData,
@@ -590,7 +590,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         );
 
         $order = $this->orderFacade->createOrder($orderData, $orderPreview, $user);
-        /* @var $order \Shopsys\FrameworkBundle\Model\Order\Order */
+        /* @var $order \Shopsys\ShopBundle\Model\Order\Order */
 
         $referenceName = self::ORDER_PREFIX . $order->getId();
         $this->addReference($referenceName, $order);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/PaymentDataFixture.php
@@ -22,13 +22,13 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
     protected $paymentFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory
      */
     protected $paymentDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
-     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface $paymentDataFactory
+     * @param \Shopsys\ShopBundle\Model\Payment\PaymentDataFactory $paymentDataFactory
      */
     public function __construct(
         PaymentFacade $paymentFacade,
@@ -94,7 +94,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
 
     /**
      * @param string $referenceName
-     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $paymentData
+     * @param \Shopsys\ShopBundle\Model\Payment\PaymentData $paymentData
      * @param array $transportsReferenceNames
      */
     protected function createPayment(
@@ -104,7 +104,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
     ) {
         $paymentData->transports = [];
         foreach ($transportsReferenceNames as $transportReferenceName) {
-            /** @var \Shopsys\FrameworkBundle\Model\Transport\Transport $transport */
+            /** @var \Shopsys\ShopBundle\Model\Transport\Transport $transport */
             $transport = $this->getReference($transportReferenceName);
             $paymentData->transports[] = $transport;
         }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductAccessoriesDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductAccessoriesDataFixture.php
@@ -12,14 +12,14 @@ use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 
 class ProductAccessoriesDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    /** @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface */
+    /** @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory */
     protected $productDataFactory;
 
     /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade */
     protected $productFacade;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface $productDataFactory
+     * @param \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
      */
     public function __construct(
@@ -36,12 +36,12 @@ class ProductAccessoriesDataFixture extends AbstractReferenceFixture implements 
     public function load(ObjectManager $manager)
     {
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $product \Shopsys\FrameworkBundle\Model\Product\Product */
+        /* @var $product \Shopsys\ShopBundle\Model\Product\Product */
 
         $productData = $this->productDataFactory->createFromProduct($product);
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product24 */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product24 */
         $product24 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '24');
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product13 */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product13 */
         $product13 = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '13');
         $productData->accessories = [
             $product24,

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductAccessoriesDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductAccessoriesDataFixture.php
@@ -35,8 +35,8 @@ class ProductAccessoriesDataFixture extends AbstractReferenceFixture implements 
      */
     public function load(ObjectManager $manager)
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1');
-        /* @var $product \Shopsys\ShopBundle\Model\Product\Product */
 
         $productData = $this->productDataFactory->createFromProduct($product);
         /** @var \Shopsys\ShopBundle\Model\Product\Product $product24 */

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
@@ -108,8 +108,8 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $variantCatnumsByMainVariantCatnum = $this->productDataFixtureLoader->getVariantCatnumsIndexedByMainVariantCatnum($csvRows);
 
         foreach ($variantCatnumsByMainVariantCatnum as $mainVariantCatnum => $variantsCatnums) {
+            /** @var \Shopsys\ShopBundle\Model\Product\Product $mainProduct */
             $mainProduct = $productsByCatnum[$mainVariantCatnum];
-            /* @var $mainProduct \Shopsys\ShopBundle\Model\Product\Product */
 
             $variants = [];
             foreach ($variantsCatnums as $variantCatnum) {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
@@ -85,8 +85,8 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
 
     /**
      * @param string $referenceName
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
+     * @return \Shopsys\ShopBundle\Model\Product\Product
      */
     protected function createProduct($referenceName, ProductData $productData)
     {
@@ -98,7 +98,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $productsByCatnum
+     * @param \Shopsys\ShopBundle\Model\Product\Product[] $productsByCatnum
      * @param int $productNo
      */
     protected function createVariants(array $productsByCatnum, $productNo)
@@ -108,7 +108,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
 
         foreach ($variantCatnumsByMainVariantCatnum as $mainVariantCatnum => $variantsCatnums) {
             $mainProduct = $productsByCatnum[$mainVariantCatnum];
-            /* @var $mainProduct \Shopsys\FrameworkBundle\Model\Product\Product */
+            /* @var $mainProduct \Shopsys\ShopBundle\Model\Product\Product */
 
             $variants = [];
             foreach ($variantsCatnums as $variantCatnum) {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixture.php
@@ -90,6 +90,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
      */
     protected function createProduct($referenceName, ProductData $productData)
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $product = $this->productFacade->create($productData);
 
         $this->addReference($referenceName, $product);

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/ProductDataFixtureLoader.php
@@ -55,7 +55,7 @@ class ProductDataFixtureLoader
     protected $availabilities;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @var \Shopsys\ShopBundle\Model\Category\Category[]
      */
     protected $categories;
 
@@ -65,7 +65,7 @@ class ProductDataFixtureLoader
     protected $flags;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     * @var \Shopsys\ShopBundle\Model\Product\Brand\Brand[]
      */
     protected $brands;
 
@@ -80,7 +80,7 @@ class ProductDataFixtureLoader
     protected $pricingGroups;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory
      */
     protected $productDataFactory;
 
@@ -96,7 +96,7 @@ class ProductDataFixtureLoader
 
     /**
      * @param \Shopsys\ShopBundle\DataFixtures\Demo\ProductParametersFixtureLoader $productParametersFixtureLoader
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface $productDataFactory
+     * @param \Shopsys\ShopBundle\Model\Product\ProductDataFactory $productDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
      */
@@ -115,9 +115,9 @@ class ProductDataFixtureLoader
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat[] $vats
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\Availability[] $availabilities
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category[] $categories
+     * @param \Shopsys\ShopBundle\Model\Category\Category[] $categories
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[] $flags
-     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[] $brands
+     * @param \Shopsys\ShopBundle\Model\Product\Brand\Brand[] $brands
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\Unit[] $units
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup[] $pricingGroups
      */
@@ -142,7 +142,7 @@ class ProductDataFixtureLoader
 
     /**
      * @param array $row
-     * @return \Shopsys\FrameworkBundle\Model\Product\ProductData
+     * @return \Shopsys\ShopBundle\Model\Product\ProductData
      */
     public function createProductDataFromRowForFirstDomain($row)
     {
@@ -169,7 +169,7 @@ class ProductDataFixtureLoader
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      * @param array $row
      */
     protected function updateProductDataFromCsvRowForFirstDomain(ProductData $productData, array $row)
@@ -245,7 +245,7 @@ class ProductDataFixtureLoader
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      * @param array $row
      */
     public function updateProductDataFromCsvRowForSecondDomain(ProductData $productData, array $row)
@@ -331,7 +331,7 @@ class ProductDataFixtureLoader
 
     /**
      * @param array $row
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      * @param int $domainId
      */
     protected function setProductDataPricesFromCsv(array $row, ProductData $productData, $domainId)

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueDataFixture.php
@@ -32,9 +32,9 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
     {
         $termsAndConditions = $this->getReference(ArticleDataFixture::ARTICLE_TERMS_AND_CONDITIONS_1);
         $privacyPolicy = $this->getReference(ArticleDataFixture::ARTICLE_PRIVACY_POLICY_1);
-        /* @var $termsAndConditions \Shopsys\FrameworkBundle\Model\Article\Article */
+        /* @var $termsAndConditions \Shopsys\ShopBundle\Model\Article\Article */
         $cookies = $this->getReference(ArticleDataFixture::ARTICLE_COOKIES_1);
-        /* @var $cookies \Shopsys\FrameworkBundle\Model\Article\Article */
+        /* @var $cookies \Shopsys\ShopBundle\Model\Article\Article */
 
         $personalDataDisplaySiteContent = 'By entering an email below, you can view your personal information that we register in our online store. 
         An email with a link will be sent to you after entering your email address, to verify your identity. 

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/SettingValueDataFixture.php
@@ -30,11 +30,12 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
      */
     public function load(ObjectManager $manager)
     {
+        /** @var \Shopsys\ShopBundle\Model\Article\Article $termsAndConditions */
         $termsAndConditions = $this->getReference(ArticleDataFixture::ARTICLE_TERMS_AND_CONDITIONS_1);
+        /** @var \Shopsys\ShopBundle\Model\Article\Article $privacyPolicy */
         $privacyPolicy = $this->getReference(ArticleDataFixture::ARTICLE_PRIVACY_POLICY_1);
-        /* @var $termsAndConditions \Shopsys\ShopBundle\Model\Article\Article */
+        /** @var \Shopsys\ShopBundle\Model\Article\Article $cookies */
         $cookies = $this->getReference(ArticleDataFixture::ARTICLE_COOKIES_1);
-        /* @var $cookies \Shopsys\ShopBundle\Model\Article\Article */
 
         $personalDataDisplaySiteContent = 'By entering an email below, you can view your personal information that we register in our online store. 
         An email with a link will be sent to you after entering your email address, to verify your identity. 

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TransportDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/TransportDataFixture.php
@@ -22,13 +22,13 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
     protected $transportFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Transport\TransportDataFactory
      */
     protected $transportDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
-     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface $transportDataFactory
+     * @param \Shopsys\ShopBundle\Model\Transport\TransportDataFactory $transportDataFactory
      */
     public function __construct(
         TransportFacade $transportFacade,
@@ -90,7 +90,7 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
 
     /**
      * @param string $referenceName
-     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportData $transportData
+     * @param \Shopsys\ShopBundle\Model\Transport\TransportData $transportData
      */
     protected function createTransport($referenceName, TransportData $transportData)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
@@ -91,7 +91,7 @@ class UserDataFixture extends AbstractReferenceFixture implements DependentFixtu
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User $customer
+     * @param \Shopsys\ShopBundle\Model\Customer\User $customer
      */
     protected function resetPassword(User $customer)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixtureLoader.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixtureLoader.php
@@ -51,7 +51,7 @@ class UserDataFixtureLoader
     protected $path;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Customer\UserDataFactory
      */
     protected $userDataFactory;
 
@@ -83,7 +83,7 @@ class UserDataFixtureLoader
     /**
      * @param string $path
      * @param \Shopsys\FrameworkBundle\Component\Csv\CsvReader $csvReader
-     * @param \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface $userDataFactory
+     * @param \Shopsys\ShopBundle\Model\Customer\UserDataFactory $userDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerDataFactoryInterface $customerDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressDataFactoryInterface $billingAddressDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactoryInterface $deliveryAddressDataFactory

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/CategoryDataFixture.php
@@ -19,7 +19,7 @@ class CategoryDataFixture
     public const FIRST_PERFORMANCE_CATEGORY = 'first_performance_category';
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Category\CategoryDataFactory
      */
     private $categoryDataFactory;
 
@@ -60,7 +60,7 @@ class CategoryDataFixture
 
     /**
      * @param int[] $categoryCountsByLevel
-     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface $categoryDataFactory
+     * @param \Shopsys\ShopBundle\Model\Category\CategoryDataFactory $categoryDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade $sqlLoggerFacade
      * @param \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade
@@ -100,7 +100,7 @@ class CategoryDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $parentCategory
+     * @param \Shopsys\ShopBundle\Model\Category\Category $parentCategory
      * @param \Symfony\Component\Console\Helper\ProgressBar $progressBar
      * @param int $categoryLevel
      */
@@ -138,8 +138,8 @@ class CategoryDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $parentCategory
-     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryData
+     * @param \Shopsys\ShopBundle\Model\Category\Category $parentCategory
+     * @return \Shopsys\ShopBundle\Model\Category\CategoryData
      */
     private function getRandomCategoryDataByParentCategory(Category $parentCategory)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
@@ -268,10 +268,10 @@ class OrderDataFixture
 
     private function loadPerformanceProductIds()
     {
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $firstPerformanceProduct */
         $firstPerformanceProduct = $this->persistentReferenceFacade->getReference(
             PerformanceProductDataFixture::FIRST_PERFORMANCE_PRODUCT
         );
-        /* @var $firstPerformanceProduct \Shopsys\ShopBundle\Model\Product\Product */
 
         $qb = $this->em->createQueryBuilder()
             ->select('p.id')
@@ -295,10 +295,10 @@ class OrderDataFixture
 
     private function loadPerformanceUserIdsOnFirstDomain()
     {
+        /** @var \Shopsys\ShopBundle\Model\Customer\User $firstPerformanceUser */
         $firstPerformanceUser = $this->persistentReferenceFacade->getReference(
             PerformanceUserDataFixture::FIRST_PERFORMANCE_USER
         );
-        /* @var $firstPerformanceUser \Shopsys\ShopBundle\Model\Customer\User */
 
         $qb = $this->em->createQueryBuilder()
             ->select('u.id')

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
@@ -98,7 +98,7 @@ class OrderDataFixture
     private $progressBarFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Order\OrderDataFactory
      */
     private $orderDataFactory;
 
@@ -114,7 +114,7 @@ class OrderDataFixture
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade
      * @param \Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory $progressBarFactory
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface $orderDataFactory
+     * @param \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory
      */
     public function __construct(
         $orderTotalCount,
@@ -193,8 +193,8 @@ class OrderDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User $user
-     * @return \Shopsys\FrameworkBundle\Model\Order\OrderData
+     * @param \Shopsys\ShopBundle\Model\Customer\User $user
+     * @return \Shopsys\ShopBundle\Model\Order\OrderData
      */
     private function createOrderData(?User $user = null)
     {
@@ -271,7 +271,7 @@ class OrderDataFixture
         $firstPerformanceProduct = $this->persistentReferenceFacade->getReference(
             PerformanceProductDataFixture::FIRST_PERFORMANCE_PRODUCT
         );
-        /* @var $firstPerformanceProduct \Shopsys\FrameworkBundle\Model\Product\Product */
+        /* @var $firstPerformanceProduct \Shopsys\ShopBundle\Model\Product\Product */
 
         $qb = $this->em->createQueryBuilder()
             ->select('p.id')
@@ -298,7 +298,7 @@ class OrderDataFixture
         $firstPerformanceUser = $this->persistentReferenceFacade->getReference(
             PerformanceUserDataFixture::FIRST_PERFORMANCE_USER
         );
-        /* @var $firstPerformanceUser \Shopsys\FrameworkBundle\Model\Customer\User */
+        /* @var $firstPerformanceUser \Shopsys\ShopBundle\Model\Customer\User */
 
         $qb = $this->em->createQueryBuilder()
             ->select('u.id')
@@ -312,7 +312,7 @@ class OrderDataFixture
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Customer\User|null
+     * @return \Shopsys\ShopBundle\Model\Customer\User|null
      */
     private function getRandomUserOrNull()
     {
@@ -327,7 +327,7 @@ class OrderDataFixture
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Transport\Transport
+     * @return \Shopsys\ShopBundle\Model\Transport\Transport
      */
     private function getRandomTransport()
     {
@@ -337,13 +337,13 @@ class OrderDataFixture
             TransportDataFixture::TRANSPORT_PERSONAL,
         ]);
 
-        /** @var \Shopsys\FrameworkBundle\Model\Transport\Transport $randomTransport */
+        /** @var \Shopsys\ShopBundle\Model\Transport\Transport $randomTransport */
         $randomTransport = $this->persistentReferenceFacade->getReference($randomTransportReferenceName);
         return $randomTransport;
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Payment\Payment
+     * @return \Shopsys\ShopBundle\Model\Payment\Payment
      */
     private function getRandomPayment()
     {
@@ -353,7 +353,7 @@ class OrderDataFixture
             PaymentDataFixture::PAYMENT_CASH,
         ]);
 
-        /** @var \Shopsys\FrameworkBundle\Model\Payment\Payment $randomPayment */
+        /** @var \Shopsys\ShopBundle\Model\Payment\Payment $randomPayment */
         $randomPayment = $this->persistentReferenceFacade->getReference($randomPaymentReferenceName);
         return $randomPayment;
     }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/OrderDataFixture.php
@@ -320,7 +320,10 @@ class OrderDataFixture
 
         if ($shouldBeRegisteredUser) {
             $userId = $this->faker->randomElement($this->performanceUserIds);
-            return $this->customerFacade->getUserById($userId);
+            /** @var \Shopsys\ShopBundle\Model\Customer\User $user */
+            $user = $this->customerFacade->getUserById($userId);
+
+            return $user;
         } else {
             return null;
         }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
@@ -370,10 +370,10 @@ class ProductDataFixture
      */
     private function isPerformanceCategory(Category $category)
     {
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $firstPerformanceCategory */
         $firstPerformanceCategory = $this->persistentReferenceFacade->getReference(
             CategoryDataFixture::FIRST_PERFORMANCE_CATEGORY
         );
-        /* @var $firstPerformanceCategory \Shopsys\ShopBundle\Model\Category\Category */
 
         return $category->getId() >= $firstPerformanceCategory->getId();
     }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
@@ -84,7 +84,7 @@ class ProductDataFixture
     private $demoDataIterationCounter;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Product[]
+     * @var \Shopsys\ShopBundle\Model\Product\Product[]
      */
     private $productsByCatnum;
 
@@ -241,7 +241,7 @@ class ProductDataFixture
 
     /**
      * @param string $catnum
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @return \Shopsys\ShopBundle\Model\Product\Product
      */
     private function getProductByCatnum($catnum)
     {
@@ -255,7 +255,7 @@ class ProductDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      */
     private function makeProductDataUnique(ProductData $productData)
     {
@@ -306,7 +306,7 @@ class ProductDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      */
     private function setRandomPerformanceCategoriesToProductData(ProductData $productData)
     {
@@ -317,7 +317,7 @@ class ProductDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      * @param int $domainId
      */
     private function cleanPerformanceCategoriesFromProductDataByDomainId(ProductData $productData, $domainId)
@@ -330,7 +330,7 @@ class ProductDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      * @param int $domainId
      */
     private function addRandomPerformanceCategoriesToProductDataByDomainId(ProductData $productData, $domainId)
@@ -364,7 +364,7 @@ class ProductDataFixture
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\ShopBundle\Model\Category\Category $category
      * @return bool
      */
     private function isPerformanceCategory(Category $category)
@@ -372,7 +372,7 @@ class ProductDataFixture
         $firstPerformanceCategory = $this->persistentReferenceFacade->getReference(
             CategoryDataFixture::FIRST_PERFORMANCE_CATEGORY
         );
-        /* @var $firstPerformanceCategory \Shopsys\FrameworkBundle\Model\Category\Category */
+        /* @var $firstPerformanceCategory \Shopsys\ShopBundle\Model\Category\Category */
 
         return $category->getId() >= $firstPerformanceCategory->getId();
     }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/ProductDataFixture.php
@@ -190,6 +190,7 @@ class ProductDataFixture
             $this->productDataFixtureLoader->updateProductDataFromCsvRowForSecondDomain($productData, $row);
             $this->makeProductDataUnique($productData);
             $this->setRandomPerformanceCategoriesToProductData($productData);
+            /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
             $product = $this->productFacade->create($productData);
 
             if ($this->countImported === 0) {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
@@ -48,7 +48,7 @@ class UserDataFixture
     private $customerEditFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Customer\UserDataFactory
      */
     private $userDataFactory;
 
@@ -88,7 +88,7 @@ class UserDataFixture
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade $sqlLoggerFacade
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerEditFacade
-     * @param \Shopsys\FrameworkBundle\Model\Customer\UserDataFactoryInterface $userDataFactory
+     * @param \Shopsys\ShopBundle\Model\Customer\UserDataFactory $userDataFactory
      * @param \Faker\Generator $faker
      * @param \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade
      * @param \Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory $progressBarFactory
@@ -157,7 +157,7 @@ class UserDataFixture
     /**
      * @param int $domainId
      * @param int $userNumber
-     * @return \Shopsys\FrameworkBundle\Model\Customer\User
+     * @return \Shopsys\ShopBundle\Model\Customer\User
      */
     private function createCustomerOnDomain($domainId, $userNumber)
     {

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Performance/UserDataFixture.php
@@ -163,7 +163,10 @@ class UserDataFixture
     {
         $customerData = $this->getRandomCustomerDataByDomainId($domainId, $userNumber);
 
-        return $this->customerEditFacade->create($customerData);
+        /** @var \Shopsys\ShopBundle\Model\Customer\User $user */
+        $user = $this->customerEditFacade->create($customerData);
+
+        return $user;
     }
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/ProductDataFixtureReferenceInjector.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/ProductDataFixtureReferenceInjector.php
@@ -83,7 +83,7 @@ class ProductDataFixtureReferenceInjector
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @return \Shopsys\ShopBundle\Model\Category\Category[]
      */
     private function getCategoryReferences(PersistentReferenceFacade $persistentReferenceFacade)
     {
@@ -117,7 +117,7 @@ class ProductDataFixtureReferenceInjector
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade
-     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     * @return \Shopsys\ShopBundle\Model\Product\Brand\Brand[]
      */
     private function getBrandReferences(PersistentReferenceFacade $persistentReferenceFacade)
     {

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/PersonalInfoFormType.php
@@ -305,7 +305,7 @@ class PersonalInfoFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
-                    /** @var \Shopsys\FrameworkBundle\Model\Order\FrontOrderData $orderData */
+                    /** @var \Shopsys\ShopBundle\Model\Order\FrontOrderData $orderData */
                     $orderData = $form->getData();
 
                     if ($orderData->companyCustomer) {

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Order/TransportAndPaymentFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Order/TransportAndPaymentFormType.php
@@ -87,7 +87,7 @@ class TransportAndPaymentFormType extends AbstractType
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
+     * @param \Shopsys\ShopBundle\Model\Order\OrderData $orderData
      * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
      */
     public function validateTransportPaymentRelation(OrderData $orderData, ExecutionContextInterface $context)

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/Category.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/Category.php
@@ -17,6 +17,10 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
  * @property \Shopsys\ShopBundle\Model\Category\Category[]|\Doctrine\Common\Collections\Collection $children
  * @method \Shopsys\ShopBundle\Model\Category\Category|null getParent()
  * @method \Shopsys\ShopBundle\Model\Category\Category[] getChildren()
+ * @method setParent(\Shopsys\ShopBundle\Model\Category\Category|null $parent)
+ * @method setTranslations(\Shopsys\ShopBundle\Model\Category\CategoryData $categoryData)
+ * @method setDomains(\Shopsys\ShopBundle\Model\Category\CategoryData $categoryData)
+ * @method createDomains(\Shopsys\ShopBundle\Model\Category\CategoryData $categoryData)
  */
 class Category extends BaseCategory
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/Category.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/Category.php
@@ -13,6 +13,10 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
  * @Gedmo\Tree(type="nested")
  * @ORM\Table(name="categories")
  * @ORM\Entity
+ * @property \Shopsys\ShopBundle\Model\Category\Category|null $parent
+ * @property \Shopsys\ShopBundle\Model\Category\Category[]|\Doctrine\Common\Collections\Collection $children
+ * @method \Shopsys\ShopBundle\Model\Category\Category|null getParent()
+ * @method \Shopsys\ShopBundle\Model\Category\Category[] getChildren()
  */
 class Category extends BaseCategory
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/CategoryData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/CategoryData.php
@@ -6,6 +6,9 @@ namespace Shopsys\ShopBundle\Model\Category;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Category\Category|null $parent
+ */
 class CategoryData extends BaseCategoryData
 {
 }

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/CurrentCategoryResolver.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/CurrentCategoryResolver.php
@@ -35,7 +35,7 @@ class CurrentCategoryResolver
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $domainId
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category|null
+     * @return \Shopsys\ShopBundle\Model\Category\Category|null
      */
     public function findCurrentCategoryByRequest(Request $request, $domainId)
     {

--- a/project-base/src/Shopsys/ShopBundle/Model/Category/CurrentCategoryResolver.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Category/CurrentCategoryResolver.php
@@ -43,12 +43,14 @@ class CurrentCategoryResolver
 
         if ($routeName === 'front_product_list') {
             $categoryId = $request->get('id');
+            /** @var \Shopsys\ShopBundle\Model\Category\Category $currentCategory */
             $currentCategory = $this->categoryFacade->getById($categoryId);
 
             return $currentCategory;
         } elseif ($routeName === 'front_product_detail') {
             $productId = $request->get('id');
             $product = $this->productFacade->getById($productId);
+            /** @var \Shopsys\ShopBundle\Model\Category\Category $currentCategory */
             $currentCategory = $this->categoryFacade->getProductMainCategoryByDomainId($product, $domainId);
 
             return $currentCategory;

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/FrontOrderData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/FrontOrderData.php
@@ -6,6 +6,15 @@ namespace Shopsys\ShopBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\FrontOrderData as BaseFrontOrderData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport|null $transport
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment|null $payment
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItemData[] $itemsWithoutTransportAndPayment
+ * @property \Shopsys\ShopBundle\Model\Administrator\Administrator|null $createdAsAdministrator
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItemData|null $orderPayment
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItemData|null $orderTransport
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItemData[] getNewItemsWithoutTransportAndPayment()
+ */
 class FrontOrderData extends BaseFrontOrderData
 {
 }

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItem.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItem.php
@@ -12,6 +12,14 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 /**
  * @ORM\Table(name="order_items")
  * @ORM\Entity
+ * @property \Shopsys\ShopBundle\Model\Order\Order $order
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport|null $transport
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment|null $payment
+ * @property \Shopsys\ShopBundle\Model\Product\Product|null $product
+ * @method \Shopsys\ShopBundle\Model\Order\Order getOrder()
+ * @method \Shopsys\ShopBundle\Model\Transport\Transport getTransport()
+ * @method \Shopsys\ShopBundle\Model\Payment\Payment getPayment()
+ * @method \Shopsys\ShopBundle\Model\Product\Product|null getProduct()
  */
 class OrderItem extends BaseOrderItem
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItem.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItem.php
@@ -20,6 +20,10 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
  * @method \Shopsys\ShopBundle\Model\Transport\Transport getTransport()
  * @method \Shopsys\ShopBundle\Model\Payment\Payment getPayment()
  * @method \Shopsys\ShopBundle\Model\Product\Product|null getProduct()
+ * @method edit(\Shopsys\ShopBundle\Model\Order\Item\OrderItemData $orderItemData)
+ * @method setTransport(\Shopsys\ShopBundle\Model\Transport\Transport $transport)
+ * @method setPayment(\Shopsys\ShopBundle\Model\Payment\Payment $payment)
+ * @method setProduct(\Shopsys\ShopBundle\Model\Product\Product|null $product)
  */
 class OrderItem extends BaseOrderItem
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItemData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItemData.php
@@ -6,6 +6,10 @@ namespace Shopsys\ShopBundle\Model\Order\Item;
 
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData as BaseOrderItemData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport|null $transport
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment|null $payment
+ */
 class OrderItemData extends BaseOrderItemData
 {
 }

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Order.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Order.php
@@ -13,14 +13,30 @@ use Shopsys\FrameworkBundle\Model\Order\OrderEditResult;
 /**
  * @ORM\Table(name="orders")
  * @ORM\Entity
+ * @property \Shopsys\ShopBundle\Model\Customer\User|null $customer
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItem[]|\Doctrine\Common\Collections\Collection $items
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport $transport
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment $payment
+ * @property \Shopsys\ShopBundle\Model\Administrator\Administrator|null $createdAsAdministrator
+ * @method \Shopsys\ShopBundle\Model\Payment\Payment getPayment()
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem getOrderPayment()
+ * @method \Shopsys\ShopBundle\Model\Transport\Transport getTransport()
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem getOrderTransport()
+ * @method \Shopsys\ShopBundle\Model\Customer\User|null getCustomer()
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getItems()
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getItemsWithoutTransportAndPayment()
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getTransportAndPaymentItems()
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem getItemById($orderItemId)
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getProductItems()
+ * @method \Shopsys\ShopBundle\Model\Administrator\Administrator|null getCreatedAsAdministrator()
  */
 class Order extends BaseOrder
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderData $orderData
+     * @param \Shopsys\ShopBundle\Model\Order\OrderData $orderData
      * @param string $orderNumber
      * @param string $urlHash
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User|null $user
+     * @param \Shopsys\ShopBundle\Model\Customer\User|null $user
      */
     public function __construct(
         BaseOrderData $orderData,

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Order.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Order.php
@@ -26,9 +26,15 @@ use Shopsys\FrameworkBundle\Model\Order\OrderEditResult;
  * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getItems()
  * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getItemsWithoutTransportAndPayment()
  * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getTransportAndPaymentItems()
- * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem getItemById($orderItemId)
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem getItemById(int $orderItemId)
  * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItem[] getProductItems()
  * @method \Shopsys\ShopBundle\Model\Administrator\Administrator|null getCreatedAsAdministrator()
+ * @method editData(\Shopsys\ShopBundle\Model\Order\OrderData $orderData)
+ * @method editOrderTransport(\Shopsys\ShopBundle\Model\Order\OrderData $orderData)
+ * @method editOrderPayment(\Shopsys\ShopBundle\Model\Order\OrderData $orderData)
+ * @method setDeliveryAddress(\Shopsys\ShopBundle\Model\Order\OrderData $orderData)
+ * @method addItem(\Shopsys\ShopBundle\Model\Order\Item\OrderItem $item)
+ * @method removeItem(\Shopsys\ShopBundle\Model\Order\Item\OrderItem $item)
  */
 class Order extends BaseOrder
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/OrderData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/OrderData.php
@@ -6,6 +6,15 @@ namespace Shopsys\ShopBundle\Model\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\OrderData as BaseOrderData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport|null $transport
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment|null $payment
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItemData[] $itemsWithoutTransportAndPayment
+ * @property \Shopsys\ShopBundle\Model\Administrator\Administrator|null $createdAsAdministrator
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItemData|null $orderPayment
+ * @property \Shopsys\ShopBundle\Model\Order\Item\OrderItemData|null $orderTransport
+ * @method \Shopsys\ShopBundle\Model\Order\Item\OrderItemData[] getNewItemsWithoutTransportAndPayment()
+ */
 class OrderData extends BaseOrderData
 {
     public function __construct()

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/OrderDataMapper.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/OrderDataMapper.php
@@ -8,10 +8,13 @@ use Shopsys\FrameworkBundle\Model\Order\FrontOrderData as BaseFrontOrderData;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataMapper as BaseOrderDataMapper;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory
+ */
 class OrderDataMapper extends BaseOrderDataMapper
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface $orderDataFactory
+     * @param \Shopsys\ShopBundle\Model\Order\OrderDataFactory $orderDataFactory
      */
     public function __construct(OrderDataFactoryInterface $orderDataFactory)
     {

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/Payment.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/Payment.php
@@ -11,6 +11,8 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
 /**
  * @ORM\Table(name="payments")
  * @ORM\Entity
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport[]|\Doctrine\Common\Collections\Collection $transports
+ * @method \Shopsys\ShopBundle\Model\Transport\Transport[] getTransports()
  */
 class Payment extends BasePayment
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/Payment.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/Payment.php
@@ -13,6 +13,12 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
  * @ORM\Entity
  * @property \Shopsys\ShopBundle\Model\Transport\Transport[]|\Doctrine\Common\Collections\Collection $transports
  * @method \Shopsys\ShopBundle\Model\Transport\Transport[] getTransports()
+ * @method addTransport(\Shopsys\ShopBundle\Model\Transport\Transport $transport)
+ * @method setTransports(\Shopsys\ShopBundle\Model\Transport\Transport[] $transports)
+ * @method removeTransport(\Shopsys\ShopBundle\Model\Transport\Transport $transport)
+ * @method setTranslations(\Shopsys\ShopBundle\Model\Payment\PaymentData $paymentData)
+ * @method setDomains(\Shopsys\ShopBundle\Model\Payment\PaymentData $paymentData)
+ * @method createDomains(\Shopsys\ShopBundle\Model\Payment\PaymentData $paymentData)
  */
 class Payment extends BasePayment
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentData.php
@@ -6,6 +6,9 @@ namespace Shopsys\ShopBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Transport\Transport[] $transports
+ */
 class PaymentData extends BasePaymentData
 {
     public function __construct()

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/Brand.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/Brand.php
@@ -11,6 +11,9 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandData as BaseBrandData;
 /**
  * @ORM\Table(name="brands")
  * @ORM\Entity
+ * @method setTranslations(\Shopsys\ShopBundle\Model\Product\Brand\BrandData $brandData)
+ * @method setDomains(\Shopsys\ShopBundle\Model\Product\Brand\BrandData $brandData)
+ * @method createDomains(\Shopsys\ShopBundle\Model\Product\Brand\BrandData $brandData)
  */
 class Brand extends BaseBrand
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
@@ -11,6 +11,15 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
 /**
  * @ORM\Table(name="products")
  * @ORM\Entity
+ * @property \Shopsys\ShopBundle\Model\Product\Brand\Brand|null $brand
+ * @property \Shopsys\ShopBundle\Model\Product\Product[]|\Doctrine\Common\Collections\Collection $variants
+ * @property \Shopsys\ShopBundle\Model\Product\Product|null $mainVariant
+ * @method static \Shopsys\ShopBundle\Model\Product\Product create($productData)
+ * @method static \Shopsys\ShopBundle\Model\Product\Product createMainVariant($productData, $variants)
+ * @method \Shopsys\ShopBundle\Model\Category\Category[][] getCategoriesIndexedByDomainId()
+ * @method \Shopsys\ShopBundle\Model\Product\Brand\Brand|null getBrand()
+ * @method \Shopsys\ShopBundle\Model\Product\Product getMainVariant()
+ * @method \Shopsys\ShopBundle\Model\Product\Product[] getVariants()
  */
 class Product extends BaseProduct
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Product.php
@@ -14,12 +14,22 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
  * @property \Shopsys\ShopBundle\Model\Product\Brand\Brand|null $brand
  * @property \Shopsys\ShopBundle\Model\Product\Product[]|\Doctrine\Common\Collections\Collection $variants
  * @property \Shopsys\ShopBundle\Model\Product\Product|null $mainVariant
- * @method static \Shopsys\ShopBundle\Model\Product\Product create($productData)
- * @method static \Shopsys\ShopBundle\Model\Product\Product createMainVariant($productData, $variants)
+ * @method static \Shopsys\ShopBundle\Model\Product\Product create(\Shopsys\ShopBundle\Model\Product\ProductData $productData)
+ * @method static \Shopsys\ShopBundle\Model\Product\Product createMainVariant(\Shopsys\ShopBundle\Model\Product\ProductData $productData, \Shopsys\ShopBundle\Model\Product\Product[] $variants)
  * @method \Shopsys\ShopBundle\Model\Category\Category[][] getCategoriesIndexedByDomainId()
  * @method \Shopsys\ShopBundle\Model\Product\Brand\Brand|null getBrand()
  * @method \Shopsys\ShopBundle\Model\Product\Product getMainVariant()
  * @method \Shopsys\ShopBundle\Model\Product\Product[] getVariants()
+ * @method setAvailabilityAndStock(\Shopsys\ShopBundle\Model\Product\ProductData $productData)
+ * @method addVariant(\Shopsys\ShopBundle\Model\Product\Product $variant)
+ * @method addVariants(\Shopsys\ShopBundle\Model\Product\Product[] $variants)
+ * @method setMainVariant(\Shopsys\ShopBundle\Model\Product\Product $mainVariant)
+ * @method setTranslations(\Shopsys\ShopBundle\Model\Product\ProductData $productData)
+ * @method setDomains(\Shopsys\ShopBundle\Model\Product\ProductData $productData)
+ * @method createDomains(\Shopsys\ShopBundle\Model\Product\ProductData $productData)
+ * @method refreshVariants(\Shopsys\ShopBundle\Model\Product\Product[] $currentVariants)
+ * @method addNewVariants(\Shopsys\ShopBundle\Model\Product\Product[] $currentVariants)
+ * @method unsetRemovedVariants(\Shopsys\ShopBundle\Model\Product\Product[] $currentVariants)
  */
 class Product extends BaseProduct
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/ProductData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/ProductData.php
@@ -6,6 +6,12 @@ namespace Shopsys\ShopBundle\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Category\Category[][] $categoriesByDomainId
+ * @property \Shopsys\ShopBundle\Model\Product\Brand\Brand|null $brand
+ * @property \Shopsys\ShopBundle\Model\Product\Product[] $accessories
+ * @property \Shopsys\ShopBundle\Model\Product\Product[] $variants
+ */
 class ProductData extends BaseProductData
 {
 }

--- a/project-base/src/Shopsys/ShopBundle/Model/Transport/Transport.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Transport/Transport.php
@@ -13,6 +13,12 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;
  * @ORM\Entity
  * @property \Shopsys\ShopBundle\Model\Payment\Payment[]|\Doctrine\Common\Collections\Collection $payments
  * @method \Shopsys\ShopBundle\Model\Payment\Payment[] getPayments()
+ * @method setTranslations(\Shopsys\ShopBundle\Model\Transport\TransportData $transportData)
+ * @method setDomains(\Shopsys\ShopBundle\Model\Transport\TransportData $transportData)
+ * @method createDomains(\Shopsys\ShopBundle\Model\Transport\TransportData $transportData)
+ * @method addPayment(\Shopsys\ShopBundle\Model\Payment\Payment $payment)
+ * @method setPayments(\Shopsys\ShopBundle\Model\Payment\Payment[] $payments)
+ * @method removePayment(\Shopsys\ShopBundle\Model\Payment\Payment $payment)
  */
 class Transport extends BaseTransport
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Transport/Transport.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Transport/Transport.php
@@ -11,6 +11,8 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;
 /**
  * @ORM\Table(name="transports")
  * @ORM\Entity
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment[]|\Doctrine\Common\Collections\Collection $payments
+ * @method \Shopsys\ShopBundle\Model\Payment\Payment[] getPayments()
  */
 class Transport extends BaseTransport
 {

--- a/project-base/src/Shopsys/ShopBundle/Model/Transport/TransportData.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Transport/TransportData.php
@@ -6,6 +6,9 @@ namespace Shopsys\ShopBundle\Model\Transport;
 
 use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;
 
+/**
+ * @property \Shopsys\ShopBundle\Model\Payment\Payment[] $payments
+ */
 class TransportData extends BaseTransportData
 {
     public function __construct()

--- a/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
+++ b/project-base/tests/ShopBundle/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
@@ -28,7 +28,7 @@ class ProductRenameRedirectPreviousUrlTest extends TransactionFunctionalTestCase
         $friendlyUrlFacade = $this->getContainer()->get(FriendlyUrlFacade::class);
         $previousFriendlyUrlSlug = $friendlyUrlFacade->findMainFriendlyUrl(1, 'front_product_detail', self::TESTED_PRODUCT_ID)->getSlug();
 
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
         $productData = $productDataFactory->createFromProduct($product);
         $productData->name['en'] = 'rename';
 

--- a/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
+++ b/project-base/tests/ShopBundle/Functional/EntityExtension/Model/ExtendedProduct.php
@@ -125,8 +125,8 @@ class ExtendedProduct extends Product
     protected $manyToManySelfReferencingInverseEntities;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product[]|null $variants
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\Product[]|null $variants
      */
     protected function __construct(ProductData $productData, ?array $variants = null)
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -97,8 +97,10 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
     {
         /** @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade */
         $productFacade = $this->getContainer()->get(ProductFacade::class);
+        /** @var \Shopsys\ShopBundle\Model\Product\Product $product */
+        $product = $productFacade->getById($productId);
 
-        return $productFacade->getById($productId);
+        return $product;
     }
 
     /**

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -91,7 +91,7 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
 
     /**
      * @param int $productId
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @return \Shopsys\ShopBundle\Model\Product\Product
      */
     private function getProductById($productId)
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartFacadeTest.php
@@ -252,7 +252,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @return \Shopsys\ShopBundle\Model\Product\Product
      */
     private function createProduct()
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
@@ -82,7 +82,7 @@ class CartTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @return \Shopsys\ShopBundle\Model\Product\Product
      */
     private function createProduct()
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Category/CategoryRepositoryTest.php
@@ -28,8 +28,11 @@ class CategoryRepositoryTest extends TransactionFunctionalTestCase
 
         $categoryData = $categoryDataFactory->create();
         $categoryData->name = ['en' => 'name', 'cs' => 'name'];
-        $categoryData->parent = $categoryFacade->getRootCategory();
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $rootCategory */
+        $rootCategory = $categoryFacade->getRootCategory();
+        $categoryData->parent = $rootCategory;
 
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $parentCategory */
         $parentCategory = $categoryFacade->create($categoryData);
 
         $categoryData->enabled[self::FIRST_DOMAIN_ID] = false;
@@ -57,8 +60,11 @@ class CategoryRepositoryTest extends TransactionFunctionalTestCase
 
         $categoryData = $categoryDataFactory->create();
         $categoryData->name = ['en' => 'name', 'cs' => 'name'];
-        $categoryData->parent = $categoryFacade->getRootCategory();
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $rootCategory */
+        $rootCategory = $categoryFacade->getRootCategory();
+        $categoryData->parent = $rootCategory;
 
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $parentCategory */
         $parentCategory = $categoryFacade->create($categoryData);
 
         $categoryData->parent = $parentCategory;

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeEditTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeEditTest.php
@@ -23,7 +23,7 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
     private const TRANSPORT_ITEM_ID = 47;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\Order
+     * @var \Shopsys\ShopBundle\Model\Order\Order
      */
     private $order;
 
@@ -33,12 +33,12 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
     private $orderFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Order\OrderDataFactory
      */
     private $orderDataFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Order\Item\OrderItemDataFactory
      */
     private $orderItemDataFactory;
 
@@ -238,9 +238,9 @@ final class OrderFacadeEditTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param \Shopsys\ShopBundle\Model\Order\Order $order
      * @param string $name
-     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItem
+     * @return \Shopsys\ShopBundle\Model\Order\Item\OrderItem
      */
     private function getOrderItemByName(Order $order, string $name): OrderItem
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/OrderFacadeTest.php
@@ -7,7 +7,6 @@ namespace Tests\ShopBundle\Functional\Model\Order;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\CartFacade;
-use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
 use Shopsys\FrameworkBundle\Model\Order\OrderRepository;
@@ -18,6 +17,7 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportRepository;
 use Shopsys\ShopBundle\DataFixtures\Demo\CountryDataFixture;
 use Shopsys\ShopBundle\DataFixtures\Demo\CurrencyDataFixture;
 use Shopsys\ShopBundle\DataFixtures\Demo\OrderStatusDataFixture;
+use Shopsys\ShopBundle\Model\Order\Item\OrderItemData;
 use Shopsys\ShopBundle\Model\Order\OrderData;
 use Tests\ShopBundle\Test\TransactionFunctionalTestCase;
 
@@ -46,7 +46,9 @@ class OrderFacadeTest extends TransactionFunctionalTestCase
 
         $cartFacade->addProductToCart($product->getId(), 1);
 
+        /** @var \Shopsys\ShopBundle\Model\Transport\Transport $transport */
         $transport = $transportRepository->getById(1);
+        /** @var \Shopsys\ShopBundle\Model\Payment\Payment $payment */
         $payment = $paymentRepository->getById(1);
 
         $orderData = new OrderData();

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Availability/AvailabilityFacadeTest.php
@@ -31,7 +31,7 @@ final class AvailabilityFacadeTest extends TransactionFunctionalTestCase
     private $availabilityFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface
+     * @var \Shopsys\ShopBundle\Model\Product\ProductDataFactory
      */
     private $productDataFactory;
 

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
@@ -71,7 +71,7 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
     /**
      * @param string $categoryReferenceName
-     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     * @return \Shopsys\ShopBundle\Model\Product\Brand\Brand[]
      */
     protected function getChoicesForCategoryReference(string $categoryReferenceName): array
     {
@@ -80,7 +80,7 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
 
-        /** @var \Shopsys\FrameworkBundle\Model\Category\Category $category */
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
         $category = $this->getReference($categoryReferenceName);
 
         return $repository->getBrandFilterChoicesInCategory(1, $pricingGroup, $category);
@@ -88,7 +88,7 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
     /**
      * @param string $searchText
-     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     * @return \Shopsys\ShopBundle\Model\Product\Brand\Brand[]
      */
     protected function getChoicesForSearchText(string $searchText): array
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
@@ -82,8 +82,10 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
         /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
         $category = $this->getReference($categoryReferenceName);
+        /** @var \Shopsys\ShopBundle\Model\Product\Brand\Brand[] $brands */
+        $brands = $repository->getBrandFilterChoicesInCategory(1, $pricingGroup, $category);
 
-        return $repository->getBrandFilterChoicesInCategory(1, $pricingGroup, $category);
+        return $brands;
     }
 
     /**
@@ -96,8 +98,10 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
+        /** @var \Shopsys\ShopBundle\Model\Product\Brand\Brand[] $brands */
+        $brands = $repository->getBrandFilterChoicesForSearch(1, $pricingGroup, 'en', $searchText);
 
-        return $repository->getBrandFilterChoicesForSearch(1, $pricingGroup, 'en', $searchText);
+        return $brands;
     }
 
     /**

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
@@ -82,7 +82,7 @@ class FlagFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
 
-        /** @var \Shopsys\FrameworkBundle\Model\Category\Category $category */
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
         $category = $this->getReference($categoryReferenceName);
 
         return $repository->getFlagFilterChoicesInCategory(1, $pricingGroup, 'en', $category);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/Filter/ParameterFilterChoiceRepositoryTest.php
@@ -60,7 +60,7 @@ class ParameterFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup */
         $pricingGroup = $this->getReference(PricingGroupDataFixture::PRICING_GROUP_ORDINARY_DOMAIN_1);
 
-        /** @var \Shopsys\FrameworkBundle\Model\Category\Category $category */
+        /** @var \Shopsys\ShopBundle\Model\Category\Category $category */
         $category = $this->getReference($categoryReferenceName);
 
         return $repository->getParameterFilterChoicesInCategory(1, $pricingGroup, 'en', $category);

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
@@ -50,7 +50,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends TransactionFunc
     abstract public function getProductOnCurrentDomainFacade(): ProductOnCurrentDomainFacadeInterface;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\ShopBundle\Model\Category\Category $category
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $filterData
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $expectedCountData
      * @dataProvider categoryTestCasesProvider

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeTest.php
@@ -271,7 +271,7 @@ abstract class ProductOnCurrentDomainFacadeTest extends TransactionFunctionalTes
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand $brand
+     * @param \Shopsys\ShopBundle\Model\Product\Brand\Brand $brand
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
     public function getPaginatedProductsForBrand(Brand $brand): PaginationResult

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductRepositoryTest.php
@@ -248,7 +248,7 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
 
     /**
      * @param string $searchText
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     * @return \Shopsys\ShopBundle\Model\Product\Product[]
      */
     private function getProductsForSearchOrderedByPriority($searchText)
     {
@@ -275,7 +275,7 @@ class ProductRepositoryTest extends TransactionFunctionalTestCase
 
     /**
      * @param \Shopsys\ShopBundle\Model\Category\Category $category
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     * @return \Shopsys\ShopBundle\Model\Product\Product[]
      */
     private function getProductsInCategoryOrderedByPriority(Category $category)
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php
@@ -118,8 +118,8 @@ final class ProductVariantCreationTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $expectedVariants
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $mainVariant
+     * @param \Shopsys\ShopBundle\Model\Product\Product[] $expectedVariants
+     * @param \Shopsys\ShopBundle\Model\Product\Product $mainVariant
      */
     private function assertContainsAllVariants(array $expectedVariants, Product $mainVariant): void
     {

--- a/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php
@@ -55,7 +55,7 @@ class ProductVisibilityRepositoryTest extends TransactionFunctionalTestCase
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\ShopBundle\Model\Product\ProductData $productData
      * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $price
      */
     private function setPriceForAllDomains(ProductData $productData, ?Money $price)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When using class inheritance (and interface implementations) for extending the behavior of the `framework` from `project-base`, static analysis tools are not able to understand the extensions, which makes the DX worse and PHPStan inspections fail. We want to use the higher level of PHPStan even in `project-base` and do not force the project developers to do the boring things manually so we created the automated tool that makes the static analysis understand the extended code properly.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes https://github.com/shopsys/shopsys/issues/914 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

## TODO
- [x] add docs
