### PR TITLE
[http-smoke-testing] HttpSmokeTestCase uses constants for kernel options

### DIFF
--- a/packages/http-smoke-testing/src/HttpSmokeTestCase.php
+++ b/packages/http-smoke-testing/src/HttpSmokeTestCase.php
@@ -11,7 +11,7 @@ abstract class HttpSmokeTestCase extends KernelTestCase
 {
     protected const APP_ENV = 'test';
     protected const APP_DEBUG = false;
-    
+
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before data provider is executed and before each test.

--- a/packages/http-smoke-testing/src/HttpSmokeTestCase.php
+++ b/packages/http-smoke-testing/src/HttpSmokeTestCase.php
@@ -9,6 +9,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 abstract class HttpSmokeTestCase extends KernelTestCase
 {
+    protected const APP_ENV = 'test';
+    protected const APP_DEBUG = false;
+    
     /**
      * Sets up the fixture, for example, open a network connection.
      * This method is called before data provider is executed and before each test.
@@ -18,8 +21,8 @@ abstract class HttpSmokeTestCase extends KernelTestCase
         parent::setUp();
 
         static::bootKernel([
-            'environment' => 'test',
-            'debug' => false,
+            'environment' => static::APP_ENV,
+            'debug' => static::APP_DEBUG,
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Allows easy modification of the default options (eg. running in debug mode).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
