### PR TITLE
[shopsys] remove docker-sync version from install guide

### DIFF
--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -75,7 +75,7 @@ sudo chmod +x /usr/local/bin/docker-compose
 Install ruby as installation tool for docker-sync in specific version for working unison synchronization strategy driver.
 ```sh
 sudo apt install -y --no-install-recommends ruby ruby-dev
-sudo gem install docker-sync -v 0.5.7
+sudo gem install docker-sync
 ```
 
 Download, compile and install unison driver.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Removed version of docker-sync from install guide because we want to install newest version of this library
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

P.S.: if you tell me you want tested version then I accept it but I will be no happy 😐 Solution can be run builds on windows too 😄 