### PR TITLE
Upgrade elasticsearch to 7.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "doctrine/doctrine-migrations-bundle": "^1.3.0",
         "doctrine/migrations": "^1.6.0",
         "doctrine/persistence": "~1.2.0",
-        "elasticsearch/elasticsearch": "^6.0.1",
+        "elasticsearch/elasticsearch": "^7.4",
         "fp/jsformvalidator-bundle": "^1.5.1",
         "friendsofphp/php-cs-fixer": "^2.14.0",
         "friendsofsymfony/ckeditor-bundle": "^2.1",

--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -96,6 +96,14 @@ services:
         environment:
             - discovery.type=single-node
 
+    kibana:
+        image: docker.elastic.co/kibana/kibana-oss:7.5.1
+        container_name: shopsys-framework-kibana
+        depends_on:
+            - elasticsearch
+        ports:
+            - "5601:5601"
+
     mkdocs:
         build:
             context: .

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -96,6 +96,14 @@ services:
         environment:
             - discovery.type=single-node
 
+    kibana:
+        image: docker.elastic.co/kibana/kibana-oss:7.5.1
+        container_name: shopsys-framework-kibana
+        depends_on:
+            - elasticsearch
+        ports:
+            - "5601:5601"
+
     mkdocs:
         build:
             context: .

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -94,6 +94,14 @@ services:
         environment:
             - discovery.type=single-node
 
+    kibana:
+        image: docker.elastic.co/kibana/kibana-oss:7.5.1
+        container_name: shopsys-framework-kibana
+        depends_on:
+            - elasticsearch
+        ports:
+            - "5601:5601"
+
     mkdocs:
         build:
             context: .

--- a/project-base/docker/elasticsearch/Dockerfile
+++ b/project-base/docker/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.5.1
 
 # install ICU Analysis plugin to sort by language properly
 RUN bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Probably Its time to upgrade elasticsearch to newest version (7.5.1). Additionally this PR provides good time to configure kibana in docker-compose. 
|New feature| Yes/No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1288 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
