### PR TITLE
[shopsys] remove old IE support

### DIFF
--- a/packages/framework/src/Resources/styles/admin/components/box/advanced-search.less
+++ b/packages/framework/src/Resources/styles/admin/components/box/advanced-search.less
@@ -14,7 +14,7 @@
 
             &--small {
                 padding: 0 5px 0 0;
-                flex: 0 25px;
+                width: 25px;
 
                 text-align: right;
 

--- a/packages/framework/src/Resources/styles/admin/components/window/fixed-bar.less
+++ b/packages/framework/src/Resources/styles/admin/components/window/fixed-bar.less
@@ -91,7 +91,7 @@
         }
 
         &__cell {
-            flex: 0 100%;
+            width: 100%;
 
             color: @color-blue;
 

--- a/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
@@ -1,8 +1,4 @@
-<!DOCTYPE html>
-<!--[if IE 7 ]>    <html lang="{{ app.request.locale }}" class="ie7 no-js"> <![endif]-->
-<!--[if IE 8 ]>    <html lang="{{ app.request.locale }}" class="ie8 no-js"> <![endif]-->
-<!--[if IE 9 ]>    <html lang="{{ app.request.locale }}" class="ie9 no-js"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html lang="{{ app.request.locale }}" class="no-js"> <!--<![endif]-->
+<html lang="{{ app.request.locale }}" class="no-js">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,9 +6,6 @@
 
         <link rel="stylesheet" type="text/css" href="{{ asset('assets/admin/styles/index_' ~ getCssVersion() ~ '.css') }}" media="screen, projection">
         <link rel="stylesheet" type="text/css" href="{{ asset('bundles/bmatznerjqueryui/css/flick/jquery-ui.css') }}">
-        <!--[if IE 8 ]>
-            <link rel="stylesheet" type="text/css" href="{{ asset('assets/admin/styles/index_' ~ getCssVersion() ~ '-ie8.css') }}" media="screen, projection">
-        <![endif]-->
 
         {# bootstrap/tooltip.js must be imported before bootstrap/popover.js #}
         {{ importJavascripts([

--- a/project-base/package.json
+++ b/project-base/package.json
@@ -15,7 +15,6 @@
         "grunt-cli": "^1.3.2",
         "grunt-contrib-less": "^2.0.0",
         "grunt-contrib-watch": "^1.1.0",
-        "grunt-legacssy": "shopsys/grunt-legacssy#v0.4.0-with-grunt1-support",
         "grunt-postcss": "^0.9.0",
         "grunt-spritesmith": "^6.6.2",
         "grunt-webfont": "^1.7.2",

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/cart-empty.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/cart-empty.less
@@ -7,22 +7,10 @@
     align-items: center;
     margin-bottom: @margin-gap;
 
-    .is-no-flex & {
-        display: block;
-
-        font-size: 0;
-    }
-
     &__image {
         flex: 1;
         padding-right: @box-cart-empty-gap-mobile;
         text-align: center;
-
-        .is-no-flex & {
-            display: inline-block;
-            vertical-align: middle;
-            width: 100%/2;
-        }
 
         @media @query-lg {
             padding-right: @box-cart-empty-gap-desktop;
@@ -35,12 +23,6 @@
         text-align: center;
 
         font-size: 12px;
-
-        .is-no-flex & {
-            display: inline-block;
-            vertical-align: middle;
-            width: 100%/2;
-        }
 
         @media @query-md {
             font-size: 14px;

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/chooser.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/chooser.less
@@ -3,7 +3,7 @@
 @box-chooser-check-width: 20px;
 @box-chooser-image-width: 40px;
 @box-chooser-price-width: 80px;
-@box-chooser-title-width: ~"calc(100% - @{box-chooser-check-width} - @{box-chooser-image-width} - @{box-chooser-price-width} - 2 * @{box-chooser-item-padding})";
+@box-chooser-title-width: ~"calc(100% - @{box-chooser-check-width} - @{box-chooser-image-width} - @{box-chooser-price-width})";
 
 
 .box-chooser {
@@ -17,38 +17,18 @@
         display: flex;
         align-items: flex-start;
 
-        .is-no-flex & {
-            display: block;
-            .clearfix();
-        }
-
         &__check {
-            flex: 0 @box-chooser-check-width;
-
-            .is-no-flex & {
-                float: left;
-                width: @box-chooser-check-width;
-            }
+            width: @box-chooser-check-width;
         }
 
         &__image {
-            flex: 0 @box-chooser-image-width;
+            width: @box-chooser-image-width;
             text-align: center;
-
-            .is-no-flex & {
-                float: left;
-                width: @box-chooser-image-width;
-            }
         }
 
         &__title {
-            flex: 1;
+            width: @box-chooser-title-width;
             padding: 0 10px;
-
-            .is-no-flex & {
-                float: left;
-                width: @box-chooser-title-width;
-            }
 
             .box-chooser__item--inactive & {
                 color: @color-inactive;
@@ -56,15 +36,10 @@
         }
 
         &__price {
-            flex: 0 @box-chooser-price-width;
+            width: @box-chooser-price-width;
             text-align: right;
 
             font-weight: bold;
-
-            .is-no-flex & {
-                float: right;
-                width: @box-chooser-price-width;
-            }
 
             .box-chooser__item--active & {
                 color: @color-price-main;

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/cookies.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/cookies.less
@@ -29,30 +29,13 @@
         justify-content: center;
         width: 100%;
 
-        .is-no-flex & {
-            display: block;
-            text-align: center;
-        }
-
         @media @query-xl {
             margin: 0 auto;
             width: @box-cookies-width;
         }
     }
 
-    &__text {
-        .is-no-flex & {
-            display: inline-block;
-            vertical-align: middle;
-        }
-    }
-
     &__btn {
         padding-left: 10px;
-
-        .is-no-flex & {
-            display: inline-block;
-            vertical-align: middle;
-        }
     }
 }

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/error-page.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/error-page.less
@@ -3,25 +3,11 @@
     align-items: center;
     flex-wrap: wrap;
 
-    .is-no-flex & {
-        display: block;
-        .clearfix();
-    }
-
     &__text {
-        flex: 0 100%;
-
-        .is-no-flex & {
-            width: 100%;
-        }
+        width: 100%;
 
         @media @query-md {
-            flex: 1;
-
-            .is-no-flex & {
-                float: left;
-                width: 100%/2;
-            }
+            width: 100%/2;
         }
 
         &__main {
@@ -30,20 +16,11 @@
     }
 
     &__image {
-        flex: 0 100%;
+        width: 100%;
         text-align: center;
 
-        .is-no-flex & {
-            width: 100%;
-        }
-
         @media @query-md {
-            flex: 1;
-
-            .is-no-flex & {
-                float: left;
-                width: 100%/2;
-            }
+            width: 100%/2;
         }
     }
 }

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/order.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/order.less
@@ -5,23 +5,13 @@
     @media @query-lg {
         width: 100%;
         display: flex;
-
-        .is-no-flex & {
-            display: block;
-            .clearfix();
-        }
     }
 
     &__info {
         margin-bottom: @margin-gap;
 
         @media @query-lg {
-            flex: 0 @box-order-info-width;
-
-            .is-no-flex & {
-                float: left;
-                width: @box-order-info-width;
-            }
+            width: @box-order-info-width;
         }
     }
 
@@ -29,13 +19,8 @@
         margin-bottom: @margin-gap;
 
         @media @query-lg {
-            flex: 0 @box-order-cart-width;
+            width: @box-order-cart-width;
             padding-left: 20px;
-
-            .is-no-flex & {
-                float: right;
-                width: @box-order-cart-width;
-            }
         }
 
         @media @query-vl {

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/progress.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/box/progress.less
@@ -7,24 +7,13 @@
     width: 100%;
     margin-bottom: @margin-gap;
 
-    .is-no-flex & {
-        display: block;
-        .clearfix();
-    }
-
     &__item {
-        flex: 1;
+        width: 100%/@box-progress-steps-count;
         display: flex;
         align-items: center;
 
         background: @color-light;
         border-left: 1px solid @color-f;
-
-        .is-no-flex & {
-            float: left;
-            width: 100%/@box-progress-steps-count;
-            display: block;
-        }
 
         &:first-child {
             border-left: 0;
@@ -51,10 +40,6 @@
             text-align: center;
 
             font-size: 12px;
-
-            .is-no-flex & {
-                display: block;
-            }
 
             @media @query-lg {
                 font-size: 14px;

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/in/action.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/in/action.less
@@ -7,22 +7,12 @@
         width: 100%;
         display: flex;
         align-items: center;
-
-        .is-no-flex & {
-            display: block;
-            .clearfix();
-        }
     }
 
     &__left {
         @media @query-md {
+            width: 100%/2;
             order: 1;
-            flex: 1;
-
-            .is-no-flex & {
-                float: left;
-                width: 100%/2;
-            }
         }
     }
 
@@ -31,14 +21,9 @@
 
         @media @query-md {
             order: 2;
-            flex: 1;
+            width: 100%/2;
             margin-bottom: 0;
             text-align: right;
-
-            .is-no-flex & {
-                float: right;
-                width: 100%/2;
-            }
         }
     }
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/categories.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/categories.less
@@ -40,40 +40,22 @@
 
             text-decoration: none;
             border: 1px solid @color-border;
-
-            .is-no-flex & {
-                display: block;
-
-                font-size: 0;
-            }
         }
 
         &__image {
             padding: @list-categories-item-padding 0 @list-categories-item-padding @list-categories-item-padding;
-            flex: 0 @list-categories-item-image-width;
+            width: @list-categories-item-image-width;
             text-align: center;
-
-            .is-no-flex & {
-                display: inline-block;
-                vertical-align: middle;
-                width: @list-categories-item-image-width;
-            }
         }
 
         &__title {
-            flex: 1;
+            width: calc(~"100% - @{list-categories-item-image-width}");
             margin: 0;
             line-height: 16px;
             padding: @list-categories-item-padding;
 
             font-size: 12px;
             font-weight: bold;
-
-            .is-no-flex & {
-                display: inline-block;
-                vertical-align: middle;
-                width: ~"calc(100% - @{list-categories-item-image-width})";
-            }
         }
     }
 }

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/products-line.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/products-line.less
@@ -28,33 +28,18 @@
 
             text-decoration: none;
             color: @color-base;
-
-            .is-no-flex & {
-                display: block;
-                .clearfix();
-            }
         }
 
         &__position {
-            flex: 0 @list-products-line-item-postion-width;
+            width: @list-products-line-item-postion-width;
 
             font-size: 14px;
-
-            .is-no-flex & {
-                width: @list-products-line-item-postion-width;
-                float: left;
-            }
         }
 
         &__image {
-            flex: 0 @list-products-line-item-image-width;
+            width: @list-products-line-item-image-width;
             padding-right: @list-products-line-item-gap;
             text-align: center;
-
-            .is-no-flex & {
-                width: @list-products-line-item-image-width;
-                float: left;
-            }
 
             img {
                 display: block;
@@ -62,39 +47,23 @@
         }
 
         &__title {
-            flex: 1;
+            width: @list-products-line-item-title-width-mobile;
             margin-bottom: 0;
             padding-left: @list-products-line-item-gap;
 
             font-size: 14px;
             font-weight: bold;
 
-            .is-no-flex & {
-                width: @list-products-line-item-title-width-mobile;
-                float: left;
-
-                @media @query-md {
-                    width: @list-products-line-item-title-width;
-                }
+            @media @query-md {
+                width: @list-products-line-item-title-width;
             }
         }
 
         &__price {
-            flex: 0 100%;
-
-            .is-no-flex & {
-                width: 100%;
-                clear: both;
-            }
+            width: 100%;
 
             @media @query-md {
-                flex: 0 @list-products-line-item-price-width;
-
-                .is-no-flex & {
-                    float: left;
-                    width: @list-products-line-item-price-width;
-                    clear: none;
-                }
+                width: @list-products-line-item-price-width;
             }
 
             &__item {

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/products.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/products.less
@@ -4,6 +4,7 @@
 @list-products-item-image-height: 120px;
 @list-products-item-title-line-height: 18px;
 @list-products-item-description-line-height: 16px;
+@list-products-item-min-height: 353px;
 
 @list-products-line-count-sm: 2;
 @list-products-line-count-md: 3;
@@ -69,10 +70,11 @@
         }
 
         &__in {
-            padding: @list-products-item-padding;
             flex: 1;
             display: flex;
             flex-direction: column;
+            padding: @list-products-item-padding;
+            min-height: @list-products-item-min-height;
         }
 
         &__block {
@@ -107,6 +109,7 @@
 
         &__image {
             height: @list-products-item-image-height;
+            min-height: @list-products-item-image-height;
             position: relative;
             margin-bottom: @list-products-item-inner-gap;
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/products.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/list/products.less
@@ -27,86 +27,44 @@
         margin-left: -@list-products-item-gap;
     }
 
-    .is-no-flex & {
-        display: block;
-        .clearfix();
-    }
-
     &__item {
-        flex: 0 100%;
+        width: 100%;
         display: flex;
         flex-direction: column;
         margin-bottom: @margin-gap;
         padding-left: @list-products-item-gap;
 
-        .is-no-flex & {
-            display: block;
-            float: left;
-        }
-
         @media @query-sm {
-            flex: 0 100%/@list-products-line-count-sm;
-
-            .is-no-flex & {
-                width: 100%/@list-products-line-count-sm;
-            }
+            width: 100%/@list-products-line-count-sm;
         }
 
         @media @query-md {
-            flex: 0 100%/@list-products-line-count-md;
-
-            .is-no-flex & {
-                width: 100%/@list-products-line-count-md;
-            }
+            width: 100%/@list-products-line-count-md;
         }
 
         @media @query-lg {
-            flex: 0 100%/@list-products-line-count-lg;
-
-            .is-no-flex & {
-                width: 100%/@list-products-line-count-lg;
-            }
+            width: 100%/@list-products-line-count-lg;
         }
 
         @media @query-vl {
-            flex: 0 100%/@list-products-line-count-vl;
-
-            .is-no-flex & {
-                width: 100%/@list-products-line-count-vl;
-            }
+            width: 100%/@list-products-line-count-vl;
         }
 
         .list-products--in-window & {
             @media @query-sm {
-                flex: 0 100%/@list-products-line-in-window-count-sm;
-
-                .is-no-flex & {
-                    width: 100%/@list-products-line-in-window-count-sm;
-                }
+                width: 100%/@list-products-line-in-window-count-sm;
             }
 
             @media @query-md {
-                flex: 0 100%/@list-products-line-in-window-count-md;
-
-                .is-no-flex & {
-                    width: 100%/@list-products-line-in-window-count-md;
-                }
+                width: 100%/@list-products-line-in-window-count-md;
             }
 
             @media @query-lg {
-                flex: 0 100%/@list-products-line-in-window-count-lg;
-
-                .is-no-flex & {
-                    width: 100%/@list-products-line-in-window-count-lg;
-                }
+                width: 100%/@list-products-line-in-window-count-lg;
             }
 
             @media @query-vl {
-                flex: 0 100%/@list-products-line-in-window-count-vl;
-
-                .is-no-flex & {
-                    width: 100%/@list-products-line-in-window-count-vl;
-                }
+                width: 100%/@list-products-line-in-window-count-vl;
             }
         }
 
@@ -115,10 +73,6 @@
             flex: 1;
             display: flex;
             flex-direction: column;
-
-            .is-no-flex & {
-                display: block;
-            }
         }
 
         &__block {
@@ -128,10 +82,6 @@
 
             text-decoration: none;
             color: @color-base;
-
-            .is-no-flex & {
-                display: block;
-            }
 
             &:hover {
                 text-decoration: none;
@@ -149,10 +99,6 @@
             font-weight: normal;
             color: @color-link;
             transition: @transition color;
-
-            .is-no-flex & {
-                .eliminate-lines(@list-products-item-title-line-height, 2);
-            }
 
             .list-products__item__block:hover & {
                 color: @color-link-hover;
@@ -176,13 +122,8 @@
             width: 100%;
             margin-bottom: @list-products-item-inner-gap;
 
-            .is-no-flex & {
-                display: block;
-                .clearfix();
-            }
-
             &__description {
-                flex: 0 100%;
+                width: 100%;
                 .eliminate-lines(@list-products-item-description-line-height, 4);
                 margin-bottom: @list-products-item-inner-gap;
 
@@ -190,13 +131,8 @@
             }
 
             &__price {
-                flex: 0 100%/2;
+                width: 100%/2;
                 padding-right: 5px;
-
-                .is-no-flex & {
-                    float: left;
-                    width: 100%/2;
-                }
 
                 &__item {
                     display: block;
@@ -213,16 +149,11 @@
             }
 
             &__availability {
-                flex: 0 100%/2;
+                width: 100%/2;
                 padding-left: 5px;
                 text-align: right;
 
                 font-size: 12px;
-
-                .is-no-flex & {
-                    float: right;
-                    width: 100%/2;
-                }
             }
         }
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/table/variants.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/table/variants.less
@@ -51,11 +51,11 @@
             border: 1px solid @color-border;
 
             tbody & {
-                flex: 0 calc( ~"100% / 2 - @{table-variants-item-gap-mobile}" );
+                width: calc( ~"100% / 2 - @{table-variants-item-gap-mobile}" );
                 margin-left: @table-variants-item-gap-mobile;
 
                 @media @query-mobile-xs-nested {
-                    flex: 0 100%;
+                    width: 100%;
                     margin-left: 0;
                 }
             }

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/window/popup.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/components/window/popup.less
@@ -27,12 +27,12 @@
     transition: @transition transform;
     border-radius: @radius;
 
-    .is-no-flex &, .is-safari &, .is-flex-popup-height-issue-detected & {
+    .is-safari &, .is-flex-popup-height-issue-detected & {
         display: block;
         .clearfix();
     }
 
-    .is-no-flex &, .is-safari &, .is-flex-popup-height-issue-detected & {
+    .is-safari &, .is-flex-popup-height-issue-detected & {
         display: block;
     }
 
@@ -110,11 +110,6 @@
                 align-items: center;
                 justify-content: space-between;
             }
-
-            .is-no-flex & {
-                display: block;
-                .clearfix();
-            }
         }
 
         &__btn {
@@ -145,13 +140,6 @@
                 @media @query-sm {
                     order: -1;
                 }
-
-                .window-popup__actions--multiple-buttons & {
-                    .is-no-flex & {
-                        float: left;
-                    }
-                }
-
             }
 
             &--continue {
@@ -159,12 +147,6 @@
                     transform: rotate(-90deg);
                     float: right;
                     margin: 0 0 0 @window-popup-button-icon-gap;
-                }
-
-                .window-popup__actions--multiple-buttons & {
-                    .is-no-flex & {
-                        float: right;
-                    }
                 }
             }
         }

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/footer.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/footer.less
@@ -34,7 +34,7 @@
 
     &__form  {
         @media @query-lg {
-            flex: 0 @footer-newsletter-form-width;
+            width: @footer-newsletter-form-width;
         }
 
         &__wrap {
@@ -61,7 +61,7 @@
             width: 100%;
 
             @media @query-sm {
-                flex: 0 @footer-newsletter-button-width;
+                width: @footer-newsletter-button-width;
             }
         }
     }
@@ -99,14 +99,14 @@
         margin-bottom: 10px;
 
         @media @query-lg {
-            flex: 0 100%/2;
+            width: 100%/2;
             margin-bottom: 0;
         }
     }
 
     &__articles {
         @media @query-lg {
-            flex: 0 100%/2;
+            width: 100%/2;
             text-align: right;
         }
     }

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/header/search.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/header/search.less
@@ -7,19 +7,9 @@
     &__form {
         display: flex;
 
-        .is-no-flex & {
-            display: block;
-            .clearfix();
-        }
-
         &__input {
-            flex: 1;
+            width: ~"calc(100% - @{search-button-width})";
             position: relative;
-
-            .is-no-flex & {
-                float: left;
-                width: ~"calc(100% - @{search-button-width})";
-            }
 
             .input {
                 padding-left: 30px;
@@ -28,14 +18,10 @@
         }
 
         &__button {
-            flex: 0 @search-button-width;
+            width: @search-button-width;
             height: @search-form-height;
             line-height: @search-form-height;
             padding: 0;
-
-            .is-no-flex & {
-                width: @search-button-width;
-            }
         }
 
         &__icon {
@@ -99,7 +85,7 @@
         &__image {
             position: relative;
             height: 30px;
-            flex: 0 30px;
+            width: 30px;
 
             img {
                 .center-image();

--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/layout.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/layout/layout.less
@@ -11,7 +11,7 @@ img {
     width: 100%;
     min-height: 100%;
 
-    .is-no-flex &, .is-safari & {
+    .is-safari & {
         display: block;
     }
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Layout/base.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Layout/base.html.twig
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<!--[if IE 7 ]>    <html lang="{{ app.request.locale }}" class="ie7 no-js"> <![endif]-->
-<!--[if IE 8 ]>    <html lang="{{ app.request.locale }}" class="ie8 no-js"> <![endif]-->
-<!--[if IE 9 ]>    <html lang="{{ app.request.locale }}" class="ie9 no-js"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html lang="{{ app.request.locale }}" class="no-js"> <!--<![endif]-->
+<html lang="{{ app.request.locale }}" class="no-js">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -11,10 +8,6 @@
         {% block meta_robots %}{% endblock %}
 
         <link rel="stylesheet" type="text/css" href="{{ asset('assets/frontend/styles/index' ~ getDomain().id ~ '_' ~ getCssVersion() ~ '.css') }}" media="screen, projection">
-        <!--[if lte IE 8 ]>
-            <link rel="stylesheet" type="text/css" href="{{ asset('assets/frontend/styles/index' ~ getDomain().id ~ '_' ~ getCssVersion() ~ '-ie8.css') }}" media="screen, projection">
-        <![endif]-->
-
         <link rel="stylesheet" type="text/css" href="{{ asset('assets/frontend/styles/print' ~ getDomain().id ~ '_' ~ getCssVersion() ~ '.css') }}" media="print">
 
         {# bootstrap/tooltip.js must be imported before bootstrap/popover.js #}

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Layout/blank.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Layout/blank.html.twig
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
-<!--[if IE 7 ]>    <html lang="{{ app.request.locale }}" class="ie7 no-js"> <![endif]-->
-<!--[if IE 8 ]>    <html lang="{{ app.request.locale }}" class="ie8 no-js"> <![endif]-->
-<!--[if IE 9 ]>    <html lang="{{ app.request.locale }}" class="ie9 no-js"> <![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--> <html lang="{{ app.request.locale }}" class="no-js"> <!--<![endif]-->
+<html lang="{{ app.request.locale }}" class="no-js">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Grunt/gruntfile.js.twig
@@ -89,39 +89,12 @@ module.exports = function(grunt) {
         postcss: {
             options: {
                 processors: [
-                    require('autoprefixer')({browsers: ['last 3 versions', 'ios 6', 'Safari 7', 'Safari 8', 'ie 7', 'ie 8', 'ie 9']})
+                    require('autoprefixer')({browserlist: ['last 3 versions']})
                 ]
             },
             dist: {
                 src: ['web/assets/frontend/styles/*.css', 'web/assets/admin/styles/*.css']
             }
-        },
-
-        legacssy: {
-            admin: {
-                options: {
-                    legacyWidth: 1200,
-                    matchingOnly: false,
-                    overridesOnly: false
-                },
-                files: {
-                    'web/assets/admin/styles/index_{{ cssVersion }}-ie8.css': 'web/assets/admin/styles/index_{{ cssVersion }}.css'
-                }
-            },
-
-            {% for domain in domains -%}
-                frontend{{ domain.id }}: {
-                    options: {
-                        legacyWidth: 1200,
-                        matchingOnly: false,
-                        overridesOnly: false
-                    },
-                    files: {
-                        'web/assets/frontend/styles/index{{ domain.id }}_{{ cssVersion }}-ie8.css': 'web/assets/frontend/styles/index{{ domain.id }}_{{ cssVersion }}.css'
-                    }
-                }{% if not loop.last %},{% endif %}
-
-            {% endfor -%}
         },
 
         sprite: {
@@ -329,15 +302,15 @@ module.exports = function(grunt) {
     });
     grunt.loadNpmTasks('grunt-spritesmith');
 
-    grunt.registerTask('default', ["sprite:admin", "sprite:frontend", "webfont", "less", "postcss", "legacssy"]);
+    grunt.registerTask('default', ["sprite:admin", "sprite:frontend", "webfont", "less", "postcss"]);
 
     {% for domain in domains -%}
-        grunt.registerTask('frontend{{ domain.id }}', ['webfont:frontend', 'sprite:frontend', 'less:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'legacssy:frontend{{ domain.id }}', 'less:wysiwyg{{ domain.id }}'], 'postcss');
+        grunt.registerTask('frontend{{ domain.id }}', ['webfont:frontend', 'sprite:frontend', 'less:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'less:wysiwyg{{ domain.id }}'], 'postcss');
     {% endfor -%}
-    grunt.registerTask('admin', ['sprite:admin', 'webfont:admin', 'less:admin', 'legacssy:admin' ]);
+    grunt.registerTask('admin', ['sprite:admin', 'webfont:admin', 'less:admin']);
 
     {% for domain in domains -%}
-        grunt.registerTask('frontendLess{{ domain.id }}', ['less:frontend{{ domain.id }}', 'legacssy:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'less:wysiwyg{{ domain.id }}']);
+        grunt.registerTask('frontendLess{{ domain.id }}', ['less:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'less:wysiwyg{{ domain.id }}']);
     {% endfor -%}
-    grunt.registerTask('adminLess', ['less:admin', 'legacssy:admin' ]);
+    grunt.registerTask('adminLess', ['less:admin']);
 };

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -484,7 +484,7 @@ There you can find links to upgrade notes for other versions too.
         + </div>
     ```
 
-- if you want to remove old Internet Explorer support ([#1461]https://github.com/shopsys/shopsys/pull/1461)
+- remove old Internet Explorer support ([#1461](https://github.com/shopsys/shopsys/pull/1461))
     - search all less files and remove `.is-no-flex` and all definitions in it.
     - search all less files and unify flex width definition like
         ```diff

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -541,6 +541,7 @@ There you can find links to upgrade notes for other versions too.
         - grunt.registerTask('adminLess', ['less:admin', 'legacssy:admin' ]);
         + grunt.registerTask('adminLess', ['less:admin']);
         ```
+        - for more information you can see the [PR](https://github.com/shopsys/shopsys/pull/1461)
 
 
 

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -484,6 +484,66 @@ There you can find links to upgrade notes for other versions too.
         + </div>
     ```
 
+- if you want to remove old Internet Explorer support ([#1461]https://github.com/shopsys/shopsys/pull/1461)
+    - search all less files and remove `.is-no-flex` and all definitions in it.
+    - search all less files and unify flex width definition like
+        ```diff
+        - flex: 0 100%;
+        + width: 100%;
+        ```
+    - remove old Internet explorer metatags from page header (search and remove in whole project-base)
+        ```diff
+        - <!--[if IE 7 ]>    <html lang="{{ app.request.locale }}" class="ie7 no-js"> <![endif]-->
+        - <!--[if IE 8 ]>    <html lang="{{ app.request.locale }}" class="ie8 no-js"> <![endif]-->
+        - <!--[if IE 9 ]>    <html lang="{{ app.request.locale }}" class="ie9 no-js"> <![endif]-->
+        - <!--[if (gt IE 9)|!(IE)]><!--> <html lang="{{ app.request.locale }}" class="no-js"> <!--<![endif]-->
+        + <html lang="{{ app.request.locale }}" class="no-js">;
+        ```
+        ```diff
+        - <!--[if lte IE 8 ]>
+        -     <link rel="stylesheet" type="text/css" href="{{ asset('assets/frontend/styles/index' ~ getDomain().id ~ '_' ~ getCssVersion() ~ '-ie8.css') }}" media="screen, projection">
+        - <![endif]-->
+        ```
+    - update `package.json` and remove legacssy
+        ```diff
+        - "grunt-legacssy": "shopsys/grunt-legacssy#v0.4.0-with-grunt1-support",
+        ```
+    - update `gruntfile.js.twig`
+        Update autoprefixer settings to `Last 3 versions` and update settings variable name to `browserlist`
+        ```diff
+        - require('autoprefixer')({browsers: ['last 3 versions', 'ios 6', 'Safari 7', 'Safari 8', 'ie 7', 'ie 8', 'ie 9']})
+        + require('autoprefixer')({browserlist: ['last 3 versions']})
+        ```
+
+        Delete whole legacssy part
+        ```diff
+        -  legacssy: {
+        -     admin: {
+        -        options: {
+        .
+        .
+        .
+        ```
+        Remove legacssy tasks
+        ```diff
+        - grunt.registerTask('default', ["sprite:admin", "sprite:frontend", "webfont", "less", "postcss", "legacssy"]);
+        + grunt.registerTask('default', ["sprite:admin", "sprite:frontend", "webfont", "less", "postcss"]);
+
+        - grunt.registerTask('frontend{{ domain.id }}', ['webfont:frontend', 'sprite:frontend', 'less:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'legacssy:frontend{{ domain.id }}', 'less:wysiwyg{{ domain.id }}'], 'postcss');
+        + grunt.registerTask('frontend{{ domain.id }}', ['webfont:frontend', 'sprite:frontend', 'less:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'less:wysiwyg{{ domain.id }}'], 'postcss');
+
+        - grunt.registerTask('admin', ['sprite:admin', 'webfont:admin', 'less:admin', 'legacssy:admin' ]);
+        + grunt.registerTask('admin', ['sprite:admin', 'webfont:admin', 'less:admin']);
+
+        - grunt.registerTask('frontendLess{{ domain.id }}', ['less:frontend{{ domain.id }}', 'legacssy:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'less:wysiwyg{{ domain.id }}']);
+        + grunt.registerTask('frontendLess{{ domain.id }}', ['less:frontend{{ domain.id }}', 'less:print{{ domain.id }}', 'less:wysiwyg{{ domain.id }}']);
+
+        - grunt.registerTask('adminLess', ['less:admin', 'legacssy:admin' ]);
+        + grunt.registerTask('adminLess', ['less:admin']);
+        ```
+
+
+
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))
     - the `RedisCacheFactory` was deprecated, use DIC configuration in YAML instead

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -395,9 +395,9 @@ There you can find links to upgrade notes for other versions too.
              ) {
         -        parent::__construct($friendlyUrlFacade, $brandFacade, $domain);
         +        parent::__construct($friendlyUrlFacade, $brandFacade, $domain, $imageFacade);
-             } 
+             }
         ```
-    
+
 - improve your data fixtures and tests so they are more resistant against domains and locales settings changes [#1425](https://github.com/shopsys/shopsys/pull/1425)
     - if you have done a lot of changes in your data fixtures you might consider to skip this upgrade
     - for detailed information, see [the separate article](upgrade-instructions-for-improved-data-fixtures-and-tests.md)
@@ -414,7 +414,7 @@ There you can find links to upgrade notes for other versions too.
     ```css
     // load main.less file from framework, variable frameworkResourcesDirectory is set in gruntfile.js
     @import "@{frameworkResourcesDirectory}/styles/admin/main.less";
-  
+
     // file for temporary styles eg. added by a programmer
     @import "todo.less";
     ```
@@ -520,9 +520,8 @@ There you can find links to upgrade notes for other versions too.
         -  legacssy: {
         -     admin: {
         -        options: {
-        .
-        .
-        .
+        // ...
+        -  }
         ```
         Remove legacssy tasks
         ```diff
@@ -542,8 +541,6 @@ There you can find links to upgrade notes for other versions too.
         + grunt.registerTask('adminLess', ['less:admin']);
         ```
         - for more information you can see the [PR](https://github.com/shopsys/shopsys/pull/1461)
-
-
 
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Removed old IE special css hacks, unifyed using flex width, old IE support removed from gruntile - generating special css ie file, updated autopreffixer settings for last browser 3 versions (removes red sign with using browserlist option name too).  
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Result before changes:
![grunt_before_changes](https://user-images.githubusercontent.com/35454496/66560501-d2a19e00-eb57-11e9-891c-12f5fa308167.png)
CSS file size: 84kb + 95kb for old IE

![grunt_after_change](https://user-images.githubusercontent.com/35454496/66560541-e51bd780-eb57-11e9-8ea9-d762eeab1ddf.png)
CSS file size: 66.8kb (no other css files)

