### PR TITLE
[coding-standards] force unix line endings

### DIFF
--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -164,6 +164,7 @@ services:
         maxCount: 30
 
 parameters:
+    line_ending: '\n'
     exclude_files:
         - '*/tests/Unit/**/wrong/*'
         - '*/tests/Unit/**/Wrong/*'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Symplify by default enforces PHP_EOL line endings, which is interpreted variously on various platforms. Therefore, on Windows, running ecs changes line endings to CRLF. See https://github.com/Symplify/EasyCodingStandard/blob/master/config/config.yaml#L12
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
