### PR TITLE
[framework] AdministratorChecker uses environment from DIC parameter

### DIFF
--- a/docs/introduction/running-acceptance-tests.md
+++ b/docs/introduction/running-acceptance-tests.md
@@ -1,7 +1,5 @@
 # Running Acceptance Tests
 
-*Note: You may want to test administrator's interaction in production environment. In that case you should follow [Upgrade Notes](/upgrade/UPGRADE-v8.1.0-dev.md#infrastructure) (search for `IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK`) or change administrator's password since we do not allow administrators to log in with default credentials in production environment.*
-
 ## Running in Docker
 There is `selenium-server` container with installed Selenium hub and Google Chrome, prepared to run the acceptance tests.
 

--- a/packages/framework/src/Model/Security/AdministratorChecker.php
+++ b/packages/framework/src/Model/Security/AdministratorChecker.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Security;
 
-use Shopsys\Environment;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Model\Security\Exception\LoginWithDefaultPasswordException;
 use Symfony\Component\Security\Core\User\UserChecker;
@@ -13,15 +12,22 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class AdministratorChecker extends UserChecker
 {
     /**
+     * @var string
+     */
+    protected $environment;
+
+    /**
      * @var bool
      */
     protected $ignoreDefaultAdminPasswordCheck;
 
     /**
+     * @param string $environment
      * @param bool $ignoreDefaultAdminPasswordCheck
      */
-    public function __construct(bool $ignoreDefaultAdminPasswordCheck)
+    public function __construct(string $environment, bool $ignoreDefaultAdminPasswordCheck)
     {
+        $this->environment = $environment;
         $this->ignoreDefaultAdminPasswordCheck = $ignoreDefaultAdminPasswordCheck;
     }
 
@@ -30,13 +36,14 @@ class AdministratorChecker extends UserChecker
      */
     public function checkPreAuth(UserInterface $user)
     {
-        if (Environment::getEnvironment(false) === EnvironmentType::PRODUCTION
+        if ($this->environment === EnvironmentType::PRODUCTION
             && !$this->ignoreDefaultAdminPasswordCheck
             && in_array($user->getUsername(), ['admin', 'superadmin'], true)
             && password_verify('admin123', $user->getPassword())
         ) {
             throw new LoginWithDefaultPasswordException();
         }
+
         return parent::checkPreAuth($user);
     }
 }

--- a/packages/framework/src/Resources/config/parameters_common.yml
+++ b/packages/framework/src/Resources/config/parameters_common.yml
@@ -14,4 +14,4 @@ parameters:
     # Default extended classes mapping
     shopsys.entity_extension.map: {}
 
-    env(IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK): 0
+    env(IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK): '0'

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -567,6 +567,7 @@ services:
 
     Shopsys\FrameworkBundle\Model\Security\AdministratorChecker:
         arguments:
+            - '%kernel.environment%'
             - '%env(bool:IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK)%'
 
     Shopsys\FrameworkBundle\Model\Security\LoginListener:

--- a/project-base/app/Environment.php
+++ b/project-base/app/Environment.php
@@ -7,6 +7,9 @@ use Composer\Script\Event;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentFileSetting;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 
+/**
+ * Helper class for use in {@see \Shopsys\Bootstrap}
+ */
 class Environment
 {
     /**

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -46,7 +46,7 @@ There you can find links to upgrade notes for other versions too.
             provider: administrators
             logout_on_user_change: true
         ```
-        - in case you need to disable this functionality (e.g. to prevent failing tests on CI which uses production environment)
+        - in case you need to disable this functionality (e.g. to allow easier logging in to a deployed application on your CI server)
         there is an environment variable `IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK` which needs to be set to `1` (for **SECURITY** reasons **DO NOT EVER** do this in real production environment)
             - when you are using kubernetes on CI server change your configuration of:
                 - `kubernetes/kustomize/overlays/ci/kustomization.yaml`
@@ -89,7 +89,7 @@ There you can find links to upgrade notes for other versions too.
                 +       environment:
                 +           - IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK=1
                 ```
-            - without containers you must set environment variable to the host machine, typically in unix like OS by executing
+            - without containers you must set environment variable on the host machine, typically in unix like OS by executing
                 ```
                 export IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK=1
                 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes environment resolving in #1360 as described in [review comment](https://github.com/shopsys/shopsys/pull/1360/files#r321710747).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


 - Shopsys\Environment should be used only in Shopsys\Bootstrap
 - fixed incorrect info in upgrade notes and docs
 - changed default value of IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK to a string to be consistent with other environment variables
