### PR TITLE
[shopsys] releaser: update symplify libraries to current version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,9 +149,10 @@
     "codeception/phpunit-wrapper": "^7.0",
     "nette/utils": "^2.5",
     "phpstan/phpstan": "^0.11",
+    "symplify/changelog-linker": "dev-master",
     "symplify/easy-coding-standard-tester": "^5.2.17",
-    "symplify/monorepo-builder": "^5.2.17",
-    "shopsys/changelog-linker": "^5.5.0",
+    "symplify/monorepo-builder": "dev-master",
+    "symplify/package-builder": "@dev",
     "phpstan/phpstan-doctrine": "^0.11.2",
     "phpstan/phpstan-phpunit": "^0.11.2"
   },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to use current versions of Symplify packages so that we do not need to maintain our forks and so we are able to use new features (such as `only` param in coding-standards config, see bb0d1af0f17131f7235c70ea93cbf16a956d1b3f) This will also help us with #1059. This PR was created because of https://github.com/shopsys/shopsys/pull/1370#pullrequestreview-284790313 as a demonstration of the update.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**TODO:**
- [ ] change the version from `dev-master` to [`^6.1.0`](https://github.com/Symplify/Symplify/compare/v6.0.5...v6.1.0)
- [ ] upgrade other required Symplify packages
- [ ] retarget to `master` to resolve the issue with `illuminate/support v5.7` and PHP `< v7.1.3`
- [ ] drop the minimal stability flag `@dev` for the indirect dependency `symplify/package-builder` (remove the requirement completely)

For the Composer error output see [Travis build log](https://travis-ci.org/shopsys/shopsys/jobs/582674627#L268).

*Note: the fork `shopsys/changelog-linker` cannot be abandoned until we stop supporting SSFW 7.3 LTS.*