### PR TITLE
[shopsys] release process: added instruction for fixing docs links when merging to higher branches

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AfterRelease/MergeBranchToTheHigherBranchesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/MergeBranchToTheHigherBranchesReleaseWorker.php
@@ -33,7 +33,8 @@ final class MergeBranchToTheHigherBranchesReleaseWorker extends AbstractShopsysR
     {
         $this->symfonyStyle->note('You need to gradually merge the branch with the new release to all the higher development branches.');
         $this->symfonyStyle->note('E.g. when releasing "7.3.x" version, you need to merge the "7.3" branch to the master branch, and then merge the master branch to the "9.0" branch provided current release series is "8.0"');
-        $this->confirm('Confirm the branch with the released version is merged to all the higher development branches.');
+        $this->symfonyStyle->note('When merging to the higher branch, check the docs and fix the links if necessary. Articles and files should be always linked in the corresponding version, see https://docs.shopsys.com/en/latest/contributing/guidelines-for-writing-documentation/.');
+        $this->confirm('Confirm the branch with the released version is merged to all the higher development branches and the links in the docs are fixed.');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| https://github.com/shopsys/shopsys/issues/1442 - this PR does not add the desired automation, however, at least it should ensure the links in docs are checked (and fixed) on a regular basis
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://github.com/shopsys/shopsys/blob/master/docs/contributing/backward-compatibility-promise.md)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
