### PR TITLE
added password environment variable from hosts

### DIFF
--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -40,6 +40,8 @@ services:
             - .:/var/www/html
         ports:
             - "35729:35729"
+        environment:
+            - IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK
 
     redis:
         image: redis:4.0-alpine


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Special jobs started failing smoke tests because of admin could not be logged in.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

---
I've added environmet variable do `docker-compose.yml.dist` but I'm a bit unsure if we want to add it into rest of docker-composes dists.