### PR TITLE
[project-base] resolved (either fixed or ignored) all the errors reported by phpstan level 4

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,69 +2,75 @@ parameters:
     ignoreErrors:
         # shopsys/framework - don't forget to add these rules to phpstan.neon in framework
         -
-            message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
+            message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Domain/Config/DomainsConfigDefinition.php
         -
-            message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
+            message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Domain/Config/DomainsUrlsConfigDefinition.php
         -
-            message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)#'
+            message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Image/Config/ImageConfigDefinition.php
         -
-            message: '#Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)#'
+            message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfigDefinition.php
         -
-            message: '#Method Doctrine\\Common\\Persistence\\ObjectManager::flush\(\) invoked with 1 parameter, 0 required\.#'
+            message: '#^Method Doctrine\\Common\\Persistence\\ObjectManager::flush\(\) invoked with 1 parameter, 0 required\.$#'
             path: *
         -
-            message: '#Property Doctrine\\ORM\\Mapping\\ClassMetadataInfo::\$discriminatorColumn \(array\) does not accept null\.#'
+            message: '#^Property Doctrine\\ORM\\Mapping\\ClassMetadataInfo::\$discriminatorColumn \(array\) does not accept null\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/EntityExtension/EntityExtensionParentMetadataCleanerEventSubscriber.php
         -
-            message: '#Argument of an invalid type Symfony\\Component\\Validator\\Constraint supplied for foreach, only iterables are supported\.#'
+            message: '#^Argument of an invalid type Symfony\\Component\\Validator\\Constraint supplied for foreach, only iterables are supported\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Form/JsFormValidatorFactory.php
         -
-            message: '#Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$transport \(Shopsys\\FrameworkBundle\\Model\\Transport\\Transport\) does not accept null\.#'
+            message: '#^Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$transport \(Shopsys\\FrameworkBundle\\Model\\Transport\\Transport\) does not accept null\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Model/Order/Order.php
         -
-            message: '#Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$payment \(Shopsys\\FrameworkBundle\\Model\\Payment\\Payment\) does not accept null\.#'
+            message: '#^Property Shopsys\\FrameworkBundle\\Model\\Order\\Order::\$payment \(Shopsys\\FrameworkBundle\\Model\\Payment\\Payment\) does not accept null\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Model/Order/Order.php
         -
-            message: '#Access to an undefined property PhpParser\\Node::\$var\.#'
+            message: '#^Access to an undefined property PhpParser\\Node::\$var\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
         -
-            message: '#Access to an undefined property PhpParser\\Node::\$name\.#'
+            message: '#^Access to an undefined property PhpParser\\Node::\$name\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
-        # shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base (only exceptions for level 1)
+        # shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base
         -
-            message: '#(PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+)#'
+            # Ignore annotations in generated code
+            message: '#^PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
         -
-            message: '#(PHPDoc tag @throws with type .+ is not subtype of Throwable)#'
+            # Ignore annotations in generated code
+            message: '#^PHPDoc tag @throws with type .+ is not subtype of Throwable$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
         -
-            message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)#'
+            # Actually, the method is called on NodeBuilder which is implementing the interface, however, annotating would worsen the readability of the code in Configuration class
+            message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)\.$#'
             path: %currentWorkingDirectory%/project-base/src/Shopsys/ShopBundle/DependencyInjection/Configuration.php
         -
