### PR TITLE
[frontend-api] Product variants and main variant can now be loaded via frontend API

### DIFF
--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -278,9 +278,9 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
     /**
      * @return array
      */
-    public function getAllListableProducts(): array
+    public function getAllOfferedProducts(): array
     {
-        return $this->productRepository->getAllListableProducts(
+        return $this->productRepository->getAllOfferedProducts(
             $this->domain->getId(),
             $this->currentCustomer->getPricingGroup()
         );

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -792,8 +792,8 @@ class ProductRepository
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return array
      */
-    public function getAllListableProducts(int $domainId, PricingGroup $pricingGroup): array
+    public function getAllOfferedProducts(int $domainId, PricingGroup $pricingGroup): array
     {
-        return $this->getAllListableQueryBuilder($domainId, $pricingGroup)->getQuery()->execute();
+        return $this->getAllOfferedQueryBuilder($domainId, $pricingGroup)->getQuery()->execute();
     }
 }

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductResolver.php
@@ -47,16 +47,10 @@ class ProductResolver implements ResolverInterface, AliasedInterface
         }
 
         try {
-            $product = $this->productFacade->getByUuid($uuid);
+            return $this->productFacade->getByUuid($uuid);
         } catch (\Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException $productNotFoundException) {
             throw new UserError($productNotFoundException->getMessage());
         }
