### PR TITLE
[shopsys] fixed copying codeception logs from pod

### DIFF
--- a/.ci/export_logs.sh
+++ b/.ci/export_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -ex
+#!/bin/sh -e
 
 # used to copy logs of codeception which are not streamed
 WEBSERVER_PHP_FPM_CONTAINER_NAME="webserver-php-fpm"

--- a/.ci/export_logs.sh
+++ b/.ci/export_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 
 # used to copy logs of codeception which are not streamed
 WEBSERVER_PHP_FPM_CONTAINER_NAME="webserver-php-fpm"
@@ -15,6 +15,8 @@ for POD_NAME in $(kubectl get pods -n ${JOB_NAME} | grep -v ^NAME | cut -f 1 -d 
     if [[ ${POD_NAME} == *${WEBSERVER_PHP_FPM_CONTAINER_NAME}* ]]; then
         # copy codeception logs from php-fpm pod to local
         # we do not need to specify the php-fpm container because it is picked by default
-        kubectl cp ${JOB_NAME}/${POD_NAME}:/var/www/html/project-base/var/logs/codeception/ ${WORKSPACE}/logs/codeception
+        if [[ -n $(kubectl -n ${JOB_NAME} exec ${POD_NAME} -- ls -1 var/logs |grep '^codeception$') ]]; then
+            kubectl cp ${JOB_NAME}/${POD_NAME}:/var/www/html/project-base/var/logs/codeception/ ${WORKSPACE}/logs/codeception
+        fi
     fi
 done

--- a/.ci/export_logs.sh
+++ b/.ci/export_logs.sh
@@ -15,7 +15,7 @@ for POD_NAME in $(kubectl get pods -n ${JOB_NAME} | grep -v ^NAME | cut -f 1 -d 
     if [[ ${POD_NAME} == *${WEBSERVER_PHP_FPM_CONTAINER_NAME}* ]]; then
         # copy codeception logs from php-fpm pod to local
         # we do not need to specify the php-fpm container because it is picked by default
-        if [[ -n $(kubectl -n ${JOB_NAME} exec ${POD_NAME} -- ls -1 var/logs |grep '^codeception$') ]]; then
+        if kubectl -n ${JOB_NAME} exec ${POD_NAME} -- test -d project-base/var/logs/codeception; then
             kubectl cp ${JOB_NAME}/${POD_NAME}:/var/www/html/project-base/var/logs/codeception/ ${WORKSPACE}/logs/codeception
         fi
     fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When there were no codeception logs `.ci/export_logs.sh` failed on non-existing directory.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
