### PR TITLE
[framework] fixed window fix bar in development mode

### DIFF
--- a/packages/framework/assets/js/admin/components/fixedBar.js
+++ b/packages/framework/assets/js/admin/components/fixedBar.js
@@ -14,6 +14,11 @@ export default class FixedBar {
     static init () {
         SymfonyToolbarSupport.registerOnToolbarShow(FixedBar.onSymfonyToolbarShow);
         SymfonyToolbarSupport.registerOnToolbarHide(FixedBar.onSymfonyToolbarHide);
+
+        // condition copied from: vendor/symfony/symfony/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+        if (typeof Sfjs !== 'undefined' && Sfjs.getPreference('toolbar/displayState') !== 'none') {
+            SymfonyToolbarSupport.notifyOnToolbarShow();
+        }
     }
 }
 

--- a/packages/framework/assets/js/admin/components/symfonyToolbarSupport.js
+++ b/packages/framework/assets/js/admin/components/symfonyToolbarSupport.js
@@ -35,11 +35,6 @@ export default class SymfonyToolbarSupport {
         $('.sf-toolbar').on('click', '[id^="sfToolbarMainContent-"] > a.hide-button', () => {
             SymfonyToolbarSupport.notifyOnToolbarHide();
         });
-
-        // condition copied from: vendor/symfony/symfony/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
-        if (typeof Sfjs !== 'undefined' && Sfjs.getPreference('toolbar/displayState') !== 'none') {
-            SymfonyToolbarSupport.notifyOnToolbarShow();
-        }
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When I have enable development mode and have  active symfony tool bar I don't see full window-fixed-bar element with action buttons in admin (on product detail page I don't see button for save changes). However when I hide/show symfony tool bar, window-fixed-bar element is moved. We moved window-fixed-bar element after page is loaded (and when symfony toolbar is enable)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1631 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
