### PR TITLE
[shopsys] unit tests don't pass on warning + fix feed packages tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -272,30 +272,44 @@
         <phingcall target="shopsys_framework.tests-unit"/>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/product-feed-google/phpunit.xml"/>
             <arg value="${path.packages}/product-feed-google/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/product-feed-heureka/phpunit.xml"/>
             <arg value="${path.packages}/product-feed-heureka/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/product-feed-heureka-delivery/phpunit.xml"/>
             <arg value="${path.packages}/product-feed-heureka-delivery/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/product-feed-zbozi/phpunit.xml"/>
             <arg value="${path.packages}/product-feed-zbozi/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/http-smoke-testing/phpunit.xml"/>
             <arg value="${path.packages}/http-smoke-testing/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/migrations/phpunit.xml"/>
             <arg value="${path.packages}/migrations/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/read-model/phpunit.xml"/>
             <arg value="${path.packages}/read-model/tests"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
@@ -310,10 +324,14 @@
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.packages}/backend-api/phpunit.xml"/>
             <arg value="${path.packages}/backend-api/tests/"/>
         </exec>
         <exec executable="${path.vendor}/bin/phpunit" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--colors=always"/>
+            <arg value="--configuration"/>
+            <arg value="${path.utils}/releaser/phpunit.xml"/>
             <arg value="${path.utils}/releaser/tests/"/>
         </exec>
     </target>

--- a/packages/backend-api/phpunit.xml
+++ b/packages/backend-api/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/http-smoke-testing/phpunit.xml
+++ b/packages/http-smoke-testing/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/migrations/phpunit.xml
+++ b/packages/migrations/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/product-feed-google/phpunit.xml
+++ b/packages/product-feed-google/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
+++ b/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
@@ -124,7 +124,7 @@ class GoogleFeedItemTest extends TestCase
     private function mockProductPrice(Product $product, DomainConfig $domain, Price $price): void
     {
         $productPrice = new ProductPrice($price, false);
-        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
+        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForCustomerUserAndDomainId')
             ->with($product, $domain->getId(), null)->willReturn($productPrice);
     }
 

--- a/packages/product-feed-heureka-delivery/phpunit.xml
+++ b/packages/product-feed-heureka-delivery/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/product-feed-heureka/phpunit.xml
+++ b/packages/product-feed-heureka/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
+++ b/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
@@ -84,7 +84,7 @@ class HeurekaFeedItemTest extends TestCase
         $this->defaultProduct->method('getCalculatedAvailability')->willReturn($availabilityMock);
 
         $productPrice = new ProductPrice(Price::zero(), false);
-        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
+        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForCustomerUserAndDomainId')
             ->with($this->defaultProduct, Domain::FIRST_DOMAIN_ID, null)->willReturn($productPrice);
 
         $this->heurekaProductDataBatchLoaderMock->method('getProductUrl')

--- a/packages/product-feed-zbozi/phpunit.xml
+++ b/packages/product-feed-zbozi/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
+++ b/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
@@ -84,7 +84,7 @@ class ZboziFeedItemTest extends TestCase
         $this->defaultProduct->method('getCalculatedAvailability')->willReturn($availabilityMock);
 
         $productPrice = new ProductPrice(Price::zero(), false);
-        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForUserAndDomainId')
+        $this->productPriceCalculationForCustomerUserMock->method('calculatePriceForCustomerUserAndDomainId')
             ->with($this->defaultProduct, Domain::FIRST_DOMAIN_ID, null)->willReturn($productPrice);
 
         $this->productUrlsBatchLoaderMock->method('getProductUrl')

--- a/packages/read-model/phpunit.xml
+++ b/packages/read-model/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>

--- a/utils/releaser/phpunit.xml
+++ b/utils/releaser/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    failOnWarning="true"
+    beStrictAboutTestsThatDoNotTestAnything="false"
+>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Unit tests will not fail on warning. The tests are marked as warning only and then skipped. This PR fixes it.<br> In #1543 was method renamed but this change was not affected in some unit tests. This PR fixes wrong tests too.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
