### PR TITLE
Enabled to rewrite exact commits

### DIFF
--- a/packages/monorepo-tools/rewrite_history_into.sh
+++ b/packages/monorepo-tools/rewrite_history_into.sh
@@ -11,12 +11,31 @@
 
 SUBDIRECTORY=$1
 REV_LIST_PARAMS=${@:2}
+[[ ${@:3} == "--filter-commits" ]] && FILTER_COMMITS=true
+if [[ $REV_LIST_PARAMS == "--filter-commits" ]]; then
+    REV_LIST_PARAMS=''
+    FILTER_COMMITS=true
+fi
+
 echo "Rewriting history into a subdirectory '$SUBDIRECTORY'"
+
+if [[ $FILTER_COMMITS == true ]]; then
+    echo "Filter commits list:"
+    COMMITS_LIST=$(cat)
+    if [ -z "$COMMITS_LIST" ]; then
+        echo "Commits list should be passed. E.g. git rev-list <options> | rewrite_history_into.sh"
+        exit 1
+    fi
+    echo "$(echo "$COMMITS_LIST" | wc -l) item(s)"
+fi
+
 # All paths in the index are prefixed with a subdirectory and the index is updated
 # Previous index file is replaced by a new one (otherwise each file would be in the index twice)
 # The tags are rewritten as well as commits (the "cat" command will use original name without any change)
-SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
+COMMITS_LIST=$COMMITS_LIST SUBDIRECTORY_SED=${SUBDIRECTORY//-/\\-} TAB=$'\t' git filter-branch \
     --index-filter '
-    git ls-files -s | sed "s-$TAB\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && if [ -f "$GIT_INDEX_FILE.new" ]; then mv "$GIT_INDEX_FILE.new" "$GIT_INDEX_FILE"; fi' \
+    if [ -z "$COMMITS_LIST" ] || [ ! -z $(echo "$COMMITS_LIST" | grep "$GIT_COMMIT") ]; then
+        git ls-files -s | sed "s-$TAB\"*-&$SUBDIRECTORY_SED/-" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && if [ -f "$GIT_INDEX_FILE.new" ]; then mv "$GIT_INDEX_FILE.new" "$GIT_INDEX_FILE"; fi
+    fi' \
     --tag-name-filter 'cat' \
     -- $REV_LIST_PARAMS


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| See below :small_red_triangle_down:
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| No <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

The motivation: I'm creating monorepo from 2 different repos. Let's assume following:
`packages/pckg1` correspondents to 1st repo
`packages/pckg2` correspondents to 2nd repo

Using `git subtree add` command, I've added whole repos (including history) to my monorepo.
Both packages has `src` folder containing sources.
Now I'd like to rewrite every commit for both packages in following way:
for `pckg1`: `src/*` => `packages/pckg1/src/*`
for `pckg2`: `src/*` => `packages/pckg2/src/*`

The approach, which doesn't work: `rewrite_history_into.sh packages/<pckg> <last commit hash>`
Here is the [reason](https://stackoverflow.com/questions/15250070/running-filter-branch-over-a-range-of-commits)

The solution:
`git rev-list <last commit hash for pckg1> | rewrite_history_into.sh packages/pckg1`
`git rev-list <last commit hash for pckg2> | rewrite_history_into.sh packages/pckg2`