### PR TITLE
[shopsys] added ECS fixer that forbids short DIC alias syntax

### DIFF
--- a/packages/backend-api/easy-coding-standard.yml
+++ b/packages/backend-api/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/coding-standards/src/CsFixer/ForbiddenDicAliasShortSyntaxFixer.php
+++ b/packages/coding-standards/src/CsFixer/ForbiddenDicAliasShortSyntaxFixer.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer;
+
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class ForbiddenDicAliasShortSyntaxFixer implements FixerInterface, DefinedFixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Forces longer syntax of DIC service aliases',
+            [
+                new CodeSample('last work.___'),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param string $code
+     * @return string
+     */
+    private function fixShortAliasSyntax(string $code): string
+    {
+        return preg_replace(
+            '~^( +)([\w\\\\]+): \'@([\w\\\\]+)\'$~m',
+            "$1$2:\n$1$1alias: $3",
+            $code
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $code = $this->fixShortAliasSyntax($tokens->generateCode());
+
+        $tokens->setCode($code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Shopsys/forbidden_dic_alias_short_syntax';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return preg_match('/\.ya?ml$/ui', $file->getFilename()) === 1;
+    }
+}

--- a/packages/coding-standards/src/Finder/FileFinder.php
+++ b/packages/coding-standards/src/Finder/FileFinder.php
@@ -30,7 +30,7 @@ final class FileFinder implements CustomSourceProviderInterface
         }
 
         $finder = Finder::create()->files()
-            ->name('#\.(twig|html(\.twig)?|php|md)$#')
+            ->name('#\.(twig|html(\.twig)?|php|md|ya?ml)$#')
             ->in($directories);
 
         // ArrayIterator will be fixed in new release

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/ForbiddenDicAliasShortSyntaxFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/ForbiddenDicAliasShortSyntaxFixerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\CsFixer\RedundantMarkDownTrailingSpacesFixer;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class ForbiddenDicAliasShortSyntaxFixerTest extends AbstractCheckerTestCase
+{
+    public function testFix(): void
+    {
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/wrong.yml', __DIR__ . '/fixed/fixed.yml');
+    }
+
+    public function testCorrect(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/correct/correct.yml');
+    }
+
+    /**
+     * @return string
+     */
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/config.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/config.yml
@@ -1,0 +1,5 @@
+imports:
+    - { resource: '../../../config.yml' }
+
+services:
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer:

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/correct/correct.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/correct/correct.yml
@@ -1,0 +1,8 @@
+# config/services.yaml
+services:
+    # ...
+
+    App\Service\Bar: ~
+
+    App\Service\Foo:
+        alias: App\Service\Bar

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/fixed/fixed.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/fixed/fixed.yml
@@ -1,0 +1,14 @@
+# config/services.yaml
+services:
+    # ...
+
+    App\Service\Bar: ~
+
+    App\Service\Foo:
+        alias: App\Service\Bar
+
+    my_service:
+        class: App\Service\FooBar
+
+    my_alias:
+        alias: my_service

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/wrong/wrong.yml
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDicAliasShortSyntaxFixer/wrong/wrong.yml
@@ -1,0 +1,12 @@
+# config/services.yaml
+services:
+    # ...
+
+    App\Service\Bar: ~
+
+    App\Service\Foo: '@App\Service\Bar'
+
+    my_service:
+        class: App\Service\FooBar
+
+    my_alias: '@my_service'

--- a/packages/form-types-bundle/easy-coding-standard.yml
+++ b/packages/form-types-bundle/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -16,6 +16,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/google-cloud-bundle/easy-coding-standard.yml
+++ b/packages/google-cloud-bundle/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/http-smoke-testing/easy-coding-standard.yml
+++ b/packages/http-smoke-testing/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/migrations/easy-coding-standard.yml
+++ b/packages/migrations/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     exclude_files:
         - '*/src/Resources/views/Migration/migration.php.twig'

--- a/packages/plugin-interface/easy-coding-standard.yml
+++ b/packages/plugin-interface/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-google/easy-coding-standard.yml
+++ b/packages/product-feed-google/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-heureka-delivery/easy-coding-standard.yml
+++ b/packages/product-feed-heureka-delivery/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/product-feed-zbozi/easy-coding-standard.yml
+++ b/packages/product-feed-zbozi/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/read-model/easy-coding-standard.yml
+++ b/packages/read-model/easy-coding-standard.yml
@@ -13,6 +13,8 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -4,6 +4,8 @@ imports:
 services:
     PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~
 
+    Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
 parameters:
     exclude_files:
         - '*/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php'

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -289,5 +289,15 @@ There you can find links to upgrade notes for other versions too.
         +        calls:
         +            - { method: setRedis, arguments: ['@snc_redis.my_custom_cache'] }
         ```
+- use new ECS rule `ForbiddenDicAliasShortSyntaxFixer` to standardize aliases in DIC config ([#1412](https://github.com/shopsys/shopsys/pull/1412))
+    - add the new service in your `easy-coding-standards.yml`:
+        ```diff
+          services:
+              PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~
+        + 
+        +     Shopsys\CodingStandards\CsFixer\ForbiddenDicAliasShortSyntaxFixer: ~
+
+        ```
+    - run `php phing standards-fix` to apply the new rule
 
 [shopsys/framework]: https://github.com/shopsys/framework


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In services.yml configuration we use two different notations for defining service aliases which is inconsistent and may be confusing. The two notations work exactly the same way (see Symfony docs on Aliasing).
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| resolves #1037  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Currently unmergable - ECS doesn't support checking YAML files atm, because it calculates cache hash of YAML files using `ContainerBuilder`. See [`FileHashComputer`](https://github.com/Symplify/Symplify/blob/v5.2.17/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/FileHashComputer.php#L28-L34) for details. This fails during of YMAL files that are not a DIC configuration (see [Travis build](https://travis-ci.org/shopsys/shopsys/builds/585509634).