### PR TITLE
[shopsys] added sniff fobidden default values in Doctrine

### DIFF
--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -31,6 +31,7 @@ services:
     Shopsys\CodingStandards\Sniffs\ForbiddenExitSniff: ~
     Shopsys\CodingStandards\Sniffs\ForbiddenSuperGlobalSniff: ~
     Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff: ~
+    Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineDefaultValueSniff: ~
     # method arguments and variables should be $camelCase
     Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff: ~
     # add all @param, @return and @var annotations, in FQN

--- a/packages/coding-standards/src/Sniffs/ForbiddenDoctrineDefaultValueSniff.php
+++ b/packages/coding-standards/src/Sniffs/ForbiddenDoctrineDefaultValueSniff.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use SlevomatCodingStandard\Helpers\TokenHelper;
+
+class ForbiddenDoctrineDefaultValueSniff implements Sniff
+{
+    /**
+     * @return array
+     */
+    public function register(): array
+    {
+        return [\T_CLASS];
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $classPosition
+     */
+    public function process(File $file, $classPosition): void
+    {
+        $tokens = $file->getTokens();
+        $docBlockOpeningTagPositions = $this->getAllDocBlockOpeningTagPositions($file, $classPosition);
+
+        foreach ($docBlockOpeningTagPositions as $docBlockOpenTagPosition) {
+            $docBlockToken = $tokens[$docBlockOpenTagPosition];
+
+            $content = TokenHelper::getContent($file, $docBlockOpenTagPosition, $docBlockToken['comment_closer']);
+
+            if ($this->annotationContainsDefaultValue($content)) {
+                $file->addError(
+                    'Default value of entity properties cannot be used.',
+                    $docBlockOpenTagPosition,
+                    self::class
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string $annotationString
+     * @return bool
+     */
+    protected function annotationContainsDefaultValue(string $annotationString): bool
+    {
+        return (bool)preg_match('~options\s*=\s*\{\s*.*"default"~', $annotationString);
+    }
+
+    /**
+     * @param \PHP_CodeSniffer\Files\File $file
+     * @param int $startPosition
+     * @return int[]
+     */
+    protected function getAllDocBlockOpeningTagPositions(File $file, int $startPosition): array
+    {
+        $tokens = $file->getTokens();
+        $classToken = $tokens[$startPosition];
+
+        return TokenHelper::findNextAll(
+            $file,
+            [\T_DOC_COMMENT_OPEN_TAG],
+            $classToken['scope_opener'],
+            $classToken['scope_closer']
+        );
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/ForbiddenDoctrineDefaultValueSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/ForbiddenDoctrineDefaultValueSniffTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Sniffs\ForbiddenDoctrineDefaultValueSniff;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+class ForbiddenDoctrineDefaultValueSniffTest extends AbstractCheckerTestCase
+{
+    public function testWrongFile(): void
+    {
+        $this->doTestWrongFile(__DIR__ . '/wrong/default_value_annotation.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/different_order_annotation.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/multiline_annotation.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/spaces_around_annotation.php');
+        $this->doTestWrongFile(__DIR__ . '/wrong/split_annotation.php');
+    }
+
+    public function testCorrectFile(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/correct/missing_default_value_annotation.php');
+        $this->doTestCorrectFile(__DIR__ . '/correct/invalid_docblock_annotation.php');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yaml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/config.yaml
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/config.yaml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: '../../../config.yaml' }
+
+services:
+    Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineDefaultValueSniff:

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/correct/invalid_docblock_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/correct/invalid_docblock_annotation.php
@@ -1,0 +1,19 @@
+<?php
+
+class Foo
+{
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    protected $recalculateVisibility;
+
+    /*
+     * @ORM\Column(type="boolean", options={"default"}) annotation is forbidden, do not use it in this method
+     */
+    public function method(): void
+    {
+
+    }
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/correct/missing_default_value_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/correct/missing_default_value_annotation.php
@@ -1,0 +1,10 @@
+<?php
+
+class Foo {
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    protected $recalculateVisibility;
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/default_value_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/default_value_annotation.php
@@ -1,0 +1,10 @@
+<?php
+
+class Foo {
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean", options={"default" = true})
+     */
+    protected $recalculateVisibility;
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/different_order_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/different_order_annotation.php
@@ -1,0 +1,10 @@
+<?php
+
+class Foo {
+    /**
+     * @var bool
+     *
+     * @ORM\Column(options={"default" = true}, type="boolean")
+     */
+    protected $recalculateVisibility;
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/multiline_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/multiline_annotation.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo {
+
+    /**
+     * @ORM\Column(
+     *     name="status",
+     *     type="boolean",
+     *     options={"default": 0}
+     * )
+     */
+    protected $recalculateVisibility;
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/spaces_around_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/spaces_around_annotation.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo {
+
+    /**
+     * @ORM\Column(
+     *     name="status",
+     *     type="boolean",
+     *     options = { "default" : 0 }
+     * )
+     */
+    protected $recalculateVisibility;
+}

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/split_annotation.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/wrong/split_annotation.php
@@ -1,0 +1,15 @@
+<?php
+
+class Foo {
+
+    /**
+     * @ORM\Column(
+     *     name="status",
+     *     type="boolean",
+     *     options={
+     *      "default": 0
+     *     }
+     * )
+     */
+    protected $recalculateVisibility;
+}

--- a/packages/framework/src/Component/Cron/CronModule.php
+++ b/packages/framework/src/Component/Cron/CronModule.php
@@ -34,14 +34,14 @@ class CronModule
     /**
      * @var bool
      *
-     * @ORM\Column(type="boolean", options={"default"=false})
+     * @ORM\Column(type="boolean")
      */
     protected $suspended;
 
     /**
      * @var bool
      *
-     * @ORM\Column(type="boolean", options={"default"=true})
+     * @ORM\Column(type="boolean")
      */
     protected $enabled;
 

--- a/packages/framework/src/Migrations/Version20200803105229.php
+++ b/packages/framework/src/Migrations/Version20200803105229.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20200803105229 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE newsletter_subscribers ALTER created_at DROP DEFAULT');
+        $this->sql('ALTER TABLE cron_modules ALTER suspended DROP DEFAULT');
+        $this->sql('ALTER TABLE cron_modules ALTER enabled DROP DEFAULT');
+        $this->sql('ALTER TABLE products ALTER recalculate_availability DROP DEFAULT');
+        $this->sql('ALTER TABLE products ALTER recalculate_price DROP DEFAULT');
+        $this->sql('ALTER TABLE products ALTER recalculate_visibility DROP DEFAULT');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Newsletter/NewsletterSubscriber.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterSubscriber.php
@@ -38,7 +38,7 @@ class NewsletterSubscriber
 
     /**
      * @var \DateTimeImmutable
-     * @ORM\Column(type="datetime_immutable", options={"default": "1970-01-01 00:00:00"})
+     * @ORM\Column(type="datetime_immutable")
      */
     protected $createdAt;
 

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -179,7 +179,7 @@ class Product extends AbstractTranslatableEntity
     /**
      * @var bool
      *
-     * @ORM\Column(type="boolean", options={"default" = true})
+     * @ORM\Column(type="boolean")
      */
     protected $recalculateAvailability;
 
@@ -213,14 +213,14 @@ class Product extends AbstractTranslatableEntity
     /**
      * @var bool
      *
-     * @ORM\Column(type="boolean", options={"default" = true})
+     * @ORM\Column(type="boolean")
      */
     protected $recalculatePrice;
 
     /**
      * @var bool
      *
-     * @ORM\Column(type="boolean", options={"default" = true})
+     * @ORM\Column(type="boolean")
      */
     protected $recalculateVisibility;
 

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -30,3 +30,12 @@ There you can find links to upgrade notes for other versions too.
 
 - add phpstan-symfony extension ([#1961](https://github.com/shopsys/shopsys/pull/1961)) and ([#1974](https://github.com/shopsys/shopsys/pull/1974))
     - see #project-base-diff1 and #project-base-diff2 to update your project
+
+- stop using Doctrine default value option ([#1395](https://github.com/shopsys/shopsys/pull/1395))
+    - following properties no longer have a database default value, check if you set a default value in the constructor
+        - `Shopsys\FrameworkBundle\Component\Cron\CronModule::$suspended`
+        - `Shopsys\FrameworkBundle\Component\Cron\CronModule::$enabled`
+        - `Shopsys\FrameworkBundle\Model\Newsletter\NewsletterSubscriber::$createdAt`
+        - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateAvailability`
+        - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculatePrice`
+        - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateVisibility`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR prevents using a DB default value in doctrine properties (with a sniff) and also removes usages through the codebase.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1242 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
