### PR TITLE
[project-base] remove unnecessary English translations

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/validators.en.po
@@ -11,16 +11,16 @@ msgid "Company name cannot be longer than {{ limit }} characters"
 msgstr ""
 
 msgid "Email cannot be longer than {{ limit }} characters"
-msgstr "Email cannot be longer than {{ limit }} characters"
+msgstr ""
 
 msgid "First name cannot be longer than {{ limit }} characters"
-msgstr "First name cannot be longer than {{ limit }} characters"
+msgstr ""
 
 msgid "First name of contact person cannot be longer than {{ limit }} characters"
-msgstr "First name of contact person cannot be longer than {{ limit }} characters"
+msgstr ""
 
 msgid "Identification number cannot be longer than {{ limit }} characters"
-msgstr "Identification number cannot be longer than {{ limit }} characters"
+msgstr ""
 
 msgid "Last name cannot be longer than {{ limit }} characters"
 msgstr ""
@@ -29,13 +29,13 @@ msgid "Last name of contact person cannot be longer than {{ limit }} characters"
 msgstr ""
 
 msgid "Password cannot be longer than {{ limit }} characters"
-msgstr "Password cannot be longer than {{ limit }} characters"
+msgstr ""
 
 msgid "Password cannot be same as email"
-msgstr "Password cannot be same as email"
+msgstr ""
 
 msgid "Password cannot be same as part of email before at sign"
-msgstr "Password cannot be same as part of email before at sign"
+msgstr ""
 
 msgid "Passwords do not match"
 msgstr ""
@@ -65,7 +65,7 @@ msgid "Please enter date of creation"
 msgstr ""
 
 msgid "Please enter email"
-msgstr "Please enter email"
+msgstr ""
 
 msgid "Please enter first name"
 msgstr ""
@@ -101,7 +101,7 @@ msgid "Please enter telephone number"
 msgstr ""
 
 msgid "Please enter valid email"
-msgstr "Please enter valid email"
+msgstr ""
 
 msgid "Please enter valid quantity"
 msgstr ""
@@ -125,7 +125,7 @@ msgid "Telephone number cannot be longer than {{ limit }} characters"
 msgstr ""
 
 msgid "This email is already registered"
-msgstr "This email is already registered"
+msgstr ""
 
 msgid "You have to agree with privacy policy"
 msgstr ""


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| No need to define translation that is the same as the message ID as there is a fallback to `IdentityTranslator`. Redundant messages were introduced in #1335, its upgrade notes are sufficient, this change requires no further upgrade note, even when it modifies the `project-base` package.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
