### PR TITLE
[shopsys] fix coding standards via 'phing standards-fix'

### DIFF
--- a/packages/backend-api/tests/Unit/Component/HeaderLinks/HeaderLinksTransformerTest.php
+++ b/packages/backend-api/tests/Unit/Component/HeaderLinks/HeaderLinksTransformerTest.php
@@ -57,7 +57,7 @@ class HeaderLinksTransformerTest extends TestCase
      * @param string|null $last
      * @return \Shopsys\BackendApiBundle\Component\HeaderLinks\HeaderLinks
      */
-    protected function createHeaderLinks(?string $first = null, ?string $prev = null, ?string $next = null, ?string  $last = null): HeaderLinks
+    protected function createHeaderLinks(?string $first = null, ?string $prev = null, ?string $next = null, ?string $last = null): HeaderLinks
     {
         $headerLinks = new HeaderLinks();
         if ($first) {

--- a/packages/framework/src/Model/Customer/UserFactory.php
+++ b/packages/framework/src/Model/Customer/UserFactory.php
@@ -28,7 +28,7 @@ class UserFactory implements UserFactoryInterface
     public function __construct(
         EntityNameResolver $entityNameResolver,
         CustomerPasswordFacade $customerPasswordFacade
-) {
+    ) {
         $this->entityNameResolver = $entityNameResolver;
         $this->customerPasswordFacade = $customerPasswordFacade;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were two violations of our coding standards in `8.0` which were cuaght by ECS only after the changes in `7.3` were merged. You can check that both #1123 and #1055 which introduced the violations passed on Travis CI.<br>Failures were probably caused by some new version of ECS or the used sniffs that fixes them (you can see that #1328 passed on Travis CI, but the 6feb368ca is failing atm).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

