### PR TITLE
[shopsys] upgrade-instructions-for-symfony-flex.md - typo

### DIFF
--- a/upgrade/upgrade-instructions-for-symfony-flex.md
+++ b/upgrade/upgrade-instructions-for-symfony-flex.md
@@ -17,7 +17,7 @@ You can read more about upgrading Symfony application to Flex <https://symfony.c
     - add any project-specific dependencies
 - in `easy-coding-standard.yml` replace
     - `*/tests/ShopBundle/` with `*/tests/App/`
-    - `*/src/Shopsys/ShopBundle/` with `*/src`
+    - `*/src/Shopsys/ShopBundle/` with `*/src/`
 - replace `phpunit.xml` with [`phpunit.xml` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/phpunit.xml)
 - replace `phpstan.neon` with [`phpstan.neon` version from GitHub](https://github.com/shopsys/project-base/blob/9.0/phpstan.neon)
     - add any project-specific configurations


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixed upgrade notes for Symfony Flex (path of source codes in easy-coding-standards.yml). Just a small typo, however it can make developers very sad :laughing: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
