### PR TITLE
[framework] Run all recalculators during deploy only if domain is created

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -433,10 +433,6 @@
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:domains-data:create"/>
         </exec>
-        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
-            <arg value="${path.bin-console}"/>
-            <arg value="shopsys:recalculations"/>
-        </exec>
     </target>
 
     <target name="domains-db-functions-create" description="Creates new domains DB functions." hidden="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Current implementation is unacceptable for projects with more products. Recalculations are now run only for newly created domains. Any products marked for recalculation are calculated with cron only and not during the deploy.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1387 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
