### PR TITLE
[shopsys] docs: installation guides: fixed formatting

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -30,12 +30,16 @@ cd project-base
 
 ### 2. Installation
 Now, you have two options:
-- **Option 1:** In the case you want to start demo of the application as fast as possible, you can simply execute the installation script and that is all:
-    ```
-    ./scripts/install.sh
-    ```
-  After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.
-- **Option 2:** If you want to know more about what is happening during installation, continue with the steps [#2.1 - #2.4](#21-create-docker-composeyml-file).
+
+#### Option 1
+In the case you want to start demo of the application as fast as possible, you can simply execute the installation script and that is all:
+```
+./scripts/install.sh
+```
+After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.
+
+#### Option 2
+If you want to know more about what is happening during installation, continue with the steps [#2.1 - #2.4](#21-create-docker-composeyml-file).
 
 #### 2.1 Create docker-compose.yml file
 Create `docker-compose.yml` from template [`docker-compose.yml.dist`](https://github.com/shopsys/shopsys/blob/master/project-base/docker/conf/docker-compose.yml.dist).

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -43,7 +43,7 @@ In the case you want to start demo of the application as fast as possible, you c
 ```
 ./scripts/install.sh
 ```
-!!! Note
+!!! note
     `--skip-aliasing` may be used in case you have already enabled second domain or you do not want to enable it for some reason. When using this option you will not be asked for sudo password.
 
 After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -37,14 +37,19 @@ cd project-base
 
 ### 2. Installation
 Now, you have two options:
-- **Option 1:** In the case you want to start demo of the application as fast as possible, you can simply execute the installation script and that is all:
-    ```
-    ./scripts/install.sh
-    ```
-    *Note: `--skip-aliasing` may be used in case you have already enabled second domain or you do not want to enable it for some reason. When using this option you will not be asked for sudo password.*
 
-  After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.
-- **Option 2:** If you want to know more about what is happening during installation, continue with the steps [#2.1 - #2.5](#21-enable-second-domain-optional).
+#### Option 1
+In the case you want to start demo of the application as fast as possible, you can simply execute the installation script and that is all:
+```
+./scripts/install.sh
+```
+!!! Note
+    `--skip-aliasing` may be used in case you have already enabled second domain or you do not want to enable it for some reason. When using this option you will not be asked for sudo password.
+
+After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.
+
+#### Option 2
+If you want to know more about what is happening during installation, continue with the steps [#2.1 - #2.5](#21-enable-second-domain-optional).
 
 #### 2.1 Enable second domain (optional)
 There are two domains each for different language in default installation. First one is available via IP adress `127.0.O.1` and second one via `127.0.0.2`.

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -139,12 +139,16 @@ cd project-base
 
 ### 2. Installation
 Now, you have two options:
-- **Option 1:** In the case you want to start demo of the application as fast as possible, you can simply execute the installation script and that is all:
-    ```
-    ./scripts/install.sh
-    ```
-  After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.
-- **Option 2:** If you want to know more about what is happening during installation, continue with the steps [#2.1 - #2.3](#21-create-docker-composeyml-and-docker-syncyml-file).
+
+#### Option 1
+In the case you want to start demo of the application as fast as possible, you can simply execute the installation script and that is all:
+```
+./scripts/install.sh
+```
+After the script is finished with installing the application, you can skip all the other steps and see [the last chapter of Application Setup Guide](./installation-using-docker-application-setup.md#2-see-it-in-your-browser) to get all the important information you might need right after the installation.
+
+#### Option 2
+If you want to know more about what is happening during installation, continue with the steps [#2.1 - #2.3](#21-create-docker-composeyml-and-docker-syncyml-file).
 
 #### 2.1 Create docker-compose.yml and docker-sync.yml file
 Create `docker-compose.yml` from template [`docker-compose-win.yml.dist`](https://github.com/shopsys/shopsys/blob/master/project-base/docker/conf/docker-compose-win.yml.dist).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When using lists, there must be a blank line above the list (or a headline) to be formatted properly on readthedocs. Moreover, headlines are more suitable here than simple bold text.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

The page on readthedocs before:
![Screenshot from 2019-09-12 16-54-45](https://user-images.githubusercontent.com/10401898/64795294-25e6f780-d57e-11e9-884e-fd5ae001d82c.png)

The page on readthedocs after:
![Screenshot from 2019-09-12 16-54-21](https://user-images.githubusercontent.com/10401898/64795323-339c7d00-d57e-11e9-8e1c-dc6f2e93c584.png)
