### PR TITLE
[framework] add js-symbol-after-input class to symbolAfterInput span

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -1015,7 +1015,7 @@
 
 {% block appendix_block %}
     {% if symbolAfterInput is defined %}
-        <span class="form-line__item form-line__item--text form-line__item--fixed-width-left">{{ symbolAfterInput }}</span>
+        <span class="form-line__item form-line__item--text form-line__item--fixed-width-left js-symbol-after-input">{{ symbolAfterInput }}</span>
     {% endif %}
     {% if attr.icon is defined %}
         <i class="svg svg-{{ attr.iconType|default('info') }} in-icon cursor-help form-line__item form-line__item--info js-tooltip"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| this might be very handy - eg. I want to change the currency symbol after my `Money` input when domain is changed in another form field
|New feature| it is a little tweak
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
