### PR TITLE
[shopsys] made image lazy loading configurable

### DIFF
--- a/docs/frontend/lazyload.md
+++ b/docs/frontend/lazyload.md
@@ -5,6 +5,8 @@ All images are lazy loaded by default. Default selector for lazyload is [loading
 Native lazy load is overrided - we are waiting for bigger browser support.
 
 ## Disable lazyload
+Lazyload might be disabled or enabled globally by defining parameter `shopsys.image.enable_lazy_load` in [`parameters_common.yml`](https://github.com/shopsys/shopsys/blob/8.1/project-base/app/config/parameters_common.yml)
+
 Slick component is used as homepage slider for cycling through images. We don't want to use lazy loading for these images. Slick has own lazyload function. We can disable minilazyload function by setting attribute `lazy: false` in img tag.
 
 ```twig

--- a/docs/frontend/lazyload.md
+++ b/docs/frontend/lazyload.md
@@ -5,7 +5,7 @@ All images are lazy loaded by default. Default selector for lazyload is [loading
 Native lazy load is overrided - we are waiting for bigger browser support.
 
 ## Disable lazyload
-Lazyload might be disabled or enabled globally by defining parameter `shopsys.image.enable_lazy_load` in [`parameters_common.yml`](https://github.com/shopsys/shopsys/blob/8.1/project-base/app/config/parameters_common.yml)
+Lazyload might be disabled or enabled globally by defining parameter `shopsys.image.enable_lazy_load` in [`parameters_common.yml`](https://github.com/shopsys/shopsys/blob/master/project-base/app/config/parameters_common.yml)
 
 Slick component is used as homepage slider for cycling through images. We don't want to use lazy loading for these images. Slick has own lazyload function. We can disable minilazyload function by setting attribute `lazy: false` in img tag.
 

--- a/packages/backend-api/install/app/config/parameters_common.yml.patch
+++ b/packages/backend-api/install/app/config/parameters_common.yml.patch
@@ -1,5 +1,5 @@
-@@ -31,3 +31,4 @@
-         Shopsys\FrameworkBundle\Model\Product\Brand\Brand: Shopsys\ShopBundle\Model\Product\Brand\Brand
+@@ -32,3 +32,4 @@
      build-version: '0000000000000000'
      shopsys.display_timezone: Europe/Prague
+     shopsys.image.enable_lazy_load: true
 +    oauth2_encryption_key: '0' #placeholder for correctly running composer post script, replaced by app/config/packages/oauth2/parameters_oauth.yml

--- a/packages/framework/src/Resources/config/parameters_common.yml
+++ b/packages/framework/src/Resources/config/parameters_common.yml
@@ -14,6 +14,8 @@ parameters:
     # Default extended classes mapping
     shopsys.entity_extension.map: {}
 
+    shopsys.image.enable_lazy_load: false
+
     env(IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK): '0'
     env(REDIS_PREFIX): ''
     env(ELASTIC_SEARCH_INDEX_PREFIX): ''

--- a/packages/framework/src/Resources/config/services/twig.yml
+++ b/packages/framework/src/Resources/config/services/twig.yml
@@ -16,7 +16,9 @@ services:
             - '%shopsys.domain_images_url_prefix%'
 
     Shopsys\FrameworkBundle\Twig\ImageExtension:
-        arguments: ['%shopsys.front_design_image_url_prefix%']
+        arguments:
+            $frontDesignImageUrlPrefix: '%shopsys.front_design_image_url_prefix%'
+            $isLazyLoadEnabled: '%shopsys.image.enable_lazy_load%'
 
     Shopsys\FrameworkBundle\Twig\LocalizationExtension:
         arguments:

--- a/packages/framework/src/Twig/ImageExtension.php
+++ b/packages/framework/src/Twig/ImageExtension.php
@@ -42,24 +42,32 @@ class ImageExtension extends Twig_Extension
     protected $templating;
 
     /**
+     * @var bool
+     */
+    protected $isLazyLoadEnabled;
+
+    /**
      * @param string $frontDesignImageUrlPrefix
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageLocator $imageLocator
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
      * @param \Symfony\Bundle\FrameworkBundle\Templating\EngineInterface $templating
+     * @param bool $isLazyLoadEnabled
      */
     public function __construct(
         $frontDesignImageUrlPrefix,
         Domain $domain,
         ImageLocator $imageLocator,
         ImageFacade $imageFacade,
-        EngineInterface $templating
+        EngineInterface $templating,
+        ?bool $isLazyLoadEnabled = false
     ) {
         $this->frontDesignImageUrlPrefix = rtrim($frontDesignImageUrlPrefix, '/');
         $this->domain = $domain;
         $this->imageLocator = $imageLocator;
         $this->imageFacade = $imageFacade;
         $this->templating = $templating;
+        $this->isLazyLoadEnabled = $isLazyLoadEnabled;
     }
 
     /**
@@ -210,7 +218,7 @@ class ImageExtension extends Twig_Extension
         $htmlAttributes = $attributes;
         unset($htmlAttributes['type'], $htmlAttributes['size']);
 
-        $useLazyLoading = array_key_exists('lazy', $attributes) ? (bool)$attributes['lazy'] : true;
+        $useLazyLoading = array_key_exists('lazy', $attributes) ? (bool)$attributes['lazy'] : $this->isLazyLoadEnabled;
         unset($htmlAttributes['lazy']);
 
         if ($useLazyLoading === true) {

--- a/packages/framework/src/Twig/ImageExtension.php
+++ b/packages/framework/src/Twig/ImageExtension.php
@@ -60,7 +60,7 @@ class ImageExtension extends Twig_Extension
         ImageLocator $imageLocator,
         ImageFacade $imageFacade,
         EngineInterface $templating,
-        ?bool $isLazyLoadEnabled = false
+        bool $isLazyLoadEnabled = false
     ) {
         $this->frontDesignImageUrlPrefix = rtrim($frontDesignImageUrlPrefix, '/');
         $this->domain = $domain;

--- a/packages/read-model/src/Resources/config/services.yml
+++ b/packages/read-model/src/Resources/config/services.yml
@@ -9,5 +9,8 @@ services:
 
     Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface: '@Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacade'
 
-    Shopsys\ReadModelBundle\Twig\ImageExtension:
-        arguments: ['%shopsys.front_design_image_url_prefix%']
+    Shopsys\FrameworkBundle\Twig\ImageExtension:
+        class: Shopsys\ReadModelBundle\Twig\ImageExtension
+        arguments:
+            $frontDesignImageUrlPrefix: '%shopsys.front_design_image_url_prefix%'
+            $isLazyLoadEnabled: '%shopsys.image.enable_lazy_load%'

--- a/project-base/app/config/parameters_common.yml
+++ b/project-base/app/config/parameters_common.yml
@@ -31,3 +31,4 @@ parameters:
         Shopsys\FrameworkBundle\Model\Product\Brand\Brand: Shopsys\ShopBundle\Model\Product\Brand\Brand
     build-version: '0000000000000000'
     shopsys.display_timezone: Europe/Prague
+    shopsys.image.enable_lazy_load: true

--- a/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php
+++ b/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php
@@ -39,7 +39,7 @@ class ImageExtensionTest extends FunctionalTestCase
 
         $imageView = new ImageView($productId, $fileExtension, $entityName, null);
 
-        $readModelBundleImageExtension = $this->createImageExtension('', $imageFacadeMock);
+        $readModelBundleImageExtension = $this->createImageExtension('', $imageFacadeMock, true);
         $html = $readModelBundleImageExtension->getImageHtml($imageView);
 
         $this->assertXmlStringEqualsXmlFile(__DIR__ . '/Resources/picture.twig', $html);
@@ -55,7 +55,7 @@ class ImageExtensionTest extends FunctionalTestCase
 
         $imageView = new ImageView($productId, $fileExtension, $entityName, null);
 
-        $readModelBundleImageExtension = $this->createImageExtension();
+        $readModelBundleImageExtension = $this->createImageExtension('', null, true);
         $html = $readModelBundleImageExtension->getImageHtml($imageView);
 
         $expected = '<picture>';
@@ -91,7 +91,7 @@ class ImageExtensionTest extends FunctionalTestCase
 
     public function testGetNoImageHtml(): void
     {
-        $readModelBundleImageExtension = $this->createImageExtension();
+        $readModelBundleImageExtension = $this->createImageExtension('', null, true);
 
         $html = $readModelBundleImageExtension->getImageHtml(null);
 
@@ -108,7 +108,7 @@ class ImageExtensionTest extends FunctionalTestCase
     {
         $defaultFrontDesignImageUrlPrefix = '/assets/frontend/images/';
 
-        $readModelBundleImageExtension = $this->createImageExtension($defaultFrontDesignImageUrlPrefix);
+        $readModelBundleImageExtension = $this->createImageExtension($defaultFrontDesignImageUrlPrefix, null, true);
         $html = $readModelBundleImageExtension->getImageHtml(null);
 
         $expected = '<picture>';
@@ -133,11 +133,14 @@ class ImageExtensionTest extends FunctionalTestCase
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
      * @return \Shopsys\ReadModelBundle\Twig\ImageExtension
      */
-    private function createImageExtension(string $frontDesignImageUrlPrefix = '', ?ImageFacade $imageFacade = null): ImageExtension
-    {
+    private function createImageExtension(
+        string $frontDesignImageUrlPrefix = '',
+        ?ImageFacade $imageFacade = null,
+        ?bool $enableLazyLoad = false
+    ): ImageExtension {
         $templating = $this->getContainer()->get('templating');
         $imageFacade = $imageFacade ?: $this->imageFacade;
 
-        return new ImageExtension($frontDesignImageUrlPrefix, $this->domain, $this->imageLocator, $imageFacade, $templating);
+        return new ImageExtension($frontDesignImageUrlPrefix, $this->domain, $this->imageLocator, $imageFacade, $templating, $enableLazyLoad);
     }
 }

--- a/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php
+++ b/project-base/tests/ReadModelBundle/Functional/Twig/ImageExtensionTest.php
@@ -131,12 +131,13 @@ class ImageExtensionTest extends FunctionalTestCase
     /**
      * @param string $frontDesignImageUrlPrefix
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade|null $imageFacade
+     * @param bool $enableLazyLoad
      * @return \Shopsys\ReadModelBundle\Twig\ImageExtension
      */
     private function createImageExtension(
         string $frontDesignImageUrlPrefix = '',
         ?ImageFacade $imageFacade = null,
-        ?bool $enableLazyLoad = false
+        bool $enableLazyLoad = false
     ): ImageExtension {
         $templating = $this->getContainer()->get('templating');
         $imageFacade = $imageFacade ?: $this->imageFacade;

--- a/project-base/tests/ShopBundle/Functional/Twig/ImageExtensionTest.php
+++ b/project-base/tests/ShopBundle/Functional/Twig/ImageExtensionTest.php
@@ -33,7 +33,7 @@ class ImageExtensionTest extends FunctionalTestCase
             new AdditionalImageData('(max-width: 480px)', 'http://webserver:8080/additional_1_2.jpg'),
         ]);
 
-        $imageExtension = new ImageExtension('', $this->domain, $this->imageLocator, $imageFacade, $templating);
+        $imageExtension = new ImageExtension('', $this->domain, $this->imageLocator, $imageFacade, $templating, true);
 
         $html = $imageExtension->getImageHtml($image);
 

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -731,6 +731,14 @@ There you can find links to upgrade notes for other versions too.
         ```
 
 - add image and iframe LazyLoad ([#1483](https://github.com/shopsys/shopsys/pull/1483))
+    - lazy load is by default disabled, you can enable it by configuring new parameter in [`parameters_common`](https://github.com/shopsys/shopsys/blob/8.1/project-base/app/config/parameters_common.yml)
+        ```diff
+                shopsys.display_timezone: Europe/Prague
+        +       shopsys.image.enable_lazy_load: true
+        ```
+        !!! note
+            lazy loading will be enabled by default in next major
+
     - update `src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js`
         ```diff
                  $paginationToItemSpan.text(paginationToItem);

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -736,8 +736,8 @@ There you can find links to upgrade notes for other versions too.
                 shopsys.display_timezone: Europe/Prague
         +       shopsys.image.enable_lazy_load: true
         ```
-        !!! note
-            lazy loading will be enabled by default in next major
+
+        Note: _lazy loading __will be enabled__ by default in next major_
 
     - update `src/Shopsys/ShopBundle/Resources/scripts/frontend/components/ajaxMoreLoader.js`
         ```diff

--- a/upgrade/UPGRADE-v8.1.0-dev.md
+++ b/upgrade/UPGRADE-v8.1.0-dev.md
@@ -731,7 +731,7 @@ There you can find links to upgrade notes for other versions too.
         ```
 
 - add image and iframe LazyLoad ([#1483](https://github.com/shopsys/shopsys/pull/1483))
-    - lazy load is by default disabled, you can enable it by configuring new parameter in [`parameters_common`](https://github.com/shopsys/shopsys/blob/8.1/project-base/app/config/parameters_common.yml)
+    - lazy load is by default disabled, you can enable it by configuring new parameter in [`parameters_common`](https://github.com/shopsys/shopsys/blob/master/project-base/app/config/parameters_common.yml)
         ```diff
                 shopsys.display_timezone: Europe/Prague
         +       shopsys.image.enable_lazy_load: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| PR #1483 introduced a BC break. This PR fixes it and making a lazyload configurable.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes