### PR TITLE
[shopsys] releaser: fixed path for upgrading-monorepo file

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -118,7 +118,7 @@ final class UpdateUpgradeReleaseWorker extends AbstractShopsysReleaseWorker
      */
     private function updateUpgradeFileForMonorepo(Version $version)
     {
-        $upgradeFilePath = getcwd() . '/docs/contributing/upgrading-monorepo.md';
+        $upgradeFilePath = getcwd() . '/upgrade/upgrading-monorepo.md';
         $upgradeFileInfo = new SmartFileInfo($upgradeFilePath);
 
         $newUpgradeContent = $this->monorepoUpgradeFileManipulator->processFileToString($upgradeFileInfo, $version, $this->initialBranchName, $this->nextDevelopmentVersionString);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1350 the upgrade notes were moved outside from the docs folder to the root as it's not the documentation. Upgrade file for monorepo was moved also, but release worker altering this file was not updated with the new file path. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
