### PR TITLE
[shopsys] fixed mocked method name for price calculation

### DIFF
--- a/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
+++ b/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
@@ -124,7 +124,7 @@ class GoogleFeedItemTest extends TestCase
     private function mockProductPrice(Product $product, DomainConfig $domain, Price $price): void
     {
         $productPrice = new ProductPrice($price, false);
-        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
+        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForCustomerUserAndDomainId')
             ->with($product, $domain->getId(), null)->willReturn($productPrice);
     }
 

--- a/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
+++ b/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
@@ -84,7 +84,7 @@ class HeurekaFeedItemTest extends TestCase
         $this->defaultProduct->method('getCalculatedAvailability')->willReturn($availabilityMock);
 
         $productPrice = new ProductPrice(Price::zero(), false);
-        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
+        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForCustomerUserAndDomainId')
             ->with($this->defaultProduct, Domain::FIRST_DOMAIN_ID, null)->willReturn($productPrice);
 
         $this->heurekaProductDataBatchLoaderMock->method('getProductUrl')

--- a/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
+++ b/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
@@ -84,7 +84,7 @@ class ZboziFeedItemTest extends TestCase
         $this->defaultProduct->method('getCalculatedAvailability')->willReturn($availabilityMock);
 
         $productPrice = new ProductPrice(Price::zero(), false);
-        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
+        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForCustomerUserAndDomainId')
             ->with($this->defaultProduct, Domain::FIRST_DOMAIN_ID, null)->willReturn($productPrice);
 
         $this->productUrlsBatchLoaderMock->method('getProductUrl')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1543 was method renamed but this change was not affected in some unit tests. This PR fixes throwing warnings when running the tests.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
