### PR TITLE
[shopsys] Dockerfile: stop defining default env vars

### DIFF
--- a/packages/framework/src/Resources/config/parameters_common.yml
+++ b/packages/framework/src/Resources/config/parameters_common.yml
@@ -15,3 +15,5 @@ parameters:
     shopsys.entity_extension.map: {}
 
     env(IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK): '0'
+    env(REDIS_PREFIX): ''
+    env(ELASTIC_SEARCH_INDEX_PREFIX): ''

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -1,8 +1,6 @@
 FROM php:7.3-fpm-stretch as base
 
 ARG project_root=.
-ENV REDIS_PREFIX=''
-ENV ELASTIC_SEARCH_INDEX_PREFIX=''
 
 # install required tools
 # git for computing diffs

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -93,6 +93,15 @@ There you can find links to upgrade notes for other versions too.
                 ```
                 export IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK=1
                 ```
+- remove default values of environment variables from your `php-fpm`'s `Dockerfile` ([#1408](https://github.com/shopsys/shopsys/pull/1408))
+    ```diff
+      FROM php:7.3-fpm-stretch as base
+
+      ARG project_root=.
+    - ENV REDIS_PREFIX=''
+    - ENV ELASTIC_SEARCH_INDEX_PREFIX=''
+
+    ```
 
 ### Tools
 - let Phing properties `is-multidomain` and `translations.dump.locales` be auto-detected ([#1309](https://github.com/shopsys/shopsys/pull/1309))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Default values moved into `parameters_common.yml` in `shopsys/framework`. This allows modifying the project defaults in `parameters.yml` (otherwise, the values set in Docker image have priority). There's no reason to overwrite the env vars in Docker image as well and it might lead to confusion...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
