### PR TITLE
[framework] Allow to run tests with test database only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,10 @@ install:
     - docker-compose up -d postgres elasticsearch redis selenium-server php-fpm webserver
     - docker-compose exec php-fpm composer install --no-interaction
 
-script:
-    - docker-compose exec php-fpm ./phing db-create test-db-create build-demo-dev tests-acceptance
+jobs:
+    include:
+        -   stage: Tests
+            name: Build all
+            script: docker-compose exec php-fpm ./phing db-create test-db-create build-demo-dev tests-acceptance
+        -   name: Build tests only
+            script: docker-compose exec php-fpm ./phing test-db-create tests tests-acceptance

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1010,7 +1010,7 @@
 
     <target name="test-elasticsearch-index-recreate" depends="production-protection,test-elasticsearch-index-delete,test-elasticsearch-index-create" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)"/>
 
-    <target name="test-error-pages-generate" depends="redis-check" description="Generates error pages displayed in production environment.">
+    <target name="test-error-pages-generate" depends="redis-check" description="Generates error pages for testing environment.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:error-page:generate-all"/>

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1010,6 +1010,14 @@
 
     <target name="test-elasticsearch-index-recreate" depends="production-protection,test-elasticsearch-index-delete,test-elasticsearch-index-create" description="Recreates structure for searching via elasticsearch in test environment (deletes existing structure and creates new one)"/>
 
+    <target name="test-error-pages-generate" depends="redis-check" description="Generates error pages displayed in production environment.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:error-page:generate-all"/>
+            <arg value="--env=test"/>
+        </exec>
+    </target>
+
     <target name="test-friendly-urls-generate" depends="production-protection" description="Generates friendly urls for supported entities when missing in test DB." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -1026,7 +1034,7 @@
         </exec>
     </target>
 
-    <target name="tests" depends="npm-install-dependencies,test-db-demo,test-elasticsearch-index-recreate,test-elasticsearch-export,error-pages-generate,tests-unit,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests. Builds new test database in the process."/>
+    <target name="tests" depends="test-db-demo,assets,npm,test-elasticsearch-index-recreate,test-elasticsearch-export,test-error-pages-generate,tests-unit,tests-functional,tests-smoke" description="Runs unit, functional and smoke tests. Builds new test database in the process."/>
 
     <target name="tests-acceptance" depends="production-protection,clean,clean-redis,test-db-dump" description="Runs acceptance tests. Running Selenium server is required (Selenium is always running in Docker setup).">
         <available file="${path.env.test}" type="file" property="path.env.test.existed"/>

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -45,24 +45,32 @@ class ErrorPagesFacade
     protected $errorIdProvider;
 
     /**
+     * @var string
+     */
+    protected $environment;
+
+    /**
      * @param string $errorPagesDir
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider $errorIdProvider
+     * @param string $environment
      */
     public function __construct(
         $errorPagesDir,
         Domain $domain,
         DomainRouterFactory $domainRouterFactory,
         Filesystem $filesystem,
-        ErrorIdProvider $errorIdProvider
+        ErrorIdProvider $errorIdProvider,
+        string $environment = EnvironmentType::PRODUCTION
     ) {
         $this->errorPagesDir = $errorPagesDir;
         $this->domain = $domain;
         $this->domainRouterFactory = $domainRouterFactory;
         $this->filesystem = $filesystem;
         $this->errorIdProvider = $errorIdProvider;
+        $this->environment = $environment;
     }
 
     public function generateAllErrorPagesForProduction()
@@ -139,7 +147,7 @@ class ErrorPagesFacade
      */
     protected function getErrorPageFilename($domainId, $statusCode)
     {
-        return $this->errorPagesDir . $statusCode . '_ ' . $domainId . '.html';
+        return $this->errorPagesDir . $this->environment . '/' . $statusCode . '_ ' . $domainId . '.html';
     }
 
     /**
@@ -149,7 +157,7 @@ class ErrorPagesFacade
      */
     protected function getUrlContent($errorPageUrl, $expectedStatusCode)
     {
-        $errorPageKernel = new Kernel(EnvironmentType::PRODUCTION, false);
+        $errorPageKernel = new Kernel($this->environment, false);
 
         $errorPageFakeRequest = Request::create($errorPageUrl);
 

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -208,7 +208,8 @@ services:
 
     Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade:
         arguments:
-            - '%shopsys.error_pages_dir%'
+            $errorPagesDir: '%shopsys.error_pages_dir%'
+            $environment: '%kernel.environment%'
 
     Shopsys\FrameworkBundle\Component\Error\ExceptionListener:
         tags:

--- a/project-base/config/paths.yaml
+++ b/project-base/config/paths.yaml
@@ -1,6 +1,5 @@
 parameters:
     shopsys.content_dir_name: 'content'
-    shopsys.css_version_filepath: '%shopsys.web_dir%/assets/cssVersion'
     shopsys.data_fixtures.resources_dir: '%shopsys.root_dir%/src/DataFixtures/resources'
     shopsys.default_db_schema_filepath: '%shopsys.framework.resources_dir%/database/schema.sql'
     shopsys.domain_config_filepath: '%shopsys.root_dir%/config/domains.yaml'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The tests are very time consuming because we need to build whole application on CI server. With this upgrade, you will be able to run tests only with test database. That will decrease time-consuming for test stage.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1039 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
