### PR TITLE
Increase slow log priority to prevent miscalculation request time

### DIFF
--- a/packages/framework/src/Component/Log/SlowLogSubscriber.php
+++ b/packages/framework/src/Component/Log/SlowLogSubscriber.php
@@ -71,7 +71,7 @@ class SlowLogSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::REQUEST => 'initStartTime',
+            KernelEvents::REQUEST => ['initStartTime', 512],
             KernelEvents::TERMINATE => 'addNotice',
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When request was redirected or ends with error (`404`, `500`) then slow log didn't correctly calculate requestTime. This PR increases `initStartTime` priority, so it will be always called even if there is error or redirect and `SlowLogSubscriber` will correctly log message.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Example output on 404 page:
```
[2019-09-19 10:21:43] slow.NOTICE: 1568881303.373  /image.php?id=635&width=294&height=487
```
Example output on redirect:
```
[2019-09-19 10:40:37] slow.NOTICE: 1568882437.9803 Shopsys\FrameworkBundle\Controller\Admin\LoginController::loginAction /admin/login-check/
```