-
-        if ($product->isVariant() === true) {
-            throw new UserError('This product is variant and there is no support for variants yet.');
-        }
-
-        return $product;
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductResolverMap.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductResolverMap.php
@@ -38,16 +38,37 @@ class ProductResolverMap extends ResolverMap
     {
         return [
             'Product' => [
-                'shortDescription' => function (Product $product) {
-                    return $product->getShortDescription($this->domain->getId());
-                },
-                'link' => function (Product $product) {
-                    return $this->getProductLink($product);
-                },
-                'categories' => function (Product $product) {
-                    return $product->getCategoriesIndexedByDomainId()[$this->domain->getId()];
+                self::RESOLVE_TYPE => function (Product $product) {
+                    if ($product->isMainVariant()) {
+                        return 'MainVariant';
+                    } elseif ($product->isVariant()) {
+                        return 'Variant';
+                    } else {
+                        return 'RegularProduct';
+                    }
                 },
             ],
+            'RegularProduct' => $this->mapProduct(),
+            'Variant' => $this->mapProduct(),
+            'MainVariant' => $this->mapProduct(),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function mapProduct(): array
+    {
+        return [
+            'shortDescription' => function (Product $product) {
+                return $product->getShortDescription($this->domain->getId());
+            },
+            'link' => function (Product $product) {
+                return $this->getProductLink($product);
+            },
+            'categories' => function (Product $product) {
+                return $product->getCategoriesIndexedByDomainId()[$this->domain->getId()];
+            },
         ];
     }
 

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -38,7 +38,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function resolve(): array
     {
-        return $this->productOnCurrentDomainFacade->getAllListableProducts();
+        return $this->productOnCurrentDomainFacade->getAllOfferedProducts();
     }
 
     /**

--- a/packages/frontend-api/src/Resources/config/graphql-types/MainVariantDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/MainVariantDecorator.types.yml
@@ -1,0 +1,11 @@
+MainVariantDecorator:
+    type: object
+    decorator: true
+    inherits:
+        - 'ProductDecorator'
+    config:
+        fields:
+            variants:
+                type: '[Product!]!'
+        interfaces:
+            - 'Product'

--- a/packages/frontend-api/src/Resources/config/graphql-types/ProductDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ProductDecorator.types.yml
@@ -1,5 +1,5 @@
 ProductDecorator:
-    type: object
+    type: interface
     decorator: true
     config:
         description: "Represents a category"

--- a/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yml
@@ -15,3 +15,5 @@ QueryDecorator:
                 args:
                     uuid:
                         type: "ID!"
+            RegularProduct:
+                type: 'RegularProduct'

--- a/packages/frontend-api/src/Resources/config/graphql-types/RegularProductDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/RegularProductDecorator.types.yml
@@ -1,0 +1,8 @@
+RegularProductDecorator:
+    type: object
+    decorator: true
+    inherits:
+        - 'ProductDecorator'
+    config:
+        interfaces:
+            - 'Product'

--- a/packages/frontend-api/src/Resources/config/graphql-types/VariantDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/VariantDecorator.types.yml
@@ -1,0 +1,11 @@
+VariantDecorator:
+    type: object
+    decorator: true
+    inherits:
+        - 'ProductDecorator'
+    config:
+        fields:
+            mainVariant:
+                type: 'Product'
+        interfaces:
+            - 'Product'

--- a/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/MainVariant.types.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/MainVariant.types.yml
@@ -1,0 +1,4 @@
+MainVariant:
+    type: object
+    inherits:
+        - 'MainVariantDecorator'

--- a/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Product.types.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Product.types.yml
@@ -1,4 +1,4 @@
 Product:
-    type: object
+    type: interface
     inherits:
         - 'ProductDecorator'

--- a/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/RegularProduct.types.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/RegularProduct.types.yml
@@ -1,0 +1,4 @@
+RegularProduct:
+    type: object
+    inherits:
+        - 'RegularProductDecorator'

--- a/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Variant.types.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Variant.types.yml
@@ -1,0 +1,4 @@
+Variant:
+    type: object
+    inherits:
+        - 'VariantDecorator'

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Product;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class ProductVariantTest extends GraphQlTestCase
+{
+    /**
+     * @var \Shopsys\ShopBundle\Model\Product\Product
+     */
+    private $productAsMainVariant;
+
+    /**
+     * @var \Shopsys\ShopBundle\Model\Product\Product
+     */
+    private $productAsVariant;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    private $domain;
+
+    protected function setUp(): void
+    {
+        $this->domain = $this->getContainer()->get(Domain::class);
+        $productFacade = $this->getContainer()->get(ProductFacade::class);
+
+        $this->productAsMainVariant = $productFacade->getById(150);
+        $this->productAsVariant = $productFacade->getById(75);
+
+        parent::setUp();
+    }
+
+    public function testProductMainVariantResultData(): void
+    {
+        $query = '
+            query {
+                product(uuid: "' . $this->productAsMainVariant->getUuid() . '") {
+                    __typename,
+                    name,
+                    shortDescription
+                    ...on MainVariant {
+                      variants {
+                        name
+                      }
+                    }
+                }
+            }
+        ';
+
+        $arrayExpected = [
+            'data' => [
+                'product' => [
+                    '__typename' => 'MainVariant',
+                    'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'shortDescription' => t('Television monitor IPS, 16: 9, 5M: 1, 200cd/m2, 5ms GTG, FullHD 1920x1080, DVB-S2/T2/C, 2x HDMI, USB, SCART, 2 x 5W speakers, energ. Class A', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'variants' => [
+                        [
+                            'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                        ],
+                        [
+                            'name' => t('60” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                        ],
+                        [
+                            'name' => t('51,5” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertQueryWithExpectedArray($query, $arrayExpected);
+    }
+
+    public function testProductVariantResultData(): void
+    {
+        $query = '
+            query {
+                product(uuid: "' . $this->productAsVariant->getUuid() . '") {
+                    __typename,
+                    name,
+                    shortDescription
+                    ...on Variant {
+                      mainVariant {
+                        name
+                      }
+                    }
+                }
+            }
+        ';
+
+        $arrayExpected = [
+            'data' => [
+                'product' => [
+                    '__typename' => 'Variant',
+                    'name' => t('27” Hyundai T27D590EY', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'shortDescription' => t('TV LED, 100Hz, diagonal 80cm 100Hz, Full HD 1920 x 1080, DVB-T / C, 2x HDMI, USB, CI +, VGA, SCART, speakers 16W, energy. Class A +', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'mainVariant' => [
+                        'name' => t('32” Hyundai 32PFL4400', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertQueryWithExpectedArray($query, $arrayExpected);
+    }
+}

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -90,6 +90,12 @@ There you can find links to upgrade notes for other versions too.
 - removed unused `block domain` defined in `Admin/Content/Slider/edit.html.twig` ([#1437](https://github.com/shopsys/shopsys/pull/1437)) 
     - in case you are using this block of code you should copy it into your project (see PR mentioned above for more details)
 
+- add optional frontend API - products variant to your project ([#1489](https://github.com/shopsys/shopsys/pull/1489)):
+    - copy necessary type definitions:
+        [MainVariant.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/MainVariant.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/MainVariant.types.yml`
+        [RegularProduct.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/RegularProduct.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/RegularProduct.types.yml`
+        [Variant.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Variant.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/Variant.types.yml`
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Added support for loading product variants and main variant via frontend API
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
