### PR TITLE
[shopsys] Unify variable annotations through codebase

### DIFF
--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -16,6 +16,7 @@ services:
 
     # Slevomat Checkers
     SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff: ~
+    SlevomatCodingStandard\Sniffs\Commenting\InlineDocCommentDeclarationSniff: ~
     SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff: ~
     SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff: ~
 

--- a/packages/coding-standards/src/CsFixer/OrmJoinColumnRequireNullableFixer.php
+++ b/packages/coding-standards/src/CsFixer/OrmJoinColumnRequireNullableFixer.php
@@ -64,8 +64,8 @@ SAMPLE
      */
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
+        /** @var \PhpCsFixer\Tokenizer\Token $token */
         foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
-            /** @var \PhpCsFixer\Tokenizer\Token $token */
             $doc = new DocBlock($token->getContent());
             foreach ($doc->getAnnotations() as $annotation) {
                 if ($this->isRelationAnnotation($annotation)) {

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -66,8 +66,8 @@ class ClassExtensionRegistry
             ->name('/.*(Data|Controller)\.php/');
 
         $otherClassesMap = [];
+        /** @var \Symfony\Component\Finder\SplFileInfo $file */
         foreach ($finder as $file) {
-            /** @var \Symfony\Component\Finder\SplFileInfo $file */
             $frameworkClassFqcn = $this->getFqcn($file->getPathname());
             $projectClassFqcn = str_replace('Shopsys\FrameworkBundle', 'App', $frameworkClassFqcn);
             if (class_exists($projectClassFqcn)) {

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -189,8 +189,9 @@ class FileUpload
     public function postFlushEntity(EntityFileUploadInterface $entity)
     {
         $filesForUpload = $entity->getTemporaryFilesForUpload();
+
+        /** @var \Shopsys\FrameworkBundle\Component\FileUpload\FileForUpload $fileForUpload */
         foreach ($filesForUpload as $fileForUpload) {
-            /* @var $fileForUpload FileForUpload */
             $sourceFilepath = TransformString::removeDriveLetterFromPath($this->getTemporaryFilepath($fileForUpload->getTemporaryFilename()));
             $originalFilename = $this->fileNamingConvention->getFilenameByNamingConvention(
                 $fileForUpload->getNameConventionType(),

--- a/packages/framework/src/Component/FlashMessage/ErrorExtractor.php
+++ b/packages/framework/src/Component/FlashMessage/ErrorExtractor.php
@@ -16,8 +16,9 @@ class ErrorExtractor
     public function getAllErrorsAsArray(FormInterface $form, array $errorFlashMessages): array
     {
         $errors = $errorFlashMessages;
+
+        /** @var \Symfony\Component\Form\FormError $error */
         foreach ($form->getErrors(true) as $error) {
-            /* @var $error \Symfony\Component\Form\FormError */
             $errors[] = $error->getMessage();
         }
 

--- a/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
+++ b/packages/framework/src/Component/FlashMessage/FlashMessageTrait.php
@@ -90,7 +90,7 @@ trait FlashMessageTrait
      */
     public function isFlashMessageBagEmpty()
     {
-        /** @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface */
+        /** @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface $flashBag */
         $flashBag = $this->container->get('session')->getFlashBag();
 
         return !$flashBag->has(FlashMessage::KEY_ERROR)
@@ -128,7 +128,7 @@ trait FlashMessageTrait
      */
     protected function getMessages($key)
     {
-        /** @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface */
+        /** @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface $flashBag */
         $flashBag = $this->container->get('session')->getFlashBag();
         $messages = $flashBag->get($key);
 

--- a/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/AbstractGridInlineEdit.php
@@ -32,8 +32,9 @@ abstract class AbstractGridInlineEdit implements GridInlineEditInterface
 
         if ($form->isSubmitted() && !$form->isValid()) {
             $formErrors = [];
+
+            /** @var \Symfony\Component\Form\FormError $error */
             foreach ($form->getErrors(true) as $error) {
-                /* @var $error \Symfony\Component\Form\FormError */
                 $formErrors[] = $error->getMessage();
             }
             throw new \Shopsys\FrameworkBundle\Component\Grid\InlineEdit\Exception\InvalidFormDataException($formErrors);

--- a/packages/framework/src/Component/Grid/InlineEdit/InlineEditFacade.php
+++ b/packages/framework/src/Component/Grid/InlineEdit/InlineEditFacade.php
@@ -54,9 +54,9 @@ class InlineEditFacade
     public function getRenderedRowHtml($serviceName, $rowId)
     {
         $gridInlineEdit = $this->gridInlineEditRegistry->getGridInlineEdit($serviceName);
-        $grid = $gridInlineEdit->getGrid();
-        /* @var $grid \Shopsys\FrameworkBundle\Component\Grid\Grid */
 
+        /** @var \Shopsys\FrameworkBundle\Component\Grid\Grid $grid */
+        $grid = $gridInlineEdit->getGrid();
         $gridView = $grid->createViewWithOneRow($rowId);
         $rows = $grid->getRows();
         $rowData = array_pop($rows);

--- a/packages/framework/src/Component/Grid/QueryBuilderDataSource.php
+++ b/packages/framework/src/Component/Grid/QueryBuilderDataSource.php
@@ -48,10 +48,7 @@ class QueryBuilderDataSource implements DataSourceInterface
 
         $queryPaginator = new QueryPaginator($queryBuilder, GroupedScalarHydrator::HYDRATION_MODE);
 
-        $paginationResult = $queryPaginator->getResult($page, $limit);
-        /* @var $paginationResult \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult */
-
-        return $paginationResult;
+        return $queryPaginator->getResult($page, $limit);
     }
 
     /**

--- a/packages/framework/src/Component/Image/ImageRepository.php
+++ b/packages/framework/src/Component/Image/ImageRepository.php
@@ -135,8 +135,8 @@ class ImageRepository
             ->addOrderBy('i.id', 'desc');
 
         $imagesByEntityId = [];
+        /** @var \Shopsys\FrameworkBundle\Component\Image\Image $image */
         foreach ($queryBuilder->getQuery()->execute() as $image) {
-            /* @var $image \Shopsys\FrameworkBundle\Component\Image\Image */
             $imagesByEntityId[$image->getEntityId()] = $image;
         }
 

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -120,12 +120,11 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @param \PhpParser\Node $node
+     * @param \PhpParser\Node\Expr\MethodCall $node
      * @return bool
      */
     protected function isAddViolationMethodCall(Node $node): bool
     {
-        /** @var \PhpParser\Node\Expr\MethodCall $node */
         return $node->var instanceof Variable
             && in_array($node->var->name, $this->currentExecutionContextVariableNames, true)
             && $node->name->name === 'addViolation';

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -87,7 +87,6 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     {
         if ($this->isTransMethodOrFuncCall($node)) {
             if (!$this->isIgnored($node)) {
-                /* @var $node \PhpParser\Node\Expr */
                 $messageId = $this->getMessageId($node);
                 $domain = $this->getDomain($node);
 

--- a/packages/framework/src/Component/Translation/TwigFileExtractor.php
+++ b/packages/framework/src/Component/Translation/TwigFileExtractor.php
@@ -34,8 +34,8 @@ class TwigFileExtractor implements FileVisitorInterface
         $reflectionObject = new ReflectionObject($this->originalTwigFileExtractor);
         $traverserReflectionProperty = $reflectionObject->getProperty('traverser');
         $traverserReflectionProperty->setAccessible(true);
+        /** @var \Twig_NodeTraverser $traverser */
         $traverser = $traverserReflectionProperty->getValue($this->originalTwigFileExtractor);
-        /** @var $traverser \Twig_NodeTraverser */
         $traverser->addVisitor(new CustomTransFiltersVisitor());
     }
 

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -179,8 +179,8 @@ class AdministratorController extends AdminBaseController
      */
     public function myAccountAction()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $loggedUser */
         $loggedUser = $this->getUser();
-        /* @var $loggedUser \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
 
         return $this->redirectToRoute('admin_administrator_edit', [
             'id' => $loggedUser->getId(),

--- a/packages/framework/src/Controller/Admin/AdvertController.php
+++ b/packages/framework/src/Controller/Admin/AdvertController.php
@@ -137,7 +137,7 @@ class AdvertController extends AdminBaseController
      */
     public function listAction()
     {
-        /* @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
 
         /** @var \Doctrine\Common\Persistence\ManagerRegistry $doctrine */

--- a/packages/framework/src/Controller/Admin/BrandController.php
+++ b/packages/framework/src/Controller/Admin/BrandController.php
@@ -116,8 +116,8 @@ class BrandController extends AdminBaseController
      */
     public function listAction()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
 
         /** @var \Doctrine\Common\Persistence\ManagerRegistry $doctrine */
         $doctrine = $this->getDoctrine();

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -177,8 +177,8 @@ class CustomerController extends AdminBaseController
      */
     public function listAction(Request $request)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
 
         $quickSearchForm = $this->createForm(QuickSearchFormType::class, new QuickSearchFormData());
         $quickSearchForm->handleRequest($request);

--- a/packages/framework/src/Controller/Admin/LoginController.php
+++ b/packages/framework/src/Controller/Admin/LoginController.php
@@ -113,8 +113,8 @@ class LoginController extends AdminBaseController
      */
     public function ssoAction(Request $request, $originalDomainId)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
         $multidomainToken = $this->administratorLoginFacade->generateMultidomainLoginTokenWithExpiration($administrator);
         $originalDomainRouter = $this->domainRouterFactory->getRouter((int)$originalDomainId);
         $redirectTo = $originalDomainRouter->generate(

--- a/packages/framework/src/Controller/Admin/OrderController.php
+++ b/packages/framework/src/Controller/Admin/OrderController.php
@@ -179,9 +179,8 @@ class OrderController extends AdminBaseController
      */
     public function listAction(Request $request)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
-
         $advancedSearchForm = $this->advancedSearchOrderFacade->createAdvancedSearchOrderForm($request);
         $advancedSearchData = $advancedSearchForm->getData();
 

--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -238,9 +238,8 @@ class ProductController extends AdminBaseController
      */
     public function listAction(Request $request)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
-
         $advancedSearchForm = $this->advancedSearchProductFacade->createAdvancedSearchForm($request);
         $advancedSearchData = $advancedSearchForm->getData();
         $quickSearchData = new QuickSearchFormData();

--- a/packages/framework/src/Controller/Admin/ProductPickerController.php
+++ b/packages/framework/src/Controller/Admin/ProductPickerController.php
@@ -111,9 +111,8 @@ class ProductPickerController extends AdminBaseController
      */
     protected function getPickerResponse(Request $request, array $viewParameters, array $gridViewParameters)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator */
-
         $advancedSearchForm = $this->advancedSearchProductFacade->createAdvancedSearchForm($request);
         $advancedSearchData = $advancedSearchForm->getData();
         $quickSearchData = new QuickSearchFormData();

--- a/packages/framework/src/Controller/Admin/PromoCodeController.php
+++ b/packages/framework/src/Controller/Admin/PromoCodeController.php
@@ -65,7 +65,7 @@ class PromoCodeController extends AdminBaseController
      */
     public function listAction()
     {
-        /* @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
 
         $grid = $this->promoCodeGridFactory->create(true);

--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -201,8 +201,8 @@ class AdvertFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
+                    /** @var \Shopsys\FrameworkBundle\Model\Advert\AdvertData $advertData */
                     $advertData = $form->getData();
-                    /* @var $advertData \Shopsys\FrameworkBundle\Model\Advert\AdvertData */
 
                     if ($advertData->type === Advert::TYPE_CODE) {
                         $validationGroups[] = static::VALIDATION_GROUP_TYPE_CODE;

--- a/packages/framework/src/Form/Admin/Country/CountryFormType.php
+++ b/packages/framework/src/Form/Admin/Country/CountryFormType.php
@@ -43,7 +43,6 @@ class CountryFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Country\Country|null $country */
         $this->country = $options['country'];
 
         if ($this->country instanceof Country) {

--- a/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/BillingAddressFormType.php
@@ -169,8 +169,8 @@ class BillingAddressFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
+                    /** @var \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $billingAddressData */
                     $billingAddressData = $form->getData();
-                    /* @var $billingAddressData \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData */
 
                     if ($billingAddressData->companyCustomer) {
                         $validationGroups[] = static::VALIDATION_GROUP_COMPANY_CUSTOMER;

--- a/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/DeliveryAddressFormType.php
@@ -176,8 +176,8 @@ class DeliveryAddressFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
+                    /** @var \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData $deliveryAddressData */
                     $deliveryAddressData = $form->getData();
-                    /* @var $deliveryAddressData \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData */
 
                     if ($deliveryAddressData->addressFilled) {
                         $validationGroups[] = static::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS;

--- a/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailTemplateFormType.php
@@ -151,7 +151,7 @@ class MailTemplateFormType extends AbstractType
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
 
-                    /* @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData $mailTemplateData */
+                    /** @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData $mailTemplateData */
                     $mailTemplateData = $form->getData();
 
                     if ($mailTemplateData->sendMail) {

--- a/packages/framework/src/Form/Admin/Module/ModulesFormType.php
+++ b/packages/framework/src/Form/Admin/Module/ModulesFormType.php
@@ -22,8 +22,8 @@ class ModulesFormType extends AbstractType
             ->add('modules', FormType::class)
             ->add('save', SubmitType::class);
 
+        /** @var \Shopsys\FrameworkBundle\Model\Module\ModuleList $moduleList */
         $moduleList = $options['module_list'];
-        /* @var $moduleList \Shopsys\FrameworkBundle\Model\Module\ModuleList */
         foreach ($moduleList->getNamesIndexedByLabel() as $moduleLabel => $moduleName) {
             $builder->get('modules')
                 ->add($moduleName, YesNoType::class, [

--- a/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Payment/PaymentFormType.php
@@ -52,9 +52,8 @@ class PaymentFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\Payment $payment */
         $payment = $options['payment'];
-        /* @var $payment Payment */
-
         $builderBasicInformationGroup = $builder->create('basicInformation', GroupType::class, [
             'label' => t('Basic information'),
         ]);

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -50,8 +50,8 @@ class BrandFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|null $brand */
         $brand = $options['brand'];
-        /* @var $brand \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|null */
 
         $seoTitlesOptionsByDomainId = [];
         $seoMetaDescriptionsOptionsByDomainId = [];

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -165,9 +165,8 @@ class ProductFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Product|null $product */
         $product = $options['product'];
-        /* @var $product \Shopsys\FrameworkBundle\Model\Product\Product|null */
-
         $disabledItemInMainVariantAttr = [];
         if ($this->isProductMainVariant($product)) {
             $disabledItemInMainVariantAttr = [
@@ -219,9 +218,8 @@ class ProductFormType extends AbstractType
                 'csrf_token_id' => self::CSRF_TOKEN_ID,
                 'validation_groups' => function (FormInterface $form) {
                     $validationGroups = [ValidationGroup::VALIDATION_GROUP_DEFAULT];
+                    /** @var \Shopsys\FrameworkBundle\Model\Product\ProductData $productData */
                     $productData = $form->getData();
-                    /* @var $productData \Shopsys\FrameworkBundle\Model\Product\ProductData */
-
                     if ($productData->usingStock) {
                         $validationGroups[] = static::VALIDATION_GROUP_USING_STOCK;
                         if ($productData->outOfStockAction === Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY) {

--- a/packages/framework/src/Form/Admin/Transport/TransportFormType.php
+++ b/packages/framework/src/Form/Admin/Transport/TransportFormType.php
@@ -52,9 +52,8 @@ class TransportFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\Transport $transport */
         $transport = $options['transport'];
-        /* @var $transport \Shopsys\FrameworkBundle\Model\Transport\Transport */
-
         $builderBasicInformationGroup = $builder->create('basicInformation', GroupType::class, [
             'label' => t('Basic information'),
         ]);

--- a/packages/framework/src/Form/DeliveryAddressListType.php
+++ b/packages/framework/src/Form/DeliveryAddressListType.php
@@ -31,7 +31,7 @@ class DeliveryAddressListType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         parent::buildView($view, $form, $options);
-        /** @var \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress[] $options['customerUser'] */
+
         $view->vars['deliveryAddresses'] = $options['customerUser']->getCustomer()->getDeliveryAddresses();
     }
 

--- a/packages/framework/src/Form/ProductType.php
+++ b/packages/framework/src/Form/ProductType.php
@@ -49,9 +49,9 @@ class ProductType extends AbstractType
         $view->vars['allow_main_variants'] = $options['allow_main_variants'];
         $view->vars['allow_variants'] = $options['allow_variants'];
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
         $product = $form->getData();
         if ($product !== null) {
-            /* @var $product \Shopsys\FrameworkBundle\Model\Product\Product */
             $view->vars['productName'] = $product->getName();
         }
     }

--- a/packages/framework/src/Form/SingleCheckboxChoiceType.php
+++ b/packages/framework/src/Form/SingleCheckboxChoiceType.php
@@ -34,8 +34,8 @@ class SingleCheckboxChoiceType extends AbstractType
     {
         parent::buildForm($builder, $options);
 
+        /** @var \Symfony\Component\Form\FormBuilderInterface $child */
         foreach ($builder->all() as $i => $child) {
-            /* @var $child \Symfony\Component\Form\FormBuilderInterface */
             $options = $child->getOptions();
             $builder->remove($i);
             $options['required'] = false;

--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -46,8 +46,8 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
         }
 
         $normValue = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData $productParameterValueData */
         foreach ($normData as $productParameterValueData) {
-            /* @var $productParameterValueData \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData */
             $parameterId = $productParameterValueData->parameter->getId();
             $locale = $productParameterValueData->parameterValueData->locale;
 
@@ -76,9 +76,8 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
         if (is_array($viewData)) {
             $normData = [];
 
+            /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData $productParameterValuesLocalizedData */
             foreach ($viewData as $productParameterValuesLocalizedData) {
-                /* @var $productParameterValuesLocalizedData \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData */
-
                 foreach ($productParameterValuesLocalizedData->valueTextsByLocale as $locale => $valueText) {
                     if ($valueText !== null) {
                         $productParameterValueData = $this->productParameterValueDataFactory->create();

--- a/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
@@ -56,7 +56,7 @@ class AdministratorRolesChangedSubscriber implements EventSubscriberInterface
     {
         $token = $this->tokenStorage->getToken();
 
-        /* @var $administrator \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null */
+        /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator|null $administrator */
         $administrator = null;
         if ($token !== null) {
             $administrator = $token->getUser();

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCreateDateFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCreateDateFilter.php
@@ -56,7 +56,7 @@ class OrderCreateDateFilter implements AdvancedSearchFilterInterface
                 continue;
             }
 
-            /* @var \DateTime $inputDate */
+            /** @var \DateTime $inputDate */
             $inputDate = clone $ruleData->value;
 
             $parameterName = 'orderCreatedAt_' . $index;

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderProductFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderProductFilter.php
@@ -54,8 +54,8 @@ class OrderProductFilter implements AdvancedSearchFilterInterface
     {
         foreach ($rulesData as $index => $ruleData) {
             if ($ruleData->operator === self::OPERATOR_CONTAINS || $ruleData->operator === self::OPERATOR_NOT_CONTAINS) {
+                /** @var \Shopsys\FrameworkBundle\Model\Product\Product|null $searchValue */
                 $searchValue = $ruleData->value;
-                /* @var $searchValue \Shopsys\FrameworkBundle\Model\Product\Product */
                 if ($searchValue === null) {
                     continue;
                 }

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -179,9 +179,8 @@ class CategoryRepository extends NestedTreeRepository
      */
     public function findById($categoryId)
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Category\Category|null $category */
         $category = $this->getCategoryRepository()->find($categoryId);
-        /* @var $category \Shopsys\FrameworkBundle\Model\Category\Category */
-
         if ($category !== null && $category->getParent() === null) {
             // Copies logic from getAllQueryBuilder() - excludes root category
             // Query builder is not used to be able to get the category from identity map if it was loaded previously

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -530,9 +530,9 @@ class OrderFacade
         foreach ($orderPreview->getQuantifiedProducts() as $index => $quantifiedProduct) {
             $product = $quantifiedProduct->getProduct();
 
-            /* @var $quantifiedItemPrice \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice */
+            /** @var \Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice $quantifiedItemPrice */
             $quantifiedItemPrice = $quantifiedItemPrices[$index];
-            /* @var $quantifiedItemDiscount \Shopsys\FrameworkBundle\Model\Pricing\Price|null */
+            /** @var \Shopsys\FrameworkBundle\Model\Pricing\Price|null $quantifiedItemDiscount */
             $quantifiedItemDiscount = $quantifiedItemDiscounts[$index];
 
             $orderItem = $this->orderItemFactory->createProduct(

--- a/packages/framework/src/Model/Order/OrderNumberSequenceRepository.php
+++ b/packages/framework/src/Model/Order/OrderNumberSequenceRepository.php
@@ -41,7 +41,7 @@ class OrderNumberSequenceRepository
             $requestedNumber = time();
 
             $orderNumberSequence = $this->getOrderNumberSequenceRepository()->find(static::ID, LockMode::PESSIMISTIC_WRITE);
-            /* @var $orderNumberSequence \Shopsys\FrameworkBundle\Model\Order\OrderNumberSequence|null */
+            /** @var \Shopsys\FrameworkBundle\Model\Order\OrderNumberSequence|null $orderNumberSequence */
             if ($orderNumberSequence === null) {
                 throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNumberSequenceNotFoundException(
                     'Order number sequence ID ' . static::ID . ' not found.'
@@ -51,7 +51,7 @@ class OrderNumberSequenceRepository
             $lastNumber = $orderNumberSequence->getNumber();
 
             if ($requestedNumber <= $lastNumber) {
-                $requestedNumber = $lastNumber + 1;
+                $requestedNumber = (int)$lastNumber + 1;
             }
 
             $orderNumberSequence->setNumber($requestedNumber);

--- a/packages/framework/src/Model/Payment/PaymentVisibilityCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentVisibilityCalculation.php
@@ -67,7 +67,6 @@ class PaymentVisibilityCalculation
     protected function hasIndependentlyVisibleTransport(Payment $payment, $domainId)
     {
         foreach ($payment->getTransports() as $transport) {
-            /* @var $transport \Shopsys\FrameworkBundle\Model\Transport\Transport */
             if ($this->independentTransportVisibilityCalculation->isIndependentlyVisible($transport, $domainId)) {
                 return true;
             }

--- a/packages/framework/src/Model/Product/Filter/ParameterFilterChoiceRepository.php
+++ b/packages/framework/src/Model/Product/Filter/ParameterFilterChoiceRepository.php
@@ -106,8 +106,8 @@ class ParameterFilterChoiceRepository
         $parameters = $parametersQueryBuilder->getQuery()->execute();
 
         $parametersIndexedById = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter */
         foreach ($parameters as $parameter) {
-            /* @var $parameter \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter */
             $parametersIndexedById[$parameter->getId()] = $parameter;
         }
 
@@ -164,8 +164,8 @@ class ParameterFilterChoiceRepository
         $values = $valuesQueryBuilder->getQuery()->execute();
 
         $valuesIndexedById = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue $value */
         foreach ($values as $value) {
-            /* @var $value \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue */
             $valuesIndexedById[$value->getId()] = $value;
         }
 

--- a/packages/framework/src/Model/Product/Filter/ParameterFilterRepository.php
+++ b/packages/framework/src/Model/Product/Filter/ParameterFilterRepository.php
@@ -16,9 +16,8 @@ class ParameterFilterRepository
     {
         $parameterIndex = 1;
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData $parameterFilterData */
         foreach ($parameters as $parameterFilterData) {
-            /* @var $parameterFilterData \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData */
-
             if (count($parameterFilterData->values) === 0) {
                 continue;
             }

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCalculation.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCalculation.php
@@ -139,9 +139,9 @@ class ProductPriceCalculation
             throw new \Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidArgumentException('Array can not be empty.');
         }
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Price|null $minimumPrice */
         $minimumPrice = null;
         foreach ($prices as $price) {
-            /** @var \Shopsys\FrameworkBundle\Model\Pricing\Price|null $minimumPrice */
             if ($minimumPrice === null || $price->getPriceWithoutVat()->isLessThan($minimumPrice->getPriceWithoutVat())) {
                 $minimumPrice = $price;
             }
@@ -160,8 +160,8 @@ class ProductPriceCalculation
             throw new \Shopsys\FrameworkBundle\Model\Pricing\Exception\InvalidArgumentException('Array can not be empty.');
         }
 
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Price $firstPrice */
         $firstPrice = array_pop($prices);
-        /* @var $firstPrice \Shopsys\FrameworkBundle\Model\Pricing\Price */
         foreach ($prices as $price) {
             if (!$price->getPriceWithoutVat()->equals($firstPrice->getPriceWithoutVat())
                 || !$price->getPriceWithVat()->equals($firstPrice->getPriceWithVat())

--- a/packages/framework/src/Model/Security/LoginAsUserFacade.php
+++ b/packages/framework/src/Model/Security/LoginAsUserFacade.php
@@ -84,7 +84,7 @@ class LoginAsUserFacade
             throw new \Shopsys\FrameworkBundle\Model\Security\Exception\LoginAsRememberedUserException('User not set.');
         }
 
-        /* @var $unserializedUser \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser */
+        /** @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $unserializedUser */
         $unserializedUser = unserialize($this->session->get(static::SESSION_LOGIN_AS));
 
         $freshUser = $this->customerUserRepository->getCustomerUserById($unserializedUser->getId());

--- a/packages/framework/src/Model/Statistics/ValueByDateTimeDataPointFormatter.php
+++ b/packages/framework/src/Model/Statistics/ValueByDateTimeDataPointFormatter.php
@@ -75,8 +75,8 @@ class ValueByDateTimeDataPointFormatter
     protected function getDateTimes(array $valueByDateTimeDataPoints)
     {
         $returnData = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Statistics\ValueByDateTimeDataPoint $valueByDateTimeDataPoint */
         foreach ($valueByDateTimeDataPoints as $key => $valueByDateTimeDataPoint) {
-            /* @var $valueByDateTimeDataPoint \Shopsys\FrameworkBundle\Model\Statistics\ValueByDateTimeDataPoint */
             $returnData[$key] = $valueByDateTimeDataPoint->getDateTime();
         }
 
@@ -90,8 +90,8 @@ class ValueByDateTimeDataPointFormatter
     public function getCounts(array $valueByDateTimeDataPoints)
     {
         $returnData = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Statistics\ValueByDateTimeDataPoint $valueByDateTimeDataPoint */
         foreach ($valueByDateTimeDataPoints as $key => $valueByDateTimeDataPoint) {
-            /* @var $valueByDateTimeDataPoint \Shopsys\FrameworkBundle\Model\Statistics\ValueByDateTimeDataPoint */
             $returnData[$key] = $valueByDateTimeDataPoint->getValue();
         }
 

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -111,9 +111,9 @@ class CronFacadeTest extends TestCase
      */
     private function createCronFacade(CronConfig $cronConfig, CronModuleFacade $cronModuleFacade)
     {
-        /* @var $loggerMock \Symfony\Bridge\Monolog\Logger */
+        /** @var \Symfony\Bridge\Monolog\Logger $loggerMock */
         $loggerMock = $this->createMock(Logger::class);
-        /* @var $mailerMock \Shopsys\FrameworkBundle\Model\Mail\Mailer */
+        /** @var \Shopsys\FrameworkBundle\Model\Mail\Mailer $mailerMock */
         $mailerMock = $this->createMock(Mailer::class);
 
         $cronModuleExecutor = new CronModuleExecutor(240);

--- a/packages/framework/tests/Unit/Component/Grid/GridTest.php
+++ b/packages/framework/tests/Unit/Component/Grid/GridTest.php
@@ -76,11 +76,10 @@ class GridTest extends TestCase
         $columns = $grid->getColumnsById();
 
         $this->assertCount(2, $columns);
+        /** @var \Shopsys\FrameworkBundle\Component\Grid\Column $column2 */
         $column2 = array_pop($columns);
-        /* @var $column2 \Shopsys\FrameworkBundle\Component\Grid\Column */
+        /** @var \Shopsys\FrameworkBundle\Component\Grid\Column $column1 */
         $column1 = array_pop($columns);
-        /* @var $column1 \Shopsys\FrameworkBundle\Component\Grid\Column */
-
         $this->assertSame('columnId1', $column1->getId());
         $this->assertSame('sourceColumnName1', $column1->getSourceColumnName());
         $this->assertSame('title1', $column1->getTitle());

--- a/packages/framework/tests/Unit/Component/HttpFoundation/SubRequestListenerTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/SubRequestListenerTest.php
@@ -100,7 +100,7 @@ class SubRequestListenerTest extends TestCase
 
     public function testOnKernelController()
     {
-        /* @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $masterRequestMock */
+        /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $masterRequestMock */
         $masterRequestMock = $this->getMockBuilder(Request::class)
             ->setMethods(['getMethod'])
             ->getMock();
@@ -112,10 +112,10 @@ class SubRequestListenerTest extends TestCase
         ]);
         $masterRequestMock->request->replace(['post' => 'value']);
 
+        /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $subRequestMock */
         $subRequestMock = $this->getMockBuilder(Request::class)
             ->setMethods(['setMethod'])
             ->getMock();
-        /* @var $subRequestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
         $subRequestMock->expects($this->once())->method('setMethod')->with($this->equalTo('POST'));
         $subRequestMock->query->replace([
             'key2' => 'value2_2',

--- a/packages/framework/tests/Unit/Component/Translation/Resources/Controller.php
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/Controller.php
@@ -10,8 +10,8 @@ class Controller extends BaseController
 {
     public function indexAction()
     {
+        /** @var \Shopsys\FrameworkBundle\Component\Translation\Translator $translator */
         $translator = $this->get(Translator::class);
-        /* @var $translator \Shopsys\FrameworkBundle\Component\Translation\Translator */
 
         $translator->trans('trans test');
         $translator->transChoice('transChoice test', 5);

--- a/packages/framework/tests/Unit/Component/UploadedFile/UploadedFileFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/UploadedFile/UploadedFileFactoryTest.php
@@ -30,9 +30,8 @@ class UploadedFileFactoryTest extends TestCase
         $uploadedFileFactory = new UploadedFileFactory($fileUploadMock, new EntityNameResolver([]));
         $uploadedFile = $uploadedFileFactory->create($entityName, $entityId, $type, $temporaryFilename, 0);
         $filesForUpload = $uploadedFile->getTemporaryFilesForUpload();
+        /** @var \Shopsys\FrameworkBundle\Component\FileUpload\FileForUpload $fileForUpload */
         $fileForUpload = array_pop($filesForUpload);
-        /* @var $fileForUpload \Shopsys\FrameworkBundle\Component\FileUpload\FileForUpload */
-
         $this->assertSame($entityId, $uploadedFile->getEntityId());
         $this->assertSame($entityName, $uploadedFile->getEntityName());
         $this->assertSame($temporaryFilename, $fileForUpload->getTemporaryFilename());

--- a/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
+++ b/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
@@ -14,7 +14,7 @@ class AuthenticatorTest extends TestCase
     {
         $authenticator = $this->getAuthenticator();
 
-        /* @var $requestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
+        /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $requestMock */
         $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
 
         $requestMock->expects($this->never())->method('getSession');
@@ -35,8 +35,8 @@ class AuthenticatorTest extends TestCase
         $sessionMock->expects($this->atLeastOnce())->method('get')->willReturn(new stdClass());
         $sessionMock->expects($this->atLeastOnce())->method('remove');
 
+        /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $requestMock */
         $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
-        /* @var $requestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
         $requestMock->expects($this->once())->method('getSession')->willReturn($sessionMock);
 
         $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
@@ -55,8 +55,8 @@ class AuthenticatorTest extends TestCase
         $sessionMock->expects($this->once())->method('get')->willReturn(null);
         $sessionMock->expects($this->once())->method('remove');
 
+        /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $requestMock */
         $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
-        /* @var $requestMock \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject */
         $requestMock->expects($this->once())->method('getSession')->willReturn($sessionMock);
 
         $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');

--- a/packages/framework/tests/autoload.php
+++ b/packages/framework/tests/autoload.php
@@ -2,9 +2,8 @@
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
+/** @var \Composer\Autoload\ClassLoader $loader */
 $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../../vendor/autoload.php';
-/* @var $loader \Composer\Autoload\ClassLoader */
-
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
 return $loader;

--- a/packages/http-smoke-testing/src/HttpSmokeTestCase.php
+++ b/packages/http-smoke-testing/src/HttpSmokeTestCase.php
@@ -64,7 +64,7 @@ abstract class HttpSmokeTestCase extends KernelTestCase
     {
         $this->setUp();
         $requestDataSetGeneratorFactory = new RequestDataSetGeneratorFactory();
-        /* @var $requestDataSetGenerators \Shopsys\HttpSmokeTesting\RequestDataSetGenerator[] */
+        /** @var \Shopsys\HttpSmokeTesting\RequestDataSetGenerator[] $requestDataSetGenerators */
         $requestDataSetGenerators = [];
 
         $allRouteInfo = $this->getRouterAdapter()->getAllRouteInfo();

--- a/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/Configuration.php
@@ -63,8 +63,8 @@ class Configuration extends DoctrineConfiguration
         if ($this->migrationVersions === null) {
             $this->migrationVersions = [];
 
+            /** @var \Doctrine\DBAL\Migrations\Version[] $foundMigrationVersionsByClass */
             $foundMigrationVersionsByClass = [];
-            /* @var $foundMigrationVersionsByClass \Doctrine\DBAL\Migrations\Version[] */
             foreach (parent::getMigrations() as $migrationVersion) {
                 $class = get_class($migrationVersion->getMigration());
                 $foundMigrationVersionsByClass[$class] = $migrationVersion;

--- a/packages/product-feed-google/src/Form/GoogleProductFormType.php
+++ b/packages/product-feed-google/src/Form/GoogleProductFormType.php
@@ -39,8 +39,8 @@ class GoogleProductFormType extends AbstractType
         ->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
             // Setting default value of multidomain form "show" to true via event because of dynamic form count
             $multidomainShowForm = $event->getForm()->get('show');
+            /** @var \Symfony\Component\Form\FormInterface $showForm */
             foreach ($multidomainShowForm as $showForm) {
-                /* @var $showForm \Symfony\Component\Form\FormInterface */
                 if ($showForm->getData() === null) {
                     $showForm->setData(true);
                 }

--- a/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
+++ b/packages/product-feed-google/tests/Unit/GoogleFeedItemTest.php
@@ -172,8 +172,8 @@ class GoogleFeedItemTest extends TestCase
 
     public function testGoogleFeedItemWithBrand()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|\PHPUnit\Framework\MockObject\MockObject $brand */
         $brand = $this->createMock(Brand::class);
-        /* @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|\PHPUnit\Framework\MockObject\MockObject $brand */
         $brand->method('getName')->willReturn('brand name');
         $this->defaultProduct->method('getBrand')->willReturn($brand);
 

--- a/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
+++ b/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
@@ -78,8 +78,8 @@ class HeurekaFeedItemTest extends TestCase
         $this->defaultProduct->method('getId')->willReturn(1);
         $this->defaultProduct->method('getName')->with('cs')->willReturn('product name');
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability|\PHPUnit\Framework\MockObject\MockObject $availabilityMock */
         $availabilityMock = $this->createMock(Availability::class);
-        /* @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability|\PHPUnit\Framework\MockObject\MockObject $availabilityMock */
         $availabilityMock->method('getDispatchTime')->willReturn(0);
         $this->defaultProduct->method('getCalculatedAvailability')->willReturn($availabilityMock);
 
@@ -174,8 +174,8 @@ class HeurekaFeedItemTest extends TestCase
 
     public function testHeurekaFeedItemWithManufacturer()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|\PHPUnit\Framework\MockObject\MockObject $brand */
         $brand = $this->createMock(Brand::class);
-        /* @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|\PHPUnit\Framework\MockObject\MockObject $brand */
         $brand->method('getName')->willReturn('manufacturer name');
         $this->defaultProduct->method('getBrand')->willReturn($brand);
 
@@ -186,12 +186,12 @@ class HeurekaFeedItemTest extends TestCase
 
     public function testHeurekaFeedItemWithCategoryText()
     {
+        /** @var \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategory|\PHPUnit\Framework\MockObject\MockObject $heurekaCategoryMock */
         $heurekaCategoryMock = $this->createMock(HeurekaCategory::class);
-        /* @var \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategory|\PHPUnit\Framework\MockObject\MockObject $heurekaCategoryMock */
         $heurekaCategoryMock->method('getFullName')->willReturn('heureka category full text');
 
+        /** @var \Shopsys\FrameworkBundle\Model\Category\Category|\PHPUnit\Framework\MockObject\MockObject $categoryMock */
         $categoryMock = $this->createMock(Category::class);
-        /* @var \Shopsys\FrameworkBundle\Model\Category\Category|\PHPUnit\Framework\MockObject\MockObject $categoryMock */
         $categoryMock->method('getId')->willReturn(1);
 
         $this->categoryFacadeMock->method('findProductMainCategoryByDomainId')

--- a/packages/product-feed-zbozi/src/Form/ZboziProductFormType.php
+++ b/packages/product-feed-zbozi/src/Form/ZboziProductFormType.php
@@ -71,8 +71,8 @@ class ZboziProductFormType extends AbstractType
             ->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
                 // Setting default value of multidomain form "show" to true via event because of dynamic form count
                 $multidomainShowForm = $event->getForm()->get('show');
+                /** @var \Symfony\Component\Form\FormInterface $showForm */
                 foreach ($multidomainShowForm as $showForm) {
-                    /* @var $showForm \Symfony\Component\Form\FormInterface */
                     if ($showForm->getData() === null) {
                         $showForm->setData(true);
                     }

--- a/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
+++ b/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
@@ -78,8 +78,8 @@ class ZboziFeedItemTest extends TestCase
         $this->defaultProduct->method('getId')->willReturn(1);
         $this->defaultProduct->method('getName')->with('cs')->willReturn('product name');
 
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability|\PHPUnit\Framework\MockObject\MockObject $availabilityMock */
         $availabilityMock = $this->createMock(Availability::class);
-        /* @var \Shopsys\FrameworkBundle\Model\Product\Availability\Availability|\PHPUnit\Framework\MockObject\MockObject $availabilityMock */
         $availabilityMock->method('getDispatchTime')->willReturn(0);
         $this->defaultProduct->method('getCalculatedAvailability')->willReturn($availabilityMock);
 
@@ -188,8 +188,8 @@ class ZboziFeedItemTest extends TestCase
 
     public function testZboziFeedItemWithManufacturer()
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|\PHPUnit\Framework\MockObject\MockObject $brand */
         $brand = $this->createMock(Brand::class);
-        /* @var \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|\PHPUnit\Framework\MockObject\MockObject $brand */
         $brand->method('getName')->willReturn('manufacturer name');
         $this->defaultProduct->method('getBrand')->willReturn($brand);
 

--- a/project-base/app/Environment.php
+++ b/project-base/app/Environment.php
@@ -21,8 +21,9 @@ class Environment
      */
     public static function checkEnvironment(Event $event)
     {
+        /** @var \Composer\IO\IOInterface $io */
         $io = $event->getIO();
-        /* @var $io \Composer\IO\IOInterface */
+
         $environmentFileSetting = self::getEnvironmentFileSetting();
         if (!$environmentFileSetting->isAnyEnvironmentSet()) {
             $environment = $event->isDevMode() ? EnvironmentType::DEVELOPMENT : EnvironmentType::PRODUCTION;

--- a/project-base/app/autoload.php
+++ b/project-base/app/autoload.php
@@ -14,7 +14,7 @@ if (file_exists(__DIR__ . '/../../' . $symfonyDumpFunctionPath)) {
     require_once __DIR__ . '/../../' . $symfonyDumpFunctionPath;
 }
 
-/* @var \Composer\Autoload\ClassLoader $loader */
+/** @var \Composer\Autoload\ClassLoader $loader */
 $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader([$loader, 'loadClass']);

--- a/project-base/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/OrderDataFixture.php
@@ -741,9 +741,8 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
             null
         );
 
+        /** @var \App\Model\Order\Order $order */
         $order = $this->orderFacade->createOrder($orderData, $orderPreview, $customerUser);
-        /* @var $order \App\Model\Order\Order */
-
         $referenceName = self::ORDER_PREFIX . $order->getId();
         $this->addReference($referenceName, $order);
     }

--- a/project-base/src/DataFixtures/Demo/UnitDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/UnitDataFixture.php
@@ -89,8 +89,8 @@ class UnitDataFixture extends AbstractReferenceFixture
 
     private function setPiecesAsDefaultUnit(): void
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $defaultUnit */
         $defaultUnit = $this->getReference(self::UNIT_PIECES);
-        /** @var $defaultUnit \Shopsys\FrameworkBundle\Model\Product\Unit\Unit */
         $this->setting->set(Setting::DEFAULT_UNIT, $defaultUnit->getId());
     }
 }

--- a/project-base/src/DataFixtures/Demo/VatDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/VatDataFixture.php
@@ -114,8 +114,8 @@ class VatDataFixture extends AbstractReferenceFixture
      */
     private function setHighVatAsDefault(int $domainId): void
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $defaultVat */
         $defaultVat = $this->getReferenceForDomain(self::VAT_HIGH, $domainId);
-        /** @var $defaultVat \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat */
         $this->setting->setForDomain(Vat::SETTING_DEFAULT_VAT, $defaultVat->getId(), $domainId);
     }
 }

--- a/project-base/tests/App/Performance/Page/PerformanceTestSamplesAggregator.php
+++ b/project-base/tests/App/Performance/Page/PerformanceTestSamplesAggregator.php
@@ -25,9 +25,8 @@ class PerformanceTestSamplesAggregator
             $worstStatusCode = null;
             $performanceTestSample = null;
 
+            /** @var \Tests\App\Performance\Page\PerformanceTestSample $performanceTestSample */
             foreach ($performanceTestSamplesOfUrl as $performanceTestSample) {
-                /* @var $performanceTestSample \Tests\App\Performance\Page\PerformanceTestSample */
-
                 $samplesCount++;
                 $totalDuration += $performanceTestSample->getDuration();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Consistency...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #555 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Fixer does not fix order in annotation (type before variable name) when phpdocs is located after variable init. It causes little manual work for move phpdocs above variable init.