### PR TITLE
[shopsys] added note about overriding templates

### DIFF
--- a/docs/cookbook/modifying-a-template-in-administration.md
+++ b/docs/cookbook/modifying-a-template-in-administration.md
@@ -29,6 +29,10 @@ See especially the new directory `ShopsysFrameworkBundle` whose title is based o
 Thanks to this exact location, your new copy of the template will be used instead of the original template from the FrameworkBundle during the rendering process.
 At this point, you just need to modify your copy of the template in such a way that product transfer status will be displayed on the page.
 
+!!! note
+    If you want to change only some block you can override the original template. For that, you need to use `extends` macro with an exclamation mark to prevent template cycling. For example: `{% extends '@!ShopsysFramework/Admin/Content/Product/detail.html.twig' %}`
+    More information can be found in [official Symfony documentation](https://symfony.com/doc/current/bundles/override.html#templates)
+
 #### The second step is the modification of the copy itself
 
 The template before the modification:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We have cookbook how to change original template from the administration, but it does not contain any information about overriding templates. This PR adds new note to inform people that it is possible to override template
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
