### PR TITLE
[project-base] added missing symfony/stopwatch dependency

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -93,6 +93,7 @@
         "symfony/property-info": "^3.4",
         "symfony/proxy-manager-bridge": "^3.4",
         "symfony/security": "^3.4",
+        "symfony/stopwatch": "^3.4",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/var-dumper": "^3.4",
         "symfony/web-server-bundle": "^3.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1492 `symfony/symfony` dependency was removed and replaced with individual packages. Unfortunatelly `symfony/stopwatch` was forgotten in project composer file causing installation of packages without dev dependencies fails on non-existing classes. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Upgrade notes not written as previous change is not part of any released version.