### PR TITLE
fix links in upgrade files

### DIFF
--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -54,8 +54,8 @@ There you can find links to upgrade notes for other versions too.
         - `templates/Admin/Content/Brand/detail.html.twig`
         - `templates/Admin/Content/Category/detail.html.twig`
         - `templates/Admin/Content/Product/detail.html.twig`
-- add [`app/getEnvironment.php`](https://github.com/shopsys/shopsys/blob/9.0/project-base/app/getEnvironment.php) file to your project ([#1368](https://github.com/shopsys/shopsys/pull/1368))
-- add optional [Frontend API](https://github.com/shopsys/shopsys/blob/9.0/docs/frontend-api/introduction-to-frontend-api.md) to your project ([#1445](https://github.com/shopsys/shopsys/pull/1445), [#1486](https://github.com/shopsys/shopsys/pull/1486), [#1493](https://github.com/shopsys/shopsys/pull/1493), [#1489](https://github.com/shopsys/shopsys/pull/1489)):
+- add [`app/getEnvironment.php`](https://github.com/shopsys/shopsys/blob/master/project-base/app/getEnvironment.php) file to your project ([#1368](https://github.com/shopsys/shopsys/pull/1368))
+- add optional [Frontend API](https://github.com/shopsys/shopsys/blob/master/docs/frontend-api/introduction-to-frontend-api.md) to your project ([#1445](https://github.com/shopsys/shopsys/pull/1445), [#1486](https://github.com/shopsys/shopsys/pull/1486), [#1493](https://github.com/shopsys/shopsys/pull/1493), [#1489](https://github.com/shopsys/shopsys/pull/1489)):
     - add `shopsys/frontend-api` dependency with `composer require shopsys/frontend-api`
     - register necessary bundles in `config/bundles.php`
         ```diff
@@ -65,11 +65,11 @@ There you can find links to upgrade notes for other versions too.
         +   Overblog\GraphiQLBundle\OverblogGraphiQLBundle::class => ['dev' => true],
             Shopsys\GoogleCloudBundle\ShopsysGoogleCloudBundle::class => ['all' => true],
         ```
-    - add new route file [`config/routes/frontend-api.yml`](https://github.com/shopsys/shopsys/blob/9.0/project-base/config/routes/frontend-api.yml) from GitHub
-    - add new route file [`config/routes/dev/frontend-api-graphiql.yaml`](https://github.com/shopsys/shopsys/blob/9.0/project-base/config/routes/dev/frontend-api-graphiql.yaml) from GitHub
-    - copy [type definitions from Github](https://github.com/shopsys/shopsys/tree/9.0/project-base/config/graphql/types) into `config/graphql/types/` folder
-    - copy necessary configuration [shopsys_frontend_api.yml from Github](https://github.com/shopsys/shopsys/blob/9.0/project-base/config/packages/shopsys_frontend_api.yml) to `config/packages/shopsys_frontend_api.yml`
-    - copy [tests for FrontendApiBundle from Github](https://github.com/shopsys/shopsys/tree/9.0/project-base/tests/FrontendApiBundle) to your `tests` folder
+    - add new route file [`config/routes/frontend-api.yml`](https://github.com/shopsys/shopsys/blob/master/project-base/config/routes/frontend-api.yml) from GitHub
+    - add new route file [`config/routes/dev/frontend-api-graphiql.yaml`](https://github.com/shopsys/shopsys/blob/master/project-base/config/routes/dev/frontend-api-graphiql.yaml) from GitHub
+    - copy [type definitions from Github](https://github.com/shopsys/shopsys/tree/master/project-base/config/graphql/types) into `config/graphql/types/` folder
+    - copy necessary configuration [shopsys_frontend_api.yml from Github](https://github.com/shopsys/shopsys/blob/master/project-base/config/packages/shopsys_frontend_api.yml) to `config/packages/shopsys_frontend_api.yml`
+    - copy [tests for FrontendApiBundle from Github](https://github.com/shopsys/shopsys/tree/master/project-base/tests/FrontendApiBundle) to your `tests` folder
     - enable Frontend API for desired domains in `config/parameters_common.yml` file
     for example
         ```diff
@@ -180,13 +180,13 @@ There you can find links to upgrade notes for other versions too.
   where you can edit main text for contact form. ([#1522](https://github.com/shopsys/shopsys/pull/1522))
 
   There are few steps need to be done, to make contact form work on FE
-    - in `ContactFormController` change previous `indexAction` with [the new one](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Controller/Front/ContactFormController.php). Please pay attention if you have some modification in previous implementation.
+    - in `ContactFormController` change previous `indexAction` with [the new one](https://github.com/shopsys/shopsys/blob/master/project-base/src/Controller/Front/ContactFormController.php). Please pay attention if you have some modification in previous implementation.
     - in `ContactFormController` add `ContactFormSettingsFacade` as dependency in constructor
     - in `ContactFormController` remove action `sendAction()`, it is not needed anymore
     - remove `src/Resources/scripts/frontend/contactForm.js`, it is not needed anymore
     - new localized route `front_contact` has been introduced with slug `contact`. This slug can be already in use in your project, because
       previous SSFW versions have an article called `Contact` which is used as the contact page. Please move the article's content to the new contact page and completely remove the article.
-      To remove the article, please create [new migration](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Migrations/Version20191121171000.php) in you project which removes the article and its slug.
+      To remove the article, please create [new migration](https://github.com/shopsys/shopsys/blob/master/project-base/src/Migrations/Version20191121171000.php) in you project which removes the article and its slug.
 
       If you don't want to remove the article, you will need to change path for the new route in the next step
 
@@ -196,7 +196,7 @@ There you can find links to upgrade notes for other versions too.
         +       path: /contact/
         +       defaults: { _controller: App\Controller\Front\ContactFormController:indexAction }
         ```
-    - add new template [`templates/Front/Content/ContactForm/index.html.twig`](https://github.com/shopsys/shopsys/blob/9.0/project-base/templates/Front/Content/ContactForm/index.html.twig)
+    - add new template [`templates/Front/Content/ContactForm/index.html.twig`](https://github.com/shopsys/shopsys/blob/master/project-base/templates/Front/Content/ContactForm/index.html.twig)
     - add link to new contact page somewhere in templates (e.g in `footer.html.twig`)
         ```diff
             <div class="footer__bottom__articles">
@@ -208,7 +208,7 @@ There you can find links to upgrade notes for other versions too.
         ```
 
 - vats can be created and managed per domains ([#1498](https://github.com/shopsys/shopsys/pull/1498))
-    - please read [upgrade instruction for vats per domain](https://github.com/shopsys/shopsys/blob/9.0/upgrade/upgrade-instruction-for-vats-per-domain.md)
+    - please read [upgrade instruction for vats per domain](https://github.com/shopsys/shopsys/blob/master/upgrade/upgrade-instruction-for-vats-per-domain.md)
 
 - apply these changes to add support for naming uploaded files([#1547](https://github.com/shopsys/shopsys/pull/1547))
     - update your `composer.json`
@@ -251,7 +251,7 @@ There you can find links to upgrade notes for other versions too.
         +       $config->skipRoute('Downloading uploaded files is not tested.');
             });
         ```
-    - add [src/Controller/Front/UploadedFileController.php](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Controller/Front/UploadedFileController.php) to your project
+    - add [src/Controller/Front/UploadedFileController.php](https://github.com/shopsys/shopsys/blob/master/project-base/src/Controller/Front/UploadedFileController.php) to your project
     - `MessageData::attachmentsFilepaths` has been replaced by `MessageData::attachments` that accepts array of `UploadedFile`
     - `MailTemplateFacade::getMailTemplateAttachmentsFilepaths()` has been replaced by `MailTemplateFacade::getMailTemplateAttachmentFilepath()` that accepts single `UploadedFile`
     - following methods has changed their interface, update your usages accordingly:
@@ -564,7 +564,7 @@ There you can find links to upgrade notes for other versions too.
 - add cart detail on hover ([#1565](https://github.com/shopsys/shopsys/pull/1565))
   
   - you can skip this task if you have your custom design
-  - Add new file [`src/Resources/styles/front/common/layout/header/cart-detail.less`](https://github.com/shopsys/shopsys/blob/9.0/project-base/src/Resources/styles/front/common/layout/header/cart-detail.less)
+  - Add new file [`src/Resources/styles/front/common/layout/header/cart-detail.less`](https://github.com/shopsys/shopsys/blob/master/project-base/src/Resources/styles/front/common/layout/header/cart-detail.less)
   - Update your `src/Resources/styles/front/common/layout/header/cart.less` like in the [diff](https://github.com/shopsys/shopsys/pull/1565/files#diff-bc98fd209f1c026440cbf870086beece)
   - Update your `src/Resources/styles/front/common/main.less`
       ```diff
@@ -572,10 +572,10 @@ There you can find links to upgrade notes for other versions too.
       + @import "layout/header/cart-detail.less";
         @import "layout/header/cart-mobile.less";
       ```
-  - Add new file [`templates/Front/Inline/Cart/cartBoxItemMacro.html.twig`](https://github.com/shopsys/shopsys/blob/9.0/project-base/templates/Front/Inline/Cart/cartBoxItemMacro.html.twig)
+  - Add new file [`templates/Front/Inline/Cart/cartBoxItemMacro.html.twig`](https://github.com/shopsys/shopsys/blob/master/project-base/templates/Front/Inline/Cart/cartBoxItemMacro.html.twig)
   - Update your `templates/Front/Inline/Cart/cartBox.html.twig` like in the [diff](https://github.com/shopsys/shopsys/pull/1565/files#diff-41605908c87d6192f16bdf03da67b192)
   - Update your `templates/Front/Layout/header.html.twig` like in the [diff](https://github.com/shopsys/shopsys/pull/1565/files#diff-fec16681aa60ba908bc8e574d24de3fd)
-  - Add new file [`assets/js/frontend/cart/cartBoxItemRemover.js`](https://github.com/shopsys/shopsys/blob/9.0/project-base/assets/js/frontend/cart/cartBoxItemRemover.js)
+  - Add new file [`assets/js/frontend/cart/cartBoxItemRemover.js`](https://github.com/shopsys/shopsys/blob/master/project-base/assets/js/frontend/cart/cartBoxItemRemover.js)
   - Update `assets/js/frontend/cart/cartBox.js`
       ```diff
         Ajax.ajax({
@@ -643,8 +643,8 @@ There you can find links to upgrade notes for other versions too.
   - run `php phing standards-fix` and fix possible violations that need to be fixed manually
 
 - if you want to add stylelint rules to check style coding standards [#1511](https://github.com/shopsys/shopsys/pull/1511)
-    -  add new file [.stylelintignore](https://github.com/shopsys/shopsys/blob/9.0/project-base/.stylelintignore)
-    -  add new file [.stylelintrc](https://github.com/shopsys/shopsys/blob/9.0/project-base/.stylelintrc)
+    -  add new file [.stylelintignore](https://github.com/shopsys/shopsys/blob/master/project-base/.stylelintignore)
+    -  add new file [.stylelintrc](https://github.com/shopsys/shopsys/blob/master/project-base/.stylelintrc)
     - update `gruntfile.js.twig` and add new task
         ```diff
         +   stylelint: {

--- a/upgrade/upgrade-instructions-for-symfony-flex.md
+++ b/upgrade/upgrade-instructions-for-symfony-flex.md
@@ -3,7 +3,7 @@
 In [#1492](https://github.com/shopsys/shopsys/pull/1492) we changed the application to be compatible with Symfony Flex.
 You can read more about upgrading Symfony application to Flex <https://symfony.com/doc/current/setup/flex.html>
 
-- copy [`.env`](https://github.com/shopsys/project-base/blob/9.0/.env) and [`.env.test`](https://github.com/shopsys/project-base/blob/9.0/.env.test) files from GitHub into the root folder
+- copy [`.env`](https://github.com/shopsys/project-base/blob/master/.env) and [`.env.test`](https://github.com/shopsys/project-base/blob/master/.env.test) files from GitHub into the root folder
 - add local environment files as ignored into `.gitignore`
 ```diff
     /docker-compose.yml
@@ -12,16 +12,16 @@ You can read more about upgrading Symfony application to Flex <https://symfony.c
 +   /.env.local.php
 +   /.env.*.local
 ```
-- copy [`symfony.lock`](https://github.com/shopsys/project-base/blob/9.0/symfony.lock) file from GitHub into the root folder
-- copy [`composer.json`](https://github.com/shopsys/project-base/blob/9.0/composer.json) file from GitHub into the root folder
+- copy [`symfony.lock`](https://github.com/shopsys/project-base/blob/master/symfony.lock) file from GitHub into the root folder
+- copy [`composer.json`](https://github.com/shopsys/project-base/blob/master/composer.json) file from GitHub into the root folder
     - add any project-specific dependencies
 - in `easy-coding-standard.yml` replace
     - `*/tests/ShopBundle/` with `*/tests/App/`
     - `*/src/Shopsys/ShopBundle/` with `*/src`
-- replace `phpunit.xml` with [`phpunit.xml` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/phpunit.xml)
-- replace `phpstan.neon` with [`phpstan.neon` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/phpstan.neon)
+- replace `phpunit.xml` with [`phpunit.xml` version from GitHub](https://github.com/shopsys/project-base/blob/master/phpunit.xml)
+- replace `phpstan.neon` with [`phpstan.neon` version from GitHub](https://github.com/shopsys/project-base/blob/master/phpstan.neon)
     - add any project-specific configurations
-- replace `build/codeception.yml` with [`build/codeception.yml` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/build/codeception.yml)
+- replace `build/codeception.yml` with [`build/codeception.yml` version from GitHub](https://github.com/shopsys/project-base/blob/master/build/codeception.yml)
 
 - move the original source code from `src/Shopsys/ShopBundle/` to `src/` and update the namespaces of every PHP file to be `App\...` (advanced IDEs can do this automatically)
 - remove bundle related files as the application itself is no longer a bundle
@@ -29,14 +29,14 @@ You can read more about upgrading Symfony application to Flex <https://symfony.c
     - `src/Shopsys/ShopBundle/DependencyInjection/Configuration.php`
     - `src/Shopsys/ShopBundle/DependencyInjection/ShopsysShopExtension.php`
 - update application bootstrapping:
-    - copy [`src/Kernel.php`](https://github.com/shopsys/project-base/blob/9.0/src/Kernel.php) file from GitHub into the `src` folder
+    - copy [`src/Kernel.php`](https://github.com/shopsys/project-base/blob/master/src/Kernel.php) file from GitHub into the `src` folder
     - delete `app/AppCache.php`, `app/AppKernel.php`, `app/router.php`, and `Bootstrap.php` as files are no longer necessary
     - change the namespace from `Shopsys` to `App` in `app/Environment.php`
-    - replace `web/index.php` with [`web/index.php` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/web/index.php)
-    - replace `bin/console` with [`bin/console` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/bin/console)
+    - replace `web/index.php` with [`web/index.php` version from GitHub](https://github.com/shopsys/project-base/blob/master/web/index.php)
+    - replace `bin/console` with [`bin/console` version from GitHub](https://github.com/shopsys/project-base/blob/master/bin/console)
 
 - all configuration files are now located in the `config` folder exclusively
-    - copy all config files to your project from the [config folder from the new version](https://github.com/shopsys/project-base/tree/9.0/config)
+    - copy all config files to your project from the [config folder from the new version](https://github.com/shopsys/project-base/tree/master/config)
     - merge your project-specific configurations from `app/config` and `src/Shopsys/ShopBundle/resources/config` folders into `config`. Keep in mind, that
         - `config.yml`, `config_dev.yml`, and `config_test.yml` should be deleted as they're no longer necessary
         - in `parameters_common.yml` all extended entities in `shopsys.entity_extension.map` have to have new namespace `App\...`


### PR DESCRIPTION
- after 9.0 became master the original links do not work anymore
- fixed in UPGRADE-v9.0.0-dev.md and upgrade-instructions-for-symfony-flex.md

| Q             | A
| ------------- | ---
|Description, reason for the PR| it is annoying to navigate to 404 page with each link :grin: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
