### PR TITLE
[shopsys] partial product export to Elastic

### DIFF
--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -4,6 +4,7 @@
 * [Configuring Jenkins for Continuous Integration](./jenkins-configuration.md)
 * [Adding a New Entity](./adding-a-new-entity.md)
 * [Adding New Attribute to an Entity](./adding-new-attribute-to-an-entity.md)
+* [Adding a New Elasticsearch Index](./adding-a-new-elasticsearch-index.md)
 * [Adding a New Administration Page](./adding-a-new-administration-page.md)
 * [Adding a New Advert Position](./adding-a-new-advert-position.md)
 * [Adding an Icon into a Button](./adding-an-icon-into-a-button.md)
@@ -15,7 +16,6 @@
 * [Create Basic Grid](./create-basic-grid.md)
 * [Create Advanced Grid](./create-advanced-grid.md)
 * [Extending Product List](./extending-product-list.md)
-* [Adding a New Elasticsearch Index](./adding-a-new-elasticsearch-index.md)
 
 ## Backend API
 

--- a/docs/cookbook/navigation.yml
+++ b/docs/cookbook/navigation.yml
@@ -4,6 +4,7 @@ arrange:
     - jenkins-configuration.md
     - adding-a-new-entity.md
     - adding-new-attribute-to-an-entity.md
+    - adding-a-new-elasticsearch-index.md
     - adding-a-new-administration-page.md
     - adding-a-new-advert-position.md
     - adding-an-icon-into-a-button.md

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -178,6 +178,9 @@ Especially useful when you need to change the structure and don't need to have f
 #### elasticsearch-export
 Exports all data for index to Elasticsearch.
 
+#### elasticsearch-export-changed
+Exports only changed data for index to Elasticsearch.
+
 ### Coding standards
 
 #### annotations-check

--- a/docs/model/elasticsearch.md
+++ b/docs/model/elasticsearch.md
@@ -30,6 +30,7 @@ The directory is configured using `%shopsys.elasticsearch.structure_dir%` parame
 - elasticsearch-index-recreate
 - elasticsearch-index-migrate
 - elasticsearch-export
+- elasticsearch-export-changed
 
 These commands takes action for all registered indexes. You can also define a single index for given action by defining parameter `elasticsearch.index` (e.g. `elasticsearch-index-recreate -D elasticsearch.index=product` will recreate a structure for index `product`).
 
@@ -89,6 +90,12 @@ Must return all rows for given row ID. It is used for partial exports.
 
 ##### getExportDataForBatch()
 Must return all rows which you want to have exported into elasticsearch.
