### PR TITLE
Fix JS sorting for ProductsType

### DIFF
--- a/packages/framework/assets/js/admin/components/productsPicker.js
+++ b/packages/framework/assets/js/admin/components/productsPicker.js
@@ -82,7 +82,7 @@ export default class ProductsPicker {
         this.$itemsContainer.find('.js-products-picker-item-input').each((index, element) => {
             const name = $(element).attr('name');
             const newName = name.substr(0, name.lastIndexOf('[') + 1) + index + ']';
-            $(this).attr('name', newName);
+            $(element).attr('name', newName);
         });
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Sorting in ProductsType doesn't work and this seems to fix it. 
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
