### PR TITLE
[shopsys] use constants instead of hard-coded domain IDs

### DIFF
--- a/packages/backend-api/tests/Unit/Controller/V1/Product/ProductControllerTest.php
+++ b/packages/backend-api/tests/Unit/Controller/V1/Product/ProductControllerTest.php
@@ -61,7 +61,7 @@ class ProductControllerTest extends TestCase
     protected function createDomain(): Domain
     {
         return new Domain(
-            [new DomainConfig(1, 'http://example.com/', 'czech', 'cs')],
+            [new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com/', 'czech', 'cs')],
             $this->createMock(Setting::class)
         );
     }

--- a/packages/framework/src/Component/Domain/Domain.php
+++ b/packages/framework/src/Component/Domain/Domain.php
@@ -10,6 +10,7 @@ class Domain implements DomainIdsProviderInterface
 {
     public const FIRST_DOMAIN_ID = 1;
     public const SECOND_DOMAIN_ID = 2;
+    public const THIRD_DOMAIN_ID = 3;
     public const MAIN_ADMIN_DOMAIN_ID = 1;
 
     /**

--- a/packages/framework/src/Model/Product/Listing/ProductListAdminFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListAdminFacade.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product\Listing;
 
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade;
 
@@ -38,7 +39,7 @@ class ProductListAdminFacade
          * temporary solution -
          * when product price type calculation is set to manual, price for first domain is shown in admin product list
          */
-        $defaultPricingGroupId = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId(1)->getId();
+        $defaultPricingGroupId = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId(Domain::FIRST_DOMAIN_ID)->getId();
 
         return $this->productListAdminRepository->getProductListQueryBuilder($defaultPricingGroupId);
     }

--- a/packages/framework/tests/Unit/Component/Constraints/UniqueSlugsOnDomainsValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/UniqueSlugsOnDomainsValidatorTest.php
@@ -20,8 +20,8 @@ class UniqueSlugsOnDomainsValidatorTest extends ConstraintValidatorTestCase
     protected function createValidator()
     {
         $domainConfigs = [
-            new DomainConfig(1, 'http://example.cz', 'name1', 'cs'),
-            new DomainConfig(2, 'http://example.com', 'name2', 'en'),
+            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.cz', 'name1', 'cs'),
+            new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.com', 'name2', 'en'),
         ];
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($domainConfigs, $settingMock);

--- a/packages/framework/tests/Unit/Component/Domain/DomainDataCreatorTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainDataCreatorTest.php
@@ -22,7 +22,7 @@ class DomainDataCreatorTest extends TestCase
     public function testCreateNewDomainsDataNoNewDomain()
     {
         $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example', 'cs'),
+            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com:8080', 'example', 'cs'),
         ];
 
         $settingMock = $this->createMock(Setting::class);
@@ -61,8 +61,8 @@ class DomainDataCreatorTest extends TestCase
     public function testCreateNewDomainsDataOneNewDomain()
     {
         $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example', 'cs'),
-            new DomainConfig(2, 'http://example.com:8080', 'example', 'cs'),
+            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com:8080', 'example', 'cs'),
+            new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.com:8080', 'example', 'cs'),
         ];
 
         $settingMock = $this->createMock(Setting::class);
@@ -70,7 +70,7 @@ class DomainDataCreatorTest extends TestCase
             ->method('getForDomain')
             ->willReturnCallback(function ($key, $domainId) {
                 $this->assertEquals(Setting::DOMAIN_DATA_CREATED, $key);
-                if ($domainId === 1) {
+                if ($domainId === Domain::FIRST_DOMAIN_ID) {
                     return true;
                 }
                 throw new \Shopsys\FrameworkBundle\Component\Setting\Exception\SettingValueNotFoundException();
@@ -128,8 +128,8 @@ class DomainDataCreatorTest extends TestCase
 
     public function testCreateNewDomainsDataNewLocale()
     {
-        $domainConfigWithDataCreated = new DomainConfig(1, 'http://example.com:8080', 'example', 'cs');
-        $domainConfigWithNewLocale = new DomainConfig(2, 'http://example.com:8080', 'example', 'en');
+        $domainConfigWithDataCreated = new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com:8080', 'example', 'cs');
+        $domainConfigWithNewLocale = new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.com:8080', 'example', 'en');
         $domainConfigs = [
             $domainConfigWithDataCreated,
             $domainConfigWithNewLocale,
@@ -140,7 +140,7 @@ class DomainDataCreatorTest extends TestCase
             ->method('get')
             ->willReturnCallback(function ($key, $domainId) {
                 $this->assertEquals(Setting::DOMAIN_DATA_CREATED, $key);
-                if ($domainId === 1) {
+                if ($domainId === Domain::FIRST_DOMAIN_ID) {
                     return true;
                 }
                 throw new \Shopsys\FrameworkBundle\Component\Setting\Exception\SettingValueNotFoundException();

--- a/packages/framework/tests/Unit/Component/Domain/DomainTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainTest.php
@@ -10,28 +10,47 @@ use Symfony\Component\HttpFoundation\Request;
 
 class DomainTest extends TestCase
 {
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
+     */
+    private function createDomainConfigFirst(): DomainConfig
+    {
+        return new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com:8080', 'example.com', 'cs');
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig
+     */
+    private function createDomainConfigSecond(): DomainConfig
+    {
+        return new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.org:8080', 'example.org', 'en');
+    }
+
+    /**
+     * @return array
+     */
+    private function getDomainConfigs(): array
+    {
+        return [
+            $this->createDomainConfigFirst(),
+            $this->createDomainConfigSecond(),
+        ];
+    }
+
     public function testGetIdNotSet()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example', 'cs'),
-            new DomainConfig(2, 'http://example.org:8080', 'example.org', 'en'),
-        ];
         $settingMock = $this->createMock(Setting::class);
 
-        $domain = new Domain($domainConfigs, $settingMock);
+        $domain = new Domain($this->getDomainConfigs(), $settingMock);
         $this->expectException(\Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException::class);
         $domain->getId();
     }
 
     public function testSwitchDomainByRequest()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example.com', 'cs'),
-            new DomainConfig(2, 'http://example.org:8080', 'example.org', 'en'),
-        ];
         $settingMock = $this->createMock(Setting::class);
 
-        $domain = new Domain($domainConfigs, $settingMock);
+        $domain = new Domain($this->getDomainConfigs(), $settingMock);
 
         $requestMock = $this->getMockBuilder(Request::class)
             ->setMethods(['getSchemeAndHttpHost'])
@@ -49,10 +68,7 @@ class DomainTest extends TestCase
 
     public function testGetAllIncludingDomainConfigsWithoutDataCreated()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example.com', 'cs'),
-            new DomainConfig(2, 'http://example.org:8080', 'example.org', 'en'),
-        ];
+        $domainConfigs = $this->getDomainConfigs();
         $settingMock = $this->createMock(Setting::class);
 
         $domain = new Domain($domainConfigs, $settingMock);
@@ -62,8 +78,8 @@ class DomainTest extends TestCase
 
     public function testGetAll()
     {
-        $domainConfigWithDataCreated = new DomainConfig(1, 'http://example.com:8080', 'example.com', 'cs');
-        $domainConfigWithoutDataCreated = new DomainConfig(2, 'http://example.org:8080', 'example.org', 'en');
+        $domainConfigWithDataCreated = $this->createDomainConfigFirst();
+        $domainConfigWithoutDataCreated = $this->createDomainConfigSecond();
         $domainConfigs = [
             $domainConfigWithDataCreated,
             $domainConfigWithoutDataCreated,
@@ -87,27 +103,24 @@ class DomainTest extends TestCase
 
     public function testGetDomainConfigById()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example.com', 'cs'),
-            new DomainConfig(2, 'http://example.org:8080', 'example.org', 'en'),
-        ];
+        $domainConfigs = $this->getDomainConfigs();
         $settingMock = $this->createMock(Setting::class);
 
         $domain = new Domain($domainConfigs, $settingMock);
 
-        $this->assertSame($domainConfigs[0], $domain->getDomainConfigById(1));
-        $this->assertSame($domainConfigs[1], $domain->getDomainConfigById(2));
+        $this->assertSame($domainConfigs[0], $domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID));
+        $this->assertSame($domainConfigs[1], $domain->getDomainConfigById(Domain::SECOND_DOMAIN_ID));
 
         $this->expectException(\Shopsys\FrameworkBundle\Component\Domain\Exception\InvalidDomainIdException::class);
-        $domain->getDomainConfigById(3);
+        $domain->getDomainConfigById(Domain::THIRD_DOMAIN_ID);
     }
 
     public function testGetAllLocales(): void
     {
         $domainConfigs = [
-            new DomainConfig(1, 'http://example.com:8080', 'example.com', 'cs'),
-            new DomainConfig(2, 'http://example.org:8080', 'example.org', 'en'),
-            new DomainConfig(3, 'http://example.cz:8080', 'example.cz', 'cs'),
+            $this->createDomainConfigFirst(),
+            $this->createDomainConfigSecond(),
+            new DomainConfig(Domain::THIRD_DOMAIN_ID, 'http://example.cz:8080', 'example.cz', 'cs'),
         ];
         $settingMock = $this->createMock(Setting::class);
 

--- a/packages/framework/tests/Unit/Component/Domain/DomainTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainTest.php
@@ -27,7 +27,7 @@ class DomainTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
      */
     private function getDomainConfigs(): array
     {
@@ -37,7 +37,7 @@ class DomainTest extends TestCase
         ];
     }
 
-    public function testGetIdNotSet()
+    public function testGetIdNotSet(): void
     {
         $settingMock = $this->createMock(Setting::class);
 
@@ -46,7 +46,7 @@ class DomainTest extends TestCase
         $domain->getId();
     }
 
-    public function testSwitchDomainByRequest()
+    public function testSwitchDomainByRequest(): void
     {
         $settingMock = $this->createMock(Setting::class);
 
@@ -66,7 +66,7 @@ class DomainTest extends TestCase
         $this->assertSame('cs', $domain->getLocale());
     }
 
-    public function testGetAllIncludingDomainConfigsWithoutDataCreated()
+    public function testGetAllIncludingDomainConfigsWithoutDataCreated(): void
     {
         $domainConfigs = $this->getDomainConfigs();
         $settingMock = $this->createMock(Setting::class);
@@ -76,7 +76,7 @@ class DomainTest extends TestCase
         $this->assertSame($domainConfigs, $domain->getAllIncludingDomainConfigsWithoutDataCreated());
     }
 
-    public function testGetAll()
+    public function testGetAll(): void
     {
         $domainConfigWithDataCreated = $this->createDomainConfigFirst();
         $domainConfigWithoutDataCreated = $this->createDomainConfigSecond();
@@ -101,7 +101,7 @@ class DomainTest extends TestCase
         $this->assertSame([$domainConfigWithDataCreated], $domain->getAll());
     }
 
-    public function testGetDomainConfigById()
+    public function testGetDomainConfigById(): void
     {
         $domainConfigs = $this->getDomainConfigs();
         $settingMock = $this->createMock(Setting::class);

--- a/packages/framework/tests/Unit/Component/Elasticsearch/ElasticsearchStructureManagerTest.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/ElasticsearchStructureManagerTest.php
@@ -5,6 +5,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Elasticsearch;
 use Elasticsearch\Client;
 use Elasticsearch\Namespaces\IndicesNamespace;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchStructureManager;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\ElasticsearchStructureException;
 
@@ -50,14 +51,14 @@ class ElasticsearchStructureManagerTest extends TestCase
         ];
         $this->indices->expects($this->once())->method('create')->with($expected);
 
-        $this->structureManager->createIndex(1, static::ELASTICSEARCH_INDEX);
-        $this->structureManager->createAliasForIndex(1, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->createIndex(Domain::FIRST_DOMAIN_ID, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->createAliasForIndex(Domain::FIRST_DOMAIN_ID, static::ELASTICSEARCH_INDEX);
     }
 
     public function testCreateWhileJsonNotExistsFails(): void
     {
         $this->expectException(ElasticsearchStructureException::class);
-        $this->structureManager->createIndex(3, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->createIndex(Domain::THIRD_DOMAIN_ID, static::ELASTICSEARCH_INDEX);
     }
 
     public function testCreateWhileJsonIsNotValidFails(): void
@@ -75,7 +76,7 @@ class ElasticsearchStructureManagerTest extends TestCase
         $expectedDelete = ['index' => '12345test-product1'];
         $this->indices->expects($this->once())->method('delete')->with($expectedDelete);
 
-        $this->structureManager->deleteCurrentIndex(1, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->deleteCurrentIndex(Domain::FIRST_DOMAIN_ID, static::ELASTICSEARCH_INDEX);
     }
 
     public function testDeleteNotExisting(): void
@@ -84,6 +85,6 @@ class ElasticsearchStructureManagerTest extends TestCase
 
         $this->indices->expects($this->never())->method('delete');
 
-        $this->structureManager->deleteCurrentIndex(1, static::ELASTICSEARCH_INDEX);
+        $this->structureManager->deleteCurrentIndex(Domain::FIRST_DOMAIN_ID, static::ELASTICSEARCH_INDEX);
     }
 }

--- a/packages/framework/tests/Unit/Component/Router/CurrentDomainRouterTest.php
+++ b/packages/framework/tests/Unit/Component/Router/CurrentDomainRouterTest.php
@@ -14,10 +14,10 @@ class CurrentDomainRouterTest extends TestCase
 {
     public function testDelegateRouter()
     {
-        $domainConfigs = new DomainConfig(1, 'http://example.com:8080', 'example', 'en');
+        $domainConfigs = new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com:8080', 'example', 'en');
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain([$domainConfigs], $settingMock);
-        $domain->switchDomainById(1);
+        $domain->switchDomainById(Domain::FIRST_DOMAIN_ID);
 
         $generateResult = 'generateResult';
         $pathInfo = 'pathInfo';

--- a/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
@@ -19,7 +19,7 @@ class DomainRouterFactoryTest extends TestCase
 {
     public function testGetRouter()
     {
-        $domainConfig = new DomainConfig(3, 'http://example.com:8080', 'example', 'en');
+        $domainConfig = new DomainConfig(Domain::THIRD_DOMAIN_ID, 'http://example.com:8080', 'example', 'en');
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain([$domainConfig], $settingMock);
 
@@ -69,7 +69,7 @@ class DomainRouterFactoryTest extends TestCase
             $requestStackMock
         );
 
-        $router = $domainRouterFactory->getRouter(3);
+        $router = $domainRouterFactory->getRouter(Domain::THIRD_DOMAIN_ID);
 
         $this->assertInstanceOf(RouterInterface::class, $router);
     }

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
@@ -16,8 +16,8 @@ class FriendlyUrlFactoryTest extends TestCase
     public function testCreateForAllDomains()
     {
         $domainConfigs = [
-            new DomainConfig(1, 'http://example.cz', 'example.cz', 'cs'),
-            new DomainConfig(2, 'http://example.com', 'example.com', 'en'),
+            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.cz', 'example.cz', 'cs'),
+            new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.com', 'example.com', 'en'),
         ];
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($domainConfigs, $settingMock);

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
@@ -13,18 +13,25 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 
 class FriendlyUrlUniqueResultFactoryTest extends TestCase
 {
+    /**
+     * @return array
+     */
+    private function getDomainConfigs(): array
+    {
+        return [
+            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com', 'example.com', 'en'),
+        ];
+    }
+
     public function testCreateNewUnique()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com', 'example.com', 'en'),
-        ];
         $settingMock = $this->createMock(Setting::class);
-        $domain = new Domain($domainConfigs, $settingMock);
+        $domain = new Domain($this->getDomainConfigs(), $settingMock);
 
         $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain, new EntityNameResolver([])));
 
         $attempt = 1;
-        $friendlyUrl = new FriendlyUrl('route_name', 7, 1, 'name');
+        $friendlyUrl = new FriendlyUrl('route_name', 7, Domain::FIRST_DOMAIN_ID, 'name');
         $matchedRouteData = null;
         $friendlyUrlUniqueResult = $friendlyUrlUniqueResultFactory->create(
             $attempt,
@@ -39,16 +46,13 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
 
     public function testCreateOldUnique()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com', 'example.com', 'en'),
-        ];
         $settingMock = $this->createMock(Setting::class);
-        $domain = new Domain($domainConfigs, $settingMock);
+        $domain = new Domain($this->getDomainConfigs(), $settingMock);
 
         $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain, new EntityNameResolver([])));
 
         $attempt = 1;
-        $friendlyUrl = new FriendlyUrl('route_name', 7, 1, 'name');
+        $friendlyUrl = new FriendlyUrl('route_name', 7, Domain::FIRST_DOMAIN_ID, 'name');
         $matchedRouteData = [
             '_route' => $friendlyUrl->getRouteName(),
             'id' => $friendlyUrl->getEntityId(),
@@ -66,16 +70,13 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
 
     public function testCreateNotUnique()
     {
-        $domainConfigs = [
-            new DomainConfig(1, 'http://example.com', 'example.com', 'en'),
-        ];
         $settingMock = $this->createMock(Setting::class);
-        $domain = new Domain($domainConfigs, $settingMock);
+        $domain = new Domain($this->getDomainConfigs(), $settingMock);
 
         $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(new FriendlyUrlFactory($domain, new EntityNameResolver([])));
 
         $attempt = 3;
-        $friendlyUrl = new FriendlyUrl('route_name', 7, 1, 'name');
+        $friendlyUrl = new FriendlyUrl('route_name', 7, Domain::FIRST_DOMAIN_ID, 'name');
         $matchedRouteData = [
             '_route' => 'another_route_name',
             'id' => 7,

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 class FriendlyUrlUniqueResultFactoryTest extends TestCase
 {
     /**
-     * @return array
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
      */
     private function getDomainConfigs(): array
     {
@@ -23,7 +23,7 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         ];
     }
 
-    public function testCreateNewUnique()
+    public function testCreateNewUnique(): void
     {
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($this->getDomainConfigs(), $settingMock);
@@ -44,7 +44,7 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $this->assertSame($friendlyUrl, $friendlyUrlUniqueResult->getFriendlyUrlForPersist());
     }
 
-    public function testCreateOldUnique()
+    public function testCreateOldUnique(): void
     {
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($this->getDomainConfigs(), $settingMock);
@@ -68,7 +68,7 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $this->assertNull($friendlyUrlUniqueResult->getFriendlyUrlForPersist());
     }
 
-    public function testCreateNotUnique()
+    public function testCreateNotUnique(): void
     {
         $settingMock = $this->createMock(Setting::class);
         $domain = new Domain($this->getDomainConfigs(), $settingMock);

--- a/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
@@ -134,8 +134,8 @@ class CountryFormTypeTest extends TypeTestCase
         $this->domain = $this->createMock(Domain::class);
         $this->domain->method('getAll')
             ->willReturn([
-                    new DomainConfig(1, '', '', 'cs'),
-                    new DomainConfig(2, '', '', 'en'),
+                    new DomainConfig(Domain::FIRST_DOMAIN_ID, '', '', 'cs'),
+                    new DomainConfig(Domain::SECOND_DOMAIN_ID, '', '', 'en'),
                 ]);
         $this->domain->method('getAllIds')->willReturn([1, 2]);
 

--- a/packages/framework/tests/Unit/Model/Customer/CurrentCustomerUserTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CurrentCustomerUserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Customer;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData;
@@ -73,7 +74,7 @@ class CurrentCustomerUserTest extends TestCase
         $customerUserData = new CustomerUserData();
         $customerUserData->email = 'no-reply@shopsys.com';
         $customerUserData->pricingGroup = $pricingGroup;
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
 
         return new CustomerUser($customerUserData, null);
     }

--- a/packages/framework/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Customer;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Country\Country;
 use Shopsys\FrameworkBundle\Model\Country\CountryData;
@@ -45,7 +46,7 @@ class CustomerUserUpdateDataFactoryTest extends TestCase
         $customerUserData->createdAt = new DateTime();
         $customerUserData->telephone = 'telephone';
         $customerUserData->email = 'no-reply@shopsys.com';
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUserData->customer = $customer;
 
         $billingCountryData = new CountryData();
@@ -147,7 +148,7 @@ class CustomerUserUpdateDataFactoryTest extends TestCase
         $customerUserData->lastName = 'lastName';
         $customerUserData->email = 'no-reply@shopsys.com';
         $customerUserData->createdAt = new DateTime();
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUserData->customer = $customer;
 
         $billingAddressData = new BillingAddressData();

--- a/packages/framework/tests/Unit/Model/Customer/UserFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/UserFactoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Customer;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData;
@@ -23,7 +24,7 @@ class UserFactoryTest extends TestCase
         $customerUserData->lastName = 'lastName';
         $customerUserData->email = 'no-reply@shopsys.com';
         $customerUserData->password = 'pa55w0rd';
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
 
         $customerUser = $customerUserFactory->create($customerUserData, $deliveryAddress);
 

--- a/packages/framework/tests/Unit/Model/Customer/UserTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/UserTest.php
@@ -5,6 +5,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Customer;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\BillingAddress;
 use Shopsys\FrameworkBundle\Model\Customer\BillingAddressData;
 use Shopsys\FrameworkBundle\Model\Customer\Customer;
@@ -20,7 +21,7 @@ class UserTest extends TestCase
         $customerUserData->firstName = 'Firstname';
         $customerUserData->lastName = 'Lastname';
         $customerUserData->email = 'no-reply@shopsys.com';
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUserData->customer = $customer;
         $customer->addBillingAddress($this->createBillingAddress());
         $customerUser = new CustomerUser($customerUserData, null);
@@ -35,7 +36,7 @@ class UserTest extends TestCase
         $customerUserData->firstName = 'Firstname';
         $customerUserData->lastName = 'Lastname';
         $customerUserData->email = 'no-reply@shopsys.com';
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUserData->customer = $customer;
         $billingAddressData = new BillingAddressData();
         $billingAddressData->companyCustomer = true;
@@ -97,7 +98,7 @@ class UserTest extends TestCase
     ) {
         $customerUserData = new CustomerUserData();
         $customerUserData->email = 'no-reply@shopsys.com';
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUser = new CustomerUser($customerUserData, null);
 
         $this->setProperty($customerUser, 'resetPasswordHash', $resetPasswordHash);

--- a/packages/framework/tests/Unit/Model/Order/OrderFacadeHeurekaTest.php
+++ b/packages/framework/tests/Unit/Model/Order/OrderFacadeHeurekaTest.php
@@ -133,7 +133,7 @@ class OrderFacadeHeurekaTest extends TestCase
      */
     private function createDomain(): Domain
     {
-        $domainConfig = new DomainConfig(1, '', '', 'cs');
+        $domainConfig = new DomainConfig(Domain::FIRST_DOMAIN_ID, '', '', 'cs');
         $domain = new Domain([$domainConfig], $this->createMock(Setting::class));
 
         return $domain;
@@ -145,7 +145,7 @@ class OrderFacadeHeurekaTest extends TestCase
     private function createOrderMock(): MockObject
     {
         $order = $this->createMock(Order::class);
-        $order->method('getDomainId')->willReturn(1);
+        $order->method('getDomainId')->willReturn(Domain::FIRST_DOMAIN_ID);
 
         return $order;
     }

--- a/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationForCustomerUserTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceCalculationForCustomerUserTest.php
@@ -28,7 +28,7 @@ class ProductPriceCalculationForCustomerUserTest extends TestCase
         $customerUserData = new CustomerUserData();
         $customerUserData->pricingGroup = $pricingGroup;
         $customerUserData->email = 'no-reply@shopsys.com';
-        $customerUserData->domainId = 1;
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUser = new CustomerUser($customerUserData, null);
         $expectedProductPrice = new ProductPrice(new Price(Money::create(1), Money::create(1)), false);
 
@@ -50,13 +50,13 @@ class ProductPriceCalculationForCustomerUserTest extends TestCase
             $domainMock
         );
 
-        $productPrice = $productPriceCalculationForCustomerUser->calculatePriceForCustomerUserAndDomainId($product, 1, $customerUser);
+        $productPrice = $productPriceCalculationForCustomerUser->calculatePriceForCustomerUserAndDomainId($product, Domain::FIRST_DOMAIN_ID, $customerUser);
         $this->assertSame($expectedProductPrice, $productPrice);
     }
 
     public function testCalculatePriceByUserAndDomainIdWithoutUser()
     {
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $product = $this->createMock(Product::class);
         $pricingGroupData = new PricingGroupData();
         $pricingGroupData->name = 'name';

--- a/packages/framework/tests/Unit/Model/Transport/TransportVisibilityCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Transport/TransportVisibilityCalculationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Model\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation;
@@ -13,7 +14,7 @@ class TransportVisibilityCalculationTest extends TestCase
 {
     public function testIsVisibleWhenIndepentlyInvisible()
     {
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $transportMock = $this->createMock(Transport::class);
 
         $independentTransportVisibilityCalculationMock = $this->getMockBuilder(IndependentTransportVisibilityCalculation::class)
@@ -39,7 +40,7 @@ class TransportVisibilityCalculationTest extends TestCase
 
     public function testIsVisibleWithHiddenPayment()
     {
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $transportMock = $this->createMock(Transport::class);
         $paymentMock = $this->createMock(Payment::class);
 
@@ -73,7 +74,7 @@ class TransportVisibilityCalculationTest extends TestCase
 
     public function testIsVisibleWithoutPayment()
     {
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $transportMock = $this->createMock(Transport::class);
         $paymentMock = $this->getMockBuilder(Payment::class)
             ->disableOriginalConstructor()
@@ -111,7 +112,7 @@ class TransportVisibilityCalculationTest extends TestCase
 
     public function testIsVisibleWithVisiblePayment()
     {
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $transportMock = $this->createMock(Transport::class);
         $paymentMock = $this->getMockBuilder(Payment::class)
             ->disableOriginalConstructor()
@@ -149,7 +150,7 @@ class TransportVisibilityCalculationTest extends TestCase
 
     public function testFilterVisible()
     {
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $transportHiddenMock = $this->createMock(Transport::class);
         $transportVisibleMock = $this->createMock(Transport::class);
         $paymentMock = $this->getMockBuilder(Payment::class)

--- a/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
+++ b/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
@@ -4,6 +4,7 @@ namespace Tests\ProductFeed\GoogleBundle\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
@@ -67,7 +68,7 @@ class GoogleFeedItemTest extends TestCase
         );
 
         $this->defaultCurrency = $this->createCurrencyMock(1, 'EUR');
-        $this->defaultDomain = $this->createDomainConfigMock(1, 'https://example.com', 'en', $this->defaultCurrency);
+        $this->defaultDomain = $this->createDomainConfigMock(Domain::FIRST_DOMAIN_ID, 'https://example.com', 'en', $this->defaultCurrency);
 
         $this->defaultProduct = $this->createMock(Product::class);
         $this->defaultProduct->method('getId')->willReturn(1);

--- a/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
+++ b/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
@@ -4,6 +4,7 @@ namespace Tests\ProductFeed\HeurekaBundle\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
@@ -71,7 +72,7 @@ class HeurekaFeedItemTest extends TestCase
             $this->categoryFacadeMock
         );
 
-        $this->defaultDomain = $this->createDomainConfigMock(1, 'https://example.cz', 'cs');
+        $this->defaultDomain = $this->createDomainConfigMock(Domain::FIRST_DOMAIN_ID, 'https://example.cz', 'cs');
 
         $this->defaultProduct = $this->createMock(Product::class);
         $this->defaultProduct->method('getId')->willReturn(1);
@@ -84,7 +85,7 @@ class HeurekaFeedItemTest extends TestCase
 
         $productPrice = new ProductPrice(Price::zero(), false);
         $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
-            ->with($this->defaultProduct, 1, null)->willReturn($productPrice);
+            ->with($this->defaultProduct, Domain::FIRST_DOMAIN_ID, null)->willReturn($productPrice);
 
         $this->heurekaProductDataBatchLoaderMock->method('getProductUrl')
             ->with($this->defaultProduct, $this->defaultDomain)->willReturn('https://example.com/product-1');

--- a/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
+++ b/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
@@ -4,6 +4,7 @@ namespace Tests\ProductFeed\ZboziBundle\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
@@ -71,7 +72,7 @@ class ZboziFeedItemTest extends TestCase
             $this->categoryFacadeMock
         );
 
-        $this->defaultDomain = $this->createDomainConfigMock(1, 'https://example.cz', 'cs');
+        $this->defaultDomain = $this->createDomainConfigMock(Domain::FIRST_DOMAIN_ID, 'https://example.cz', 'cs');
 
         $this->defaultProduct = $this->createMock(Product::class);
         $this->defaultProduct->method('getId')->willReturn(1);
@@ -84,7 +85,7 @@ class ZboziFeedItemTest extends TestCase
 
         $productPrice = new ProductPrice(Price::zero(), false);
         $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
-            ->with($this->defaultProduct, 1, null)->willReturn($productPrice);
+            ->with($this->defaultProduct, Domain::FIRST_DOMAIN_ID, null)->willReturn($productPrice);
 
         $this->productUrlsBatchLoaderMock->method('getProductUrl')
             ->with($this->defaultProduct, $this->defaultDomain)->willReturn('https://example.com/product-1');

--- a/packages/read-model/tests/Unit/Product/Action/ProductActionViewFacadeTest.php
+++ b/packages/read-model/tests/Unit/Product/Action/ProductActionViewFacadeTest.php
@@ -65,7 +65,7 @@ class ProductActionViewFacadeTest extends TestCase
      */
     protected function createDomainMock(): Domain
     {
-        $domainConfig = new DomainConfig(1, 'http://webserver:8080/', 'shopsys', 'en');
+        $domainConfig = new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://webserver:8080/', 'shopsys', 'en');
 
         $domain = $this->createMock(Domain::class);
         $domain->method('getCurrentDomainConfig')->willReturn($domainConfig);

--- a/project-base/src/DataFixtures/Performance/OrderDataFixture.php
+++ b/project-base/src/DataFixtures/Performance/OrderDataFixture.php
@@ -16,6 +16,7 @@ use Faker\Generator as Faker;
 use Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlLoggerFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
 use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct;
@@ -243,7 +244,7 @@ class OrderDataFixture
         $orderData->deliveryCountry = $this->getRandomCountryFromFirstDomain();
         $orderData->note = $this->faker->text(200);
         $orderData->createdAt = $this->faker->dateTimeBetween('-1 year', 'now');
-        $orderData->domainId = 1;
+        $orderData->domainId = Domain::FIRST_DOMAIN_ID;
         $orderData->currency = $this->persistentReferenceFacade->getReference(CurrencyDataFixture::CURRENCY_CZK);
 
         return $orderData;

--- a/project-base/tests/App/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
+++ b/project-base/tests/App/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
@@ -34,7 +34,7 @@ class ProductRenameRedirectPreviousUrlTest extends TransactionFunctionalTestCase
     {
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . self::TESTED_PRODUCT_ID);
 
-        $previousFriendlyUrlSlug = $this->friendlyUrlFacade->findMainFriendlyUrl(1, 'front_product_detail', self::TESTED_PRODUCT_ID)->getSlug();
+        $previousFriendlyUrlSlug = $this->friendlyUrlFacade->findMainFriendlyUrl(Domain::FIRST_DOMAIN_ID, 'front_product_detail', self::TESTED_PRODUCT_ID)->getSlug();
 
         /** @var \App\Model\Product\Product $product */
         $productData = $this->productDataFactory->createFromProduct($product);

--- a/project-base/tests/App/Functional/Model/Customer/UserFacadeTest.php
+++ b/project-base/tests/App/Functional/Model/Customer/UserFacadeTest.php
@@ -27,7 +27,10 @@ class UserFacadeTest extends TransactionFunctionalTestCase
 
     public function testChangeEmailToExistingEmailButDifferentDomainDoNotThrowException()
     {
-        $customerUser = $this->customerUserFacade->findCustomerUserByEmailAndDomain(self::EXISTING_EMAIL_ON_DOMAIN_1, Domain::FIRST_DOMAIN_ID);
+        $customerUser = $this->customerUserFacade->findCustomerUserByEmailAndDomain(
+            self::EXISTING_EMAIL_ON_DOMAIN_1,
+            Domain::FIRST_DOMAIN_ID
+        );
         $customerUserUpdateData = $this->customerUserUpdateDataFactory->createFromCustomerUser($customerUser);
         $customerUserUpdateData->customerUserData->email = self::EXISTING_EMAIL_ON_DOMAIN_2;
 
@@ -39,8 +42,11 @@ class UserFacadeTest extends TransactionFunctionalTestCase
     public function testCreateNotDuplicateEmail()
     {
         $customerUserUpdateData = $this->customerUserUpdateDataFactory->create();
-        $customerUserUpdateData->customerUserData->pricingGroup = $this->getReferenceForDomain(PricingGroupDataFixture::PRICING_GROUP_ORDINARY, Domain::FIRST_DOMAIN_ID);
-        $customerUserUpdateData->customerUserData->domainId = 1;
+        $customerUserUpdateData->customerUserData->pricingGroup = $this->getReferenceForDomain(
+            PricingGroupDataFixture::PRICING_GROUP_ORDINARY,
+            Domain::FIRST_DOMAIN_ID
+        );
+        $customerUserUpdateData->customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUserUpdateData->customerUserData->email = 'unique-email@shopsys.com';
         $customerUserUpdateData->customerUserData->firstName = 'John';
         $customerUserUpdateData->customerUserData->lastName = 'Doe';
@@ -53,7 +59,10 @@ class UserFacadeTest extends TransactionFunctionalTestCase
 
     public function testCreateDuplicateEmail()
     {
-        $customerUser = $this->customerUserFacade->findCustomerUserByEmailAndDomain(self::EXISTING_EMAIL_ON_DOMAIN_1, 1);
+        $customerUser = $this->customerUserFacade->findCustomerUserByEmailAndDomain(
+            self::EXISTING_EMAIL_ON_DOMAIN_1,
+            Domain::FIRST_DOMAIN_ID
+        );
         $customerUserUpdateData = $this->customerUserUpdateDataFactory->createFromCustomerUser($customerUser);
         $customerUserUpdateData->customerUserData->password = 'password';
         $this->expectException(\Shopsys\FrameworkBundle\Model\Customer\Exception\DuplicateEmailException::class);
@@ -63,7 +72,10 @@ class UserFacadeTest extends TransactionFunctionalTestCase
 
     public function testCreateDuplicateEmailCaseInsentitive()
     {
-        $customerUser = $this->customerUserFacade->findCustomerUserByEmailAndDomain(self::EXISTING_EMAIL_ON_DOMAIN_1, 1);
+        $customerUser = $this->customerUserFacade->findCustomerUserByEmailAndDomain(
+            self::EXISTING_EMAIL_ON_DOMAIN_1,
+            Domain::FIRST_DOMAIN_ID
+        );
         $customerUserUpdateData = $this->customerUserUpdateDataFactory->createFromCustomerUser($customerUser);
         $customerUserUpdateData->customerUserData->password = 'password';
         $customerUserUpdateData->customerUserData->email = mb_strtoupper(self::EXISTING_EMAIL_ON_DOMAIN_1);

--- a/project-base/tests/App/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
+++ b/project-base/tests/App/Functional/Model/Newsletter/NewsletterRepository/GetAllEmailsDataIteratorMethodTest.php
@@ -6,6 +6,7 @@ namespace Tests\App\Functional\Model\Newsletter\NewsletterRepository;
 
 use Doctrine\ORM\Internal\Hydration\IterableResult;
 use PHPUnit\Framework\Assert;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\App\Test\TransactionFunctionalTestCase;
 
 class GetAllEmailsDataIteratorMethodTest extends TransactionFunctionalTestCase
@@ -20,13 +21,13 @@ class GetAllEmailsDataIteratorMethodTest extends TransactionFunctionalTestCase
 
     public function testSubscriberFoundInFirstDomain(): void
     {
-        $iterator = $this->newsletterRepository->getAllEmailsDataIteratorByDomainId(1);
+        $iterator = $this->newsletterRepository->getAllEmailsDataIteratorByDomainId(Domain::FIRST_DOMAIN_ID);
         $this->assertContainsNewsletterSubscriber($iterator, self::FIRST_DOMAIN_SUBSCRIBER_EMAIL);
     }
 
     public function testSubscriberNotFoundInSecondDomain(): void
     {
-        $iterator = $this->newsletterRepository->getAllEmailsDataIteratorByDomainId(2);
+        $iterator = $this->newsletterRepository->getAllEmailsDataIteratorByDomainId(Domain::SECOND_DOMAIN_ID);
         $this->assertNotContainsNewsletterSubscriber($iterator, self::FIRST_DOMAIN_SUBSCRIBER_EMAIL);
     }
 

--- a/project-base/tests/App/Functional/Model/Newsletter/Subscriber/NewsletterSubscriberPersistenceTest.php
+++ b/project-base/tests/App/Functional/Model/Newsletter/Subscriber/NewsletterSubscriberPersistenceTest.php
@@ -6,6 +6,7 @@ namespace Tests\App\Functional\Model\Newsletter\Subscriber;
 
 use DateTimeImmutable;
 use PHPUnit\Framework\Assert;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Newsletter\NewsletterSubscriber;
 use Tests\App\Test\TransactionFunctionalTestCase;
 
@@ -29,7 +30,7 @@ class NewsletterSubscriberPersistenceTest extends TransactionFunctionalTestCase
         ->from(NewsletterSubscriber::class, 'ns')
         ->where('ns.email = :email')
         ->andWhere('ns.domainId = :domainId')
-        ->setParameters(['email' => 'no-reply@shopsys.com', 'domainId' => 1])
+        ->setParameters(['email' => 'no-reply@shopsys.com', 'domainId' => Domain::FIRST_DOMAIN_ID])
         ->getQuery()->getOneOrNullResult();
 
         Assert::assertEquals($newsletterSubscriber, $found);

--- a/project-base/tests/App/Functional/Model/Order/Mail/OrderMailTest.php
+++ b/project-base/tests/App/Functional/Model/Order/Mail/OrderMailTest.php
@@ -67,7 +67,7 @@ class OrderMailTest extends FunctionalTestCase
         $dateTimeFormatterExtensionMock = $this->getMockBuilder(DateTimeFormatterExtension::class)->disableOriginalConstructor()->getMock();
         $orderUrlGeneratorMock = $this->getMockBuilder(OrderUrlGenerator::class)->disableOriginalConstructor()->getMock();
 
-        $domainConfig = new DomainConfig(1, 'http://example.com:8080', 'example', 'cs');
+        $domainConfig = new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.com:8080', 'example', 'cs');
         $domain = new Domain([$domainConfig], $settingMock);
 
         $orderMail = new OrderMail(
@@ -86,7 +86,7 @@ class OrderMailTest extends FunctionalTestCase
         $mailTemplateData = new MailTemplateData();
         $mailTemplateData->subject = 'subject';
         $mailTemplateData->body = 'body';
-        $mailTemplate = new MailTemplate('templateName', 1, $mailTemplateData);
+        $mailTemplate = new MailTemplate('templateName', Domain::FIRST_DOMAIN_ID, $mailTemplateData);
 
         $messageData = $orderMail->createMessage($mailTemplate, $order);
 

--- a/project-base/tests/App/Functional/Model/Order/OrderFacadeTest.php
+++ b/project-base/tests/App/Functional/Model/Order/OrderFacadeTest.php
@@ -9,6 +9,7 @@ use App\DataFixtures\Demo\CurrencyDataFixture;
 use App\DataFixtures\Demo\OrderStatusDataFixture;
 use App\Model\Order\Item\OrderItemData;
 use App\Model\Order\OrderData;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Tests\App\Test\TransactionFunctionalTestCase;
 
@@ -104,7 +105,7 @@ class OrderFacadeTest extends TransactionFunctionalTestCase
         $orderData->deliveryPostcode = 'deliveryPostcode';
         $orderData->deliveryCountry = $this->persistentReferenceFacade->getReference(CountryDataFixture::COUNTRY_CZECH_REPUBLIC);
         $orderData->note = 'note';
-        $orderData->domainId = 1;
+        $orderData->domainId = Domain::FIRST_DOMAIN_ID;
         $orderData->currency = $this->getReference(CurrencyDataFixture::CURRENCY_CZK);
 
         $orderPreview = $this->orderPreviewFactory->createForCurrentUser($transport, $payment);

--- a/project-base/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
+++ b/project-base/tests/App/Functional/Model/Pricing/Group/PricingGroupFacadeTest.php
@@ -51,7 +51,7 @@ class PricingGroupFacadeTest extends TransactionFunctionalTestCase
 
         $pricingGroupData = new PricingGroupData();
         $pricingGroupData->name = 'pricing_group_name';
-        $domainId = 1;
+        $domainId = Domain::FIRST_DOMAIN_ID;
         $pricingGroup = $this->pricingGroupFacade->create($pricingGroupData, $domainId);
         $this->productPriceRecalculator->runAllScheduledRecalculations();
         $productCalculatedPrice = $em->getRepository(ProductCalculatedPrice::class)->findOneBy([

--- a/project-base/tests/App/Performance/Feed/AllFeedsTest.php
+++ b/project-base/tests/App/Performance/Feed/AllFeedsTest.php
@@ -47,7 +47,7 @@ class AllFeedsTest extends KernelTestCase
 
         $container = self::$kernel->getContainer();
         $container->get(Domain::class)
-            ->switchDomainById(1);
+            ->switchDomainById(Domain::FIRST_DOMAIN_ID);
 
         $this->maxDuration = $container->getParameter('shopsys.performance_test.feed.max_duration_seconds');
         $this->deliveryMaxDuration = $container->getParameter('shopsys.performance_test.feed.delivery.max_duration_seconds');

--- a/project-base/tests/App/Performance/Page/AllPagesTest.php
+++ b/project-base/tests/App/Performance/Page/AllPagesTest.php
@@ -34,7 +34,7 @@ class AllPagesTest extends KernelTestCase
         ]);
 
         self::$kernel->getContainer()->get(Domain::class)
-            ->switchDomainById(1);
+            ->switchDomainById(Domain::FIRST_DOMAIN_ID);
     }
 
     /**

--- a/project-base/tests/App/Smoke/Http/HttpSmokeTest.php
+++ b/project-base/tests/App/Smoke/Http/HttpSmokeTest.php
@@ -16,7 +16,7 @@ class HttpSmokeTest extends HttpSmokeTestCase
         parent::setUp();
 
         self::$kernel->getContainer()->get(Domain::class)
-            ->switchDomainById(1);
+            ->switchDomainById(Domain::FIRST_DOMAIN_ID);
     }
 
     /**

--- a/project-base/tests/App/Test/Codeception/Helper/DomainHelper.php
+++ b/project-base/tests/App/Test/Codeception/Helper/DomainHelper.php
@@ -23,7 +23,7 @@ class DomainHelper extends Module
         /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
         $domain = $symfonyHelper->grabServiceFromContainer(Domain::class);
 
-        $domainConfig = $domain->getDomainConfigById(1);
+        $domainConfig = $domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID);
 
         $webDriver->_reconfigure(['url' => $domainConfig->getUrl()]);
     }

--- a/project-base/tests/App/Unit/Form/Front/Order/PersonalInfoFormTypeTest.php
+++ b/project-base/tests/App/Unit/Form/Front/Order/PersonalInfoFormTypeTest.php
@@ -114,7 +114,7 @@ class PersonalInfoFormTypeTest extends TypeTestCase
         $this->countryFacade->method('getAllEnabledOnDomain')->willReturn([$countryMock]);
 
         $this->domain = $this->createMock(Domain::class);
-        $this->domain->method('getId')->willReturn(1);
+        $this->domain->method('getId')->willReturn(Domain::FIRST_DOMAIN_ID);
 
         $this->heurekaFacade = $this->createMock(HeurekaFacade::class);
         parent::setUp();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are using hardcoded values for domain IDs. This PR replaces them via constants.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1453  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
