### PR TITLE
[read-model] ProductActionView creation: use calculatedSellingDenied

### DIFF
--- a/packages/read-model/src/Product/Action/ProductActionViewFactory.php
+++ b/packages/read-model/src/Product/Action/ProductActionViewFactory.php
@@ -37,7 +37,7 @@ class ProductActionViewFactory
     {
         return $this->create(
             $product->getId(),
-            $product->isSellingDenied(),
+            $product->getCalculatedSellingDenied(),
             $product->isMainVariant(),
             $absoluteUrl
         );
@@ -51,7 +51,7 @@ class ProductActionViewFactory
     {
         return $this->create(
             $productArray['id'],
-            $productArray['selling_denied'],
+            $productArray['calculated_selling_denied'],
             $productArray['is_main_variant'],
             $productArray['detail_url']
         );

--- a/packages/read-model/tests/Unit/Product/Action/ProductActionViewFacadeTest.php
+++ b/packages/read-model/tests/Unit/Product/Action/ProductActionViewFacadeTest.php
@@ -54,7 +54,7 @@ class ProductActionViewFacadeTest extends TestCase
         $productMock = $this->createMock(Product::class);
 
         $productMock->method('getId')->willReturn($id);
-        $productMock->method('isSellingDenied')->willReturn(false);
+        $productMock->method('getCalculatedSellingDenied')->willReturn(false);
         $productMock->method('isMainVariant')->willReturn(false);
 
         return $productMock;

--- a/packages/read-model/tests/Unit/Product/Action/ProductActionViewFactoryTest.php
+++ b/packages/read-model/tests/Unit/Product/Action/ProductActionViewFactoryTest.php
@@ -16,7 +16,7 @@ class ProductActionViewFactoryTest extends TestCase
         $productMock = $this->createMock(Product::class);
 
         $productMock->method('getId')->willReturn(1);
-        $productMock->method('isSellingDenied')->willReturn(false);
+        $productMock->method('getCalculatedSellingDenied')->willReturn(false);
         $productMock->method('isMainVariant')->willReturn(false);
 
         $productActionViewFactory = new ProductActionViewFactory();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If I am not mistaken, `productActionView.sellingDenied` is used on one place only - https://github.com/shopsys/shopsys/blob/master/project-base/templates/Front/Inline/Cart/productAction.html.twig#L7. It does not make sense to use the value of product's `sellingDenied` attribute directly, we should use the calculated attribute. The reason is following: When a product is sold out and has "out of stock action" set to "exclude from sale" (i.e. `sellingDenied` might be `false`, but `calculatedSellingDenied` is `true` in such a case), "Product no longer on sale" should be displayed in product list as well.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No, but maybe it should be mentioned in upgrade notes anyway <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

If this is approved, it raises another question - what is `selling_denied` good for in Elastic? I would say it is useless and might be removed.
