### PR TITLE
[framework] fix call sleep() on null on sleep cron module between two feeds

### DIFF
--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -89,7 +89,12 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
 
             $this->currentFeedExport = null;
 
-            return $this->getFeedExportCreationDataQueue()->next();
+            $existsNext = $this->getFeedExportCreationDataQueue()->next();
+            if ($existsNext === true) {
+                $this->currentFeedExport = $this->createCurrentFeedExport();
+            }
+
+            return $existsNext;
         }
 
         return true;
@@ -100,10 +105,14 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
      */
     public function sleep(): void
     {
-        $this->currentFeedExport->sleep();
+        $lastSeekId = $this->currentFeedExport !== null ? $this->currentFeedExport->getLastSeekId() : null;
+
+        if ($lastSeekId !== null) {
+            $this->currentFeedExport->sleep();
+        }
+
         $currentFeedName = $this->getFeedExportCreationDataQueue()->getCurrentFeedName();
         $currentDomain = $this->getFeedExportCreationDataQueue()->getCurrentDomain();
-        $lastSeekId = $this->currentFeedExport !== null ? $this->currentFeedExport->getLastSeekId() : null;
 
         $this->setting->set(Setting::FEED_NAME_TO_CONTINUE, $currentFeedName);
         $this->setting->set(Setting::FEED_DOMAIN_ID_TO_CONTINUE, $currentDomain->getId());

--- a/packages/framework/tests/Unit/Model/Feed/DailyFeedCronModuleTest.php
+++ b/packages/framework/tests/Unit/Model/Feed/DailyFeedCronModuleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Feed;
+
+use Monolog\Handler\NullHandler;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Shopsys\FrameworkBundle\Model\Feed\DailyFeedCronModule;
+use Shopsys\FrameworkBundle\Model\Feed\FeedExport;
+use Shopsys\FrameworkBundle\Model\Feed\FeedFacade;
+use Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface;
+use Symfony\Bridge\Monolog\Logger;
+
+class DailyFeedCronModuleTest extends TestCase
+{
+    public function testSleepExactBetweenFeeds(): void
+    {
+        $feedInfoMock = $this->getMockBuilder(FeedInfoInterface::class)
+            ->getMockForAbstractClass();
+
+        $settingMock = $this->getMockBuilder(Setting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $domainConfig = new DomainConfig(1, 'http://example.com', 'name', 'en');
+        $domain = new Domain([$domainConfig], $settingMock);
+
+        $feedExportMock = $this->getMockBuilder(FeedExport::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isFinished', 'generateBatch', 'getFeedInfo', 'getDomainConfig', 'sleep'])
+            ->getMock();
+        $feedExportMock->expects($this->atLeastOnce())->method('isFinished')->willReturn(true);
+        $feedExportMock->expects($this->any())->method('generateBatch');
+        $feedExportMock->expects($this->any())->method('getFeedInfo')->willReturn(new $feedInfoMock());
+        $feedExportMock->expects($this->any())->method('getDomainConfig')->willReturn($domainConfig);
+
+        $logger = new Logger('loggerName');
+        $logger->setHandlers([new NullHandler()]);
+
+        $feedFacadeMock = $this->getMockBuilder(FeedFacade::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getFeedNames', 'createFeedExport', 'getFeedFilepath'])
+            ->getMock();
+        $feedFacadeMock->expects($this->any())->method('getFeedNames')->willReturn(['feed1', 'feed2']);
+        $feedFacadeMock->expects($this->any())->method('createFeedExport')->willReturn($feedExportMock);
+        $feedFacadeMock->expects($this->any())->method('getFeedFilepath')->willReturn('path');
+
+        $dailyFeedCronModule = new DailyFeedCronModule($feedFacadeMock, $domain, $settingMock);
+        $dailyFeedCronModule->setLogger($logger);
+
+        $dailyFeedCronModule->iterate();
+        $dailyFeedCronModule->sleep();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| when feed cron module finish one feed exact before sleep, it causes fatal error. This PR prevents such case.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1253 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
