### PR TITLE
[shopsys] fixed links to moved upgrade files

### DIFF
--- a/upgrade/UPGRADE-v8.0.0.md
+++ b/upgrade/UPGRADE-v8.0.0.md
@@ -55,7 +55,7 @@ There you can find links to upgrade notes for other versions too.
 
 ### Tools
 - check and get rid of the use of all removed phing targets ([#1193](https://github.com/shopsys/shopsys/pull/1193))
-    - the targets were marked as deprecated in `v7.3.0` version, see [the upgrade notes](/docs/upgrade/UPGRADE-v7.3.0.md#tools) and [#1068](https://github.com/shopsys/shopsys/pull/1068)
+    - the targets were marked as deprecated in `v7.3.0` version, see [the upgrade notes](/upgrade/UPGRADE-v7.3.0.md#tools) and [#1068](https://github.com/shopsys/shopsys/pull/1068)
 - use YAML standards checker ([#539](https://github.com/shopsys/shopsys/pull/539))
     - for your YAML files to be checked and fixed automatically, install `sspooky13/yaml-standards` as a dev-dependency via Composer
         - you can do this by running `composer require --dev sspooky13/yaml-standards:^4.2`

--- a/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md
+++ b/upgrade/upgrade-instructions-for-read-model-for-product-lists-from-elasticsearch.md
@@ -2,7 +2,7 @@
 
 There is a new layer in Shopsys Framework, called [read model](/docs/model/introduction-to-read-model.md), separating the templates and application model.
 
-This upgrade requires the [Upgrade Instructions for Read Model for Product Lists](/docs/upgrade/upgrade-instructions-for-read-model-for-product-lists.md) to be applied first.
+This upgrade requires the [Upgrade Instructions for Read Model for Product Lists](/upgrade/upgrade-instructions-for-read-model-for-product-lists.md) to be applied first.
 
 - update Elasticsearch structure in `src/Shopsys/ShopBundle/Resources/definition/product/*.json` like this:
     ```diff


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1350 the upgrade notes were moved outside from the docs folder to the root as it's not the documentation. In some upgrade files remained old (invalid) links. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes