### PR TITLE
[shopsys] fixed build.xml.patch

### DIFF
--- a/packages/backend-api/install/build.xml.patch
+++ b/packages/backend-api/install/build.xml.patch
@@ -1,5 +1,6 @@
-@@ -5,9 +5,16 @@
+@@ -5,10 +5,17 @@
 
+     <property name="check-and-fix-annotations" value="true"/>
      <property name="path.root" value="${project.basedir}"/>
      <property name="path.vendor" value="${path.root}/vendor"/>
 +    <property name="path.backend-api" value="${path.vendor}/shopsys/backend-api"/>


### PR DESCRIPTION
- the file should have been updated in https://github.com/shopsys/shopsys/pull/1379

| Q             | A
| ------------- | ---
|Description, reason for the PR| I have forgotten to update the patch file needed for API install in #1379 :man_facepalming: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
