### PR TITLE
[shopsys] releaser simplification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,8 +150,8 @@
     "nette/utils": "^2.5",
     "phpstan/phpstan": "^0.11",
     "symplify/easy-coding-standard-tester": "^5.2.17",
+    "symplify/monorepo-builder": "^5.2.17",
     "shopsys/changelog-linker": "^5.5.0",
-    "shopsys/monorepo-builder": "^5.5.0",
     "phpstan/phpstan-doctrine": "^0.11.2",
     "phpstan/phpstan-phpunit": "^0.11.2"
   },

--- a/utils/releaser/config/services.yaml
+++ b/utils/releaser/config/services.yaml
@@ -3,7 +3,12 @@ parameters:
     monorepo_package_name: "shopsys/shopsys"
 
     # these stages can use already existing tag; newer version than the last one is required in all other stages by default
+    # this can be used to skip the tag validation completely
+    # we need this as we are supporting multiple versions and we need to release tags that are lower than the newest one
+    # e.g. we want to release "v7.3.2" even if "v8.0.0" is already released
     stages_to_allow_existing_tag:
+        - "release-candidate"
+        - "release"
         - "after-release"
 
 services:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to allow releasing of a lower tag than the newest one as we we are supporting multiple versions. This is now allowed by the usage of our own fork of MonorepoBuilder (see https://github.com/Symplify/MonorepoBuilder/pull/4), however, I found out that it is completely unnecessary. The desired result can be achieved by configuration :man_facepalming: Thanks to that, I could also simplify my PR https://github.com/Symplify/Symplify/pull/1589
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

After this is merged, [the fork](https://github.com/shopsys/MonorepoBuilder) should be removed from github and from packagist (despite the fact it is a bad practice, I believe we can do that and cause no harm to anybody)
