### PR TITLE
[shopsys] restricted doctrine/persistence to version 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
     "doctrine/doctrine-fixtures-bundle": "^3.0.2",
     "doctrine/doctrine-migrations-bundle": "^1.3.0",
     "doctrine/migrations": "^1.6.0",
+    "doctrine/persistence": "~1.2.0",
     "egeloen/ckeditor-bundle": "^4.0.6",
     "egeloen/ordered-form": "^3.0",
     "elasticsearch/elasticsearch": "^6.0.1",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -51,6 +51,7 @@
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
+        "doctrine/persistence": "~1.2.0",
         "egeloen/ckeditor-bundle": "^4.0.6",
         "egeloen/ordered-form": "^3.0",
         "elasticsearch/elasticsearch": "^6.0.1",

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -26,6 +26,7 @@
         "ext-json": "*",
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
+        "doctrine/persistence": "~1.2.0",
         "shopsys/doctrine-orm": "^2.6.2",
         "shopsys/form-types-bundle": "7.3.x-dev",
         "shopsys/framework": "7.3.x-dev",

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -29,6 +29,7 @@
         "doctrine/collections": "^1.5",
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
+        "doctrine/persistence": "~1.2.0",
         "shopsys/doctrine-orm": "^2.6.2",
         "shopsys/form-types-bundle": "7.3.x-dev",
         "shopsys/framework": "7.3.x-dev",

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -26,6 +26,7 @@
         "ext-json": "*",
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
+        "doctrine/persistence": "~1.2.0",
         "shopsys/doctrine-orm": "^2.6.2",
         "shopsys/form-types-bundle": "7.3.x-dev",
         "shopsys/framework": "7.3.x-dev",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -48,6 +48,7 @@
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/doctrine-migrations-bundle": "^1.3.0",
+        "doctrine/persistence": "~1.2.0",
         "egeloen/ckeditor-bundle": "^4.0.6",
         "fp/jsformvalidator-bundle": "^1.5.1",
         "fzaninotto/faker": "^1.7.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| doctrine/persistence 1.3 seems to be released prematurely and includes BC breaks that were not intended so we decided to restrict i to version 1.2
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
