### PR TITLE
[project-base] add missing dependency for webpack encore in composer.json

### DIFF
--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -96,6 +96,7 @@
         "symfony/web-link": "^3.4",
         "symfony/web-profiler-bundle": "^3.4",
         "symfony/web-server-bundle": "^3.4",
+        "symfony/webpack-encore-bundle": "^1.7",
         "symfony/workflow": "^3.4",
         "tracy/tracy": "^2.4.13",
         "twig/extensions": "^1.5.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1545  was introduced webpack encore and package `webpack-encore-bundle` that is needed to build application was forgotten to add to project-base `composer.json`. That means you will be not able to build new application after you will release SSFW 9.0.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
