### PR TITLE
[framework] higher priority for static routes, lower for dynamic routes

### DIFF
--- a/packages/framework/src/Component/Router/DomainRouter.php
+++ b/packages/framework/src/Component/Router/DomainRouter.php
@@ -40,9 +40,9 @@ class DomainRouter extends ChainRouter
         $this->freeze = true;
         $this->friendlyUrlRouter = $friendlyUrlRouter;
 
-        $this->add($basicRouter, 10);
+        $this->add($basicRouter, 30);
         $this->add($localizedRouter, 20);
-        $this->add($friendlyUrlRouter, 30);
+        $this->add($friendlyUrlRouter, 10);
     }
 
     /**


### PR DESCRIPTION
static routers (faster) have higher priorties than dynamic friendly url (slower)

| Q             | A
| ------------- | ---
|Description, reason for the PR| little performance boost -> pages without friendly url save one query to database
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1071 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
