### PR TITLE
[http-smoke-testing] added Symfony 5 support to shopsys/http-smoke-testing package

### DIFF
--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -23,10 +23,10 @@
     "require": {
         "php": "^7.2",
         "phpunit/phpunit": "^8.0",
-        "symfony/framework-bundle": "^3.4|^4.0",
-        "symfony/http-foundation": "^3.4|^4.0",
-        "symfony/dependency-injection": "^3.4|^4.0",
-        "symfony/routing": "^3.4|^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0",
+        "symfony/http-foundation": "^3.4|^4.0|^5.0",
+        "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+        "symfony/routing": "^3.4|^4.0|^5.0",
         "doctrine/annotations": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| I want to use http smoke tests for my project on symfony 5
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No 
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
