### PR TITLE
[framework] ElasticsearchStructureManager: fix error message hint

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureManager.php
+++ b/packages/framework/src/Component/Elasticsearch/ElasticsearchStructureManager.php
@@ -120,7 +120,7 @@ class ElasticsearchStructureManager
             if ($this->buildVersion === '0000000000000000' || $this->buildVersion === null) {
                 $message .= ' Please start using build version or delete current index before creating a new one.';
             } else {
-                $message .= ' Maybe you forgot to execute "php phing generate-build-version" before creating new index?';
+                $message .= ' Maybe you forgot to execute "php phing build-version-generate" before creating new index?';
             }
             throw new ElasticsearchStructureException($message);
         }


### PR DESCRIPTION
- "generate-build-version" phing target was deprecated in 7.3.0 and removed in 8.0.0
- it was replaced by "build-version-generate" phing target

| Q             | A
| ------------- | ---
|Description, reason for the PR| fixed misleading hint as the target does not exist anymore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1443  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
