### PR TITLE
[framework] fixed phpstan issue with changed namespace of doctrine/persistence

### DIFF
--- a/packages/framework/src/Controller/Admin/AdvertController.php
+++ b/packages/framework/src/Controller/Admin/AdvertController.php
@@ -138,11 +138,13 @@ class AdvertController extends AdminBaseController
      */
     public function listAction()
     {
+        /* @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
 
+        /** @var \Doctrine\Common\Persistence\ManagerRegistry $doctrine */
+        $doctrine = $this->getDoctrine();
         /** @var \Doctrine\ORM\EntityManager $em */
-        $em = $this->getDoctrine()->getManager();
+        $em = $doctrine->getManager();
 
         $queryBuilder = $em->createQueryBuilder()
             ->select('a')

--- a/packages/framework/src/Controller/Admin/BrandController.php
+++ b/packages/framework/src/Controller/Admin/BrandController.php
@@ -119,8 +119,11 @@ class BrandController extends AdminBaseController
         $administrator = $this->getUser();
         /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
 
+        /** @var \Doctrine\Common\Persistence\ManagerRegistry $doctrine */
+        $doctrine = $this->getDoctrine();
         /** @var \Doctrine\ORM\EntityManager $em */
-        $em = $this->getDoctrine()->getManager();
+        $em = $doctrine->getManager();
+
         $queryBuilder = $em->createQueryBuilder()->select('b')->from(Brand::class, 'b');
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'b.id');
 

--- a/packages/framework/src/Controller/Admin/SliderController.php
+++ b/packages/framework/src/Controller/Admin/SliderController.php
@@ -67,8 +67,11 @@ class SliderController extends AdminBaseController
      */
     public function listAction()
     {
+        /** @var \Doctrine\Common\Persistence\ManagerRegistry $doctrine */
+        $doctrine = $this->getDoctrine();
         /** @var \Doctrine\ORM\EntityManager $em */
-        $em = $this->getDoctrine()->getManager();
+        $em = $doctrine->getManager();
+
         $queryBuilder = $em->createQueryBuilder()
             ->select('s')
             ->from(SliderItem::class, 's')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR added variable annotation to help PhpStan understand returned variable. More description follows.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Symfony/symfony#34949 (on the line  https://github.com/symfony/symfony/pull/34949/files#diff-064e58dbe11951327d614e6922caaae5R418) added annotation of multiple types, but the correct type depends on the version of installed `doctrine/persistence` package. 
The other type is always incorrect. 
PhpStan checks return types and fail with error
```
Call to method getManager() on an unknown class Shopsys\FrameworkBundle\Controller\Admin\Doctrine\Common\Persistence\ManagerRegistry
```