### PR TITLE
[shopsys] docs: explain forced version of PHP in config.platform.php

### DIFF
--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -26,6 +26,7 @@ For more detailed information about the Shopsys Framework, please see [Shopsys F
 - [How can I create Front-end Breadcrumb navigation?](#how-can-i-create-front-end-breadcrumb-navigation)
 - [Do you have any tips how to debug emails during development in Docker?](#do-you-have-any-tips-how-to-debug-emails-during-development-in-docker)
 - [Can I see what is really happening in the Codeception acceptance tests when using Docker?](#can-i-see-what-is-really-happening-in-the-codeception-acceptance-tests-when-using-docker)
+- [Why is there a faked PHP 7.2 platform in the Composer config?](#why-is-there-a-faked-php-72-platform-in-the-composer-config)
 
 ## What are the phing targets?
 Every phing target is a task that can be executed simply by `php phing <target-name>` command.
@@ -148,3 +149,16 @@ See [Outgoing emails](https://github.com/djfarrelly/MailDev#outgoing-email) in t
 
 ## Can I see what is really happening in the Codeception acceptance tests when using Docker?
 Yes, you can! Check [the quick guide](/docs/introduction/running-acceptance-tests.md#how-to-watch-what-is-going-on-in-the-selenium-browser).
+
+## Why is there a faked PHP 7.2 platform in the Composer config?
+As a general rule, packages and libraries that depend on PHP 7.2 will work as expected even on PHP 7.3 (any higher 7.x version), but not vice versa.
+This is the maintainers of PHP focus on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration73.incompatible.php) introduced in PHP 7.3, in practice it doesn't cause issues).
+
+Using [the `config.platform.php` option](https://getcomposer.org/doc/06-config.md#platform) in `composer.json` allows us to force Composer to install such dependencies, that work for all supported versions of PHP by Shopsys Framework.
+These dependencies are locked during each release of SSFW so users that install it can download exact versions of all libraries and tools that were tested and proved working.
+This helps to eliminate unforeseen issues during installation.
+See [Composer docs](https://getcomposer.org/doc/01-basic-usage.md#installing-with-composer-lock) for more details on version locking.
+
+Without this forced platform version, you could encounter issues when working on your project with developers that use a different version of PHP.
+For example, your `composer.lock` could contain dependencies that not all developers can install.
+If that's not your case, you can safely remove the `config.platform.php` option from your `composer.json` and run `composer update` to use higher versions of your dependencies.

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -152,7 +152,7 @@ Yes, you can! Check [the quick guide](/docs/introduction/running-acceptance-test
 
 ## Why is there a faked PHP 7.2 platform in the Composer config?
 As a general rule, packages and libraries that depend on PHP 7.2 will work as expected even on PHP 7.3 (any higher 7.x version), but not vice versa.
-This is the maintainers of PHP focus on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration73.incompatible.php) introduced in PHP 7.3, in practice it doesn't cause issues).
+Mainteiners of PHP are focusing on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration73.incompatible.php) introduced in PHP 7.3, in practice it doesn't cause issues).
 
 Using [the `config.platform.php` option](https://getcomposer.org/doc/06-config.md#platform) in `composer.json` allows us to force Composer to install such dependencies, that work for all supported versions of PHP by Shopsys Framework.
 These dependencies are locked during each release of SSFW so users that install it can download exact versions of all libraries and tools that were tested and proved working.

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -113,6 +113,24 @@ switch ($domainId) {
     case 3: $defaultCurrency = $this->getReference(CurrencyDataFixture::CURRENCY_CZK); break;
     ...
 ```
+
+## Fine-tune your configuration
+If all developers working on your project use the same version of PHP (eg. because all use SSFW via Docker), you can use higher versions of the libraries and tools installed via Composer.
+To do so, remove the `config.platform.php` option from your `composer.json`:
+```diff
+     "config": {
+         "preferred-install": "dist",
+         "component-dir": "project-base/web/components",
+-        "platform": {
+-            "php": "7.2"
+-        }
+     },
+```
+Run `composer update` to install updated versions of your dependencies (versions that don't support the lowest PHP version supported by SSFW).
+Then commit the changed `composer.json` and `composer.lock` so all the devs can share the same configuration.
+
+If you're interested in why we use the forced PHP version in the first place, read [our FAQ](../introduction/faq-and-common-issues.md#why-is-there-a-faked-php-72-platform-in-the-composer-config).
+
 ## Think about optional features of Shopsys Framework
 
 ### Backend API

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -131,6 +131,35 @@ Then commit the changed `composer.json` and `composer.lock` so all the devs can 
 
 If you're interested in why we use the forced PHP version in the first place, read [our FAQ](../introduction/faq-and-common-issues.md#why-is-there-a-faked-php-72-platform-in-the-composer-config).
 
+---
+
+On the other hand, if you're planning to run your project in production on a natively installed PHP, you should respect the version installed on that server.
+We recommend to use the same version in your `php-fpm`'s `Dockerfile`, so that developers using Docker run the app in the same environment.
+After all, your production server is the one that matters most.
+
+First, run `php -v` on your server to find our the exact version, for example:
+```
+PHP 7.2.19-0ubuntu0.18.04.1 (cli) (built: Jun  4 2019 14:48:12) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.2.19-0ubuntu0.18.04.1, Copyright (c) 1999-2018, by Zend Technologies
+```
+Then change the version in your `docker/php-fpm/Dockerfile`:
+```diff
+- FROM php:7.3-fpm-stretch as base
++ FROM php:7.2.19-fpm-stretch as base
+```
+After running `docker-compose up -d --build` you'll have the application running on the same PHP.
+
+Now you can modify the version in your `composer.json` as well so all packages will always be installed in a compatible version.
+```diff
+         "platform": {
+-            "php": "7.2"
++            "php": "7.2.19"
+         }
+```
+To apply the new setting, execute `composer update` and commit the changes.
+
 ## Think about optional features of Shopsys Framework
 
 ### Backend API

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -120,10 +120,11 @@ To do so, remove the `config.platform.php` option from your `composer.json`:
 ```diff
      "config": {
          "preferred-install": "dist",
-         "component-dir": "project-base/web/components",
+-        "component-dir": "project-base/web/components",
 -        "platform": {
 -            "php": "7.2"
 -        }
++        "component-dir": "project-base/web/components"
      },
 ```
 Run `composer update` to install updated versions of your dependencies (versions that don't support the lowest PHP version supported by SSFW).

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -115,7 +115,7 @@ switch ($domainId) {
 ```
 
 ## Fine-tune your configuration
-If all developers working on your project use the same version of PHP (eg. because all use SSFW via Docker), you can use higher versions of the libraries and tools installed via Composer.
+If all developers working on your project use the same version of PHP (e.g. because all use SSFW via Docker), you can use higher versions of the libraries and tools installed via Composer.
 To do so, remove the `config.platform.php` option from your `composer.json`:
 ```diff
      "config": {

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -136,7 +136,7 @@ If you're interested in why we use the forced PHP version in the first place, re
 
 On the other hand, if you're planning to run your project in production on a natively installed PHP, you should respect the version installed on that server.
 We recommend to use the same version in your `php-fpm`'s `Dockerfile`, so that developers using Docker run the app in the same environment.
-After all, your production server is the one that matters most.
+After all, your production server is the one that matters the most.
 
 First, run `php -v` on your server to find our the exact version, for example:
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were questions about the forced version of PHP in the `config.platform.php` option in Composer configuration.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #1178 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

To see that all dependencies support higher versions of PHP you can search for `"php":` in your `composer.lock`. You'll see all version requirements defined in the dependencies' `composer.json` config.

They all use wider intervals such as `>=5.3.0`, `^5.3.2 || ^7.0 || ^8.0`, `^7.1`...
