### PR TITLE
[shopsys] fix start docker sync on windows

### DIFF
--- a/docker/conf/docker-sync-win.yml.dist
+++ b/docker/conf/docker-sync-win.yml.dist
@@ -8,22 +8,22 @@ syncs:
         sync_strategy: 'unison'
         src: './'
         sync_excludes:
-            - .ci'
-            - .git'
-            - .github'
-            - .idea'
-            - .docker-sync'
-            - .DS_Store'
-            - docker'
-            - nbproject'
-            - project-base/docker'
-            - project-base/kubernetes'
-            - project-base/node_modules'
-            - project-base/var/cache'
-            - project-base/var/elasticsearch-data'
-            - project-base/var/postgres-data'
-            - project-base/web'
-            - vendor'
+            - .ci
+            - .git
+            - .github
+            - .idea
+            - .docker-sync
+            - .DS_Store
+            - docker
+            - nbproject
+            - project-base/docker
+            - project-base/kubernetes
+            - project-base/node_modules
+            - project-base/var/cache
+            - project-base/var/elasticsearch-data
+            - project-base/var/postgres-data
+            - project-base/web
+            - vendor
         host_disk_mount_mode: 'delegated'
 
     shopsys-framework-web-sync:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| remove forgotten apostrophes from `sync_excludes`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Please, fix/accept this issue high priority because `docker-sync start` on windows doesn't work.

This command `docker-sync start` write now:
```bash
$ docker-sync start
ok  Starting unison for sync shopsys-framework-sync
doing initial sync with unison
unison: Garbled argument -ignore.
real    0m 0.13s
user    0m 0.06s
sys     0m 0.01s
chown ing file to uid 1000
Traceback (most recent call last):
        15: from /usr/local/bin/docker-sync:23:in `<main>'
        14: from /usr/local/bin/docker-sync:23:in `load'
        13: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/bin/docker-sync:14:in `<top (required)>'
        12: from /var/lib/gems/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
        11: from /var/lib/gems/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
        10: from /var/lib/gems/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
         9: from /var/lib/gems/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
         8: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/tasks/sync/sync.thor:47:in `start'
         7: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/tasks/sync/sync.thor:163:in `daemonize'
         6: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_manager.rb:102:in `start_container'
         5: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_manager.rb:102:in `each'
         4: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_manager.rb:103:in `block in start_container'
         3: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_process.rb:105:in `start_container'
         2: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_strategy/unison.rb:211:in `start_container'
         1: from /var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_strategy/unison.rb:211:in `loop'
/var/lib/gems/2.5.0/gems/docker-sync-0.5.11/lib/docker-sync/sync_strategy/unison.rb:216:in `block in start_container': Failed to start unison container in time, try to increase max_attempt (currently 15) in your configuration. See https://github.com/EugenMayer/docker-sync/wiki/2.-Configuration for more informations (RuntimeError)
Creating network "shopsys_default" with the default driver
ERROR: Volume shopsys-framework-vendor-sync declared as external, but could not be found. Please create the volume manually using `docker volume create --name=shopsys-framework-vendor-sync` and try again.
ERROR: No container found for php-fpm_1
```