### PR TITLE
[project-base] ErrorController uses environment from DIC parameter

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -40,21 +40,29 @@ class ErrorController extends FrontBaseController
     private $domain;
 
     /**
+     * @var string
+     */
+    private $environment;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionController $exceptionController
      * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionListener $exceptionListener
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param string $environment
      */
     public function __construct(
         ExceptionController $exceptionController,
         ExceptionListener $exceptionListener,
         ErrorPagesFacade $errorPagesFacade,
-        Domain $domain
+        Domain $domain,
+        string $environment
     ) {
         $this->exceptionController = $exceptionController;
         $this->exceptionListener = $exceptionListener;
         $this->errorPagesFacade = $errorPagesFacade;
         $this->domain = $domain;
+        $this->environment = $environment;
     }
 
     /**
@@ -186,7 +194,7 @@ class ErrorController extends FrontBaseController
         $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
         $content = sprintf("You are trying to access an unknown domain '%s'.", $url);
 
-        if (EnvironmentType::TEST === Environment::getEnvironment(false)) {
+        if ($this->environment === EnvironmentType::TEST) {
             $overwriteDomainUrl = $this->getParameter('overwrite_domain_url');
             $content .= sprintf(" TEST environment is active, current domain url is '%s'.", $overwriteDomainUrl);
         }

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -101,3 +101,7 @@ services:
     Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~
 
     Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: '@Shopsys\ShopBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig'
+
+    Shopsys\ShopBundle\Controller\Front\ErrorController:
+        arguments:
+            $environment: '%kernel.environment%'

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -10,47 +10,47 @@ There you can find links to upgrade notes for other versions too.
 ### Application
 - use Environment from DIC parameter in ErrorController ([#1389](https://github.com/shopsys/shopsys/pull/1389))
     - change your `services.yml` to inject `%kernel.environment%` to your `Shopsys\ShopBundle\Controller\Front\ErrorController`
-    ```diff
-    +   Shopsys\ShopBundle\Controller\Front\ErrorController:
-    +       arguments:
-    +           $environment: '%kernel.environment%'
-    ```
+        ```diff
+        +   Shopsys\ShopBundle\Controller\Front\ErrorController:
+        +       arguments:
+        +           $environment: '%kernel.environment%'
+        ```
     - change `Shopsys\ShopBundle\Controller\Front\ErrorController` to use injected environment instead of `Environment::getEnvironment(false)`
-    ```diff
-    +   /**
-    +    * @var string
-    +    */
-    +   private $environment;
-    
-        /**
-         * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionController $exceptionController
-         * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionListener $exceptionListener
-         * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
-         * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-    +    * @param string $environment
-         */
-        public function __construct(
-            ExceptionController $exceptionController,
-            ExceptionListener $exceptionListener,
-            ErrorPagesFacade $errorPagesFacade,
-    -       Domain $domain
-    +       Domain $domain,
-    +       string $environment
-        ) {
-            $this->exceptionController = $exceptionController;
-            $this->exceptionListener = $exceptionListener;
-            $this->errorPagesFacade = $errorPagesFacade;
-            $this->domain = $domain;
-    +       $this->environment = $environment;
-        }
-        
-        //...
-        
-        private function createUnableToResolveDomainResponse(Request $request): Response
-            {
-                $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
-                $content = sprintf("You are trying to access an unknown domain '%s'.", $url);
-    
-    -           if (EnvironmentType::TEST === Environment::getEnvironment(false)) {    
-    +           if ($this->environment === EnvironmentType::TEST) {
-    ```
+        ```diff
+        +   /**
+        +    * @var string
+        +    */
+        +   private $environment;
+
+            /**
+             * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionController $exceptionController
+             * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionListener $exceptionListener
+             * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
+             * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+        +    * @param string $environment
+             */
+            public function __construct(
+                ExceptionController $exceptionController,
+                ExceptionListener $exceptionListener,
+                ErrorPagesFacade $errorPagesFacade,
+        -       Domain $domain
+        +       Domain $domain,
+        +       string $environment
+            ) {
+                $this->exceptionController = $exceptionController;
+                $this->exceptionListener = $exceptionListener;
+                $this->errorPagesFacade = $errorPagesFacade;
+                $this->domain = $domain;
+        +       $this->environment = $environment;
+            }
+
+            //...
+
+            private function createUnableToResolveDomainResponse(Request $request): Response
+                {
+                    $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
+                    $content = sprintf("You are trying to access an unknown domain '%s'.", $url);
+
+        -           if (EnvironmentType::TEST === Environment::getEnvironment(false)) {    
+        +           if ($this->environment === EnvironmentType::TEST) {
+        ```

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -4,3 +4,53 @@ This guide contains instructions to upgrade from version v7.3.2 to v7.3.3-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+## [shopsys/framework]
+
+### Application
+- use Environment from DIC parameter in ErrorController ([#1389](https://github.com/shopsys/shopsys/pull/1389))
+    - change your `services.yml` to inject `%kernel.environment%` to your `Shopsys\ShopBundle\Controller\Front\ErrorController`
+    ```diff
+    +   Shopsys\ShopBundle\Controller\Front\ErrorController:
+    +       arguments:
+    +           $environment: '%kernel.environment%'
+    ```
+    - change `Shopsys\ShopBundle\Controller\Front\ErrorController` to use injected environment instead of `Environment::getEnvironment(false)`
+    ```diff
+    +   /**
+    +    * @var string
+    +    */
+    +   private $environment;
+    
+        /**
+         * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionController $exceptionController
+         * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionListener $exceptionListener
+         * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
+         * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+    +    * @param string $environment
+         */
+        public function __construct(
+            ExceptionController $exceptionController,
+            ExceptionListener $exceptionListener,
+            ErrorPagesFacade $errorPagesFacade,
+    -       Domain $domain
+    +       Domain $domain,
+    +       string $environment
+        ) {
+            $this->exceptionController = $exceptionController;
+            $this->exceptionListener = $exceptionListener;
+            $this->errorPagesFacade = $errorPagesFacade;
+            $this->domain = $domain;
+    +       $this->environment = $environment;
+        }
+        
+        //...
+        
+        private function createUnableToResolveDomainResponse(Request $request): Response
+            {
+                $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
+                $content = sprintf("You are trying to access an unknown domain '%s'.", $url);
+    
+    -           if (EnvironmentType::TEST === Environment::getEnvironment(false)) {    
+    +           if ($this->environment === EnvironmentType::TEST) {
+    ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Shopsys\Environment should be used only in Shopsys\Bootstrap
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

- [x] add upgrade notes