### PR TITLE
[framework] use protected properties in Transformers and AdvancedSearch

### DIFF
--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -12,6 +12,8 @@ services:
                             - Shopsys\FrameworkBundle\Model
                             - Shopsys\FrameworkBundle\Component
                             - Shopsys\FrameworkBundle\Controller
+                            - Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch
+                            - Shopsys\FrameworkBundle\Form\Transformer
                             - Shopsys\FrameworkBundle\Twig
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~

--- a/packages/framework/src/Form/Admin/AdvancedSearch/AdvancedSearchFilterTranslation.php
+++ b/packages/framework/src/Form/Admin/AdvancedSearch/AdvancedSearchFilterTranslation.php
@@ -7,7 +7,7 @@ class AdvancedSearchFilterTranslation
     /**
      * @var string[]
      */
-    private $filtersTranslationsByFilterName;
+    protected $filtersTranslationsByFilterName;
 
     public function __construct()
     {

--- a/packages/framework/src/Form/Admin/AdvancedSearch/AdvancedSearchOperatorTranslation.php
+++ b/packages/framework/src/Form/Admin/AdvancedSearch/AdvancedSearchOperatorTranslation.php
@@ -9,7 +9,7 @@ class AdvancedSearchOperatorTranslation
     /**
      * @var string[]
      */
-    private $operatorsTranslations;
+    protected $operatorsTranslations;
 
     public function __construct()
     {

--- a/packages/framework/src/Form/Transformers/CategoriesIdsToCategoriesTransformer.php
+++ b/packages/framework/src/Form/Transformers/CategoriesIdsToCategoriesTransformer.php
@@ -10,7 +10,7 @@ class CategoriesIdsToCategoriesTransformer implements DataTransformerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryRepository
      */
-    private $categoryRepository;
+    protected $categoryRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryRepository $categoryRepository

--- a/packages/framework/src/Form/Transformers/CategoriesTypeTransformer.php
+++ b/packages/framework/src/Form/Transformers/CategoriesTypeTransformer.php
@@ -10,7 +10,7 @@ class CategoriesTypeTransformer implements DataTransformerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
-    private $categoryFacade;
+    protected $categoryFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade

--- a/packages/framework/src/Form/Transformers/FilesIdsToFilesTransformer.php
+++ b/packages/framework/src/Form/Transformers/FilesIdsToFilesTransformer.php
@@ -12,7 +12,7 @@ class FilesIdsToFilesTransformer implements DataTransformerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade
      */
-    private $uploadedFileFacade;
+    protected $uploadedFileFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade

--- a/packages/framework/src/Form/Transformers/ImagesIdsToImagesTransformer.php
+++ b/packages/framework/src/Form/Transformers/ImagesIdsToImagesTransformer.php
@@ -10,7 +10,7 @@ class ImagesIdsToImagesTransformer implements DataTransformerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
      */
-    private $imageFacade;
+    protected $imageFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageRepository

--- a/packages/framework/src/Form/Transformers/InverseMultipleChoiceTransformer.php
+++ b/packages/framework/src/Form/Transformers/InverseMultipleChoiceTransformer.php
@@ -9,7 +9,7 @@ class InverseMultipleChoiceTransformer implements DataTransformerInterface
     /**
      * @var array
      */
-    private $allChoices;
+    protected $allChoices;
 
     /**
      * @param array $allChoices Choices from ChoiceType options
@@ -47,7 +47,7 @@ class InverseMultipleChoiceTransformer implements DataTransformerInterface
      * @param array $inputValues
      * @return array
      */
-    private function getInvertedValues(array $inputValues)
+    protected function getInvertedValues(array $inputValues)
     {
         $outputValues = [];
 

--- a/packages/framework/src/Form/Transformers/NumericToMoneyTransformer.php
+++ b/packages/framework/src/Form/Transformers/NumericToMoneyTransformer.php
@@ -13,7 +13,7 @@ final class NumericToMoneyTransformer implements DataTransformerInterface
     /**
      * @var int
      */
-    private $floatScale;
+    protected $floatScale;
 
     /**
      * @param int $floatScale

--- a/packages/framework/src/Form/Transformers/ProductIdToProductTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductIdToProductTransformer.php
@@ -11,7 +11,7 @@ class ProductIdToProductTransformer implements DataTransformerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository

--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -12,12 +12,12 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactoryInterface
      */
-    private $productParameterValueDataFactory;
+    protected $productParameterValueDataFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueDataFactoryInterface
      */
-    private $parameterValueDataFactory;
+    protected $parameterValueDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactoryInterface $productParameterValueDataFactory

--- a/packages/framework/src/Form/Transformers/ProductsIdsToProductsTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductsIdsToProductsTransformer.php
@@ -10,7 +10,7 @@ class ProductsIdsToProductsTransformer implements DataTransformerInterface
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
-    private $productRepository;
+    protected $productRepository;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| simpler extensibility, Eg. creating new operator for Advanced search was pain (array with translations was private)<br> We forbid using private properties in framework classes due to extensibility. This PR changes its visibility to protected.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
