### PR TITLE
[framework] AdministratorChecker: verify default password after regular authentication

### DIFF
--- a/packages/framework/src/Model/Security/AdministratorChecker.php
+++ b/packages/framework/src/Model/Security/AdministratorChecker.php
@@ -34,7 +34,7 @@ class AdministratorChecker extends UserChecker
     /**
      * @param \Symfony\Component\Security\Core\User\UserInterface $user
      */
-    public function checkPreAuth(UserInterface $user)
+    public function checkPostAuth(UserInterface $user)
     {
         if ($this->environment === EnvironmentType::PRODUCTION
             && !$this->ignoreDefaultAdminPasswordCheck
@@ -44,6 +44,6 @@ class AdministratorChecker extends UserChecker
             throw new LoginWithDefaultPasswordException();
         }
 
-        return parent::checkPreAuth($user);
+        return parent::checkPostAuth($user);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When this check is done before real authentication (as introduced in #1360), it will throw `LoginWithDefaultPasswordException` any time someone tries to login as admin who has the default password. Now, it's thrown only when someone successfully logs in as admin using the default password.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No  <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
