### PR TITLE
[framework] fixed contact form text db migration

### DIFF
--- a/packages/framework/src/Migrations/Version20191121145700.php
+++ b/packages/framework/src/Migrations/Version20191121145700.php
@@ -21,10 +21,11 @@ class Version20191121145700 extends AbstractMigration
                 'SELECT COUNT(*) FROM setting_values WHERE name = \'contactFormMainText\' AND domain_id = :domainId;',
                 [
                     'domainId' => $domainId,
-            ]
+                ]
             )->fetchColumn(0);
             if ($contactFormMainTextCount <= 0) {
-                $this->sql('INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'contactFormMainText\', 1, :text, \'string\')', [
+                $this->sql('INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'contactFormMainText\', :domainId, :text, \'string\')', [
+                    'domainId' => $domainId,
                     'text' => 'Hi there, our team is happy and ready to answer your question. Please fill out the form below and we will get in touch as soon as possible.',
                 ]);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1522 migration for contact page was introduced, but when migration is run on the already running project (with some data in database), migration fails on the duplicate primary key because contact page text was always inserted with domainId = 1. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

_migration is not part of any released version, so it can be changed_
