### PR TITLE
[shopsys] Unify working with images

### DIFF
--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -122,6 +122,7 @@ class ImageFacade
      * @param object $entity
      * @param array $temporaryFilenames
      * @param string|null $type
+     * @deprecated This function will be changed to protected in the next major release, use ImageFacade::manageImages instead
      */
     public function uploadImage($entity, $temporaryFilenames, $type)
     {
@@ -151,6 +152,7 @@ class ImageFacade
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Image\Image[] $orderedImages
+     * @deprecated This function will be changed to protected in the next major release, use ImageFacade::manageImages instead
      */
     public function saveImageOrdering($orderedImages)
     {
@@ -162,6 +164,7 @@ class ImageFacade
      * @param object $entity
      * @param array|null $temporaryFilenames
      * @param string|null $type
+     * @deprecated This function will be changed to protected in the next major release, use ImageFacade::manageImages instead
      */
     public function uploadImages($entity, $temporaryFilenames, $type)
     {
@@ -180,6 +183,7 @@ class ImageFacade
     /**
      * @param object $entity
      * @param \Shopsys\FrameworkBundle\Component\Image\Image[] $images
+     * @deprecated This function will be changed to protected in the next major release, use ImageFacade::manageImages instead
      */
     public function deleteImages($entity, array $images)
     {

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -158,6 +158,7 @@ class AdvertFormType extends AbstractType
         $builderImageGroup
             ->add('image', ImageUploadType::class, [
                 'required' => false,
+                'image_entity_class' => Advert::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -219,6 +219,7 @@ class CategoryFormType extends AbstractType
         $builderImageGroup
             ->add('image', ImageUploadType::class, [
                 'required' => false,
+                'image_entity_class' => Category::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -161,6 +161,7 @@ class PaymentFormType extends AbstractType
             ->add('image', ImageUploadType::class, [
                 'required' => false,
                 'label' => t('Upload image'),
+                'image_entity_class' => Payment::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -153,6 +153,7 @@ class BrandFormType extends AbstractType
         $builderImageGroup
             ->add('image', ImageUploadType::class, [
                 'required' => false,
+                'image_entity_class' => Brand::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -868,7 +868,7 @@ class ProductFormType extends AbstractType
         $builderImageGroup
             ->add('images', ImageUploadType::class, [
                 'required' => false,
-                'multiple' => true,
+                'image_entity_class' => Product::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -96,6 +96,7 @@ class SliderItemFormType extends AbstractType
             ->add('image', ImageUploadType::class, [
                 'required' => $options['scenario'] === self::SCENARIO_CREATE,
                 'constraints' => $imageConstraints,
+                'image_entity_class' => SliderItem::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg'],

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -158,6 +158,7 @@ class TransportFormType extends AbstractType
             ->add('image', ImageUploadType::class, [
                 'required' => false,
                 'label' => t('Upload image'),
+                'image_entity_class' => Transport::class,
                 'file_constraints' => [
                     new Constraints\Image([
                         'mimeTypes' => ['image/png', 'image/jpg', 'image/jpeg', 'image/gif'],

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -2,7 +2,9 @@
 
 namespace Shopsys\FrameworkBundle\Form;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadData;
+use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Form\Transformers\ImagesIdsToImagesTransformer;
 use Symfony\Component\Form\AbstractType;
@@ -27,13 +29,39 @@ class ImageUploadType extends AbstractType
     private $imagesIdsToImagesTransformer;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig|null
+     */
+    private $imageConfig;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
      * @param \Shopsys\FrameworkBundle\Form\Transformers\ImagesIdsToImagesTransformer $imagesIdsToImagesTransformer
+     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig|null $imageConfig
      */
-    public function __construct(ImageFacade $imageFacade, ImagesIdsToImagesTransformer $imagesIdsToImagesTransformer)
-    {
+    public function __construct(
+        ImageFacade $imageFacade,
+        ImagesIdsToImagesTransformer $imagesIdsToImagesTransformer,
+        ?ImageConfig $imageConfig = null
+    ) {
         $this->imageFacade = $imageFacade;
         $this->imagesIdsToImagesTransformer = $imagesIdsToImagesTransformer;
+        $this->imageConfig = $imageConfig;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig $imageConfig
+     */
+    public function setImageConfig(ImageConfig $imageConfig): void
+    {
+        if ($this->imageConfig !== null && $this->imageConfig !== $imageConfig) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->imageConfig === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->imageConfig = $imageConfig;
+        }
     }
 
     /**
@@ -45,6 +73,8 @@ class ImageUploadType extends AbstractType
             'data_class' => ImageUploadData::class,
             'entity' => null,
             'image_type' => null,
+            'multiple' => null,
+            'image_entity_class' => null,
         ]);
     }
 
@@ -59,6 +89,7 @@ class ImageUploadType extends AbstractType
         $view->vars['multiple'] = $options['multiple'];
         $view->vars['images_by_id'] = $this->getImagesIndexedById($options);
         $view->vars['image_type'] = $options['image_type'];
+        $view->vars['multiple'] = $options['multiple'] ?? $this->isMultiple($options);
     }
 
     /**
@@ -96,6 +127,21 @@ class ImageUploadType extends AbstractType
         }
 
         return $this->imageFacade->getImagesByEntityIndexedById($options['entity'], $options['image_type']);
+    }
+
+    /**
+     * @param array $options
+     * @return bool
+     */
+    private function isMultiple(array $options)
+    {
+        if ($options['image_entity_class'] === null) {
+            return false;
+        }
+
+        $imageEntityConfig = $this->imageConfig->getImageEntityConfigByClass($options['image_entity_class']);
+
+        return $imageEntityConfig->isMultiple($options['image_type']);
     }
 
     /**

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -69,22 +69,20 @@ class ImageUploadType extends AbstractType
     {
         $builder->resetModelTransformers();
 
-        if ($options['multiple']) {
-            $builder->add(
-                $builder->create('orderedImages', CollectionType::class, [
-                    'required' => false,
-                    'entry_type' => HiddenType::class,
-                ])->addModelTransformer($this->imagesIdsToImagesTransformer)
-            );
-            $builder->add('imagesToDelete', ChoiceType::class, [
+        $builder->add(
+            $builder->create('orderedImages', CollectionType::class, [
                 'required' => false,
-                'multiple' => true,
-                'expanded' => true,
-                'choices' => $this->getImagesIndexedById($options),
-                'choice_label' => 'filename',
-                'choice_value' => 'id',
-            ]);
-        }
+                'entry_type' => HiddenType::class,
+            ])->addModelTransformer($this->imagesIdsToImagesTransformer)
+        );
+        $builder->add('imagesToDelete', ChoiceType::class, [
+            'required' => false,
+            'multiple' => true,
+            'expanded' => true,
+            'choices' => $this->getImagesIndexedById($options),
+            'choice_label' => 'filename',
+            'choice_value' => 'id',
+        ]);
     }
 
     /**

--- a/packages/framework/src/Model/Advert/AdvertDataFactory.php
+++ b/packages/framework/src/Model/Advert/AdvertDataFactory.php
@@ -2,8 +2,40 @@
 
 namespace Shopsys\FrameworkBundle\Model\Advert;
 
+use BadMethodCallException;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+
 class AdvertDataFactory implements AdvertDataFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null
+     */
+    protected $imageFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
+     */
+    public function __construct(?ImageFacade $imageFacade = null)
+    {
+        $this->imageFacade = $imageFacade;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     */
+    public function setImageFacade(ImageFacade $imageFacade): void
+    {
+        if ($this->imageFacade !== null && $this->imageFacade !== $imageFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->imageFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->imageFacade = $imageFacade;
+        }
+    }
+
     /**
      * @return \Shopsys\FrameworkBundle\Model\Advert\AdvertData
      */
@@ -36,5 +68,6 @@ class AdvertDataFactory implements AdvertDataFactoryInterface
         $advertData->positionName = $advert->getPositionName();
         $advertData->hidden = $advert->isHidden();
         $advertData->domainId = $advert->getDomainId();
+        $advertData->image->orderedImages = $this->imageFacade->getImagesByEntityIndexedById($advert, null);
     }
 }

--- a/packages/framework/src/Model/Advert/AdvertFacade.php
+++ b/packages/framework/src/Model/Advert/AdvertFacade.php
@@ -92,7 +92,7 @@ class AdvertFacade
 
         $this->em->persist($advert);
         $this->em->flush();
-        $this->imageFacade->uploadImage($advert, $advertData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($advert, $advertData->image);
         $this->em->flush();
 
         return $advert;
@@ -109,7 +109,7 @@ class AdvertFacade
         $advert->edit($advertData);
 
         $this->em->flush();
-        $this->imageFacade->uploadImage($advert, $advertData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($advert, $advertData->image);
         $this->em->flush();
 
         return $advert;

--- a/packages/framework/src/Model/Category/CategoryDataFactory.php
+++ b/packages/framework/src/Model/Category/CategoryDataFactory.php
@@ -2,7 +2,9 @@
 
 namespace Shopsys\FrameworkBundle\Model\Category;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 
@@ -29,21 +31,45 @@ class CategoryDataFactory implements CategoryDataFactoryInterface
     protected $domain;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null
+     */
+    protected $imageFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryRepository $categoryRepository
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginCrudExtensionFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
      */
     public function __construct(
         CategoryRepository $categoryRepository,
         FriendlyUrlFacade $friendlyUrlFacade,
         PluginCrudExtensionFacade $pluginCrudExtensionFacade,
-        Domain $domain
+        Domain $domain,
+        ?ImageFacade $imageFacade = null
     ) {
         $this->categoryRepository = $categoryRepository;
         $this->friendlyUrlFacade = $friendlyUrlFacade;
         $this->pluginCrudExtensionFacade = $pluginCrudExtensionFacade;
         $this->domain = $domain;
+        $this->imageFacade = $imageFacade;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     */
+    public function setImageFacade(ImageFacade $imageFacade): void
+    {
+        if ($this->imageFacade !== null && $this->imageFacade !== $imageFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->imageFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->imageFacade = $imageFacade;
+        }
     }
 
     /**
@@ -108,5 +134,6 @@ class CategoryDataFactory implements CategoryDataFactoryInterface
         }
 
         $categoryData->pluginData = $this->pluginCrudExtensionFacade->getAllData('category', $category->getId());
+        $categoryData->image->orderedImages = $this->imageFacade->getImagesByEntityIndexedById($category, null);
     }
 }

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -119,7 +119,7 @@ class CategoryFacade
         $this->em->persist($category);
         $this->em->flush($category);
         $this->friendlyUrlFacade->createFriendlyUrls('front_product_list', $category->getId(), $category->getNames());
-        $this->imageFacade->uploadImage($category, $categoryData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($category, $categoryData->image);
 
         $this->pluginCrudExtensionFacade->saveAllData('category', $category->getId(), $categoryData->pluginData);
 
@@ -144,7 +144,7 @@ class CategoryFacade
         $this->em->flush();
         $this->friendlyUrlFacade->saveUrlListFormData('front_product_list', $category->getId(), $categoryData->urls);
         $this->friendlyUrlFacade->createFriendlyUrls('front_product_list', $category->getId(), $category->getNames());
-        $this->imageFacade->uploadImage($category, $categoryData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($category, $categoryData->image);
 
         $this->pluginCrudExtensionFacade->saveAllData('category', $category->getId(), $categoryData->pluginData);
 

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -150,7 +150,7 @@ class PaymentFacade
     {
         $transports = $this->transportRepository->getAllByIds($paymentData->transports);
         $payment->setTransports($transports);
-        $this->imageFacade->uploadImage($payment, $paymentData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($payment, $paymentData->image);
         $this->em->flush();
     }
 

--- a/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
@@ -2,7 +2,9 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 
 class BrandDataFactory implements BrandDataFactoryInterface
@@ -23,18 +25,42 @@ class BrandDataFactory implements BrandDataFactoryInterface
     protected $domain;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null
+     */
+    protected $imageFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
      */
     public function __construct(
         FriendlyUrlFacade $friendlyUrlFacade,
         BrandFacade $brandFacade,
-        Domain $domain
+        Domain $domain,
+        ?ImageFacade $imageFacade = null
     ) {
         $this->friendlyUrlFacade = $friendlyUrlFacade;
         $this->brandFacade = $brandFacade;
         $this->domain = $domain;
+        $this->imageFacade = $imageFacade;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     */
+    public function setImageFacade(ImageFacade $imageFacade): void
+    {
+        if ($this->imageFacade !== null && $this->imageFacade !== $imageFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->imageFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->imageFacade = $imageFacade;
+        }
     }
 
     /**
@@ -104,5 +130,7 @@ class BrandDataFactory implements BrandDataFactoryInterface
                     $brand->getId()
                 );
         }
+
+        $brandData->image->orderedImages = $this->imageFacade->getImagesByEntityIndexedById($brand, null);
     }
 }

--- a/packages/framework/src/Model/Product/Brand/BrandFacade.php
+++ b/packages/framework/src/Model/Product/Brand/BrandFacade.php
@@ -82,7 +82,7 @@ class BrandFacade
         $brand = $this->brandFactory->create($brandData);
         $this->em->persist($brand);
         $this->em->flush();
-        $this->imageFacade->uploadImage($brand, $brandData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($brand, $brandData->image);
 
         foreach ($domains as $domain) {
             $this->friendlyUrlFacade->createFriendlyUrlForDomain(
@@ -107,7 +107,7 @@ class BrandFacade
         $domains = $this->domain->getAll();
         $brand = $this->brandRepository->getById($brandId);
         $brand->edit($brandData);
-        $this->imageFacade->uploadImage($brand, $brandData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($brand, $brandData->image);
         $this->em->flush();
 
         $this->friendlyUrlFacade->saveUrlListFormData('front_brand_detail', $brand->getId(), $brandData->urls);

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -273,7 +273,7 @@ class ProductFacade
         $this->productHiddenRecalculator->calculateHiddenForProduct($product);
         $this->productSellingDeniedRecalculator->calculateSellingDeniedForProduct($product);
 
-        $this->imageFacade->uploadImages($product, $productData->images->uploadedFiles, null);
+        $this->imageFacade->manageImages($product, $productData->images);
         $this->friendlyUrlFacade->createFriendlyUrls('front_product_detail', $product->getId(), $product->getNames());
 
         $this->productAvailabilityRecalculationScheduler->scheduleProductForImmediateRecalculation($product);
@@ -304,9 +304,7 @@ class ProductFacade
         $this->em->flush();
         $this->productHiddenRecalculator->calculateHiddenForProduct($product);
         $this->productSellingDeniedRecalculator->calculateSellingDeniedForProduct($product);
-        $this->imageFacade->saveImageOrdering($productData->images->orderedImages);
-        $this->imageFacade->uploadImages($product, $productData->images->uploadedFiles, null);
-        $this->imageFacade->deleteImages($product, $productData->images->imagesToDelete);
+        $this->imageFacade->manageImages($product, $productData->images);
         $this->friendlyUrlFacade->saveUrlListFormData('front_product_detail', $product->getId(), $productData->urls);
         $this->friendlyUrlFacade->createFriendlyUrls('front_product_detail', $product->getId(), $product->getNames());
 

--- a/packages/framework/src/Model/Slider/SliderItemDataFactory.php
+++ b/packages/framework/src/Model/Slider/SliderItemDataFactory.php
@@ -2,8 +2,40 @@
 
 namespace Shopsys\FrameworkBundle\Model\Slider;
 
+use BadMethodCallException;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+
 class SliderItemDataFactory implements SliderItemDataFactoryInterface
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null
+     */
+    protected $imageFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
+     */
+    public function __construct(?ImageFacade $imageFacade = null)
+    {
+        $this->imageFacade = $imageFacade;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     */
+    public function setImageFacade(ImageFacade $imageFacade): void
+    {
+        if ($this->imageFacade !== null && $this->imageFacade !== $imageFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->imageFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->imageFacade = $imageFacade;
+        }
+    }
+
     /**
      * @return \Shopsys\FrameworkBundle\Model\Slider\SliderItemData
      */
@@ -34,5 +66,6 @@ class SliderItemDataFactory implements SliderItemDataFactoryInterface
         $sliderItemData->link = $sliderItem->getLink();
         $sliderItemData->hidden = $sliderItem->isHidden();
         $sliderItemData->domainId = $sliderItem->getDomainId();
+        $sliderItemData->image->orderedImages = $this->imageFacade->getImagesByEntityIndexedById($sliderItem, null);
     }
 }

--- a/packages/framework/src/Model/Slider/SliderItemFacade.php
+++ b/packages/framework/src/Model/Slider/SliderItemFacade.php
@@ -73,7 +73,7 @@ class SliderItemFacade
 
         $this->em->persist($sliderItem);
         $this->em->flush();
-        $this->imageFacade->uploadImage($sliderItem, $sliderItemData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($sliderItem, $sliderItemData->image);
 
         return $sliderItem;
     }
@@ -89,7 +89,7 @@ class SliderItemFacade
         $sliderItem->edit($sliderItemData);
 
         $this->em->flush();
-        $this->imageFacade->uploadImage($sliderItem, $sliderItemData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($sliderItem, $sliderItemData->image);
 
         return $sliderItem;
     }

--- a/packages/framework/src/Model/Transport/TransportDataFactory.php
+++ b/packages/framework/src/Model/Transport/TransportDataFactory.php
@@ -2,7 +2,9 @@
 
 namespace Shopsys\FrameworkBundle\Model\Transport;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 
 class TransportDataFactory implements TransportDataFactoryInterface
@@ -23,18 +25,42 @@ class TransportDataFactory implements TransportDataFactoryInterface
     protected $domain;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null
+     */
+    protected $imageFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
      */
     public function __construct(
         TransportFacade $transportFacade,
         VatFacade $vatFacade,
-        Domain $domain
+        Domain $domain,
+        ?ImageFacade $imageFacade = null
     ) {
         $this->transportFacade = $transportFacade;
         $this->vatFacade = $vatFacade;
         $this->domain = $domain;
+        $this->imageFacade = $imageFacade;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     */
+    public function setImageFacade(ImageFacade $imageFacade): void
+    {
+        if ($this->imageFacade !== null && $this->imageFacade !== $imageFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->imageFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->imageFacade = $imageFacade;
+        }
     }
 
     /**
@@ -112,5 +138,7 @@ class TransportDataFactory implements TransportDataFactoryInterface
         foreach ($transport->getPrices() as $transportPrice) {
             $transportData->pricesByCurrencyId[$transportPrice->getCurrency()->getId()] = $transportPrice->getPrice();
         }
+
+        $transportData->image->orderedImages = $this->imageFacade->getImagesByEntityIndexedById($transport, null);
     }
 }

--- a/packages/framework/src/Model/Transport/TransportFacade.php
+++ b/packages/framework/src/Model/Transport/TransportFacade.php
@@ -107,7 +107,7 @@ class TransportFacade
         $this->em->persist($transport);
         $this->em->flush();
         $this->updateTransportPrices($transport, $transportData->pricesByCurrencyId);
-        $this->imageFacade->uploadImage($transport, $transportData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($transport, $transportData->image);
         $transport->setPayments($transportData->payments);
         $this->em->flush();
 
@@ -122,7 +122,7 @@ class TransportFacade
     {
         $transport->edit($transportData);
         $this->updateTransportPrices($transport, $transportData->pricesByCurrencyId);
-        $this->imageFacade->uploadImage($transport, $transportData->image->uploadedFiles, null);
+        $this->imageFacade->manageImages($transport, $transportData->image);
         $transport->setPayments($transportData->payments);
         $this->em->flush();
     }

--- a/packages/framework/src/Resources/styles/admin/todo.less
+++ b/packages/framework/src/Resources/styles/admin/todo.less
@@ -2,3 +2,6 @@
 * use this file for temporary css changes
 * content will be added at the end of css file
 */
+.list-images__item__overlay.list-images__item__overlay__show {
+	display: block;
+}

--- a/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
@@ -9,7 +9,7 @@
                             <li class="list-images__item js-image-upload-image" data-id="{{ image.id }}" data-delete-input="#{{ form.imagesToDelete.vars.id }}">
                                 <div class="list-images__item__in">
                                     <div class="list-images__item__image js-image-upload-preview">
-                                        {{ image(image, {size: 'original', height: '100'}) }}
+                                        {{ image(image, {size: 'original', height: '100', type: image_type}) }}
                                     </div>
                                     <span class="list-images__item__main">
                                         {{ 'Main image'|trans }}

--- a/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
@@ -10,15 +10,17 @@
                                 <div class="list-images__item__image js-image-upload-preview">
                                     {{ image(image, {size: 'original', height: '100', type: image_type}) }}
                                 </div>
-                                <span class="list-images__item__main">
-                                    {{ 'Main image'|trans }}
-                                </span>
+                                {% if multiple %}
+                                    <span class="list-images__item__main">
+                                        {{ 'Main image'|trans }}
+                                    </span>
+                                    <span class="js-image-upload-image-handle list-images__item__move" title="{{ 'Move'|trans }}">
+                                        <i class="svg svg-move"></i>
+                                    </span>
+                                {% endif %}
                                 <button class="js-image-upload-delete-button btn-no-style list-images__item__remove" type="button" title="{{ 'Delete'|trans }}">
                                     <i class="svg svg-delete"></i>
                                 </button>
-                                <span class="js-image-upload-image-handle list-images__item__move" title="{{ 'Move'|trans }}">
-                                    <i class="svg svg-move"></i>
-                                </span>
                                 <button class="btn-no-style js-image-upload-delete-revert-button display-none list-images__item__revert" type="button" title="{{ 'Return back'|trans }}">
                                     <i class="svg svg-forward-page"></i>
                                 </button>

--- a/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
@@ -1,44 +1,39 @@
 {% block image_upload_row %}
     {% if entity is not null %}
-        {% if multiple %}
-            {% if form.orderedImages|length > 0 %}
-                <div class="list-images__wrap">
-                    <ul class="list-images js-image-upload">
-                        {% for imageForm in form.orderedImages %}
-                            {% set image = images_by_id[imageForm.vars.value] %}
-                            <li class="list-images__item js-image-upload-image" data-id="{{ image.id }}" data-delete-input="#{{ form.imagesToDelete.vars.id }}">
-                                <div class="list-images__item__in">
-                                    <div class="list-images__item__image js-image-upload-preview">
-                                        {{ image(image, {size: 'original', height: '100', type: image_type}) }}
-                                    </div>
-                                    <span class="list-images__item__main">
-                                        {{ 'Main image'|trans }}
-                                    </span>
-                                    <button class="js-image-upload-delete-button btn-no-style list-images__item__remove" type="button" title="{{ 'Delete'|trans }}">
-                                        <i class="svg svg-delete"></i>
-                                    </button>
-                                    <span class="js-image-upload-image-handle list-images__item__move" title="{{ 'Move'|trans }}">
-                                        <i class="svg svg-move"></i>
-                                    </span>
-                                    <button class="btn-no-style js-image-upload-delete-revert-button display-none list-images__item__revert" type="button" title="{{ 'Return back'|trans }}">
-                                        <i class="svg svg-forward-page"></i>
-                                    </button>
-                                    <span class="list-images__item__overlay js-image-upload-image-overlay">
-                                        {{ 'Image will be deleted after saving.'|trans }}
-                                    </span>
+        {% if form.orderedImages|length > 0 %}
+            <div class="list-images__wrap">
+                <ul class="list-images js-image-upload">
+                    {% for imageForm in form.orderedImages %}
+                        {% set image = images_by_id[imageForm.vars.value] %}
+                        <li class="list-images__item js-image-upload-image" data-id="{{ image.id }}" data-delete-input="#{{ form.imagesToDelete.vars.id }}">
+                            <div class="list-images__item__in">
+                                <div class="list-images__item__image js-image-upload-preview">
+                                    {{ image(image, {size: 'original', height: '100', type: image_type}) }}
                                 </div>
-                                {# Ignore indices from form definition. Let them reflect new positions. #}
-                                {{ form_widget(imageForm, { full_name: form.orderedImages.vars.full_name ~ '[]'}) }}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            {% endif %}
-            {% do form.orderedImages.setRendered %}
-            <div class="display-none">
-                {{ form_widget(form.imagesToDelete) }}
+                                <span class="list-images__item__main">
+                                    {{ 'Main image'|trans }}
+                                </span>
+                                <button class="js-image-upload-delete-button btn-no-style list-images__item__remove" type="button" title="{{ 'Delete'|trans }}">
+                                    <i class="svg svg-delete"></i>
+                                </button>
+                                <span class="js-image-upload-image-handle list-images__item__move" title="{{ 'Move'|trans }}">
+                                    <i class="svg svg-move"></i>
+                                </span>
+                                <button class="btn-no-style js-image-upload-delete-revert-button display-none list-images__item__revert" type="button" title="{{ 'Return back'|trans }}">
+                                    <i class="svg svg-forward-page"></i>
+                                </button>
+                                <span class="list-images__item__overlay js-image-upload-image-overlay">
+                                    {{ 'Image will be deleted after saving.'|trans }}
+                                </span>
+                            </div>
+                            {# Ignore indices from form definition. Let them reflect new positions. #}
+                            {{ form_widget(imageForm, { full_name: form.orderedImages.vars.full_name ~ '[]'}) }}
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         {% else %}
+            {% do form.orderedImages.setRendered %}
             <div class="form-line">
                 <label class="form-line__label">
                     {{ 'Image'|trans }}:
@@ -50,6 +45,9 @@
                 </div>
             </div>
         {% endif %}
+        <div class="display-none">
+            {{ form_widget(form.imagesToDelete) }}
+        </div>
     {% endif %}
     <div class="form-line{{ disabledField is defined ? ' form-input-disabled form-line--disabled' }}">
         {{ form_errors(form) }}

--- a/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
@@ -5,9 +5,13 @@
                 <ul class="list-images js-image-upload">
                     {% for imageForm in form.orderedImages %}
                         {% set image = images_by_id[imageForm.vars.value] %}
+                        {% set isRemoved = false %}
+                        {% if not multiple and loop.index > 1 %}
+                            {% set isRemoved = true %}
+                        {% endif %}
                         <li class="list-images__item js-image-upload-image" data-id="{{ image.id }}" data-delete-input="#{{ form.imagesToDelete.vars.id }}">
                             <div class="list-images__item__in">
-                                <div class="list-images__item__image js-image-upload-preview">
+                                <div class="list-images__item__image js-image-upload-preview {% if isRemoved %}list-images__item__in--removed{% endif %}">
                                     {{ image(image, {size: 'original', height: '100', type: image_type}) }}
                                 </div>
                                 {% if multiple %}
@@ -18,13 +22,15 @@
                                         <i class="svg svg-move"></i>
                                     </span>
                                 {% endif %}
-                                <button class="js-image-upload-delete-button btn-no-style list-images__item__remove" type="button" title="{{ 'Delete'|trans }}">
-                                    <i class="svg svg-delete"></i>
-                                </button>
-                                <button class="btn-no-style js-image-upload-delete-revert-button display-none list-images__item__revert" type="button" title="{{ 'Return back'|trans }}">
-                                    <i class="svg svg-forward-page"></i>
-                                </button>
-                                <span class="list-images__item__overlay js-image-upload-image-overlay">
+                                {% if not isRemoved %}
+                                    <button class="js-image-upload-delete-button btn-no-style list-images__item__remove" type="button" title="{{ 'Delete'|trans }}">
+                                        <i class="svg svg-delete"></i>
+                                    </button>
+                                    <button class="btn-no-style js-image-upload-delete-revert-button display-none list-images__item__revert" type="button" title="{{ 'Return back'|trans }}">
+                                        <i class="svg svg-forward-page"></i>
+                                    </button>
+                                {% endif %}
+                                <span class="list-images__item__overlay {% if isRemoved %}list-images__item__overlay__show{% endif %} js-image-upload-image-overlay">
                                     {{ 'Image will be deleted after saving.'|trans }}
                                 </span>
                             </div>

--- a/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Payment/PaymentDataFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\ShopBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Model\Payment\Payment as BasePayment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory as BasePaymentDataFactory;
@@ -17,13 +18,15 @@ class PaymentDataFactory extends BasePaymentDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
      */
     public function __construct(
         PaymentFacade $paymentFacade,
         VatFacade $vatFacade,
-        Domain $domain
+        Domain $domain,
+        ImageFacade $imageFacade
     ) {
-        parent::__construct($paymentFacade, $vatFacade, $domain);
+        parent::__construct($paymentFacade, $vatFacade, $domain, $imageFacade);
     }
 
     /**

--- a/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/BrandDataFactory.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Product/Brand/BrandDataFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\ShopBundle\Model\Product\Brand;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand as BaseBrand;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandData as BaseBrandData;
@@ -17,13 +18,15 @@ class BrandDataFactory extends BaseBrandDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
      */
     public function __construct(
         FriendlyUrlFacade $friendlyUrlFacade,
         BrandFacade $brandFacade,
-        Domain $domain
+        Domain $domain,
+        ImageFacade $imageFacade
     ) {
-        parent::__construct($friendlyUrlFacade, $brandFacade, $domain);
+        parent::__construct($friendlyUrlFacade, $brandFacade, $domain, $imageFacade);
     }
 
     /**

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -371,6 +371,33 @@ There you can find links to upgrade notes for other versions too.
         +        Assert::assertNotSame($errorIdFirstAccess, $errorIdSecondAccess);
         +    }
         ```
+- autowire service `ImageFacade` in data object factories ([#1476](https://github.com/shopsys/shopsys/pull/1476))
+    - `src/Shopsys/ShopBundle/Model/Payment/PaymentDataFactory.php`
+        ```diff
+            public function __construct(
+                PaymentFacade $paymentFacade,
+                VatFacade $vatFacade,
+        -       Domain $domain
+        +       Domain $domain,
+        +       ImageFacade $imageFacade
+            ) {
+        -       parent::__construct($paymentFacade, $vatFacade, $domain);
+        +       parent::__construct($paymentFacade, $vatFacade, $domain, $imageFacade);
+        ```
+    - `src/Shopsys/ShopBundle/Model/Product/Brand/BrandDataFactory.php`
+        ```diff
+             public function __construct(
+                 FriendlyUrlFacade $friendlyUrlFacade,
+                 BrandFacade $brandFacade,
+        -        Domain $domain
+        +        Domain $domain,
+        +        ImageFacade $imageFacade
+             ) {
+        -        parent::__construct($friendlyUrlFacade, $brandFacade, $domain);
+        +        parent::__construct($friendlyUrlFacade, $brandFacade, $domain, $imageFacade);
+             } 
+        ```
+    
 - improve your data fixtures and tests so they are more resistant against domains and locales settings changes [#1425](https://github.com/shopsys/shopsys/pull/1425)
     - if you have done a lot of changes in your data fixtures you might consider to skip this upgrade
     - for detailed information, see [the separate article](upgrade-instructions-for-improved-data-fixtures-and-tests.md)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Working with single image is the same as working with multiple images. There exists a new function `ImageFacade::manageImages`, which unites the calling of the orginal methods. It gives an advantage to easily switch between multiple and single image support for the entities. Moreover, it allows admin to delete single image.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions]| Yes