-            message: '#(Property Shopsys\\.+::\$.+ \(Shopsys\\.+\) does not accept object\.)#'
+            # In data fixtures, we often access persistent references using $this->getReference()
+            message: '#^Property Shopsys\\.+::\$.+ \(Shopsys\\.+\) does not accept object\.$#'
             path: %currentWorkingDirectory%/project-base/src/Shopsys/ShopBundle/DataFixtures/*
         -
-            message: '#Method Shopsys\\ShopBundle\\DataFixtures\\ProductDataFixtureReferenceInjector::.+\(\) should return array<.+> but returns array<string, object>\.#'
+            # A helper methods returning an array of persistent references using $this->getReference()
+            message: '#^Method Shopsys\\ShopBundle\\DataFixtures\\ProductDataFixtureReferenceInjector::.+\(\) should return array<.+> but returns array<string, object>\.$#'
             path: %currentWorkingDirectory%/project-base/src/Shopsys/ShopBundle/DataFixtures/ProductDataFixtureReferenceInjector.php
         -
-            message: '#(Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept object\.)#'
+            # In tests, we often grab services using $container->get() or access persistent references using $this->getReference()
+            message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
         -
-            message: '#(Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept object\|null\.)#'
+            # In tests, there are helper methods for grabbing services using $container->get()
+            message: '#^Method .+::.+\(\) should return .+ but returns (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
         -
-            message: '#(Method .+::.+\(\) should return .+ but returns (object|Codeception\\Module).)#'
-            path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
-        -
-            message: '#Array \(array<.+>\) does not accept object\.#'
+            # Actually, we are setting an array item using "$array[] = $this->getReference()"
+            message: '#^Array \(array<.+>\) does not accept object\.$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
         -
-            message: '#Undefined variable: \$undefined#'
-            path: *
+            # We need to have undefined variable for testing purposes
+            message: '#^Undefined variable: \$undefined$#'
+            path: %currentWorkingDirectory%/project-base/src/Shopsys/ShopBundle/Controller/Test/ErrorHandlerController.php
     excludes_analyse:
         # Exclude coding standards from packages as it is in incompatible version
         - %currentWorkingDirectory%/packages/coding-standards/*

--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -1,8 +1,41 @@
 parameters:
     ignoreErrors:
-        # Add ignored errors here as regular expressions, e.g.:
-        # - '#PHPUnit_Framework_MockObject_MockObject(.*) given#'
-        - '#Undefined variable: \$undefined#'
+        -
+            # Ignore annotations in generated code
+            message: '#^PHPDoc tag @(param|return) has invalid value (.|\n)+ expected TOKEN_IDENTIFIER at offset \d+$#'
+            path: %currentWorkingDirectory%/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
+        -
+            # Ignore annotations in generated code
+            message: '#^PHPDoc tag @throws with type .+ is not subtype of Throwable$#'
+            path: %currentWorkingDirectory%/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php
+        -
+            # Actually, the method is called on NodeBuilder which is implementing the interface, however, annotating would worsen the readability of the code in Configuration class
+            message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)\.$#'
+            path: %currentWorkingDirectory%/src/Shopsys/ShopBundle/DependencyInjection/Configuration.php
+        -
+            # In data fixtures, we often access persistent references using $this->getReference()
+            message: '#^Property Shopsys\\.+::\$.+ \(Shopsys\\.+\) does not accept object\.$#'
+            path: %currentWorkingDirectory%/src/Shopsys/ShopBundle/DataFixtures/*
+        -
+            # A helper methods returning an array of persistent references using $this->getReference()
+            message: '#^Method Shopsys\\ShopBundle\\DataFixtures\\ProductDataFixtureReferenceInjector::.+\(\) should return array<.+> but returns array<string, object>\.$#'
+            path: %currentWorkingDirectory%/src/Shopsys/ShopBundle/DataFixtures/ProductDataFixtureReferenceInjector.php
+        -
+            # In tests, we often grab services using $container->get() or access persistent references using $this->getReference()
+            message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
+            path: %currentWorkingDirectory%/tests/ShopBundle/*
+        -
+            # In tests, there are helper methods for grabbing services using $container->get()
+            message: '#^Method .+::.+\(\) should return .+ but returns (object|object\|null)\.$#'
+            path: %currentWorkingDirectory%/tests/ShopBundle/*
+        -
+            # Actually, we are setting an array item using "$array[] = $this->getReference()"
+            message: '#^Array \(array<.+>\) does not accept object\.$#'
+            path: %currentWorkingDirectory%/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+        -
+            # We need to have undefined variable for testing purposes
+            message: '#^Undefined variable: \$undefined$#'
+            path: %currentWorkingDirectory%/src/Shopsys/ShopBundle/Controller/Test/ErrorHandlerController.php
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -127,7 +127,7 @@ team of {domain}
     }
 
     /**
-     * @param \Doctrine\Common\Persistence\ObjectManager $manager
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator $manager
      * @param mixed $name
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData $mailTemplateData
      */

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/UserDataFixture.php
@@ -28,7 +28,7 @@ class UserDataFixture extends AbstractReferenceFixture implements DependentFixtu
     /** @var \Faker\Generator */
     protected $faker;
 
