### PR TITLE
[framework] Correctly create prices for transports and payments 

### DIFF
--- a/packages/framework/src/Model/Pricing/Currency/CurrencyFacade.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyFacade.php
@@ -262,12 +262,12 @@ class CurrencyFacade
     protected function createTransportAndPaymentPrices(Currency $currency)
     {
         $toFlush = [];
-        foreach ($this->paymentRepository->getAll() as $payment) {
+        foreach ($this->paymentRepository->getAllIncludingDeleted() as $payment) {
             $paymentPrice = $this->paymentPriceFactory->create($payment, $currency, Money::zero());
             $this->em->persist($paymentPrice);
             $toFlush[] = $paymentPrice;
         }
-        foreach ($this->transportRepository->getAll() as $transport) {
+        foreach ($this->transportRepository->getAllIncludingDeleted() as $transport) {
             $transportPrice = $this->transportPriceFactory->create($transport, $currency, Money::zero());
             $this->em->persist($transportPrice);
             $toFlush[] = $transportPrice;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After you create new currency there is a method `createTransportAndPaymentPrices` that will create prices for transport and payments. The problem is when you have some deleted payments or transports. Because of this function https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Payment/PaymentFacade.php#L200 or this https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Transport/TransportFacade.php#L203 that is called every time you are going to order detail, you will get 404 error because payment price doesn't exist.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
