### PR TITLE
[project-base] - upgrade notes for lazyload

### DIFF
--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -647,24 +647,15 @@ There you can find links to upgrade notes for other versions too.
         ```
 
 - add image and iframe LazyLoad ([#1483](https://github.com/shopsys/shopsys/pull/1483))
-    - update docs `index.md` file
-        ```diff
-        ## Implementation
-        - * [Page layout design](./page-layout-design.md)
-        + * [Lazyload](./lazyload.md)
-          * [Override admin styles from project-base](./override-admin-styles.md)
-        + * [Page layout design](./page-layout-design.md)
-        ```
-    - add [page-layout-design.md](https://github.com/shopsys/project-base/blob/master/docs/frontend/lazyload.md) file
 
-    - update `listGrid.html.twig`(https://github.com/shopsys/project-base/blob/master/packages/framework/src/Resources/views/Admin/Content/Advert/listGrid.html.twig)
+    - update [listGrid.html.twig](https://github.com/shopsys/project-base/blob/master/packages/framework/src/Resources/views/Admin/Content/Advert/listGrid.html.twig)
         ```diff
           {% if row.advert.type == TYPE_IMAGE %}
         -    {{ image(row.advert, {size: 'original', height: 30}) }}
         +    {{ image(row.advert, {size: 'original', height: 30, lazy: false}) }}
            {% else %}
         ```
-    - update `imageuploadFields.html.twig`(https://github.com/shopsys/project-base/blob/master/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig)
+    - update [imageuploadFields.html.twig](https://github.com/shopsys/project-base/blob/master/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig)
         ```diff
           <div class="list-images__item__image js-image-upload-preview {% if isRemoved %}list-images__item__in--removed{% endif %}">
         -     {{ image(image, {size: 'original', height: '100', type: image_type}) }}
@@ -675,7 +666,7 @@ There you can find links to upgrade notes for other versions too.
         +      {{ image(entity, { size: 'original', height: 100, type: image_type, lazy: false }) }}
           </div>
         ```
-    - update `ImageExtension.php`(https://github.com/shopsys/project-base/blob/master/packages/framework/src/Twig/ImageExtension.php)
+    - update [ImageExtension.php](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Twig/ImageExtension.php)
         ```diff
            $htmlAttributes = $attributes;
            unset($htmlAttributes['type'], $htmlAttributes['size']);
@@ -688,7 +679,7 @@ There you can find links to upgrade notes for other versions too.
         +  }
         +
         ```
-    - update `ajaxMoreLoader.js`(https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js)
+    - update [ajaxMoreLoader.js](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js)
         ```diff
                  $paginationToItemSpan.text(paginationToItem);
                  updateLoadMoreButton();
@@ -696,16 +687,43 @@ There you can find links to upgrade notes for other versions too.
                  Shopsys.register.registerNewContent($nextItems);
              }
         ```
-    - update `productList.AjaxFilter.js`(https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.AjaxFilter.js)
+    - update [productList.AjaxFilter.js](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.AjaxFilter.js)
         ```diff
                  $productsWithControls.show();
         +        Shopsys.lazyLoadCall.inContainer($productsWithControls);
                  Shopsys.register.registerNewContent($productsWithControls);
              };
         ```
-    - add new file `lazyLoadInit.js`(https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js)
+    - add new file [lazyLoadInit.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js)
+
+    - add new file [minilazyload.min.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js)
+
     - update admin files
-      - `index.html.twig`(https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Default/index.html.twig)
+      - [listGrid.html.twig](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Resources/views/Admin/Content/Advert/listGrid.html.twig)
+
+      ```diff
+        {% if row.advert.type == TYPE_IMAGE %}
+      -     {{ image(row.advert, {size: 'original', height: 30}) }}
+      +     {{ image(row.advert, {size: 'original', height: 30, lazy: false}) }}
+        {% else %}
+      ```
+      - [imageuploadFields.html.twig](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig})
+
+      ```diff
+        <div class="list-images__item__image js-image-upload-preview {% if isRemoved %}list-images__item__in--removed{% endif %}">
+      -     {{ image(image, {size: 'original', height: '100', type: image_type}) }}
+      +     {{ image(image, {size: 'original', height: '100', type: image_type, lazy: false}) }}
+        </div>
+
+        <div class="form-line__item">
+            {{ image(entity, { size: 'original', height: 100, type: image_type }) }}
+            {{ image(entity, { size: 'original', height: 100, type: image_type, lazy: false }) }}
+        </div>
+      ```
+
+
+    - update frontend files and disable image lazyload
+      - [index.html.twig](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Default/index.html.twig)
 
       ```diff
         <div class="box-slider__item">
