### PR TITLE
[framework] file upload: add NotBlank contraints for "currentFilenamesIndexedById" and "uploadedFilenames" fields

### DIFF
--- a/packages/framework/src/Form/AbstractFileUploadType.php
+++ b/packages/framework/src/Form/AbstractFileUploadType.php
@@ -114,6 +114,7 @@ class AbstractFileUploadType extends AbstractType implements DataTransformerInte
                 'allow_add' => true,
                 'entry_options' => [
                     'constraints' => [
+                        new Constraints\NotBlank(['message' => 'Please enter the filename']),
                         new Constraints\Length(['max' => 245, 'maxMessage' => 'File name cannot be longer than {{ limit }} characters']),
                     ],
                 ],

--- a/packages/framework/src/Form/FileUploadType.php
+++ b/packages/framework/src/Form/FileUploadType.php
@@ -102,6 +102,7 @@ class FileUploadType extends AbstractType
                     'entry_type' => TextType::class,
                     'entry_options' => [
                         'constraints' => [
+                            new Constraints\NotBlank(['message' => 'Please enter the filename']),
                             new Constraints\Length(['max' => 245, 'maxMessage' => 'File name cannot be longer than {{ limit }} characters']),
                         ],
                     ],

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -322,6 +322,9 @@ msgstr "Vyplňte prosím předmět"
 msgid "Please enter telephone number"
 msgstr "Vyplňte prosím telefon"
 
+msgid "Please enter the filename"
+msgstr "Prosím vyplňte název souboru"
+
 msgid "Please enter total price with VAT"
 msgstr "Vyplňte prosím celkovou cenu s DPH"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -322,6 +322,9 @@ msgstr ""
 msgid "Please enter telephone number"
 msgstr ""
 
+msgid "Please enter the filename"
+msgstr ""
+
 msgid "Please enter total price with VAT"
 msgstr ""
 


### PR DESCRIPTION
- otherwise, when the file name is empty, the application fails on type error:
	- UploadedFile::setNameAndSlug() must be of the type string, null given

| Q             | A
| ------------- | ---
|Description, reason for the PR| the "not blank" constraints are essential
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
