### PR TITLE
[shopsys] added branch-alias master - 9.0.x-dev for all packages

### DIFF
--- a/packages/backend-api/composer.json
+++ b/packages/backend-api/composer.json
@@ -40,5 +40,10 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "shopsys/coding-standards": "9.0.x-dev"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -37,5 +37,10 @@
         "psr-4": {
             "Tests\\CodingStandards\\": "tests/"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/form-types-bundle/composer.json
+++ b/packages/form-types-bundle/composer.json
@@ -30,5 +30,10 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -117,5 +117,10 @@
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -42,5 +42,10 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "shopsys/coding-standards": "9.0.x-dev"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/google-cloud-bundle/composer.json
+++ b/packages/google-cloud-bundle/composer.json
@@ -31,5 +31,10 @@
     },
     "require-dev": {
         "shopsys/coding-standards": "9.0.x-dev"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -35,5 +35,10 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -41,5 +41,10 @@
     },
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/plugin-interface/composer.json
+++ b/packages/plugin-interface/composer.json
@@ -21,5 +21,10 @@
     },
     "require-dev": {
         "shopsys/coding-standards": "9.0.x-dev"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -47,5 +47,10 @@
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -41,5 +41,10 @@
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -50,5 +50,10 @@
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -47,5 +47,10 @@
     "conflict": {
         "symfony/dependency-injection": "3.4.15|3.4.16",
         "twig/twig": "2.6.1"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/packages/read-model/composer.json
+++ b/packages/read-model/composer.json
@@ -34,5 +34,10 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "shopsys/coding-standards": "9.0.x-dev"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        }
     }
 }

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -155,6 +155,9 @@
         "src-dir": "src",
         "var-dir": "var",
         "public-dir": "web",
+        "branch-alias": {
+            "dev-master": "9.0.x-dev"
+        },
         "symfony": {
             "allow-contrib": true,
             "require": "^3.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR aliases `master` branch as version `9.0.x-dev`. More description follows.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Master branch is now the development version of release 9.0. Anyone who already has `9.0.x-dev`  as the version constraint in their composer.json file will get outdated code as new features and fixes will be merged into master and not into branch 9.0. (version 9.0.x-dev is created automatically if branch 9.0 exists).

To ensure a smooth developer experience, `master` branch will be from now aliased as 9.0.x-dev so nobody will need to update their dependencies. 

After this PR is merged we need to 
- **delete version 9.0.x-dev from all packages on packagist** (Because version-like branches have priority over branch-alias!)
- **delete branch 9.0 from GitHub** (on every push the version from version-like branch is created again)

