### PR TITLE
[shopsys] do not change product availability to default when availability cannot be calculated immediately

### DIFF
--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -63,11 +63,11 @@ class ProductAvailabilityCalculation
     public function calculateAvailability(Product $product)
     {
         // If the product is not managed by EntityManager yet, it's not possible to calculate its availability consistently
-        // Let's return a default availability for the moment and mark the product for recalculation
+        // Let's return a same availability for the moment, do not change it now and mark the product for recalculation
         if ($this->em->contains($product) === false) {
             $product->markForAvailabilityRecalculation();
 
-            return $this->availabilityFacade->getDefaultInStockAvailability();
+            return $product->getCalculatedAvailability();
         }
 
         if ($product->isMainVariant()) {

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -395,16 +395,15 @@ class Product extends AbstractTranslatableEntity
     protected function setAvailabilityAndStock(ProductData $productData): void
     {
         $this->usingStock = $productData->usingStock;
+        $this->availability = $productData->availability;
         if ($this->usingStock) {
             $this->stockQuantity = $productData->stockQuantity;
             $this->outOfStockAction = $productData->outOfStockAction;
             $this->outOfStockAvailability = $productData->outOfStockAvailability;
-            $this->availability = null;
         } else {
             $this->stockQuantity = null;
             $this->outOfStockAction = null;
             $this->outOfStockAvailability = null;
-            $this->availability = $productData->availability;
         }
     }
 
@@ -572,7 +571,7 @@ class Product extends AbstractTranslatableEntity
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
+     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability|null
      */
     public function getAvailability()
     {

--- a/project-base/tests/App/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/App/Functional/Model/Product/ProductVariantCreationTest.php
@@ -101,6 +101,7 @@ final class ProductVariantCreationTest extends TransactionFunctionalTestCase
         $productData->usingStock = true;
         $productData->stockQuantity = $quantity;
         $productData->outOfStockAction = $outOfStockAction;
+        $productData->availability = $this->getReference(AvailabilityDataFixture::AVAILABILITY_IN_STOCK);
         if ($outOfStockAvailabilityReference !== null) {
             $productData->outOfStockAvailability = $this->getReference($outOfStockAvailabilityReference);
         }

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1121,6 +1121,9 @@ There you can find links to upgrade notes for other versions too.
 - add cron overview ([#1407](https://github.com/shopsys/shopsys/pull/1407))
     - update your files using [this diff](https://github.com/shopsys/project-base/commit/fdac77abc9fd7f167ccd544f4691ee25b2de169d)
 
+- update your aplication to do not change product availability to default when availability can not be calculated immediately ([#1659](https://github.com/shopsys/shopsys/pull/1659))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is better to keep current availability, then changing it to default, until calculation is run.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
