### PR TITLE
[project-base] fix path resolving for domain icons

### DIFF
--- a/project-base/config/paths.yml
+++ b/project-base/config/paths.yml
@@ -5,7 +5,7 @@ parameters:
     shopsys.default_db_schema_filepath: '%shopsys.framework.resources_dir%/database/schema.sql'
     shopsys.domain_config_filepath: '%shopsys.root_dir%/config/domains.yml'
     shopsys.domain_images_dir: '/web%shopsys.domain_images_url_prefix%'
-    shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain/'
+    shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
     shopsys.domain_urls_config_filepath: '%shopsys.root_dir%/config/domains_urls.yml'
     shopsys.error_pages_dir: '%shopsys.root_dir%/var/errorPages/'
     shopsys.feed_dir: '/web%shopsys.feed_url_prefix%'

--- a/project-base/src/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ImageDataFixture.php
@@ -91,7 +91,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
         $this->truncateImagesFromDb();
 
         if (file_exists($this->dataFixturesImagesDirectory)) {
-            $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory . 'domain/', $this->targetDomainImagesDirectory);
+            $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory . 'domain/', $this->targetDomainImagesDirectory . '/');
             $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory, $this->targetImagesDirectory);
             $this->processDbImagesChanges();
         }

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -636,7 +636,22 @@ There you can find links to upgrade notes for other versions too.
                {{ 'Search [verb]'|trans }}
            </button>
         ```
- 
+- fix domain icon rendering and loading ([#1655](https://github.com/shopsys/shopsys/pull/1655))
+    - remove trailing slash in `config/paths.yml`
+        ```diff
+        -   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain/'
+        +   shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
+        ```
+    - fix icon path in `ImageDataFixture` (`src/DataFixtures/Demo/ImageDataFixture.php`)
+        ```diff
+            public function load(ObjectManager $manager)
+            {
+                $this->truncateImagesFromDb();
+                if (file_exists($this->dataFixturesImagesDirectory)) {
+        -           $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory . 'domain/', $this->targetDomainImagesDirectory);
+        +           $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory . 'domain/', $this->targetDomainImagesDirectory . '/');
+        ```
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
- when trailing slash was used in the path, there were two slashes in the path to domain icon (see DomainExtension::getDomainIconHtml())
- when using abstract filesystem (S3), the icon was not found when there were two slashes in the path

| Q             | A
| ------------- | ---
|Description, reason for the PR| I could not see domain icons on my project that uses S3 filesystem
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
