### PR TITLE
[shopsys] fix configuration of PhpStan

### DIFF
--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -31,7 +31,6 @@ parameters:
         -
             message: '#Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$payment \(Shopsys\\FrameworkBundle\\Model\\Payment\\Payment\) does not accept null\.#'
             path: %currentWorkingDirectory%/src/Model/Order/Order.php
-        #TODO delete after changing typehint in the next major release#
         -
             message: '#Access to an undefined property PhpParser\\Node::\$var\.#'
             path: %currentWorkingDirectory%/src/Component/Translation/ConstraintViolationExtractor.php

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -2,11 +2,15 @@ parameters:
     ignoreErrors:
         # Don't forget to add these rules to phpstan.neon in monorepo
         # Ignoring absence of \AppKernel, which should be provided by project implementation
-        - '~Instantiated class AppKernel not found~'
+        -
+            message: '~Instantiated class AppKernel not found~'
+            path: *
         -
             message: '#Call to method .+\(\) on an unknown class AppKernel\.#'
             path: %currentWorkingDirectory%/src/Component/Error/ErrorPagesFacade.php
-        - '#Method Doctrine\\Common\\Persistence\\ObjectManager::flush\(\) invoked with 1 parameter, 0 required\.#'
+        -
+            message: '#Method Doctrine\\Common\\Persistence\\ObjectManager::flush\(\) invoked with 1 parameter, 0 required\.#'
+            path: *
         -
             message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
             path: %currentWorkingDirectory%/src/Component/Domain/Config/DomainsConfigDefinition.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -53,6 +53,9 @@ parameters:
             message: '#(Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept object\.)#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
         -
+            message: '#(Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept object\|null\.)#'
+            path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
+        -
             message: '#(Method .+::.+\(\) should return .+ but returns (object|Codeception\\Module).)#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -66,5 +66,5 @@ parameters:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*
 includes:
-	- vendor/phpstan/phpstan-doctrine/extension.neon
-	- vendor/phpstan/phpstan-phpunit/extension.neon 
+    - vendor/phpstan/phpstan-doctrine/extension.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,7 +13,9 @@ parameters:
         -
             message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigDefinition.php
-        - '#Method Doctrine\\Common\\Persistence\\ObjectManager::flush\(\) invoked with 1 parameter, 0 required\.#'
+        -
+            message: '#Method Doctrine\\Common\\Persistence\\ObjectManager::flush\(\) invoked with 1 parameter, 0 required\.#'
+            path: *
         -
             message: '#Property Doctrine\\ORM\\Mapping\\ClassMetadataInfo::\$discriminatorColumn \(array\) does not accept null\.#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/EntityExtension/EntityExtensionParentMetadataCleanerEventSubscriber.php
@@ -60,7 +62,9 @@ parameters:
         -
             message: '#Array \(array<.+>\) does not accept object\.#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
-        - '#Undefined variable: \$undefined#'
+        -
+            message: '#Undefined variable: \$undefined#'
+            path: *
     excludes_analyse:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
     ignoreErrors:
-        #Shopsys/framework - don't forget to add these rules to phpstan.neon in framework
+        # shopsys/framework - don't forget to add these rules to phpstan.neon in framework
         -
             message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Domain/Config/DomainsConfigDefinition.php
@@ -33,7 +33,7 @@ parameters:
         -
             message: '#Access to an undefined property PhpParser\\Node::\$name\.#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
-        #Shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base
+        # shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base (only exceptions for level 1)
         -
             message: '#(PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+)#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,7 +26,6 @@ parameters:
         -
             message: '#Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$payment \(Shopsys\\FrameworkBundle\\Model\\Payment\\Payment\) does not accept null\.#'
             path: %currentWorkingDirectory%/packages/framework/src/Model/Order/Order.php
-        #TODO delete after changing typehint in the next major release#
         -
             message: '#Access to an undefined property PhpParser\\Node::\$var\.#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After update of `symfony/symfony` to `v3.4.31` Travis started failing on `phing phpstan` because of property type mismatch when filled from the DIC (see [failing build](https://travis-ci.org/shopsys/shopsys/jobs/576955885)) due to https://github.com/symfony/symfony/pull/33149. Also, some cleanup of the `phpstan.neon` was made (see commits messages for details).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| failing check on Travis CI <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
