### PR TITLE
[coding-standards] FunctionCallSignatureSniff.Indent is now disabled

### DIFF
--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -180,4 +180,5 @@ parameters:
         PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ControlStructureSpacingSniff.NoLineAfterClose: ~
         # allow empty "catch (Exception $exception) { }"
         PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.DetectedCatch: ~
-        # ignore php code in markdown file
+
+        PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff.Indent: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| FunctionCallSignatureSniff.Indent (added in https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.1) was disabled because it was setting wrong indentation and MethodArgumentSpaceFixer was fixing it back.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| No <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
