### PR TITLE
[framework] deliveryAddressChoiceFields.html.twig: fix risk of getter call on null

### DIFF
--- a/packages/framework/src/Resources/views/Front/Form/deliveryAddressChoiceFields.html.twig
+++ b/packages/framework/src/Resources/views/Front/Form/deliveryAddressChoiceFields.html.twig
@@ -16,7 +16,9 @@
                                         {{ deliveryAddress.companyName }}<br>
                                     {% endif %}
                                     {{ deliveryAddress.street }}, {{ deliveryAddress.city }} {{ deliveryAddress.postcode }}<br>
-                                    {{ deliveryAddress.country.name }}<br>
+                                    {% if deliveryAddress.country %}
+                                        {{ deliveryAddress.country.name }}<br>
+                                    {% endif %}
                                 </div>
                                 <div class="list-addresses__item__right">
                                     {% if deliveryAddress.telephone %}

--- a/packages/framework/src/Resources/views/Front/Form/deliveryAddressChoiceFields.html.twig
+++ b/packages/framework/src/Resources/views/Front/Form/deliveryAddressChoiceFields.html.twig
@@ -16,7 +16,7 @@
                                         {{ deliveryAddress.companyName }}<br>
                                     {% endif %}
                                     {{ deliveryAddress.street }}, {{ deliveryAddress.city }} {{ deliveryAddress.postcode }}<br>
-                                    {% if deliveryAddress.country %}
+                                    {% if deliveryAddress.country is not null %}
                                         {{ deliveryAddress.country.name }}<br>
                                     {% endif %}
                                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `DeliveryAddress::$country` is nullable so it might happen that getter on null is called in the template
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
