### PR TITLE
Order item has new type `discount`

### DIFF
--- a/packages/framework/src/Model/Order/Item/OrderItem.php
+++ b/packages/framework/src/Model/Order/Item/OrderItem.php
@@ -22,7 +22,8 @@ class OrderItem
     public const
         TYPE_PAYMENT = 'payment',
         TYPE_PRODUCT = 'product',
-        TYPE_TRANSPORT = 'transport';
+        TYPE_TRANSPORT = 'transport',
+        TYPE_DISCOUNT = 'discount';
 
     /**
      * @var int|null
@@ -355,7 +356,7 @@ class OrderItem
      */
     public function getProduct(): ?Product
     {
-        $this->checkTypeProduct();
+        $this->checkTypeProductOrDiscount();
         return $this->product;
     }
 
@@ -364,7 +365,7 @@ class OrderItem
      */
     public function hasProduct()
     {
-        $this->checkTypeProduct();
+        $this->checkTypeProductOrDiscount();
         return $this->product !== null;
     }
 
@@ -373,7 +374,7 @@ class OrderItem
      */
     public function setProduct(?Product $product): void
     {
-        $this->checkTypeProduct();
+        $this->checkTypeProductOrDiscount();
 
         if ($product !== null && $product->isMainVariant()) {
             throw new MainVariantCannotBeOrderedException();
@@ -406,6 +407,21 @@ class OrderItem
         return $this->type === self::TYPE_TRANSPORT;
     }
 
+    /**
+     * @return bool
+     */
+    public function isTypeDiscount(): bool
+    {
+        return $this->type === self::TYPE_DISCOUNT;
+    }
+
+    protected function checkTypeDiscount(): void
+    {
+        if (!$this->isTypeDiscount()) {
+            throw new WrongItemTypeException(self::TYPE_DISCOUNT, $this->type);
+        }
+    }
+
     protected function checkTypeTransport(): void
     {
         if (!$this->isTypeTransport()) {
@@ -420,9 +436,19 @@ class OrderItem
         }
     }
 
+    /**
+     * @deprecated This method is deprecated since 8.1.0 and will be removed in next major release, use OrderItem::checkTypeProductOrDiscount() instead
+     */
     protected function checkTypeProduct(): void
     {
         if (!$this->isTypeProduct()) {
+            throw new WrongItemTypeException(self::TYPE_PRODUCT, $this->type);
+        }
+    }
+
+    protected function checkTypeProductOrDiscount(): void
+    {
+        if (!$this->isTypeProduct() && !$this->isTypeDiscount()) {
             throw new WrongItemTypeException(self::TYPE_PRODUCT, $this->type);
         }
     }

--- a/packages/framework/src/Model/Order/Item/OrderItemFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactory.php
@@ -130,4 +130,44 @@ class OrderItemFactory implements OrderItemFactoryInterface
         $orderTransport->setTransport($transport);
         return $orderTransport;
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param string $name
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $price
+     * @param string $vatPercent
+     * @param int $quantity
+     * @param string|null $unitName
+     * @param string|null $catnum
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
+     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItem
+     */
+    public function createDiscount(
+        Order $order,
+        string $name,
+        Price $price,
+        string $vatPercent,
+        int $quantity,
+        ?string $unitName,
+        ?string $catnum,
+        ?Product $product = null
+    ): OrderItem {
+        $classData = $this->entityNameResolver->resolve(OrderItem::class);
+
+        /** @var \Shopsys\ShopBundle\Model\Order\Item\OrderItem $orderDiscount */
+        $orderDiscount = new $classData(
+            $order,
+            $name,
+            $price,
+            $vatPercent,
+            $quantity,
+            OrderItem::TYPE_DISCOUNT,
+            $unitName,
+            $catnum
+        );
+
+        $orderDiscount->setProduct($product);
+
+        return $orderDiscount;
+    }
 }

--- a/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactoryInterface.php
@@ -67,4 +67,26 @@ interface OrderItemFactoryInterface
         int $quantity,
         Transport $transport
     ): OrderItem;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @param string $name
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $price
+     * @param string $vatPercent
+     * @param int $quantity
+     * @param string|null $unitName
+     * @param string|null $catnum
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
+     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItem
+     */
+    public function createDiscount(
+        Order $order,
+        string $name,
+        Price $price,
+        string $vatPercent,
+        int $quantity,
+        ?string $unitName,
+        ?string $catnum,
+        ?Product $product = null
+    ): OrderItem;
 }

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -629,7 +629,7 @@ class OrderFacade
             $orderItem->getName()
         );
 
-        $this->orderItemFactory->createProduct(
+        $this->orderItemFactory->createDiscount(
             $orderItem->getOrder(),
             $name,
             $quantifiedItemDiscount->inverse(),
@@ -637,7 +637,7 @@ class OrderFacade
             1,
             null,
             null,
-            null
+            $orderItem->getProduct()
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Until now, all discounts had typed `product`. That was unwanted for a lot of projects because they need to know what is product and what is discount for product. This PR adds new type `discount` to recognition product discount.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1390, closes #1263 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
