### PR TITLE
[shopsys] added upgrade notes for Symfony Flex

### DIFF
--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -166,7 +166,7 @@ There you can find links to upgrade notes for other versions too.
     - in `ContactFormController` remove action `sendAction()`, it is not needed anymore
     - remove `src/Resources/scripts/frontend/contactForm.js`, it is not needed anymore
     - new localized route `front_contact` has been introduced with slug `contact`. This slug can be already in use in your project, because
-      previous SSFW versions have an article called `Contact` which was used as the contact page. Please move the article's content to the new contact page and completely remove the article.
+      previous SSFW versions have an article called `Contact` which is used as the contact page. Please move the article's content to the new contact page and completely remove the article.
       To remove the article, please create [new migration](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Migrations/Version20191121171000.php) in you project which removes the article and its slug.
       
       If you don't want to remove the article, you will need to change path for the new route in the next step
@@ -188,7 +188,7 @@ There you can find links to upgrade notes for other versions too.
             </div>
         ```
 
-- vats can be create and manage per domains ([#1498](https://github.com/shopsys/shopsys/pull/1498))
+- vats can be created and managed per domains ([#1498](https://github.com/shopsys/shopsys/pull/1498))
     - please read [upgrade instruction for vats per domain](https://github.com/shopsys/shopsys/blob/9.0/upgrade/upgrade-instruction-for-vats-per-domain.md)
 ### Tools
 

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -7,6 +7,10 @@ There you can find links to upgrade notes for other versions too.
 
 ## [shopsys/framework]
 
+- Before doing any other upgrade instructions, you have to upgrade your application to Symfony Flex as some file paths are changed.
+  Follow upgrade instructions in the [separate article](./upgrade-instructions-for-symfony-flex.md) ([#1492](https://github.com/shopsys/shopsys/pull/1492))  
+  All following upgrade instructions are written for upgraded application with Symfony Flex
+
 ### Infrastructure
 - update your `kubernetes/deployments/webserver-php-fpm.yml` file: ([#1368](https://github.com/shopsys/shopsys/pull/1368))
     ```diff
