### PR TITLE
[shopsys] added transport and payment to frontend API

### DIFF
--- a/packages/framework/src/Migrations/Version20200310120000.php
+++ b/packages/framework/src/Migrations/Version20200310120000.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20200310120000 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->sql('ALTER TABLE payments ADD uuid UUID DEFAULT NULL');
+        $this->sql('UPDATE payments SET uuid = uuid_generate_v4()');
+        $this->sql('ALTER TABLE payments ALTER uuid SET NOT NULL');
+        $this->sql('CREATE UNIQUE INDEX UNIQ_65D29B32D17F50A6 ON payments (uuid)');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20200310130000.php
+++ b/packages/framework/src/Migrations/Version20200310130000.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20200310130000 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->sql('ALTER TABLE transports ADD uuid UUID DEFAULT NULL');
+        $this->sql('UPDATE transports SET uuid = uuid_generate_v4()');
+        $this->sql('ALTER TABLE transports ALTER uuid SET NOT NULL');
+        $this->sql('CREATE UNIQUE INDEX UNIQ_C7BE69E5D17F50A6 ON transports (uuid)');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+    }
+}

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
+use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
@@ -90,6 +91,13 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     protected $domains;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(type="guid", unique=true)
+     */
+    protected $uuid;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $paymentData
      */
     public function __construct(PaymentData $paymentData)
@@ -104,6 +112,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
         $this->prices = new ArrayCollection();
         $this->czkRounding = $paymentData->czkRounding;
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
+        $this->uuid = $paymentData->uuid ?: Uuid::uuid4()->toString();
     }
 
     /**
@@ -380,5 +389,13 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
 
         $message = 'Payment price for domain ID ' . $domainId . ' and payment ID ' . $this->getId() . 'not found.';
         throw new \Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentPriceNotFoundException($message);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid(): string
+    {
+        return $this->uuid;
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentData.php
+++ b/packages/framework/src/Model/Payment/PaymentData.php
@@ -56,6 +56,11 @@ class PaymentData
      */
     public $vatsIndexedByDomainId;
 
+    /**
+     * @var string|null
+     */
+    public $uuid;
+
     public function __construct()
     {
         $this->name = [];

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -273,5 +275,14 @@ class PaymentFacade
         }
 
         return $prices;
+    }
+
+    /**
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Payment\Payment
+     */
+    public function getByUuid(string $uuid): Payment
+    {
+        return $this->paymentRepository->getOneByUuid($uuid);
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentRepository.php
+++ b/packages/framework/src/Model/Payment/PaymentRepository.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentNotFoundException;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
 class PaymentRepository
@@ -94,5 +97,20 @@ class PaymentRepository
             ->andWhere('t = :transport')->setParameter('transport', $transport)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Payment\Payment
+     */
+    public function getOneByUuid(string $uuid): Payment
+    {
+        $payment = $this->getPaymentRepository()->findOneBy(['uuid' => $uuid]);
+
+        if ($payment === null) {
+            throw new PaymentNotFoundException('Payment with UUID ' . $uuid . ' does not exist.');
+        }
+
+        return $payment;
     }
 }

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\ManyToMany;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
+use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Grid\Ordering\OrderableEntityInterface;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
@@ -82,6 +83,13 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
     protected $payments;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(type="guid", unique=true)
+     */
+    protected $uuid;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportData $transportData
      */
     public function __construct(TransportData $transportData)
@@ -95,6 +103,7 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
         $this->prices = new ArrayCollection();
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->payments = new ArrayCollection();
+        $this->uuid = $transportData->uuid ?: Uuid::uuid4()->toString();
     }
 
     /**
@@ -361,5 +370,13 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
 
         $message = 'Transport price with domain ID ' . $domainId . ' and payment ID ' . $this->getId() . 'not found.';
         throw new \Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentPriceNotFoundException($message);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid(): string
+    {
+        return $this->uuid;
     }
 }

--- a/packages/framework/src/Model/Transport/TransportData.php
+++ b/packages/framework/src/Model/Transport/TransportData.php
@@ -51,6 +51,11 @@ class TransportData
      */
     public $vatsIndexedByDomainId;
 
