### PR TITLE
[backend-api] prevent forgotten file after install and uninstall backend api in monorepo + fix patch

### DIFF
--- a/packages/backend-api/install/config/packages/security.yml.patch
+++ b/packages/backend-api/install/config/packages/security.yml.patch
@@ -1,4 +1,4 @@
-@@ -45,6 +45,15 @@ security:
+@@ -48,6 +48,15 @@ security:
              guard:
                  authenticators:
                      - Shopsys\FrontendApiBundle\Model\Token\TokenAuthenticator

--- a/packages/backend-api/install/install.sh
+++ b/packages/backend-api/install/install.sh
@@ -4,52 +4,61 @@ INSTALL_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 PWD_PROJECT_BASE_PATH=`[ -d "$PWD/project-base" ] && echo "$PWD/project-base" || echo "$PWD"`
 
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+ORANGE="\e[38;5;137m"
+GREY="\e[90m"
+NC="\e[0m"
+
 if [ "$1" == "monorepo" ]
 then
     PROJECT_BASE_PATH=`realpath ${INSTALL_DIR}/../../../project-base`
     if [ "$PWD_PROJECT_BASE_PATH" != "$PROJECT_BASE_PATH" ]
     then
-        echo "You have to run install.sh from monorepo root. Eg. /var/www/html"
+        printf "${RED}You have to run install.sh from monorepo root. Eg. /var/www/html${NC}\n"
         exit 1
     fi
 else
     PROJECT_BASE_PATH=`realpath ${INSTALL_DIR}/../../../../`
     if [ "$PWD_PROJECT_BASE_PATH" != "$PROJECT_BASE_PATH" ]
     then
-        echo "You have to run install.sh from the project root. Eg. /var/www/html"
+        printf "${RED}You have to run install.sh from the project root. Eg. /var/www/html{$NC}\n"
         exit 1
     fi
 fi
 
-echo "Copying FOS REST configuration..."
+printf "Copying FOS REST configuration..."
 cp ${INSTALL_DIR}/config/packages/fos_rest.yml ${PROJECT_BASE_PATH}/config/packages/fos_rest.yml
 cp ${INSTALL_DIR}/config/packages/test/fos_rest.yml ${PROJECT_BASE_PATH}/config/packages/test/fos_rest.yml
-echo "Done"
+printf "${GREEN}Done${NC}\n"
 
-echo "Copying OAuth2 configuration..."
+printf "Copying OAuth2 configuration..."
 cp ${INSTALL_DIR}/config/packages/trikoder_oauth2.yml ${PROJECT_BASE_PATH}/config/packages/trikoder_oauth2.yml
 mkdir -p ${PROJECT_BASE_PATH}/config/oauth2
 cp ${INSTALL_DIR}/config/oauth2/.gitignore ${PROJECT_BASE_PATH}/config/oauth2/.gitignore
 cp ${INSTALL_DIR}/config/oauth2/parameters_oauth.yml.dist ${PROJECT_BASE_PATH}/config/oauth2/parameters_oauth.yml.dist
-echo "Done"
+printf "${GREEN}Done${NC}\n"
 
-echo "Creating directory src/Controller/Api/V1..."
+printf "Creating directory src/Controller/Api/V1..."
 mkdir -p ${PROJECT_BASE_PATH}/src/Controller/Api/V1/Product
 touch ${PROJECT_BASE_PATH}/src/Controller/Api/V1/Product/.gitkeep
-echo "Done"
+printf "${GREEN}Done${NC}\n"
 
-echo "Copying tests..."
+printf "Copying tests..."
 cp ${INSTALL_DIR}/tests/App/Smoke/BackendApiTest.php ${PROJECT_BASE_PATH}/tests/App/Smoke/BackendApiTest.php
 cp ${INSTALL_DIR}/tests/App/Smoke/BackendApiCreateProductTest.php ${PROJECT_BASE_PATH}/tests/App/Smoke/BackendApiCreateProductTest.php
 cp ${INSTALL_DIR}/tests/App/Smoke/BackendApiDeleteProductTest.php ${PROJECT_BASE_PATH}/tests/App/Smoke/BackendApiDeleteProductTest.php
 cp ${INSTALL_DIR}/tests/App/Smoke/BackendApiUpdateProductTest.php ${PROJECT_BASE_PATH}/tests/App/Smoke/BackendApiUpdateProductTest.php
 cp ${INSTALL_DIR}/tests/App/Test/OauthTestCase.php ${PROJECT_BASE_PATH}/tests/App/Test/OauthTestCase.php
