### PR TITLE
[project-base] CartCest now uses correct translations

### DIFF
--- a/project-base/tests/App/Acceptance/acceptance/CartCest.php
+++ b/project-base/tests/App/Acceptance/acceptance/CartCest.php
@@ -63,10 +63,10 @@ class CartCest
         // tv-audio
         $me->amOnLocalizedRoute('front_product_list', ['id' => 3]);
         $productListPage->addProductToCartByName('Defender 2.0 SPK-480', 1);
-        $me->seeTranslationFrontend('Product <strong>%name%</strong> (%quantity% %unitName%) added to the cart', 'messages', [
-            '%name%' => t('Defender 2.0 SPK-480', [], 'dataFixtures', $me->getFrontendLocale()),
-            '%quantity%' => 1,
-            '%unitName%' => $me->getDefaultUnitName(),
+        $me->seeTranslationFrontend('Product <strong>{{ name }}</strong> ({{ quantity|formatNumber }} {{ unitName }}) added to the cart', 'messages', [
+            '{{ name }}' => t('Defender 2.0 SPK-480', [], 'dataFixtures', $me->getFrontendLocale()),
+            '{{ quantity|formatNumber }}' => 1,
+            '{{ unitName }}' => $me->getDefaultUnitName(),
         ]);
         $floatingWindowPage->closeFloatingWindow();
         $cartBoxPage->seeCountAndPriceRoundedByCurrencyInCartBox(1, '119');
@@ -91,10 +91,10 @@ class CartCest
         $me->wantTo('add product to cart from homepage');
         $me->amOnPage('/');
         $homepagePage->addTopProductToCartByName('22" Sencor SLE 22F46DM4 HELLO KITTY', 1);
-        $me->seeTranslationFrontend('Product <strong>%name%</strong> (%quantity% %unitName%) added to the cart', 'messages', [
-            '%name%' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $me->getFrontendLocale()),
-            '%quantity%' => 1,
-            '%unitName%' => $me->getDefaultUnitName(),
+        $me->seeTranslationFrontend('Product <strong>{{ name }}</strong> ({{ quantity|formatNumber }} {{ unitName }}) added to the cart', 'messages', [
+            '{{ name }}' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $me->getFrontendLocale()),
+            '{{ quantity|formatNumber }}' => 1,
+            '{{ unitName }}' => $me->getDefaultUnitName(),
         ]);
         $floatingWindowPage->closeFloatingWindow();
         $cartBoxPage->seeCountAndPriceRoundedByCurrencyInCartBox(1, '3499');
@@ -119,10 +119,10 @@ class CartCest
         $me->amOnLocalizedRoute('front_product_detail', ['id' => 1]);
         $me->seeTranslationFrontend('Add to cart');
         $productDetailPage->addProductIntoCart(3);
-        $me->seeTranslationFrontend('Product <strong>%name%</strong> (%quantity% %unitName%) added to the cart', 'messages', [
-            '%name%' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $me->getFrontendLocale()),
-            '%quantity%' => 3,
-            '%unitName%' => $me->getDefaultUnitName(),
+        $me->seeTranslationFrontend('Product <strong>{{ name }}</strong> ({{ quantity|formatNumber }} {{ unitName }}) added to the cart', 'messages', [
+            '{{ name }}' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $me->getFrontendLocale()),
+            '{{ quantity|formatNumber }}' => 3,
+            '{{ unitName }}' => $me->getDefaultUnitName(),
         ]);
         $floatingWindowPage->closeFloatingWindow();
         $cartBoxPage->seeCountAndPriceRoundedByCurrencyInCartBox(1, '10497');
@@ -184,8 +184,8 @@ class CartCest
         $cartPage->assertProductIsNotInCartByName('JURA Impressa J9 TFT Carbon');
 
         $cartPage->removeProductFromCart('PANASONIC DMC FT5EP');
-        $me->seeTranslationFrontend('Your cart is unfortunately empty. To create order, you have to <a href="{{ url }}">choose</a> some product first', 'messages', [
-            '{{ url }}' => '',
+        $me->seeTranslationFrontend('Your cart is unfortunately empty. To create order, you have to <a href="%url%">choose</a> some product first', 'messages', [
+            '%url%' => '',
         ]);
     }
 

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -30,3 +30,6 @@ There you can find links to upgrade notes for other versions too.
 
 - restrict access to Admin > Pricing > Currencies only to superadmin ([#1338](https://github.com/shopsys/shopsys/pull/1338))
     - see #project-base-diff to upgrade your project 
+
+- fix wrong translations in CartCest ([#1582](https://github.com/shopsys/shopsys/pull/1582))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In CartCest were used wrong translations and that cause problems with different language on first domain. This is now fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
