### PR TITLE
[framework] fixed code sent to TransformationFailedException

### DIFF
--- a/packages/framework/src/Form/Transformers/FilesIdsToFilesTransformer.php
+++ b/packages/framework/src/Form/Transformers/FilesIdsToFilesTransformer.php
@@ -52,7 +52,7 @@ class FilesIdsToFilesTransformer implements DataTransformerInterface
                 try {
                     $files[] = $this->uploadedFileFacade->getById((int)$fileId);
                 } catch (\Shopsys\FrameworkBundle\Component\UploadedFile\Exception\FileNotFoundException $e) {
-                    throw new \Symfony\Component\Form\Exception\TransformationFailedException('File not found', null, $e);
+                    throw new \Symfony\Component\Form\Exception\TransformationFailedException('File not found', 0, $e);
                 }
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Wrong code has been sent to TransformationFailedException as it only accepts integer.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
