### PR TITLE
[shopsys] fix typo in upgrade-instructions-for-symfony-flex.md

### DIFF
--- a/upgrade/upgrade-instructions-for-symfony-flex.md
+++ b/upgrade/upgrade-instructions-for-symfony-flex.md
@@ -103,7 +103,7 @@ You can read more about upgrading Symfony application to Flex <https://symfony.c
     - `scripts/install.sh`
     - `kubernetes/kustomize/base/kustomization.yaml`
 
-- change namespaces in `migrations.lock` file from `Shopsys\ShopBundle\...` to `App\...`, eg.
+- change namespaces in `migrations-lock.yml` file from `Shopsys\ShopBundle\...` to `App\...`, eg.
     ```diff
         20191114101504:
     -       class: Shopsys\ShopBundle\Migrations\Version20191114101504


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixed wrong filename of migrations-lock.yml file in upgrade instructions for flex.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
