### PR TITLE
[project-base] suppress Phpstan in App tests for getReference()

### DIFF
--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -14,7 +14,7 @@ parameters:
             path: %currentWorkingDirectory%/src/DataFixtures/*
         -
             # In tests, we often grab services using $container->get() or access persistent references using $this->getReference()
-            message: '#^Property (Shopsys|Tests)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
+            message: '#^Property (Shopsys|Tests|App)\\.+::\$.+ \(.+\) does not accept (object|object\|null)\.$#'
             path: %currentWorkingDirectory%/tests/App/*
         -
             # In tests, there are helper methods for grabbing services using $container->get()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When getReferrence() is used in test for project-base class, php stan fails. It is caused by changing of namespace from ShopBundle to App.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
