### PR TITLE
[project-base] Do not throw exception if CSRF token is expired on logout

### DIFF
--- a/packages/framework/src/Model/Security/FrontLogoutHandler.php
+++ b/packages/framework/src/Model/Security/FrontLogoutHandler.php
@@ -8,6 +8,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
+/**
+ * @deprecated This class is deprecated since SSFW 7.3.3 and will be removed in next major release, use Shopsys\ShopBundle\Model\Security\FrontLogoutHandler instead.
+ */
 class FrontLogoutHandler implements LogoutSuccessHandlerInterface
 {
     /**

--- a/project-base/app/config/packages/security.yml
+++ b/project-base/app/config/packages/security.yml
@@ -59,7 +59,7 @@ security:
                 remember_me_parameter: "front_login_form[rememberMe]"
             logout:
                 path: front_logout
-                success_handler: Shopsys\FrameworkBundle\Model\Security\FrontLogoutHandler
+                success_handler: Shopsys\ShopBundle\Model\Security\FrontLogoutHandler
                 csrf_parameter: _csrf_token
                 csrf_token_generator: security.csrf.token_manager
                 csrf_token_id: frontend_logout

--- a/project-base/src/Shopsys/ShopBundle/Model/Security/FrontLogoutHandler.php
+++ b/project-base/src/Shopsys/ShopBundle/Model/Security/FrontLogoutHandler.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ShopBundle\Model\Security;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessageSender;
+use Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer;
+use Shopsys\FrameworkBundle\Model\Order\OrderFlowFacade;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+
+class FrontLogoutHandler implements LogoutSuccessHandlerInterface, AuthenticationFailureHandlerInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessageSender
+     */
+    private $flashMessageSender;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Order\OrderFlowFacade
+     */
+    protected $orderFlowFacade;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer
+     */
+    private $currentCustomer;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    private $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessageSender $flashMessageSender
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     * @param \Shopsys\FrameworkBundle\Model\Order\OrderFlowFacade $orderFlowFacade
+     * @param \Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer $currentCustomer
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(FlashMessageSender $flashMessageSender, RouterInterface $router, OrderFlowFacade $orderFlowFacade, CurrentCustomer $currentCustomer, Domain $domain)
+    {
+        $this->router = $router;
+        $this->orderFlowFacade = $orderFlowFacade;
+        $this->currentCustomer = $currentCustomer;
+        $this->domain = $domain;
+        $this->flashMessageSender = $flashMessageSender;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function onLogoutSuccess(Request $request): Response
+    {
+        $this->orderFlowFacade->resetOrderForm();
+        $url = $this->router->generate('front_homepage');
+        $request->getSession()->migrate();
+
+        return new RedirectResponse($url);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Symfony\Component\Security\Core\Exception\AuthenticationException $exception
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        if ($this->currentCustomer->findCurrentUser() !== null) {
+            $domainId = $this->currentCustomer->findCurrentUser()->getDomainId();
+            $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
+
+            $this->flashMessageSender->addErrorFlash(t('There was an error trying to log out. If you really want to sign out, please try it again.', [], 'messages', $locale));
+        }
+
+        $referer = $request->headers->get('referer');
+
+        return new RedirectResponse($referer == null ? $this->router->generate('front_homepage') : $referer);
+    }
+}

--- a/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
+++ b/project-base/src/Shopsys/ShopBundle/Resources/config/services.yml
@@ -105,3 +105,7 @@ services:
     Shopsys\ShopBundle\Controller\Front\ErrorController:
         arguments:
             $environment: '%kernel.environment%'
+
+    Shopsys\ShopBundle\Model\Security\FrontLogoutHandler:
+        arguments:
+            $flashMessageSender: '@shopsys.shop.component.flash_message.sender.front'

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.cs.po
@@ -544,6 +544,9 @@ msgstr "V průběhu objednávkového procesu byla změněna cena platby {{ payme
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."
 msgstr "V průběhu objednávkového procesu byla změněna cena dopravy {{ transportName }}. Prosím, překontrolujte si objednávku."
 
+msgid "There was an error trying to log out. If you really want to sign out, please try it again."
+msgstr "Při pokusu o odhlášení došlo k problému. Pokud se opravdu chcete odhlásit, prosím, zkuste to ještě jednou."
+
 msgid "This account doesn't exist or password is incorrect"
 msgstr "Zadali jste špatné uživatelské jméno nebo heslo"
 

--- a/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
+++ b/project-base/src/Shopsys/ShopBundle/Resources/translations/messages.en.po
@@ -544,6 +544,9 @@ msgstr ""
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."
 msgstr ""
 
+msgid "There was an error trying to log out. If you really want to sign out, please try it again."
+msgstr ""
+
 msgid "This account doesn't exist or password is incorrect"
 msgstr ""
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR fixes problem with CSRF token on logout. Instead of error there will be flash message shown for user.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #769 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
