### PR TITLE
[framework] administrator roles are stored in database

### DIFF
--- a/packages/framework/src/Controller/Admin/AccessController.php
+++ b/packages/framework/src/Controller/Admin/AccessController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Controller\Admin;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AccessController extends AdminBaseController
+{
+    /**
+     * @Route("/access-denied/")
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function deniedAction(Request $request): Response
+    {
+        $this->getFlashMessageSender()->addErrorFlashTwig(
+            t('You are not allowed to access the requested page. Please ask your administrator to grant you access to the requested page.')
+        );
+        return new RedirectResponse($this->generateUrl('admin_default_dashboard'));
+    }
+}

--- a/packages/framework/src/Migrations/Version20191113133455.php
+++ b/packages/framework/src/Migrations/Version20191113133455.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20191113133455 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('
+            CREATE TABLE administrator_roles (
+                administrator_id INT NOT NULL,
+                role VARCHAR(255) NOT NULL,
+                PRIMARY KEY(administrator_id, role)
+            )');
+        $this->sql('CREATE INDEX IDX_680C3A6E4B09E92C ON administrator_roles (administrator_id)');
+        $this->sql('
+            ALTER TABLE
+                administrator_roles
+            ADD
+                CONSTRAINT FK_680C3A6E4B09E92C FOREIGN KEY (administrator_id) REFERENCES administrators (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $this->sql('INSERT INTO administrator_roles(administrator_id, role) 
+            SELECT id, 
+                CASE WHEN superadmin = TRUE 
+                    THEN \'ROLE_SUPER_ADMIN\' 
+                    ELSE \'ROLE_ADMIN\' 
+                END
+            FROM administrators
+        ');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20191113212555.php
+++ b/packages/framework/src/Migrations/Version20191113212555.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20191113212555 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE administrators DROP COLUMN superadmin');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20191113231735.php
+++ b/packages/framework/src/Migrations/Version20191113231735.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20191113231735 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE administrators ADD roles_changed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->sql('ALTER TABLE administrators ALTER roles_changed_at DROP DEFAULT');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -74,13 +74,6 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     protected $gridLimits;
 
     /**
-     * @ORM\Column(type="boolean")
-     *
-     * @var bool
-     */
-    protected $superadmin;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole[]|\Doctrine\Common\Collections\Collection
      *
      * @ORM\OneToMany(
@@ -122,7 +115,6 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
         $this->lastActivity = new DateTime();
         $this->gridLimits = new ArrayCollection();
         $this->loginToken = '';
-        $this->superadmin = $administratorData->superadmin;
         $this->multidomainLogin = false;
         $this->multidomainLoginToken = '';
         $this->multidomainLoginTokenExpiration = new DateTime();
@@ -221,14 +213,6 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
         }
 
         return false;
-    }
-
-    /**
-     * @param bool $superadmin
-     */
-    public function setSuperadmin($superadmin)
-    {
-        $this->superadmin = $superadmin;
     }
 
     /**

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -7,6 +7,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Serializable;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
+use Shopsys\FrameworkBundle\Model\Administrator\Exception\MandatoryAdministratorRoleIsMissingException;
 use Shopsys\FrameworkBundle\Model\Security\Roles;
 use Shopsys\FrameworkBundle\Model\Security\TimelimitLoginInterface;
 use Shopsys\FrameworkBundle\Model\Security\UniqueLoginInterface;
@@ -80,6 +81,18 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     protected $superadmin;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole[]|\Doctrine\Common\Collections\Collection
+     *
+     * @ORM\OneToMany(
+     *     targetEntity="\Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole",
+     *     mappedBy="administrator",
+     *     cascade={"persist"},
+     *     orphanRemoval=true
+     * )
+     */
+    protected $roles;
+
+    /**
      * @var bool
      */
     protected $multidomainLogin;
@@ -113,6 +126,7 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
         $this->multidomainLogin = false;
         $this->multidomainLoginToken = '';
         $this->multidomainLoginTokenExpiration = new DateTime();