-    /** @var \Doctrine\ORM\EntityManagerInterface */
+    /** @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator */
     protected $em;
 
     /** @var \Shopsys\FrameworkBundle\Component\String\HashGenerator */
@@ -38,7 +38,7 @@ class UserDataFixture extends AbstractReferenceFixture implements DependentFixtu
      * @param \Shopsys\FrameworkBundle\Model\Customer\CustomerFacade $customerFacade
      * @param \Shopsys\ShopBundle\DataFixtures\Demo\UserDataFixtureLoader $loaderService
      * @param \Faker\Generator $faker
-     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator $em
      * @param \Shopsys\FrameworkBundle\Component\String\HashGenerator $hashGenerator
      */
     public function __construct(

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/WebDriverHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/WebDriverHelper.php
@@ -15,7 +15,10 @@ class WebDriverHelper extends Module
      */
     private function getWebDriver()
     {
-        return $this->getModule(StrictWebDriver::class);
+        /** @var \Tests\ShopBundle\Test\Codeception\Module\StrictWebDriver $strictWebDriver */
+        $strictWebDriver = $this->getModule(StrictWebDriver::class);
+
+        return $strictWebDriver;
     }
 
     /**

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -193,14 +193,14 @@ There you can find links to upgrade notes for other versions too.
     - run `php phing annotations-fix` to fix or add all the relevant annotations for your extended classes
     - thanks to the fixes, your IDE (PHPStorm) will understand your code better
     - you can read more about the whole topic in the ["Framework extensibility" article](../introduction/framework-extensibility.md#making-the-static-analysis-understand-the-extended-code)
-- increase your PHPStan level to 4 in your `build.xml` ([#1040](https://github.com/shopsys/shopsys/pull/1040))
+- for the better quality of code in your project we recommend you to increase your PHPStan level to 4 in your `build.xml` and address all the reported violations ([#1381](https://github.com/shopsys/shopsys/pull/1381))
     ```diff
   - <property name="phpstan.level" value="1"/>
   + <property name="phpstan.level" value="4"/>
     ```
     - a lot of the possible issues should be already resolved if you followed the previous instruction and ran the `php phing annotations-fix` phing command
     - some of the issues related to class extension need to be addressed manually nevertheless (see the ["Framework extensibility" article](../introduction/framework-extensibility.md#problem-3)) for more information
-    - you need to resolve all the other reported problems (any of them can be ignored in your `phpstan.neon`). You can find inspiration in [#1040](https://github.com/shopsys/shopsys/pull/1040)
+    - you need to resolve all the other reported problems (it is up to you whether you decide to address them directly or add ignores in your `phpstan.neon`). You can find inspiration in [#1381](https://github.com/shopsys/shopsys/pull/1381) and [#1040](https://github.com/shopsys/shopsys/pull/1040)
 ### Database migrations
 - run database migrations so products will use a DateTime type for columns for "Selling start date" (selling_from) and "Selling end date" (selling_to) ([#1343](https://github.com/shopsys/shopsys/pull/1343))
     - please check [`Version20190823110846`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Migrations/Version20190823110846.php)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1344, level of PHPStan was raised to 4 in project base, however, from monorepo there were no errors reported. The problem occured lately, after the project-base was split, see https://travis-ci.org/shopsys/project-base/jobs/581096169
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