@@ -713,7 +731,7 @@ There you can find links to upgrade notes for other versions too.
       +     <a href="{{ item.link }}">{{ image(item, { lazy: false }) }}</a>
         </div>
       ```
-      - `detail.html.twig`(https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/detail.html.twig)
+      - [detail.html.twig](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/detail.html.twig)
 
       ```diff
         <div class="box-slider__item">
@@ -722,9 +740,9 @@ There you can find links to upgrade notes for other versions too.
         </div>
       ```
     - update test files according to PR:
-        - [ReadModelBundle/Functional/Twig/ImageExtensionTest.php](https://github.com/shopsys/project-base/blob/master/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php)
-        - [ReadModelBundle/Functional/Twig/Resources/picture.twig](https://github.com/shopsys/project-base/blob/master/project-base/tests/ReadModelBundle/Functional/Twig/Resources/picture.twig)
-        - [ShopBundle/Functional/Twig/Resources/picture.twig](https://github.com/shopsys/project-base/blob/master/project-base/tests/ShopBundle/Functional/Twig/Resources/picture.twig)
+        - [ReadModelBundle/Functional/Twig/ImageExtensionTest.php](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php)
+        - [ReadModelBundle/Functional/Twig/Resources/picture.twig](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ReadModelBundle/Functional/Twig/Resources/picture.twig)
+        - [ShopBundle/Functional/Twig/Resources/picture.twig](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Twig/Resources/picture.twig)
 
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -648,26 +648,7 @@ There you can find links to upgrade notes for other versions too.
 
 - add image and iframe LazyLoad ([#1483](https://github.com/shopsys/shopsys/pull/1483))
 
-    - update [listGrid.html.twig](https://github.com/shopsys/project-base/blob/master/packages/framework/src/Resources/views/Admin/Content/Advert/listGrid.html.twig)
-        ```diff
-          {% if row.advert.type == TYPE_IMAGE %}
-        -    {{ image(row.advert, {size: 'original', height: 30}) }}
-        +    {{ image(row.advert, {size: 'original', height: 30, lazy: false}) }}
-           {% else %}
-        ```
-    - update [imageuploadFields.html.twig](https://github.com/shopsys/project-base/blob/master/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig)
-        ```diff
-          <div class="list-images__item__image js-image-upload-preview {% if isRemoved %}list-images__item__in--removed{% endif %}">
-        -     {{ image(image, {size: 'original', height: '100', type: image_type}) }}
-        +     {{ image(image, {size: 'original', height: '100', type: image_type, lazy: false}) }}
-          </div>
-          <div class="form-line__item">
-        -      {{ image(entity, { size: 'original', height: 100, type: image_type }) }}
-        +      {{ image(entity, { size: 'original', height: 100, type: image_type, lazy: false }) }}
-          </div>
-        ```
-
-    - update [ajaxMoreLoader.js](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js)
+    - update `src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js`
         ```diff
                  $paginationToItemSpan.text(paginationToItem);
                  updateLoadMoreButton();
@@ -675,42 +656,19 @@ There you can find links to upgrade notes for other versions too.
                  Shopsys.register.registerNewContent($nextItems);
              }
         ```
-    - update [productList.AjaxFilter.js](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.AjaxFilter.js)
+    - update `src/Shopsys/ShopBundle/Resources/scripts/frontend/product/productList.AjaxFilter.js`
         ```diff
                  $productsWithControls.show();
         +        Shopsys.lazyLoadCall.inContainer($productsWithControls);
                  Shopsys.register.registerNewContent($productsWithControls);
              };
         ```
-    - add new file [project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js)
+    - add new file [src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js)
 
-    - add new file [project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js)
-
-    - update admin files
-      - [listGrid.html.twig](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Resources/views/Admin/Content/Advert/listGrid.html.twig)
-
-      ```diff
-        {% if row.advert.type == TYPE_IMAGE %}
-      -     {{ image(row.advert, {size: 'original', height: 30}) }}
-      +     {{ image(row.advert, {size: 'original', height: 30, lazy: false}) }}
-        {% else %}
-      ```
-      - [imageuploadFields.html.twig](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig})
-
-      ```diff
-        <div class="list-images__item__image js-image-upload-preview {% if isRemoved %}list-images__item__in--removed{% endif %}">
-      -     {{ image(image, {size: 'original', height: '100', type: image_type}) }}
-      +     {{ image(image, {size: 'original', height: '100', type: image_type, lazy: false}) }}
-        </div>
-
-        <div class="form-line__item">
-            {{ image(entity, { size: 'original', height: 100, type: image_type }) }}
-            {{ image(entity, { size: 'original', height: 100, type: image_type, lazy: false }) }}
-        </div>
-      ```
+    - add new file [src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js)
 
     - update frontend files and disable image lazyload
-      - [index.html.twig](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Default/index.html.twig)
+      - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Default/index.html.twig`
 
       ```diff
         <div class="box-slider__item">
@@ -718,7 +676,7 @@ There you can find links to upgrade notes for other versions too.
       +     <a href="{{ item.link }}">{{ image(item, { lazy: false }) }}</a>
         </div>
       ```
