### PR TITLE
[project-base] prevent throwing error 500 after order is sent if SMTP is down

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/OrderController.php
@@ -225,7 +225,7 @@ class OrderController extends FrontBaseController
 
                 try {
                     $this->sendMail($order);
-                } catch (\Shopsys\FrameworkBundle\Model\Mail\Exception\MailException $e) {
+                } catch (\Exception $e) {
                     $this->getFlashMessageSender()->addErrorFlash(
                         t('Unable to send some emails, please contact us for order verification.')
                     );

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -60,3 +60,16 @@ There you can find links to upgrade notes for other versions too.
     - `tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`
 
 - exception `CartIsEmptyException` has been marked as deprecated and will be removed in 9.0 ([#1494](https://github.com/shopsys/shopsys/pull/1494))
+
+- prevent throwing error 500 for users when your SMTP server is down ([#1529](https://github.com/shopsys/shopsys/pull/1529))
+    - update your `indexAction` method in `src\Shopsys\ShopBundle\Controller\Front\OrderController.php` 
+        ```diff
+            try {
+                $this->sendMail($order);
+        -    } catch (\Shopsys\FrameworkBundle\Model\Mail\Exception\MailException $e) {
+        +    } catch (\Exception $e) {
+                $this->getFlashMessageSender()->addErrorFlash(
+                    t('Unable to send some emails, please contact us for order verification.')
+                );
+            }
+        ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When application cannot connect to SMTP server, then application will throw error 500 for user. This PR prevents to throw error. Instead of it, user will be notified with flash message that is saying `Unable to send some emails, please contact us for order verification`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
