### PR TITLE
[frontend-api] Entity images can now be loaded via fronted API

### DIFF
--- a/packages/framework/src/Component/Image/Image.php
+++ b/packages/framework/src/Component/Image/Image.php
@@ -137,6 +137,14 @@ class Image implements EntityFileUploadInterface
     }
 
     /**
+     * @return int|null
+     */
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    /**
      * @return string
      */
     public function getFilename()

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -10,11 +10,13 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ImagesResolver implements ResolverInterface
 {
     protected const IMAGE_ENTITY_PRODUCT = 'product';
+    protected const IMAGE_ENTITY_CATEGORY = 'category';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
@@ -55,6 +57,17 @@ class ImagesResolver implements ResolverInterface
     public function resolveByProduct(Product $product, ?string $type, ?string $size): array
     {
         return $this->resolveByEntity($product, static::IMAGE_ENTITY_PRODUCT, $type, $size);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param string|null $type
+     * @param string|null $size
+     * @return array
+     */
+    public function resolveByCategory(Category $category, ?string $type, ?string $size): array
+    {
+        return $this->resolveByEntity($category, static::IMAGE_ENTITY_CATEGORY, $type, $size);
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Image;
+
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Error\UserError;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
+use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+
+class ImagesResolver implements ResolverInterface
+{
+    protected const IMAGE_ENTITY_PRODUCT = 'product';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
+     */
+    protected $imageFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig
+     */
+    protected $imageConfig;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig $imageConfig
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        ImageFacade $imageFacade,
+        ImageConfig $imageConfig,
+        Domain $domain
+    ) {
+        $this->imageFacade = $imageFacade;
+        $this->imageConfig = $imageConfig;
+        $this->domain = $domain;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param string|null $type
+     * @param string|null $size
+     * @return array
+     */
+    public function resolveByProduct(Product $product, ?string $type, ?string $size): array
+    {
+        return $this->resolveByEntity($product, static::IMAGE_ENTITY_PRODUCT, $type, $size);
+    }
+
+    /**
+     * @param object $entity
+     * @param string $entityName
+     * @param string|null $type
+     * @param string|null $size
+     * @return array
+     */
+    protected function resolveByEntity(object $entity, string $entityName, ?string $type, ?string $size): array
+    {
+        $sizeConfigs = $this->getSizeConfigs($type, $size, $entityName);
+        $images = $this->imageFacade->getImagesByEntityIndexedById($entity, $type);
+
+        return $this->getResolvedImages($images, $sizeConfigs);
+    }
+
+    /**
+     * @param string|null $type
+     * @param string|null $size
+     * @param string $entityName
+     * @return \Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig[]
+     */
+    protected function getSizeConfigs(?string $type, ?string $size, string $entityName): array
+    {
+        $imageConfig = $this->imageConfig->getEntityConfigByEntityName($entityName);
+
+        if ($size === ImageConfig::DEFAULT_SIZE_NAME) {
+            $size = ImageEntityConfig::WITHOUT_NAME_KEY;
+        }
+
+        try {
+            if ($type === null) {
+                if ($size === null) {
+                    $sizeConfigs = $imageConfig->getSizeConfigs();
+                } else {
+                    $sizeConfigs = [$imageConfig->getSizeConfig($size)];
+                }
+            } else {
+                if ($size === null) {
+                    $sizeConfigs = $imageConfig->getSizeConfigsByType($type);
+                } else {
+                    $sizeConfigs = [$imageConfig->getSizeConfigByType($type, $size)];
+                }
+            }
+        } catch (\Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageSizeNotFoundException $e) {
+            throw new UserError(sprintf('Image size %s not found for %s', $size, $entityName));
+        } catch (\Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageTypeNotFoundException $e) {
+            throw new UserError(sprintf('Image type %s not found for %s', $type, $entityName));
+        }
+
+        return $sizeConfigs;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\Image[] $images
+     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig[] $sizeConfigs
+     * @return array
+     */
+    protected function getResolvedImages(array $images, array $sizeConfigs): array
+    {
+        $resolvedImages = [];
+
+        foreach ($images as $image) {
+            foreach ($sizeConfigs as $sizeConfig) {
+                $resolvedImages[] = [
+                    'type' => $image->getType(),
+                    'position' => $image->getPosition(),
+                    'width' => $sizeConfig->getWidth(),
+                    'height' => $sizeConfig->getHeight(),
+                    'size' => $sizeConfig->getName() === null ? ImageConfig::DEFAULT_SIZE_NAME : $sizeConfig->getName(),
+                    'url' => $this->imageFacade->getImageUrl($this->domain->getCurrentDomainConfig(), $image, $sizeConfig->getName(), $image->getType()),
+                ];
+            }
+        }
+
+        return $resolvedImages;
+    }
+}

--- a/packages/frontend-api/src/Resources/config/graphql-types/CategoryDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/CategoryDecorator.types.yml
@@ -16,3 +16,13 @@ CategoryDecorator:
             parent:
                 type: "Category"
                 description: "Ancestor category"
+            images:
+                type: "[Image]!"
+                description: "Category images"
+                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByCategory(value, args["type"], args["size"])'
+                args:
+                    type:
+                        type: "String"
+                        defaultValue: null
+                    size:
+                        type: "String"

--- a/packages/frontend-api/src/Resources/config/graphql-types/ImageDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ImageDecorator.types.yml
@@ -1,0 +1,24 @@
+ImageDecorator:
+    type: object
+    decorator: true
+    config:
+        description: "Represents an image"
+        fields:
+            type:
+                type: "String"
+                description: "Image type"
+            position:
+                type: "Int"
+                description: "Position of image in list"
+            size:
+                type: "String"
+                description: "Image size defined in images.yml"
+            url:
+                type: "String"
+                description: "URL address of image"
+            width:
+                type: "Int"
+                description: "Width in pixels defined in images.yml"
+            height:
+                type: "Int"
+                description: "Height in pixels defined in images.yml"

--- a/packages/frontend-api/src/Resources/config/graphql-types/ProductDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ProductDecorator.types.yml
@@ -35,3 +35,13 @@ ProductDecorator:
                 type: "Price"
                 description: "Product price"
                 resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByProduct(value)'
+            images:
+                type: "[Image]!"
+                description: "Product images"
+                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByProduct(value, args["type"], args["size"])'
+                args:
+                    type:
+                        type: "String"
+                        defaultValue: null
+                    size:
+                        type: "String"

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -24,6 +24,7 @@ parameters:
             - '*/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php'
             - '*/tests/ShopBundle/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'
             - '*/tests/ShopBundle/Functional/Model/Cart/CartMigrationFacadeTest.php'
+            - '*/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php'
 
         ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff:
             - '*/tests/ShopBundle/Functional/Model/Product/ProductVisibilityRepositoryTest.php'

--- a/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Image.types.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Image.types.yml
@@ -1,0 +1,4 @@
+Image:
+    type: object
+    inherits:
+        - 'ImageDecorator'

--- a/project-base/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Image;
+
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class ProductImagesTest extends GraphQlTestCase
+{
+    /**
+     * @var \Shopsys\ShopBundle\Model\Product\Product
+     */
+    private $product;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $productFacade = $this->getContainer()->get(ProductFacade::class);
+        $this->product = $productFacade->getById(1);
+    }
+
+    public function testFirstProductWithAllImages(): void
+    {
+        $query = '
+            query {
+                product(uuid: "' . $this->product->getUuid() . '") {
+                    images{
+                        url,
+                        type,
+                        size,
+                        width,
+                        height,
+                        position
+                    }
+                }
+            }
+        ';
+
+        $jsonExpected = '
+{
+    "data": {
+        "product": {
+            "images": [
+                {
+                    "url": "http://webserver:8080/content-test/images/product/default/1.jpg",
+                    "type": null,
+                    "size": "default",
+                    "width": 410,
+                    "height": null,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/galleryThumbnail/1.jpg",
+                    "type": null,
+                    "size": "galleryThumbnail",
+                    "width": null,
+                    "height": 35,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/list/1.jpg",
+                    "type": null,
+                    "size": "list",
+                    "width": 150,
+                    "height": null,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/thumbnail/1.jpg",
+                    "type": null,
+                    "size": "thumbnail",
+                    "width": 50,
+                    "height": 40,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/original/1.jpg",
+                    "type": null,
+                    "size": "original",
+                    "width": null,
+                    "height": null,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/default/64.jpg",
+                    "type": null,
+                    "size": "default",
+                    "width": 410,
+                    "height": null,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/galleryThumbnail/64.jpg",
+                    "type": null,
+                    "size": "galleryThumbnail",
+                    "width": null,
+                    "height": 35,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/list/64.jpg",
+                    "type": null,
+                    "size": "list",
+                    "width": 150,
+                    "height": null,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/thumbnail/64.jpg",
+                    "type": null,
+                    "size": "thumbnail",
+                    "width": 50,
+                    "height": 40,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/original/64.jpg",
+                    "type": null,
+                    "size": "original",
+                    "width": null,
+                    "height": null,
+                    "position": null
+                }
+            ]
+        }
+    }
+}';
+
+        $this->assertQueryWithExpectedJson($query, $jsonExpected);
+    }
+
+    public function testFirstProductWithListImages(): void
+    {
+        $query = '
+            query {
+                product(uuid: "' . $this->product->getUuid() . '") {
+                    images(size: "list") {
+                        url,
+                        type,
+                        size,
+                        width,
+                        height,
+                        position
+                    }
+                }
+            }
+        ';
+
+        $jsonExpected = '
+{
+    "data": {
+        "product": {
+            "images": [
+                {
+                    "url": "http://webserver:8080/content-test/images/product/list/1.jpg",
+                    "type": null,
+                    "size": "list",
+                    "width": 150,
+                    "height": null,
+                    "position": null
+                },
+                {
+                    "url": "http://webserver:8080/content-test/images/product/list/64.jpg",
+                    "type": null,
+                    "size": "list",
+                    "width": 150,
+                    "height": null,
+                    "position": null
+                }
+            ]
+        }
+    }
+}';
+
+        $this->assertQueryWithExpectedJson($query, $jsonExpected);
+    }
+}

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -87,6 +87,13 @@ There you can find links to upgrade notes for other versions too.
           +    message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
           +    path: %currentWorkingDirectory%/tests/FrontendApiBundle/*
       ```
+- add optional fronted API - product and category images to your project ([#1486](https://github.com/shopsys/shopsys/pull/1486))
+    - copy necessary type definitions:
+        [Category.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Category.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/Category.types.yml`
+        [Image.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Image.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/Image.types.yml`
+        [Product.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Product.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/Product.types.yml`
+    - update your `easy-coding-standard.yml` file:
+        - add `'*/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php'` in `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff` part
 - removed unused `block domain` defined in `Admin/Content/Slider/edit.html.twig` ([#1437](https://github.com/shopsys/shopsys/pull/1437)) 
     - in case you are using this block of code you should copy it into your project (see PR mentioned above for more details)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Images are necessary part of e-commerce solutions. This PR enabled possibility to load images of all current entities with images.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
