### PR TITLE
[framework] handle error when the last cart item has been removed

### DIFF
--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -145,7 +145,7 @@ class CartFacade
         $cart = $this->findCartOfCurrentCustomer();
 
         if ($cart === null) {
-            throw new \Shopsys\FrameworkBundle\Model\Cart\Exception\CartIsEmptyException();
+            return;
         }
 
         $cart->changeQuantities($quantitiesByCartItemId);
@@ -160,7 +160,7 @@ class CartFacade
         $cart = $this->findCartOfCurrentCustomer();
 
         if ($cart === null) {
-            throw new \Shopsys\FrameworkBundle\Model\Cart\Exception\CartIsEmptyException();
+            return;
         }
 
         $cartItemToDelete = $cart->getItemById($cartItemId);

--- a/packages/framework/src/Model/Cart/Exception/CartIsEmptyException.php
+++ b/packages/framework/src/Model/Cart/Exception/CartIsEmptyException.php
@@ -4,6 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Cart\Exception;
 
 use Exception;
 
+/**
+ * @deprecated exception is not used and will be removed in 9.0
+ */
 class CartIsEmptyException extends Exception implements CartException
 {
     /**

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -58,3 +58,5 @@ There you can find links to upgrade notes for other versions too.
     - `tests/ShopBundle/Functional/Model/Cart/CartItemTest.php`
     - `tests/ShopBundle/Functional/Model/Cart/CartTest.php`
     - `tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`
+
+- exception `CartIsEmptyException` has been marked as deprecated and will be removed in 9.0 ([#1494](https://github.com/shopsys/shopsys/pull/1494))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Handle error when the last cart item has been removed
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1438  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes