### PR TITLE
[shopsys] Add annotation based configuration for smoke tests

### DIFF
--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -124,6 +124,45 @@ All configured options will extend the values from default request data set (eve
 *Note: All three methods of [`RouteConfigCustomizer`](./src/RouteConfigCustomizer.php) accept `string $debugNote` as an argument.*
 *It is useful for describing the reasons of your configuration change because it may help you with debugging when the test fails.*
 
+To make smoke test configuration a little easier, you can use the annotations:
+
+- `@DataSet()`
+- `@Parameter()`
+- `@Skipped()`
+
+You can add them directly to your controller methods. Here is an example:
+
+```php
+<?php declare(strict_types=1);
+
+use Symfony\Component\Routing\Annotation\Route;
+use Shopsys\HttpSmokeTesting\Annotation\DataSet;
+use Shopsys\HttpSmokeTesting\Annotation\Parameter;
+use Shopsys\HttpSmokeTesting\Annotation\Skipped;
+
+class TestController
+{
+    /**
+     * @Route("/hello/name")
+     * @DataSet(parameters={@Parameter(name="name", value="test")})
+     * @DataSet(statusCode=404, parameters={@Parameter(name="name", value="notExist"})
+     */
+    public function helloAction(string $name)
+    {
+        // ...
+    }
+    
+    /**
+     * @Route("/untested")
+     * @Skipped()
+     */
+    public function untestedAction()
+    {
+        //
+    }
+}
+```
+
 Additionally you can override these methods in your implementation of [`HttpSmokeTestCase`](./src/HttpSmokeTestCase.php) to further change the test behavior:
 * `setUp` to change the way your kernel is booted (eg. boot it with different options).
 * `getRouterAdapter` to change the object responsible for collecting routes from your application and generating urls.

--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -164,6 +164,8 @@ Mark test as skipped
 
 You can add them directly to your controller methods. See the example in [`Shopsys\HttpSmokeTesting\Test\TestController`](./src/Test/TestController.php).
 
+*Note: You should avoid using annotations with configuring via `changeDefaultRequestDataSet()` on same route. It may result in unexpected behavior.*
+
 ## Troubleshooting
 
 ### Tests do not fail on non-existing route

--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -127,7 +127,7 @@ All configured options will extend the values from default request data set (eve
 To make smoke test configuration a little easier, you can use the annotations:
 
 - `@DataSet()`
-- `@Parameter()`
+- `@Parameter(name="name", value="value")`
 - `@Skipped()`
 
 You can add them directly to your controller methods. See the example in `Shopsys\HttpSmokeTesting\Test\TestController`.

--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -130,38 +130,7 @@ To make smoke test configuration a little easier, you can use the annotations:
 - `@Parameter()`
 - `@Skipped()`
 
-You can add them directly to your controller methods. Here is an example:
-
-```php
-<?php declare(strict_types=1);
-
-use Symfony\Component\Routing\Annotation\Route;
-use Shopsys\HttpSmokeTesting\Annotation\DataSet;
-use Shopsys\HttpSmokeTesting\Annotation\Parameter;
-use Shopsys\HttpSmokeTesting\Annotation\Skipped;
-
-class TestController
-{
-    /**
-     * @Route("/hello/name")
-     * @DataSet(parameters={@Parameter(name="name", value="test")})
-     * @DataSet(statusCode=404, parameters={@Parameter(name="name", value="notExist"})
-     */
-    public function helloAction(string $name)
-    {
-        // ...
-    }
-    
-    /**
-     * @Route("/untested")
-     * @Skipped()
-     */
-    public function untestedAction()
-    {
-        //
-    }
-}
-```
+You can add them directly to your controller methods. See the example in `Shopsys\HttpSmokeTesting\Test\TestController`.
 
 Additionally you can override these methods in your implementation of [`HttpSmokeTestCase`](./src/HttpSmokeTestCase.php) to further change the test behavior:
 * `setUp` to change the way your kernel is booted (eg. boot it with different options).

--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -130,7 +130,7 @@ To make smoke test configuration a little easier, you can use the annotations:
 - `@Parameter(name="name", value="value")`
 - `@Skipped()`
 
-You can add them directly to your controller methods. See the example in `Shopsys\HttpSmokeTesting\Test\TestController`.
+You can add them directly to your controller methods. See the example in [`Shopsys\HttpSmokeTesting\Test\TestController`](./src/Test/TestController.php).
 
 Additionally you can override these methods in your implementation of [`HttpSmokeTestCase`](./src/HttpSmokeTestCase.php) to further change the test behavior:
 * `setUp` to change the way your kernel is booted (eg. boot it with different options).

--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -124,19 +124,45 @@ All configured options will extend the values from default request data set (eve
 *Note: All three methods of [`RouteConfigCustomizer`](./src/RouteConfigCustomizer.php) accept `string $debugNote` as an argument.*
 *It is useful for describing the reasons of your configuration change because it may help you with debugging when the test fails.*
 
-To make smoke test configuration a little easier, you can use the annotations:
-
-- `@DataSet()`
-- `@Parameter(name="name", value="value")`
-- `@Skipped()`
-
-You can add them directly to your controller methods. See the example in [`Shopsys\HttpSmokeTesting\Test\TestController`](./src/Test/TestController.php).
-
 Additionally you can override these methods in your implementation of [`HttpSmokeTestCase`](./src/HttpSmokeTestCase.php) to further change the test behavior:
 * `setUp` to change the way your kernel is booted (eg. boot it with different options).
 * `getRouterAdapter` to change the object responsible for collecting routes from your application and generating urls.
 * `createRequest` if you have specific needs about the way `Request` is created from [`RequestDataSet`](./src/RequestDataSet.php).
 * `handleRequest` to customize handling `Request` in your application (eg. you can wrap it in database transaction to roll it back into original state).
+
+### Annotations
+To make smoke test configuration a little easier, you can use the annotations:
+
+#### DataSet
+Used for setting expected status code based on provided paramteters.
+
+```
+@DataSet(statusCode=404, parameters={
+    @Parameter(name="name", value="Batman")
+})
+```
+- arguments:
+    - `parameters` _(optional)_
+    - `statusCode` _(optional, default = `200`)_
+
+#### Parameter
+Parameter defines value for specified parameter.
+
+```
+@Parameter(name="name", value="Batman")
+```  
+- arguments:
+    - `name` _(required)_
+    - `value` _(required)_  
+
+#### Skipped
+Mark test as skipped
+
+```
+@Skipped()
+```
+
+You can add them directly to your controller methods. See the example in [`Shopsys\HttpSmokeTesting\Test\TestController`](./src/Test/TestController.php).
 
 ## Troubleshooting
 

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -26,7 +26,8 @@
         "symfony/framework-bundle": "^3.4|^4.0",
         "symfony/http-foundation": "^3.4|^4.0",
         "symfony/dependency-injection": "^3.4|^4.0",
-        "symfony/routing": "^3.4|^4.0"
+        "symfony/routing": "^3.4|^4.0",
+        "doctrine/annotations": "^1.7"
     },
     "require-dev": {
         "shopsys/coding-standards": "dev-master",

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-foundation": "^3.4|^4.0",
         "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/routing": "^3.4|^4.0",
-        "doctrine/annotations": "^1.7"
+        "doctrine/annotations": "^1.6"
     },
     "require-dev": {
         "shopsys/coding-standards": "dev-master",

--- a/packages/http-smoke-testing/src/Annotation/DataSet.php
+++ b/packages/http-smoke-testing/src/Annotation/DataSet.php
@@ -12,9 +12,13 @@ use Doctrine\Common\Annotations\Annotation\Target;
  */
 class DataSet
 {
-    /** @var int */
+    /**
+     * @var int
+     */
     public $statusCode;
 
-    /** @var array<\Shopsys\HttpSmokeTesting\Annotation\Parameter> */
+    /**
+     * @var \Shopsys\HttpSmokeTesting\Annotation\Parameter[]
+     */
     public $parameters;
 }

--- a/packages/http-smoke-testing/src/Annotation/DataSet.php
+++ b/packages/http-smoke-testing/src/Annotation/DataSet.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopsys\HttpSmokeTesting\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+class DataSet
+{
+    /** @var int */
+    public $statusCode;
+
+    /** @var array<\Shopsys\HttpSmokeTesting\Annotation\Parameter> */
+    public $parameters;
+}

--- a/packages/http-smoke-testing/src/Annotation/DataSet.php
+++ b/packages/http-smoke-testing/src/Annotation/DataSet.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopsys\HttpSmokeTesting\Annotation;
 

--- a/packages/http-smoke-testing/src/Annotation/DataSet.php
+++ b/packages/http-smoke-testing/src/Annotation/DataSet.php
@@ -15,10 +15,10 @@ class DataSet
     /**
      * @var int
      */
-    public $statusCode;
+    public $statusCode = 200;
 
     /**
      * @var \Shopsys\HttpSmokeTesting\Annotation\Parameter[]
      */
-    public $parameters;
+    public $parameters = [];
 }

--- a/packages/http-smoke-testing/src/Annotation/Parameter.php
+++ b/packages/http-smoke-testing/src/Annotation/Parameter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\HttpSmokeTesting\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\Required;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
@@ -12,9 +13,15 @@ use Doctrine\Common\Annotations\Annotation\Target;
  */
 class Parameter
 {
-    /** @var string */
+    /**
+     * @var string
+     * @Required()
+     */
     public $name;
 
-    /** @var string */
+    /**
+     * @var string
+     * @Required()
+     */
     public $value;
 }

--- a/packages/http-smoke-testing/src/Annotation/Parameter.php
+++ b/packages/http-smoke-testing/src/Annotation/Parameter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopsys\HttpSmokeTesting\Annotation;
 

--- a/packages/http-smoke-testing/src/Annotation/Parameter.php
+++ b/packages/http-smoke-testing/src/Annotation/Parameter.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopsys\HttpSmokeTesting\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * @Annotation
+ * @Target({"ANNOTATION"})
+ */
+class Parameter
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $value;
+}

--- a/packages/http-smoke-testing/src/Annotation/Skipped.php
+++ b/packages/http-smoke-testing/src/Annotation/Skipped.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopsys\HttpSmokeTesting\Annotation;
 
@@ -10,5 +12,4 @@ use Doctrine\Common\Annotations\Annotation\Target;
  */
 class Skipped
 {
-
 }

--- a/packages/http-smoke-testing/src/Annotation/Skipped.php
+++ b/packages/http-smoke-testing/src/Annotation/Skipped.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopsys\HttpSmokeTesting\Annotation;
+
+use Doctrine\Common\Annotations\Annotation\Target;
+
+/**
+ * @Annotation
+ * @Target({"METHOD"})
+ */
+class Skipped
+{
+
+}

--- a/packages/http-smoke-testing/src/HttpSmokeTestCase.php
+++ b/packages/http-smoke-testing/src/HttpSmokeTestCase.php
@@ -63,13 +63,13 @@ abstract class HttpSmokeTestCase extends KernelTestCase
     final public function httpResponseTestDataProvider()
     {
         $this->setUp();
-
-        $requestDataSetGenerators = [];
+        $requestDataSetGeneratorFactory = new RequestDataSetGeneratorFactory();
         /* @var $requestDataSetGenerators \Shopsys\HttpSmokeTesting\RequestDataSetGenerator[] */
+        $requestDataSetGenerators = [];
 
         $allRouteInfo = $this->getRouterAdapter()->getAllRouteInfo();
         foreach ($allRouteInfo as $routeInfo) {
-            $requestDataSetGenerators[] = new RequestDataSetGenerator($routeInfo);
+            $requestDataSetGenerators[] = $requestDataSetGeneratorFactory->create($routeInfo);
         }
 
         $routeConfigCustomizer = new RouteConfigCustomizer($requestDataSetGenerators);

--- a/packages/http-smoke-testing/src/RequestDataSetGenerator.php
+++ b/packages/http-smoke-testing/src/RequestDataSetGenerator.php
@@ -47,7 +47,7 @@ class RequestDataSetGenerator implements RouteConfig
                         $requestDataSet->setExpectedStatusCode($annotation->statusCode);
                     }
 
-                    /** @var Parameter $parameter */
+                    /** @var \Shopsys\HttpSmokeTesting\Annotation\Parameter $parameter */
                     foreach ($annotation->parameters as $parameter) {
                         $requestDataSet->setParameter($parameter->name, $parameter->value);
                     }

--- a/packages/http-smoke-testing/src/RequestDataSetGenerator.php
+++ b/packages/http-smoke-testing/src/RequestDataSetGenerator.php
@@ -52,7 +52,6 @@ class RequestDataSetGenerator implements RouteConfig
 
     /**
      * @param int $index
-     *
      * @return \Shopsys\HttpSmokeTesting\RequestDataSet
      */
     private function getRequestDataSetForIteration(int $index): RequestDataSet
@@ -74,7 +73,6 @@ class RequestDataSetGenerator implements RouteConfig
             $requestDataSet->setExpectedStatusCode($annotation->statusCode);
         }
 
-        /** @var \Shopsys\HttpSmokeTesting\Annotation\Parameter $parameter */
         foreach ($annotation->parameters as $parameter) {
             $requestDataSet->setParameter($parameter->name, $parameter->value);
         }

--- a/packages/http-smoke-testing/src/RequestDataSetGenerator.php
+++ b/packages/http-smoke-testing/src/RequestDataSetGenerator.php
@@ -30,18 +30,11 @@ class RequestDataSetGenerator implements RouteConfig
         $this->routeInfo = $routeInfo;
         $this->defaultRequestDataSet = new RequestDataSet($this->routeInfo->getRouteName());
         $this->extraRequestDataSets = [];
-
-        if ($routeInfo->getAnnotations() !== null) {
-            $this->fulfillRequestFromAnnotations($routeInfo->getAnnotations());
-        }
     }
 
-    /**
-     * @param array $annotations
-     */
-    private function fulfillRequestFromAnnotations(array $annotations): void
+    public function fulfillRequestFromAnnotations(): void
     {
-        foreach ($annotations as $index => $annotation) {
+        foreach ($this->routeInfo->getAnnotations() as $index => $annotation) {
             if ($annotation instanceof Skipped) {
                 $this->defaultRequestDataSet->skip();
             } elseif ($annotation instanceof DataSet) {

--- a/packages/http-smoke-testing/src/RequestDataSetGeneratorFactory.php
+++ b/packages/http-smoke-testing/src/RequestDataSetGeneratorFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Shopsys\HttpSmokeTesting;
+
+class RequestDataSetGeneratorFactory
+{
+    /**
+     * @param \Shopsys\HttpSmokeTesting\RouteInfo $routeInfo
+     * @return \Shopsys\HttpSmokeTesting\RequestDataSetGenerator
+     */
+    public function create(RouteInfo $routeInfo): RequestDataSetGenerator
+    {
+        $requestDataSetGenerator = new RequestDataSetGenerator($routeInfo);
+        $requestDataSetGenerator->fulfillRequestFromAnnotations();
+        return $requestDataSetGenerator;
+    }
+}

--- a/packages/http-smoke-testing/src/RouteInfo.php
+++ b/packages/http-smoke-testing/src/RouteInfo.php
@@ -17,14 +17,14 @@ class RouteInfo
     private $route;
 
     /**
-     * @var array<int, object>|null
+     * @var array
      */
     private $annotations;
 
     /**
      * @param string $routeName
      * @param \Symfony\Component\Routing\Route $route
-     * @param array<int, object>|null $annotations
+     * @param array $annotations
      */
     public function __construct($routeName, Route $route, array $annotations = [])
     {

--- a/packages/http-smoke-testing/src/RouteInfo.php
+++ b/packages/http-smoke-testing/src/RouteInfo.php
@@ -17,13 +17,20 @@ class RouteInfo
     private $route;
 
     /**
+     * @var array<int, object>|null
+     */
+    private $annotations;
+
+    /**
      * @param string $routeName
      * @param \Symfony\Component\Routing\Route $route
+     * @param array<int, object>|null $annotations
      */
-    public function __construct($routeName, Route $route)
+    public function __construct($routeName, Route $route, array $annotations = [])
     {
         $this->routeName = $routeName;
         $this->route = $route;
+        $this->annotations = $annotations;
     }
 
     /**
@@ -78,5 +85,13 @@ class RouteInfo
         $compiledRoute = $this->route->compile();
 
         return $compiledRoute->getVariables();
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getAnnotations(): ?array
+    {
+        return $this->annotations;
     }
 }

--- a/packages/http-smoke-testing/src/RouteInfo.php
+++ b/packages/http-smoke-testing/src/RouteInfo.php
@@ -88,9 +88,9 @@ class RouteInfo
     }
 
     /**
-     * @return array|null
+     * @return array
      */
-    public function getAnnotations(): ?array
+    public function getAnnotations(): array
     {
         return $this->annotations;
     }

--- a/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
+++ b/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
@@ -47,7 +47,6 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
 
     /**
      * @param \Symfony\Component\Routing\Route $route
-     *
      * @return array
      */
     private function extractAnnotationsForRoute(Route $route): array
@@ -61,7 +60,6 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
 
     /**
      * @param string $controller
-     *
      * @return array
      */
     private function extractAnnotationForController(string $controller): array
@@ -77,7 +75,6 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
 
     /**
      * @param \ReflectionMethod $reflectionMethod
-     *
      * @return array
      */
     private function getControllerMethodAnnotations(\ReflectionMethod $reflectionMethod): array

--- a/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
+++ b/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
@@ -38,16 +38,16 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
             $annotations = [];
 
             if ($route->hasDefault('_controller')) {
-                try {
-                    $reflectionMethod = new \ReflectionMethod($route->getDefault('_controller'));
+                list($className, $methodName) = explode('::', $route->getDefault('_controller'));
+
+                if (method_exists($className, $methodName)) {
+                    $reflectionMethod = new \ReflectionMethod($className, $methodName);
 
                     foreach ($annotationReader->getMethodAnnotations($reflectionMethod) as $annotation) {
                         if ($annotation instanceof DataSet || $annotation instanceof Skipped) {
                             $annotations[] = $annotation;
                         }
                     }
-                } catch (\ReflectionException $exception) {
-                    // Just could not parse the reflection. Do noting.
                 }
             }
 

--- a/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
+++ b/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
@@ -54,22 +54,34 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
         return [];
     }
 
+    /**
+     * @param string $controller
+     *
+     * @return array
+     */
     private function extractAnnotationForController(string $controller): array
     {
-        $annotations = [];
-
-        list($className, $methodName) = explode('::', $controller);
-
-        if (method_exists($className, $methodName)) {
-            $reflectionMethod = new \ReflectionMethod($className, $methodName);
-
-            foreach ($this->annotationsReader->getMethodAnnotations($reflectionMethod) as $annotation) {
-                if ($annotation instanceof DataSet || $annotation instanceof Skipped) {
-                    $annotations[] = $annotation;
-                }
-            }
+        try {
+            $reflectionMethod = new \ReflectionMethod($controller);
+        } catch (\ReflectionException $e) {
+            return [];
         }
 
+        return $this->getControllerMethodAnnotations($reflectionMethod);
+    }
+
+    /**
+     * @param \ReflectionMethod $reflectionMethod
+     *
+     * @return array
+     */
+    private function getControllerMethodAnnotations(\ReflectionMethod $reflectionMethod) {
+        $annotations = [];
+        foreach ($this->annotationsReader->getMethodAnnotations($reflectionMethod) as $annotation) {
+            if ($annotation instanceof DataSet || $annotation instanceof Skipped) {
+                $annotations[] = $annotation;
+            }
+        }
         return $annotations;
     }
 

--- a/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
+++ b/packages/http-smoke-testing/src/RouterAdapter/SymfonyRouterAdapter.php
@@ -34,7 +34,7 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
     /**
      * @return \Shopsys\HttpSmokeTesting\RouteInfo[]
      */
-    public function getAllRouteInfo()
+    public function getAllRouteInfo(): array
     {
         $allRouteInfo = [];
 
@@ -45,6 +45,11 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
         return $allRouteInfo;
     }
 
+    /**
+     * @param \Symfony\Component\Routing\Route $route
+     *
+     * @return array
+     */
     private function extractAnnotationsForRoute(Route $route): array
     {
         if ($route->hasDefault('_controller')) {
@@ -75,7 +80,8 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
      *
      * @return array
      */
-    private function getControllerMethodAnnotations(\ReflectionMethod $reflectionMethod) {
+    private function getControllerMethodAnnotations(\ReflectionMethod $reflectionMethod): array
+    {
         $annotations = [];
         foreach ($this->annotationsReader->getMethodAnnotations($reflectionMethod) as $annotation) {
             if ($annotation instanceof DataSet || $annotation instanceof Skipped) {
@@ -87,9 +93,9 @@ class SymfonyRouterAdapter implements RouterAdapterInterface
 
     /**
      * @param \Shopsys\HttpSmokeTesting\RequestDataSet $requestDataSet
-     * @return string
+     * @return string|null
      */
-    public function generateUri(RequestDataSet $requestDataSet)
+    public function generateUri(RequestDataSet $requestDataSet): ?string
     {
         return $this->router->generate($requestDataSet->getRouteName(), $requestDataSet->getParameters());
     }

--- a/packages/http-smoke-testing/src/Test/TestController.php
+++ b/packages/http-smoke-testing/src/Test/TestController.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopsys\HttpSmokeTesting\Test;
 
@@ -12,7 +14,7 @@ class TestController
 {
     /**
      * @param string $name
-     * @return Response
+     * @return \Symfony\Component\HttpFoundation\Response
      * @Route("/hello/{name}")
      *
      * @DataSet(parameters={
@@ -32,7 +34,7 @@ class TestController
     }
 
     /**
-     * @return Response
+     * @return \Symfony\Component\HttpFoundation\Response
      * @Route("/untested")
      * @Skipped()
      */

--- a/packages/http-smoke-testing/src/Test/TestController.php
+++ b/packages/http-smoke-testing/src/Test/TestController.php
@@ -34,6 +34,24 @@ class TestController
     }
 
     /**
+     * @param string $name
+     * @return \Symfony\Component\HttpFoundation\Response
+     * @Route("/test")
+     *
+     * @DataSet(parameters={
+     *     @Parameter(name="myName", value="Batman")
+     * })
+     */
+    public function testAction(string $name): Response
+    {
+        if ($name === 'Batman') {
+            return new Response(sprintf('I am %1$s!', $name), 200);
+        } else {
+            return new Response('Nothing found.', 404);
+        }
+    }
+
+    /**
      * @return \Symfony\Component\HttpFoundation\Response
      * @Route("/untested")
      * @Skipped()

--- a/packages/http-smoke-testing/src/Test/TestController.php
+++ b/packages/http-smoke-testing/src/Test/TestController.php
@@ -18,10 +18,10 @@ class TestController
      * @Route("/hello/{name}")
      *
      * @DataSet(parameters={
-     *     @Parameter("name", value="Batman")
+     *     @Parameter(name="name", value="Batman")
      * })
      * @DataSet(statusCode=404, parameters={
-     *     @Parameter("name", value="World")
+     *     @Parameter(name="name", value="World")
      * })
      */
     public function helloAction(string $name): Response

--- a/packages/http-smoke-testing/src/Test/TestController.php
+++ b/packages/http-smoke-testing/src/Test/TestController.php
@@ -16,7 +16,6 @@ class TestController
      * @param string $name
      * @return \Symfony\Component\HttpFoundation\Response
      * @Route("/hello/{name}")
-     *
      * @DataSet(parameters={
      *     @Parameter(name="name", value="Batman")
      * })
@@ -37,7 +36,6 @@ class TestController
      * @param string $name
      * @return \Symfony\Component\HttpFoundation\Response
      * @Route("/test")
-     *
      * @DataSet(parameters={
      *     @Parameter(name="myName", value="Batman")
      * })

--- a/packages/http-smoke-testing/src/Test/TestController.php
+++ b/packages/http-smoke-testing/src/Test/TestController.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopsys\HttpSmokeTesting\Test;
+
+use Shopsys\HttpSmokeTesting\Annotation\DataSet;
+use Shopsys\HttpSmokeTesting\Annotation\Parameter;
+use Shopsys\HttpSmokeTesting\Annotation\Skipped;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class TestController
+{
+    /**
+     * @param string $name
+     * @return Response
+     * @Route("/hello/{name}")
+     *
+     * @DataSet(parameters={
+     *     @Parameter("name", value="Batman")
+     * })
+     * @DataSet(statusCode=404, parameters={
+     *     @Parameter("name", value="World")
+     * })
+     */
+    public function helloAction(string $name): Response
+    {
+        if ($name === 'Batman') {
+            return new Response(sprintf('I am %1$s!', $name), 200);
+        } else {
+            return new Response('Nothing found.', 404);
+        }
+    }
+
+    /**
+     * @return Response
+     * @Route("/untested")
+     * @Skipped()
+     */
+    public function untestedAction(): Response
+    {
+        return new Response('', 500);
+    }
+}

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -61,7 +61,7 @@ class RequestDataSetGeneratorTest extends TestCase
     {
         $parameters = [
             [new Parameter()],
-            [new Parameter()]
+            [new Parameter()],
         ];
         $annotations = [
             new DataSet(),

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -58,7 +58,7 @@ class RequestDataSetGeneratorTest extends TestCase
     }
 
     /**
-     * @param DataSet $dataSet
+     * @param \Shopsys\HttpSmokeTesting\Annotation\DataSet $dataSet
      * @param int $statusCode
      * @param array $parameters
      * @dataProvider getDataSets
@@ -117,6 +117,9 @@ class RequestDataSetGeneratorTest extends TestCase
         self::assertSame(404, $requestDataSets[1]->getExpectedStatusCode());
     }
 
+    /**
+     * @return array
+     */
     public function getDataSets(): array
     {
         $parameter1 = new Parameter();

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -57,6 +57,29 @@ class RequestDataSetGeneratorTest extends TestCase
         return $requestDataSetGeneratorFactory->create($routeInfo);
     }
 
+    /**
+     * @param DataSet $dataSet
+     * @param int $statusCode
+     * @param array $parameters
+     * @dataProvider getDataSets
+     */
+    public function testGeneratorGenerateRequestDataSetFromDataSerAnnotation(
+        DataSet $dataSet,
+        int $statusCode,
+        array $parameters
+    ) {
+        $requestDataSetGenerator = $this->createRequestDataSetGenerator(
+            'test_route_path',
+            'test_route_name',
+            [$dataSet]
+        );
+        $requestDataSets = $requestDataSetGenerator->generateRequestDataSets();
+
+        self::assertCount(1, $requestDataSets);
+        self::assertSame($statusCode, $requestDataSets[0]->getExpectedStatusCode());
+        self::assertEquals($parameters, $requestDataSets[0]->getParameters());
+    }
+
     public function testGeneratorGeneratesRequestDataSetsFromDataSetAnnotations()
     {
         $parameter1 = new Parameter();
@@ -92,5 +115,40 @@ class RequestDataSetGeneratorTest extends TestCase
         self::assertEquals(['name' => 'Batman'], $requestDataSets[0]->getParameters());
         self::assertEquals(['name' => 'World'], $requestDataSets[1]->getParameters());
         self::assertSame(404, $requestDataSets[1]->getExpectedStatusCode());
+    }
+
+    public function getDataSets(): array
+    {
+        $parameter1 = new Parameter();
+        $parameter1->name = 'name';
+        $parameter1->value = 'Batman';
+
+        $parameter2 = new Parameter();
+        $parameter2->name = 'foo';
+        $parameter2->value = 'Bar';
+
+        $dataSet1 = new DataSet();
+        $dataSet1->parameters = [$parameter1];
+
+        $dataSet2 = new DataSet();
+        $dataSet2->parameters = [$parameter1, $parameter2];
+        $dataSet2->statusCode = 404;
+
+        $dataSet3 = new DataSet();
+
+        $dataSet4 = new DataSet();
+        $dataSet4->statusCode = 302;
+
+        $dataSet5 = new DataSet();
+        $dataSet5->statusCode = 500;
+        $dataSet5->parameters = [];
+
+        return [
+            [$dataSet1, 200, ['name' => 'Batman']],
+            [$dataSet2, 404, ['name' => 'Batman', 'foo' => 'Bar']],
+            [$dataSet3, 200, []],
+            [$dataSet4, 302, []],
+            [$dataSet5, 500, []],
+        ];
     }
 }

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -3,6 +3,8 @@
 namespace Tests\HttpSmokeTesting\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\HttpSmokeTesting\Annotation\DataSet;
+use Shopsys\HttpSmokeTesting\Annotation\Parameter;
 use Shopsys\HttpSmokeTesting\RequestDataSetGenerator;
 use Shopsys\HttpSmokeTesting\RouteInfo;
 use Symfony\Component\Routing\Route;
@@ -43,14 +45,50 @@ class RequestDataSetGeneratorTest extends TestCase
     /**
      * @param string $routePath
      * @param string $routeName
+     * @param array $annotations
      * @return \Shopsys\HttpSmokeTesting\RequestDataSetGenerator
      */
-    private function createRequestDataSetGenerator($routePath, $routeName)
+    private function createRequestDataSetGenerator($routePath, $routeName, array $annotations = [])
     {
         $route = new Route($routePath);
-        $routeInfo = new RouteInfo($routeName, $route);
+        $routeInfo = new RouteInfo($routeName, $route, $annotations);
         $requestDataSetGenerator = new RequestDataSetGenerator($routeInfo);
 
         return $requestDataSetGenerator;
+    }
+
+    public function testGeneratorGeneratesRequestDataSetsFromDataSetAnnotations()
+    {
+        $parameters = [
+            [new Parameter()],
+            [new Parameter()]
+        ];
+        $annotations = [
+            new DataSet(),
+            new DataSet(),
+        ];
+
+        $parameters[0][0]->name = 'name';
+        $parameters[0][0]->value = 'Batman';
+        $parameters[1][0]->name = 'name';
+        $parameters[1][0]->value = 'World';
+
+        $annotations[0]->parameters = $parameters[0];
+        $annotations[1]->parameters = $parameters[1];
+        $annotations[1]->statusCode = 404;
+
+        $requestDataSetGenerator = $this->createRequestDataSetGenerator(
+            'test_route_path',
+            'test_route_name',
+            $annotations
+        );
+
+        $requestDataSets = $requestDataSetGenerator->generateRequestDataSets();
+
+        self::assertCount(2, $requestDataSets);
+
+        self::assertEquals(['name' => 'Batman'], $requestDataSets[0]->getParameters());
+        self::assertEquals(['name' => 'World'], $requestDataSets[1]->getParameters());
+        self::assertSame(404, $requestDataSets[1]->getExpectedStatusCode());
     }
 }

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -63,7 +63,7 @@ class RequestDataSetGeneratorTest extends TestCase
      * @param array $parameters
      * @dataProvider getDataSets
      */
-    public function testGeneratorGenerateRequestDataSetFromDataSerAnnotation(
+    public function testGeneratorGenerateRequestDataSetFromDataSetAnnotation(
         DataSet $dataSet,
         int $statusCode,
         array $parameters

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -5,7 +5,7 @@ namespace Tests\HttpSmokeTesting\Unit;
 use PHPUnit\Framework\TestCase;
 use Shopsys\HttpSmokeTesting\Annotation\DataSet;
 use Shopsys\HttpSmokeTesting\Annotation\Parameter;
-use Shopsys\HttpSmokeTesting\RequestDataSetGenerator;
+use Shopsys\HttpSmokeTesting\RequestDataSetGeneratorFactory;
 use Shopsys\HttpSmokeTesting\RouteInfo;
 use Symfony\Component\Routing\Route;
 
@@ -52,9 +52,9 @@ class RequestDataSetGeneratorTest extends TestCase
     {
         $route = new Route($routePath);
         $routeInfo = new RouteInfo($routeName, $route, $annotations);
-        $requestDataSetGenerator = new RequestDataSetGenerator($routeInfo);
+        $requestDataSetGeneratorFactory = new RequestDataSetGeneratorFactory();
 
-        return $requestDataSetGenerator;
+        return $requestDataSetGeneratorFactory->create($routeInfo);
     }
 
     public function testGeneratorGeneratesRequestDataSetsFromDataSetAnnotations()

--- a/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RequestDataSetGeneratorTest.php
@@ -59,23 +59,25 @@ class RequestDataSetGeneratorTest extends TestCase
 
     public function testGeneratorGeneratesRequestDataSetsFromDataSetAnnotations()
     {
-        $parameters = [
-            [new Parameter()],
-            [new Parameter()],
-        ];
+        $parameter1 = new Parameter();
+        $parameter1->name = 'name';
+        $parameter1->value = 'Batman';
+
+        $parameter2 = new Parameter();
+        $parameter2->name = 'name';
+        $parameter2->value = 'World';
+
+        $dataSet1 = new DataSet();
+        $dataSet1->parameters = [$parameter1];
+
+        $dataSet2 = new DataSet();
+        $dataSet2->parameters = [$parameter2];
+        $dataSet2->statusCode = 404;
+
         $annotations = [
-            new DataSet(),
-            new DataSet(),
+            $dataSet1,
+            $dataSet2,
         ];
-
-        $parameters[0][0]->name = 'name';
-        $parameters[0][0]->value = 'Batman';
-        $parameters[1][0]->name = 'name';
-        $parameters[1][0]->value = 'World';
-
-        $annotations[0]->parameters = $parameters[0];
-        $annotations[1]->parameters = $parameters[1];
-        $annotations[1]->statusCode = 404;
 
         $requestDataSetGenerator = $this->createRequestDataSetGenerator(
             'test_route_path',

--- a/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\HttpSmokeTesting\Unit\RouterAdapter;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\TestCase;
+use Shopsys\HttpSmokeTesting\Annotation\DataSet;
+use Shopsys\HttpSmokeTesting\Annotation\Skipped;
+use Shopsys\HttpSmokeTesting\RouteInfo;
+use Shopsys\HttpSmokeTesting\RouterAdapter\SymfonyRouterAdapter;
+use Shopsys\HttpSmokeTesting\Test\TestController;
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
+use Symfony\Component\Routing\Router;
+
+class SymfonyRouterAdapterTest extends TestCase
+{
+    public function testGetAllRouteInfoExtractsInformationFromRouteCollection()
+    {
+        $router = new Router(
+            new AnnotatedRouteControllerLoader(new AnnotationReader()),
+            TestController::class
+        );
+
+        $adapter = new SymfonyRouterAdapter($router);
+
+        $routeInfos = $adapter->getAllRouteInfo();
+
+        self::assertCount(2, $routeInfos);
+
+        self::assertInstanceOf(RouteInfo::class, $routeInfos[0]);
+        self::assertSame('/hello/{name}', $routeInfos[0]->getRoutePath());
+        self::assertCount(2, $routeInfos[0]->getAnnotations());
+        self::assertInstanceOf(DataSet::class, $routeInfos[0]->getAnnotations()[0]);
+        self::assertInstanceOf(DataSet::class, $routeInfos[0]->getAnnotations()[1]);
+        self::assertSame(404, $routeInfos[0]->getAnnotations()[1]->statusCode);
+        self::assertCount(1, $routeInfos[0]->getAnnotations()[1]->parameters);
+
+        self::assertInstanceOf(RouteInfo::class, $routeInfos[1]);
+        self::assertSame('/untested', $routeInfos[1]->getRoutePath());
+        self::assertCount(1, $routeInfos[1]->getAnnotations());
+        self::assertInstanceOf(Skipped::class, $routeInfos[1]->getAnnotations()[0]);
+    }
+}

--- a/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
@@ -25,29 +25,39 @@ class SymfonyRouterAdapterTest extends TestCase
         $adapter = new SymfonyRouterAdapter($router);
 
         $routeInfos = $adapter->getAllRouteInfo();
-
         self::assertCount(3, $routeInfos);
 
-        self::assertInstanceOf(RouteInfo::class, $routeInfos[0]);
-        self::assertSame('/hello/{name}', $routeInfos[0]->getRoutePath());
-        self::assertCount(2, $routeInfos[0]->getAnnotations());
-        self::assertInstanceOf(DataSet::class, $routeInfos[0]->getAnnotations()[0]);
-        self::assertInstanceOf(DataSet::class, $routeInfos[0]->getAnnotations()[1]);
-        self::assertSame(404, $routeInfos[0]->getAnnotations()[1]->statusCode);
-        self::assertCount(1, $routeInfos[0]->getAnnotations()[1]->parameters);
-        self::assertInstanceOf(Parameter::class, $routeInfos[0]->getAnnotations()[1]->parameters[0]);
+        $route1 = $routeInfos[0];
+        self::assertInstanceOf(RouteInfo::class, $route1);
+        self::assertSame('/hello/{name}', $route1->getRoutePath());
+        self::assertCount(2, $route1->getAnnotations());
 
-        self::assertInstanceOf(RouteInfo::class, $routeInfos[1]);
-        self::assertSame('/test', $routeInfos[1]->getRoutePath());
-        self::assertCount(1, $routeInfos[1]->getAnnotations());
-        self::assertInstanceOf(DataSet::class, $routeInfos[1]->getAnnotations()[0]);
-        self::assertInstanceOf(Parameter::class, $routeInfos[1]->getAnnotations()[0]->parameters[0]);
-        self::assertSame('myName', $routeInfos[1]->getAnnotations()[0]->parameters[0]->name);
-        self::assertSame('Batman', $routeInfos[1]->getAnnotations()[0]->parameters[0]->value);
+        $route1DataSet1 = $route1->getAnnotations()[0];
+        $route1DataSet2 = $route1->getAnnotations()[1];
+        self::assertInstanceOf(DataSet::class, $route1DataSet1);
+        self::assertInstanceOf(DataSet::class, $route1DataSet2);
+        self::assertSame(404, $route1DataSet2->statusCode);
+        self::assertCount(1, $route1DataSet2->parameters);
+        self::assertInstanceOf(Parameter::class, $route1DataSet2->parameters[0]);
 
-        self::assertInstanceOf(RouteInfo::class, $routeInfos[2]);
-        self::assertSame('/untested', $routeInfos[2]->getRoutePath());
-        self::assertCount(1, $routeInfos[2]->getAnnotations());
-        self::assertInstanceOf(Skipped::class, $routeInfos[2]->getAnnotations()[0]);
+        $route2 = $routeInfos[1];
+        self::assertInstanceOf(RouteInfo::class, $route2);
+        self::assertSame('/test', $route2->getRoutePath());
+        self::assertCount(1, $route2->getAnnotations());
+
+        $route2DataSet1 = $route2->getAnnotations()[0];
+        self::assertInstanceOf(DataSet::class, $route2DataSet1);
+
+        self::assertCount(1, $route2DataSet1->parameters);
+        $route2DataSetParameter = $route2DataSet1->parameters[0];
+        self::assertInstanceOf(Parameter::class, $route2DataSetParameter);
+        self::assertSame('myName', $route2DataSetParameter->name);
+        self::assertSame('Batman', $route2DataSetParameter->value);
+
+        $route3 = $routeInfos[2];
+        self::assertInstanceOf(RouteInfo::class, $route3);
+        self::assertSame('/untested', $route3->getRoutePath());
+        self::assertCount(1, $route3->getAnnotations());
+        self::assertInstanceOf(Skipped::class, $route3->getAnnotations()[0]);
     }
 }

--- a/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
@@ -26,7 +26,7 @@ class SymfonyRouterAdapterTest extends TestCase
 
         $routeInfos = $adapter->getAllRouteInfo();
 
-        self::assertCount(2, $routeInfos);
+        self::assertCount(3, $routeInfos);
 
         self::assertInstanceOf(RouteInfo::class, $routeInfos[0]);
         self::assertSame('/hello/{name}', $routeInfos[0]->getRoutePath());
@@ -38,8 +38,16 @@ class SymfonyRouterAdapterTest extends TestCase
         self::assertInstanceOf(Parameter::class, $routeInfos[0]->getAnnotations()[1]->parameters[0]);
 
         self::assertInstanceOf(RouteInfo::class, $routeInfos[1]);
-        self::assertSame('/untested', $routeInfos[1]->getRoutePath());
+        self::assertSame('/test', $routeInfos[1]->getRoutePath());
         self::assertCount(1, $routeInfos[1]->getAnnotations());
-        self::assertInstanceOf(Skipped::class, $routeInfos[1]->getAnnotations()[0]);
+        self::assertInstanceOf(DataSet::class, $routeInfos[1]->getAnnotations()[0]);
+        self::assertInstanceOf(Parameter::class, $routeInfos[1]->getAnnotations()[0]->parameters[0]);
+        self::assertSame('myName', $routeInfos[1]->getAnnotations()[0]->parameters[0]->name);
+        self::assertSame('Batman', $routeInfos[1]->getAnnotations()[0]->parameters[0]->value);
+
+        self::assertInstanceOf(RouteInfo::class, $routeInfos[2]);
+        self::assertSame('/untested', $routeInfos[2]->getRoutePath());
+        self::assertCount(1, $routeInfos[2]->getAnnotations());
+        self::assertInstanceOf(Skipped::class, $routeInfos[2]->getAnnotations()[0]);
     }
 }

--- a/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
+++ b/packages/http-smoke-testing/tests/Unit/RouterAdapter/SymfonyRouterAdapterTest.php
@@ -5,6 +5,7 @@ namespace Tests\HttpSmokeTesting\Unit\RouterAdapter;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Shopsys\HttpSmokeTesting\Annotation\DataSet;
+use Shopsys\HttpSmokeTesting\Annotation\Parameter;
 use Shopsys\HttpSmokeTesting\Annotation\Skipped;
 use Shopsys\HttpSmokeTesting\RouteInfo;
 use Shopsys\HttpSmokeTesting\RouterAdapter\SymfonyRouterAdapter;
@@ -34,6 +35,7 @@ class SymfonyRouterAdapterTest extends TestCase
         self::assertInstanceOf(DataSet::class, $routeInfos[0]->getAnnotations()[1]);
         self::assertSame(404, $routeInfos[0]->getAnnotations()[1]->statusCode);
         self::assertCount(1, $routeInfos[0]->getAnnotations()[1]->parameters);
+        self::assertInstanceOf(Parameter::class, $routeInfos[0]->getAnnotations()[1]->parameters[0]);
 
         self::assertInstanceOf(RouteInfo::class, $routeInfos[1]);
         self::assertSame('/untested', $routeInfos[1]->getRoutePath());

--- a/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
+++ b/project-base/tests/ShopBundle/Performance/Page/AllPagesTest.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\HttpSmokeTesting\RequestDataSet;
-use Shopsys\HttpSmokeTesting\RequestDataSetGenerator;
+use Shopsys\HttpSmokeTesting\RequestDataSetGeneratorFactory;
 use Shopsys\HttpSmokeTesting\RouteConfig;
 use Shopsys\HttpSmokeTesting\RouteConfigCustomizer;
 use Shopsys\HttpSmokeTesting\RouteInfo;
@@ -81,8 +81,9 @@ class AllPagesTest extends KernelTestCase
     {
         $requestDataSetGenerators = [];
         $allRouteInfo = $this->getRouterAdapter()->getAllRouteInfo();
+        $requestDataSetGeneratorFactory = new RequestDataSetGeneratorFactory();
         foreach ($allRouteInfo as $routeInfo) {
-            $requestDataSetGenerators[] = new RequestDataSetGenerator($routeInfo);
+            $requestDataSetGenerators[] = $requestDataSetGeneratorFactory->create($routeInfo);
         }
 
         $routeConfigCustomizer = new RouteConfigCustomizer($requestDataSetGenerators);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| I wanted a solution for configuring my smoke tests directly on the controllers.
|New feature| Yes
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
