### PR TITLE
fix wrong migration on database with data

### DIFF
--- a/packages/framework/src/Migrations/Version20200127085928.php
+++ b/packages/framework/src/Migrations/Version20200127085928.php
@@ -15,13 +15,13 @@ class Version20200127085928 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE delivery_addresses ADD customer_id INT NOT NULL DEFAULT 0');
+        $this->sql('UPDATE delivery_addresses SET customer_id = (SELECT customer_id FROM customer_users WHERE delivery_address_id = delivery_addresses.id)');
         $this->sql('
             ALTER TABLE
                 delivery_addresses
             ADD
                 CONSTRAINT FK_2BAF39849395C3F3 FOREIGN KEY (customer_id) REFERENCES customers (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->sql('CREATE INDEX IDX_2BAF39849395C3F3 ON delivery_addresses (customer_id)');
-        $this->sql('UPDATE delivery_addresses SET customer_id = (SELECT customer_id FROM customer_users WHERE delivery_address_id = delivery_addresses.id)');
         $this->sql('ALTER TABLE customer_users DROP delivery_address_id');
         $this->sql('ALTER TABLE delivery_addresses ALTER customer_id DROP DEFAULT');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| migration does not work on existing database
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

It causes
```
Migration 20200127085928 failed during Execution. Error An exception occurred while executing '
            ALTER TABLE
                delivery_addresses
            ADD
                CONSTRAINT FK_2BAF39849395C3F3 FOREIGN KEY (customer_id) REFERENCES customers (id) NOT DEFERRABLE INITIALLY IMMEDIATE':

SQLSTATE[23503]: Foreign key violation: 7 ERROR:  insert or update on table "delivery_addresses" violates foreign key constraint "fk_2baf39849395c3f3"
DETAIL:  Key (customer_id)=(0) is not present in table "customers".
```
