### PR TITLE
[shopsys] "annotations-check" and "annotations-fix" are turned off by default for existing projects to avoid BC-breaks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Shopsys Framework" default="list">
 
+    <property name="check-and-fix-annotations" value="true"/>
     <property name="path.root" value="${project.basedir}/project-base"/>
     <property name="path.vendor" value="${project.basedir}/vendor"/>
     <property name="path.packages" value="${project.basedir}/packages"/>

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -2,7 +2,7 @@
 <project name="shopsys_framework" default="list">
 
     <property name="is-multidomain" value="true" description="This property is @deprecated, see 'domains-info-load' target instead."/>
-    <property name="check-and-fix-annotations" value="true"/>
+    <property name="check-and-fix-annotations" value="false"/>
     <property name="path.app" value="${path.root}/app"/>
     <property name="path.bin" value="${path.vendor}/bin"/>
     <property name="path.bin-console" value="${path.root}/bin/console"/>

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -3,6 +3,7 @@
 
     <property file="${project.basedir}/build/build.local.properties"/>
 
+    <property name="check-and-fix-annotations" value="true"/>
     <property name="path.root" value="${project.basedir}"/>
     <property name="path.vendor" value="${path.root}/vendor"/>
     <property name="path.framework" value="${path.vendor}/shopsys/framework"/>

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -182,16 +182,17 @@ There you can find links to upgrade notes for other versions too.
         + docker-compose exec -T php-fpm composer install
         + docker-compose exec -T php-fpm ./phing db-create test-db-create build-demo-dev-quick error-pages-generate
         ```
-- run `php phing annotations-fix` to fix or add all the relevant annotations for your extended classes ([#1344](https://github.com/shopsys/shopsys/pull/1344))
-    - thanks to the fixes, your IDE (PHPStorm) will understand your code better
-    - you can read more about the whole topic in the ["Framework extensibility" article](../introduction/framework-extensibility.md#making-the-static-analysis-understand-the-extended-code)
-    - the checks and fixes of the proper annotations are now included in all `standards-*` phing targets, if you want to turn this feature off, add the following line into your `build.xml`:
+- enable automated checks and fixes of annotations for extended classes in your project ([#1344](https://github.com/shopsys/shopsys/pull/1344))
+    - in your `build.xml` add the following line to include the checks and fixes for annotations of extended classes to all `standards-*` phing targets
     ```diff
-      <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
-    + <property name="check-and-fix-annotations" value="false"/>
-
+    + <property name="check-and-fix-annotations" value="true"/>
+      <property name="path.root" value="${project.basedir}"/>
+      ...
       <import file="${path.framework}/build.xml"/>
     ```
+    - run `php phing annotations-fix` to fix or add all the relevant annotations for your extended classes
+    - thanks to the fixes, your IDE (PHPStorm) will understand your code better
+    - you can read more about the whole topic in the ["Framework extensibility" article](../introduction/framework-extensibility.md#making-the-static-analysis-understand-the-extended-code)
 - increase your PHPStan level to 4 in your `build.xml` ([#1040](https://github.com/shopsys/shopsys/pull/1040))
     ```diff
   - <property name="phpstan.level" value="1"/>


### PR DESCRIPTION
- existing projects now must opt-in for this feature by enabling it in their build.xml
- new projects have this feature enabled by default
- in monorepo, the feature is turned on as well

| Q             | A
| ------------- | ---
|Description, reason for the PR| after discussion with @DavidOstrozlik, I relized that adding this feature to standards would be a BC break as standards on current projects start to fail after upgrading. Therefore I changed the default setting as described above.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
