### PR TITLE
[shopsys] coding standards for using strict comparison operators

### DIFF
--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -18,6 +18,9 @@ services:
 
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~
 
+    # @deprecated This will be moved from project-base to coding-standards package in next major version
+    SlevomatCodingStandard\Sniffs\Operators\DisallowEqualOperatorsSniff: ~
+
 parameters:
     skip:
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/framework/src/Command/ChangeAdminPasswordCommand.php
+++ b/packages/framework/src/Command/ChangeAdminPasswordCommand.php
@@ -72,7 +72,7 @@ class ChangeAdminPasswordCommand extends Command
         $question->setHidden(true);
         $question->setHiddenFallback(false);
         $question->setValidator(function ($password) use ($io) {
-            if ($password == '') {
+            if ($password === null) {
                 throw new \Exception('The password cannot be empty');
             }
 

--- a/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
+++ b/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
@@ -44,7 +44,7 @@ class VolumeDriver extends Driver
         $stat = $this->_stat($thumbnailPath, $hash);
 
         if (isset($stat['tmb'])) {
-            $res = $stat['tmb'] == '1' ? $this->createTmb($thumbnailPath, $stat) : $stat['tmb'];
+            $res = (string)$stat['tmb'] === '1' ? $this->createTmb($thumbnailPath, $stat) : $stat['tmb'];
 
             if (!$res) {
                 list($type) = explode('/', $stat['mime']);
@@ -134,7 +134,7 @@ class VolumeDriver extends Driver
                         $this->rmTmb($this->stat($p));
                     }
                 }
-            } elseif (!empty($stat['tmb']) && $stat['tmb'] != '1') {
+            } elseif (!empty($stat['tmb']) && (string)$stat['tmb'] !== '1') {
                 $thumbnailPath = $this->createThumbnailPath(rawurldecode($stat['tmb']));
                 $this->_unlink($thumbnailPath);
                 clearstatcache();

--- a/packages/framework/src/Form/Constraints/UniqueEmailValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmailValidator.php
@@ -45,7 +45,9 @@ class UniqueEmailValidator extends ConstraintValidator
 
         $domainId = $constraint->domainId ?? $this->domain->getId();
 
-        if ($constraint->ignoredEmail != $value && $this->customerUserFacade->findCustomerUserByEmailAndDomain($email, $domainId) !== null) {
+        if ($constraint->ignoredEmail !== $value
+            && $this->customerUserFacade->findCustomerUserByEmailAndDomain($email, $domainId) !== null
+        ) {
             $this->context->addViolation(
                 $constraint->message,
                 [

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
@@ -53,7 +53,7 @@ class OrderCityFilter implements AdvancedSearchFilterInterface
     public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData)
     {
         foreach ($rulesData as $index => $ruleData) {
-            if ($ruleData->value === null || $ruleData->value == '') {
+            if ($ruleData->value === null || $ruleData->value === '') {
                 $searchValue = '%';
             } else {
                 $searchValue = DatabaseSearching::getFullTextLikeSearchString($ruleData->value);

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
@@ -50,7 +50,7 @@ class OrderEmailFilter implements AdvancedSearchFilterInterface
     public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData)
     {
         foreach ($rulesData as $index => $ruleData) {
-            if ($ruleData->value === null || $ruleData->value == '') {
+            if ($ruleData->value === null || $ruleData->value === '') {
                 $searchValue = '%';
             } else {
                 $searchValue = DatabaseSearching::getFullTextLikeSearchString($ruleData->value);

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
@@ -53,7 +53,7 @@ class OrderLastNameFilter implements AdvancedSearchFilterInterface
     public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData)
     {
         foreach ($rulesData as $index => $ruleData) {
-            if ($ruleData->value === null || $ruleData->value == '') {
+            if ($ruleData->value === null || $ruleData->value === '') {
                 $searchValue = '%';
             } else {
                 $searchValue = DatabaseSearching::getLikeSearchString($ruleData->value) . '%';

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
@@ -53,7 +53,7 @@ class OrderNameFilter implements AdvancedSearchFilterInterface
     public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData)
     {
         foreach ($rulesData as $index => $ruleData) {
-            if ($ruleData->value === null || $ruleData->value == '') {
+            if ($ruleData->value === null || $ruleData->value === '') {
                 $searchValue = '%';
             } else {
                 $searchValue = DatabaseSearching::getLikeSearchString($ruleData->value) . '%';

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNumberFilter.php
@@ -54,7 +54,7 @@ class OrderNumberFilter implements AdvancedSearchFilterInterface
     {
         foreach ($rulesData as $index => $ruleData) {
             if ($ruleData->operator === self::OPERATOR_CONTAINS || $ruleData->operator === self::OPERATOR_NOT_CONTAINS) {
-                if ($ruleData->value === null || $ruleData->value == '') {
+                if ($ruleData->value === null || $ruleData->value === '') {
                     $searchValue = '%';
                 } else {
                     $searchValue = DatabaseSearching::getFullTextLikeSearchString($ruleData->value);

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
@@ -53,7 +53,7 @@ class OrderPhoneNumberFilter implements AdvancedSearchFilterInterface
     public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData)
     {
         foreach ($rulesData as $index => $ruleData) {
-            if ($ruleData->value === null || $ruleData->value == '') {
+            if ($ruleData->value === null || $ruleData->value === '') {
                 $searchValue = '%';
             } else {
                 $searchValue = DatabaseSearching::getFullTextLikeSearchString($ruleData->value);

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPriceFilterWithVatFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPriceFilterWithVatFilter.php
@@ -55,7 +55,7 @@ class OrderPriceFilterWithVatFilter implements AdvancedSearchFilterInterface
     {
         foreach ($rulesData as $index => $ruleData) {
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
-            if ($dqlOperator === null || $ruleData->value == '' || $ruleData->value === null) {
+            if ($dqlOperator === null || $ruleData->value === '' || $ruleData->value === null) {
                 continue;
             }
             $searchValue = $ruleData->value;

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
@@ -53,7 +53,7 @@ class OrderStreetFilter implements AdvancedSearchFilterInterface
     public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData)
     {
         foreach ($rulesData as $index => $ruleData) {
-            if ($ruleData->value === null || $ruleData->value == '') {
+            if ($ruleData->value === null || $ruleData->value === '') {
                 $searchValue = '%';
             } else {
                 $searchValue = DatabaseSearching::getFullTextLikeSearchString($ruleData->value);

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculator.php
@@ -153,7 +153,7 @@ class InputPriceRecalculator
 
             $callback($object);
 
-            if (($iteration % static::BATCH_SIZE) == 0) {
+            if (($iteration % static::BATCH_SIZE) === 0) {
                 $this->em->flush();
             }
         }

--- a/packages/framework/src/Twig/NumberFormatterExtension.php
+++ b/packages/framework/src/Twig/NumberFormatterExtension.php
@@ -152,6 +152,6 @@ class NumberFormatterExtension extends AbstractExtension
      */
     public function isInteger($number)
     {
-        return is_numeric($number) && (int)$number == $number;
+        return is_numeric($number) && (string)(int)$number === (string)$number;
     }
 }

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -3,6 +3,8 @@ imports:
 
 services:
     PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~
+    # @deprecated This will be moved from project-base to coding-standards package in next major version
+    SlevomatCodingStandard\Sniffs\Operators\DisallowEqualOperatorsSniff: ~
 
 parameters:
     exclude_files:

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -39,3 +39,7 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateAvailability`
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculatePrice`
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateVisibility`
+
+- introduced sniff for strict comparasion ([#1658](https://github.com/shopsys/shopsys/pull/1658))
+    - this change is temporary to help you prepare your project for next major version, where this will be required directly in coding-standards package
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Disallows using loose == and != comparison operators. Use === and !== instead, they are much more secure, predictable and consistent.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Fixer needs manual check, because some code could rely on less strict comparisons -> BC break in my opinion.