### PR TITLE
[framework] CKEditor is now rendered right in full width

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Form/localizedFullWidth.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/localizedFullWidth.html.twig
@@ -8,10 +8,13 @@
             {% for locale, formName in form.children %}
                 <div class="form-full__field">
                     <div class="input__wrap">
-                        {{ form_widget(formName, { attr: { class: 'input--flag form-full__field__input'} }) }}
-                        <span class="input__flag">
-                            {{ localeFlag(locale) }}
-                        </span>
+                        {{ form_widget(formName, { localized: true, locale: locale, attr: { class: 'input--flag form-full__field__input'} }) }}
+
+                        {% if formName.vars.block_prefixes | slice(-2,1) | first is not same as('ckeditor') %}
+                            <span class="input__flag">
+                                {{ localeFlag(locale) }}
+                            </span>
+                        {% endif %}
                     </div>
                     {{ form_errors(formName) }}
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| CKEditor rendered as full width had flag flowing over first button, this was fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