-      - [detail.html.twig](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/detail.html.twig)
+      - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/detail.html.twig`
 
       ```diff
         <div class="box-slider__item">
@@ -727,9 +685,9 @@ There you can find links to upgrade notes for other versions too.
         </div>
       ```
     - update test files according to PR:
-        - [ReadModelBundle/Functional/Twig/ImageExtensionTest.php](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php)
-        - [ReadModelBundle/Functional/Twig/Resources/picture.twig](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ReadModelBundle/Functional/Twig/Resources/picture.twig)
-        - [ShopBundle/Functional/Twig/Resources/picture.twig](https://github.com/shopsys/shopsys/blob/master/project-base/tests/ShopBundle/Functional/Twig/Resources/picture.twig)
+        - `tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php`
+        - `tests/ReadModelBundle/Functional/Twig/Resources/picture.twig`
+        - `tests/ShopBundle/Functional/Twig/Resources/picture.twig`
 
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -666,19 +666,7 @@ There you can find links to upgrade notes for other versions too.
         +      {{ image(entity, { size: 'original', height: 100, type: image_type, lazy: false }) }}
           </div>
         ```
-    - update [ImageExtension.php](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Twig/ImageExtension.php)
-        ```diff
-           $htmlAttributes = $attributes;
-           unset($htmlAttributes['type'], $htmlAttributes['size']);
-        +  $useLazyLoading = array_key_exists('lazy', $attributes) ? (bool)$attributes['lazy'] : true;
-        +  unset($htmlAttributes['lazy']);
-        +  if ($useLazyLoading === true) {
-              $htmlAttributes['loading'] = 'lazy';
-              $htmlAttributes['data-src'] = $htmlAttributes['src'];
-              $htmlAttributes['src'] = '';
-        +  }
-        +
-        ```
+
     - update [ajaxMoreLoader.js](https://github.com/shopsys/project-base/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js)
         ```diff
                  $paginationToItemSpan.text(paginationToItem);
@@ -694,9 +682,9 @@ There you can find links to upgrade notes for other versions too.
                  Shopsys.register.registerNewContent($productsWithControls);
              };
         ```
-    - add new file [lazyLoadInit.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js)
+    - add new file [project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/lazyLoadInit.js)
 
-    - add new file [minilazyload.min.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js)
+    - add new file [project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/scripts/frontend/plugins/minilazyload.min.js)
 
     - update admin files
       - [listGrid.html.twig](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Resources/views/Admin/Content/Advert/listGrid.html.twig)
@@ -720,7 +708,6 @@ There you can find links to upgrade notes for other versions too.
             {{ image(entity, { size: 'original', height: 100, type: image_type, lazy: false }) }}
         </div>
       ```
-
 
     - update frontend files and disable image lazyload
       - [index.html.twig](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Content/Default/index.html.twig)

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -647,7 +647,6 @@ There you can find links to upgrade notes for other versions too.
         ```
 
 - add image and iframe LazyLoad ([#1483](https://github.com/shopsys/shopsys/pull/1483))
-
     - update `src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js`
         ```diff
                  $paginationToItemSpan.text(paginationToItem);
@@ -685,9 +684,9 @@ There you can find links to upgrade notes for other versions too.
         </div>
       ```
     - update test files according to PR:
-        - `tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php`
-        - `tests/ReadModelBundle/Functional/Twig/Resources/picture.twig`
-        - `tests/ShopBundle/Functional/Twig/Resources/picture.twig`
+        - [`tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php`](https://github.com/shopsys/shopsys/pull/1483/files#diff-00773500c9249efed8065b6832744d31)
+        - [`tests/ReadModelBundle/Functional/Twig/Resources/picture.twig`](https://github.com/shopsys/shopsys/pull/1483/files#diff-f9ab2d66d30131a8d66df0a7c6eed4e4)
+        - [`tests/ShopBundle/Functional/Twig/Resources/picture.twig`](https://github.com/shopsys/shopsys/pull/1483/files#diff-b57160edc2db5a01659693b4b417dafd)
 
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| this PR adding upgrade notes for added support for image and iframe lazy loading introduced in #1483
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
