### PR TITLE
[shopsys] added FAQ entry about setting hostname for SMTP container

### DIFF
--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -110,7 +110,7 @@ If you want to change its behavior (e.g. make the EAN not as important or change
 
 ## SMTP container cannot send email with error "Helo command rejected: need fully-qualified hostname"
 SMTP container should have set hostname to the domain of the server, where your application is running.
-You can set this hostname in a docker-compose file like this:
+You can set this hostname in your `docker-compose` file like this:
 ```diff
   smtp-server:
       restart: always

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -20,7 +20,7 @@ For more detailed information about the Shopsys Framework, please see [Shopsys F
 - [Why are you using entity data instead of entities for Symfony forms?](#why-are-you-using-entity-data-instead-of-entities-for-symfony-forms)
 - [What is the configuration file `services_test.yml` good for?](#what-is-the-configuration-file-services_testyml-good-for)
 - [How to change the behavior of the product search on the front-end?](#how-to-change-the-behavior-of-the-product-search-on-the-front-end)
-
+- [SMTP container cannot send email with error "Helo command rejected: need fully-qualified hostname"](#smtp-container-cannot-send-email-with-error-helo-command-rejected-need-fully-qualified-hostname)
 
 ## What are the phing targets?
 Every phing target is a task that can be executed simply by `php phing <target-name>` command.
@@ -107,3 +107,13 @@ E.g., by default, all our services are defined as private. However, in tests, we
 ## How to change the behavior of the product search on the front-end?
 Full-text product search on the front-end is handled via Elasticsearch.
 If you want to change its behavior (e.g. make the EAN not as important or change the way the search string is handled - whether to use an n-gram or not) please see [Product Searching](../model/front-end-product-searching.md).
+
+## SMTP container cannot send email with error "Helo command rejected: need fully-qualified hostname"
+SMTP container should have set hostname to the domain of the server, where your application is running.
+You can set this hostname in a docker-compose file like this:
+```diff
+  smtp-server:
+      restart: always
+      image: namshi/smtp:latest
++     hostname: my-host-machine-hostname.provider.org
+```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This FAQ entry helps the people strugling with sending emails from SMTP container with `Helo command rejected: need fully-qualified hostname` log entry
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes