### PR TITLE
Removed info about not extensible admin forms in docs

### DIFF
--- a/docs/extensibility/framework-extensibility.md
+++ b/docs/extensibility/framework-extensibility.md
@@ -39,7 +39,6 @@ as well as a list of customizations that are not (and will not be) possible at a
 ## Which issues are going to be addressed soon
 * Extending data fixtures (including performance data fixtures)
 * Extending data grids in the administration
-* Extending all forms in the administration without the need of the template overriding
 * Extending classes like Repositories without the need for changing the project-base tests
 
 ## What is not supported


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| All forms in administration has been refactored so they can be extended without the need of the template overriding and our docs didn't reflect that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
