### PR TITLE
releaser: excluded forked shopsys/changelog-linker from travis check

### DIFF
--- a/utils/releaser/src/Travis/TravisStatusReporter.php
+++ b/utils/releaser/src/Travis/TravisStatusReporter.php
@@ -24,6 +24,7 @@ final class TravisStatusReporter
         'shopsys/postgres-search-bundle',
         'shopsys/doctrine-orm',
         'shopsys/jparser',
+        'shopsys/changelog-linker',
         // old packages
         'shopsys/syscart',
         'shopsys/sysconfig',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1244 we introduced new forked package, but Travis status of all shopsys packages is checked while releasing the new version. Forked packages should be excluded from these checks and this PR exclude newly added shopsys/changelog-linker fork.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
