### PR TITLE
[framework] default product data now have availability set

### DIFF
--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository;
+use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductInputPriceFacade;
@@ -77,6 +78,11 @@ class ProductDataFactory implements ProductDataFactoryInterface
     protected $pricingGroupFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade
+     */
+    protected $availabilityFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductInputPriceFacade $productInputPriceFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
@@ -89,6 +95,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
      * @param \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginDataFormExtensionFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactoryInterface $productParameterValueDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade
      */
     public function __construct(
         VatFacade $vatFacade,
@@ -102,7 +109,8 @@ class ProductDataFactory implements ProductDataFactoryInterface
         ImageFacade $imageFacade,
         PluginCrudExtensionFacade $pluginDataFormExtensionFacade,
         ProductParameterValueDataFactoryInterface $productParameterValueDataFactory,
-        PricingGroupFacade $pricingGroupFacade
+        PricingGroupFacade $pricingGroupFacade,
+        AvailabilityFacade $availabilityFacade
     ) {
         $this->vatFacade = $vatFacade;
         $this->productInputPriceFacade = $productInputPriceFacade;
@@ -116,6 +124,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
         $this->pluginDataFormExtensionFacade = $pluginDataFormExtensionFacade;
         $this->productParameterValueDataFactory = $productParameterValueDataFactory;
         $this->pricingGroupFacade = $pricingGroupFacade;
+        $this->availabilityFacade = $availabilityFacade;
     }
 
     /**
@@ -167,6 +176,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
             $productData->name[$locale] = null;
             $productData->variantAlias[$locale] = null;
         }
+        $productData->availability = $this->availabilityFacade->getDefaultInStockAvailability();
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade;
@@ -95,7 +96,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
      * @param \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginDataFormExtensionFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactoryInterface $productParameterValueDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade|null $availabilityFacade
      */
     public function __construct(
         VatFacade $vatFacade,
@@ -110,7 +111,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
         PluginCrudExtensionFacade $pluginDataFormExtensionFacade,
         ProductParameterValueDataFactoryInterface $productParameterValueDataFactory,
         PricingGroupFacade $pricingGroupFacade,
-        AvailabilityFacade $availabilityFacade
+        ?AvailabilityFacade $availabilityFacade = null
     ) {
         $this->vatFacade = $vatFacade;
         $this->productInputPriceFacade = $productInputPriceFacade;
@@ -125,6 +126,21 @@ class ProductDataFactory implements ProductDataFactoryInterface
         $this->productParameterValueDataFactory = $productParameterValueDataFactory;
         $this->pricingGroupFacade = $pricingGroupFacade;
         $this->availabilityFacade = $availabilityFacade;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade
+     */
+    public function setAvailabilityFacade(AvailabilityFacade $availabilityFacade) {
+        if ($this->availabilityFacade !== null && $this->availabilityFacade !== $availabilityFacade) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->availabilityFacade === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->availabilityFacade = $availabilityFacade;
+        }
     }
 
     /**

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -33,3 +33,26 @@ There you can find links to upgrade notes for other versions too.
 
 - fix wrong translations in CartCest ([#1582](https://github.com/shopsys/shopsys/pull/1582))
     - see #project-base-diff to update your project
+
+- set default availability for ProductData ([#1723](https://github.com/shopsys/shopsys/pull/1723))
+    - following constructor changed its interface:
+        - `ProductDataFactory::__construct()`
+        
+            ```diff
+                public function __construct(
+                    VatFacade $vatFacade,
+                    ProductInputPriceFacade $productInputPriceFacade,
+                    UnitFacade $unitFacade,
+                    Domain $domain,
+                    ProductRepository $productRepository,
+                    ParameterRepository $parameterRepository,
+                    FriendlyUrlFacade $friendlyUrlFacade,
+                    ProductAccessoryRepository $productAccessoryRepository,
+                    ImageFacade $imageFacade,
+                    PluginCrudExtensionFacade $pluginDataFormExtensionFacade,
+                    ProductParameterValueDataFactoryInterface $productParameterValueDataFactory,
+            -       PricingGroupFacade $pricingGroupFacade
+            +       PricingGroupFacade $pricingGroupFacade,
+            +       ?AvailabilityFacade $availabilityFacade = null
+                ) {
+            ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When new `ProductData` are created, `usingStock` [attribute is set to `false` by default](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Product/ProductData.php#L181). Therefore, `$availability` attribute must be set, otherwise invalid product can be created. Related to https://github.com/shopsys/shopsys/pull/1115
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
