### PR TITLE
[project-base] fixed importing css files for styleguide

### DIFF
--- a/project-base/src/Shopsys/ShopBundle/Resources/styles/styleguide/main.less
+++ b/project-base/src/Shopsys/ShopBundle/Resources/styles/styleguide/main.less
@@ -1,4 +1,4 @@
-@import (less) "structure.css";
-@import (less) "styleguide.css";
-@import (less) "plugins/codemirror/codemirror.minified.css";
-@import (less) "plugins/codemirror/theme/hopscotch.css";
+@import (inline) "structure.css";
+@import (inline) "styleguide.css";
+@import (inline) "plugins/codemirror/codemirror.minified.css";
+@import (inline) "plugins/codemirror/theme/hopscotch.css";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are importing css files for styleguide like a less file even they are css. This cause troubles for older grunt-contrib-less package which results in wrong calculations.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes