### PR TITLE
[shopsys] Added possibility to change source that FE API gets data from

### DIFF
--- a/docs/frontend-api/introduction-to-frontend-api.md
+++ b/docs/frontend-api/introduction-to-frontend-api.md
@@ -24,6 +24,9 @@ parmeters:
         - 2
 ```
 
+You can also configure the place from which are the data for products taken from by choosing implementation of `ProductOnCurrentDomainFacadeInterface`.  
+You can find more about this feature in [separate article](../model/front-end-product-filtering.md).
+
 ## Try it
 GraphQL endpoint is available directly on the domain of your online store on the `/graphql/` path (ie. while running locally on Docker, it's http://127.0.0.1:8000/graphql/).
 

--- a/docs/model/front-end-product-filtering.md
+++ b/docs/model/front-end-product-filtering.md
@@ -36,7 +36,7 @@ Each filtering method calls appropriate method in `Shopsys\FrameworkBundle\Model
 ## Choose an Implementation
 You can choose which one of them will be used by setting one of the previously mentioned implementations in your `services.yaml` and `services_test.yml` configuration.
 
-Along with filtering the choice will influence the data source for the product lists for increased performance.
+Along with filtering the choice will influence the data source for the product lists and product data of front-end API for increased performance.
 
 You can find more about this topic in [Introduction to Read Model](./introduction-to-read-model.md#read-model-options).
 

--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -229,6 +229,21 @@ class ImageFacade
     }
 
     /**
+     * @param int $entityId
+     * @param string $entityName
+     * @param string|null $type
+     * @return \Shopsys\FrameworkBundle\Component\Image\Image[]
+     */
+    public function getImagesByEntityIdAndNameIndexedById(int $entityId, string $entityName, $type)
+    {
+        return $this->imageRepository->getImagesByEntityIndexedById(
+            $entityName,
+            $entityId,
+            $type
+        );
+    }
+
+    /**
      * @param object $entity
      * @return \Shopsys\FrameworkBundle\Component\Image\Image[]
      */

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Product;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
+use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
@@ -102,7 +103,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getVisibleProductById($productId): Product
+    public function getVisibleProductById(int $productId): Product
     {
         return $this->productRepository->getVisible(
             $productId,
@@ -138,8 +139,13 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getPaginatedProductsInCategory(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId): PaginationResult
-    {
+    public function getPaginatedProductsInCategory(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $categoryId
+    ): PaginationResult {
         $filterQuery = $this->createListableProductsInCategoryFilterQuery($productFilterData, $orderingModeId, $page, $limit, $categoryId);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
@@ -155,8 +161,13 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    protected function createListableProductsInCategoryFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId): FilterQuery
-    {
+    protected function createListableProductsInCategoryFilterQuery(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $categoryId
+    ): FilterQuery {
         return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->filterByCategory([$categoryId]);
     }
@@ -164,7 +175,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getPaginatedProductsForBrand($orderingModeId, $page, $limit, $brandId): PaginationResult
+    public function getPaginatedProductsForBrand(string $orderingModeId, int $page, int $limit, int $brandId): PaginationResult
     {
         $emptyProductFilterData = new ProductFilterData();
 
@@ -183,8 +194,13 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    protected function createListableProductsForBrandFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $brandId): FilterQuery
-    {
+    protected function createListableProductsForBrandFilterQuery(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $brandId
+    ): FilterQuery {
         return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->filterByBrands([$brandId]);
     }
@@ -192,8 +208,13 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getPaginatedProductsForSearch($searchText, ProductFilterData $productFilterData, $orderingModeId, $page, $limit): PaginationResult
-    {
+    public function getPaginatedProductsForSearch(
+        string $searchText,
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit
+    ): PaginationResult {
         $filterQuery = $this->createListableProductsForSearchTextFilterQuery($productFilterData, $orderingModeId, $page, $limit, $searchText);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
@@ -206,11 +227,16 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param string $orderingModeId
      * @param int $page
      * @param int $limit
-     * @param string $searchText
+     * @param string|null $searchText
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    protected function createListableProductsForSearchTextFilterQuery(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $searchText): FilterQuery
-    {
+    protected function createListableProductsForSearchTextFilterQuery(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        ?string $searchText
+    ): FilterQuery {
         $searchText = $searchText ?? '';
 
         return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
@@ -224,8 +250,12 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    protected function createFilterQueryWithProductFilterData(ProductFilterData $productFilterData, $orderingModeId, $page, $limit): FilterQuery
-    {
+    protected function createFilterQueryWithProductFilterData(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit
+    ): FilterQuery {
         $filterQuery = $this->filterQueryFactory->create($this->getIndexName())
             ->filterOnlySellable()
             ->filterOnlyVisible($this->currentCustomerUser->getPricingGroup())
@@ -245,7 +275,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getSearchAutocompleteProducts($searchText, $limit): PaginationResult
+    public function getSearchAutocompleteProducts(?string $searchText, int $limit): PaginationResult
     {
         $emptyProductFilterData = new ProductFilterData();
         $page = 1;
@@ -262,8 +292,11 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
-    {
+    public function getProductFilterCountDataInCategory(
+        int $categoryId,
+        ProductFilterConfig $productFilterConfig,
+        ProductFilterData $productFilterData
+    ): ProductFilterCountData {
         $baseFilterQuery = $this->filterQueryFactory->create($this->getIndexName())
             ->filterOnlySellable()
             ->filterOnlyVisible($this->currentCustomerUser->getPricingGroup())
@@ -280,8 +313,11 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     /**
      * {@inheritdoc}
      */
-    public function getProductFilterCountDataForSearch($searchText, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData): ProductFilterCountData
-    {
+    public function getProductFilterCountDataForSearch(
+        ?string $searchText,
+        ProductFilterConfig $productFilterConfig,
+        ProductFilterData $productFilterData
+    ): ProductFilterCountData {
         $searchText = $searchText ?? '';
 
         $baseFilterQuery = $this->filterQueryFactory->create($this->getIndexName())
@@ -306,5 +342,47 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
             $this->domain->getId(),
             ProductElasticsearchRepository::ELASTICSEARCH_INDEX
         );
+    }
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     */
+    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $filterQuery = $this->createFilterQueryWithProductFilterData(
+            $emptyProductFilterData,
+            $orderingModeId,
+            1,
+            $limit
+        )->setFrom($offset);
+
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
+        return $productsResult->getHits();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     */
+    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $filterQuery = $this->createListableProductsInCategoryFilterQuery(
+            $emptyProductFilterData,
+            $orderingModeId,
+            1,
+            $limit,
+            $category->getId()
+        )->setFrom($offset);
+
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
+        return $productsResult->getHits();
     }
 }

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
@@ -1,8 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Product;
 
+use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
+use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 
 interface ProductOnCurrentDomainFacadeInterface
@@ -11,19 +16,19 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param int $productId
      * @return \Shopsys\FrameworkBundle\Model\Product\Product
      */
-    public function getVisibleProductById($productId);
+    public function getVisibleProductById(int $productId): Product;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    public function getAccessoriesForProduct(Product $product);
+    public function getAccessoriesForProduct(Product $product): array;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    public function getVariantsForProduct(Product $product);
+    public function getVariantsForProduct(Product $product): array;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
@@ -33,7 +38,13 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductsInCategory(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId);
+    public function getPaginatedProductsInCategory(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $categoryId
+    ): PaginationResult;
 
     /**
      * @param string $orderingModeId
@@ -42,24 +53,35 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductsForBrand($orderingModeId, $page, $limit, $brandId);
+    public function getPaginatedProductsForBrand(
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $brandId
+    ): PaginationResult;
 
     /**
-     * @param string|null $searchText
+     * @param string $searchText
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @param string $orderingModeId
      * @param int $page
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getPaginatedProductsForSearch($searchText, ProductFilterData $productFilterData, $orderingModeId, $page, $limit);
+    public function getPaginatedProductsForSearch(
+        string $searchText,
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit
+    ): PaginationResult;
 
     /**
      * @param string|null $searchText
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult
      */
-    public function getSearchAutocompleteProducts($searchText, $limit);
+    public function getSearchAutocompleteProducts(?string $searchText, int $limit): PaginationResult;
 
     /**
      * @param int $categoryId
@@ -67,7 +89,11 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
      */
-    public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData);
+    public function getProductFilterCountDataInCategory(
+        int $categoryId,
+        ProductFilterConfig $productFilterConfig,
+        ProductFilterData $productFilterData
+    ): ProductFilterCountData;
 
     /**
      * @param string|null $searchText
@@ -75,5 +101,26 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData
      */
-    public function getProductFilterCountDataForSearch($searchText, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData);
+    public function getProductFilterCountDataForSearch(
+        ?string $searchText,
+        ProductFilterConfig $productFilterConfig,
+        ProductFilterData $productFilterData
+    ): ProductFilterCountData;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     */
+    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array;
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     */
+    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array;
 }

--- a/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
+++ b/packages/framework/src/Model/Product/Search/Export/ProductSearchExportWithFilterRepository.php
@@ -152,6 +152,7 @@ class ProductSearchExportWithFilterRepository
         $prices = $this->extractPrices($domainId, $product);
         $visibility = $this->extractVisibility($domainId, $product);
         $detailUrl = $this->extractDetailUrl($domainId, $product);
+        $variantIds = $this->extractVariantIds($product);
 
         return [
             'id' => $product->getId(),
@@ -171,10 +172,31 @@ class ProductSearchExportWithFilterRepository
             'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
             'selling_denied' => $product->isSellingDenied(),
             'availability' => $product->getCalculatedAvailability()->getName($locale),
-            'main_variant' => $product->isMainVariant(),
+            'is_main_variant' => $product->isMainVariant(),
             'detail_url' => $detailUrl,
             'visibility' => $visibility,
+            'uuid' => $product->getUuid(),
+            'unit' => $product->getUnit()->getName($locale),
+            'is_using_stock' => $product->isUsingStock(),
+            'stock_quantity' => $product->getStockQuantity(),
+            'variants' => $variantIds,
+            'main_variant' => $product->isVariant() ? $product->getMainVariant()->getId() : null,
         ];
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return int[]
+     */
+    protected function extractVariantIds(Product $product): array
+    {
+        $variantIds = [];
+
+        foreach ($product->getVariants() as $variant) {
+            $variantIds[] = $variant->getId();
+        }
+
+        return $variantIds;
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -30,6 +30,9 @@ class FilterQuery
     /** @var array */
     protected $match;
 
+    /** @var int|null */
+    protected $from;
+
     /**
      * @param string $indexName
      */
@@ -393,6 +396,19 @@ class FilterQuery
     }
 
     /**
+     * @param int $from
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function setFrom(int $from): self
+    {
+        $clone = clone $this;
+
+        $clone->from = $from;
+
+        return $clone;
+    }
+
+    /**
      * @return array
      */
     public function getQuery(): array
@@ -401,7 +417,7 @@ class FilterQuery
             'index' => $this->indexName,
             'type' => '_doc',
             'body' => [
-                'from' => $this->countFrom($this->page, $this->limit),
+                'from' => $this->from !== null ? $this->from : $this->countFrom($this->page, $this->limit),
                 'size' => $this->limit,
                 'sort' => $this->sorting,
                 'query' => [

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -49,14 +49,15 @@ class ImagesResolver implements ResolverInterface
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product|array $data
      * @param string|null $type
      * @param string|null $size
      * @return array
      */
-    public function resolveByProduct(Product $product, ?string $type, ?string $size): array
+    public function resolveByProduct($data, ?string $type, ?string $size): array
     {
-        return $this->resolveByEntity($product, static::IMAGE_ENTITY_PRODUCT, $type, $size);
+        $productId = $data instanceof Product ? $data->getId() : $data['id'];
+        return $this->resolveByEntityId($productId, static::IMAGE_ENTITY_PRODUCT, $type, $size);
     }
 
     /**
@@ -67,20 +68,20 @@ class ImagesResolver implements ResolverInterface
      */
     public function resolveByCategory(Category $category, ?string $type, ?string $size): array
     {
-        return $this->resolveByEntity($category, static::IMAGE_ENTITY_CATEGORY, $type, $size);
+        return $this->resolveByEntityId($category->getId(), static::IMAGE_ENTITY_CATEGORY, $type, $size);
     }
 
     /**
-     * @param object $entity
+     * @param int $entityId
      * @param string $entityName
      * @param string|null $type
      * @param string|null $size
      * @return array
      */
-    protected function resolveByEntity(object $entity, string $entityName, ?string $type, ?string $size): array
+    protected function resolveByEntityId(int $entityId, string $entityName, ?string $type, ?string $size): array
     {
         $sizeConfigs = $this->getSizeConfigs($type, $size, $entityName);
-        $images = $this->imageFacade->getImagesByEntityIndexedById($entity, $type);
+        $images = $this->imageFacade->getImagesByEntityIdAndNameIndexedById($entityId, $entityName, $type);
 
         return $this->getResolvedImages($images, $sizeConfigs);
     }

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
@@ -9,6 +9,7 @@ use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
 
 class PriceResolver implements ResolverInterface, AliasedInterface
 {
@@ -18,19 +19,29 @@ class PriceResolver implements ResolverInterface, AliasedInterface
     protected $productCachedAttributesFacade;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade $productCachedAttributesFacade
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
      */
-    public function __construct(ProductCachedAttributesFacade $productCachedAttributesFacade)
-    {
+    protected $productOnCurrentDomainFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade $productCachedAttributesFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
+     */
+    public function __construct(
+        ProductCachedAttributesFacade $productCachedAttributesFacade,
+        ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
+    ) {
         $this->productCachedAttributesFacade = $productCachedAttributesFacade;
+        $this->productOnCurrentDomainFacade = $productOnCurrentDomainFacade;
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product|array $data
      * @return \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice
      */
-    public function resolveByProduct(Product $product): ProductPrice
+    public function resolveByProduct($data): ProductPrice
     {
+        $product = $data instanceof Product ? $data : $this->productOnCurrentDomainFacade->getVisibleProductById($data['id']);
         return $this->productCachedAttributesFacade->getProductSellingPrice($product);
     }
 

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductResolverMap.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductResolverMap.php
@@ -6,7 +6,9 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Collection\ProductCollectionFacade;
+use Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductResolverMap extends ResolverMap
@@ -22,13 +24,31 @@ class ProductResolverMap extends ResolverMap
     protected $productCollectionFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade
+     */
+    protected $flagFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
+     */
+    protected $categoryFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Product\Collection\ProductCollectionFacade $productCollectionFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      */
-    public function __construct(Domain $domain, ProductCollectionFacade $productCollectionFacade)
-    {
+    public function __construct(
+        Domain $domain,
+        ProductCollectionFacade $productCollectionFacade,
+        FlagFacade $flagFacade,
+        CategoryFacade $categoryFacade
+    ) {
         $this->domain = $domain;
         $this->productCollectionFacade = $productCollectionFacade;
+        $this->flagFacade = $flagFacade;
+        $this->categoryFacade = $categoryFacade;
     }
 
     /**
@@ -38,10 +58,13 @@ class ProductResolverMap extends ResolverMap
     {
         return [
             'Product' => [
-                self::RESOLVE_TYPE => function (Product $product) {
-                    if ($product->isMainVariant()) {
+                self::RESOLVE_TYPE => function ($data) {
+                    $isMainVariant = $data instanceof Product ? $data->isMainVariant() : $data['is_main_variant'];
+                    $isVariant = $data instanceof Product ? $data->isVariant() : $data['main_variant'] !== null;
+
+                    if ($isMainVariant) {
                         return 'MainVariant';
-                    } elseif ($product->isVariant()) {
+                    } elseif ($isVariant) {
                         return 'Variant';
                     } else {
                         return 'RegularProduct';
@@ -60,26 +83,74 @@ class ProductResolverMap extends ResolverMap
     protected function mapProduct(): array
     {
         return [
-            'shortDescription' => function (Product $product) {
-                return $product->getShortDescription($this->domain->getId());
+            'shortDescription' => function ($data) {
+                return $data instanceof Product ? $data->getShortDescription($this->domain->getId()) : $data['short_description'];
             },
-            'link' => function (Product $product) {
-                return $this->getProductLink($product);
+            'link' => function ($data) {
+                $productId = $data instanceof Product ? $data->getId() : $data['id'];
+                return $this->getProductLink($productId);
             },
-            'categories' => function (Product $product) {
-                return $product->getCategoriesIndexedByDomainId()[$this->domain->getId()];
+            'categories' => function ($data) {
+                return $data instanceof Product ? $data->getCategoriesIndexedByDomainId()[$this->domain->getId()] : $this->getCategoriesForData($data);
+            },
+            'flags' => function ($data) {
+                return $this->getFlagsForData($data);
+            },
+            'availability' => function ($data) {
+                return $data instanceof Product ? $data->getCalculatedAvailability() : ['name' => $data['availability']];
+            },
+            'unit' => function ($data) {
+                return $data instanceof Product ? $data->getUnit() : ['name' => $data['unit']];
+            },
+            'stockQuantity' => function ($data) {
+                return $data instanceof Product ? $data->getStockQuantity() : $data['stock_quantity'];
+            },
+            'isUsingStock' => function ($data) {
+                return $data instanceof Product ? $data->isUsingStock() : $data['is_using_stock'];
             },
         ];
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param int $productId
      * @return string
      */
-    protected function getProductLink(Product $product): string
+    protected function getProductLink(int $productId): string
     {
-        $absoluteUrlsIndexedByProductId = $this->productCollectionFacade->getAbsoluteUrlsIndexedByProductId([$product->getId()], $this->domain->getCurrentDomainConfig());
+        $absoluteUrlsIndexedByProductId = $this->productCollectionFacade->getAbsoluteUrlsIndexedByProductId([$productId], $this->domain->getCurrentDomainConfig());
 
-        return $absoluteUrlsIndexedByProductId[$product->getId()];
+        return $absoluteUrlsIndexedByProductId[$productId];
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product|array $data
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    protected function getFlagsForData($data): array
+    {
+        if ($data instanceof Product) {
+            return $data->getFlags();
+        } else {
+            $flags = [];
+            foreach ($data['flags'] as $flagId) {
+                $flags[] = $this->flagFacade->getById($flagId);
+            }
+            return $flags;
+        }
+    }
+
+    /**
+     * @param array $data
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     */
+    protected function getCategoriesForData($data): array
+    {
+        $categoryIds = $data['categories'];
+
+        $categories = [];
+        foreach ($categoryIds as $categoryId) {
+            $categories[] = $this->categoryFacade->getById($categoryId);
+        }
+        return $categories;
     }
 }

--- a/project-base/src/Resources/definition/product/1.json
+++ b/project-base/src/Resources/definition/product/1.json
@@ -208,7 +208,7 @@
         "availability": {
           "type": "text"
         },
-        "main_variant": {
+        "is_main_variant": {
           "type": "boolean"
         },
         "detail_url": {
@@ -224,6 +224,24 @@
               "type": "boolean"
             }
           }
+        },
+        "uuid": {
+          "type": "text"
+        },
+        "unit": {
+          "type": "text"
+        },
+        "is_using_stock": {
+          "type": "boolean"
+        },
+        "stock_quantity": {
+          "type": "integer"
+        },
+        "variants": {
+          "type": "integer"
+        },
+        "main_variant": {
+          "type": "integer"
         }
       }
     }

--- a/project-base/src/Resources/definition/product/2.json
+++ b/project-base/src/Resources/definition/product/2.json
@@ -208,7 +208,7 @@
         "availability": {
           "type": "text"
         },
-        "main_variant": {
+        "is_main_variant": {
           "type": "boolean"
         },
         "detail_url": {
@@ -224,6 +224,24 @@
               "type": "boolean"
             }
           }
+        },
+        "uuid": {
+          "type": "text"
+        },
+        "unit": {
+          "type": "text"
+        },
+        "is_using_stock": {
+          "type": "boolean"
+        },
+        "stock_quantity": {
+          "type": "integer"
+        },
+        "variants": {
+          "type": "integer"
+        },
+        "main_variant": {
+          "type": "integer"
         }
       }
     }

--- a/project-base/tests/App/Functional/Model/Product/Search/ProductSearchExportWithFilterRepositoryTest.php
+++ b/project-base/tests/App/Functional/Model/Product/Search/ProductSearchExportWithFilterRepositoryTest.php
@@ -55,8 +55,14 @@ class ProductSearchExportWithFilterRepositoryTest extends TransactionFunctionalT
             'ordering_priority',
             'calculated_selling_denied',
             'selling_denied',
-            'main_variant',
+            'is_main_variant',
             'visibility',
+            'uuid',
+            'unit',
+            'is_using_stock',
+            'stock_quantity',
+            'variants',
+            'main_variant',
         ];
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php
@@ -4,22 +4,26 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Image;
 
-use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class ProductImagesTest extends GraphQlTestCase
 {
     /**
-     * @var \App\Model\Product\Product
+     * @var \Shopsys\FrameworkBundle\Model\Product\Product
      */
     private $product;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     * @inject
+     */
+    private $productFacade;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $productFacade = $this->getContainer()->get(ProductFacade::class);
-        $this->product = $productFacade->getById(1);
+        $this->product = $this->productFacade->getById(1);
     }
 
     public function testFirstProductWithAllImages(): void

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductTest.php
@@ -99,7 +99,9 @@ class ProductTest extends GraphQlTestCase
                     'unit' => [
                         'name' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
                     ],
-                    'availability' => null,
+                    'availability' => [
+                        'name' => t('In stock', [], 'dataFixtures', $firstDomainLocale),
+                    ],
                     'stockQuantity' => 300,
                     'categories' => [
                         [

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -101,7 +101,9 @@ class ProductsTest extends GraphQlTestCase
                 'unit' => [
                     'name' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
                 ],
-                'availability' => null,
+                'availability' => [
+                    'name' => t('In stock', [], 'dataFixtures', $firstDomainLocale),
+                ],
                 'stockQuantity' => 100,
                 'categories' => [
                     [

--- a/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Test;
 
-use Shopsys\FrontendApiBundle\Component\Domain\EnabledOnDomainChecker;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\App\Test\FunctionalTestCase;
 
@@ -15,13 +14,17 @@ abstract class GraphQlTestCase extends FunctionalTestCase
      */
     protected $client;
 
+    /**
+     * @var \Shopsys\FrontendApiBundle\Component\Domain\EnabledOnDomainChecker
+     * @inject
+     */
+    protected $enabledOnCurrentDomainChecker;
+
     protected function setUp(): void
     {
         $this->client = $this->getClient(true);
 
-        $enabledOnCurrentDomainChecker = $this->getContainer()->get(EnabledOnDomainChecker::class);
-
-        if (!$enabledOnCurrentDomainChecker->isEnabledOnCurrentDomain()) {
+        if (!$this->enabledOnCurrentDomainChecker->isEnabledOnCurrentDomain()) {
             $this->markTestSkipped('Frontend API disabled on domain');
         }
 

--- a/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -72,7 +72,7 @@ abstract class GraphQlTestCase extends FunctionalTestCase
      */
     private function getResponseForQuery(string $query, array $variables): ?Response
     {
-        $path = $this->getContainer()->get('router')->generate('overblog_graphql_endpoint');
+        $path = $this->getLocalizedPathOnFirstDomainByRouteName('overblog_graphql_endpoint');
 
         $this->client->request(
             'GET',

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -397,6 +397,118 @@ There you can find links to upgrade notes for other versions too.
         +     <li class="list-menu__item js-category-item js-hover-intent" data-hover-intent-force-click="true" data-hover-intent-force-click-element=".js-category-collapse-control">
                   <a href="{{ url('front_product_list'
         ```
+- allow getting data for FE API from Elastic ([#1557](https://github.com/shopsys/shopsys/pull/1557))
+    - add and change fields in your elasticsearch definition files
+        ```diff
+        -   main_variant
+        +   is_main_variant
+         
+        +   "uuid": {
+        +      "type": "text"
+        +   },
+        +   "unit": {
+        +      "type": "text"
+        +   },
+        +   "is_using_stock": {
+        +      "type": "boolean"
+        +   },
+        +   "stock_quantity": {
+        +      "type": "boolean"
+        +   },
+        +   "variants": {
+        +       "type": "integer"
+        +   },
+        +   "main_variant": {
+        +      "type": "integer"
+        +   }
+        ```
+        Be aware that to make this change in production environment you'll need to delete old structure and then create
+        a new one because of the change of `type` in `main_variant` field. If you want to know more you can see [this article](../docs/introduction/console-commands-for-application-management-phing-targets.md#product-search-migrate-structure)
+
+    - change and include new fields in ProductSearchExportWithFilterRepositoryTest
+        ```diff
+            'selling_denied',
+        -   'main_variant',
+        +   'is_main_variant',
+            'visibility',
+        +   'uuid',
+        +   'unit',
+        +   'is_using_stock',
+        +   'stock_quantity',
+        +   'variants',
+        +   'main_variant',
+        ```
+    - if you extended these methods in `ProductOnCurrentDomainFacadeInterface`, `ProductOnCurrentDomainFacade` or `ProductOnCurrentDomainElasticFacade`,
+     change their definitions (as strict types and typehints were added or changed)
+        ```diff
+        -   public function getVisibleProductById($productId);
+        +   public function getVisibleProductById(int $productId): Product;
+
+        //...
+
+        -   public function getAccessoriesForProduct(Product $product);
+        +   public function getAccessoriesForProduct(Product $product): array;
+
+        //...
+
+        -   public function getVariantsForProduct(Product $product);
+        +   public function getVariantsForProduct(Product $product): array;
+
+        //...
+
+        -   public function getPaginatedProductsInCategory(ProductFilterData $productFilterData, $orderingModeId, $page, $limit, $categoryId);
+        +   public function getPaginatedProductsInCategory(
+        +       ProductFilterData $productFilterData,
+        +       string $orderingModeId,
+        +       int $page,
+        +       int $limit,
+        +       int $categoryId
+        +   ): PaginationResult;
+
+        //...
+
+        -   public function getPaginatedProductsForBrand($orderingModeId, $page, $limit, $brandId);
+        +   public function getPaginatedProductsForBrand(
+        +       string $orderingModeId,
+        +       int $page,
+        +       int $limit,
+        +       int $brandId
+        +   ): PaginationResult;
+
+        //...
+
+        -   public function getPaginatedProductsForSearch($searchText, ProductFilterData $productFilterData, $orderingModeId, $page, $limit);
+        +   public function getPaginatedProductsForSearch(
+        +       string $searchText,
+        +       ProductFilterData $productFilterData,
+        +       string $orderingModeId,
+        +       int $page,
+        +       int $limit
+        +   ): PaginationResult;
+
+        //...
+
+        -   public function getSearchAutocompleteProducts($searchText, $limit);
+        +   public function getSearchAutocompleteProducts(?string $searchText, int $limit): PaginationResult;
+
+        //...
+
+        -   public function getProductFilterCountDataInCategory($categoryId, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData);
+        +   public function getProductFilterCountDataInCategory(
+        +       int $categoryId,
+        +       ProductFilterConfig $productFilterConfig,
+        +       ProductFilterData $productFilterData
+        +   ): ProductFilterCountData;
+
+        //...
+ 
+        -   public function getProductFilterCountDataForSearch($searchText, ProductFilterConfig $productFilterConfig, ProductFilterData $productFilterData);
+        +   public function getProductFilterCountDataForSearch(
+        +       ?string $searchText,
+        +       ProductFilterConfig $productFilterConfig,
+        +       ProductFilterData $productFilterData
+        +   ): ProductFilterCountData;
+        ```
 
 ### Tools
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Our FE API used ProductOnCurrentDomainFacade and not ProductOnCurrentDomainFacadeInterface so there was no way to choose if the data should be taken from database or elasticsearch
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