-echo "Done"
+printf "${GREEN}Done${NC}\n"
+
+printf "\n"
 
 function apply_patch () {
     if [ -z $1 ]
     then
-        echo "Please provide path as first parameter of apply_patch function"
+        printf "${RED}Please provide path as first parameter of apply_patch function${NC}\n"
         exit 1
     fi
 
@@ -69,21 +78,23 @@ function apply_patch () {
 
     if [ ! -z "${PATCH_REVERSED}" ]
     then
-        echo "Applied patch detected: patch for ${FILE_PATH} already applied. Doing nothing"
+        printf "${ORANGE}Applied patch detected: patch for ${FILE_PATH} already applied. Doing nothing${NC}\n"
     elif [ ! -z "${PATCH_FAIL}" ]
     then
         echo ${PATCH_FAIL}
-        echo "Patch for ${FILE_PATH} cannot be applied!"
+        printf "${RED}Patch for ${FILE_PATH} cannot be applied!${NC}\n"
         AT_LEAST_ONE_PATCH_FAILED=1
     elif [ ! -z "${PATCH_WARNING}" ]
     then
-        echo "Patch can be applied for ${FILE_PATH} however patching did not have perfect match!"
-        echo "Verify patchfile and apply manually with 'patch -t ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch'"
+        printf "${RED}Patch can be applied for ${FILE_PATH} however patching did not have perfect match!${NC}\n"
+        printf "Verify patchfile and apply manually with ${GREY}'patch -t ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch'${NC}\n"
         AT_LEAST_ONE_PATCH_FAILED=1
     else
         patch -t ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch
-        echo "Done"
+        printf "${GREEN}Done${NC}\n"
     fi
+
+    printf "\n"
 }
 
 apply_patch "src/Kernel.php"
@@ -95,16 +106,16 @@ apply_patch "build.xml"
 
 if [ "$1" == "monorepo" ]
 then
-    echo "Running from monorepo, not applying patch for project-base composer.json because it has no effect in monorepo."
+    printf "${GREY}Running from monorepo, not applying patch for project-base composer.json because it has no effect in monorepo.${NC}\n"
 else
     apply_patch "composer.json"
 fi
 
 if [ -z $AT_LEAST_ONE_PATCH_FAILED ]
 then
-    echo "Backend API installation was successful!"
+    printf "${GREEN}Backend API installation was successful!${NC}\n"
     exit 0
 else
-    echo "Backend API installation failed!"
+    printf "${RED}Backend API installation failed!${NC}\n"
     exit 1
 fi

--- a/packages/backend-api/install/install.sh
+++ b/packages/backend-api/install/install.sh
@@ -62,7 +62,7 @@ function apply_patch () {
     fi
 
     echo "Applying patch for ${FILE_PATH}..."
-    local PATCH_DRY_RUN=`patch -st --dry-run ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch`
+    local PATCH_DRY_RUN=`patch -t --dry-run ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch`
     local PATCH_REVERSED=`grep "Reversed" <<< ${PATCH_DRY_RUN}`
     local PATCH_FAIL=`grep "FAILED" <<< ${PATCH_DRY_RUN}`
 
@@ -75,7 +75,7 @@ function apply_patch () {
         echo "Patch for ${FILE_PATH} cannot be applied!"
         AT_LEAST_ONE_PATCH_FAILED=1
     else
-        patch -st ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch
+        patch -t ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch
         echo "Done"
     fi
 }

--- a/packages/backend-api/install/install.sh
+++ b/packages/backend-api/install/install.sh
@@ -64,6 +64,7 @@ function apply_patch () {
     echo "Applying patch for ${FILE_PATH}..."
     local PATCH_DRY_RUN=`patch -t --dry-run ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch`
     local PATCH_REVERSED=`grep "Reversed" <<< ${PATCH_DRY_RUN}`
+    local PATCH_WARNING=`grep "Hunk #" <<< ${PATCH_DRY_RUN}`
     local PATCH_FAIL=`grep "FAILED" <<< ${PATCH_DRY_RUN}`
 
     if [ ! -z "${PATCH_REVERSED}" ]
@@ -73,6 +74,11 @@ function apply_patch () {
     then
         echo ${PATCH_FAIL}
         echo "Patch for ${FILE_PATH} cannot be applied!"
+        AT_LEAST_ONE_PATCH_FAILED=1
+    elif [ ! -z "${PATCH_WARNING}" ]
+    then
+        echo "Patch can be applied for ${FILE_PATH} however patching did not have perfect match!"
+        echo "Verify patchfile and apply manually with 'patch -t ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch'"
         AT_LEAST_ONE_PATCH_FAILED=1
     else
         patch -t ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch

--- a/packages/backend-api/install/uninstall.sh
+++ b/packages/backend-api/install/uninstall.sh
@@ -4,19 +4,26 @@ INSTALL_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 PWD_PROJECT_BASE_PATH=`[ -d "$PWD/project-base" ] && echo "$PWD/project-base" || echo "$PWD"`
 
+# ANSI color codes
+RED="\e[31m"
+GREEN="\e[32m"
+ORANGE="\e[38;5;137m"
+GREY="\e[90m"
+NC="\e[0m"
+
 if [ "$1" == "monorepo" ]
 then
     PROJECT_BASE_PATH=`realpath ${INSTALL_DIR}/../../../project-base`
     if [ "$PWD_PROJECT_BASE_PATH" != "$PROJECT_BASE_PATH" ]
     then
-        echo "You have to run uninstall.sh from monorepo root. Eg. /var/www/html"
+        printf "${RED}You have to run install.sh from monorepo root. Eg. /var/www/html${NC}\n"
         exit 1
     fi
 else
     PROJECT_BASE_PATH=`realpath ${INSTALL_DIR}/../../../../`
     if [ "$PWD_PROJECT_BASE_PATH" != "$PROJECT_BASE_PATH" ]
     then
-        echo "You have to run uninstall.sh from the project root. Eg. /var/www/html"
+        printf "${RED}You have to run uninstall.sh from the project root. Eg. /var/www/html{$NC}\n"
         exit 1
     fi
 fi
@@ -38,7 +45,7 @@ rm -f ${PROJECT_BASE_PATH}/tests/App/Test/OauthTestCase.php
 function apply_patch_reverse () {
     if [ -z $1 ]
     then
-        echo "Please provide path as first parameter of apply_patch_reverse function"
+        printf "${RED}Please provide path as first parameter of apply_patch_reverse function${NC}\n"
         exit 1
     fi
 
@@ -57,24 +64,26 @@ function apply_patch_reverse () {
 
     if [ ! -z "${PATCH_FAIL}" ]
     then
-        local PATCH_APPLY_DRY_RUN=`patch -st --dry-run ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch`
+        local PATCH_APPLY_DRY_RUN=`patch -t --dry-run ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch`
         if [ -z "${PATCH_APPLY_DRY_RUN}" ]
         then
-            echo "Applied patch detected: ${FILE_PATH} already reverted, Doing nothing"
+            printf "${ORANGE}Applied patch detected: ${FILE_PATH} already reverted, Doing nothing${NC}\n"
         else
             echo ${PATCH_FAIL}
-            echo "${FILE_PATH} cannot be reverted!"
+            printf "${RED}${FILE_PATH} cannot be reverted!${NC}\n"
             AT_LEAST_ONE_PATCH_FAILED=1
         fi
     elif [ ! -z "${PATCH_WARNING}" ]
     then
-        echo "Patch can be applied for ${FILE_PATH} however patching did not have perfect match!"
-        echo "Verify patchfile and apply manually with 'patch -Rf ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch'"
+        printf "${RED}Patch can be reverted for ${FILE_PATH} however patching did not have perfect match!${NC}\n"
+        printf "Verify patchfile and apply manually with ${GREY}'patch -Rf ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch'${NC}\n"
         AT_LEAST_ONE_PATCH_FAILED=1
     else
         patch -Rf ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch
-        echo "Done"
+        printf "${GREEN}Done${NC}\n"
     fi
+
+    printf "\n"
 }
 
 apply_patch_reverse "src/Kernel.php"
@@ -86,15 +95,16 @@ apply_patch_reverse "build.xml"
 
 if [ "$1" == "monorepo" ]
 then
-    echo "Running from monorepo, not applying patch for project-base composer.json because it has no effect in monorepo."
+    printf "${GREY}Running from monorepo, not applying patch for project-base composer.json because it has no effect in monorepo.${NC}\n"
 else
     apply_patch_reverse "composer.json"
 fi
 
 if [ -z $AT_LEAST_ONE_PATCH_FAILED ]
 then
+    printf "${GREEN}Backend API uninstallation was successful!${NC}\n"
     exit 0
 else
-    echo "Backend API uninstallation failed!"
+    printf "${RED}Backend API uninstallation failed!${NC}\n"
     exit 1
 fi

--- a/packages/backend-api/install/uninstall.sh
+++ b/packages/backend-api/install/uninstall.sh
@@ -52,6 +52,7 @@ function apply_patch_reverse () {
 
     echo "Reverting ${FILE_PATH}..."
     local PATCH_DRY_RUN=`patch -Rf --dry-run ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch`
+    local PATCH_WARNING=`grep "Hunk #" <<< ${PATCH_DRY_RUN}`
     local PATCH_FAIL=`grep "FAILED" <<< ${PATCH_DRY_RUN}`
 
     if [ ! -z "${PATCH_FAIL}" ]
@@ -65,6 +66,11 @@ function apply_patch_reverse () {
             echo "${FILE_PATH} cannot be reverted!"
             AT_LEAST_ONE_PATCH_FAILED=1
         fi
+    elif [ ! -z "${PATCH_WARNING}" ]
+    then
+        echo "Patch can be applied for ${FILE_PATH} however patching did not have perfect match!"
+        echo "Verify patchfile and apply manually with 'patch -Rf ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch'"
+        AT_LEAST_ONE_PATCH_FAILED=1
     else
         patch -Rf ${PROJECT_BASE_PATH}/${FILE_PATH} ${INSTALL_DIR}/${SOURCE_FILE_PATH}.patch
         echo "Done"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| command `phing backend-api-install backend-api-uninstall` created new file `project-base/config/packages/security.yml.orig` because patch contains small discrepancy. It can caused commiting this useles file.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
