### PR TITLE
preserve custom checkbox CSS classes

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig
+++ b/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig
@@ -51,7 +51,8 @@
 {% block checkbox_row %}
     <div class="{{ rowClass|default('form-line') }}">
         <div class="form-choice">
-            {{ form_widget(form, { attr: { class: "css-checkbox" } }) }}
+            {% set checkboxAttr = attr|merge({'class': (attr.class|default('') ~ ' css-checkbox')|trim}) %}
+            {{ form_widget(form, { attr: checkboxAttr }) }}
             {{ form_label(form, label, { label_attr: { class: "css-checkbox__image" }}) }}
             {% set errors_attr = errors_attr|default({})|merge({'class': (errors_attr.class|default('form-error--choice'))}) %}
             {{ form_errors(form, { errors_attr: errors_attr } ) }}

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -693,7 +693,8 @@ There you can find links to upgrade notes for other versions too.
         -     </dl>
         +     <div class="{{ rowClass|default('form-line') }}">
         +        <div class="form-choice">
-        +            {{ form_widget(form, { attr: { class: "css-checkbox" } }) }}
+        +            {% set checkboxAttr = attr|merge({'class': (attr.class|default('') ~ ' css-checkbox')|trim}) %}
+        +            {{ form_widget(form, { attr: checkboxAttr }) }}
         +            {{ form_label(form, label, { label_attr: { class: "css-c+heckbox__image" }}) }}
         +            {% set errors_attr = errors_attr|default({})|merge({'class': (errors_attr.class|default('form-error--choice'))}) %}
         +            {{ form_errors(form, { errors_attr: errors_attr } ) }}

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -662,8 +662,8 @@ There you can find links to upgrade notes for other versions too.
           cursor: help;
         ```
 
-    - add new file `ttps://github.com/shopsys/shopsys/blob/8.1/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/core/form/custom-inputs.less` according to pull request
-    - link this new file in `ttps://github.com/shopsys/shopsys/blob/8.1/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/main.less`
+    - add new [`src/Shopsys/ShopBundle/Resources/styles/front/common/core/form/custom-inputs.less`](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/core/form/custom-inputs.less) file according to pull request
+    - link this new file in [main.less](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/styles/front/common/main.less)
 
     ```diff
           @import "core/form/input.less";
@@ -671,7 +671,7 @@ There you can find links to upgrade notes for other versions too.
           @import "core/form/btn.less";
     ```
 
-    - Update `ttps://github.com/shopsys/shopsys/blob/8.1/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.less`
+    - Update [theme.html.twig](https://github.com/shopsys/shopsys/blob/master/project-base/src/Shopsys/ShopBundle/Resources/views/Front/Form/theme.html.twig)
 
     ```diff
           {% block checkbox_row %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| preserve custom checkbox CSS classes
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes  #1520  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes