### PR TITLE
[shopsys] fixed monolog-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,7 @@
     "symfony-cmf/routing": "^2.0.3",
     "symfony-cmf/routing-bundle": "^2.0.3",
     "symfony/monolog-bridge": "^3.0.0",
-    "symfony/monolog-bundle": "^3.3.1",
+    "symfony/monolog-bundle": "~3.4.0",
     "symfony/proxy-manager-bridge": "^3.4",
     "symfony/swiftmailer-bundle": "^3.2.2",
     "symfony/symfony": "^3.4.8",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -86,7 +86,7 @@
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/assetic-bundle": "^2.8.2",
-        "symfony/monolog-bundle": "^3.3.1",
+        "symfony/monolog-bundle": "~3.4.0",
         "symfony/proxy-manager-bridge": "^3.4",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/symfony": "^3.4.8",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -79,7 +79,7 @@
         "snc/redis-bundle": "^2.1.8",
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/assetic-bundle": "^2.8.2",
-        "symfony/monolog-bundle": "^3.3.1",
+        "symfony/monolog-bundle": "~3.4.0",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/symfony": "^3.4.8",
         "symfony-cmf/routing": "^2.0.3",

--- a/upgrade/UPGRADE-v8.0.1-dev.md
+++ b/upgrade/UPGRADE-v8.0.1-dev.md
@@ -12,4 +12,12 @@ This guide contains instructions to upgrade from version v8.0.0 to v8.0.1-dev.
 **Before you start, don't forget to take a look at [general instructions](/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+### Application
+- change required version for `symfony/monolog-bundle` ([#1506](https://github.com/shopsys/shopsys/pull/1506))
+    - edit `composer.json`
+        ```diff
+        -       "symfony/monolog-bundle": "^3.3.1",
+        +       "symfony/monolog-bundle": "~3.4.0",
+        ```
+
 [shopsys/framework]: https://github.com/shopsys/framework


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Hotfix. After releasing `symfony/monolog-bundle` `v3.5.0` the composer installs `monolog/monolog` v2 which results in `Symfony 5 is required for Monolog 2 support. Please downgrade Monolog to version 1.`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
