### PR TITLE
delete backup index if exists before creating new backup

### DIFF
--- a/project-base/tests/App/Functional/Component/Elasticsearch/ElasticsearchStructureUpdateCheckerTest.php
+++ b/project-base/tests/App/Functional/Component/Elasticsearch/ElasticsearchStructureUpdateCheckerTest.php
@@ -118,7 +118,6 @@ final class ElasticsearchStructureUpdateCheckerTest extends FunctionalTestCase
     private function revertStructureFromBackup(array $oldDefinition, string $indexName, string $aliasName): void
     {
         $backupIndexName = $indexName . '_backup';
-        $this->elasticsearchIndexes->delete(['index' => $indexName]);
         $this->moveStructureByReindexing($backupIndexName, $indexName, $oldDefinition);
         $this->elasticsearchIndexes->putAlias(['index' => $indexName, 'name' => $aliasName]);
     }
@@ -130,6 +129,9 @@ final class ElasticsearchStructureUpdateCheckerTest extends FunctionalTestCase
      */
     private function moveStructureByReindexing(string $oldName, string $newName, array $definition): void
     {
+        if ($this->elasticsearchIndexes->exists(['index' => $newName]) === true) {
+            $this->elasticsearchIndexes->delete(['index' => $newName]);
+        }
         $this->elasticsearchIndexes->create([
             'index' => $newName,
             'body' => $definition,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

When function tests of elasticsearch sometimes fail and backup index is not deleted, next run of tests fail on somethink like that 
```
Elasticsearch\Common\Exceptions\BadRequest400Exception: {"error":{"root_cause":[{"type":"resource_already_exists_exception","reason":"index [ss__20200207001104product1_backup/dIl3WY0SRAujJB7z_OcCHQ] already exists","index_uuid":"dIl3WY0SRAujJB7z_OcCHQ","index":"ss__20200207001104product1_backup"}],"type":"resource_already_exists_exception","reason":"index [ss__20200207001104product1_backup/dIl3WY0SRAujJB7z_OcCHQ] already exists","index_uuid":"dIl3WY0SRAujJB7z_OcCHQ","index":"ss__20200207001104product1_backup"},"status":400}
```
