### PR TITLE
[framework] VAT edit form tooltip

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Content/Vat/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Vat/listGrid.html.twig
@@ -4,19 +4,19 @@
     <span class="form-edit-block form-edit-block--size-0">
         {% form_theme form '@ShopsysFramework/Admin/Form/theme.html.twig' %}
         {{ form_widget(form.percent) }}
-        <span class="form-edit-block__info relative">
+        <span class="form-edit-block__info">
             %
-            {% if row is not null %}
-                <span
-                    title="{{ 'Rate can\'t be modified. It is necessary to create new rate, remove existing one and replace it with new one.'|trans }}"
-                    class="js-tooltip table-action cursor-help in-action-icons__item"
-                    data-toggle="tooltip"
-                    data-placement="top"
-                >
-                    <i class="svg svg-info"></i>
-                </span>
-            {% endif %}
         </span>
+        {% if row is not null %}
+            <span
+                title="{{ 'Rate can\'t be modified. It is necessary to create new rate, remove existing one and replace it with new one.'|trans }}"
+                class="js-tooltip table-action cursor-help in-action-icons__item"
+                data-toggle="tooltip"
+                data-placement="top"
+                >
+                <i class="svg svg-info"></i>
+            </span>
+        {% endif %}
     </span>
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes tooltip position and size in VAT edit form.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1556  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
