### PR TITLE
[shopsys] fix issues with QueryBuilderExtender's method AddOrExtendJoin

### DIFF
--- a/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
+++ b/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
@@ -55,7 +55,6 @@ class QueryBuilderExtender
         $joinAlreadyUsed = false;
         $resolvedClass = $this->entityNameResolver->resolve($class);
         foreach ($joins as $join) {
-            /* @var $join \Doctrine\ORM\Query\Expr\Join */
             $resolvedJoinClass = $this->entityNameResolver->resolve($join->getJoin());
             if ($resolvedJoinClass === $resolvedClass) {
                 $joinAlreadyUsed = true;

--- a/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
+++ b/packages/framework/src/Component/Doctrine/QueryBuilderExtender.php
@@ -19,11 +19,10 @@ class QueryBuilderExtender
      */
     public function addOrExtendJoin(QueryBuilder $queryBuilder, $class, $alias, $condition)
     {
-        $rootAlias = $this->getRootAlias($queryBuilder);
+        $joins = $this->getJoinsFromQueryBuilder($queryBuilder);
 
         $joinAlreadyUsed = false;
-
-        foreach ($queryBuilder->getDQLPart('join')[$rootAlias] as $join) {
+        foreach ($joins as $join) {
             /* @var $join \Doctrine\ORM\Query\Expr\Join */
             if ($join->getJoin() === $class) {
                 $joinAlreadyUsed = true;
@@ -58,5 +57,21 @@ class QueryBuilderExtender
         $firstAlias = reset($rootAliases);
 
         return $firstAlias;
+    }
+
+    /**
+     * @param \Doctrine\ORM\QueryBuilder $queryBuilder
+     * @return array
+     */
+    protected function getJoinsFromQueryBuilder(QueryBuilder $queryBuilder): array
+    {
+        $rootAlias = $this->getRootAlias($queryBuilder);
+
+        $joinDqlPart = $queryBuilder->getDQLPart('join');
+        if (array_key_exists($rootAlias, $joinDqlPart) === true) {
+            return $joinDqlPart[$rootAlias];
+        }
+
+        return [];
     }
 }

--- a/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
-use Shopsys\ShopBundle\Model\Product\Product;
+use Tests\FrameworkBundle\Unit\Component\Doctrine\__fixtures\Product;
 
 class QueryBuilderExtenderTest extends TestCase
 {

--- a/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender;
+use Shopsys\FrameworkBundle\Model\Category\Category;
+use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
+
+class QueryBuilderExtenderTest extends TestCase
+{
+    public function testAddFirstJoinToQueryBuilder(): void
+    {
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        $entityManager = $this->getMockBuilder(EntityManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $queryBuilder = new QueryBuilder($entityManager);
+
+        $queryBuilderExtender = new QueryBuilderExtender();
+        $queryBuilder->from(Category::class, 'c');
+        $queryBuilderExtender->addOrExtendJoin($queryBuilder, BaseProduct::class, 'p', '1 = 1');
+
+        $joinDqlPart = $queryBuilder->getDQLPart('join');
+        $this->assertCount(1, reset($joinDqlPart));
+    }
+}

--- a/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -60,7 +60,14 @@ class QueryBuilderExtenderTest extends TestCase
         $queryBuilderExtender->addOrExtendJoin($queryBuilder, $secondJoinedEntity, 'p', '1 = 1');
 
         $dql = $queryBuilder->getDQL();
-        $this->assertSame('SELECT c FROM ' . Category::class . ' c INNER JOIN ' . $expectedJoinedEntity . ' p WITH 0 = 0 WHERE 1 = 1', $dql);
+        $this->assertSame(
+            sprintf(
+                'SELECT c FROM %s c INNER JOIN %s p WITH 0 = 0 WHERE 1 = 1',
+                Category::class,
+                $expectedJoinedEntity
+            ),
+            $dql
+        );
     }
 
     /**

--- a/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -8,8 +8,10 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
+use Shopsys\ShopBundle\Model\Product\Product;
 
 class QueryBuilderExtenderTest extends TestCase
 {
@@ -21,11 +23,65 @@ class QueryBuilderExtenderTest extends TestCase
             ->getMockForAbstractClass();
         $queryBuilder = new QueryBuilder($entityManager);
 
-        $queryBuilderExtender = new QueryBuilderExtender();
+        $entityNameResolver = new EntityNameResolver([]);
+        $queryBuilderExtender = new QueryBuilderExtender($entityNameResolver);
         $queryBuilder->from(Category::class, 'c');
         $queryBuilderExtender->addOrExtendJoin($queryBuilder, BaseProduct::class, 'p', '1 = 1');
 
         $joinDqlPart = $queryBuilder->getDQLPart('join');
         $this->assertCount(1, reset($joinDqlPart));
+    }
+
+    /**
+     * @dataProvider extendJoinWithExtendedEntityProvider
+     * @param string $firstJoinedEntity
+     * @param string $secondJoinedEntity
+     * @param string $expectedJoinedEntity
+     * @param array $extensionMap
+     */
+    public function testExtendJoinWithExtendedEntity(
+        string $firstJoinedEntity,
+        string $secondJoinedEntity,
+        string $expectedJoinedEntity,
+        array $extensionMap
+    ): void {
+        /** @var \Doctrine\ORM\EntityManager $entityManager */
+        $entityManager = $this->getMockBuilder(EntityManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $queryBuilder = new QueryBuilder($entityManager);
+
+        $entityNameResolver = new EntityNameResolver($extensionMap);
+        $queryBuilderExtender = new QueryBuilderExtender($entityNameResolver);
+        $queryBuilder
+            ->select('c')
+            ->from(Category::class, 'c');
+        $queryBuilderExtender->addOrExtendJoin($queryBuilder, $firstJoinedEntity, 'p', '0 = 0');
+        $queryBuilderExtender->addOrExtendJoin($queryBuilder, $secondJoinedEntity, 'p', '1 = 1');
+
+        $dql = $queryBuilder->getDQL();
+        $this->assertSame('SELECT c FROM ' . Category::class . ' c INNER JOIN ' . $expectedJoinedEntity . ' p WITH 0 = 0 WHERE 1 = 1', $dql);
+    }
+
+    /**
+     * @return array
+     */
+    public function extendJoinWithExtendedEntityProvider(): array
+    {
+        $extensionMap = [BaseProduct::class => Product::class];
+        return [
+            'extend base entity join with extended entity' => [
+                'firstJoinedEntity' => BaseProduct::class,
+                'secondJoinedEntity' => Product::class,
+                'expectedJoinedEntity' => Product::class,
+                'extensionMap' => $extensionMap,
+            ],
+            'extend extended entity join with base entity' => [
+                'firstJoinedEntity' => Product::class,
+                'secondJoinedEntity' => BaseProduct::class,
+                'expectedJoinedEntity' => Product::class,
+                'extensionMap' => $extensionMap,
+            ],
+        ];
     }
 }

--- a/packages/framework/tests/Unit/Component/Doctrine/__fixtures/Product.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/__fixtures/Product.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Doctrine\__fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler;
+use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
+use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface;
+use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
+
+/**
+ * @ORM\Table(name="products")
+ * @ORM\Entity
+ */
+class Product extends BaseProduct
+{
+    /**
+     * @param \Tests\FrameworkBundle\Unit\Component\Doctrine\__fixtures\ProductData $productData
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface $productCategoryDomainFactory
+     * @param \Tests\FrameworkBundle\Unit\Component\Doctrine\__fixtures\Product[]|null $variants
+     */
+    protected function __construct(BaseProductData $productData, ProductCategoryDomainFactoryInterface $productCategoryDomainFactory, array $variants = null)
+    {
+        parent::__construct($productData, $productCategoryDomainFactory, $variants);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomainFactoryInterface $productCategoryDomainFactory
+     * @param \Tests\FrameworkBundle\Unit\Component\Doctrine\__fixtures\ProductData $productData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler $productPriceRecalculationScheduler
+     */
+    public function edit(
+        ProductCategoryDomainFactoryInterface $productCategoryDomainFactory,
+        BaseProductData $productData,
+        ProductPriceRecalculationScheduler $productPriceRecalculationScheduler
+    ) {
+        parent::edit($productCategoryDomainFactory, $productData, $productPriceRecalculationScheduler);
+    }
+}

--- a/packages/framework/tests/Unit/Component/Doctrine/__fixtures/ProductData.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/__fixtures/ProductData.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Doctrine\__fixtures;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
+
+class ProductData extends BaseProductData
+{
+}

--- a/project-base/tests/ShopBundle/Functional/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -26,7 +26,7 @@ class QueryBuilderExtenderTest extends FunctionalTestCase
     ): void {
         /** @var \Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender $queryBuilderExtender */
         $queryBuilderExtender = $this->getContainer()->get(QueryBuilderExtender::class);
-        /** @var \Doctrine\ORM\EntityManager $em */
+        /** @var \Doctrine\ORM\EntityManagerInterface $em */
         $em = $this->getContainer()->get('doctrine.orm.entity_manager');
 
         $queryBuilder = $em->createQueryBuilder();

--- a/project-base/tests/ShopBundle/Functional/Component/Doctrine/QueryBuilderExtenderTest.php
+++ b/project-base/tests/ShopBundle/Functional/Component/Doctrine/QueryBuilderExtenderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ShopBundle\Functional\Component\Doctrine;
+
+use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender;
+use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
+use Shopsys\ShopBundle\Model\Category\Category;
+use Shopsys\ShopBundle\Model\Product\Product;
+use Tests\ShopBundle\Test\FunctionalTestCase;
+
+class QueryBuilderExtenderTest extends FunctionalTestCase
+{
+    /**
+     * @dataProvider extendJoinWithExtendedEntityProvider
+     * @param string $firstJoinedEntity
+     * @param string $secondJoinedEntity
+     * @param string $expectedJoinedEntity
+     */
+    public function testExtendJoinWithExtendedEntity(
+        string $firstJoinedEntity,
+        string $secondJoinedEntity,
+        string $expectedJoinedEntity
+    ): void {
+        /** @var \Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender $queryBuilderExtender */
+        $queryBuilderExtender = $this->getContainer()->get(QueryBuilderExtender::class);
+        /** @var \Doctrine\ORM\EntityManager $em */
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $queryBuilder = $em->createQueryBuilder();
+        $queryBuilder
+            ->select('c')
+            ->from(Category::class, 'c')
+            ->join($firstJoinedEntity, 'p', Join::WITH, '0 = 0');
+        $queryBuilderExtender->addOrExtendJoin($queryBuilder, $secondJoinedEntity, 'p', '1 = 1');
+
+        $dql = $queryBuilder->getDQL();
+        $this->assertSame('SELECT c FROM ' . Category::class . ' c INNER JOIN ' . $expectedJoinedEntity . ' p WITH 0 = 0 WHERE 1 = 1', $dql);
+    }
+
+    /**
+     * @return array
+     */
+    public function extendJoinWithExtendedEntityProvider(): array
+    {
+        return [
+            'extend base entity join with extended entity' => [
+                'firstJoinedEntity' => BaseProduct::class,
+                'secondJoinedEntity' => Product::class,
+                'expectedJoinedEntity' => Product::class,
+            ],
+            'extend extended entity join with base entity' => [
+                'firstJoinedEntity' => Product::class,
+                'secondJoinedEntity' => BaseProduct::class,
+                'expectedJoinedEntity' => Product::class,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| there are problems with QueryBuilderExtender's method AddOrExtendJoin 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #997  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


- [x] fix AddOrExtendJoin then creating first join
- [x] fix AddOrExtendJoin when you try to extend framework's class with extended class
- [x] add test for first issue
- [x] add unit test for second issue
- [x] add functional test for second issue