### PR TITLE
[shopsys] fixed version of symfony/monolog-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,6 +167,7 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
+        "symfony/monolog-bundle": "3.5.0",
         "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
         "twig/twig": "2.6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
         "symfony/monolog-bridge": "^3.0.0",
-        "symfony/monolog-bundle": "^3.3.1",
+        "symfony/monolog-bundle": "~3.4.0",
         "symfony/proxy-manager-bridge": "^3.4",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/symfony": "^3.4.8",
@@ -167,7 +167,6 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
-        "symfony/monolog-bundle": "3.5.0",
         "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
         "twig/twig": "2.6.1"
     },

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -79,7 +79,7 @@
         "snc/redis-bundle": "^2.1.8",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/assetic-bundle": "^2.8.2",
-        "symfony/monolog-bundle": "^3.3.1",
+        "symfony/monolog-bundle": "~3.4.0",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/symfony": "^3.4.8",
         "symfony-cmf/routing": "^2.0.3",

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -639,6 +639,13 @@ There you can find links to upgrade notes for other versions too.
         ```
         - for more information you can see the [PR](https://github.com/shopsys/shopsys/pull/1461)
 
+- change required version for `symfony/monolog-bundle` ([#1506](https://github.com/shopsys/shopsys/pull/1506))
+    - edit `composer.json`
+        ```diff
+        -       "symfony/monolog-bundle": "^3.3.1",
+        +       "symfony/monolog-bundle": "~3.4.0",
+        ```
+
 ## Configuration
 - use DIC configuration instead of `RedisCacheFactory` to create redis caches ([#1361](https://github.com/shopsys/shopsys/pull/1361))
     - the `RedisCacheFactory` was deprecated, use DIC configuration in YAML instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Hotfix. After releasing `symfony/monolog-bundle v3.5.0` the composer installs `monolog/monolog v2` which results in `Symfony 5 is required for Monolog 2 support. Please downgrade Monolog to version 1.`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
