### PR TITLE
[project-base] OrderCest is now more reliable

### DIFF
--- a/project-base/tests/ShopBundle/Acceptance/acceptance/OrderCest.php
+++ b/project-base/tests/ShopBundle/Acceptance/acceptance/OrderCest.php
@@ -30,6 +30,7 @@ class OrderCest
 
         $orderPage->assertTransportIsNotSelected('Czech post');
         $orderPage->selectTransport('Czech post');
+        $me->waitForAjax();
         $orderPage->assertPaymentIsNotSelected('Cash on delivery');
         $orderPage->selectPayment('Cash on delivery');
         $me->waitForAjax();

--- a/upgrade/UPGRADE-v7.3.3-dev.md
+++ b/upgrade/UPGRADE-v7.3.3-dev.md
@@ -60,3 +60,9 @@ There you can find links to upgrade notes for other versions too.
     - `tests/ShopBundle/Functional/Model/Cart/Watcher/CartWatcherTest.php`
 
 - exception `CartIsEmptyException` has been marked as deprecated and will be removed in 9.0 ([#1494](https://github.com/shopsys/shopsys/pull/1494))
+- update your `OrderCest` so it is more reliable ([#1551](https://github.com/shopsys/shopsys/pull/1551))
+    ```diff
+        $orderPage->selectTransport(self::TRANSPORT_CZECH_POST_POSITION);
+    +   $me->waitForAjax();
+        $orderPage->assertPaymentIsNotSelected('Cash on delivery');
+    ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Sometimes OrderCast failed on selecting right payment method. This PR should fix it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
