### PR TITLE
[framework] ProductExportRepository: prevent Undefined offset notice

### DIFF
--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -294,8 +294,11 @@ class ProductExportRepository
     protected function extractCategories(int $domainId, Product $product): array
     {
         $categoryIds = [];
-        foreach ($product->getCategoriesIndexedByDomainId()[$domainId] as $category) {
-            $categoryIds[] = $category->getId();
+        $categoriesIndexedByDomainId = $product->getCategoriesIndexedByDomainId();
+        if (isset($categoriesIndexedByDomainId[$domainId])) {
+            foreach ($categoriesIndexedByDomainId[$domainId] as $category) {
+                $categoryIds[] = $category->getId();
+            }
         }
 
         return $categoryIds;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `$product->getCategoriesIndexedByDomainId` may not contain categories for provided domain ID
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
