### PR TITLE
[framework] restrict date picker settings per instance 

### DIFF
--- a/packages/framework/src/Resources/scripts/common/components/datePicker.js
+++ b/packages/framework/src/Resources/scripts/common/components/datePicker.js
@@ -5,7 +5,7 @@
     var datePicker = function ($container) {
         $container.filterAllNodes('.js-date-picker').each(function () {
             // Loads regional settings for current locale
-            var options = $.datepicker.regional[global.locale] || $.datepicker.regional[''];
+            var options = $.extend({}, $.datepicker.regional[global.locale] || $.datepicker.regional['']);
 
             // Date format is fixed so that it is understood by back-end
             options.dateFormat = Shopsys.constant('\\Shopsys\\FrameworkBundle\\Form\\DatePickerType::FORMAT_JS');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description| If there are more datepicker on the page, the settings are copied among themselves. For example, I have two datepicker for the first set max date to today and the second not. At this point, the secound datepicker has max date set and should not have.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| 
No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
