### PR TITLE
[project-base] fix wrong annotation in Administrator

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Model/Administrator/Administrator.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Administrator/Administrator.php
@@ -28,7 +28,7 @@ class Administrator extends BaseAdministrator
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $administratorData
+     * @param \Shopsys\ShopBundle\Model\Administrator\AdministratorData $administratorData
      */
     public function edit(BaseAdministratorData $administratorData): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| we have wrong annotation for AdministratorData in Administrator class
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