@@ -19,50 +23,36 @@ There you can find links to upgrade notes for other versions too.
 ### Application
 
 - update your twig files ([#1284](https://github.com/shopsys/shopsys/pull/1284/)):
-    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/list.html.twig`
-        - remove: `{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}`
-    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/listByBrand.html.twig`
-        - remove: `{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}`
-    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/productListMacro.html.twig`
-        - remove: `{% import '@ShopsysShop/Front/Inline/Product/productFlagsMacro.html.twig' as productFlags %}`
-    - `src/Shopsys/ShopBundle/Resources/views/Front/Content/Product/search.html.twig`
-        - remove: `{% import '@ShopsysShop/Front/Content/Product/productListMacro.html.twig' as productList %}`
+    - `templates/Front/Content/Product/list.html.twig`
+        - remove: `{% import 'Front/Content/Product/productListMacro.html.twig' as productList %}`
+    - `templates/Front/Content/Product/listByBrand.html.twig`
+        - remove: `{% import 'Front/Content/Product/productListMacro.html.twig' as productList %}`
+    - `templates/Front/Content/Product/productListMacro.html.twig`
+        - remove: `{% import 'Front/Inline/Product/productFlagsMacro.html.twig' as productFlags %}`
+    - `templates/Front/Content/Product/search.html.twig`
+        - remove: `{% import 'Front/Content/Product/productListMacro.html.twig' as productList %}`
     - check your templates if you are extending or importing any of the following templates as imports of unused macros were removed from them:
-        - `src/Resources/views/Admin/Content/Article/detail.html.twig`
-        - `src/Resources/views/Admin/Content/Brand/detail.html.twig`
-        - `src/Resources/views/Admin/Content/Category/detail.html.twig`
-        - `src/Resources/views/Admin/Content/Product/detail.html.twig`
+        - `templates/Admin/Content/Article/detail.html.twig`
+        - `templates/Admin/Content/Brand/detail.html.twig`
+        - `templates/Admin/Content/Category/detail.html.twig`
+        - `templates/Admin/Content/Product/detail.html.twig`
 - add [`app/getEnvironment.php`](https://github.com/shopsys/shopsys/blob/9.0/project-base/app/getEnvironment.php) file to your project ([#1368](https://github.com/shopsys/shopsys/pull/1368))
 - add optional [Frontend API](https://github.com/shopsys/shopsys/blob/9.0/docs/frontend-api/introduction-to-frontend-api.md) to your project ([#1445](https://github.com/shopsys/shopsys/pull/1445), [#1486](https://github.com/shopsys/shopsys/pull/1486), [#1493](https://github.com/shopsys/shopsys/pull/1493), [#1489](https://github.com/shopsys/shopsys/pull/1489)):
     - add `shopsys/frontend-api` dependency with `composer require shopsys/frontend-api`
-    - register necessary bundles in `app/AppKernel.php`
+    - register necessary bundles in `config/bundles.php`
         ```diff
-          new JMS\TranslationBundle\JMSTranslationBundle(),
-          new Knp\Bundle\MenuBundle\KnpMenuBundle(),
-        + new Shopsys\FrontendApiBundle\ShopsysFrontendApiBundle(),
-        + new Overblog\GraphQLBundle\OverblogGraphQLBundle(),
-          new Presta\SitemapBundle\PrestaSitemapBundle(),
+            Shopsys\FormTypesBundle\ShopsysFormTypesBundle::class => ['all' => true],
+        +   Shopsys\FrontendApiBundle\ShopsysFrontendApiBundle::class => ['all' => true],
+        +   Overblog\GraphQLBundle\OverblogGraphQLBundle::class => ['all' => true],
+        +   Overblog\GraphiQLBundle\OverblogGraphiQLBundle::class => ['dev' => true],
+            Shopsys\GoogleCloudBundle\ShopsysGoogleCloudBundle::class => ['all' => true],
         ```
-        ```diff
-          if ($this->getEnvironment() === EnvironmentType::DEVELOPMENT) {
-        +     $bundles[] = new Overblog\GraphiQLBundle\OverblogGraphiQLBundle();
-        ```
-    - add new route resource at the end of `app/config/routing.yml`
-        ```diff
-        + shopsys_frontend_api:
-        +     resource: "@ShopsysFrontendApiBundle/Resources/config/routing.yml"
-        +     prefix: /graphql
-        ```
-    - add new route resource at the end of `app/config/routing_dev.yml`
-        ```diff
-        + shopsys_frontend_api:
-        +     resource: "@ShopsysFrontendApiBundle/Resources/config/routing_dev.yml"
-        +     prefix: /graphql
-        ```
-    - copy [type definitions from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Shopsys/ShopBundle/Resources/graphql-types/) into `src/Shopsys/ShopBundle/Resources/graphql-types/` folder
-    - copy necessary configuration [shopsys_frontend_api.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/app/config/packages/shopsys_frontend_api.yml) to `app/config/packages/shopsys_frontend_api.yml`
+    - add new route file [`config/routes/frontend-api.yml`](https://github.com/shopsys/shopsys/blob/9.0/project-base/config/routes/frontend-api.yml) from GitHub
+    - add new route file [`config/routes/dev/frontend-api-graphiql.yaml`](https://github.com/shopsys/shopsys/blob/9.0/project-base/config/routes/dev/frontend-api-graphiql.yaml) from GitHub
+    - copy [type definitions from Github](https://github.com/shopsys/shopsys/tree/9.0/project-base/config/graphql/types) into `config/graphql/types/` folder
+    - copy necessary configuration [shopsys_frontend_api.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/config/packages/shopsys_frontend_api.yml) to `config/packages/shopsys_frontend_api.yml`
     - copy [tests for FrontendApiBundle from Github](https://github.com/shopsys/shopsys/tree/9.0/project-base/tests/FrontendApiBundle) to your `tests` folder
-    - enable Frontend API for desired domains in `app/config/parameters_common.yml` file  
+    - enable Frontend API for desired domains in `config/parameters_common.yml` file  
     for example
         ```diff
           parmeters:
@@ -74,7 +64,7 @@ There you can find links to upgrade notes for other versions too.
         - add `'*/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php'` in `ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff` part
 - removed unused `block domain` defined in `Admin/Content/Slider/edit.html.twig` ([#1437](https://github.com/shopsys/shopsys/pull/1437)) 
     - in case you are using this block of code you should copy it into your project (see PR mentioned above for more details)
-- add access denied url to `security.yml` for users which are not granted with access to the requested page ([#1504](https://github.com/shopsys/shopsys/pull/1504))
+- add access denied url to `config/packages/security.yml` for users which are not granted with access to the requested page ([#1504](https://github.com/shopsys/shopsys/pull/1504))
     ```diff
          administration:
              pattern: ^/(admin/|efconnect|elfinder)
@@ -203,16 +193,6 @@ There you can find links to upgrade notes for other versions too.
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))
-    - add `app/router.php` to skipped files for two rules in your `easy-coding-standard.yml`:
-        ```diff
-          Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff:
-              - '*/tests/ShopBundle/Functional/EntityExtension/EntityExtensionTest.php'
-              - '*/tests/ShopBundle/Test/Codeception/_generated/AcceptanceTesterActions.php'
-        +     - '*/app/router.php'
-
-        + Shopsys\CodingStandards\Sniffs\ForbiddenSuperGlobalSniff:
-        +     - '*/app/router.php'
-        ```
   - run `php phing standards-fix` and fix possible violations that need to be fixed manually
 
 [shopsys/framework]: https://github.com/shopsys/framework

--- a/upgrade/upgrade-instructions-for-symfony-flex.md
+++ b/upgrade/upgrade-instructions-for-symfony-flex.md
@@ -1,0 +1,148 @@
+# Upgrade Instructions for Symfony Flex
+
+In [#1492](https://github.com/shopsys/shopsys/pull/1492) we changed the application to be compatible with Symfony Flex.
+You can read more about upgrading Symfony application to Flex <https://symfony.com/doc/current/setup/flex.html>
+
+- copy [`.env`](https://github.com/shopsys/project-base/blob/9.0/.env) and [`.env.test`](https://github.com/shopsys/project-base/blob/9.0/.env.test) files from GitHub into the root folder
+- add local environment files as ignored into `.gitignore`
+```diff
+    /docker-compose.yml
+    /docker-sync.yml
++   /.env.local
++   /.env.local.php
++   /.env.*.local
+```
+- copy [`symfony.lock`](https://github.com/shopsys/project-base/blob/9.0/symfony.lock) file from GitHub into the root folder
+- copy [`composer.json`](https://github.com/shopsys/project-base/blob/9.0/composer.json) file from GitHub into the root folder
+    - add any project-specific dependencies
+- in `easy-coding-standard.yml` replace
+    - `*/tests/ShopBundle/` with `*/tests/App/`
+    - `*/src/Shopsys/ShopBundle/` with `*/src`
+- replace `phpunit.xml` with [`phpunit.xml` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/phpunit.xml)
+- replace `phpstan.neon` with [`phpstan.neon` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/phpstan.neon)
+    - add any project-specific configurations
+- replace `build/codeception.yml` with [`build/codeception.yml` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/build/codeception.yml)
+
+- move the original source code from `src/Shopsys/ShopBundle/` to `src/` and update the namespaces of every PHP file to be `App\...` (advanced IDEs can do this automatically)
+- remove bundle related files as the application itself is no longer a bundle
+    - `src/Shopsys/ShopBundle/ShopsysShopBundle.php`
+    - `src/Shopsys/ShopBundle/DependencyInjection/Configuration.php`
+    - `src/Shopsys/ShopBundle/DependencyInjection/ShopsysShopExtension.php`
+- update application bootstrapping:
+    - copy [`src/Kernel.php`](https://github.com/shopsys/project-base/blob/9.0/src/Kernel.php) file from GitHub into the `src` folder
+    - delete `app/AppCache.php`, `app/AppKernel.php`, `app/router.php`, and `Bootstrap.php` as files are no longer necessary
+    - change the namespace from `Shopsys` to `App` in `app/Environment.php`
+    - replace `web/index.php` with [`web/index.php` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/web/index.php)
+    - replace `bin/console` with [`bin/console` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/bin/console)
+
+- all configuration files are now located in the `config` folder exclusively
+    - copy all config files to your project from the [config folder from the new version](https://github.com/shopsys/project-base/tree/9.0/config)
+    - merge your project-specific configurations from `app/config` and `src/Shopsys/ShopBundle/resources/config` folders into `config`. Keep in mind, that
+        - `config.yml`, `config_dev.yml`, and `config_test.yml` should be deleted as they're no longer necessary
+        - in `parameters_common.yml` all extended entities in `shopsys.entity_extension.map` have to have new namespace `App\...`
+        - some paths in `paths.yml` have changed, so be extra careful when changing with your modifications
+        - routing files (`routing.yml`, `routing_dev.yml`, and `routing_test.yml`) are no longer necessary
+        - any project-specific routes have to be moved into `routes`, `routes/dev`, or `routes/test` folders into a separate file
+        - any project-specific form extensions have to be added into `config/forms.yml`
+        - any project-specific image configurations have to be added into `config/images.yml`
+        - any project-specific cron definitions have to be added into `config/services/cron.yml`
+
+- move templates from `src/Shopsys/ShopBundle/Resources/views/` to `templates/` folder
+- remove `@ShopsysShop` Twig namespace in every template, eg.
+    ```diff
+    -   {% extends '@ShopsysShop/Front/Layout/base.html.twig' %}
+    -   {% use '@ShopsysShop/Front/Layout/header.html.twig' %}
+    +   {% extends 'Front/Layout/base.html.twig' %}
+    +   {% use 'Front/Layout/header.html.twig' %}
+    ```
+- remove `@ShopsysShop` Twig namespace from render methods in controllers, eg.
+    ```diff
+    -   return $this->render('@ShopsysShop/Front/Content/Article/menu.html.twig', [
+    +   return $this->render('Front/Content/Article/menu.html.twig', [
+            'articles' => $articles,
+        ]);
+    ```
+- change rendering of embedded controllers in templates from three-part notation to standard string syntax for controllers, eg.
+    ```diff
+    -   {{ render(controller('ShopsysShopBundle:Front/Heureka:embedWidget')) }}
+    +   {{ render(controller('App\\Controller\\Front\\HeurekaController:embedWidgetAction')) }}
+    ```
+    - _Tip: you can use regular expression search for `ShopsysShopBundle:Front/(\w+):(\w+)` and replace with `App\\Controller\\Front\\$1Controller:$2Action` in Twig files_
+- update constant in `templates/Front/Content/Product/filterFormMacro.html.twig`
+    ```diff
+        {% if isSearch %}
+            <input
+                type="hidden"
+    -           name="{{ constant('Shopsys\\ShopBundle\\Controller\\Front\\ProductController::SEARCH_TEXT_PARAMETER') }}"
+    +           name="{{ constant('App\\Controller\\Front\\ProductController::SEARCH_TEXT_PARAMETER') }}"
+    ```
+
+- change redirect/forward calls in controllers from three-part notation to fully qualified name, eg.
+    ```diff
+    -   return $this->forward('ShopsysShopBundle:Front/FlashMessage:index');
+    +   return $this->forward(FlashMessageController::class . ':indexAction');
+    ```
+- move overridden bundle templates from `app/Resources/views/` to `templates/bundle` (see more about template overriding <https://symfony.com/doc/current/bundles/override.html#templates>)
+
+- move translation files from `src/Shopsys/ShopBundle/Resources/translations/` to `translations/`
+
+- move rest of a files from `src/Shopsys/ShopBundle/Resources/` to `src/Resources/`
+
+- update Grunt template directory in `templates/Grunt/gruntfile.js.twig` (2 occurrences)
+    ```diff
+        destHtml: 'docs/generated',
+        htmlDemo: true,
+    -   htmlDemoTemplate: '{{ customResourcesDirectory|raw }}/views/Grunt/htmlDocumentTemplate.html',
+    +   htmlDemoTemplate: '{{ gruntTemplateDirectory|raw }}/htmlDocumentTemplate.html',
+        htmlDemoFilename: 'webfont-admin-svg',
+    ```
+
+- update config file paths from `app/config` to `config` in following files any others you may have create
+    - `.ci/build_kubernetes.sh`
+    - `.ci/deploy-to-google-cloud.sh`
+    - `scripts/install.sh`
+    - `kubernetes/kustomize/base/kustomization.yaml`
+
+- change namespaces in `migrations.lock` file from `Shopsys\ShopBundle\...` to `App\...`, eg.
+    ```diff
+        20191114101504:
+    -       class: Shopsys\ShopBundle\Migrations\Version20191114101504
+    +       class: App\Migrations\Version20191114101504
+            skip: false
+    ```
+
+
+- move tests from `tests/ShopBundle/` to `tests/App/` and update the namespaces of every PHP file to be `Tests\App\...` (advanced IDEs can do this automatically)
+- change namespace from `Tests\ShopBundle\...` to `Tests\App\...` in following files
+    - `tests/App/Acceptance/acceptance.suite.yml`
+    - `tests/App/Functional/Component/Javascript/Compiler/Constant/JsConstantCompilerPassTest.php`
+    - `tests/App/Functional/Component/Javascript/Compiler/Constant/testClassName.expected.js`
+    - `tests/App/Functional/Component/Javascript/Compiler/Constant/testClassName.js`
+    - `tests/App/Functional/Component/Javascript/Compiler/Constant/testDefinedConstant.js`
+    - `tests/App/Functional/Component/Javascript/Compiler/Constant/testUndefinedConstant.js`
+- update `tests/App/Test/Codeception/Helper/SymfonyHelper.php` with the new Kernel class
+    ```diff
+    -   use AppKernel;
+    +   use App\Kernel;
+        use Codeception\Configuration;
+        use Codeception\Module;
+
+        ...
+
+            {
+                require_once Configuration::projectDir() . '/../app/autoload.php';
+
+    -           $this->kernel = new AppKernel(EnvironmentType::TEST, EnvironmentType::isDebug(EnvironmentType::TEST));
+    +           $this->kernel = new Kernel(EnvironmentType::TEST, EnvironmentType::isDebug(EnvironmentType::TEST));
+                $this->kernel->boot();
+            }
+    ```
+
+- change namespace from `Shopsys/ShopBundle` to `App` in constants in following JS files and any others you created
+    - `src/Resources/scripts/frontend/cart/cartRecalculator.js`
+    - `src/Resources/scripts/frontend/validation/form/customer.js`
+    - `src/Resources/scripts/frontend/validation/form/order.js`
+    - `src/Resources/scripts/frontend/promoCode.js`
+
+- run `composer update`
+- clean caches and regenerate assets with `phing clean clean-redis npm assets grunt`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1492 we introduced Symfony Flex. This PR adds upgrade instructions to upgrade application to Symfony Flex structure and namespaces
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

already existing upgrade notes were updated as they are meant to be done after