### PR TITLE
[framework] creating OrderItem type product from OrderItemData is now done via OrderItemFactory

### DIFF
--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -79,4 +79,8 @@ There you can find links to upgrade notes for other versions too.
         +       arguments:
         +           $useInlineEditation: false
         ```
+- introduced `\Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFactory::createProductFromOrderItemData()` which provides more flexibility when `\Shopsys\FrameworkBundle\Model\Order\Item\OrderItem` is extended
+	- simplifies SSFW usage in `\Shopsys\FrameworkBundle\Model\Order\OrderFacade::refreshOrderItemsWithoutTransportAndPayment()` where the logic was moved into new method which can be well overriden without needs to duplicate `OrderFacade`'s code
+	- `\Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFactoryInterface` is deprecated and method `createProductFromOrderItemData()` will be added in next major version
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/src/Model/Order/Item/OrderItemFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactory.php
@@ -63,6 +63,31 @@ class OrderItemFactory implements OrderItemFactoryInterface
         return $orderProduct;
     }
 
+    public function createProductFromOrderItemData(Order $order, OrderItemData $orderItemData): OrderItem
+    {
+        $classData = $this->entityNameResolver->resolve(OrderItem::class);
+
+        $orderItem = new $classData(
+            $order,
+            $orderItemData->name,
+            new Price(
+                $orderItemData->priceWithoutVat,
+                $orderItemData->priceWithVat
+            ),
+            $orderItemData->vatPercent,
+            $orderItemData->quantity,
+            OrderItem::TYPE_PRODUCT,
+            $orderItemData->unitName,
+            $orderItemData->catnum
+        );
+        if (!$orderItemData->usePriceCalculation) {
+            $orderItem->setTotalPrice(
+                new Price($orderItemData->totalPriceWithoutVat, $orderItemData->totalPriceWithVat)
+            );
+        }
+        return $orderItem;
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
      * @param string $name

--- a/packages/framework/src/Model/Order/Item/OrderItemFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactory.php
@@ -63,6 +63,11 @@ class OrderItemFactory implements OrderItemFactoryInterface
         return $orderProduct;
     }
 
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData $orderItemData
+     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItem
+     */
     public function createProductFromOrderItemData(Order $order, OrderItemData $orderItemData): OrderItem
     {
         $classData = $this->entityNameResolver->resolve(OrderItem::class);

--- a/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
@@ -9,7 +9,7 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
 /**
- * @method createProductFromOrderItemData(Order $order, OrderItemData $orderItemData): OrderItem
+ * @method OrderItem createProductFromOrderItemData(Order $order, OrderItemData $orderItemData)
  */
 interface OrderItemFactoryInterface
 {

--- a/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
@@ -8,6 +8,9 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
+/**
+ * @method createProductFromOrderItemData(Order $order, OrderItemData $orderItemData): OrderItem
+ */
 interface OrderItemFactoryInterface
 {
     /**

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -720,7 +720,7 @@ services:
         alias: Shopsys\FrameworkBundle\Model\Order\OrderNumberSequenceFactory
 
     Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFactoryInterface:
-        alias: Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFactory
+        alias: Shopsys\ShopBundle\Model\Order\Item\OrderItemFactory
 
     Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFactory

--- a/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItemFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Order/Item/OrderItemFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Order\Item;
+
+use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFactory as BaseOrderItemFactory;
+
+class OrderItemFactory extends BaseOrderItemFactory
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Extending OrderItem cannot be extended in easy way. There are many uncomfortable changes required. We can partially bypass those with adding a new factory method.
|New feature| Yes
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Fixes issues| closes #1266 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

With this PR comes up also branch https://github.com/shopsys/shopsys/tree/ds-create-order-item-from-data-test-code which can provide basic code for testing it or to demostrate extending OrderItem class
