### PR TITLE
[framework] unified rendering of currency and symbolAfterInput in forms

### DIFF
--- a/packages/framework/src/Form/MoneyTypeExtension.php
+++ b/packages/framework/src/Form/MoneyTypeExtension.php
@@ -49,7 +49,10 @@ class MoneyTypeExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['money_pattern'] = $this->getPattern($options['currency']);
+        $view->vars['money_pattern'] = $this->getPattern();
+        if ($options['currency']) {
+            $view->vars['symbolAfterInput'] = $this->intlCurrencyRepository->get($options['currency'], $this->localization->getLocale());
+        }
     }
 
     /**
@@ -73,18 +76,11 @@ class MoneyTypeExtension extends AbstractTypeExtension
     /**
      * Returns the pattern for this locale. Always places currency symbol after widget.
      * The pattern contains the placeholder "{{ widget }}" where the HTML tag should be inserted
-     * @see \Symfony\Component\Form\Extension\Core\Type\MoneyType::getPattern()
-     * @param string|bool $currency
      * @return string
+     * @see \Symfony\Component\Form\Extension\Core\Type\MoneyType::getPattern()
      */
-    private function getPattern($currency)
+    private function getPattern()
     {
-        if (!$currency) {
-            return '{{ widget }}';
-        } else {
-            $intlCurrency = $this->intlCurrencyRepository->get($currency, $this->localization->getLocale());
-
-            return '{{ widget }} ' . $intlCurrency->getSymbol();
-        }
+        return '{{ widget }}';
     }
 }

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -656,6 +656,8 @@ There you can find links to upgrade notes for other versions too.
         -           $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory . 'domain/', $this->targetDomainImagesDirectory);
         +           $this->moveFilesFromLocalFilesystemToFilesystem($this->dataFixturesImagesDirectory . 'domain/', $this->targetDomainImagesDirectory . '/');
         ```
+- check your custom form types with currencies after Money input ([#1675](https://github.com/shopsys/shopsys/pull/1675))
+    - form field option `currency` is now rendered with `appendix_block` block (inside span tag) instead of plain text
 
 ### Tools
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Setting currency in `MoneyFormType` now renders the currency the same way as `symbolAfterInput` is (wrapped in span) – default `appendix_block`from `theme.html.twig` is used. So it's easier to style everything after input same way.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Possible <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes