### PR TITLE
[project-base] removed usage of non-existing property ProductData::$price

### DIFF
--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php
@@ -34,7 +34,6 @@ class CartItemTest extends TransactionFunctionalTestCase
         $availability = new Availability($availabilityData);
         $productData = $productDataFactory->create();
         $productData->name = [];
-        $productData->price = 100;
         $productData->vat = $vat;
         $productData->availability = $availability;
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php
@@ -37,7 +37,6 @@ class CartTest extends TransactionFunctionalTestCase
         $availability = new Availability($availabilityData);
         $productData = $productDataFactory->create();
         $productData->name = [];
-        $productData->price = 100;
         $productData->vat = $vat;
         $productData->availability = $availability;
         $productData->unit = $this->getReference(UnitDataFixture::UNIT_PIECES);
@@ -129,7 +128,6 @@ class CartTest extends TransactionFunctionalTestCase
     {
         $productDataFactory = $this->getContainer()->get(ProductDataFactoryInterface::class);
 
-        $price = 100;
         $vatData = new VatData();
         $vatData->name = 'vat';
         $vatData->percent = '21';
@@ -137,7 +135,6 @@ class CartTest extends TransactionFunctionalTestCase
 
         $productData = $productDataFactory->create();
         $productData->name = ['cs' => 'Any name'];
-        $productData->price = $price;
         $productData->vat = $vat;
         $product = Product::create($productData, new ProductCategoryDomainFactory());
 

--- a/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php
@@ -91,7 +91,6 @@ class CartWatcherTest extends TransactionFunctionalTestCase
 
         $productData = $productDataFactory->create();
         $productData->name = [];
-        $productData->price = 100;
         $vatData = new VatData();
         $vatData->name = 'vat';
         $vatData->percent = '21';

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -55,6 +55,6 @@ There you can find links to upgrade notes for other versions too.
         +           if ($this->environment === EnvironmentType::TEST) {
         ```
 - remove unused usages of property `ProductData::$price` in following tests ([#1459](https://github.com/shopsys/shopsys/pull/1459))
-    - [`tests/ShopBundle/Functional/Model/Cart/CartItemTest.php`](https://github.com/shopsys/shopsys/pull/1459/files#diff-a00850a718c91d2fc057e182c72ce13c)
-    - [`tests/ShopBundle/Functional/Model/Cart/CartTest.php`](https://github.com/shopsys/shopsys/pull/1459/files#diff-e5523042560228cc06e1cf49cf4e1ec2)
-    - [`tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`](https://github.com/shopsys/shopsys/pull/1459/files#diff-51c8da3c731810f6e72b0e4b676490a9)
+    - `tests/ShopBundle/Functional/Model/Cart/CartItemTest.php`
+    - `tests/ShopBundle/Functional/Model/Cart/CartTest.php`
+    - `tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -54,3 +54,9 @@ There you can find links to upgrade notes for other versions too.
         -           if (EnvironmentType::TEST === Environment::getEnvironment(false)) {    
         +           if ($this->environment === EnvironmentType::TEST) {
         ```
+- remove unused usages of property `ProductData::$price` ([#1459](https://github.com/shopsys/shopsys/pull/1459))
+    - occurrences were found at
+        - [`tests/ShopBundle/Functional/Model/Cart/CartItemTest.php`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php)
+        - [`tests/ShopBundle/Functional/Model/Cart/CartTest.php`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php)
+        - [`tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php)
+    - more details might be seen in out pull request

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -54,9 +54,7 @@ There you can find links to upgrade notes for other versions too.
         -           if (EnvironmentType::TEST === Environment::getEnvironment(false)) {    
         +           if ($this->environment === EnvironmentType::TEST) {
         ```
-- remove unused usages of property `ProductData::$price` ([#1459](https://github.com/shopsys/shopsys/pull/1459))
-    - occurrences were found at
-        - [`tests/ShopBundle/Functional/Model/Cart/CartItemTest.php`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Model/Cart/CartItemTest.php)
-        - [`tests/ShopBundle/Functional/Model/Cart/CartTest.php`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Model/Cart/CartTest.php)
-        - [`tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php)
-    - more details might be seen in out pull request
+- remove unused usages of property `ProductData::$price` in following tests ([#1459](https://github.com/shopsys/shopsys/pull/1459))
+    - [`tests/ShopBundle/Functional/Model/Cart/CartItemTest.php`](https://github.com/shopsys/shopsys/pull/1459/files#diff-a00850a718c91d2fc057e182c72ce13c)
+    - [`tests/ShopBundle/Functional/Model/Cart/CartTest.php`](https://github.com/shopsys/shopsys/pull/1459/files#diff-e5523042560228cc06e1cf49cf4e1ec2)
+    - [`tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`](https://github.com/shopsys/shopsys/pull/1459/files#diff-51c8da3c731810f6e72b0e4b676490a9)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixing forgotten occurrences of property `ProductData::$price` which no longer exists.<br> (Came from https://github.com/shopsys/shopsys/pull/1392)<br> Bug introduced in https://github.com/shopsys/shopsys/commit/ba446bf83f06906ef68aa3df04ffab03d35d8431
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes