### PR TITLE
[project-base] - lazyload call after cart recalculation, price with VAT table position

### DIFF
--- a/project-base/src/Resources/scripts/frontend/cart/cartRecalculator.js
+++ b/project-base/src/Resources/scripts/frontend/cart/cartRecalculator.js
@@ -63,7 +63,6 @@
 
                 Shopsys.register.registerNewContent($mainContent);
                 Shopsys.register.registerNewContent($cartBox);
-                Shopsys.lazyLoadCall.inContainer('.js-cart');
             }
         });
     };

--- a/project-base/src/Resources/scripts/frontend/cart/cartRecalculator.js
+++ b/project-base/src/Resources/scripts/frontend/cart/cartRecalculator.js
@@ -63,6 +63,7 @@
 
                 Shopsys.register.registerNewContent($mainContent);
                 Shopsys.register.registerNewContent($cartBox);
+                Shopsys.lazyLoadCall.inContainer('.js-cart');
             }
         });
     };

--- a/project-base/src/Resources/scripts/frontend/components/ajaxMoreLoader.js
+++ b/project-base/src/Resources/scripts/frontend/components/ajaxMoreLoader.js
@@ -63,7 +63,6 @@
                     paginationToItem += $nextItems.length;
                     $paginationToItemSpan.text(paginationToItem);
                     updateLoadMoreButton();
-                    Shopsys.lazyLoadCall.inContainer($currentList);
                     Shopsys.register.registerNewContent($nextItems);
                 }
             });

--- a/project-base/src/Resources/scripts/frontend/lazyLoadInit.js
+++ b/project-base/src/Resources/scripts/frontend/lazyLoadInit.js
@@ -15,4 +15,5 @@
         });
     };
 
+    Shopsys.register.registerCallback(Shopsys.lazyLoadCall.inContainer);
 })(jQuery);

--- a/project-base/src/Resources/scripts/frontend/product/productList.AjaxFilter.js
+++ b/project-base/src/Resources/scripts/frontend/product/productList.AjaxFilter.js
@@ -44,7 +44,6 @@
             var $productsHtml = $wrappedData.find('.js-product-list-ajax-filter-products-with-controls');
             $productsWithControls.html($productsHtml.html());
             $productsWithControls.show();
-            Shopsys.lazyLoadCall.inContainer($productsWithControls);
             Shopsys.register.registerNewContent($productsWithControls);
         };
 

--- a/project-base/templates/Front/Content/Cart/index.html.twig
+++ b/project-base/templates/Front/Content/Cart/index.html.twig
@@ -103,7 +103,7 @@
                                 <td class="table-cart__cell table-cart__cell--image">&nbsp;</td>
                                 <td class="table-cart__cell table-cart__cell--name">&nbsp;</td>
                                 <td class="table-cart__cell  table-cart__cell--price">&nbsp;</td>
-                                <td class="table-cart__cell table-cart__cell--total-price js-cart-total-price" colspan="2">
+                                <td class="table-cart__cell table-cart__cell--total-price js-cart-total-price" colspan="3">
                                     {{ 'Total price including VAT'|trans }}:
                                     <span>
                                         {{ productsPrice.priceWithVat|price }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After adding lazyload, we need to call lazyload function manually after cart recalculation. Price with VAT position in table was too on right. Now it is correct.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1570 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Screen before:
https://www.screencast.com/t/M4lCCmm4
![obrazek](https://user-images.githubusercontent.com/35454496/72048106-57699880-32bc-11ea-8498-95b931927175.png)

Screen after:
![obrazek](https://user-images.githubusercontent.com/35454496/72048136-67817800-32bc-11ea-8894-5decfb7efea6.png)



