### PR TITLE
[framework] Padding categories by level in advanced search

### DIFF
--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter;
 use Doctrine\ORM\QueryBuilder;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface;
+use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -71,7 +72,10 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
             'expanded' => false,
             'multiple' => false,
             'choices' => $this->categoryFacade->getTranslatedAll($this->domain->getCurrentDomainConfig()),
-            'choice_label' => 'name',
+            'choice_label' => function (Category $category) {
+                $padding = str_repeat("\u{00a0}", ($category->getLevel() - 1) * 2);
+                return $padding . $category->getName();
+            },
             'choice_value' => 'id',
             'attr' => ['class' => 'js-autocomplete-selectbox'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Categories in advanced search have only one level of nesting. This PR simply adds spaces before the category name according to the nesting level.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
