### PR TITLE
[project-base] Fixed missing zalas/phpunit-injector into project-base

### DIFF
--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -100,7 +100,8 @@
         "shopsys/http-smoke-testing": "dev-master",
         "phpstan/phpstan-doctrine": "^0.11.2",
         "phpstan/phpstan-phpunit": "^0.11.2",
-        "sspooky13/yaml-standards": "^4.2.5"
+        "sspooky13/yaml-standards": "^4.2.5",
+        "zalas/phpunit-injector": "^1.2"
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1392 we forgot to add the dependency to compose.json in project-base. This one fixing it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
