### PR TITLE
[shopsys] executed commands in export logs from container script are not now printed

### DIFF
--- a/.ci/export_logs.sh
+++ b/.ci/export_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
 # used to copy logs of codeception which are not streamed
 WEBSERVER_PHP_FPM_CONTAINER_NAME="webserver-php-fpm"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR removes printing of each executed command in `export_logs.sh` script as it's not useful and just clutters the console log output on the CI server
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

#### State before

![Snímek obrazovky 2019-09-10 v 20 41 26](https://user-images.githubusercontent.com/1177414/64648708-c7a20380-d41b-11e9-8924-d0a846d5f61a.png)


#### State after

![Snímek obrazovky 2019-09-10 v 20 40 50](https://user-images.githubusercontent.com/1177414/64648745-d8527980-d41b-11e9-9219-1600194bd5ef.png)