+    /**
+     * @var string|null
+     */
+    public $uuid;
+
     public function __construct()
     {
         $this->name = [];

--- a/packages/framework/src/Model/Transport/TransportFacade.php
+++ b/packages/framework/src/Model/Transport/TransportFacade.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Transport;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -268,5 +270,14 @@ class TransportFacade
         }
 
         return $prices;
+    }
+
+    /**
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Transport\Transport
+     */
+    public function getByUuid(string $uuid): Transport
+    {
+        return $this->transportRepository->getOneByUuid($uuid);
     }
 }

--- a/packages/framework/src/Model/Transport/TransportRepository.php
+++ b/packages/framework/src/Model/Transport/TransportRepository.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle\Model\Transport;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Model\Transport\Exception\TransportNotFoundException;
 
 class TransportRepository
 {
@@ -107,6 +108,21 @@ class TransportRepository
             throw new \Shopsys\FrameworkBundle\Model\Transport\Exception\TransportNotFoundException(
                 'Transport with ID ' . $id . ' not found.'
             );
+        }
+
+        return $transport;
+    }
+
+    /**
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Transport\Transport
+     */
+    public function getOneByUuid(string $uuid): Transport
+    {
+        $transport = $this->getTransportRepository()->findOneBy(['uuid' => $uuid]);
+
+        if ($transport === null) {
+            throw new TransportNotFoundException('Transport with UUID ' . $uuid . ' does not exist.');
         }
 
         return $transport;

--- a/packages/frontend-api/easy-coding-standard.yml
+++ b/packages/frontend-api/easy-coding-standard.yml
@@ -20,3 +20,4 @@ parameters:
 
         PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff:
             - '*src/Model/Resolver/Payment/*'
+            - '*src/Model/Resolver/Transport/*'

--- a/packages/frontend-api/easy-coding-standard.yml
+++ b/packages/frontend-api/easy-coding-standard.yml
@@ -17,3 +17,6 @@ parameters:
     skip:
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:
             - '*/tests/*'
+
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\DisallowMultipleAssignmentsSniff:
+            - '*src/Model/Resolver/Payment/*'

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -11,12 +11,14 @@ use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Model\Category\Category;
+use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ImagesResolver implements ResolverInterface
 {
     protected const IMAGE_ENTITY_PRODUCT = 'product';
     protected const IMAGE_ENTITY_CATEGORY = 'category';
+    protected const IMAGE_ENTITY_PAYMENT = 'payment';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
@@ -69,6 +71,17 @@ class ImagesResolver implements ResolverInterface
     public function resolveByCategory(Category $category, ?string $type, ?string $size): array
     {
         return $this->resolveByEntityId($category->getId(), static::IMAGE_ENTITY_CATEGORY, $type, $size);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Payment\Payment $payment
+     * @param string|null $type
+     * @param string|null $size
+     * @return array
+     */
+    public function resolveByPayment(Payment $payment, ?string $type, ?string $size): array
+    {
+        return $this->resolveByEntityId($payment->getId(), static::IMAGE_ENTITY_PAYMENT, $type, $size);
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -13,12 +13,14 @@ use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
 class ImagesResolver implements ResolverInterface
 {
     protected const IMAGE_ENTITY_PRODUCT = 'product';
     protected const IMAGE_ENTITY_CATEGORY = 'category';
     protected const IMAGE_ENTITY_PAYMENT = 'payment';
+    protected const IMAGE_ENTITY_TRANSPORT = 'transport';
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Image\ImageFacade
@@ -82,6 +84,17 @@ class ImagesResolver implements ResolverInterface
     public function resolveByPayment(Payment $payment, ?string $type, ?string $size): array
     {
         return $this->resolveByEntityId($payment->getId(), static::IMAGE_ENTITY_PAYMENT, $type, $size);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
+     * @param string|null $type
+     * @param string|null $size
+     * @return array
+     */
+    public function resolveByTransport(Transport $transport, ?string $type, ?string $size): array
+    {
+        return $this->resolveByEntityId($transport->getId(), static::IMAGE_ENTITY_TRANSPORT, $type, $size);
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Payment;
+
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Error\UserError;
+use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Payment\Payment;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
+
+class PaymentResolver implements ResolverInterface, AliasedInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade
+     */
+    protected $paymentFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(PaymentFacade $paymentFacade, Domain $domain)
+    {
+        $this->paymentFacade = $paymentFacade;
+        $this->domain = $domain;
+    }
+
+    /**
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Payment\Payment
+     */
+    public function resolver(string $uuid): Payment
+    {
+        if (Uuid::isValid($uuid) === false) {
+            throw new UserError('Provided argument is not valid UUID.');
+        }
+
+        try {
+            return $this->paymentFacade->getByUuid($uuid);
+        } catch (\Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentNotFoundException $paymentNotFoundException) {
+            throw new UserError($paymentNotFoundException->getMessage());
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases(): array
+    {
+        return [
+            'resolver' => 'payment',
+        ];
+    }
+}

--- a/packages/frontend-api/src/Model/Resolver/Payment/PaymentsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/PaymentsResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Payment;
+
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
+
+class PaymentsResolver implements ResolverInterface, AliasedInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade
+     */
+    protected $paymentFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
+     */
+    public function __construct(PaymentFacade $paymentFacade)
+    {
+        $this->paymentFacade = $paymentFacade;
+    }
+
+    /**
+     * @return array
+     */
+    public function resolve(): array
+    {
+        return $payments = $this->paymentFacade->getVisibleOnCurrentDomain();
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases(): array
+    {
+        return [
+            'resolve' => 'payments',
+        ];
+    }
+}

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
@@ -15,6 +15,8 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+use Shopsys\FrameworkBundle\Model\Transport\Transport;
+use Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation;
 
 class PriceResolver implements ResolverInterface, AliasedInterface
 {
@@ -44,24 +46,32 @@ class PriceResolver implements ResolverInterface, AliasedInterface
     protected $currencyFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation
+     */
+    protected $transportPriceCalculation;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade $productCachedAttributesFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation $paymentPriceCalculation
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation $transportPriceCalculation
      */
     public function __construct(
         ProductCachedAttributesFacade $productCachedAttributesFacade,
         ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade,
         PaymentPriceCalculation $paymentPriceCalculation,
         Domain $domain,
-        CurrencyFacade $currencyFacade
+        CurrencyFacade $currencyFacade,
+        TransportPriceCalculation $transportPriceCalculation
     ) {
         $this->productCachedAttributesFacade = $productCachedAttributesFacade;
         $this->productOnCurrentDomainFacade = $productOnCurrentDomainFacade;
         $this->paymentPriceCalculation = $paymentPriceCalculation;
         $this->domain = $domain;
         $this->currencyFacade = $currencyFacade;
+        $this->transportPriceCalculation = $transportPriceCalculation;
     }
 
     /**
@@ -82,6 +92,19 @@ class PriceResolver implements ResolverInterface, AliasedInterface
     {
         return $this->paymentPriceCalculation->calculateIndependentPrice(
             $payment,
+            $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId()),
+            $this->domain->getId()
+        );
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
+     */
+    public function resolveByTransport(Transport $transport): Price
+    {
+        return $this->transportPriceCalculation->calculateIndependentPrice(
+            $transport,
             $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId()),
             $this->domain->getId()
         );

--- a/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Transport;
+
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Error\UserError;
+use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Transport\Transport;
+use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
+
+class TransportResolver implements ResolverInterface, AliasedInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade
+     */
+    protected $transportFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(TransportFacade $transportFacade, Domain $domain)
+    {
+        $this->transportFacade = $transportFacade;
+        $this->domain = $domain;
+    }
+
+    /**
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Transport\Transport
+     */
+    public function resolver(string $uuid): Transport
+    {
+        if (Uuid::isValid($uuid) === false) {
+            throw new UserError('Provided argument is not valid UUID.');
+        }
+
+        try {
+            return $this->transportFacade->getByUuid($uuid);
+        } catch (\Shopsys\FrameworkBundle\Model\Transport\Exception\TransportNotFoundException $transportNotFoundException) {
+            throw new UserError($transportNotFoundException->getMessage());
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases(): array
+    {
+        return [
+            'resolver' => 'transport',
+        ];
+    }
+}

--- a/packages/frontend-api/src/Model/Resolver/Transport/TransportsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/TransportsResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Transport;
+
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
+use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
+
+class TransportsResolver implements ResolverInterface, AliasedInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade
+     */
+    protected $transportFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade
+     */
+    protected $paymentFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
+     */
+    public function __construct(TransportFacade $transportFacade, PaymentFacade $paymentFacade)
+    {
+        $this->transportFacade = $transportFacade;
+        $this->paymentFacade = $paymentFacade;
+    }
+
+    /**
+     * @return array
+     */
+    public function resolve(): array
+    {
+        return $transports = $this->transportFacade->getVisibleOnCurrentDomain($this->paymentFacade->getVisibleOnCurrentDomain());
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases(): array
+    {
+        return [
+            'resolve' => 'transports',
+        ];
+    }
+}

--- a/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yml
@@ -33,3 +33,6 @@ PaymentDecorator:
                         defaultValue: null
                     size:
                         type: "String"
+            transports:
+                type: "[Transport!]!"
+                description: "List of assigned transports"

--- a/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yml
@@ -1,0 +1,35 @@
+PaymentDecorator:
+    type: interface
+    decorator: true
+    config:
+        description: "Represents a payment"
+        fields:
+            uuid:
+                type: "ID!"
+                description: "UUID"
+            name:
+                type: "String!"
+                description: "Payment name"
+            description:
+                type: "String"
+                description: "Localized payment description (domain dependent)"
+            instruction:
+                type: "String"
+                description: "Localized payment instruction (domain dependent)"
+            position:
+                type: "Int!"
+                description: "Payment position"
+            price:
+                type: "Price"
+                description: "Payment price"
+                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByPayment(value)'
+            images:
+                type: "[Image]!"
+                description: "Payment images"
+                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByPayment(value, args["type"], args["size"])'
+                args:
+                    type:
+                        type: "String"
+                        defaultValue: null
+                    size:
+                        type: "String"

--- a/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yml
@@ -24,3 +24,12 @@ QueryDecorator:
                 args:
                     uuid:
                         type: "ID!"
+            payments:
+                type: '[Payment!]!'
+                resolve: "@=resolver('payments')"
+            payment:
+                type: 'Payment'
+                resolve: "@=resolver('payment', [args['uuid']])"
+                args:
+                    uuid:
+                        type: "ID!"

--- a/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yml
@@ -33,3 +33,12 @@ QueryDecorator:
                 args:
                     uuid:
                         type: "ID!"
+            transports:
+                type: '[Transport!]!'
+                resolve: "@=resolver('transports')"
+            transport:
+                type: 'Transport'
+                resolve: "@=resolver('transport', [args['uuid']])"
+                args:
+                    uuid:
+                        type: "ID!"

--- a/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yml
@@ -33,3 +33,6 @@ TransportDecorator:
                         defaultValue: null
                     size:
                         type: "String"
+            payments:
+                type: "[Payment!]!"
+                description: "List of assigned payments"

--- a/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yml
@@ -1,0 +1,35 @@
+TransportDecorator:
+    type: interface
+    decorator: true
+    config:
+        description: "Represents a transport"
+        fields:
+            uuid:
+                type: "ID!"
+                description: "UUID"
+            name:
+                type: "String!"
+                description: "Transport name"
+            description:
+                type: "String"
+                description: "Localized transport description (domain dependent)"
+            instruction:
+                type: "String"
+                description: "Localized transport instruction (domain dependent)"
+            position:
+                type: "Int!"
+                description: "Transport position"
+            price:
+                type: "Price"
+                description: "Transport price"
+                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByTransport(value)'
+            images:
+                type: "[Image]!"
+                description: "Transport images"
+                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByTransport(value, args["type"], args["size"])'
+                args:
+                    type:
+                        type: "String"
+                        defaultValue: null
+                    size:
+                        type: "String"

--- a/project-base/config/graphql/types/Payment.types.yml
+++ b/project-base/config/graphql/types/Payment.types.yml
@@ -1,0 +1,4 @@
+Payment:
+    type: object
+    inherits:
+        - 'PaymentDecorator'

--- a/project-base/config/graphql/types/Transport.types.yml
+++ b/project-base/config/graphql/types/Transport.types.yml
@@ -1,0 +1,4 @@
+Transport:
+    type: object
+    inherits:
+        - 'TransportDecorator'

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -26,6 +26,7 @@ parameters:
             - '*/tests/App/Functional/Model/Cart/CartMigrationFacadeTest.php'
             - '*/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php'
             - '*/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php'
+            - '*/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php'
 
         ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff:
             - '*/tests/App/Functional/Model/Product/ProductVisibilityRepositoryTest.php'

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -25,6 +25,7 @@ parameters:
             - '*/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php'
             - '*/tests/App/Functional/Model/Cart/CartMigrationFacadeTest.php'
             - '*/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php'
+            - '*/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php'
 
         ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff:
             - '*/tests/App/Functional/Model/Product/ProductVisibilityRepositoryTest.php'

--- a/project-base/tests/FrontendApiBundle/Functional/Category/CategoryTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Category/CategoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Category;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
@@ -126,13 +125,5 @@ class CategoryTest extends GraphQlTestCase
         ];
 
         $this->assertQueryWithExpectedArray($query, $arrayExpected);
-    }
-
-    /**
-     * @return string
-     */
-    private function getLocaleForFirstDomain(): string
-    {
-        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Payment;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class PaymentTest extends GraphQlTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade
+     * @inject
+     */
+    protected $paymentFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Payment\Payment
+     */
+    protected $payment;
+
+    protected function setUp(): void
+    {
+        $this->payment = $this->paymentFacade->getById(2);
+
+        parent::setUp();
+    }
+
+    public function testPaymentNameByUuid(): void
+    {
+        $query = '
+            query {
+                payment(uuid: "' . $this->payment->getUuid() . '") {
+                    name
+                }
+            }
+        ';
+
+        $arrayExpected = [
+            'data' => [
+                'payment' => [
+                    'name' => t('Cash on delivery', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                ],
+            ],
+        ];
+
+        $this->assertQueryWithExpectedArray($query, $arrayExpected);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLocaleForFirstDomain(): string
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Payment;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class PaymentTest extends GraphQlTestCase
@@ -46,13 +45,5 @@ class PaymentTest extends GraphQlTestCase
         ];
 
         $this->assertQueryWithExpectedArray($query, $arrayExpected);
-    }
-
-    /**
-     * @return string
-     */
-    protected function getLocaleForFirstDomain(): string
-    {
-        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Payment;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class PaymentsTest extends GraphQlTestCase
@@ -96,13 +95,5 @@ class PaymentsTest extends GraphQlTestCase
         ];
 
         $this->assertQueryWithExpectedArray($query, $arrayExpected);
-    }
-
-    /**
-     * @return string
-     */
-    protected function getLocaleForFirstDomain(): string
-    {
-        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Payment;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class PaymentsTest extends GraphQlTestCase
+{
+    public function testPayments(): void
+    {
+        $query = '
+            query {
+                payments {
+                    name,
+                    description,
+                    instruction,
+                    position,
+                    price {
+                        priceWithVat
+                        priceWithoutVat
+                        vatAmount
+                    },
+                    images {
+                        url
+                    },
+                    transports {
+                        name
+                    }
+                }
+            }
+        ';
+
+        $arrayExpected = [
+            'data' => [
+                'payments' => [
+                    [
+                        'name' => t('Credit card', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'description' => t('Quick, cheap and reliable!', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'instruction' => null,
+                        'position' => 0,
+                        'price' => [
+                            'priceWithVat' => '100',
+                            'priceWithoutVat' => '100.00',
+                            'vatAmount' => '0.00',
+                        ],
+                        'images' => [
+                            ['url' => 'http://webserver:8080/content-test/images/payment/default/53.jpg'],
+                            ['url' => 'http://webserver:8080/content-test/images/payment/original/53.jpg'],
+                        ],
+                        'transports' => [
+                            ['name' => t('PPL', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                            ['name' => t('Personal collection', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                        ],
+                    ],
+                    [
+                        'name' => t('Cash on delivery', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'description' => null,
+                        'instruction' => null,
+                        'position' => 1,
+                        'price' => [
+                            'priceWithVat' => '50',
+                            'priceWithoutVat' => '50.00',
+                            'vatAmount' => '0.00',
+                        ],
+                        'images' => [
+                            ['url' => 'http://webserver:8080/content-test/images/payment/default/55.jpg'],
+                            ['url' => 'http://webserver:8080/content-test/images/payment/original/55.jpg'],
+                        ],
+                        'transports' => [
+                            ['name' => t('Czech post', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                        ],
+                    ],
+                    [
+                        'name' => t('Cash', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'description' => null,
+                        'instruction' => null,
+                        'position' => 2,
+                        'price' => [
+                            'priceWithVat' => '0',
+                            'priceWithoutVat' => '0',
+                            'vatAmount' => '0',
+                        ],
+                        'images' => [
+                            ['url' => 'http://webserver:8080/content-test/images/payment/default/54.jpg'],
+                            ['url' => 'http://webserver:8080/content-test/images/payment/original/54.jpg'],
+                        ],
+                        'transports' => [
+                            ['name' => t('Personal collection', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertQueryWithExpectedArray($query, $arrayExpected);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLocaleForFirstDomain(): string
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
@@ -55,13 +55,13 @@ class ProductVariantTest extends GraphQlTestCase
                     'shortDescription' => t('Television monitor IPS, 16: 9, 5M: 1, 200cd/m2, 5ms GTG, FullHD 1920x1080, DVB-S2/T2/C, 2x HDMI, USB, SCART, 2 x 5W speakers, energ. Class A', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
                     'variants' => [
                         [
-                            'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                            'name' => t('51,5” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
                         ],
                         [
                             'name' => t('60” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
                         ],
                         [
-                            'name' => t('51,5” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                            'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
                         ],
                     ],
                 ],

--- a/project-base/tests/FrontendApiBundle/Functional/Transport/TransportTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Transport/TransportTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Transport;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class TransportTest extends GraphQlTestCase
@@ -46,13 +45,5 @@ class TransportTest extends GraphQlTestCase
         ];
 
         $this->assertQueryWithExpectedArray($query, $arrayExpected);
-    }
-
-    /**
-     * @return string
-     */
-    protected function getLocaleForFirstDomain(): string
-    {
-        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Transport/TransportTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Transport/TransportTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Transport;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class TransportTest extends GraphQlTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade
+     * @inject
+     */
+    protected $transportFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Transport\Transport
+     */
+    protected $transport;
+
+    protected function setUp(): void
+    {
+        $this->transport = $this->transportFacade->getById(2);
+
+        parent::setUp();
+    }
+
+    public function testTransportNameByUuid(): void
+    {
+        $query = '
+            query {
+                transport(uuid: "' . $this->transport->getUuid() . '") {
+                    name
+                }
+            }
+        ';
+
+        $arrayExpected = [
+            'data' => [
+                'transport' => [
+                    'name' => t('PPL', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                ],
+            ],
+        ];
+
+        $this->assertQueryWithExpectedArray($query, $arrayExpected);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLocaleForFirstDomain(): string
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Transport;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class TransportsTest extends GraphQlTestCase
@@ -96,13 +95,5 @@ class TransportsTest extends GraphQlTestCase
         ];
 
         $this->assertQueryWithExpectedArray($query, $arrayExpected);
-    }
-
-    /**
-     * @return string
-     */
-    protected function getLocaleForFirstDomain(): string
-    {
-        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Transport;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class TransportsTest extends GraphQlTestCase
+{
+    public function testPayments(): void
+    {
+        $query = '
+            query {
+                transports {
+                    name,
+                    description,
+                    instruction,
+                    position,
+                    price {
+                        priceWithVat
+                        priceWithoutVat
+                        vatAmount
+                    },
+                    images {
+                        url
+                    },
+                    payments {
+                        name
+                    }
+                }
+            }
+        ';
+
+        $arrayExpected = [
+            'data' => [
+                'transports' => [
+                    [
+                        'name' => t('Czech post', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'description' => null,
+                        'instruction' => null,
+                        'position' => 0,
+                        'price' => [
+                            'priceWithVat' => '121',
+                            'priceWithoutVat' => '100.00',
+                            'vatAmount' => '21.00',
+                        ],
+                        'images' => [
+                            ['url' => 'http://webserver:8080/content-test/images/transport/default/56.jpg'],
+                            ['url' => 'http://webserver:8080/content-test/images/transport/original/56.jpg'],
+                        ],
+                        'payments' => [
+                            ['name' => t('Cash on delivery', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                        ],
+                    ],
+                    [
+                        'name' => t('PPL', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'description' => null,
+                        'instruction' => null,
+                        'position' => 1,
+                        'price' => [
+                            'priceWithVat' => '242',
+                            'priceWithoutVat' => '200.00',
+                            'vatAmount' => '42.00',
+                        ],
+                        'images' => [
+                            ['url' => 'http://webserver:8080/content-test/images/transport/default/57.jpg'],
+                            ['url' => 'http://webserver:8080/content-test/images/transport/original/57.jpg'],
+                        ],
+                        'payments' => [
+                            ['name' => t('Credit card', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                        ],
+                    ],
+                    [
+                        'name' => t('Personal collection', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'description' => t('You will be welcomed by friendly staff!', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
+                        'instruction' => null,
+                        'position' => 2,
+                        'price' => [
+                            'priceWithVat' => '0',
+                            'priceWithoutVat' => '0',
+                            'vatAmount' => '0',
+                        ],
+                        'images' => [
+                            ['url' => 'http://webserver:8080/content-test/images/transport/default/58.jpg'],
+                            ['url' => 'http://webserver:8080/content-test/images/transport/original/58.jpg'],
+                        ],
+                        'payments' => [
+                            ['name' => t('Credit card', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                            ['name' => t('Cash', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertQueryWithExpectedArray($query, $arrayExpected);
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLocaleForFirstDomain(): string
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Test;
 
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\App\Test\FunctionalTestCase;
 
@@ -86,5 +87,13 @@ abstract class GraphQlTestCase extends FunctionalTestCase
         );
 
         return $this->client->getResponse();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLocaleForFirstDomain(): string
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }
 }

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1124,6 +1124,9 @@ There you can find links to upgrade notes for other versions too.
 - update your aplication to do not change product availability to default when availability can not be calculated immediately ([#1659](https://github.com/shopsys/shopsys/pull/1659))
     - see #project-base-diff to update your project
 
+- update your application to include transports and payments in your frontend API ([#1726](https://github.com/shopsys/shopsys/pull/1726))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to add orders to frontend API, in order to do that we need other connected entities to be on API too. This PR adds first of them - transport and payment
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
