### PR TITLE
[framework] fix wrongly placed annotation in BasePriceCalculation

### DIFF
--- a/packages/framework/src/Model/Pricing/BasePriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/BasePriceCalculation.php
@@ -79,6 +79,8 @@ class BasePriceCalculation
      */
     public function applyCoefficients(Price $price, Vat $vat, array $coefficients): Price
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. This method is not used, only in tests.', __METHOD__), E_USER_DEPRECATED);
+
         $priceWithVatBeforeRounding = $price->getPriceWithVat();
         foreach ($coefficients as $coefficient) {
             $priceWithVatBeforeRounding = $priceWithVatBeforeRounding->multiply($coefficient);

--- a/packages/framework/src/Model/Pricing/BasePriceCalculation.php
+++ b/packages/framework/src/Model/Pricing/BasePriceCalculation.php
@@ -50,8 +50,6 @@ class BasePriceCalculation
     }
 
     /**
-     * @deprecated method is deprecated and will be removed in the next major. This method is not used, only in tests
-     *
      * @param \Shopsys\FrameworkBundle\Component\Money\Money $inputPrice
      * @param int $inputPriceType
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
@@ -72,6 +70,8 @@ class BasePriceCalculation
     }
 
     /**
+     * @deprecated method is deprecated and will be removed in the next major. This method is not used, only in tests
+     *
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $price
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat
      * @param string[] $coefficients


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Function `calculateBasePriceRoundedByCurrency` for price calculation with rounding by currency has deprecated annotation, which is wrong. This annotation belongs to `applyCoefficients`. This PR fixes wrongly placed anntoation. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
