### PR TITLE
[shopsys] bad constraint message for minimum password length

### DIFF
--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -99,7 +99,7 @@ class AdministratorFormType extends AbstractType
     private function getFirstPasswordConstraints($scenario)
     {
         $constraints = [
-            new Constraints\Length(['min' => 6, 'minMessage' => 'Password cannot be longer then {{ limit }} characters']),
+            new Constraints\Length(['min' => 6, 'minMessage' => 'Password must be at least {{ limit }} characters long']),
         ];
 
         if ($scenario === self::SCENARIO_CREATE) {

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -196,7 +196,7 @@ class CustomerUserFormType extends AbstractType
     private function getFirstPasswordConstraints($isCreatingNewUser)
     {
         $constraints = [
-            new Constraints\Length(['min' => 6, 'minMessage' => 'Password cannot be longer then {{ limit }} characters']),
+            new Constraints\Length(['min' => 6, 'minMessage' => 'Password must be at least {{ limit }} characters long']),
         ];
 
         if ($isCreatingNewUser) {

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -121,9 +121,6 @@ msgstr "Výrobní číslo nesmí být delší než {{ limit }} znaků"
 msgid "Password cannot be local part of e-mail."
 msgstr "Heslo nesmí být stejné jako první část e-mailu."
 
-msgid "Password cannot be longer then {{ limit }} characters"
-msgstr "Heslo musí mít minimálně {{ limit }} znaků"
-
 msgid "Password cannot be same as e-mail"
 msgstr "Heslo nesmí být stejné jako přihlašovací e-mail."
 
@@ -132,6 +129,9 @@ msgstr "Heslo nesmí být stejné jako část e-mailu před zavináčem."
 
 msgid "Password cannot be same as username"
 msgstr "Heslo nesmí být stejné jako přihlašovací jméno"
+
+msgid "Password must be at least {{ limit }} characters long"
+msgstr "Heslo musí mít minimálně {{ limit }} znaků"
 
 msgid "Passwords do not match"
 msgstr "Hesla se neshodují"

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -121,9 +121,6 @@ msgstr ""
 msgid "Password cannot be local part of e-mail."
 msgstr "Password cannot be local part of email."
 
-msgid "Password cannot be longer then {{ limit }} characters"
-msgstr "Password cannot be longer than {{ limit }} characters"
-
 msgid "Password cannot be same as e-mail"
 msgstr "Password cannot be same as email"
 
@@ -131,6 +128,9 @@ msgid "Password cannot be same as part of e-mail before at sign"
 msgstr "Password cannot be same as part of email before at sign"
 
 msgid "Password cannot be same as username"
+msgstr ""
+
+msgid "Password must be at least {{ limit }} characters long"
 msgstr ""
 
 msgid "Passwords do not match"

--- a/project-base/src/Form/Front/Customer/Password/NewPasswordFormType.php
+++ b/project-base/src/Form/Front/Customer/Password/NewPasswordFormType.php
@@ -29,7 +29,7 @@ class NewPasswordFormType extends AbstractType
                 'first_options' => [
                     'constraints' => [
                         new Constraints\NotBlank(['message' => 'Please enter password']),
-                        new Constraints\Length(['min' => 6, 'minMessage' => 'Password cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(['min' => 6, 'minMessage' => 'Password must be at least {{ limit }} characters long']),
                     ],
                 ],
                 'invalid_message' => 'Passwords do not match',

--- a/project-base/src/Form/Front/Customer/User/CustomerUserFormType.php
+++ b/project-base/src/Form/Front/Customer/User/CustomerUserFormType.php
@@ -59,7 +59,7 @@ class CustomerUserFormType extends AbstractType
                 ],
                 'first_options' => [
                     'constraints' => [
-                        new Constraints\Length(['min' => 6, 'minMessage' => 'Password cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(['min' => 6, 'minMessage' => 'Password must be at least {{ limit }} characters long']),
                     ],
                 ],
                 'invalid_message' => 'Passwords do not match',

--- a/project-base/src/Form/Front/Registration/RegistrationFormType.php
+++ b/project-base/src/Form/Front/Registration/RegistrationFormType.php
@@ -59,7 +59,7 @@ class RegistrationFormType extends AbstractType
                 'first_options' => [
                     'constraints' => [
                         new Constraints\NotBlank(['message' => 'Please enter password']),
-                        new Constraints\Length(['min' => 6, 'minMessage' => 'Password cannot be longer than {{ limit }} characters']),
+                        new Constraints\Length(['min' => 6, 'minMessage' => 'Password must be at least {{ limit }} characters long']),
                     ],
                 ],
                 'invalid_message' => 'Passwords do not match',

--- a/project-base/translations/validators.cs.po
+++ b/project-base/translations/validators.cs.po
@@ -28,14 +28,14 @@ msgstr "Příjmení nesmí být delší než {{ limit }} znaků"
 msgid "Last name of contact person cannot be longer than {{ limit }} characters"
 msgstr "Příjmení kontaktní osoby nesmí být delší než {{ limit }} znaků"
 
-msgid "Password cannot be longer than {{ limit }} characters"
-msgstr "Heslo musí mít minimálně {{ limit }} znaků"
-
 msgid "Password cannot be same as email"
 msgstr "Heslo nesmí být stejné jako přihlašovací e-mail."
 
 msgid "Password cannot be same as part of email before at sign"
 msgstr "Heslo nesmí být stejné jako část e-mailu před zavináčem."
+
+msgid "Password must be at least {{ limit }} characters long"
+msgstr "Heslo musí mít minimálně {{ limit }} znaků"
 
 msgid "Passwords do not match"
 msgstr "Hesla se neshodují"

--- a/project-base/translations/validators.en.po
+++ b/project-base/translations/validators.en.po
@@ -28,13 +28,13 @@ msgstr ""
 msgid "Last name of contact person cannot be longer than {{ limit }} characters"
 msgstr ""
 
-msgid "Password cannot be longer than {{ limit }} characters"
-msgstr ""
-
 msgid "Password cannot be same as email"
 msgstr ""
 
 msgid "Password cannot be same as part of email before at sign"
+msgstr ""
+
+msgid "Password must be at least {{ limit }} characters long"
 msgstr ""
 
 msgid "Passwords do not match"

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1332,6 +1332,9 @@ There you can find links to upgrade notes for other versions too.
 - fix your version of jms/translation-bundle to 1.4.4 in order to prevent problems with translations dumping ([#1732](https://github.com/shopsys/shopsys/pull/1732))
     - see #project-base-diff to update your project
 
+- fix your password minimum length constraint message ([#1478](https://github.com/shopsys/shopsys/pull/1478))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| "Password must be longer than {{ limit }} characters" was not good for min length constraint. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1518 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

PS: Again. I want dump translation so I want to use `php phing dump-translations` as I am used to but this command not exists 😐. Only exists info `php phing dump-translations` [is deprecated](https://github.com/shopsys/shopsys/blame/master/upgrade/UPGRADE-v7.3.0.md#L130). Maybe I am just dumb but I don't see exactly message `php phing dump-translations` is renamed/deleted. Maybe I understand wrong changelogs? 🤔 

PPS: It's BC break so I wanted to change all "then" to "than" in constraint but `php phing translations-dump` stopped working (I don't know why 😄) so I give it up 😄 