### PR TITLE
[framework] fixed wrong variable name in customer detail template

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Content/Customer/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Customer/detail.html.twig
@@ -11,7 +11,7 @@
         {% embed '@ShopsysFramework/Admin/Inline/FixedBar/fixedBar.html.twig' %}
             {% block fixed_bar_content %}
                 <a href="{{ url('admin_customer_list') }}" class="btn-link-style">{{ 'Back to overview'|trans }}</a>
-                {{ form_save(user|default(null), form) }}
+                {{ form_save(customerUser|default(null), form) }}
             {% endblock %}
         {% endembed %}
     {{ form_end(form) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes wrong variable name. From Controller comes `customerUser`, but template used `user`. That caused the save button was labeled "Create" even on edit page.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
