### PR TITLE
[framework] exclude styleguide plugins from dumping translations

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1050,6 +1050,7 @@
             <arg value="--dir=${path.src}/Shopsys/ShopBundle"/>
             <arg value="--dir=${path.app}/Resources"/>
             <arg value="--exclude-dir=frontend/plugins"/>
+            <arg value="--exclude-dir=styleguide/plugins"/>
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.src}/Shopsys/ShopBundle/Resources/translations"/>
             <arg line="${translations.dump.flags}"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR fixes failing `./phing translations-dump` command due to parse error in minified JS files. In #1485 we introduced basic styleguide. This styleguide has minified js files in plugins folder (similarly as in frontend folder). These files should not be taken into account when dumping translations.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
