### PR TITLE
[framework] used methods for providing config definition classes

### DIFF
--- a/packages/framework/src/Component/Domain/Config/DomainsConfigLoader.php
+++ b/packages/framework/src/Component/Domain/Config/DomainsConfigLoader.php
@@ -29,8 +29,8 @@ class DomainsConfigLoader
      */
     public function loadDomainConfigsFromYaml($domainsConfigFilepath, $domainsUrlsConfigFilepath)
     {
-        $processedConfig = $this->getProcessedConfig($domainsConfigFilepath, new DomainsConfigDefinition());
-        $processedUrlsConfig = $this->getProcessedConfig($domainsUrlsConfigFilepath, new DomainsUrlsConfigDefinition());
+        $processedConfig = $this->getProcessedConfig($domainsConfigFilepath, $this->getDomainsConfigDefinition());
+        $processedUrlsConfig = $this->getProcessedConfig($domainsUrlsConfigFilepath, $this->getDomainsUrlsConfigDefinition());
         $domainConfigsByDomainId = $processedConfig[DomainsConfigDefinition::CONFIG_DOMAINS];
         $domainUrlsConfigsByDomainId = $processedUrlsConfig[DomainsUrlsConfigDefinition::CONFIG_DOMAINS_URLS];
 
@@ -41,9 +41,23 @@ class DomainsConfigLoader
         }
         $processedConfigsWithUrlsByDomainId = $this->addUrlsToProcessedConfig($domainConfigsByDomainId, $domainUrlsConfigsByDomainId);
 
-        $domainConfigs = $this->loadDomainConfigsFromArray($processedConfigsWithUrlsByDomainId);
+        return $this->loadDomainConfigsFromArray($processedConfigsWithUrlsByDomainId);
+    }
 
-        return $domainConfigs;
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigDefinition
+     */
+    protected function getDomainsConfigDefinition(): DomainsConfigDefinition
+    {
+        return new DomainsConfigDefinition();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainsUrlsConfigDefinition
+     */
+    protected function getDomainsUrlsConfigDefinition(): DomainsUrlsConfigDefinition
+    {
+        return new DomainsUrlsConfigDefinition();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| To extend parameters in `domains.yml` and `domains_url.yml`, you need to copy and paste the whole method `loadDomainConfigsFromYaml` with changed config definition classes. This PR adds method for obtaining those classes without need of duplicating the whole original method.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
