### PR TITLE
ProductCodeController now autowires PromoCodeDataFactoryInterface instead of PromoCodeDataFactory

### DIFF
--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -201,26 +201,6 @@ There you can find links to upgrade notes for other versions too.
     - these methods are deprecated and will be removed in the next major release:
         - `CronFacade::runModulesForInstance()` use method `runModules()` instead
         - `CronFacade::runModule()` use method `runSingleModule()` instead
-- fix argument's type hint in [`Shopsys\FrameworkBundle\Controller\Admin\PromoCodeController`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Controller/Admin/PromoCodeController.php) [#1364](https://github.com/shopsys/shopsys/pull/1364)
-    - if you haven't extended `PromoCodeController` class in your project you don't have to do anything
-    - otherwise you must replace type hint in
-        - `PromoCodeController::__construct()`
-            ```diff
-                public function __construct(
-                    PromoCodeFacade $promoCodeFacade,
-                    PromoCodeInlineEdit $promoCodeInlineEdit,
-                    AdministratorGridFacade $administratorGridFacade,
-                    ?PromoCodeDataFactory $promoCodeDataFactory = null,
-            -       ?PromoCodeDataFactory $promoCodeDataFactory = null,
-            +       ?PromoCodeDataFactoryInterface $promoCodeDataFactory = null,
-                    ?PromoCodeGridFactory $promoCodeGridFactory = null,
-                    ?BreadcrumbOverrider $breadcrumbOverrider = null,
-            ``` 
-        - `PromoCodeController::setPromoCodeDataFactory()`
-            ```diff
-            -   public function setPromoCodeDataFactory(PromoCodeDataFactory $promoCodeDataFactory)
-            +   public function setPromoCodeDataFactory(PromoCodeDataFactoryInterface $promoCodeDataFactory)
-            ```
 
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))

--- a/docs/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/docs/upgrade/UPGRADE-v8.1.0-dev.md
@@ -201,6 +201,26 @@ There you can find links to upgrade notes for other versions too.
     - these methods are deprecated and will be removed in the next major release:
         - `CronFacade::runModulesForInstance()` use method `runModules()` instead
         - `CronFacade::runModule()` use method `runSingleModule()` instead
+- fix argument's type hint in [`Shopsys\FrameworkBundle\Controller\Admin\PromoCodeController`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Controller/Admin/PromoCodeController.php) [#1364](https://github.com/shopsys/shopsys/pull/1364)
+    - if you haven't extended `PromoCodeController` class in your project you don't have to do anything
+    - otherwise you must replace type hint in
+        - `PromoCodeController::__construct()`
+            ```diff
+                public function __construct(
+                    PromoCodeFacade $promoCodeFacade,
+                    PromoCodeInlineEdit $promoCodeInlineEdit,
+                    AdministratorGridFacade $administratorGridFacade,
+                    ?PromoCodeDataFactory $promoCodeDataFactory = null,
+            -       ?PromoCodeDataFactory $promoCodeDataFactory = null,
+            +       ?PromoCodeDataFactoryInterface $promoCodeDataFactory = null,
+                    ?PromoCodeGridFactory $promoCodeGridFactory = null,
+                    ?BreadcrumbOverrider $breadcrumbOverrider = null,
+            ``` 
+        - `PromoCodeController::setPromoCodeDataFactory()`
+            ```diff
+            -   public function setPromoCodeDataFactory(PromoCodeDataFactory $promoCodeDataFactory)
+            +   public function setPromoCodeDataFactory(PromoCodeDataFactoryInterface $promoCodeDataFactory)
+            ```
 
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))

--- a/packages/framework/src/Controller/Admin/PromoCodeController.php
+++ b/packages/framework/src/Controller/Admin/PromoCodeController.php
@@ -10,7 +10,7 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade;
 use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
 use Shopsys\FrameworkBundle\Model\Order\PromoCode\Grid\PromoCodeGridFactory;
 use Shopsys\FrameworkBundle\Model\Order\PromoCode\Grid\PromoCodeInlineEdit;
-use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory;
+use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -55,7 +55,7 @@ class PromoCodeController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade $promoCodeFacade
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\Grid\PromoCodeInlineEdit $promoCodeInlineEdit
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade $administratorGridFacade
-     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory|null $promoCodeDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface|null $promoCodeDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\Grid\PromoCodeGridFactory|null $promoCodeGridFactory
      * @param \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider|null $breadcrumbOverrider
      * @param bool $useInlineEditation
@@ -64,7 +64,7 @@ class PromoCodeController extends AdminBaseController
         PromoCodeFacade $promoCodeFacade,
         PromoCodeInlineEdit $promoCodeInlineEdit,
         AdministratorGridFacade $administratorGridFacade,
-        ?PromoCodeDataFactory $promoCodeDataFactory = null,
+        ?PromoCodeDataFactoryInterface $promoCodeDataFactory = null,
         ?PromoCodeGridFactory $promoCodeGridFactory = null,
         ?BreadcrumbOverrider $breadcrumbOverrider = null,
         bool $useInlineEditation = true
@@ -81,9 +81,9 @@ class PromoCodeController extends AdminBaseController
     /**
      * @required
      * @internal This function will be replaced by constructor injection in next major
-     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory $promoCodeDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface $promoCodeDataFactory
      */
-    public function setPromoCodeDataFactory(PromoCodeDataFactory $promoCodeDataFactory)
+    public function setPromoCodeDataFactory(PromoCodeDataFactoryInterface $promoCodeDataFactory)
     {
         if ($this->promoCodeDataFactory !== null && $this->promoCodeDataFactory !== $promoCodeDataFactory) {
             throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));

--- a/packages/framework/src/Controller/Admin/PromoCodeController.php
+++ b/packages/framework/src/Controller/Admin/PromoCodeController.php
@@ -32,7 +32,7 @@ class PromoCodeController extends AdminBaseController
     protected $administratorGridFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory|null
+     * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface|null
      */
     protected $promoCodeDataFactory;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| To extend promo codes you should not need to extend PromoCodeController just because of wrong argument type hint.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
