### PR TITLE
[framework] remove route prefix (app_) for project-base

### DIFF
--- a/packages/framework/src/Component/AnnotatedRouteControllerLoader.php
+++ b/packages/framework/src/Component/AnnotatedRouteControllerLoader.php
@@ -21,6 +21,6 @@ class AnnotatedRouteControllerLoader extends SensioAnnotatedRouteControllerLoade
     {
         $routeName = parent::getDefaultRouteName($class, $method);
 
-        return preg_replace('/^shopsys_(shop|framework)_/', '', $routeName);
+        return preg_replace('/^(app_|shopsys_framework_)/', '', $routeName);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| routes do not have prefix `shopsys_shop_` yet from using flex. It caused duplication of routes after override controller without overriden action (one with prefix `app_admin_` and another one only with prefix `admin_`). It could cause problems with breadcumb etc... Another problem is all new routes in administration have annoying and inconsistent prefix `app_`
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
