### PR TITLE
[shopsys] Highlight info about rebuilding image on next deploys

### DIFF
--- a/docs/installation/installation-using-docker-on-production-server.md
+++ b/docs/installation/installation-using-docker-on-production-server.md
@@ -371,7 +371,8 @@ We need to follow some steps that will change old version of the shop for the ne
 
 To preserve created data we need to use phing target `build-deploy-part-2-db-dependent` for building application environment of `php-fpm` container, maintenance page is needed if there exist unapplied database migrations.
 
-With each update of master branch in our repository we need to rebuild image based on [Docker Image Building](./installation-using-docker-on-production-server.md#docker-image-building) section.
+!!! important
+    With each update of master branch in our repository we need to rebuild image based on [Docker Image Building](./installation-using-docker-on-production-server.md#docker-image-building) section.
 
 We log into the server using ssh.  
 Now we are logged in production server and we start to deploy newly built production image.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| One of the essentials steps is the need to rebuild the image, but information about this step can be easily missed (see more in #841). This PR turn the sentence into admonition which is nicely rendered on the documentation website (https://docs.shopsys.com)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #841 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

output:
![Snímek obrazovky 2019-09-17 v 14 58 56](https://user-images.githubusercontent.com/1177414/65043704-bac16a80-d95b-11e9-8a90-ffb4067945a5.png)