+
+##### getChangedCount()
+Optional - must return the number of changed rows you want to have exported for given index. Used for export of only changed rows.
+
+##### getChangedIdsForBatch()
+Optional - must return IDs of rows you want to have exported into elasticsearch. Used for export of only changed rows.
 
 ## Where does Elasticsearch run?
 When using docker installation, Elasticsearch API is available on the address [http://127.0.0.1:9200](http://127.0.0.1:9200).

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -536,6 +536,15 @@
         </exec>
     </target>
 
+    <target name="elasticsearch-export-changed" description="Exports only changed indexes data into elasticsearch.">
+        <property name="elasticsearch.index" value=""/>
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:elasticsearch:changed-data-export"/>
+            <arg value="${elasticsearch.index}"/>
+        </exec>
+    </target>
+
     <target name="elasticsearch-index-create" description="Creates indexes into elasticsearch." hidden="true">
         <property name="elasticsearch.index" value=""/>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">

--- a/packages/framework/src/Command/Elasticsearch/AbstractElasticsearchIndexCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/AbstractElasticsearchIndexCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinition;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
@@ -81,12 +82,7 @@ abstract class AbstractElasticsearchIndexCommand extends Command
         $output->writeln($this->getActionStartedMessage());
 
         foreach ($this->getAffectedIndexes($indexName) as $index) {
-            foreach ($this->domain->getAll() as $domainConfig) {
-                $this->executeCommand(
-                    $this->indexDefinitionLoader->getIndexDefinition($index::getName(), $domainConfig->getId()),
-                    $output
-                );
-            }
+            $this->executeForIndex($output, $index);
         }
 
         $symfonyStyleIo->success($this->getActionFinishedMessage());
@@ -103,6 +99,20 @@ abstract class AbstractElasticsearchIndexCommand extends Command
             return [$this->indexRegistry->getIndexByIndexName($indexName)];
         }
         return $this->indexRegistry->getRegisteredIndexes();
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex $index
+     */
+    protected function executeForIndex(OutputInterface $output, AbstractIndex $index): void
+    {
+        foreach ($this->domain->getAll() as $domainConfig) {
+            $this->executeCommand(
+                $this->indexDefinitionLoader->getIndexDefinition($index::getName(), $domainConfig->getId()),
+                $output
+            );
+        }
     }
 
     /**

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchChangedDataExportCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchChangedDataExportCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command\Elasticsearch;
+
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinition;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ElasticsearchChangedDataExportCommand extends ElasticsearchDataExportCommand
+{
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'shopsys:elasticsearch:changed-data-export';
+
+    /**
+     * @inheritDoc
+     */
+    protected function executeCommand(IndexDefinition $indexDefinition, OutputInterface $output): void
+    {
+        $this->indexFacade->exportChanged(
+            $this->indexRegistry->getIndexByIndexName($indexDefinition->getIndexName()),
+            $indexDefinition,
+            $output
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getCommandDescription(): string
+    {
+        return 'Export changed data to Elasticsearch';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getActionStartedMessage(): string
+    {
+        return 'Exporting changed data';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getActionFinishedMessage(): string
+    {
+        return 'Changed data was exported successfully!';
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/AbstractExportChangedCronModule.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractExportChangedCronModule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+use Symfony\Bridge\Monolog\Logger;
+use Symfony\Component\Console\Output\NullOutput;
+
+abstract class AbstractExportChangedCronModule implements SimpleCronModuleInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex
+     */
+    protected $index;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade
+     */
+    protected $indexFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader
+     */
+    protected $indexDefinitionLoader;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex $index
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade $indexFacade
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        AbstractIndex $index,
+        IndexFacade $indexFacade,
+        IndexDefinitionLoader $indexDefinitionLoader,
+        Domain $domain
+    ) {
+        $this->index = $index;
+        $this->indexFacade = $indexFacade;
+        $this->indexDefinitionLoader = $indexDefinitionLoader;
+        $this->domain = $domain;
+    }
+
+    /**
+     * @param \Symfony\Bridge\Monolog\Logger $logger
+     */
+    public function setLogger(Logger $logger)
+    {
+    }
+
+    public function run()
+    {
+        foreach ($this->domain->getAllIds() as $domainId) {
+            $indexDefinition = $this->indexDefinitionLoader->getIndexDefinition($this->index::getName(), $domainId);
+            $this->indexFacade->exportChanged($this->index, $indexDefinition, new NullOutput());
+        }
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/IndexExportedEvent.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexExportedEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class IndexExportedEvent extends Event
+{
+    public const INDEX_EXPORTED = 'elasticsearch.index.exported';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex
+     */
+    protected $index;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex $index
+     */
+    public function __construct(AbstractIndex $index)
+    {
+        $this->index = $index;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex
+     */
+    public function getIndex(): AbstractIndex
+    {
+        return $this->index;
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/IndexSupportChangesOnlyInterface.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexSupportChangesOnlyInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
+
+interface IndexSupportChangesOnlyInterface
+{
+    /**
+     * @param int $domainId
+     * @return int
+     */
+    public function getChangedCount(int $domainId): int;
+
+    /**
+     * @param int $domainId
+     * @param int $lastProcessedId
+     * @param int $batchSize
+     * @return int[]
+     */
+    public function getChangedIdsForBatch(int $domainId, int $lastProcessedId, int $batchSize): array;
+}

--- a/packages/framework/src/Migrations/Version20200129073328.php
+++ b/packages/framework/src/Migrations/Version20200129073328.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20200129073328 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE products ADD export_product BOOLEAN NOT NULL DEFAULT false');
+        $this->sql('ALTER TABLE products ALTER export_product DROP DEFAULT ');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20200206111017.php
+++ b/packages/framework/src/Migrations/Version20200206111017.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20200206111017 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->sql('
+            CREATE OR REPLACE FUNCTION set_export_product_by_product_visibility() RETURNS trigger AS $$
+                BEGIN
+                    IF TG_OP = \'INSERT\' OR NEW.visible <> OLD.visible THEN
+                        UPDATE products p
+                        SET export_product = TRUE
+                        WHERE p.id = NEW.product_id;
+                    END IF;
+                    RETURN NEW;
+                END;
+            $$ LANGUAGE plpgsql;
+        ');
+
+        $this->sql('DROP TRIGGER IF EXISTS mark_product_for_export ON product_visibilities');
+        $this->sql('
+            CREATE TRIGGER mark_product_for_export
+            AFTER INSERT OR UPDATE OF visible
+            ON product_visibilities
+            FOR EACH ROW
+            EXECUTE PROCEDURE set_export_product_by_product_visibility();
+        ');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupEvent.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Pricing\Group;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PricingGroupEvent extends Event
+{
+    /**
+     * The CREATE event occurs once a pricing group was created.
+     *
+     * This event allows you to run jobs dependent on the pricing group creation.
+     */
+    public const CREATE = 'pricingGroup.create';
+    /**
+     * The UPDATE event occurs once a pricing group was changed.
+     *
+     * This event allows you to run jobs dependent on the pricing group change.
+     */
+    public const UPDATE = 'pricingGroup.update';
+    /**
+     * The DELETE event occurs once a pricing group was deleted.
+     *
+     * This event allows you to run jobs dependent on the pricing group deletion.
+     */
+    public const DELETE = 'pricingGroup.delete';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup
+     */
+    protected $pricingGroup;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     */
+    public function __construct(PricingGroup $pricingGroup)
+    {
+        $this->pricingGroup = $pricingGroup;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup
+     */
+    public function getPricingGroup(): PricingGroup
+    {
+        return $this->pricingGroup;
+    }
+}

--- a/packages/framework/src/Model/Product/Availability/AvailabilityEvent.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Availability;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class AvailabilityEvent extends Event
+{
+    /**
+     * The CREATE event occurs once a availability was created.
+     *
+     * This event allows you to run jobs dependent on the availability creation.
+     */
+    public const CREATE = 'availability.create';
+    /**
+     * The UPDATE event occurs once a availability was changed.
+     *
+     * This event allows you to run jobs dependent on the availability change.
+     */
+    public const UPDATE = 'availability.update';
+    /**
+     * The DELETE event occurs once a availability was deleted.
+     *
+     * This event allows you to run jobs dependent on the availability deletion.
+     */
+    public const DELETE = 'availability.delete';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
+     */
+    protected $availability;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\Availability $availability
+     */
+    public function __construct(Availability $availability)
+    {
+        $this->availability = $availability;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
+     */
+    public function getAvailability(): Availability
+    {
+        return $this->availability;
+    }
+}

--- a/packages/framework/src/Model/Product/Brand/BrandEvent.php
+++ b/packages/framework/src/Model/Product/Brand/BrandEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Brand;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class BrandEvent extends Event
+{
+    /**
+     * The CREATE event occurs once a brand was created.
+     *
+     * This event allows you to run jobs dependent on the brand creation.
+     */
+    public const CREATE = 'brand.create';
+    /**
+     * The UPDATE event occurs once a brand was changed.
+     *
+     * This event allows you to run jobs dependent on the brand change.
+     */
+    public const UPDATE = 'brand.update';
+    /**
+     * The DELETE event occurs once a brand was deleted.
+     *
+     * This event allows you to run jobs dependent on the brand deletion.
+     */
+    public const DELETE = 'brand.delete';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand
+     */
+    protected $brand;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand $brand
+     */
+    public function __construct(Brand $brand)
+    {
+        $this->brand = $brand;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand
+     */
+    public function getBrand(): Brand
+    {
+        return $this->brand;
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/MarkProductForExportSubscriber.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/MarkProductForExportSubscriber.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch;
+
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupEvent;
+use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityEvent;
+use Shopsys\FrameworkBundle\Model\Product\Brand\BrandEvent;
+use Shopsys\FrameworkBundle\Model\Product\Flag\FlagEvent;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterEvent;
+use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Shopsys\FrameworkBundle\Model\Product\Unit\UnitEvent;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class MarkProductForExportSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     */
+    protected $productFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
+     */
+    public function __construct(ProductFacade $productFacade)
+    {
+        $this->productFacade = $productFacade;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityEvent $availabilityEvent
+     */
+    public function markAffectedByAvailability(AvailabilityEvent $availabilityEvent): void
+    {
+        $products = $this->productFacade->getProductsWithAvailability($availabilityEvent->getAvailability());
+        $this->productFacade->markProductsForExport($products);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandEvent $brandEvent
+     */
+    public function markAffectedByBrand(BrandEvent $brandEvent): void
+    {
+        $productIds = $this->productFacade->getProductsWithBrand($brandEvent->getBrand());
+        $this->productFacade->markProductsForExport($productIds);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagEvent $flagEvent
+     */
+    public function markAffectedByFlag(FlagEvent $flagEvent): void
+    {
+        $products = $this->productFacade->getProductsWithFlag($flagEvent->getFlag());
+        $this->productFacade->markProductsForExport($products);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterEvent $parameterEvent
+     */
+    public function markAffectedByParameter(ParameterEvent $parameterEvent): void
+    {
+        $products = $this->productFacade->getProductsWithParameter($parameterEvent->getParameter());
+        $this->productFacade->markProductsForExport($products);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitEvent $unitEvent
+     */
+    public function markAffectedByUnit(UnitEvent $unitEvent): void
+    {
+        $products = $this->productFacade->getProductsWithUnit($unitEvent->getUnit());
+        $this->productFacade->markProductsForExport($products);
+    }
+
+    /**
+     * @param \Symfony\Component\EventDispatcher\Event $event
+     */
+    public function markAll(Event $event): void
+    {
+        $this->productFacade->markAllProductsForExport();
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ParameterEvent::DELETE => 'markAffectedByParameter',
+            BrandEvent::DELETE => 'markAffectedByBrand',
+            AvailabilityEvent::UPDATE => 'markAffectedByAvailability',
+            AvailabilityEvent::DELETE => 'markAffectedByAvailability',
+            UnitEvent::UPDATE => 'markAffectedByUnit',
+            UnitEvent::DELETE => 'markAffectedByUnit',
+            FlagEvent::DELETE => 'markAffectedByFlag',
+            PricingGroupEvent::CREATE => 'markAll',
+            PricingGroupEvent::DELETE => 'markAll',
+        ];
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/MarkProductForExportSubscriber.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/MarkProductForExportSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch;
 
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexExportedEvent;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupEvent;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityEvent;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandEvent;
@@ -83,6 +84,16 @@ class MarkProductForExportSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexExportedEvent $indexExportedEvent
+     */
+    public function markAllAsExported(IndexExportedEvent $indexExportedEvent): void
+    {
+        if ($indexExportedEvent->getIndex() instanceof ProductIndex) {
+            $this->productFacade->markAllProductsAsExported();
+        }
+    }
+
+    /**
      * @return array
      */
     public static function getSubscribedEvents(): array
@@ -97,6 +108,7 @@ class MarkProductForExportSubscriber implements EventSubscriberInterface
             FlagEvent::DELETE => 'markAffectedByFlag',
             PricingGroupEvent::CREATE => 'markAll',
             PricingGroupEvent::DELETE => 'markAll',
+            IndexExportedEvent::INDEX_EXPORTED => 'markAllAsExported',
         ];
     }
 }

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportChangedCronModule.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportChangedCronModule.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractExportChangedCronModule;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
+
+class ProductExportChangedCronModule extends AbstractExportChangedCronModule
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex $index
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade $indexFacade
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        ProductIndex $index,
+        IndexFacade $indexFacade,
+        IndexDefinitionLoader $indexDefinitionLoader,
+        Domain $domain
+    ) {
+        parent::__construct($index, $indexFacade, $indexDefinitionLoader, $domain);
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -142,6 +142,42 @@ class ProductExportRepository
     }
 
     /**
+     * @param int $lastProcessedId
+     * @param int $batchSize
+     * @return int[]
+     */
+    public function getProductIdsForChanged(int $lastProcessedId, int $batchSize): array
+    {
+        $result = $this->em->createQueryBuilder()
+            ->select('p.id')
+            ->from(Product::class, 'p')
+            ->where('p.exportProduct = TRUE')
+            ->andWhere('p.id > :lastProcessedId')
+            ->orderBy('p.id')
+            ->setParameter('lastProcessedId', $lastProcessedId)
+            ->setMaxResults($batchSize)
+            ->getQuery()
+            ->getArrayResult();
+
+        return array_column($result, 'id');
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductChangedCount(): int
+    {
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->select('p.id')
+            ->from(Product::class, 'p')
+            ->where('p.exportProduct = TRUE');
+
+        $result = new QueryPaginator($queryBuilder);
+
+        return $result->getTotalCount();
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param int $domainId
      * @param string $locale

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
@@ -6,8 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexSupportChangesOnlyInterface;
 
-class ProductIndex extends AbstractIndex
+class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
@@ -37,6 +38,22 @@ class ProductIndex extends AbstractIndex
     public function getTotalCount(int $domainId): int
     {
         return $this->productExportRepository->getProductTotalCountForDomain($domainId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getChangedCount(int $domainId): int
+    {
+        return $this->productExportRepository->getProductChangedCount();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getChangedIdsForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
+    {
+        return $this->productExportRepository->getProductIdsForChanged($lastProcessedId, $batchSize);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Flag/FlagEvent.php
+++ b/packages/framework/src/Model/Product/Flag/FlagEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Flag;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class FlagEvent extends Event
+{
+    /**
+     * The CREATE event occurs once a flag was created.
+     *
+     * This event allows you to run jobs dependent on the flag creation.
+     */
+    public const CREATE = 'flag.create';
+    /**
+     * The UPDATE event occurs once a flag was changed.
+     *
+     * This event allows you to run jobs dependent on the flag change.
+     */
+    public const UPDATE = 'flag.update';
+    /**
+     * The DELETE event occurs once a flag was deleted.
+     *
+     * This event allows you to run jobs dependent on the flag deletion.
+     */
+    public const DELETE = 'flag.delete';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Flag\Flag
+     */
+    protected $flag;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\Flag $flag
+     */
+    public function __construct(Flag $flag)
+    {
+        $this->flag = $flag;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag
+     */
+    public function getFlag(): Flag
+    {
+        return $this->flag;
+    }
+}

--- a/packages/framework/src/Model/Product/Parameter/ParameterEvent.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class ParameterEvent extends Event
+{
+    /**
+     * The CREATE event occurs once a parameter was created.
+     *
+     * This event allows you to run jobs dependent on the parameter creation.
+     */
+    public const CREATE = 'parameter.create';
+    /**
+     * The UPDATE event occurs once a parameter was changed.
+     *
+     * This event allows you to run jobs dependent on the parameter change.
+     */
+    public const UPDATE = 'parameter.update';
+    /**
+     * The DELETE event occurs once a parameter was deleted.
+     *
+     * This event allows you to run jobs dependent on the parameter deletion.
+     */
+    public const DELETE = 'parameter.delete';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter
+     */
+    protected $parameter;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter
+     */
+    public function __construct(Parameter $parameter)
+    {
+        $this->parameter = $parameter;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter
+     */
+    public function getParameter(): Parameter
+    {
+        return $this->parameter;
+    }
+}

--- a/packages/framework/src/Model/Product/Pricing/ProductInputPriceFacade.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductInputPriceFacade.php
@@ -141,6 +141,7 @@ class ProductInputPriceFacade
                 );
 
                 $product->changeVatForDomain($newVat, $domainId);
+                $product->markForExport();
             }
         }
 

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -276,6 +276,13 @@ class Product extends AbstractTranslatableEntity
     protected $uuid;
 
     /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    protected $exportProduct;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[]|null $variants
      */
@@ -303,6 +310,7 @@ class Product extends AbstractTranslatableEntity
         $this->recalculateVisibility = true;
         $this->calculatedHidden = true;
         $this->calculatedSellingDenied = true;
+        $this->exportProduct = true;
         $this->brand = $productData->brand;
         $this->orderingPriority = $productData->orderingPriority;
 
@@ -744,6 +752,11 @@ class Product extends AbstractTranslatableEntity
     public function markForAvailabilityRecalculation()
     {
         $this->recalculateAvailability = true;
+    }
+
+    public function markForExport(): void
+    {
+        $this->exportProduct = true;
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -14,9 +14,13 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupRepository;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository;
+use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculationScheduler;
+use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportScheduler;
+use Shopsys\FrameworkBundle\Model\Product\Flag\Flag;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade;
@@ -24,6 +28,7 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice;
+use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;
 
 class ProductFacade
 {
@@ -485,5 +490,63 @@ class ProductFacade
     public function getByUuid(string $uuid): Product
     {
         return $this->productRepository->getOneByUuid($uuid);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
+     */
+    public function markProductsForExport(array $products): void
+    {
+        $this->productRepository->markProductsForExport($products);
+    }
+
+    public function markAllProductsForExport(): void
+    {
+        $this->productRepository->markAllProductsForExport();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\Availability $availability
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getProductsWithAvailability(Availability $availability): array
+    {
+        return $this->productRepository->getProductsWithAvailability($availability);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getProductsWithParameter(Parameter $parameter): array
+    {
+        return $this->productRepository->getProductsWithParameter($parameter);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand $brand
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getProductsWithBrand(Brand $brand): array
+    {
+        return $this->productRepository->getProductsWithBrand($brand);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\Flag $flag
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getProductsWithFlag(Flag $flag): array
+    {
+        return $this->productRepository->getProductsWithFlag($flag);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $unit
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     */
+    public function getProductsWithUnit(Unit $unit): array
+    {
+        return $this->productRepository->getProductsWithUnit($unit);
     }
 }

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -505,6 +505,11 @@ class ProductFacade
         $this->productRepository->markAllProductsForExport();
     }
 
+    public function markAllProductsAsExported(): void
+    {
+        $this->productRepository->markAllProductsAsExported();
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\Availability $availability
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -870,6 +870,12 @@ class ProductRepository
             ->execute();
     }
 
+    public function markAllProductsAsExported(): void
+    {
+        $this->em->createQuery('UPDATE ' . Product::class . ' p SET p.exportProduct = FALSE')
+            ->execute();
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter
      * @return array

--- a/packages/framework/src/Model/Product/Unit/UnitEvent.php
+++ b/packages/framework/src/Model/Product/Unit/UnitEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Unit;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class UnitEvent extends Event
+{
+    /**
+     * The CREATE event occurs once a unit was created.
+     *
+     * This event allows you to run jobs dependent on the unit creation.
+     */
+    public const CREATE = 'unit.create';
+    /**
+     * The UPDATE event occurs once a unit was changed.
+     *
+     * This event allows you to run jobs dependent on the unit change.
+     */
+    public const UPDATE = 'unit.update';
+    /**
+     * The DELETE event occurs once a unit was deleted.
+     *
+     * This event allows you to run jobs dependent on the unit deletion.
+     */
+    public const DELETE = 'unit.delete';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit
+     */
+    protected $unit;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $unit
+     */
+    public function __construct(Unit $unit)
+    {
+        $this->unit = $unit;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Unit\Unit
+     */
+    public function getUnit(): Unit
+    {
+        return $this->unit;
+    }
+}

--- a/packages/framework/src/Resources/config/services/cron.yml
+++ b/packages/framework/src/Resources/config/services/cron.yml
@@ -6,6 +6,10 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportCronModule:
         tags:
+            - { name: shopsys.cron, hours: '0', minutes: '0' }
+
+    Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportChangedCronModule:
+        tags:
             - { name: shopsys.cron, hours: '*', minutes: '*' }
 
     Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule:

--- a/packages/framework/tests/Unit/Component/Elasticsearch/IndexFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/IndexFacadeTest.php
@@ -131,6 +131,7 @@ class IndexFacadeTest extends TestCase
         /** @var \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex|\PHPUnit\Framework\MockObject\MockObject $indexMock */
         $indexMock = $this->createMock(ProductIndex::class);
         $indexMock->method('getExportDataForIds')->with(Domain::FIRST_DOMAIN_ID, $affectedIds)->willReturn($exportData);
+        $indexMock->method('getExportBatchSize')->willReturn(100);
 
         /** @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinition|\PHPUnit\Framework\MockObject\MockObject $indexDefinitionMock */
         $indexDefinitionMock = $this->getIndexDefinitionMockReturningDomainId();

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -814,6 +814,18 @@ There you can find links to upgrade notes for other versions too.
                     return $filter->filterOnlySellable();
                 }
             ```
+- update your project to export to Elasticsearch only changed products ([#1636](https://github.com/shopsys/shopsys/pull/1636))
+    - if you have registered products export by yourself, you can update `config/services/cron.yml` to run frequently export of only changed products and full export at midnight
+    ```diff
+        Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportCronModule:
+            tags:
+    -           - { name: shopsys.cron, hours: '*', minutes: '*' }
+    +           - { name: shopsys.cron, hours: '0', minutes: '0' }
+
+    +   Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportChangedCronModule:
+    +       tags:
+    +           - { name: shopsys.cron, hours: '*', minutes: '*' }
+    ```
 
 - update FpJsFormValidator bundle ([#1664](https://github.com/shopsys/shopsys/pull/1664))
     - update your `composer.json`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Adds the possibility to export only changed data into Elasticsearch. Products are now marked to export from indirect sources (list below) and with 5-minute cron only marked products are exported. Full export is by default run at midnight.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


List of changes affecting the products:
- parameter deleted
- brand deleted
- availability updated
- availability deleted
- unit updated
- unit deleted
- flag deleted
- pricing group created
- pricinggroup deleted
- calculated visibility changed