### PR TITLE
[frontend-api] Removed unnecessary domain property from fe api tests

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -56,10 +56,6 @@ parameters:
             message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*
         -
-            # In tests, we often grab services using $container->get() or access persistent references using $this->getReference()
-            message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
-            path: %currentWorkingDirectory%/project-base/tests/FrontendApiBundle/*
-        -
             # In tests, there are helper methods for grabbing services using $container->get()
             message: '#^Method .+::.+\(\) should return .+ but returns (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/project-base/tests/ShopBundle/*

--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -21,10 +21,6 @@ parameters:
             message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/tests/ShopBundle/*
         -
-            # In tests, we often grab services using $container->get() or access persistent references using $this->getReference()
-            message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
-            path: %currentWorkingDirectory%/tests/FrontendApiBundle/*
-        -
             # In tests, there are helper methods for grabbing services using $container->get()
             message: '#^Method .+::.+\(\) should return .+ but returns (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/tests/ShopBundle/*

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductTest.php
@@ -15,14 +15,8 @@ class ProductTest extends GraphQlTestCase
      */
     private $product;
 
-    /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
-     */
-    private $domain;
-
     protected function setUp(): void
     {
-        $this->domain = $this->getContainer()->get(Domain::class);
         $productFacade = $this->getContainer()->get(ProductFacade::class);
         $this->product = $productFacade->getById(1);
 

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
@@ -20,14 +20,8 @@ class ProductVariantTest extends GraphQlTestCase
      */
     private $productAsVariant;
 
-    /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
-     */
-    private $domain;
-
     protected function setUp(): void
     {
-        $this->domain = $this->getContainer()->get(Domain::class);
         $productFacade = $this->getContainer()->get(ProductFacade::class);
 
         $this->productAsMainVariant = $productFacade->getById(150);

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -9,18 +9,6 @@ use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class ProductsTest extends GraphQlTestCase
 {
-    /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
-     */
-    private $domain;
-
-    protected function setUp(): void
-    {
-        $this->domain = $this->getContainer()->get(Domain::class);
-
-        parent::setUp();
-    }
-
     public function testFirstFiveProductsWithName(): void
     {
         $firstDomainLocale = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -80,13 +80,6 @@ There you can find links to upgrade notes for other versions too.
         +     shopsys.frontend_api.domains:
         +         - 1
         +         - 2
-    - update your [`phpstan.neon`](https://github.com/shopsys/shopsys/blob/9.0/project-base/phpstan.neon): ([#1471](https://github.com/shopsys/shopsys/pull/1471))
-      ```diff
-      ignoreErrors:
-          +    # In tests, we often grab services using $container->get() or access persistent references using $this->getReference()
-          +    message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
-          +    path: %currentWorkingDirectory%/tests/FrontendApiBundle/*
-      ```
 - add optional fronted API - product and category images to your project ([#1486](https://github.com/shopsys/shopsys/pull/1486))
     - copy necessary type definitions:
         [Category.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Category.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/Category.types.yml`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Since #1392, `$domain` is available from parent class and should not be rewritten. Moreover, in parent class it's with protected visibility, and in these child classes with private, which is forbidden.  
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
