### PR TITLE
[shopsys] added error ID to 500 error page

### DIFF
--- a/packages/framework/src/Component/Error/ErrorIdProvider.php
+++ b/packages/framework/src/Component/Error/ErrorIdProvider.php
@@ -11,18 +11,24 @@ class ErrorIdProvider
     /**
      * @var \Shopsys\FrameworkBundle\Component\String\HashGenerator
      */
-    private $hashGenerator;
+    protected $hashGenerator;
 
     /**
      * @var string|null
      */
-    private $errorId;
+    protected $errorId;
 
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\String\HashGenerator $hashGenerator
+     */
     public function __construct(HashGenerator $hashGenerator)
     {
         $this->hashGenerator = $hashGenerator;
     }
 
+    /**
+     * @return string
+     */
     public function getErrorId(): string
     {
         if (!$this->errorId) {

--- a/packages/framework/src/Component/Error/ErrorIdProvider.php
+++ b/packages/framework/src/Component/Error/ErrorIdProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Error;
+
+use Shopsys\FrameworkBundle\Component\String\HashGenerator;
+
+class ErrorIdProvider
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\String\HashGenerator
+     */
+    private $hashGenerator;
+
+    /**
+     * @var string|null
+     */
+    private $errorId;
+
+    public function __construct(HashGenerator $hashGenerator)
+    {
+        $this->hashGenerator = $hashGenerator;
+    }
+
+    public function getErrorId(): string
+    {
+        if (!$this->errorId) {
+            $this->errorId = $this->hashGenerator->generateHash(32);
+        }
+        return $this->errorId;
+    }
+}

--- a/packages/framework/src/Component/Error/ErrorIdProvider.php
+++ b/packages/framework/src/Component/Error/ErrorIdProvider.php
@@ -32,7 +32,7 @@ class ErrorIdProvider
     public function getErrorId(): string
     {
         if (!$this->errorId) {
-            $this->errorId = $this->hashGenerator->generateHash(32);
+            $this->errorId = $this->hashGenerator->generateHash(10);
         }
         return $this->errorId;
     }

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -37,7 +37,7 @@ class ErrorPagesFacade
     protected $filesystem;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
+     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider|null
      */
     protected $errorIdProvider;
 
@@ -46,14 +46,14 @@ class ErrorPagesFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
-     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider|null $errorIdProvider
      */
     public function __construct(
         $errorPagesDir,
         Domain $domain,
         DomainRouterFactory $domainRouterFactory,
         Filesystem $filesystem,
-        ErrorIdProvider $errorIdProvider
+        ?ErrorIdProvider $errorIdProvider = null
     ) {
         $this->errorPagesDir = $errorPagesDir;
         $this->domain = $domain;
@@ -157,5 +157,29 @@ class ErrorPagesFacade
         }
 
         return $errorPageResponse->getContent();
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setErrorIdProvider(ErrorIdProvider $errorIdProvider): void
+    {
+        if ($this->errorIdProvider && $this->errorIdProvider !== $errorIdProvider) {
+            throw new \BadMethodCallException(
+                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
+            );
+        }
+        if (!$this->errorIdProvider) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+            $this->errorIdProvider = $errorIdProvider;
+        }
     }
 }

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Component\Error;
 
 use AppKernel;

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -39,8 +39,7 @@ class ErrorPagesFacade
     /**
      * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
      */
-    private $errorIdProvider;
-
+    protected $errorIdProvider;
 
     /**
      * @param string $errorPagesDir

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -37,21 +37,30 @@ class ErrorPagesFacade
     protected $filesystem;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
+     */
+    private $errorIdProvider;
+
+
+    /**
      * @param string $errorPagesDir
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
      */
     public function __construct(
         $errorPagesDir,
         Domain $domain,
         DomainRouterFactory $domainRouterFactory,
-        Filesystem $filesystem
+        Filesystem $filesystem,
+        ErrorIdProvider $errorIdProvider
     ) {
         $this->errorPagesDir = $errorPagesDir;
         $this->domain = $domain;
         $this->domainRouterFactory = $domainRouterFactory;
         $this->filesystem = $filesystem;
+        $this->errorIdProvider = $errorIdProvider;
     }
 
     public function generateAllErrorPagesForProduction()
@@ -73,6 +82,8 @@ class ErrorPagesFacade
         if ($errorPageContent === false) {
             throw new \Shopsys\FrameworkBundle\Component\Error\Exception\ErrorPageNotFoundException($domainId, $statusCode);
         }
