### PR TITLE
[framework] User has now set orphan removal on billingAddress association

### DIFF
--- a/packages/framework/src/Model/Customer/User.php
+++ b/packages/framework/src/Model/Customer/User.php
@@ -57,7 +57,7 @@ class User implements UserInterface, TimelimitLoginInterface, Serializable
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\BillingAddress
-     * @ORM\OneToOne(targetEntity="Shopsys\FrameworkBundle\Model\Customer\BillingAddress", cascade={"persist"})
+     * @ORM\OneToOne(targetEntity="Shopsys\FrameworkBundle\Model\Customer\BillingAddress", cascade={"persist"}, orphanRemoval=true)
      * @ORM\JoinColumn(name="billing_address_id", referencedColumnName="id", nullable=false)
      */
     protected $billingAddress;


### PR DESCRIPTION
- hence the billing address is removed along with user (when is not used by any other user)
- the same setting is already used for deliveryAddress association

| Q             | A
| ------------- | ---
|Description, reason for the PR| I do not see any reason why we should keep the unused addresses in DB
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #663 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
