### PR TITLE
Improve working with currency rounding and fraction digits

### DIFF
--- a/packages/framework/src/Component/CurrencyFormatter/CurrencyFormatterFactory.php
+++ b/packages/framework/src/Component/CurrencyFormatter/CurrencyFormatterFactory.php
@@ -7,9 +7,13 @@ namespace Shopsys\FrameworkBundle\Component\CurrencyFormatter;
 use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
 use CommerceGuys\Intl\Formatter\CurrencyFormatter;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 
 class CurrencyFormatterFactory
 {
+    /**
+     * @deprecated Will be removed in the next major release, this constant can be edited by admin
+     */
     public const MINIMUM_FRACTION_DIGITS = 2;
     public const MAXIMUM_FRACTION_DIGITS = 10;
 
@@ -34,11 +38,15 @@ class CurrencyFormatterFactory
     }
 
     /**
+     * @deprecated Will be removed in the next major release, use CurrencyFormatterFactory::createByLocaleAndCurrency instead
+     *
      * @param string $locale
      * @return \CommerceGuys\Intl\Formatter\CurrencyFormatter
      */
     public function create(string $locale): CurrencyFormatter
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the CurrencyFormatterFactory::createByLocaleAndCurrency instead.', __METHOD__), E_USER_DEPRECATED);
+
         $currencyFormatter = new CurrencyFormatter(
             $this->numberFormatRepository,
             $this->intlCurrencyRepository,
@@ -46,6 +54,27 @@ class CurrencyFormatterFactory
                 'locale' => $locale,
                 'style' => 'standard',
                 'minimum_fraction_digits' => static::MINIMUM_FRACTION_DIGITS,
+                'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
+            ]
+        );
+
+        return $currencyFormatter;
+    }
+
+    /**
+     * @param string $locale
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency
+     * @return \CommerceGuys\Intl\Formatter\CurrencyFormatter
+     */
+    public function createByLocaleAndCurrency(string $locale, Currency $currency): CurrencyFormatter
+    {
+        $currencyFormatter = new CurrencyFormatter(
+            $this->numberFormatRepository,
+            $this->intlCurrencyRepository,
+            [
+                'locale' => $locale,
+                'style' => 'standard',
+                'minimum_fraction_digits' => $currency->getMinFractionDigits(),
                 'maximum_fraction_digits' => static::MAXIMUM_FRACTION_DIGITS,
             ]
         );

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -5,8 +5,10 @@ namespace Shopsys\FrameworkBundle\Form\Admin\Pricing\Currency;
 use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
 use Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -87,6 +89,15 @@ class CurrencyFormType extends AbstractType
                     new Constraints\GreaterThanOrEqual(0),
                     new Constraints\LessThanOrEqual(CurrencyFormatterFactory::MAXIMUM_FRACTION_DIGITS),
                 ],
+            ])
+            ->add('roundingType', ChoiceType::class, [
+                'required' => true,
+                'choices' => [
+                    t('To hundredths (cents)') => Currency::ROUNDING_TYPE_HUNDREDTHS,
+                    t('To fifty hundredths (halfs)') => Currency::ROUNDING_TYPE_FIFTIES,
+                    t('To whole numbers') => Currency::ROUNDING_TYPE_INTEGER,
+                ],
+                'label' => t('Price including VAT rounding'),
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Form\Admin\Pricing\Currency;
 
 use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
+use Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
 use Symfony\Component\Form\AbstractType;
@@ -77,6 +78,14 @@ class CurrencyFormType extends AbstractType
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter currency exchange rate']),
                     new Constraints\GreaterThan(0),
+                ],
+            ])
+            ->add('minFractionDigits', NumberType::class, [
+                'required' => true,
+                'constraints' => [
+                    new Constraints\NotBlank(['message' => 'Please enter currency minimum fraction digits']),
+                    new Constraints\GreaterThanOrEqual(0),
+                    new Constraints\LessThanOrEqual(CurrencyFormatterFactory::MAXIMUM_FRACTION_DIGITS),
                 ],
             ]);
     }

--- a/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
+++ b/packages/framework/src/Form/Admin/Vat/VatSettingsFormType.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Form\Admin\Vat;
 
 use Shopsys\FrameworkBundle\Form\GroupType;
-use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -50,15 +49,6 @@ class VatSettingsFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter default VAT']),
                 ],
                 'label' => t('Default VAT rate'),
-            ])
-            ->add('roundingType', ChoiceType::class, [
-                'required' => true,
-                'choices' => [
-                    t('To hundredths (cents)') => PricingSetting::ROUNDING_TYPE_HUNDREDTHS,
-                    t('To fifty hundredths (halfs)') => PricingSetting::ROUNDING_TYPE_FIFTIES,
-                    t('To whole numbers') => PricingSetting::ROUNDING_TYPE_INTEGER,
-                ],
-                'label' => t('Price including VAT rounding'),
             ]);
 
         $builder

--- a/packages/framework/src/Migrations/Version20191029123329.php
+++ b/packages/framework/src/Migrations/Version20191029123329.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20191029123329 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE currencies ADD min_fraction_digits INT NOT NULL DEFAULT 2');
+        $this->sql('ALTER TABLE currencies ALTER min_fraction_digits DROP DEFAULT');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20191029210140.php
+++ b/packages/framework/src/Migrations/Version20191029210140.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20191029210140 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE currencies ADD rounding_type VARCHAR(15) NOT NULL DEFAULT \'integer\'');
+        $this->sql('ALTER TABLE currencies ALTER rounding_type DROP DEFAULT');
+
+        $roundingTypeSetting = $this->sql('SELECT value FROM setting_values WHERE name = \'roundingType\' AND domain_id = 0;')->fetchColumn(0);
+        if ($roundingTypeSetting !== false) {
+            switch ($roundingTypeSetting) {
+                case 1:
+                    $currencyRoundingType = 'hundredths';
+                    break;
+                case 2:
+                    $currencyRoundingType = 'fifties';
+                    break;
+                default:
+                    $currencyRoundingType = 'integer';
+            }
+            $this->sql('UPDATE currencies SET rounding_type = :currencyRoundingType', ['currencyRoundingType' => $currencyRoundingType]);
+        }
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Order/OrderPriceCalculation.php
+++ b/packages/framework/src/Model/Order/OrderPriceCalculation.php
@@ -77,7 +77,7 @@ class OrderPriceCalculation
         $priceWithVat = $orderTotalPrice->getPriceWithVat();
         $roundedPriceWithVat = $priceWithVat->round(0);
 
-        $roundingPrice = $this->rounding->roundPriceWithVat($roundedPriceWithVat->subtract($priceWithVat));
+        $roundingPrice = $this->rounding->roundPriceWithVatByCurrency($roundedPriceWithVat->subtract($priceWithVat), $currency);
 
         if ($roundingPrice->isZero()) {
             return null;

--- a/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php
+++ b/packages/framework/src/Model/Order/Preview/OrderPreviewCalculation.php
@@ -87,9 +87,10 @@ class OrderPreviewCalculation
             $domainId,
             $user
         );
