### PR TITLE
[framework] use DIC configuration instead of factory class to create Redis caches

### DIFF
--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -190,4 +190,17 @@ There you can find links to upgrade notes for other versions too.
         - `CronFacade::runModulesForInstance()` use method `runModules()` instead
         - `CronFacade::runModule()` use method `runSingleModule()` instead
 
+## Configuration
+- use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))
+    - the `RedisCacheFactory` was deprecated, use DIC configuration in YAML instead
+        ```diff
+         shopsys.shop.my_custom_cache:
+             class: Doctrine\Common\Cache\RedisCache
+        -        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
+        -        arguments:
+        -            - '@snc_redis.my_custom_cache'
+        +        calls:
+        +            - { method: setRedis, arguments: ['@snc_redis.my_custom_cache'] }
+        ```
+
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/packages/framework/src/Component/Doctrine/Cache/RedisCacheFactory.php
+++ b/packages/framework/src/Component/Doctrine/Cache/RedisCacheFactory.php
@@ -5,6 +5,10 @@ namespace Shopsys\FrameworkBundle\Component\Doctrine\Cache;
 use Doctrine\Common\Cache\RedisCache;
 use Redis;
 
+/**
+ * @deprecated This factory class is deprecated since SSFW 8.1, use setter injection of the Redis instance in DIC configuration of the RedisCache service instead
+ * @see https://symfony.com/doc/3.4/service_container/calls.html
+ */
 class RedisCacheFactory
 {
     /**
@@ -13,6 +17,8 @@ class RedisCacheFactory
      */
     public function create(Redis $redis)
     {
+        @trigger_error(sprintf('The factory class %s is deprecated, use setter injection of the Redis instance in DIC configuration of the RedisCache service instead', __CLASS__), E_USER_DEPRECATED);
+
         $redisCache = new RedisCache();
         $redisCache->setRedis($redis);
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -104,9 +104,8 @@ services:
 
     shopsys.doctrine.cache_driver.query_cache:
         class: Doctrine\Common\Cache\RedisCache
-        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
-        arguments:
-            - '@snc_redis.doctrine_query'
+        calls:
+            - { method: setRedis, arguments: ['@snc_redis.doctrine_query'] }
 
     shopsys.doctrine.cache_driver.metadata_cache:
         class: Doctrine\Common\Cache\CacheProvider
@@ -487,9 +486,8 @@ services:
 
     shopsys.shop.product.bestselling_product.cache_provider:
         class: Doctrine\Common\Cache\RedisCache
-        factory: 'Shopsys\FrameworkBundle\Component\Doctrine\Cache\RedisCacheFactory:create'
-        arguments:
-            - '@snc_redis.bestselling_products'
+        calls:
+            - { method: setRedis, arguments: ['@snc_redis.bestselling_products'] }
 
     Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\CachedBestsellingProductFacade:
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The `RedisCacheFactory` is trivial and can be removed altogether and replaced by a one line YAML configuration. This would mean one less class (and DIC service) in the project.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
