### PR TITLE
[framework] only set new url as main when entity doesn't have one

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -75,7 +75,8 @@ class FriendlyUrlFacade
         $friendlyUrls = $this->friendlyUrlFactory->createForAllDomains($routeName, $entityId, $namesByLocale);
         foreach ($friendlyUrls as $friendlyUrl) {
             $locale = $this->domain->getDomainConfigById($friendlyUrl->getDomainId())->getLocale();
-            $this->resolveUniquenessOfFriendlyUrlAndFlush($friendlyUrl, $namesByLocale[$locale]);
+            $mainFriendlyUrl = $this->findMainFriendlyUrl($friendlyUrl->getDomainId(), $routeName, $entityId);
+            $this->resolveUniquenessOfFriendlyUrlAndFlush($friendlyUrl, $namesByLocale[$locale], $mainFriendlyUrl === null);
         }
     }
 
@@ -96,8 +97,9 @@ class FriendlyUrlFacade
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl $friendlyUrl
      * @param string $entityName
+     * @param bool $setAsMain
      */
-    protected function resolveUniquenessOfFriendlyUrlAndFlush(FriendlyUrl $friendlyUrl, $entityName)
+    protected function resolveUniquenessOfFriendlyUrlAndFlush(FriendlyUrl $friendlyUrl, $entityName, bool $setAsMain = true)
     {
         $attempt = 0;
         do {
@@ -128,7 +130,9 @@ class FriendlyUrlFacade
         if ($friendlyUrl !== null) {
             $this->em->persist($friendlyUrl);
             $this->em->flush($friendlyUrl);
-            $this->setFriendlyUrlAsMain($friendlyUrl);
+            if ($setAsMain === true) {
+                $this->setFriendlyUrlAsMain($friendlyUrl);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| if you have your custom url and delete the one that was generated from name of the entity, application will create a new url from name and set it as main
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #668  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