+        $this->roles = new ArrayCollection();
     }
 
     /**
@@ -200,7 +214,13 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
      */
     public function isSuperadmin()
     {
-        return $this->superadmin;
+        foreach ($this->roles as $role) {
+            if ($role->getRole() === Roles::ROLE_SUPER_ADMIN) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -241,6 +261,14 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     public function setEmail($email)
     {
         $this->email = $email;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole[]
+     */
+    public function getAdministratorRoles(): array
+    {
+        return $this->roles->toArray();
     }
 
     /**
@@ -315,10 +343,13 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
      */
     public function getRoles()
     {
-        if ($this->superadmin) {
-            return [Roles::ROLE_SUPER_ADMIN];
+        $roles = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole $role */
+        foreach ($this->roles->toArray() as $role) {
+            $roles[] = $role->getRole();
         }
-        return [Roles::ROLE_ADMIN];
+
+        return $roles;
     }
 
     /**
@@ -362,5 +393,33 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     public function addGridLimit(AdministratorGridLimit $administratorGridLimit): void
     {
         $this->gridLimits->add($administratorGridLimit);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole[] $administratorRoles
+     */
+    public function addRoles(array $administratorRoles): void
+    {
+        foreach ($administratorRoles as $role) {
+            $this->roles->add($role);
+        }
+
+        $this->checkRolesContainAdminRole();
+    }
+
+    protected function checkRolesContainAdminRole(): void
+    {
+        foreach ($this->roles->toArray() as $role) {
+            if (in_array($role->getRole(), Roles::getMandatoryAdministratorRoles(), true)) {
+                return;
+            }
+        }
+
+        $message = sprintf(
+            'There is no mandatory role for administrator with ID `%s`. One of this role is expected: %s.',
+            $this->id,
+            implode(', ', Roles::getMandatoryAdministratorRoles())
+        );
+        throw new MandatoryAdministratorRoleIsMissingException($message);
     }
 }

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -105,6 +105,13 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     protected $multidomainLoginTokenExpiration;
 
     /**
+     * @var \DateTime|null
+     *
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    protected $rolesChangedAt;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $administratorData
      */
     public function __construct(AdministratorData $administratorData)
@@ -256,6 +263,19 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     }
 
     /**
+     * @return \DateTime|null
+     */
+    public function getRolesChangedAt(): ?DateTime
+    {
+        return $this->rolesChangedAt;
+    }
+
+    public function setRolesChangedNow(): void
+    {
+        $this->rolesChangedAt = new DateTime();
+    }
+
+    /**
      * @param string $loginToken
      */
     public function setLoginToken($loginToken)
@@ -295,6 +315,7 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
             $this->realName,
             $this->loginToken,
             time(),
+            $this->rolesChangedAt,
         ]);
     }
 
@@ -309,8 +330,8 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
             $this->password,
             $this->realName,
             $this->loginToken,
-            $timestamp
-        ) = unserialize($serialized);
+            $timestamp,
+            $this->rolesChangedAt) = unserialize($serialized);
         $this->lastActivity = new DateTime();
         $this->lastActivity->setTimestamp($timestamp);
     }
