### PR TITLE
[framework] production protection phing target now returns 1 on error

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -810,7 +810,7 @@
                 <if>
                     <not><equals arg1="${production.confirm.action}" arg2="y"/></not>
                     <then>
-                        <fail message="Terminated by user" status="0"/>
+                        <fail message="Terminated by user"/>
                     </then>
                 </if>
             </then>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Production protection phing target now not return 0 as the return code when user chooses to not proceed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| maybe (when relying on the return code 0 on fail) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


The default value is `n` (do not proceed) and when some "dangerous" target is run on the CI server (ie. Jenkins), the console output says "FAIL", but job result is a success (as the job/phing target exited with 0). This is very confusing and can lead to false assumptions that my tests pass while they weren't actually even executed.