+
+        $errorPageContent = str_replace('{{ERROR_ID}}', $this->errorIdProvider->getErrorId(), $errorPageContent);
 
         return $errorPageContent;
     }

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -25,7 +25,7 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
     protected function logException(\Exception $exception, $message)
     {
         if (!$exception instanceof \Shopsys\FrameworkBundle\Component\Error\Exception\FakeHttpException) {
-            $message .= sprintf('Error ID: %s' . $this->errorIdProvider->getErrorId());
+            $message .= sprintf('Error ID: %s', $this->errorIdProvider->getErrorId());
             parent::logException($exception, $message);
         }
     }

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Component\Error;
 
-use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Psr\Log\LoggerInterface;
 
 class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
 {
@@ -18,7 +18,7 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
      * @param \Psr\Log\LoggerInterface|null $logger
      * @param bool $debug
      */
-    public function __construct($controller, ErrorIdProvider $errorIdProvider, ?LoggerInterface $logger = null, bool $debug = false)
+    public function __construct($controller, ?LoggerInterface $logger = null, bool $debug = false, ErrorIdProvider $errorIdProvider = null)
     {
         parent::__construct($controller, $logger, $debug);
         $this->errorIdProvider = $errorIdProvider;
@@ -30,8 +30,32 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
     protected function logException(\Exception $exception, $message)
     {
         if (!$exception instanceof \Shopsys\FrameworkBundle\Component\Error\Exception\FakeHttpException) {
-            $message .= sprintf('Error ID: %s', $this->errorIdProvider->getErrorId());
+            $message .= sprintf(' Error ID: %s', $this->errorIdProvider->getErrorId());
             parent::logException($exception, $message);
+        }
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setErrorIdProvider(ErrorIdProvider $errorIdProvider): void
+    {
+        if ($this->errorIdProvider && $this->errorIdProvider !== $errorIdProvider) {
+            throw new \BadMethodCallException(
+                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
+            );
+        }
+        if (!$this->errorIdProvider) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+            $this->errorIdProvider = $errorIdProvider;
         }
     }
 }

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -2,16 +2,30 @@
 
 namespace Shopsys\FrameworkBundle\Component\Error;
 
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
 
 class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
+     */
+    private $errorIdProvider;
+
+    public function __construct($controller, ErrorIdProvider $errorIdProvider, LoggerInterface $logger = null, bool $debug = false)
+    {
+        parent::__construct($controller, $logger, $debug);
+        $this->errorIdProvider = $errorIdProvider;
+    }
+
     /**
      * @inheritDoc
      */
     protected function logException(\Exception $exception, $message)
     {
         if (!$exception instanceof \Shopsys\FrameworkBundle\Component\Error\Exception\FakeHttpException) {
+            $message .= sprintf('Error ID: %s' . $this->errorIdProvider->getErrorId());
             parent::logException($exception, $message);
         }
     }

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Component\Error;
 
 use Psr\Log\LoggerInterface;

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Component\Error;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
 
 class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
@@ -11,9 +10,15 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
     /**
      * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
      */
-    private $errorIdProvider;
+    protected $errorIdProvider;
 
-    public function __construct($controller, ErrorIdProvider $errorIdProvider, LoggerInterface $logger = null, bool $debug = false)
+    /**
+     * @param mixed $controller
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
+     * @param \Psr\Log\LoggerInterface|null $logger
+     * @param bool $debug
+     */
+    public function __construct($controller, ErrorIdProvider $errorIdProvider, ?LoggerInterface $logger = null, bool $debug = false)
     {
         parent::__construct($controller, $logger, $debug);
         $this->errorIdProvider = $errorIdProvider;

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
 class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
+     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider|null
      */
     protected $errorIdProvider;
 
@@ -42,12 +42,12 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
      */
     public function setErrorIdProvider(ErrorIdProvider $errorIdProvider): void
     {
-        if ($this->errorIdProvider !== null && $this->errorIdProvider !== $errorIdProvider) {
+        if ($this->errorIdProvider && $this->errorIdProvider !== $errorIdProvider) {
             throw new \BadMethodCallException(
                 sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
             );
         }
-        if ($this->errorIdProvider === null) {
+        if (!$this->errorIdProvider) {
             @trigger_error(
                 sprintf(
                     'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsExceptionListener.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Component\Error;
 
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
 
 class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
 {
@@ -14,11 +14,11 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
 
     /**
      * @param mixed $controller
-     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
      * @param \Psr\Log\LoggerInterface|null $logger
      * @param bool $debug
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider|null $errorIdProvider
      */
-    public function __construct($controller, ?LoggerInterface $logger = null, bool $debug = false, ErrorIdProvider $errorIdProvider = null)
+    public function __construct($controller, ?LoggerInterface $logger = null, bool $debug = false, ?ErrorIdProvider $errorIdProvider = null)
     {
         parent::__construct($controller, $logger, $debug);
         $this->errorIdProvider = $errorIdProvider;
@@ -42,12 +42,12 @@ class NotLogFakeHttpExceptionsExceptionListener extends ExceptionListener
      */
     public function setErrorIdProvider(ErrorIdProvider $errorIdProvider): void
     {
-        if ($this->errorIdProvider && $this->errorIdProvider !== $errorIdProvider) {
+        if ($this->errorIdProvider !== null && $this->errorIdProvider !== $errorIdProvider) {
             throw new \BadMethodCallException(
                 sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
             );
         }
-        if (!$this->errorIdProvider) {
+        if ($this->errorIdProvider === null) {
             @trigger_error(
                 sprintf(
                     'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -1011,3 +1011,7 @@ services:
     Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsAdder: ~
 
     Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer: ~
+
+    Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider: ~
+
+#vendor/bin/codecept run -c project-base/build/codeception.yml acceptance project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php:test500ErrorPage

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -600,6 +600,7 @@ services:
             - { name: 'monolog.logger', channel: 'request' }
         arguments:
             - '%twig.exception_listener.controller%'
+            - '@Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider'
             - '@?logger'
             - '%kernel.debug%'
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -1014,5 +1014,3 @@ services:
     Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer: ~
 
     Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider: ~
-
-#vendor/bin/codecept run -c project-base/build/codeception.yml acceptance project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php:test500ErrorPage

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -600,9 +600,9 @@ services:
             - { name: 'monolog.logger', channel: 'request' }
         arguments:
             - '%twig.exception_listener.controller%'
-            - '@Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider'
             - '@?logger'
             - '%kernel.debug%'
+            - '@Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider'
 
     twig.stringloader:
         class: Twig_Loader_Array
@@ -1012,5 +1012,3 @@ services:
     Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsAdder: ~
 
     Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer: ~
-
-    Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider: ~

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -43,29 +43,21 @@ class ErrorController extends FrontBaseController
     private $domain;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
-     */
-    private $errorIdProvider;
-
-    /**
      * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionController $exceptionController
      * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionListener $exceptionListener
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
      */
     public function __construct(
         ExceptionController $exceptionController,
         ExceptionListener $exceptionListener,
         ErrorPagesFacade $errorPagesFacade,
-        Domain $domain,
-        ErrorIdProvider $errorIdProvider
+        Domain $domain
     ) {
         $this->exceptionController = $exceptionController;
         $this->exceptionListener = $exceptionListener;
         $this->errorPagesFacade = $errorPagesFacade;
         $this->domain = $domain;
-        $this->errorIdProvider = $errorIdProvider;
     }
 
     /**
@@ -136,7 +128,6 @@ class ErrorController extends FrontBaseController
             $errorPageStatusCode
         );
 
-        $errorPageContent = str_replace('{{ERROR_ID}}', $this->errorIdProvider->getErrorId(), $errorPageContent);
         return new Response($errorPageContent, $errorPageStatusCode);
     }
 

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -9,7 +9,6 @@ use Shopsys\Environment;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\UnableToResolveDomainException;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
-use Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider;
 use Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade;
 use Shopsys\FrameworkBundle\Component\Error\ExceptionController;
 use Shopsys\FrameworkBundle\Component\Error\ExceptionListener;

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -9,6 +9,7 @@ use Shopsys\Environment;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\UnableToResolveDomainException;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
+use Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider;
 use Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade;
 use Shopsys\FrameworkBundle\Component\Error\ExceptionController;
 use Shopsys\FrameworkBundle\Component\Error\ExceptionListener;
@@ -42,21 +43,29 @@ class ErrorController extends FrontBaseController
     private $domain;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider
+     */
+    private $errorIdProvider;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionController $exceptionController
      * @param \Shopsys\FrameworkBundle\Component\Error\ExceptionListener $exceptionListener
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
      */
     public function __construct(
         ExceptionController $exceptionController,
         ExceptionListener $exceptionListener,
         ErrorPagesFacade $errorPagesFacade,
-        Domain $domain
+        Domain $domain,
+        ErrorIdProvider $errorIdProvider
     ) {
         $this->exceptionController = $exceptionController;
         $this->exceptionListener = $exceptionListener;
         $this->errorPagesFacade = $errorPagesFacade;
         $this->domain = $domain;
+        $this->errorIdProvider = $errorIdProvider;
     }
 
     /**
@@ -127,6 +136,7 @@ class ErrorController extends FrontBaseController
             $errorPageStatusCode
         );
 
+        $errorPageContent = str_replace('{{ERROR_ID}}', $this->errorIdProvider->getErrorId(), $errorPageContent);
         return new Response($errorPageContent, $errorPageStatusCode);
     }
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Error/error.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Error/error.html.twig
@@ -41,7 +41,7 @@
                     </p>
 
                     <p>
-                        {{ 'Error ID: <span id="js-error-id">{{ERROR_ID}}</span>' }}
+                        Error ID: <span id="js-error-id">{{ '{{ERROR_ID}}' }}</span>
                     </p>
                 </div>
             {% endif %}

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Error/error.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Error/error.html.twig
@@ -39,6 +39,10 @@
                     <p>
                         {{ 'Please excuse this error, we are working on fixing it. If needed, contact us on %mail% or by phone %phone%.'|trans({ '%mail%': getShopInfoEmail(), '%phone%': getShopInfoPhoneNumber() }) }}
                     </p>
+
+                    <p>
+                        {{ 'Error ID: <span id="js-error-id">{{ERROR_ID}}</span>' }}
+                    </p>
                 </div>
             {% endif %}
         </div>

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\ShopBundle\Acceptance\acceptance;
 
+use PHPUnit\Framework\Assert;
 use Tests\ShopBundle\Test\Codeception\AcceptanceTester;
 
 class ErrorHandlingCest
@@ -28,5 +29,23 @@ class ErrorHandlingCest
         $me->amOnPage('/test/error-handler/unknown-domain');
         $me->see('You are trying to access an unknown domain');
         $me->dontSee('Page not found!');
+    }
+
+    /**
+     * @param \Tests\ShopBundle\Test\Codeception\AcceptanceTester $me
+     */
+    public function test500ErrorPage(AcceptanceTester $me)
+    {
+        $me->wantTo('display 500 error and check error ID uniqueness');
+        $me->amOnPage('/test/error-handler/exception');
+        $me->see('Oops! Error occurred');
+
+        $cssIdentifier = ['css' => '#js-error-id'];
+        $errorIdFirstAccess = $me->grabTextFrom($cssIdentifier);
+
+        $me->amOnPage('/test/error-handler/exception');
+        $errorIdSecondAccess = $me->grabTextFrom($cssIdentifier);
+
+        Assert::assertNotSame($errorIdFirstAccess, $errorIdSecondAccess);
     }
 }

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -297,41 +297,7 @@ There you can find links to upgrade notes for other versions too.
         +       </p>
             </div>
         ```
-    - in [`ErrorController`](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php) 
-        - pass [`ErrorIdProvider`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/Error/ErrorIdProvider.php) to it
-            ```diff
-                 * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
-                 * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-            +    * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
-                 */
-                public function __construct(
-                    ExceptionController $exceptionController,
-                    ExceptionListener $exceptionListener,
-                    ErrorPagesFacade $errorPagesFacade,
-                    Domain $domain
-                    Domain $domain,
-            +       ErrorIdProvider $errorIdProvider
-                ) {
-                    $this->exceptionController = $exceptionController;
-                    $this->exceptionListener = $exceptionListener;
-                    $this->errorPagesFacade = $errorPagesFacade;
-                    $this->domain = $domain;
-            +       $this->errorIdProvider = $errorIdProvider;
-                }
-            ```
-        - replace placeholder `{{ERROR_ID}}` by actual error ID in variable `$errorPageContent` in it
-            ```diff
-                private function createErrorPageResponse($statusCode)
-                {
-                    $errorPageStatusCode = $this->errorPagesFacade->getErrorPageStatusCodeByStatusCode($statusCode);
-                    $errorPageContent = $this->errorPagesFacade->getErrorPageContentByDomainIdAndStatusCode(
-                        $this->domain->getId(),
-                        $errorPageStatusCode
-                    );
-            +       $errorPageContent = str_replace('{{ERROR_ID}}', $this->errorIdProvider->getErrorId(), $errorPageContent);
-                    return new Response($errorPageContent, $errorPageStatusCode);
-                }
-            ```
+        - doing so will require regenerating error page templates by running `php phing error-pages-generate` inside `php-fpm` container
     - create new acceptance test in [`ErrorHandlingCest`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Acceptance/acceptance/ErrorHandlingCest.php)
         ```diff   
         +    /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When application dies on 500 error it is hard to find out why it happend.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1365 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
