### PR TITLE
[framework] VAT - use same icons for market action icons

### DIFF
--- a/packages/framework/src/Resources/styles/admin/components/in/icon.less
+++ b/packages/framework/src/Resources/styles/admin/components/in/icon.less
@@ -28,8 +28,9 @@
         top: 2px;
     }
 
-    &--info {
-        color: @color-a;
+    &--in-text {
+        position: relative;
+        top: 3px;
     }
 
     &--visible {
@@ -88,6 +89,7 @@
     }
 
     &--info {
+        color: @color-a;
         font-size: 14px;
     }
 

--- a/packages/framework/src/Resources/views/Admin/Content/Vat/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Vat/listGrid.html.twig
@@ -26,12 +26,10 @@
             {{ value }}
             <span
                 title="{{ 'VAT rate is marked for deleting and will be soon automatically removed. Conversion rate is several hundreds of products in 5 minutes.'|trans }}"
-                class="js-tooltip table-action cursor-help"
+                class="in-icon in-icon--delete svg svg-warning js-tooltip table-action cursor-help"
                 data-toggle="tooltip"
                 data-placement="right"
-            >
-                <i class="svg svg-warning"></i>
-            </span>
+            ></span>
         </span>
     {% else %}
         {{ value }}
@@ -42,21 +40,17 @@
     {% if row.vat.markedAsDeleted %}
         <span
             title="{{ 'VAT rate is marked for deleting and will be soon automatically removed. Conversion rate is several hundreds of products in 5 minutes.'|trans }}"
-            class="js-tooltip table-action cursor-help text-muted"
+            class="in-icon in-icon--delete svg svg-trash js-tooltip table-action cursor-help text-muted"
             data-toggle="tooltip"
             data-placement="bottom"
-        >
-            <i class="svg svg-trash"></i>
-        </span>
+        ></span>
     {% elseif row.asReplacementCount > 0 %}
         <span
             title="{{ 'VAT rate can\'t be removed because it is being currently used for conversion to this VAT rate'|trans }}"
-            class="js-tooltip table-action cursor-help text-muted"
+            class="in-icon in-icon--delete svg svg-trash js-tooltip table-action cursor-help text-muted"
             data-toggle="tooltip"
             data-placement="bottom"
-        >
-            <i class="svg svg-trash"></i>
-        </span>
+        ></span>
     {% else %}
         {{ parent() }}
     {% endif %}

--- a/packages/framework/src/Resources/views/Admin/Content/Vat/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Vat/listGrid.html.twig
@@ -26,7 +26,7 @@
             {{ value }}
             <span
                 title="{{ 'VAT rate is marked for deleting and will be soon automatically removed. Conversion rate is several hundreds of products in 5 minutes.'|trans }}"
-                class="in-icon in-icon--delete svg svg-warning js-tooltip table-action cursor-help"
+                class="in-icon in-icon--in-text in-icon--info svg svg-warning js-tooltip table-action cursor-help"
                 data-toggle="tooltip"
                 data-placement="right"
             ></span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Unify icons element in action icons. Muted items uses same html as non-muted items. Fix warning icon position in text - when VAT is marked to delete action.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1292, fixes #1295   <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Screen before:
![obrazek](https://user-images.githubusercontent.com/35454496/64403662-b3f04900-d079-11e9-811e-3b8318ec1b74.png)

![obrazek](https://user-images.githubusercontent.com/35454496/64404277-b05dc180-d07b-11e9-8e5d-f60891f10f5a.png)


Sceen after:
![obrazek](https://user-images.githubusercontent.com/35454496/64403645-a5099680-d079-11e9-8118-116b302fc546.png)

![obrazek](https://user-images.githubusercontent.com/35454496/64404249-991ed400-d07b-11e9-9697-9faa429f0375.png)

