### PR TITLE
[shopsys] nginx.conf: remove access_log directive and use default settings

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -4,7 +4,6 @@ upstream php-upstream {
 
 server {
     listen 8080;
-    access_log /var/log/nginx/shopsys-framework.access.log;
     root /var/www/html/project-base/web;
     server_tokens off;
     client_max_body_size 32M;

--- a/docs/upgrade/UPGRADE-v7.3.2-dev.md
+++ b/docs/upgrade/UPGRADE-v7.3.2-dev.md
@@ -48,5 +48,15 @@ There you can find links to upgrade notes for other versions too.
     +      prefix: Shopsys\ShopBundle\Component
     +      is_bundle: false
     ```
+- remove `access_log` directive from Nginx configuration to use the default path ([#1362](https://github.com/shopsys/shopsys/pull/1362))
+    - remove the directive from all `nginx.conf` files you use
+        ```diff
+         server {
+             listen 8080;
+        -    access_log /var/log/nginx/shopsys-framework.access.log;
+             root /var/www/html/web;
+        ```
+    - restart you Nginx for the changes to take effect
+        - for example, run `docker-compose up -d --force-recreate webserver` to restart the container in Docker Compose
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/project-base/docker/nginx/google-cloud/nginx.conf
+++ b/project-base/docker/nginx/google-cloud/nginx.conf
@@ -4,7 +4,6 @@ upstream php-upstream {
 
 server {
     listen 8080;
-    access_log /var/log/nginx/shopsys-framework.access.log;
     root /var/www/html/web;
     server_tokens off;
     client_max_body_size 32M;

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -4,7 +4,6 @@ upstream php-upstream {
 
 server {
     listen 8080;
-    access_log /var/log/nginx/shopsys-framework.access.log;
     root /var/www/html/web;
     server_tokens off;
     client_max_body_size 32M;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Configuring the access log filepath is not neccessary, `/var/log/nginx/access.log` is used by default.<br>In `nginx` Docker image, the `/var/log/nginx/access.log` is a symlink to `/dev/stdout` which means that using the path is in accordance with [12-factor app recommendation](https://12factor.net/logs).<br><br>There is still an open related issue #1337
|New feature| Yes (access logs are now on standard output which can be seen as a feature, but if we agree it's a bugfix we should retarget to `7.3` instead) <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #1326 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes