### PR TITLE
[shopsys] fixed links to docs in 8.0 branch

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-# For details about this script, see https://docs.shopsys.com/en/7.3/kubernetes/continuous-integration-using-kubernetes/
+# For details about this script, see https://docs.shopsys.com/en/8.0/kubernetes/continuous-integration-using-kubernetes/
 
 # Login to Docker Hub for pushing images into register
 echo ${DOCKER_PASSWORD} | docker login --username ${DOCKER_USERNAME} --password-stdin

--- a/.ci/restart_kubernetes.sh
+++ b/.ci/restart_kubernetes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-# For details about this script, see https://docs.shopsys.com/en/7.3/kubernetes/continuous-integration-using-kubernetes/
+# For details about this script, see https://docs.shopsys.com/en/8.0/kubernetes/continuous-integration-using-kubernetes/
 
 # This restarts the application in Kubernetes, assuming it has been already built
 # Useful after deleting the namespace (via "kubectl delete namespace ${JOB_NAME}")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ You can take part in making Shopsys Framework better.
 * [Create a pull request](https://github.com/shopsys/shopsys/compare)
 * [Report an issue](https://github.com/shopsys/shopsys/issues/new)
 * [Backward Compatibility Promise](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)
-* [Guidelines for Working with Monorepo](https://docs.shopsys.com/en/7.3/introduction/monorepo/)
+* [Guidelines for Working with Monorepo](https://docs.shopsys.com/en/8.0/introduction/monorepo/)
 * [Guidelines for Creating Commits](https://docs.shopsys.com/en/latest/contributing/guidelines-for-creating-commits/)
 * [Guidelines for Writing Documentation](https://docs.shopsys.com/en/latest/contributing/guidelines-for-writing-documentation/)
 * [Guidelines for Pull Request](https://docs.shopsys.com/en/latest/contributing/guidelines-for-pull-request/)
@@ -27,4 +27,4 @@ Apply the same procedure if you make the changes in Dockerfile or docker-compose
 
 These rules ensure that the code will remain consistent and the project is maintainable in the future.
 
-*Tip: Read more about automatic checks in [Console Commands for Application Management (Phing Targets)](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/) and [Running Acceptance Tests](https://docs.shopsys.com/en/7.3/introduction/running-acceptance-tests/).*
+*Tip: Read more about automatic checks in [Console Commands for Application Management (Phing Targets)](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/) and [Running Acceptance Tests](https://docs.shopsys.com/en/8.0/introduction/running-acceptance-tests/).*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The platform is based on one of the best PHP frameworks on the market - **Symfon
 
 ## Shopsys Framework Package Architecture
 These are most important packages and the way they depend on each other.
-For more info see the article [Basics About Package Architecture](https://docs.shopsys.com/en/7.3/introduction/basics-about-package-architecture/) in our knowledge base.
+For more info see the article [Basics About Package Architecture](https://docs.shopsys.com/en/8.0/introduction/basics-about-package-architecture/) in our knowledge base.
 
 ![Shopsys Framework package architecture schema](./docs/img/package-architecture.png 'Shopsys Framework Package Architecture')
 *Note: The specific modules in this diagram are just examples.*
@@ -29,17 +29,17 @@ Shopsys Framework is fully functional e-commerce platform with all basic functio
 * Registered customers
 * Basic orders management
 * Back-end administration
-* Front-end [full-text search](https://docs.shopsys.com/en/7.3/model/front-end-product-searching/) and [product filtering](https://docs.shopsys.com/en/7.3/model/front-end-product-filtering/)
+* Front-end [full-text search](https://docs.shopsys.com/en/8.0/model/front-end-product-searching/) and [product filtering](https://docs.shopsys.com/en/8.0/model/front-end-product-filtering/)
 * 3-step ordering process
 * Basic CMS
-* Support for several currencies, [languages, and domains](https://docs.shopsys.com/en/7.3/introduction/domain-multidomain-multilanguage/)
+* Support for several currencies, [languages, and domains](https://docs.shopsys.com/en/8.0/introduction/domain-multidomain-multilanguage/)
 * Full friendly URL for main entities
 * Performance optimization through Elasticsearch, Redis, PostgreSQL
 * Full core upgradability
 * GDPR compliance
 * Preparation for scalability
-* Manifest for orchestration via [Kubernetes](https://docs.shopsys.com/en/7.3/kubernetes/introduction-to-kubernetes/)
-* Support to easier [deployment to Google Cloud via Terraform](https://docs.shopsys.com/en/7.3/kubernetes/how-to-deploy-ssfw-to-google-cloud-platform/)
+* Manifest for orchestration via [Kubernetes](https://docs.shopsys.com/en/8.0/kubernetes/introduction-to-kubernetes/)
+* Support to easier [deployment to Google Cloud via Terraform](https://docs.shopsys.com/en/8.0/kubernetes/how-to-deploy-ssfw-to-google-cloud-platform/)
 
 ### Plans for next releases
 
@@ -59,21 +59,21 @@ List of typical projects built on previous versions of Shopsys Framework:
 
 ## How to Start a New Project
 The *shopsys/shopsys* package is a monolithic repository, a single development environment, for management of all parts of Shopsys Framework.
-See more information about the monorepo approach in [the Monorepo article](https://docs.shopsys.com/en/7.3/introduction/monorepo/).
+See more information about the monorepo approach in [the Monorepo article](https://docs.shopsys.com/en/8.0/introduction/monorepo/).
 
 For the purposes of building a new project use our [shopsys/project-base](https://github.com/shopsys/project-base),
 which is fully ready as the base for building your Shopsys Framework project.
 
 For more detailed instructions, follow one of the installation guides:
 
-* [Installation Guide](https://docs.shopsys.com/en/7.3/installation/installation-guide/)
-* [Deployment to Google Cloud](https://docs.shopsys.com/en/7.3/kubernetes/how-to-deploy-ssfw-to-google-cloud-platform/)
-* [Installation on production server](https://docs.shopsys.com/en/7.3/installation/installation-using-docker-on-production-server/)
+* [Installation Guide](https://docs.shopsys.com/en/8.0/installation/installation-guide/)
+* [Deployment to Google Cloud](https://docs.shopsys.com/en/8.0/kubernetes/how-to-deploy-ssfw-to-google-cloud-platform/)
+* [Installation on production server](https://docs.shopsys.com/en/8.0/installation/installation-using-docker-on-production-server/)
 
 ## Documentation
-For documentation of Shopsys Framework itself, see [Shopsys Framework Knowledge Base](https://docs.shopsys.com/en/7.3/).
+For documentation of Shopsys Framework itself, see [Shopsys Framework Knowledge Base](https://docs.shopsys.com/en/8.0/).
 
-For the frequently asked questions, see [FAQ and Common Issues](https://docs.shopsys.com/en/7.3/introduction/faq-and-common-issues/).
+For the frequently asked questions, see [FAQ and Common Issues](https://docs.shopsys.com/en/8.0/introduction/faq-and-common-issues/).
 
 ## Contributing
 If you have some ideas or you want to help to improve Shopsys Framework, let us know!
@@ -87,7 +87,7 @@ What to do when you are in troubles or need some help?
 The best way is to contact us on our [Slack](http://slack.shopsys-framework.com/).
 
 If you are experiencing problems during installation or running Shopsys Framework on Docker,
-please see our [Docker troubleshooting](https://docs.shopsys.com/en/7.3/docker/docker-troubleshooting/).
+please see our [Docker troubleshooting](https://docs.shopsys.com/en/8.0/docker/docker-troubleshooting/).
 
 Or ultimately, just [report an issue](https://github.com/shopsys/shopsys/issues/new).
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,7 +34,7 @@ Follow the instructions in the [monorepo upgrade guide](upgrade/upgrading-monore
     * run `php phing db-migrations` to run the database migrations
     * test your app locally
     * commit your changes
-* if any of the database migrations does not suit you, there is an option to skip it, see [our Database Migrations docs](https://docs.shopsys.com/en/7.3/introduction/database-migrations/#reordering-and-skipping-migrations)
+* if any of the database migrations does not suit you, there is an option to skip it, see [our Database Migrations docs](https://docs.shopsys.com/en/8.0/introduction/database-migrations/#reordering-and-skipping-migrations)
 * even we care a lot about these instructions, it is possible we miss something. In case something doesn't work after the upgrade, you'll find more information in the [CHANGELOG](CHANGELOG.md)
 
 ## Upgrade guides

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -14,10 +14,10 @@ This repository is maintained by [shopsys/shopsys] monorepo, information about c
 ## How to Start New Project
 For the purposes of building the new project use our [shopsys/project-base](https://github.com/shopsys/project-base), which is fully ready as the base for building your Shopsys Framework based project.
 
-For more detailed instructions, follow the [Installation Guide](https://docs.shopsys.com/en/7.3/installation/installation-guide/).
+For more detailed instructions, follow the [Installation Guide](https://docs.shopsys.com/en/8.0/installation/installation-guide/).
 
 ## Documentation
-For documentation of Shopsys Framework itself see [Shopsys Framework Knowledge Base](https://docs.shopsys.com/en/7.3/).
+For documentation of Shopsys Framework itself see [Shopsys Framework Knowledge Base](https://docs.shopsys.com/en/8.0/).
 
 Documentation of the specific project built on Shopsys Framework should be in [Project Documentation](https://github.com/shopsys/project-base/blob/master/docs/index.md).
 

--- a/packages/read-model/README.md
+++ b/packages/read-model/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/shopsys/read-model.svg?branch=master)](https://travis-ci.org/shopsys/read-model)
 [![Downloads](https://img.shields.io/packagist/dt/shopsys/read-model.svg)](https://packagist.org/packages/shopsys/read-model)
 
-This bundle for [Shopsys Framework](https://www.shopsys.com) separates templates from model using [read model concept](https://docs.shopsys.com/en/7.3/model/introduction-to-read-model/).
+This bundle for [Shopsys Framework](https://www.shopsys.com) separates templates from model using [read model concept](https://docs.shopsys.com/en/8.0/model/introduction-to-read-model/).
 The bundle is dedicated for projects based on Shopsys Framework (i.e. created from [`shopsys/project-base`](https://github.com/shopsys/project-base)) exclusively.
 
 This repository is maintained by [shopsys/shopsys] monorepo, information about changes is in [monorepo CHANGELOG.md](https://github.com/shopsys/shopsys/blob/master/CHANGELOG.md).

--- a/packages/read-model/src/Image/ImageView.php
+++ b/packages/read-model/src/Image/ImageView.php
@@ -9,7 +9,7 @@ namespace Shopsys\ReadModelBundle\Image;
  *
  * Class representing images in frontend
  *
- * @see https://docs.shopsys.com/en/7.3/model/introduction-to-read-model/
+ * @see https://docs.shopsys.com/en/8.0/model/introduction-to-read-model/
  */
 class ImageView
 {

--- a/packages/read-model/src/Product/Action/ProductActionView.php
+++ b/packages/read-model/src/Product/Action/ProductActionView.php
@@ -10,7 +10,7 @@ namespace Shopsys\ReadModelBundle\Product\Action;
  * Class representing products actions in lists in frontend
  *
  * @see \Shopsys\ReadModelBundle\Product\Listed\ListedProductView
- * @see https://docs.shopsys.com/en/7.3/model/introduction-to-read-model/
+ * @see https://docs.shopsys.com/en/8.0/model/introduction-to-read-model/
  */
 class ProductActionView
 {

--- a/packages/read-model/src/Product/Listed/ListedProductView.php
+++ b/packages/read-model/src/Product/Listed/ListedProductView.php
@@ -14,7 +14,7 @@ use Webmozart\Assert\Assert;
  *
  * Class representing products in lists in frontend
  *
- * @see https://docs.shopsys.com/en/7.3/model/introduction-to-read-model/
+ * @see https://docs.shopsys.com/en/8.0/model/introduction-to-read-model/
  */
 class ListedProductView
 {

--- a/project-base/README.md
+++ b/project-base/README.md
@@ -16,10 +16,10 @@ In the future we want to add new technologies to Shopsys Framework (e.g. Elastic
 because such an update will be done just by running `docker-compose build`.
 And that is all!
 
-Create new project on Shopsys Framework easily from this package following the [Installation Guide](https://docs.shopsys.com/en/7.3/installation/installation-guide/).
+Create new project on Shopsys Framework easily from this package following the [Installation Guide](https://docs.shopsys.com/en/8.0/installation/installation-guide/).
 
 ## Documentation
-For documentation of Shopsys Framework itself see [Shopsys Framework Knowledge Base](https://docs.shopsys.com/en/7.3/).
+For documentation of Shopsys Framework itself see [Shopsys Framework Knowledge Base](https://docs.shopsys.com/en/8.0/).
 
 Documentation of the specific project built on Shopsys Framework should be in [Project Documentation](https://github.com/shopsys/project-base/blob/master/docs/index.md).
 

--- a/project-base/docs/index.md
+++ b/project-base/docs/index.md
@@ -1,6 +1,6 @@
 # Project Documentation
 
 *This is a place where to put any important information that other developers should know about the project. For advices on what should be documented see
-[Guidelines for Project Documentation](https://docs.shopsys.com/en/7.3/project/guidelines-for-project-documentation/)*.
+[Guidelines for Project Documentation](https://docs.shopsys.com/en/8.0/project/guidelines-for-project-documentation/)*.
 
 **{Put the content here}**

--- a/upgrade/UPGRADE-v7.0.0-alpha4.md
+++ b/upgrade/UPGRADE-v7.0.0-alpha4.md
@@ -10,7 +10,7 @@ There you can find links to upgrade notes for other versions too.
 - already existing data object factories changed their signatures
 - to change the last item in admin breadcrumb, use `BreadcrumbOverrider:overrideLastItem(string $label)` instead of `Breadcrumb::overrideLastItem(MenuItem $item)`
 - if you've customized the admin menu by using your own `admin_menu.yml`, implement event listeners instead
-    - see the [Adding a New Administration Page](https://docs.shopsys.com/en/7.3/cookbook/adding-a-new-administration-page/) cookbook for details
+    - see the [Adding a New Administration Page](https://docs.shopsys.com/en/8.0/cookbook/adding-a-new-administration-page/) cookbook for details
 
 ## [shopsys/product-feed-google]
 - move creation of data objects into factories

--- a/upgrade/UPGRADE-v7.0.0-alpha6.md
+++ b/upgrade/UPGRADE-v7.0.0-alpha6.md
@@ -77,7 +77,7 @@ There you can find links to upgrade notes for other versions too.
 - run `php phing ecs-fix` to apply new coding standards - [keep class spacing consistent #384](https://github.com/shopsys/shopsys/pull/384)
 
 ## [shopsys/shopsys]
-- when upgrading your installed [monorepo](https://docs.shopsys.com/en/7.3/introduction/monorepo/), you'll have to change the build context for the images of the microservices in `docker-compose.yml`
+- when upgrading your installed [monorepo](https://docs.shopsys.com/en/8.0/introduction/monorepo/), you'll have to change the build context for the images of the microservices in `docker-compose.yml`
     - `build.context` should be the root of the microservice (eg. `microservices/product-search-export`)
     - `build.dockerfile` should be `docker/Dockerfile`
     - execute `docker-compose up -d --build`, microservices should be up and running

--- a/upgrade/UPGRADE-v7.0.0-beta5.md
+++ b/upgrade/UPGRADE-v7.0.0-beta5.md
@@ -16,7 +16,7 @@ There you can find links to upgrade notes for other versions too.
 - add `!docker/nginx` line into `.dockerignore` file so `docker/nginx` directory is not excluded during building `php-fpm` image ([#674](https://github.com/shopsys/shopsys/pull/674))
 - make sure your `webserver` service depends on `php-fpm` in your `docker-compose.yml` file so webserver will not fail on error `host not found in upstream php-fpm:9000` ([#679](https://github.com/shopsys/shopsys/pull/679))
 - on a production server enable compression of static files ([#703](https://github.com/shopsys/shopsys/pull/703))
-    - you can see example configuration in [Installation using Docker on Production Server](https://docs.shopsys.com/en/7.3/installation/installation-using-docker-on-production-server/) guide
+    - you can see example configuration in [Installation using Docker on Production Server](https://docs.shopsys.com/en/8.0/installation/installation-using-docker-on-production-server/) guide
 - *(low priority)* Switched to Debian PHP-FPM image ([#702](https://github.com/shopsys/shopsys/pull/702))
     - update your Dockerfile to extend from debian image, follow [changes](https://github.com/shopsys/project-base/commit/023d6f20f3d041dce09d381522bd6c438ed9fa59) and [fix #740](https://github.com/shopsys/shopsys/pull/740/files)
     - change `runAsUser` value in `webserver-php-fpm.yml` manifest to 33 as it is Debian default `www-data` UID

--- a/upgrade/UPGRADE-v7.0.0.md
+++ b/upgrade/UPGRADE-v7.0.0.md
@@ -23,7 +23,7 @@ if you want to have products data exported to Elasticsearch after `build-demo` t
 - check whether you extended class or method `ImageFacade::copyImages` or used it in your project and make sure it works like you intended ([#851](https://github.com/shopsys/shopsys/pull/851))
     - *(low priority)* remove `/var/www/html/var/cache` folder from your `@main_filesystem` filesystem storage if exists, set as local filesystem storage in path `%kernel.project_dir%` by default
 - use `Money` class for representing monetary values in the whole application ([#821](https://github.com/shopsys/shopsys/pull/821))
-    - we recommend first reading the article [How to Work with Money](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/) which explains the concept
+    - we recommend first reading the article [How to Work with Money](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/) which explains the concept
     - you can take a look at [what was modified in `shopsys/project-base` during this change](https://github.com/shopsys/project-base/compare/cb6d02f335819aeff575dec01bda5b228263a2eb...c08cac7b55ebc46b43c2e988d36e2f122cbb4598#files_bucket) (24 files)
     - you'll find detailed instructions in separate article [Upgrade Instructions for Money Class](money-class.md)
 - you need to provide `$temporaryFilenames` parameter anywhere you use `ImageFactoryInterface::create()` and `ImageFacade::uploadImage()` functions ([#869](https://github.com/shopsys/shopsys/pull/869))

--- a/upgrade/UPGRADE-v7.2.1.md
+++ b/upgrade/UPGRADE-v7.2.1.md
@@ -16,7 +16,7 @@ There you can find links to upgrade notes for other versions too.
         ```
 - fix the typo in Twig template `@ShopsysShop/Front/Content/Category/panel.html.twig` ([#1043](https://github.com/shopsys/shopsys/pull/1043))
     - `categoriyWithLazyLoadedVisibleChildren` ⟶ `categoryWithLazyLoadedVisibleChildren`
-- create an empty file `app/Resources/.gitkeep` to prepare a folder for [your overwritten templates](https://docs.shopsys.com/en/7.3/cookbook/modifying-a-template-in-administration/) ([#1073](https://github.com/shopsys/shopsys/pull/1073))
+- create an empty file `app/Resources/.gitkeep` to prepare a folder for [your overwritten templates](https://docs.shopsys.com/en/8.0/cookbook/modifying-a-template-in-administration/) ([#1073](https://github.com/shopsys/shopsys/pull/1073))
 - fix `FilterQueryTest` to use ElasticSearch index prefix properly via `ElasticsearchStructureManager` ([#1082](https://github.com/shopsys/shopsys/pull/1082))
     ```diff
     - private const ELASTICSEARCH_INDEX = 'product1';

--- a/upgrade/UPGRADE-v7.3.0.md
+++ b/upgrade/UPGRADE-v7.3.0.md
@@ -91,7 +91,7 @@ There you can find links to upgrade notes for other versions too.
     - you'll find the configuration file in `src/Shopsys/ShopBundle/Resources/config/`
 
 ### Tools
-- use the `build.xml` [Phing configuration](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))
+- use the `build.xml` [Phing configuration](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/) from the `shopsys/framework` package ([#1068](https://github.com/shopsys/shopsys/pull/1068))
     - assuming your `build.xml` and `build-dev.xml` are the same as in `shopsys/project-base` in `v7.2.2`, just remove `build-dev.xml` and replace `build.xml` with this file:
         ```xml
         <?xml version="1.0" encoding="UTF-8"?>
@@ -111,7 +111,7 @@ There you can find links to upgrade notes for other versions too.
         </project>
         ```
     - if there are any changes in the your phing configuration, you'll need to make some customizations
-        - read about [customization of phing targets and properties](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/#customization-of-phing-targets-and-properties) in the docs
+        - read about [customization of phing targets and properties](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/#customization-of-phing-targets-and-properties) in the docs
         - if you have some own additional target definitions, copy them into your `build.xml`
         - if you have modified any targets, overwrite them in your `build.xml`
             - examine the target in the `shopsys/framework` package (either on [GitHub](https://github.com/shopsys/shopsys/blob/7.3/packages/framework/build.xml) or locally in `vendor/shopsys/framework/build.xml`)
@@ -156,7 +156,7 @@ There you can find links to upgrade notes for other versions too.
         ```
     - in other places you might have used it in your custom code
 - follow instructions in [the separate article](upgrade-instructions-for-read-model-for-product-lists.md) to introduce read model for frontend product lists into your project ([#1018](https://github.com/shopsys/shopsys/pull/1018))
-    - we recommend to read [Introduction to Read Model](https://docs.shopsys.com/en/7.3/model/introduction-to-read-model/) article
+    - we recommend to read [Introduction to Read Model](https://docs.shopsys.com/en/8.0/model/introduction-to-read-model/) article
 - copy a new functional test to avoid regression of issues with creating product variants in the future ([#1113](https://github.com/shopsys/shopsys/pull/1113))
     - you can copy-paste the class [`ProductVariantCreationTest.php`](https://github.com/shopsys/project-base/blob/v7.3.0/tests/ShopBundle/Functional/Model/Product/ProductVariantCreationTest.php) into `tests/ShopBundle/Functional/Model/Product/` in your project
 - prevent indexing `CustomerPassword:setNewPassword` by robots ([#1119](https://github.com/shopsys/shopsys/pull/1119))

--- a/upgrade/interchangeable-filtering.md
+++ b/upgrade/interchangeable-filtering.md
@@ -9,7 +9,7 @@ we decided to allow to use either the current (SQL) or the newly created (Elasti
 Thanks to this, you can still easily upgrade to the new version without the need to rewrite your application
 or use faster filtering with Elasticsearch we were able to deliver in the minor version as it does not break our BC promise.
 
-You can learn more about [Product filtering](https://docs.shopsys.com/en/7.3/model/front-end-product-filtering/) in the particular article.
+You can learn more about [Product filtering](https://docs.shopsys.com/en/8.0/model/front-end-product-filtering/) in the particular article.
 
 ## Use current SQL Filtering
 You can still filter products via SQL if your filtering is more complex and/or you don't want to implement your custom modification in Elasticsearch.

--- a/upgrade/money-class.md
+++ b/upgrade/money-class.md
@@ -6,7 +6,7 @@ Follow these instructions only if you upgrade from `v7.0.0-beta6` to `v7.0.0`.
 
 All monetary values (*prices, account balances, discount amounts, price limits etc.*) should be represented by an instance of the class `\Shopsys\FrameworkBundle\Component\Money\Money`.
 
-Before the upgrade, we recommend reading the article [How to Work with Money](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/) which explains the concept in detail.
+Before the upgrade, we recommend reading the article [How to Work with Money](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/) which explains the concept in detail.
 
 **When in doubt, you can take a look at [what was modified in `shopsys/project-base` during this change](https://github.com/shopsys/project-base/compare/cb6d02f335819aeff575dec01bda5b228263a2eb...c08cac7b55ebc46b43c2e988d36e2f122cbb4598#files_bucket).**
 
@@ -24,7 +24,7 @@ Register the new Doctrine type in `doctrine.dbal.types` in your `app/config/pack
 ```
 
 ## Extended and Custom Entities
-If you have created your custom entities that store monetary value or added a new such column [by entity extension](https://docs.shopsys.com/en/7.3/extensibility/entity-extension/), change your `decimal` Doctrine type to the new `money` type:
+If you have created your custom entities that store monetary value or added a new such column [by entity extension](https://docs.shopsys.com/en/8.0/extensibility/entity-extension/), change your `decimal` Doctrine type to the new `money` type:
 
 ```diff
   /**
@@ -36,14 +36,14 @@ If you have created your custom entities that store monetary value or added a ne
   protected $myMonetaryValue;
 ```
 
-If you do so, you'll have to create [a database migration](https://docs.shopsys.com/en/7.3/introduction/database-migrations/) which will add a `(DC2Type:money)` comment on the columns, informing Doctrine about the specified type (similarly to the [`Version20190215092226`](https://github.com/shopsys/shopsys/blob/7.3/packages/framework/src/Migrations/Version20190215092226.php) in `shopsys/framework`).
+If you do so, you'll have to create [a database migration](https://docs.shopsys.com/en/8.0/introduction/database-migrations/) which will add a `(DC2Type:money)` comment on the columns, informing Doctrine about the specified type (similarly to the [`Version20190215092226`](https://github.com/shopsys/shopsys/blob/7.3/packages/framework/src/Migrations/Version20190215092226.php) in `shopsys/framework`).
 
-Because the entity property now changed the type, its usages (along with the related [entity data class](https://docs.shopsys.com/en/7.3/model/entities/#entity-data)) have to be reviewed and changed as well.
+Because the entity property now changed the type, its usages (along with the related [entity data class](https://docs.shopsys.com/en/8.0/model/entities/#entity-data)) have to be reviewed and changed as well.
 We recommend using type-hinting in the changed methods as explained in [Working With Money in PHP](#working-with-money-in-php) below.
 
-If you need to set a value to the property in these custom entities or data objects directly, you should use the `Money::create()` method that accepts a string or an integer (or another [construction method](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#construction)).
+If you need to set a value to the property in these custom entities or data objects directly, you should use the `Money::create()` method that accepts a string or an integer (or another [construction method](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#construction)).
 
-For more details read [the Money in Doctrine section](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#money-in-doctrine) of the documentation.
+For more details read [the Money in Doctrine section](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#money-in-doctrine) of the documentation.
 
 ## Working With Money in PHP
 You should use `Money` for all monetary values across your project.
@@ -54,12 +54,12 @@ If you need to compute money, use its methods `add`, `subtract`, `multiply` and 
 If you need to compare two instances of `Money`, use its methods `equals`, `isGreaterThan`, `isGreaterThanOrEqualTo`, `isLessThan`, `isLessThanOrEqualTo` and `compare` instead of the operators `==`/`===`, `>`, `>=`, `<`, `<=` and `<=>`.
 If you want to compare `Money` with zero, you can use the methods `isZero`, `isPositive` and `isNegative`.
 
-For more details read [the Money Class section](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#money-class) of the documentation.
+For more details read [the Money Class section](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#money-class) of the documentation.
 
 There were no changes needed in `shopsys/project-base` as most PHP implementation is in `shopsys/framework`.
 You might need to update your custom classes working with prices and overridden services, because of the changed types.
 
-*Note: Running the `phpstan` [Phing target](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/) will help you find out problems with incompatible method declarations mentioned in this section and in [Strict Typing](#strict-typing) below.*
+*Note: Running the `phpstan` [Phing target](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/) will help you find out problems with incompatible method declarations mentioned in this section and in [Strict Typing](#strict-typing) below.*
 *In case of problems, it will fail on a `PHP Fatal error` with a reference to the incompatible method (unfortunately it is unable to continue with the checks as it cannot recover from this error).*
 
 ## Strict Typing
@@ -88,21 +88,21 @@ Check how you use or extend these classes, into which the statement `declare(str
 - `\Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation`
 - `\Shopsys\FrameworkBundle\Twig\PriceExtension`
 
-*Note: Running the `phpstan` [Phing target](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/) will help you find out problems with incompatible method declarations as mentioned in the note above.*
+*Note: Running the `phpstan` [Phing target](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/) will help you find out problems with incompatible method declarations as mentioned in the note above.*
 
 ## Twig Templates
-Templates mostly use [the `price` Twig filter](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#price) (or one of its `price*` variants) for rendering monetary values.
+Templates mostly use [the `price` Twig filter](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#price) (or one of its `price*` variants) for rendering monetary values.
 The filters work the same way, but they now require an instance of `Money` to be provided.
 If you pass a value of a different type into one of the `price*` filters (it would fail on a `TypeError`) you should check where it came from and fix it there - all monetary values have to be represented by the new `Money` value object.
 Because the monetary value is mostly taken from a `Price` object and its getters use `Money` as a return type now, the templates usually don't need any changes.
 
-*Note: [HTTP smoke tests](https://docs.shopsys.com/en/7.3/introduction/automated-testing/#http-smoke-tests) can be very helpful when finding issues in your templates.*
-*You can run them by executing the `tests-smoke` [Phing target](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/).*
+*Note: [HTTP smoke tests](https://docs.shopsys.com/en/8.0/introduction/automated-testing/#http-smoke-tests) can be very helpful when finding issues in your templates.*
+*You can run them by executing the `tests-smoke` [Phing target](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/).*
 
 There are some cases in which you'll have to modify your templates:
 
 ### Manipulation with money before rendering
-Instead of arithmetic operators, you should use the methods for [computation with Money](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#computation) such as `add`, `subtract`, `multiply`, etc.
+Instead of arithmetic operators, you should use the methods for [computation with Money](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#computation) such as `add`, `subtract`, `multiply`, etc.
 Also, you can use the `Price::inverse()` for inverting the value, which might come handy in presenting discounts.
 
 As an example, see the change in `@ShopsysShop/Front/Content/Order/preview.html.twig` from `shopsys/project-base`:
@@ -112,10 +112,10 @@ As an example, see the change in `@ShopsysShop/Front/Content/Order/preview.html.
 ```
 
 Code manipulating with prices in a complex way does not belong into templates.
-In such situation, you should probably refactor your code and move the logic into your [model](https://docs.shopsys.com/en/7.3/model/introduction-to-model-architecture/).
+In such situation, you should probably refactor your code and move the logic into your [model](https://docs.shopsys.com/en/8.0/model/introduction-to-model-architecture/).
 
 ### Comparing monetary values in templates
-Instead of comparison operators, you should use the methods for [comparing Money](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#comparing) such as `equals`, `isGreaterThan`, `isGreaterOrEqualTo`, etc.
+Instead of comparison operators, you should use the methods for [comparing Money](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#comparing) such as `equals`, `isGreaterThan`, `isGreaterOrEqualTo`, etc.
 To compare a value with zero, you may use `isZero`, `isPositive`, or `isNegative`.
 
 Don't forget to check conditions without any operators (such as `{% if money %}` / `{% if not money %}`).
@@ -138,7 +138,7 @@ As an example, see the change in `@ShopsysShop/Front/Content/PersonalData/orders
 ```
 
 ### Displaying money without a currency symbol
-Instead of rendering a monetary value directly, you should use [the new `moneyFormat` Twig filter](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#moneyformat) which accepts `Money` instances.
+Instead of rendering a monetary value directly, you should use [the new `moneyFormat` Twig filter](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#moneyformat) which accepts `Money` instances.
 So instead of `{{ money }}`, you should use `{{ money|moneyFormat }}`.
 
 See all the changes that were needed in `shopsys/project-base`:
@@ -216,7 +216,7 @@ For inspiration, [see the commit where we implemented the MoneyRange constraint]
 
 *Note: You don't have to specify the option `'currency' => false` for the `MoneyType` field as this is its new default value.*
 
-You'll find more info about the form type and constraints in [the Money in Forms section](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#money-in-forms) of the documentation.
+You'll find more info about the form type and constraints in [the Money in Forms section](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#money-in-forms) of the documentation.
 
 ---
 
@@ -307,7 +307,7 @@ Previously, the `MoneyToLocalizedStringTransformer` (which is a default view tra
 
 ## Data in SettingValue Entities
 The [`Setting`](https://github.com/shopsys/shopsys/blob/7.3/packages/framework/src/Component/Setting/Setting.php) component is now able to save and load [`SettingValue`](https://github.com/shopsys/shopsys/blob/7.3/packages/framework/src/Component/Setting/SettingValue.php) entities with an instance of `Money` as a value.
-To make sure that monetary values that are currently saved as a decimal string will be loaded as a `Money` instance, you have to manually create [a database migration](https://docs.shopsys.com/en/7.3/introduction/database-migrations/) that changes the `type` to `money` for all `SettingValue` entities holding monetary values that you added into your project.
+To make sure that monetary values that are currently saved as a decimal string will be loaded as a `Money` instance, you have to manually create [a database migration](https://docs.shopsys.com/en/8.0/introduction/database-migrations/) that changes the `type` to `money` for all `SettingValue` entities holding monetary values that you added into your project.
 Previously, any of types `string`, `integer` or `float` might have been used to save a numeric value into the database.
 
 For example see the `up` method of migration class [`Version20190220101938`](https://github.com/shopsys/shopsys/blob/7.3/packages/framework/src/Migrations/Version20190220101938.php) that migrates the `freeTransportAndPaymentPriceLimit` setting values to the `Money` type:
@@ -328,17 +328,17 @@ public function up(Schema $schema)
 All monetary values in data fixtures should use `Money` as well.
 If you haven't altered the data fixtures in any way, you should be ready to go when you copy the data fixtures from `shopsys/project-base` in `v7.0.0` (as explained in the upgrade notes of [PR #854](https://github.com/shopsys/shopsys/pull/854/files#diff-da18024d2b6b8b4b2fafe94d18cb2866)).
 
-You should manage to upgrade your custom data fixtures by using [the static methods `Money::create()` and `Money::zero()`](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#construction) when setting a monetary value.
+You should manage to upgrade your custom data fixtures by using [the static methods `Money::create()` and `Money::zero()`](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#construction) when setting a monetary value.
 
 These 3 data fixture classes had to be changed in `shopsys/project-base`:
 - `\Shopsys\ShopBundle\DataFixtures\Demo\PaymentDataFixture.php`
 - `\Shopsys\ShopBundle\DataFixtures\Demo\ProductDataFixtureLoader.php`
 - `\Shopsys\ShopBundle\DataFixtures\Demo\TransportDataFixture.php`
 
-*Note: Thanks to [the parameter type declarations](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) you should be able to see very quickly if your data fixtures use a wrong type when you run the `db-demo` [Phing target](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/).*
+*Note: Thanks to [the parameter type declarations](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) you should be able to see very quickly if your data fixtures use a wrong type when you run the `db-demo` [Phing target](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/).*
 
 ## Tests
-Changes will be required in all your [unit tests](https://docs.shopsys.com/en/7.3/introduction/automated-testing/#unit-tests) and [functional tests](https://docs.shopsys.com/en/7.3/introduction/automated-testing/#functional-tests) that deal with money.
+Changes will be required in all your [unit tests](https://docs.shopsys.com/en/8.0/introduction/automated-testing/#unit-tests) and [functional tests](https://docs.shopsys.com/en/8.0/introduction/automated-testing/#functional-tests) that deal with money.
 
 You'll have to create instances of `Money` instead of using integers, floats or strings in your data providers (or directly in your test methods) like in these examples:
 
@@ -405,7 +405,7 @@ Take a look at the examples:
 
 Furthermore, you'll have to apply same changes as in [section Working with Money in PHP](#working-with-money-in-php) if your tests make arithmetic operations or comparisons with Money.
 
-You can read more about it in [the Unit and Functional Tests section](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#unit-and-functional-tests).
+You can read more about it in [the Unit and Functional Tests section](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#unit-and-functional-tests).
 
 These 13 functional test classes had to be changed in `shopsys/project-base`:
 - `\Tests\ShopBundle\Functional\Model\Cart\CartFacadeDeleteOldCartsTest`
@@ -422,12 +422,12 @@ These 13 functional test classes had to be changed in `shopsys/project-base`:
 - `\Tests\ShopBundle\Functional\PersonalData\PersonalDataExportXmlTest`
 - `\Tests\ShopBundle\Functional\Twig\PriceExtensionTest`
 
-Your [HTTP smoke tests](https://docs.shopsys.com/en/7.3/introduction/automated-testing/#http-smoke-tests) and [acceptance test](https://docs.shopsys.com/en/7.3/introduction/automated-testing/#acceptance-tests-aka-functional-tests-or-selenium-tests) shouldn't require any changes.
+Your [HTTP smoke tests](https://docs.shopsys.com/en/8.0/introduction/automated-testing/#http-smoke-tests) and [acceptance test](https://docs.shopsys.com/en/8.0/introduction/automated-testing/#acceptance-tests-aka-functional-tests-or-selenium-tests) shouldn't require any changes.
 
 ## Javascript
 The `Money` class implements the `JsonSerializable` interface so it can be serialized using `json_encode` into an object usable in JS.
 
-You can read more about it in [the Money in Javascript section](https://docs.shopsys.com/en/7.3/model/how-to-work-with-money/#money-in-javascript) of the documentation if you work with monetary values using JS in your project.
+You can read more about it in [the Money in Javascript section](https://docs.shopsys.com/en/8.0/model/how-to-work-with-money/#money-in-javascript) of the documentation if you work with monetary values using JS in your project.
 There were no changes needed in `shopsys/project-base`.
 
 ## Other

--- a/upgrade/phpstan-level-1.md
+++ b/upgrade/phpstan-level-1.md
@@ -11,7 +11,7 @@ To upgrade level of PHPStan you need to:
     ```xml
     <property name="phpstan.level" value="1"/>
     ```
-    - if you have [overridden the `phpstan` Phing target](https://docs.shopsys.com/en/7.3/introduction/console-commands-for-application-management-phing-targets/#customization-of-phing-targets-and-properties) or don't use the `build.xml` from `shopsys/framework` package yet, look for `<arg value="--level=0"/>` in your `build.xml` and change its value instead.
+    - if you have [overridden the `phpstan` Phing target](https://docs.shopsys.com/en/8.0/introduction/console-commands-for-application-management-phing-targets/#customization-of-phing-targets-and-properties) or don't use the `build.xml` from `shopsys/framework` package yet, look for `<arg value="--level=0"/>` in your `build.xml` and change its value instead.
 - add `phpstan-doctrine` and `phpstan-phpunit` extension packages as dev dependencies to `composer.json`
     ```diff
     "require-dev": {

--- a/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
+++ b/upgrade/upgrade-instructions-for-read-model-for-product-lists.md
@@ -1,6 +1,6 @@
 # Upgrade Instructions for Read Model for Product Lists
 
-There is a new layer in Shopsys Framework, called [read model](https://docs.shopsys.com/en/7.3/model/introduction-to-read-model/), separating the templates and application model.
+There is a new layer in Shopsys Framework, called [read model](https://docs.shopsys.com/en/8.0/model/introduction-to-read-model/), separating the templates and application model.
 Besides better logical separation of the application, it is a first step towards usage of Elasticsearch for frontend product lists, and hence significant performance boost in the near future.
 The read model package is marked as *experimental* at the moment so there is a possibility we might introduce some BC breaking changes there.
 You do not need to perform the upgrade instantly, however, if you do so, you will be better prepared for the upcoming changes.

--- a/upgrade/upgrading-monorepo.md
+++ b/upgrade/upgrading-monorepo.md
@@ -150,7 +150,7 @@ Typical upgrade sequence should be:
     - you can stop providing the `github_oauth_token` in your `docker-compose.yml`
 
 ## [From v7.0.0-alpha5 to v7.0.0-alpha6]
-- when upgrading your installed [monorepo](https://docs.shopsys.com/en/7.3/introduction/monorepo/), you'll have to change the build context for the images of the microservices in `docker-compose.yml`
+- when upgrading your installed [monorepo](https://docs.shopsys.com/en/8.0/introduction/monorepo/), you'll have to change the build context for the images of the microservices in `docker-compose.yml`
     - `build.context` should be the root of the microservice (eg. `microservices/product-search-export`)
     - `build.dockerfile` should be `docker/Dockerfile`
     - execute `docker-compose up -d --build`, microservices should be up and running


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| wrongy merged `7.3` branch to `8.0` after https://github.com/shopsys/shopsys/pull/1428 was merged.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