-        $quantifiedItemsDiscounts = $this->quantifiedProductDiscountCalculation->calculateDiscounts(
+        $quantifiedItemsDiscounts = $this->quantifiedProductDiscountCalculation->calculateDiscountsRoundedByCurrency(
             $quantifiedItemsPrices,
-            $promoCodeDiscountPercent
+            $promoCodeDiscountPercent,
+            $currency
         );
 
         $productsPrice = $this->getProductsPrice($quantifiedItemsPrices, $quantifiedItemsDiscounts);

--- a/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
@@ -60,10 +60,11 @@ class PaymentPriceCalculation
      */
     public function calculateIndependentPrice(Payment $payment, Currency $currency): Price
     {
-        return $this->basePriceCalculation->calculateBasePrice(
+        return $this->basePriceCalculation->calculateBasePriceRoundedByCurrency(
             $payment->getPrice($currency)->getPrice(),
             $this->pricingSetting->getInputPriceType(),
-            $payment->getVat()
+            $payment->getVat(),
+            $currency
         );
     }
 

--- a/packages/framework/src/Model/Pricing/BasePriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/BasePriceCalculation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Pricing;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 
 class BasePriceCalculation
@@ -30,6 +31,8 @@ class BasePriceCalculation
     }
 
     /**
+     * @deprecated Will be removed in the next major release, use BasePriceCalculation::calculateBasePriceRoundedByCurrency instead
+     *
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
      * @param int $inputPriceType
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
@@ -37,7 +40,31 @@ class BasePriceCalculation
      */
     public function calculateBasePrice(Money $inputPrice, int $inputPriceType, Vat $vat): Price
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the BasePriceCalculation::calculateBasePriceRoundedByCurrency instead.', __METHOD__), E_USER_DEPRECATED);
+
         $basePriceWithVat = $this->getBasePriceWithVat($inputPrice, $inputPriceType, $vat);
+        $vatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($basePriceWithVat, $vat);
+        $basePriceWithoutVat = $this->rounding->roundPriceWithoutVat($basePriceWithVat->subtract($vatAmount));
+
+        return new Price($basePriceWithoutVat, $basePriceWithVat);
+    }
+
+    /**
+     * @deprecated method is deprecated and will be removed in the next major. This method is not used, only in tests
+     *
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
+     * @param int $inputPriceType
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
+     */
+    public function calculateBasePriceRoundedByCurrency(
+        Money $inputPrice,
+        int $inputPriceType,
+        Vat $vat,
+        Currency $currency
+    ): Price {
+        $basePriceWithVat = $this->getBasePriceWithVatRoundedByCurrency($inputPrice, $inputPriceType, $vat, $currency);
         $vatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($basePriceWithVat, $vat);
         $basePriceWithoutVat = $this->rounding->roundPriceWithoutVat($basePriceWithVat->subtract($vatAmount));
 
@@ -64,6 +91,8 @@ class BasePriceCalculation
     }
 
     /**
+     * @deprecated Will be removed in the next major release, use BasePriceCalculation::getBasePriceWithVatRoundedCurrency instead
+     *
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
      * @param int $inputPriceType
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
@@ -71,12 +100,42 @@ class BasePriceCalculation
      */
     protected function getBasePriceWithVat(Money $inputPrice, int $inputPriceType, Vat $vat): Money
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the BasePriceCalculation::getBasePriceWithVatRoundedCurrency instead.', __METHOD__), E_USER_DEPRECATED);
+
         switch ($inputPriceType) {
             case PricingSetting::INPUT_PRICE_TYPE_WITH_VAT:
                 return $this->rounding->roundPriceWithVat($inputPrice);
 
             case PricingSetting::INPUT_PRICE_TYPE_WITHOUT_VAT:
                 return $this->rounding->roundPriceWithVat($this->priceCalculation->applyVatPercent($inputPrice, $vat));
+
+            default:
+                throw new \Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException();
+        }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
+     * @param int $inputPriceType
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency
+     * @return \Shopsys\FrameworkBundle\Component\Money\Money
+     */
+    protected function getBasePriceWithVatRoundedByCurrency(
+        Money $inputPrice,
+        int $inputPriceType,
+        Vat $vat,
+        Currency $currency
+    ): Money {
+        switch ($inputPriceType) {
+            case PricingSetting::INPUT_PRICE_TYPE_WITH_VAT:
+                return $this->rounding->roundPriceWithVatByCurrency($inputPrice, $currency);
+
+            case PricingSetting::INPUT_PRICE_TYPE_WITHOUT_VAT:
+                return $this->rounding->roundPriceWithVatByCurrency(
+                    $this->priceCalculation->applyVatPercent($inputPrice, $vat),
+                    $currency
+                );
 
             default:
                 throw new \Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidInputPriceTypeException();

--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Pricing\Currency;
 
 use Doctrine\ORM\Mapping as ORM;
+use Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidRoundingTypeException;
 
 /**
  * @ORM\Table(name="currencies")
@@ -13,8 +14,13 @@ class Currency
     public const CODE_CZK = 'CZK';
     public const CODE_EUR = 'EUR';
 
+    public const ROUNDING_TYPE_HUNDREDTHS = 'hundredths';
+    public const ROUNDING_TYPE_FIFTIES = 'fifties';
+    public const ROUNDING_TYPE_INTEGER = 'integer';
+
     public const DEFAULT_EXCHANGE_RATE = '1';
     public const DEFAULT_MIN_FRACTION_DIGITS = 2;
+    public const DEFAULT_ROUNDING_TYPE = self::ROUNDING_TYPE_INTEGER;
 
     /**
      * @var int
@@ -54,6 +60,13 @@ class Currency
     protected $minFractionDigits;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=15)
+     */
+    protected $roundingType;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
      */
     public function __construct(CurrencyData $currencyData)
@@ -62,6 +75,7 @@ class Currency
         $this->code = $currencyData->code;
         $this->exchangeRate = $currencyData->exchangeRate;
         $this->minFractionDigits = $currencyData->minFractionDigits;
+        $this->setRoundingType($currencyData->roundingType);
     }
 
     /**
@@ -113,6 +127,38 @@ class Currency
     }
 
     /**
+     * @return string
+     */
+    public function getRoundingType(): string
+    {
+        return $this->roundingType;
+    }
+
+    /**
+     * @param string $roundingType
+     */
+    protected function setRoundingType(string $roundingType): void
+    {
+        if (in_array($roundingType, self::getRoundingTypes(), true) === true) {
+            $this->roundingType = $roundingType;
+        } else {
+            throw new InvalidRoundingTypeException($roundingType);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    protected static function getRoundingTypes(): array
+    {
+        return [
+            self::ROUNDING_TYPE_HUNDREDTHS,
+            self::ROUNDING_TYPE_FIFTIES,
+            self::ROUNDING_TYPE_INTEGER,
+        ];
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
      */
     public function edit(CurrencyData $currencyData)
@@ -120,5 +166,6 @@ class Currency
         $this->name = $currencyData->name;
         $this->code = $currencyData->code;
         $this->minFractionDigits = $currencyData->minFractionDigits;
+        $this->setRoundingType($currencyData->roundingType);
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -14,6 +14,7 @@ class Currency
     public const CODE_EUR = 'EUR';
 
     public const DEFAULT_EXCHANGE_RATE = '1';
+    public const DEFAULT_MIN_FRACTION_DIGITS = 2;
 
     /**
      * @var int
@@ -46,6 +47,13 @@ class Currency
     protected $exchangeRate;
 
     /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     */
+    protected $minFractionDigits;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
      */
     public function __construct(CurrencyData $currencyData)
@@ -53,6 +61,7 @@ class Currency
         $this->name = $currencyData->name;
         $this->code = $currencyData->code;
         $this->exchangeRate = $currencyData->exchangeRate;
+        $this->minFractionDigits = $currencyData->minFractionDigits;
     }
 
     /**
@@ -96,11 +105,20 @@ class Currency
     }
 
     /**
+     * @return int
+     */
+    public function getMinFractionDigits(): int
+    {
+        return $this->minFractionDigits;
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
      */
     public function edit(CurrencyData $currencyData)
     {
         $this->name = $currencyData->name;
         $this->code = $currencyData->code;
+        $this->minFractionDigits = $currencyData->minFractionDigits;
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyData.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyData.php
@@ -19,8 +19,14 @@ class CurrencyData
      */
     public $exchangeRate;
 
+    /**
+     * @var int
+     */
+    public $minFractionDigits;
+
     public function __construct()
     {
         $this->exchangeRate = Currency::DEFAULT_EXCHANGE_RATE;
+        $this->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyData.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyData.php
@@ -24,9 +24,15 @@ class CurrencyData
      */
     public $minFractionDigits;
 
+    /**
+     * @var string
+     */
+    public $roundingType;
+
     public function __construct()
     {
         $this->exchangeRate = Currency::DEFAULT_EXCHANGE_RATE;
         $this->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
+        $this->roundingType = Currency::DEFAULT_ROUNDING_TYPE;
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyDataFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyDataFactory.php
@@ -33,5 +33,6 @@ class CurrencyDataFactory implements CurrencyDataFactoryInterface
         $currencyData->name = $currency->getName();
         $currencyData->code = $currency->getCode();
         $currencyData->exchangeRate = $currency->getExchangeRate();
+        $currencyData->minFractionDigits = $currency->getMinFractionDigits();
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyDataFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyDataFactory.php
@@ -34,5 +34,6 @@ class CurrencyDataFactory implements CurrencyDataFactoryInterface
         $currencyData->code = $currency->getCode();
         $currencyData->exchangeRate = $currency->getExchangeRate();
         $currencyData->minFractionDigits = $currency->getMinFractionDigits();
+        $currencyData->roundingType = $currency->getRoundingType();
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/Exception/InvalidCurrencyRoundingTypeException.php
+++ b/packages/framework/src/Model/Pricing/Currency/Exception/InvalidCurrencyRoundingTypeException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Pricing\Currency\Exception;
+
+use Exception;
+
+class InvalidCurrencyRoundingTypeException extends Exception implements CurrencyException
+{
+    /**
+     * @param string $roundingType
+     * @param \Exception|null $previous
+     */
+    public function __construct(string $roundingType, ?Exception $previous = null)
+    {
+        $message = sprintf('Currency rounding type `%s` is not valid', $roundingType);
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
@@ -56,6 +56,7 @@ class CurrencyGridFactory implements GridFactoryInterface
         $grid->setDefaultOrder('name');
         $grid->addColumn('name', 'c.name', t('Name'), true);
         $grid->addColumn('code', 'c.code', t('Code'), true);
+        $grid->addColumn('minFractionDigits', 'c.minFractionDigits', t('Min fraction digits'), true);
         $grid->addColumn('exchangeRate', 'c.exchangeRate', t('Exchange rate'), true);
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_currency_deleteconfirm', ['id' => 'c.id'])

--- a/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/Grid/CurrencyGridFactory.php
@@ -57,6 +57,7 @@ class CurrencyGridFactory implements GridFactoryInterface
         $grid->addColumn('name', 'c.name', t('Name'), true);
         $grid->addColumn('code', 'c.code', t('Code'), true);
         $grid->addColumn('minFractionDigits', 'c.minFractionDigits', t('Min fraction digits'), true);
+        $grid->addColumn('roundingType', 'c.roundingType', t('Rounding type'), true);
         $grid->addColumn('exchangeRate', 'c.exchangeRate', t('Exchange rate'), true);
         $grid->setActionColumnClassAttribute('table-col table-col-10');
         $grid->addDeleteActionColumn('admin_currency_deleteconfirm', ['id' => 'c.id'])

--- a/packages/framework/src/Model/Pricing/PriceConverter.php
+++ b/packages/framework/src/Model/Pricing/PriceConverter.php
@@ -54,6 +54,6 @@ class PriceConverter
         $currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
         $price = $price->divide($currency->getExchangeRate(), static::DEFAULT_SCALE);
 
-        return $this->rounding->roundPriceWithVat($price);
+        return $this->rounding->roundPriceWithVatByCurrency($price, $currency);
     }
 }

--- a/packages/framework/src/Model/Pricing/PricingSetting.php
+++ b/packages/framework/src/Model/Pricing/PricingSetting.php
@@ -10,6 +10,9 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationSched
 class PricingSetting
 {
     public const INPUT_PRICE_TYPE = 'inputPriceType';
+    /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency
+     */
     public const ROUNDING_TYPE = 'roundingType';
     public const DEFAULT_CURRENCY = 'defaultCurrencyId';
     public const DEFAULT_DOMAIN_CURRENCY = 'defaultDomainCurrencyId';
@@ -18,8 +21,17 @@ class PricingSetting
     public const INPUT_PRICE_TYPE_WITH_VAT = 1;
     public const INPUT_PRICE_TYPE_WITHOUT_VAT = 2;
 
+    /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency.
+     */
     public const ROUNDING_TYPE_HUNDREDTHS = 1;
+    /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency.
+     */
     public const ROUNDING_TYPE_FIFTIES = 2;
+    /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency.
+     */
     public const ROUNDING_TYPE_INTEGER = 3;
 
     /**
@@ -53,10 +65,14 @@ class PricingSetting
     }
 
     /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency
+     *
      * @return int
      */
     public function getRoundingType()
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Rounding type can be set per Currency.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->setting->get(self::ROUNDING_TYPE);
     }
 
@@ -96,10 +112,14 @@ class PricingSetting
     }
 
     /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency
+     *
      * @param int $roundingType
      */
     public function setRoundingType($roundingType)
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Rounding type can be set per Currency.', __METHOD__), E_USER_DEPRECATED);
+
         if (!in_array($roundingType, self::getRoundingTypes(), true)) {
             throw new \Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidRoundingTypeException(
                 sprintf('Rounding type %s is not valid', $roundingType)
@@ -140,10 +160,14 @@ class PricingSetting
     }
 
     /**
+     * @deprecated Will be removed in the next major release. Rounding type can be set per Currency.
+     *
      * @return array
      */
     public static function getRoundingTypes()
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Rounding type can be set per Currency.', __METHOD__), E_USER_DEPRECATED);
+
         return [
             self::ROUNDING_TYPE_HUNDREDTHS,
             self::ROUNDING_TYPE_FIFTIES,

--- a/packages/framework/src/Model/Product/Pricing/ProductInputPriceRecalculator.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductInputPriceRecalculator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Pricing;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\InputPriceCalculation;
 
 class ProductInputPriceRecalculator
@@ -20,15 +22,39 @@ class ProductInputPriceRecalculator
     protected $inputPriceCalculation;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade|null
+     */
+    protected $currencyFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation $basePriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\InputPriceCalculation $inputPriceCalculation
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade|null $currencyFacade
      */
     public function __construct(
         BasePriceCalculation $basePriceCalculation,
-        InputPriceCalculation $inputPriceCalculation
+        InputPriceCalculation $inputPriceCalculation,
+        ?CurrencyFacade $currencyFacade = null
     ) {
         $this->basePriceCalculation = $basePriceCalculation;
         $this->inputPriceCalculation = $inputPriceCalculation;
+        $this->currencyFacade = $currencyFacade;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setCurrencyFacade(CurrencyFacade $currencyFacade): void
+    {
+        if ($this->currencyFacade !== null && $this->currencyFacade !== $currencyFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->currencyFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->currencyFacade = $currencyFacade;
+        }
     }
 
     /**
@@ -42,10 +68,14 @@ class ProductInputPriceRecalculator
         string $newVatPercent
     ): void {
         if ($productManualInputPrice->getInputPrice() !== null) {
-            $basePriceForPricingGroup = $this->basePriceCalculation->calculateBasePrice(
+            $domainId = $productManualInputPrice->getPricingGroup()->getDomainId();
+            $defaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($domainId);
+
+            $basePriceForPricingGroup = $this->basePriceCalculation->calculateBasePriceRoundedByCurrency(
                 $productManualInputPrice->getInputPrice(),
                 $inputPriceType,
-                $productManualInputPrice->getProduct()->getVat()
+                $productManualInputPrice->getProduct()->getVat(),
+                $defaultCurrency
             );
             $inputPriceForPricingGroup = $this->inputPriceCalculation->getInputPrice(
                 $inputPriceType,

--- a/packages/framework/src/Model/Product/Pricing/QuantifiedProductDiscountCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/QuantifiedProductDiscountCalculation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Pricing;
 
 use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
@@ -34,12 +35,16 @@ class QuantifiedProductDiscountCalculation
     }
 
     /**
+     * @deprecated Will be removed in the next major release, use QuantifiedProductDiscountCalculation::calculateDiscountRoundedByCurrency instead
+     *
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice $quantifiedItemPrice
      * @param string $discountPercent
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price|null
      */
     protected function calculateDiscount(QuantifiedItemPrice $quantifiedItemPrice, string $discountPercent): ?Price
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the QuantifiedProductDiscountCalculation::calculateDiscountRoundedByCurrency instead.', __METHOD__), E_USER_DEPRECATED);
+
         $vat = $quantifiedItemPrice->getVat();
         $multiplier = (string)($discountPercent / 100);
         $priceWithVat = $this->rounding->roundPriceWithVat(
@@ -57,18 +62,74 @@ class QuantifiedProductDiscountCalculation
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice $quantifiedItemPrice
+     * @param string $discountPercent
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price|null
+     */
+    protected function calculateDiscountRoundedByCurrency(
+        QuantifiedItemPrice $quantifiedItemPrice,
+        string $discountPercent,
+        Currency $currency
+    ): ?Price {
+        $vat = $quantifiedItemPrice->getVat();
+        $multiplier = (string)($discountPercent / 100);
+        $priceWithVat = $this->rounding->roundPriceWithVatByCurrency(
+            $quantifiedItemPrice->getTotalPrice()->getPriceWithVat()->multiply($multiplier),
+            $currency
+        );
+
+        if ($priceWithVat->isZero()) {
+            return null;
+        }
+
+        $priceVatAmount = $this->priceCalculation->getVatAmountByPriceWithVat($priceWithVat, $vat);
+        $priceWithoutVat = $priceWithVat->subtract($priceVatAmount);
+
+        return new Price($priceWithoutVat, $priceWithVat);
+    }
+
+    /**
+     * @deprecated Will be removed in the next major release, use QuantifiedProductDiscountCalculation::calculateDiscountsRoundedByCurrency instead
+     *
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice[] $quantifiedItemsPrices
      * @param string|null $discountPercent
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price[]
      */
     public function calculateDiscounts(array $quantifiedItemsPrices, ?string $discountPercent): array
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the QuantifiedProductDiscountCalculation::calculateDiscountsRoundedByCurrency instead.', __METHOD__), E_USER_DEPRECATED);
+
         $quantifiedItemsDiscounts = [];
         foreach ($quantifiedItemsPrices as $quantifiedItemIndex => $quantifiedItemPrice) {
             if ($discountPercent === null) {
                 $quantifiedItemsDiscounts[$quantifiedItemIndex] = null;
             } else {
                 $quantifiedItemsDiscounts[$quantifiedItemIndex] = $this->calculateDiscount($quantifiedItemPrice, $discountPercent);
+            }
+        }
+
+        return $quantifiedItemsDiscounts;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice[] $quantifiedItemsPrices
+     * @param string|null $discountPercent
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price[]
+     */
+    public function calculateDiscountsRoundedByCurrency(array $quantifiedItemsPrices, ?string $discountPercent, Currency $currency): array
+    {
+        $quantifiedItemsDiscounts = [];
+        foreach ($quantifiedItemsPrices as $quantifiedItemIndex => $quantifiedItemPrice) {
+            if ($discountPercent === null) {
+                $quantifiedItemsDiscounts[$quantifiedItemIndex] = null;
+            } else {
+                $quantifiedItemsDiscounts[$quantifiedItemIndex] = $this->calculateDiscountRoundedByCurrency(
+                    $quantifiedItemPrice,
+                    $discountPercent,
+                    $currency
+                );
             }
         }
 

--- a/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/QuantifiedProductPriceCalculation.php
@@ -21,6 +21,8 @@ class QuantifiedProductPriceCalculation
     protected $productPriceCalculationForUser;
 
     /**
+     * @deprecated Will be removed in the next major release, this service is not used here
+     *
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Rounding
      */
     protected $rounding;

--- a/packages/framework/src/Model/Transport/TransportPriceCalculation.php
+++ b/packages/framework/src/Model/Transport/TransportPriceCalculation.php
@@ -62,10 +62,11 @@ class TransportPriceCalculation
         Transport $transport,
         Currency $currency
     ): Price {
-        return $this->basePriceCalculation->calculateBasePrice(
+        return $this->basePriceCalculation->calculateBasePriceRoundedByCurrency(
             $transport->getPrice($currency)->getPrice(),
             $this->pricingSetting->getInputPriceType(),
-            $transport->getVat()
+            $transport->getVat(),
+            $currency
         );
     }
 

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
@@ -49,6 +49,13 @@
     {% endif %}
 {% endblock %}
 
+{% block grid_value_cell_edit_id_minFractionDigits %}
+    <span class="form-edit-block form-edit-block--size-1">
+        {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
+        {{ form_widget(form.minFractionDigits, {attr: {class: "input--half-width"}}) }}
+    </span>
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No currencies found. You have to create some first.'|trans }}
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
@@ -56,6 +56,26 @@
     </span>
 {% endblock %}
 
+{% block grid_value_cell_id_roundingType %}
+    <span class="form-edit-block form-edit-block--size-1">
+        {% if value == constant('Shopsys\\FrameworkBundle\\Model\\Pricing\\Currency\\Currency::ROUNDING_TYPE_HUNDREDTHS') %}
+            {{ 'To hundredths (cents)'|trans }}
+        {% elseif value == constant('Shopsys\\FrameworkBundle\\Model\\Pricing\\Currency\\Currency::ROUNDING_TYPE_FIFTIES') %}
+            {{ 'To fifty hundredths (halfs)'|trans }}
+        {% elseif value == constant('Shopsys\\FrameworkBundle\\Model\\Pricing\\Currency\\Currency::ROUNDING_TYPE_INTEGER') %}
+            {{ 'To whole numbers'|trans }}
+        {% endif %}
+    </span>
+{% endblock %}
+
+
+{% block grid_value_cell_edit_id_roundingType %}
+    <span class="form-edit-block form-edit-block--size-1">
+        {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
+        {{ form_widget(form.roundingType, {attr: {class: "input--half-width"}}) }}
+    </span>
+{% endblock %}
+
 {% block grid_no_data %}
     {{ 'No currencies found. You have to create some first.'|trans }}
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
@@ -102,4 +102,11 @@
 {% block grid_inline_edit_add_button %}
     {% set addEntity = 'Create currency'|trans %}
     {{ parent() }}
+        <div class="in-message in-message--block in-message--warning js-flash-message">
+            <ul class="in-message__list">
+                <li class="in-message__list__item">
+                    {{ 'If you change currency settings, prices of all products will be recalculated'| trans}}
+                </li>
+            </ul>
+        </div>
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/listGrid.html.twig
@@ -19,7 +19,7 @@
 {% block grid_value_cell_edit_id_exchangeRate %}
     <span class="form-edit-block form-edit-block--size-1">
         {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
-        {{ form_widget(form.exchangeRate, {attr: {class: "input--half-width"}}) }}
+        {{ form_widget(form.exchangeRate, {attr: {class: "input--small"}}) }}
         <span class="form-edit-block__info relative">
             {% if row is null %}
                 <span title="" class="js-tooltip cursor-help in-icon in-icon--after-input" data-toggle="tooltip" data-placement="top" data-original-title="{{ '%defaultCurrency% per unit'|trans({'%defaultCurrency%': currencySymbolByCurrencyId(defaultCurrency.id)}) }}">
@@ -52,7 +52,7 @@
 {% block grid_value_cell_edit_id_minFractionDigits %}
     <span class="form-edit-block form-edit-block--size-1">
         {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
-        {{ form_widget(form.minFractionDigits, {attr: {class: "input--half-width"}}) }}
+        {{ form_widget(form.minFractionDigits, {attr: {class: "input--small"}}) }}
     </span>
 {% endblock %}
 
@@ -73,6 +73,20 @@
     <span class="form-edit-block form-edit-block--size-1">
         {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
         {{ form_widget(form.roundingType, {attr: {class: "input--half-width"}}) }}
+    </span>
+{% endblock %}
+
+{% block grid_value_cell_edit_id_name %}
+    <span class="form-edit-block form-edit-block--size-1">
+        {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
+        {{ form_widget(form.name, {attr: {class: "input--half-width"}}) }}
+    </span>
+{% endblock %}
+
+{% block grid_value_cell_edit_id_code %}
+    <span class="form-edit-block form-edit-block--size-1">
+        {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
+        {{ form_widget(form.code, {attr: {class: "input--small"}}) }}
     </span>
 {% endblock %}
 

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -270,7 +270,7 @@ class PriceExtension extends Twig_Extension
             $locale = $this->localization->getLocale();
         }
 
-        $currencyFormatter = $this->currencyFormatterFactory->create($locale);
+        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($locale, $currency);
         $intlCurrency = $this->intlCurrencyRepository->get(
             $currency->getCode(),
             $locale

--- a/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderPriceCalculationTest.php
@@ -119,10 +119,10 @@ class OrderPriceCalculationTest extends TestCase
         $orderTotalPrice = new Price(Money::create(100), Money::create('120.3'));
 
         $roundingMock = $this->getMockBuilder(Rounding::class)
-            ->setMethods(['roundPriceWithVat'])
+            ->setMethods(['roundPriceWithVatByCurrency'])
             ->disableOriginalConstructor()
             ->getMock();
-        $roundingMock->expects($this->any())->method('roundPriceWithVat')->willReturnCallback(function (Money $value) {
+        $roundingMock->expects($this->any())->method('roundPriceWithVatByCurrency')->willReturnCallback(function (Money $value) {
             return $value->round(2);
         });
 
@@ -148,10 +148,10 @@ class OrderPriceCalculationTest extends TestCase
         $orderTotalPrice = new Price(Money::create(100), Money::create('120.9'));
 
         $roundingMock = $this->getMockBuilder(Rounding::class)
-            ->setMethods(['roundPriceWithVat'])
+            ->setMethods(['roundPriceWithVatByCurrency'])
             ->disableOriginalConstructor()
             ->getMock();
-        $roundingMock->expects($this->any())->method('roundPriceWithVat')->willReturnCallback(function (Money $value) {
+        $roundingMock->expects($this->any())->method('roundPriceWithVatByCurrency')->willReturnCallback(function (Money $value) {
             return $value->round(2);
         });
 

--- a/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
@@ -80,15 +80,12 @@ class PaymentPriceCalculationTest extends TestCase
         Money $priceWithVat
     ) {
         $pricingSettingMock = $this->getMockBuilder(PricingSetting::class)
-            ->setMethods(['getInputPriceType', 'getRoundingType'])
+            ->setMethods(['getInputPriceType'])
             ->disableOriginalConstructor()
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
                 ->willReturn($inputPriceType);
-        $pricingSettingMock
-            ->expects($this->any())->method('getRoundingType')
-                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
 
@@ -101,7 +98,13 @@ class PaymentPriceCalculationTest extends TestCase
         $vatData->name = 'vat';
         $vatData->percent = $vatPercent;
         $vat = new Vat($vatData);
-        $currency = new Currency(new CurrencyData());
+        $currencyData = new CurrencyData();
+        $currencyData->name = 'currencyName';
+        $currencyData->code = Currency::CODE_CZK;
+        $currencyData->exchangeRate = '1.0';
+        $currencyData->minFractionDigits = 2;
+        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
+        $currency = new Currency($currencyData);
 
         $paymentData = new PaymentData();
         $paymentData->name = ['cs' => 'paymentName'];
@@ -134,15 +137,12 @@ class PaymentPriceCalculationTest extends TestCase
     ) {
         $priceLimit = Money::create(1000);
         $pricingSettingMock = $this->getMockBuilder(PricingSetting::class)
-            ->setMethods(['getInputPriceType', 'getRoundingType', 'getFreeTransportAndPaymentPriceLimit'])
+            ->setMethods(['getInputPriceType', 'getFreeTransportAndPaymentPriceLimit'])
             ->disableOriginalConstructor()
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
                 ->willReturn($inputPriceType);
-        $pricingSettingMock
-            ->expects($this->any())->method('getRoundingType')
-                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
         $pricingSettingMock
             ->expects($this->any())->method('getFreeTransportAndPaymentPriceLimit')
                 ->willReturn($priceLimit);
@@ -158,7 +158,13 @@ class PaymentPriceCalculationTest extends TestCase
         $vatData->name = 'vat';
         $vatData->percent = $vatPercent;
         $vat = new Vat($vatData);
-        $currency = new Currency(new CurrencyData());
+        $currencyData = new CurrencyData();
+        $currencyData->name = 'currencyName';
+        $currencyData->code = Currency::CODE_CZK;
+        $currencyData->exchangeRate = '1.0';
+        $currencyData->minFractionDigits = 2;
+        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
+        $currency = new Currency($currencyData);
 
         $paymentData = new PaymentData();
         $paymentData->name = ['cs' => 'paymentName'];

--- a/packages/framework/tests/Unit/Model/Pricing/BasePriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/BasePriceCalculationTest.php
@@ -5,6 +5,8 @@ namespace Tests\FrameworkBundle\Unit\Model\Pricing;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
@@ -38,6 +40,8 @@ class BasePriceCalculationTest extends TestCase
     }
 
     /**
+     * @deprecated test is deprecated and will be removed in the next major
+     *
      * @dataProvider calculateBasePriceProvider
      * @param int $inputPriceType
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
@@ -78,6 +82,50 @@ class BasePriceCalculationTest extends TestCase
         $this->assertThat($basePrice->getVatAmount(), new IsMoneyEqual($basePriceVatAmount));
     }
 
+    /**
+     * @dataProvider calculateBasePriceProvider
+     * @param int $inputPriceType
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
+     * @param mixed $vatPercent
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $basePriceWithoutVat
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $basePriceWithVat
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $basePriceVatAmount
+     */
+    public function testCalculateBasePriceRoundedByCurrency(
+        int $inputPriceType,
+        Money $inputPrice,
+        $vatPercent,
+        Money $basePriceWithoutVat,
+        Money $basePriceWithVat,
+        Money $basePriceVatAmount
+    ) {
+        $pricingSettingMock = $this->getMockBuilder(PricingSetting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $rounding = new Rounding($pricingSettingMock);
+        $priceCalculation = new PriceCalculation($rounding);
+        $basePriceCalculation = new BasePriceCalculation($priceCalculation, $rounding);
+
+        $vatData = new VatData();
+        $vatData->name = 'vat';
+        $vatData->percent = $vatPercent;
+        $vat = new Vat($vatData);
+
+        $currencyData = new CurrencyData();
+        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
+        $currency = new Currency($currencyData);
+
+        $basePrice = $basePriceCalculation->calculateBasePriceRoundedByCurrency($inputPrice, $inputPriceType, $vat, $currency);
+
+        $this->assertThat($basePrice->getPriceWithoutVat(), new IsMoneyEqual($basePriceWithoutVat));
+        $this->assertThat($basePrice->getPriceWithVat(), new IsMoneyEqual($basePriceWithVat));
+        $this->assertThat($basePrice->getVatAmount(), new IsMoneyEqual($basePriceVatAmount));
+    }
+
+    /**
+     * @deprecated provider is deprecated and will be removed in the next major.
+     * Test uses this provider works with unused function
+     */
     public function applyCoefficientProvider()
     {
         return [
@@ -109,6 +157,8 @@ class BasePriceCalculationTest extends TestCase
     }
 
     /**
+     * @deprecated test is deprecated and will be removed in the next major. Test works with unused function
+     *
      * @dataProvider applyCoefficientProvider
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $priceWithVat
      * @param mixed $vatPercent

--- a/packages/framework/tests/Unit/Model/Pricing/RoundingTest.php
+++ b/packages/framework/tests/Unit/Model/Pricing/RoundingTest.php
@@ -4,6 +4,9 @@ namespace Tests\FrameworkBundle\Unit\Model\Pricing;
 
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
+use Shopsys\FrameworkBundle\Model\Pricing\Currency\Exception\InvalidCurrencyRoundingTypeException;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
 use Tests\FrameworkBundle\Test\IsMoneyEqual;
@@ -53,6 +56,8 @@ class RoundingTest extends TestCase
     }
 
     /**
+     * @deprecated test is deprecated and will be removed in the next major
+     *
      * @dataProvider roundingProvider
      * @param mixed $unroundedPrice
      * @param mixed $expectedAsPriceWithVat
@@ -76,6 +81,33 @@ class RoundingTest extends TestCase
         $rounding = new Rounding($pricingSettingMock);
 
         $this->assertThat($rounding->roundPriceWithVat($unroundedPrice), new IsMoneyEqual($expectedAsPriceWithVat));
+        $this->assertThat($rounding->roundPriceWithoutVat($unroundedPrice), new IsMoneyEqual($expectedAsPriceWithoutVat));
+        $this->assertThat($rounding->roundVatAmount($unroundedPrice), new IsMoneyEqual($expectedAsVatAmount));
+    }
+
+    /**
+     * @dataProvider roundingProvider
+     * @param mixed $unroundedPrice
+     * @param mixed $expectedAsPriceWithVat
+     * @param mixed $expectedAsPriceWithoutVat
+     * @param mixed $expectedAsVatAmount
+     */
+    public function testRoundingByCurrency(
+        $unroundedPrice,
+        $expectedAsPriceWithVat,
+        $expectedAsPriceWithoutVat,
+        $expectedAsVatAmount
+    ) {
+        $pricingSettingMock = $this->getMockBuilder(PricingSetting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $rounding = new Rounding($pricingSettingMock);
+
+        $currencyData = new CurrencyData();
+        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
+        $currency = new Currency($currencyData);
+
+        $this->assertThat($rounding->roundPriceWithVatByCurrency($unroundedPrice, $currency), new IsMoneyEqual($expectedAsPriceWithVat));
         $this->assertThat($rounding->roundPriceWithoutVat($unroundedPrice), new IsMoneyEqual($expectedAsPriceWithoutVat));
         $this->assertThat($rounding->roundVatAmount($unroundedPrice), new IsMoneyEqual($expectedAsVatAmount));
     }
@@ -132,6 +164,8 @@ class RoundingTest extends TestCase
     }
 
     /**
+     * @deprecated test is deprecated and will be removed in the next major
+     *
      * @dataProvider roundingPriceWithVatProvider
      * @param mixed $roundingType
      * @param mixed $inputPrice
@@ -152,5 +186,57 @@ class RoundingTest extends TestCase
         $roundedPrice = $rounding->roundPriceWithVat($inputPrice);
 
         $this->assertThat($roundedPrice, new IsMoneyEqual($outputPrice));
+    }
+
+    /**
+     * @dataProvider roundingPriceWithVatProvider
+     * @param mixed $roundingType
+     * @param mixed $inputPrice
+     * @param mixed $outputPrice
+     */
+    public function testRoundingPriceWithVatByCurrency(
+        $roundingType,
+        $inputPrice,
+        $outputPrice
+    ) {
+        $pricingSettingMock = $this->getMockBuilder(PricingSetting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $currencyRoundingType = $this->converPricingRoundingTypeToCurrencyRoundingType($roundingType);
+
+        $currencyData = new CurrencyData();
+        $currencyData->roundingType = $currencyRoundingType;
+        $currency = new Currency($currencyData);
+
+        $rounding = new Rounding($pricingSettingMock);
+        $roundedPrice = $rounding->roundPriceWithVatByCurrency($inputPrice, $currency);
+
+        $this->assertThat($roundedPrice, new IsMoneyEqual($outputPrice));
+    }
+
+    /**
+     * @param int $roundingType
+     * @return string
+     */
+    private function converPricingRoundingTypeToCurrencyRoundingType(int $roundingType)
+    {
+        switch ($roundingType) {
+            case 1:
+                return Currency::ROUNDING_TYPE_HUNDREDTHS;
+
+            case 2:
+                return Currency::ROUNDING_TYPE_FIFTIES;
+                break;
+
+            case 3:
+                return Currency::ROUNDING_TYPE_INTEGER;
+                break;
+
+            default:
+                throw new InvalidCurrencyRoundingTypeException(
+                    sprintf('Rounding type %s is not valid', $roundingType)
+                );
+        }
     }
 }

--- a/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
@@ -57,15 +57,12 @@ class TransportPriceCalculationTest extends TestCase
         Money $priceWithVat
     ) {
         $pricingSettingMock = $this->getMockBuilder(PricingSetting::class)
-            ->setMethods(['getInputPriceType', 'getRoundingType'])
+            ->setMethods(['getInputPriceType'])
             ->disableOriginalConstructor()
             ->getMock();
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
                 ->willReturn($inputPriceType);
-        $pricingSettingMock
-            ->expects($this->any())->method('getRoundingType')
-                ->willReturn(PricingSetting::ROUNDING_TYPE_INTEGER);
 
         $rounding = new Rounding($pricingSettingMock);
         $priceCalculation = new PriceCalculation($rounding);
@@ -77,7 +74,13 @@ class TransportPriceCalculationTest extends TestCase
         $vatData->name = 'vat';
         $vatData->percent = $vatPercent;
         $vat = new Vat($vatData);
-        $currency = new Currency(new CurrencyData());
+        $currencyData = new CurrencyData();
+        $currencyData->name = 'currencyName';
+        $currencyData->code = Currency::CODE_CZK;
+        $currencyData->exchangeRate = '1.0';
+        $currencyData->minFractionDigits = 2;
+        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
+        $currency = new Currency($currencyData);
 
         $transportData = new TransportData();
         $transportData->name = ['cs' => 'transportName'];

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
@@ -63,6 +63,7 @@ class CurrencyDataFixture extends AbstractReferenceFixture
             $currencyData->name = 'Euro';
             $currencyData->code = Currency::CODE_EUR;
             $currencyData->exchangeRate = '25';
+            $currencyData->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
             $currencyEuro = $this->currencyFacade->create($currencyData);
             $this->addReference(self::CURRENCY_EUR, $currencyEuro);
         }

--- a/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
+++ b/project-base/src/Shopsys/ShopBundle/DataFixtures/Demo/CurrencyDataFixture.php
@@ -56,6 +56,10 @@ class CurrencyDataFixture extends AbstractReferenceFixture
          * @see \Shopsys\FrameworkBundle\Migrations\Version20180603135342
          */
         $currencyCzk = $this->currencyFacade->getById(1);
+        $currencyData = $this->currencyDataFactory->createFromCurrency($currencyCzk);
+        $currencyData->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
+        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
+        $currencyCzk = $this->currencyFacade->edit($currencyCzk->getId(), $currencyData);
         $this->addReference(self::CURRENCY_CZK, $currencyCzk);
 
         if (count($this->domain->getAll()) > 1) {
@@ -64,6 +68,7 @@ class CurrencyDataFixture extends AbstractReferenceFixture
             $currencyData->code = Currency::CODE_EUR;
             $currencyData->exchangeRate = '25';
             $currencyData->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
+            $currencyData->roundingType = Currency::ROUNDING_TYPE_HUNDREDTHS;
             $currencyEuro = $this->currencyFacade->create($currencyData);
             $this->addReference(self::CURRENCY_EUR, $currencyEuro);
         }

--- a/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
+++ b/project-base/src/Shopsys/ShopBundle/Form/Front/Product/ProductFilterFormType.php
@@ -87,6 +87,10 @@ class ProductFilterFormType extends AbstractType
     }
 
     /**
+     * @deprecated This method will be removed in the next major release, it is used for price range widget placeholders
+     * It is recommended to edit placeholders in `filterFormMacro` and set values on your own, e.g you can format
+     * values with price formatter
+     *
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $money
      * @param \Symfony\Component\Form\FormBuilderInterface $moneyBuilder
      * @return string

--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/filterFormMacro.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/filterFormMacro.html.twig
@@ -13,8 +13,16 @@
         {% endif %}
 
         <div class="box-filter__price">
-            {{ form_row(filterForm.minimalPrice, {label: 'Price from'|trans, symbolAfterInput: currencySymbolByDomainId(getDomain().id), attr: { class: 'js-product-filter-call-change-after-reset'} }) }}
-            {{ form_row(filterForm.maximalPrice, {label: 'Price to'|trans, symbolAfterInput: currencySymbolByDomainId(getDomain().id), attr: { class: 'js-product-filter-call-change-after-reset'} }) }}
+            {{ form_row(filterForm.minimalPrice, {
+                label: 'Price from'|trans,
+                symbolAfterInput: currencySymbolByDomainId(getDomain().id),
+                attr: { class: 'js-product-filter-call-change-after-reset', placeholder:priceRange.minimalPrice|price }
+            }) }}
+            {{ form_row(filterForm.maximalPrice, {
+                label: 'Price to'|trans,
+                symbolAfterInput: currencySymbolByDomainId(getDomain().id),
+                attr: { class: 'js-product-filter-call-change-after-reset', placeholder:priceRange.maximalPrice|price}
+            }) }}
             <div
                 class="js-range-slider"
                 data-minimum-input-id="{{ filterForm.minimalPrice.vars.id }}"

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartBoxPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartBoxPage.php
@@ -10,6 +10,8 @@ use Tests\ShopBundle\Acceptance\acceptance\PageObject\AbstractPage;
 class CartBoxPage extends AbstractPage
 {
     /**
+     * @deprecated test is deprecated and will be removed in the next major
+     *
      * @param int $expectedCount
      * @param string $expectedPrice
      */
@@ -17,6 +19,20 @@ class CartBoxPage extends AbstractPage
     {
         $convertedPrice = Money::create($this->tester->getPriceWithVatConvertedToDomainDefaultCurrency($expectedPrice));
         $expectedFormattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolOnFrontend($convertedPrice);
+        $messageId = '{1} <strong class="cart__state">%itemsCount%</strong> item for <strong class="cart__state">%priceWithVat%</strong>|[2,Inf] <strong class="cart__state">%itemsCount%</strong> items for <strong class="cart__state">%priceWithVat%</strong>';
+        $translatedMessageWithTags = tc($messageId, $expectedCount, ['%itemsCount%' => $expectedCount, '%priceWithVat%' => $expectedFormattedPriceWithCurrency], 'messages', $this->tester->getFrontendLocale());
+
+        $this->tester->seeInCss(strip_tags($translatedMessageWithTags), '.js-cart-info');
+    }
+
+    /**
+     * @param int $expectedCount
+     * @param string $expectedPrice
+     */
+    public function seeCountAndPriceRoundedByCurrencyInCartBox(int $expectedCount, string $expectedPrice): void
+    {
+        $convertedPrice = Money::create($this->tester->getPriceWithVatConvertedToDomainDefaultCurrency($expectedPrice));
+        $expectedFormattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend($convertedPrice);
         $messageId = '{1} <strong class="cart__state">%itemsCount%</strong> item for <strong class="cart__state">%priceWithVat%</strong>|[2,Inf] <strong class="cart__state">%itemsCount%</strong> items for <strong class="cart__state">%priceWithVat%</strong>';
         $translatedMessageWithTags = tc($messageId, $expectedCount, ['%itemsCount%' => $expectedCount, '%priceWithVat%' => $expectedFormattedPriceWithCurrency], 'messages', $this->tester->getFrontendLocale());
 

--- a/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartPage.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/PageObject/Front/CartPage.php
@@ -22,6 +22,8 @@ class CartPage extends AbstractPage
     }
 
     /**
+     * @deprecated test is deprecated and will be removed in the next major
+     *
      * @param string $productName
      * @param string $price
      */
@@ -34,11 +36,36 @@ class CartPage extends AbstractPage
     }
 
     /**
+     * @param string $productName
+     * @param string $price
+     */
+    public function assertProductPriceRoundedByCurrency($productName, $price)
+    {
+        $convertedPrice = $this->tester->getPriceWithVatConvertedToDomainDefaultCurrency($price);
+        $formattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money::create($convertedPrice));
+        $productPriceCell = $this->getProductTotalPriceCellByName($productName);
+        $this->tester->seeInElement($formattedPriceWithCurrency, $productPriceCell);
+    }
+
+    /**
+     * @deprecated test is deprecated and will be removed in the next major
+     *
      * @param string $price
      */
     public function assertTotalPriceWithVat($price)
     {
         $formattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolOnFrontend(Money::create($price));
+        $orderPriceCell = $this->getTotalProductsPriceCell();
+        $message = t('Total price including VAT', [], 'messages', $this->tester->getFrontendLocale());
+        $this->tester->seeInElement($message . ': ' . $formattedPriceWithCurrency, $orderPriceCell);
+    }
+
+    /**
+     * @param string $price
+     */
+    public function assertTotalPriceWithVatRoundedByCurrency($price)
+    {
+        $formattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money::create($price));
         $orderPriceCell = $this->getTotalProductsPriceCell();
         $message = t('Total price including VAT', [], 'messages', $this->tester->getFrontendLocale());
         $this->tester->seeInElement($message . ': ' . $formattedPriceWithCurrency, $orderPriceCell);

--- a/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
+++ b/project-base/tests/ShopBundle/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php
@@ -49,10 +49,10 @@ class OrderPreviewCalculationTest extends FunctionalTestCase
             ->willReturn($quantifiedItemsPrices);
 
         $quantifiedProductDiscountCalculationMock = $this->getMockBuilder(QuantifiedProductDiscountCalculation::class)
-            ->setMethods(['calculateDiscounts', '__construct'])
+            ->setMethods(['calculateDiscountsRoundedByCurrency', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
-        $quantifiedProductDiscountCalculationMock->expects($this->once())->method('calculateDiscounts')
+        $quantifiedProductDiscountCalculationMock->expects($this->once())->method('calculateDiscountsRoundedByCurrency')
             ->willReturn($quantifiedProductsDiscounts);
 
         $paymentPriceCalculationMock = $this->getMockBuilder(PaymentPriceCalculation::class)
@@ -132,10 +132,10 @@ class OrderPreviewCalculationTest extends FunctionalTestCase
             ->willReturn($quantifiedItemsPrices);
 
         $quantifiedProductDiscountCalculationMock = $this->getMockBuilder(QuantifiedProductDiscountCalculation::class)
-            ->setMethods(['calculateDiscounts', '__construct'])
+            ->setMethods(['calculateDiscountsRoundedByCurrency', '__construct'])
             ->disableOriginalConstructor()
             ->getMock();
-        $quantifiedProductDiscountCalculationMock->expects($this->once())->method('calculateDiscounts')
+        $quantifiedProductDiscountCalculationMock->expects($this->once())->method('calculateDiscountsRoundedByCurrency')
             ->willReturn($quantifiedProductsDiscounts);
 
         $paymentPriceCalculationMock = $this->getMockBuilder(PaymentPriceCalculation::class)

--- a/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/PriceExtensionTest.php
@@ -125,11 +125,15 @@ class PriceExtensionTest extends FunctionalTestCase
         $domain1DefaultCurrencyData->name = 'Czech crown';
         $domain1DefaultCurrencyData->code = Currency::CODE_CZK;
         $domain1DefaultCurrencyData->exchangeRate = 1;
+        $domain1DefaultCurrencyData->minFractionDigits = 2;
+        $domain1DefaultCurrencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
 
         $domain2DefaultCurrencyData = $currencyDataFactory->create();
         $domain2DefaultCurrencyData->name = 'Euro';
         $domain2DefaultCurrencyData->code = Currency::CODE_EUR;
         $domain2DefaultCurrencyData->exchangeRate = 25;
+        $domain1DefaultCurrencyData->minFractionDigits = 2;
+        $domain1DefaultCurrencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
 
         $domain1DefaultCurrency = $currencyFactory->create($domain1DefaultCurrencyData);
         $domain2DefaultCurrency = $currencyFactory->create($domain2DefaultCurrencyData);

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/NumberFormatHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/NumberFormatHelper.php
@@ -79,6 +79,8 @@ class NumberFormatHelper extends Module
     }
 
     /**
+     * @deprecated test is deprecated and will be removed in the next major.
+     *
      * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
      * @return string
@@ -104,11 +106,55 @@ class NumberFormatHelper extends Module
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
      * @return string
      */
+    public function getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money $price): string
+    {
+        $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(Domain::FIRST_DOMAIN_ID);
+        $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
+        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($firstDomainLocale, $firstDomainDefaultCurrency);
+
+        $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
+
+        $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
+            $this->rounding->roundPriceWithVat($price)->getAmount(),
+            $intlCurrency->getCurrencyCode()
+        );
+
+        return $this->normalizeSpaces($formattedPriceWithCurrencySymbol);
+    }
+
+    /**
+     * @deprecated test is deprecated and will be removed in the next major.
+     *
+     * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
+     * @return string
+     */
     public function getFormattedPriceOnFrontend(Money $price): string
     {
         $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(Domain::FIRST_DOMAIN_ID);
         $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
         $currencyFormatter = $this->currencyFormatterFactory->create($firstDomainLocale);
+
+        $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
+
+        $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
+            $this->rounding->roundPriceWithVat($price)->getAmount(),
+            $intlCurrency->getCurrencyCode()
+        );
+
+        return $this->normalizeSpaces($formattedPriceWithCurrencySymbol);
+    }
+
+    /**
+     * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
+     * @return string
+     */
+    public function getFormattedPriceRoundedByCurrencyOnFrontend(Money $price): string
+    {
+        $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(Domain::FIRST_DOMAIN_ID);
+        $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
+        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($firstDomainLocale, $firstDomainDefaultCurrency);
 
         $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
 

--- a/project-base/tests/ShopBundle/Test/Codeception/Helper/NumberFormatHelper.php
+++ b/project-base/tests/ShopBundle/Test/Codeception/Helper/NumberFormatHelper.php
@@ -115,7 +115,7 @@ class NumberFormatHelper extends Module
         $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
 
         $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
-            $this->rounding->roundPriceWithVat($price)->getAmount(),
+            $this->rounding->roundPriceWithVatByCurrency($price, $firstDomainDefaultCurrency)->getAmount(),
             $intlCurrency->getCurrencyCode()
         );
 
@@ -159,7 +159,7 @@ class NumberFormatHelper extends Module
         $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
 
         $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
-            $this->rounding->roundPriceWithVat($price)->getAmount(),
+            $this->rounding->roundPriceWithVatByCurrency($price, $firstDomainDefaultCurrency)->getAmount(),
             $intlCurrency->getCurrencyCode()
         );
 

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -401,6 +401,9 @@ There you can find links to upgrade notes for other versions too.
 - improve your data fixtures and tests so they are more resistant against domains and locales settings changes [#1425](https://github.com/shopsys/shopsys/pull/1425)
     - if you have done a lot of changes in your data fixtures you might consider to skip this upgrade
     - for detailed information, see [the separate article](upgrade-instructions-for-improved-data-fixtures-and-tests.md)
+
+- cover new rounding functionality with tests, for detail information see [the separate article](upgrade-instructions-for-currency-rounding.md)
+
 - add possibility to override admin styles from project-base
  ([#1472](https://github.com/shopsys/shopsys/pull/1472))
     - delete all files from `src/Shopsys/ShopBundle/styles/admin/` and create two new files in it - `main.less` and `todo.less`

--- a/upgrade/upgrade-instructions-for-currency-rounding.md
+++ b/upgrade/upgrade-instructions-for-currency-rounding.md
@@ -7,6 +7,29 @@ can manage minimum fraction digits, which will be displayed on fronted, for ever
 To avoid of [BC breaks](/docs/contributing/backward-compatibility-promise.md), new functions for rounding by currency have been implemented.
 Because of new functions, new tests have been introduced.
 
+### Data fixture
+- set up default settings for demo currencies in `CurrencyDataFixture`
+```diff
+         /**
+          * The "CZK" currency is created in database migration.
+          * @see \Shopsys\FrameworkBundle\Migrations\Version20180603135342
+          */
+         $currencyCzk = $this->currencyFacade->getById(1);
++        $currencyData = $this->currencyDataFactory->createFromCurrency($currencyCzk);
++        $currencyData->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
++        $currencyData->roundingType = Currency::ROUNDING_TYPE_INTEGER;
++        $currencyCzk = $this->currencyFacade->edit($currencyCzk->getId(), $currencyData);
+         $this->addReference(self::CURRENCY_CZK, $currencyCzk);
+```
+```diff
+          $currencyData->code = Currency::CODE_EUR;
+          $currencyData->exchangeRate = '25';
++         $currencyData->minFractionDigits = Currency::DEFAULT_MIN_FRACTION_DIGITS;
++         $currencyData->roundingType = Currency::ROUNDING_TYPE_HUNDREDTHS;
+          $currencyEuro = $this->currencyFacade->create($currencyData);
+```
+- If you would like to use different settings in your existing projects, we recommend you to create migration on your own 
+
 ### New tests for price formatting 
 - add tests for `NumberFormatHelper`
 ```

--- a/upgrade/upgrade-instructions-for-currency-rounding.md
+++ b/upgrade/upgrade-instructions-for-currency-rounding.md
@@ -30,6 +30,25 @@ Because of new functions, new tests have been introduced.
 ```
 - If you would like to use different settings in your existing projects, we recommend you to create migration on your own 
 
+### Format prices in filter price range
+- It is recommended to edit filter price range placeholders directly in `filterFormMacro.html.twig` instead of in `ProductFilterFormType`. 
+You can set placeholders on your own, e.g you can format values with price formatter
+- edit `filterFormMacro.html.twig`
+```diff
+-       {{ form_row(filterForm.minimalPrice, {label: 'Price from'|trans, symbolAfterInput: currencySymbolByDomainId(getDomain().id), attr: { class: 'js-product-filter-call-change-after-reset'} }) }}
+-       {{ form_row(filterForm.maximalPrice, {label: 'Price to'|trans, symbolAfterInput: currencySymbolByDomainId(getDomain().id), attr: { class: 'js-product-filter-call-change-after-reset'} }) }}
++       {{ form_row(filterForm.minimalPrice, {
++          label: 'Price from'|trans,
++          symbolAfterInput: currencySymbolByDomainId(getDomain().id),
++          attr: { class: 'js-product-filter-call-change-after-reset', placeholder:priceRange.minimalPrice|price }
++       }) }}
++       {{ form_row(filterForm.maximalPrice, {
++          label: 'Price to'|trans,
++          symbolAfterInput: currencySymbolByDomainId(getDomain().id),
++          attr: { class: 'js-product-filter-call-change-after-reset', placeholder:priceRange.maximalPrice|price}
++       }) }}
+```
+
 ### New tests for price formatting 
 - add tests for `NumberFormatHelper`
 ```
@@ -371,6 +390,7 @@ Because of new functions, new tests have been introduced.
     - `Rounding::roundPriceWithVat()` use `roundPriceWithVatByCurrency()`
     - `BasePriceCalculation::getBasePriceWithVat()` use `getBasePriceWithVatRoundedByCurrency()`
     - `BasePriceCalculation::calculateBasePrice()` use `calculateBasePriceRoundedByCurrency()`
+    - `ProductFilterFormType::transformMoneyToView`, set up filter price range placeholders in `filterFormMacro.html.twig`
 - these tests are deprecated and will be removed in the next major release
     - `CartBoxPage::seeCountAndPriceInCartBox()`
     - `CartPage::assertProductPrice()`

--- a/upgrade/upgrade-instructions-for-currency-rounding.md
+++ b/upgrade/upgrade-instructions-for-currency-rounding.md
@@ -1,0 +1,107 @@
+# Upgrade Instructions for rounding by Currency
+
+There is a new way of rounding prices. Previously global rounding setting was removed.
+Rounding depends on currency settings, which can be managed by administrator. In addition, administrator 
+can manage minimum fraction digits, which will be displayed on fronted, for every currency separately.
+
+To avoid of [BC breaks](/docs/contributing/backward-compatibility-promise.md), new functions for rounding by currency have been implemented.
+Because of new functions, new tests have been introduced.
+
+### New tests for price formatting 
+- add tests for `NumberFormatHelper`
+```
+    /**
+     * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
+     * @return string
+     */
+    public function getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money $price): string
+    {
+        $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(Domain::FIRST_DOMAIN_ID);
+        $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
+        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($firstDomainLocale, $firstDomainDefaultCurrency);
+
+        $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
+
+        $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
+            $this->rounding->roundPriceWithVat($price)->getAmount(),
+            $intlCurrency->getCurrencyCode()
+        );
+
+        return $this->normalizeSpaces($formattedPriceWithCurrencySymbol);
+    }
+```
+```
+    /**
+     * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
+     * @return string
+     */
+    public function getFormattedPriceRoundedByCurrencyOnFrontend(Money $price): string
+    {
+        $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(Domain::FIRST_DOMAIN_ID);
+        $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
+        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($firstDomainLocale, $firstDomainDefaultCurrency);
+
+        $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
+
+        $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
+            $this->rounding->roundPriceWithVat($price)->getAmount(),
+            $intlCurrency->getCurrencyCode()
+        );
+
+        return $this->normalizeSpaces($formattedPriceWithCurrencySymbol);
+    }
+```
+- add test for `CartBoxPage`
+```
+    /**
+     * @param int $expectedCount
+     * @param string $expectedPrice
+     */
+    public function seeCountAndPriceRoundedByCurrencyInCartBox(int $expectedCount, string $expectedPrice): void
+    {
+        $convertedPrice = Money::create($this->tester->getPriceWithVatConvertedToDomainDefaultCurrency($expectedPrice));
+        $expectedFormattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend($convertedPrice);
+        $messageId = '{1} <strong class="cart__state">%itemsCount%</strong> item for <strong class="cart__state">%priceWithVat%</strong>|[2,Inf] <strong class="cart__state">%itemsCount%</strong> items for <strong class="cart__state">%priceWithVat%</strong>';
+        $translatedMessageWithTags = tc($messageId, $expectedCount, ['%itemsCount%' => $expectedCount, '%priceWithVat%' => $expectedFormattedPriceWithCurrency], 'messages', $this->tester->getFrontendLocale());
+
+        $this->tester->seeInCss(strip_tags($translatedMessageWithTags), '.js-cart-info');
+    }
+```
+- add tests for `CartPage`
+```
+    /**
+     * @param string $productName
+     * @param string $price
+     */
+    public function assertProductPriceRoundedByCurrency($productName, $price)
+    {
+        $convertedPrice = $this->tester->getPriceWithVatConvertedToDomainDefaultCurrency($price);
+        $formattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money::create($convertedPrice));
+        $productPriceCell = $this->getProductTotalPriceCellByName($productName);
+        $this->tester->seeInElement($formattedPriceWithCurrency, $productPriceCell);
+    }
+```
+```
+    /**
+     * @param string $price
+     */
+    public function assertTotalPriceWithVatRoundedByCurrency($price)
+    {
+        $formattedPriceWithCurrency = $this->tester->getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money::create($price));
+        $orderPriceCell = $this->getTotalProductsPriceCell();
+        $message = t('Total price including VAT', [], 'messages', $this->tester->getFrontendLocale());
+        $this->tester->seeInElement($message . ': ' . $formattedPriceWithCurrency, $orderPriceCell);
+    }
+```
+
+### Deprecated functions and test
+- these methods are deprecated and will be removed in the next major release
+    - `CurrencyFormatterFactory::create()` use `createByLocaleAndCurrency()` instead
+- these tests are deprecated and will be removed in the next major release
+    - `CartBoxPage::seeCountAndPriceInCartBox()`
+    - `CartPage::assertProductPrice()`
+    - `CartPage::assertTotalPriceWithVat()`
+    - `NumberFormatHelper::getFormattedPriceWithCurrencySymbolOnFrontend()`
+    - `NumberFormatHelper::getFormattedPriceOnFrontend()`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There is a new way of rounding prices. Rounding depends on currency settings, which can be managed by administrator. In addition, administrator can manage minimum fraction digits, which will be displayed on fronted, for every currency separately. Previously global rounding has been removed.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1027 #1444 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
