### PR TITLE
[shopsys] documentation is now available on CI and local

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -36,6 +36,10 @@ yq write --inplace project-base/app/config/parameters_test.yml parameters.overwr
 DOCKER_IMAGE_TAG=ci-commit-${GIT_COMMIT}
 DOCKER_ELASTIC_IMAGE_TAG=ci-elasticsearch
 
+## Build documentation with mkdocs to be available in ./documentation directory
+docker build -t mkdocs-build:latest -f docker/mkdocs/Dockerfile .
+docker run -v "${WORKSPACE}":/var/www/html mkdocs-build:latest mkdocs build --site-dir documentation
+
 ## Docker image for application php-fpm container
 docker image pull ${DOCKER_USERNAME}/php-fpm:${DOCKER_IMAGE_TAG} || (
     echo "Image not found (see warning above), building it instead..." &&

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -96,6 +96,15 @@ services:
         environment:
             - discovery.type=single-node
 
+    mkdocs:
+        build:
+            context: .
+            dockerfile: docker/mkdocs/Dockerfile
+        ports:
+            - "1300:8000"
+        volumes:
+            - shopsys-framework-sync:/var/www/html
+
 volumes:
     shopsys-framework-sync:
         external: true

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -97,6 +97,15 @@ services:
         environment:
             - discovery.type=single-node
 
+    mkdocs:
+        build:
+            context: .
+            dockerfile: docker/mkdocs/Dockerfile
+        ports:
+            - "1300:8000"
+        volumes:
+            - shopsys-framework-sync:/var/www/html
+
 volumes:
     pgdata:
         driver: local

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -94,6 +94,15 @@ services:
         environment:
             - discovery.type=single-node
 
+    mkdocs:
+        build:
+            context: .
+            dockerfile: docker/mkdocs/Dockerfile
+        ports:
+            - "1300:8000"
+        volumes:
+            - .:/var/www/html
+
 volumes:
     elasticsearch-data:
         driver: local

--- a/docker/mkdocs/Dockerfile
+++ b/docker/mkdocs/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7.4-slim-buster
+
+WORKDIR /var/www
+
+COPY docs/requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /var/www/html
+
+CMD ["mkdocs", "serve", "--dev-addr=0.0.0.0:8000"]

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -8,6 +8,10 @@ server {
     server_tokens off;
     client_max_body_size 32M;
 
+    location /documentation/ {
+        root /var/www/html;
+        index index.html;
+    }
     location ~ /\. {
         # hide dotfiles (send to @app)
         try_files @app @app;

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,4 +39,4 @@ If you are struggling with Docker, [Docker Troubleshooting](./docker/docker-trou
 For the frequently asked questions, see [FAQ and Common Issues](./introduction/faq-and-common-issues.md).
 
 ## Documenting your own project
-We strongly believe that not only the framework itself needs documentation, but also your your project deserves it's own docs. The tips for writing project documentation are written down in [Guidelines for Project Documentation](./project/guidelines-for-project-documentation.md).
+We strongly believe that not only the framework itself needs documentation, but also your project deserves it's own docs. The tips for writing project documentation are written down in [Guidelines for Project Documentation](./project/guidelines-for-project-documentation.md).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+mkdocs<1.1
 mkdocs-awesome-pages-plugin==2.1.0

--- a/upgrade/upgrading-monorepo.md
+++ b/upgrade/upgrading-monorepo.md
@@ -14,6 +14,8 @@ Typical upgrade sequence should be:
 ***Note:** During the execution of `build-demo-dev phing target`, there will be installed 3-rd party software as dependencies of Shopsys Framework by [composer](https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies) and [npm](https://docs.npmjs.com/about-the-public-npm-registry) with licenses that are described in document [Open Source License Acknowledgements and Third-Party Copyrights](https://github.com/shopsys/shopsys/blob/7.3/open-source-license-acknowledgements-and-third-party-copyrights.md)*
 
 ## [From v7.3.2 to v7.3.3-dev]
+- add mkdocs container to your `docker-compose.yml` to be able to see rendered documentation ([#1432](https://github.com/shopsys/shopsys/pull/1432))
+    - copy proper definition from dist file for your platform from `docker/conf` directory
 
 ## [From v7.3.1 to v7.3.2]
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR allows to see generated documentation on the local machine and on CI server. 
|New feature| Yes (for writing documentation) <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Documentation for local development is available on http://127.0.0.1:1300 and each change in documentation is immediately propagated (no need to restart containers).

On the CI server is documentation generated into `./documentation`folder and nginx is configured to show this generated documentation on `http://\<hostname\>/documentation/` url