### PR TITLE
[project-base] sellingFrom moved to the future for not yet sellable product in data fixtures

### DIFF
--- a/project-base/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ProductDataFixture.php
@@ -3417,7 +3417,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $this->setPriceForAllPricingGroups($productData, '1110.54896');
 
         $this->setVat($productData, VatDataFixture::VAT_HIGH);
-        $this->setSellingFrom($productData, '11.2.2020');
+        $this->setSellingFrom($productData, '11.2.2320');
         $this->setSellingTo($productData, null);
         $productData->usingStock = true;
         $productData->stockQuantity = 100;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Product sellable in the future should be in the future even after 11.2.2020 :trollface: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