@@ -384,6 +405,8 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
      */
     public function addRoles(array $administratorRoles): void
     {
+        $this->setRolesChangedNow();
+
         foreach ($administratorRoles as $role) {
             $this->roles->add($role);
         }

--- a/packages/framework/src/Model/Administrator/AdministratorData.php
+++ b/packages/framework/src/Model/Administrator/AdministratorData.php
@@ -2,6 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+
 class AdministratorData
 {
     /**
@@ -29,8 +31,14 @@ class AdministratorData
      */
     public $email;
 
+    /**
+     * @var string[]
+     */
+    public $roles;
+
     public function __construct()
     {
         $this->superadmin = false;
+        $this->roles[] = Roles::ROLE_ADMIN;
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorData.php
+++ b/packages/framework/src/Model/Administrator/AdministratorData.php
@@ -7,11 +7,6 @@ use Shopsys\FrameworkBundle\Model\Security\Roles;
 class AdministratorData
 {
     /**
-     * @var bool
-     */
-    public $superadmin;
-
-    /**
      * @var string|null
      */
     public $username;
@@ -38,7 +33,6 @@ class AdministratorData
 
     public function __construct()
     {
-        $this->superadmin = false;
         $this->roles[] = Roles::ROLE_ADMIN;
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
@@ -32,7 +32,6 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
         $administratorData->email = $administrator->getEmail();
         $administratorData->realName = $administrator->getRealName();
         $administratorData->username = $administrator->getUsername();
-        $administratorData->superadmin = $administrator->isSuperadmin();
         $administratorData->roles = $administrator->getRoles();
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
@@ -33,5 +33,6 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
         $administratorData->realName = $administrator->getRealName();
         $administratorData->username = $administrator->getUsername();
         $administratorData->superadmin = $administrator->isSuperadmin();
+        $administratorData->roles = $administrator->getRoles();
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFacade.php
@@ -186,4 +186,13 @@ class AdministratorFacade
     {
         return $this->administratorRepository->getAllListableQueryBuilder();
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
+     */
+    public function setRolesChangedNow(Administrator $administrator)
+    {
+        $administrator->setRolesChangedNow();
+        $this->em->flush($administrator);
+    }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFacade.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFacade;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
@@ -24,6 +25,11 @@ class AdministratorFacade
     protected $administratorFactory;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFacade
+     */
+    protected $administratorRoleFacade;
+
+    /**
      * @var \Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface
      */
     protected $encoderFactory;
@@ -37,6 +43,7 @@ class AdministratorFacade
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository $administratorRepository
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFactoryInterface $administratorFactory
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFacade $administratorRoleFacade
      * @param \Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface $encoderFactory
      * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage
      */
@@ -44,12 +51,14 @@ class AdministratorFacade
         EntityManagerInterface $em,
         AdministratorRepository $administratorRepository,
         AdministratorFactoryInterface $administratorFactory,
+        AdministratorRoleFacade $administratorRoleFacade,
         EncoderFactoryInterface $encoderFactory,
         TokenStorageInterface $tokenStorage
     ) {
         $this->administratorRepository = $administratorRepository;
         $this->em = $em;
         $this->administratorFactory = $administratorFactory;
+        $this->administratorRoleFacade = $administratorRoleFacade;
         $this->encoderFactory = $encoderFactory;
         $this->tokenStorage = $tokenStorage;
     }
@@ -70,6 +79,8 @@ class AdministratorFacade
         $this->em->persist($administrator);
         $this->em->flush();
 
+        $this->administratorRoleFacade->refreshAdministratorRoles($administrator, $administratorData->roles);
+
         return $administrator;
     }
 
@@ -88,6 +99,8 @@ class AdministratorFacade
         }
 
         $this->em->flush();
+
+        $this->administratorRoleFacade->refreshAdministratorRoles($administrator, $administratorData->roles);
 
         return $administrator;
     }

--- a/packages/framework/src/Model/Administrator/AdministratorRepository.php
+++ b/packages/framework/src/Model/Administrator/AdministratorRepository.php
@@ -116,12 +116,4 @@ class AdministratorRepository
             ->select('COUNT(a)')
             ->getQuery()->getSingleScalarResult());
     }
-
-    /**
-     * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator[]
-     */
-    public function getAllSuperadmins()
-    {
-        return $this->getAdministratorRepository()->findBy(['superadmin' => true]);
-    }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorRepository.php
+++ b/packages/framework/src/Model/Administrator/AdministratorRepository.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
 
 class AdministratorRepository
 {
@@ -101,10 +102,10 @@ class AdministratorRepository
      */
     public function getAllListableQueryBuilder()
     {
-        return $this->getAdministratorRepository()
-            ->createQueryBuilder('a')
-            ->where('a.superadmin = :isSuperadmin')
-            ->setParameter('isSuperadmin', false);
+        return $this->getAdministratorRepository()->createQueryBuilder('a')
+            ->join('a.roles', 'ar')
+            ->where('ar.role = :role')
+            ->setParameter('role', Roles::ROLE_ADMIN);
     }
 
     /**

--- a/packages/framework/src/Model/Administrator/Exception/EditingSuperadminException.php
+++ b/packages/framework/src/Model/Administrator/Exception/EditingSuperadminException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Shopsys\FrameworkBundle\Model\Administrator\Exception;
-
-use Exception;
-
-class EditingSuperadminException extends Exception implements AdministratorException
-{
-}

--- a/packages/framework/src/Model/Administrator/Exception/MandatoryAdministratorRoleIsMissingException.php
+++ b/packages/framework/src/Model/Administrator/Exception/MandatoryAdministratorRoleIsMissingException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Exception;
+
+use Exception;
+
+class MandatoryAdministratorRoleIsMissingException extends Exception implements AdministratorException
+{
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRole.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRole.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+use Doctrine\ORM\Mapping as ORM;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+
+/**
+ * @ORM\Table(name="administrator_roles")
+ * @ORM\Entity
+ */
+class AdministratorRole
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator
+     *
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Administrator\Administrator", inversedBy="roles")
+     * @ORM\JoinColumn(nullable=false, name="administrator_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    protected $administrator;
+
+    /**
+     * @var string
+     *
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+    protected $role;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData $administratorRoleData
+     */
+    public function __construct(AdministratorRoleData $administratorRoleData)
+    {
+        $this->administrator = $administratorRoleData->administrator;
+        $this->role = $administratorRoleData->role;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Administrator
+     */
+    public function getAdministrator(): Administrator
+    {
+        return $this->administrator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleData.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleData.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+class AdministratorRoleData
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null
+     */
+    public $administrator;
+
+    /**
+     * @var string|null
+     */
+    public $role;
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactory.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+class AdministratorRoleDataFactory implements AdministratorRoleDataFactoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function create(): AdministratorRoleData
+    {
+        return new AdministratorRoleData();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createFromAdministratorRole(AdministratorRole $administratorRole): AdministratorRoleData
+    {
+        $administratorRoleData = new AdministratorRoleData();
+        $this->fillFromAdministratorRole($administratorRoleData, $administratorRole);
+
+        return $administratorRoleData;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData $administratorRoleData
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole $administratorRole
+     */
+    protected function fillFromAdministratorRole(
+        AdministratorRoleData $administratorRoleData,
+        AdministratorRole $administratorRole
+    ): void {
+        $administratorRoleData->administrator = $administratorRole->getAdministrator();
+        $administratorRoleData->role = $administratorRole->getRole();
+    }
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactoryInterface.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+interface AdministratorRoleDataFactoryInterface
+{
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData
+     */
+    public function create(): AdministratorRoleData;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole $administratorRole
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData
+     */
+    public function createFromAdministratorRole(AdministratorRole $administratorRole): AdministratorRoleData;
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleFacade.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleFacade.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+use Shopsys\FrameworkBundle\Model\Security\Roles;
+
+class AdministratorRoleFacade
+{
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFactoryInterface
+     */
+    protected $administratorRoleFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleDataFactoryInterface
+     */
+    protected $administratorRoleDataFactory;
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFactoryInterface $administratorRoleFactory
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleDataFactoryInterface $administratorRoleDataFactory
+     */
+    public function __construct(
+        EntityManagerInterface $em,
+        AdministratorRoleFactoryInterface $administratorRoleFactory,
+        AdministratorRoleDataFactoryInterface $administratorRoleDataFactory
+    ) {
+        $this->em = $em;
+        $this->administratorRoleFactory = $administratorRoleFactory;
+        $this->administratorRoleDataFactory = $administratorRoleDataFactory;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
+     * @param string[] $roles
+     */
+    public function refreshAdministratorRoles(Administrator $administrator, array $roles)
+    {
+        $roles = $this->addAdminRoleIfMissing($administrator, $roles);
+
+        $this->removeAllByAdministrator($administrator);
+
+        $newRoles = [];
+        foreach ($roles as $role) {
+            $newRoles[] = $this->createNewRole($administrator, $role);
+        }
+        $administrator->addRoles($newRoles);
+
+        $this->em->flush();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
+     * @param string[] $roles
+     * @return string[]
+     */
+    protected function addAdminRoleIfMissing(Administrator $administrator, array $roles): array
+    {
+        $adminRole = Roles::ROLE_ADMIN;
+        if ($administrator->isSuperadmin()) {
+            $adminRole = Roles::ROLE_SUPER_ADMIN;
+        }
+
+        if (in_array($adminRole, $roles, true) === false) {
+            $roles[] = $adminRole;
+        }
+
+        return $roles;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
+     */
+    protected function removeAllByAdministrator(Administrator $administrator): void
+    {
+        $oldAdministratorRoles = $administrator->getAdministratorRoles();
+        foreach ($oldAdministratorRoles as $oldAdministratorRole) {
+            $this->em->remove($oldAdministratorRole);
+        }
+        $this->em->flush();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
+     * @param string $role
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole
+     */
+    protected function createNewRole(Administrator $administrator, string $role): AdministratorRole
+    {
+        $administratorRoleData = $this->administratorRoleDataFactory->create();
+        $administratorRoleData->administrator = $administrator;
+        $administratorRoleData->role = $role;
+
+        return $this->administratorRoleFactory->create($administratorRoleData);
+    }
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleFactory.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class AdministratorRoleFactory implements AdministratorRoleFactoryInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
+     */
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(EntityNameResolver $entityNameResolver)
+    {
+        $this->entityNameResolver = $entityNameResolver;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData $administratorRoleData
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole
+     */
+    public function create(AdministratorRoleData $administratorRoleData): AdministratorRole
+    {
+        $classData = $this->entityNameResolver->resolve(AdministratorRole::class);
+
+        return new $classData($administratorRoleData);
+    }
+}

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleFactoryInterface.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
+
+interface AdministratorRoleFactoryInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData $administratorRoleData
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole
+     */
+    public function create(AdministratorRoleData $administratorRoleData): AdministratorRole;
+}

--- a/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator\Security;
+
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class AdministratorRolesChangedSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var bool
+     */
+    protected $rolesChanged;
+
+    /**
+     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade
+     */
+    protected $administratorFacade;
+
+    /**
+     * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, AdministratorFacade $administratorFacade)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->administratorFacade = $administratorFacade;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest'],
+        ];
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $token = $this->tokenStorage->getToken();
+
+        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null */
+        $administrator = null;
+        if ($token !== null) {
+            $administrator = $token->getUser();
+        }
+
+        if ($administrator instanceof Administrator && $this->rolesChanged === true) {
+            $token = new UsernamePasswordToken($administrator, $administrator->getPassword(), 'administration', $administrator->getRoles());
+            $this->tokenStorage->setToken($token);
+            $this->administratorFacade->setRolesChangedNow($administrator);
+            $this->rolesChanged = false;
+        }
+    }
+
+    public function updateRoles(): void
+    {
+        $this->rolesChanged = true;
+    }
+}

--- a/packages/framework/src/Model/Security/Roles.php
+++ b/packages/framework/src/Model/Security/Roles.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Security;
 
 class Roles
@@ -8,4 +10,12 @@ class Roles
     public const ROLE_ADMIN_AS_CUSTOMER = 'ROLE_ADMIN_AS_CUSTOMER';
     public const ROLE_LOGGED_CUSTOMER = 'ROLE_LOGGED_CUSTOMER';
     public const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
+
+    /**
+     * @return string[]
+     */
+    public static function getMandatoryAdministratorRoles(): array
+    {
+        return [self::ROLE_ADMIN, self::ROLE_SUPER_ADMIN];
+    }
 }

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -829,7 +829,6 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleDataFactory
 
-
     Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactory
 

--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -673,6 +673,9 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactory
 
+    Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleFactory
+
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridLimitFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridLimitFactory
 
@@ -822,6 +825,10 @@ services:
 
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory
+
+    Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleDataFactoryInterface:
+        alias: Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleDataFactory
+
 
     Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactory

--- a/packages/framework/tests/Unit/Model/Administrator/AdministratorTest.php
+++ b/packages/framework/tests/Unit/Model/Administrator/AdministratorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Administrator;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
+use Shopsys\FrameworkBundle\Model\Administrator\Exception\MandatoryAdministratorRoleIsMissingException;
+use Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole;
+use Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRoleData;
+use Shopsys\ShopBundle\Model\Administrator\AdministratorData;
+
+class AdministratorTest extends TestCase
+{
+    public function administratorRolesDataProvider()
+    {
+        return [
+            [
+                'roles' => ['ROLE_ADMIN', 'ROLE_PRODUCTS', 'ROLE_CATEGORIES'],
+                'expectedRole' => 'ROLE_ADMIN',
+            ],
+            [
+                'roles' => ['ROLE_SUPER_ADMIN', 'ROLE_PRODUCTS', 'ROLE_CATEGORIES'],
+                'expectedRole' => 'ROLE_SUPER_ADMIN',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider administratorRolesDataProvider
+     * @param array $roles
+     * @param string $expectedRole
+     */
+    public function testSetAdministratorRolesWithMandatoryRole(array $roles, string $expectedRole)
+    {
+        $administratorData = new AdministratorData();
+        $administratorData->realName = 'Administrator';
+        $administratorData->username = 'admin';
+        $administratorData->email = 'no-reply@shopsys.com';
+        $administratorData->password = 'pa55w0rd';
+
+        $administrator = new Administrator($administratorData);
+
+        $administratorRoles = [];
+        foreach ($roles as $role) {
+            $administratorRoleData = new AdministratorRoleData();
+            $administratorRoleData->administrator = $administrator;
+            $administratorRoleData->role = $role;
+            $administratorRoles[] = new AdministratorRole($administratorRoleData);
+        }
+        $administrator->addRoles($administratorRoles);
+
+        $this->assertContains($expectedRole, $administrator->getRoles());
+    }
+
+    public function testSetAdministratorRolesWithoutMandatoryRole()
+    {
+        $administratorData = new AdministratorData();
+        $administratorData->realName = 'Administrator';
+        $administratorData->username = 'admin';
+        $administratorData->email = 'no-reply@shopsys.com';
+        $administratorData->password = 'pa55w0rd';
+
+        $administrator = new Administrator($administratorData);
+
+        $administratorRoleData = new AdministratorRoleData();
+        $administratorRoleData->administrator = $administrator;
+        $administratorRoleData->role = 'ROLE_PRODUCTS';
+        $administratorRoles[] = new AdministratorRole($administratorRoleData);
+
+        $this->expectException(MandatoryAdministratorRoleIsMissingException::class);
+
+        $administrator->addRoles($administratorRoles);
+    }
+}

--- a/project-base/app/config/packages/security.yml
+++ b/project-base/app/config/packages/security.yml
@@ -22,6 +22,7 @@ security:
             anonymous: ~
             provider: administrators
             logout_on_user_change: true
+            access_denied_url: "/admin/access-denied/"
             form_login:
                 check_path: admin_login_check
                 login_path: admin_login

--- a/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/ShopBundle/Smoke/Http/RouteConfigCustomization.php
@@ -101,6 +101,10 @@ class RouteConfigCustomization
                 if ($this->isSingleDomain()) {
                     $config->skipRoute('Domain list in administration is not available when only 1 domain exists.');
                 }
+            })
+            ->customizeByRouteName('admin_access_denied', function (RouteConfig $config) {
+                $config->changeDefaultRequestDataSet('This route serves as "access_denied_url" (see security.yml) and always redirects to a referer (or dashboard).')
+                    ->setExpectedStatusCode(302);
             });
     }
 
@@ -157,7 +161,7 @@ class RouteConfigCustomization
             ->customize(function (RouteConfig $config, RouteInfo $info) {
                 if (preg_match('~^admin_(superadmin_|translation_list$)~', $info->getRouteName())) {
                     $config->changeDefaultRequestDataSet('Only superadmin should be able to see this route.')
-                        ->setExpectedStatusCode(404);
+                        ->setExpectedStatusCode(302);
                     $config->addExtraRequestDataSet('Should be OK when logged in as "superadmin".')
                         ->setAuth(new BasicHttpAuth('superadmin', 'admin123'))
                         ->setExpectedStatusCode(200);
@@ -177,7 +181,7 @@ class RouteConfigCustomization
             })
             ->customizeByRouteName('admin_administrator_edit', function (RouteConfig $config) {
                 $config->changeDefaultRequestDataSet('Standard admin is not allowed to edit superadmin (with ID 1)')
-                    ->setExpectedStatusCode(404);
+                    ->setExpectedStatusCode(302);
                 $config->addExtraRequestDataSet('Superadmin can edit superadmin')
                     ->setAuth(new BasicHttpAuth('superadmin', 'admin123'))
                     ->setExpectedStatusCode(200);

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -95,6 +95,44 @@ There you can find links to upgrade notes for other versions too.
         [MainVariant.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/MainVariant.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/MainVariant.types.yml`
         [RegularProduct.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/RegularProduct.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/RegularProduct.types.yml`
         [Variant.types.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/Variant.types.yml) to `src/Shopsys/ShopBundle/Resources/graphql-types/Variant.types.yml`
+        
+- add access denied url to `security.yml` for users which are not granted with access to the requested page ([#1504](https://github.com/shopsys/shopsys/pull/1504))
+    ```diff
+         administration:
+             pattern: ^/(admin/|efconnect|elfinder)
+             user_checker: Shopsys\FrameworkBundle\Model\Security\AdministratorChecker
+             anonymous: ~
+             provider: administrators
+             logout_on_user_change: true
+    +        access_denied_url: "/admin/access-denied/"
+             form_login:
+    ```
+    - add new customized route `admin_access_denied` in `RouteConfigCustomization`
+    ```diff
+         ->customizeByRouteName('admin_domain_list', function (RouteConfig $config) {
+             if ($this->isSingleDomain()) {
+                $config->skipRoute('Domain list in administration is not available when only 1 domain exists.');
+             }
+    +    })
+    +    ->customizeByRouteName('admin_access_denied', function (RouteConfig $config) {
+    +        $config->changeDefaultRequestDataSet('This route serves as "access_denied_url" (see security.yml) and always redirects to a referer (or dashboard).')
+    +           ->setExpectedStatusCode(302);
+             });
+        }
+    ```
+    - change expected status code for testing superadmin routes from code `404` to `302`
+    ```diff
+         if (preg_match('~^admin_(superadmin_|translation_list$)~', $info->getRouteName())) {
+             $config->changeDefaultRequestDataSet('Only superadmin should be able to see this route.')
+    -           ->setExpectedStatusCode(404);
+    +           ->setExpectedStatusCode(302);
+    ```
+    ```diff
+        ->customizeByRouteName('admin_administrator_edit', function (RouteConfig $config) {
+            $config->changeDefaultRequestDataSet('Standard admin is not allowed to edit superadmin (with ID 1)')
+    -           ->setExpectedStatusCode(404);
+    +           ->setExpectedStatusCode(302);
+    ```
 
 ### Tools
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Roles are now stored in database so it is possible to easily add other roles to restrict access to some sections of administration.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks] Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1347, closes #1349  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
