### PR TITLE
[project-base] fixed usage of sed command on macos

### DIFF
--- a/project-base/.travis.yml
+++ b/project-base/.travis.yml
@@ -19,7 +19,7 @@ jobs:
             script:
                 - sudo apt install ruby
                 - gem install docker-sync
-                - sed -i -r "s#sed -i -E#sed -i -r#" ./scripts/install.sh
+                - sed -i -r "s#sed -i '' -E#sed -i -r#" ./scripts/install.sh
                 - mkdir -p ./var/elasticsearch-data
                 - chmod -R 777 ./var/elasticsearch-data
                 - echo 2 | ./scripts/install.sh --skip-aliasing

--- a/project-base/scripts/install.sh
+++ b/project-base/scripts/install.sh
@@ -55,8 +55,8 @@ case "$operatingSystem" in
         cp -f docker/conf/docker-compose-mac.yml.dist docker-compose.yml
         cp -f docker/conf/docker-sync.yml.dist docker-sync.yml
 
-        sed -i -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
-        sed -i -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
+        sed -i '' -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
+        sed -i '' -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
 
         if [[ $1 != --skip-aliasing ]]; then
             echo "You will be asked to enter sudo password in case to allow second domain alias in your system config.."

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -203,7 +203,7 @@ There you can find links to upgrade notes for other versions too.
                     script:
                         - sudo apt install ruby
                         - gem install docker-sync
-                        - sed -i -r "s#sed -i -E#sed -i -r#" ./scripts/install.sh
+                        - sed -i -r "s#sed -i \'\' -E#sed -i -r#" ./scripts/install.sh
                         - mkdir -p ./var/elasticsearch-data
                         - chmod -R 777 ./var/elasticsearch-data
                         - echo 2 | ./scripts/install.sh --skip-aliasing
@@ -225,8 +225,8 @@ There you can find links to upgrade notes for other versions too.
 
         -        echo "You will be asked to enter sudo password in case to allow second domain alias in your system config.."
         -        sudo ifconfig lo0 alias 127.0.0.2 up
-        +        sed -i -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
-        +        sed -i -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
+        +        sed -i '' -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
+        +        sed -i '' -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
         +
         +        if [[ $1 != --skip-aliasing ]]; then
         +            echo "You will be asked to enter sudo password in case to allow second domain alias in your system config.."

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -203,7 +203,7 @@ There you can find links to upgrade notes for other versions too.
                     script:
                         - sudo apt install ruby
                         - gem install docker-sync
-                        - sed -i -r "s#sed -i \'\' -E#sed -i -r#" ./scripts/install.sh
+                        - sed -i -r "s#sed -i '' -E#sed -i -r#" ./scripts/install.sh
                         - mkdir -p ./var/elasticsearch-data
                         - chmod -R 777 ./var/elasticsearch-data
                         - echo 2 | ./scripts/install.sh --skip-aliasing


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On MacOS when running script `install.sh` there was created duplicity of `docker-compose.yml` named as `docker-compose.yml-E` because of wrong usage of `sed` command. This PR will fix it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
