### PR TITLE
[shopsys] jms/translation-bundle fixed to version 1.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "jdorn/sql-formatter": "^1.2",
         "jms/metadata": "^1.6",
         "jms/serializer-bundle": "^2.4",
-        "jms/translation-bundle": "^1.4.4",
+        "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "league/flysystem": "^1.0",

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -42,7 +42,7 @@
     <property name="path.web.styles.styleguide" value="${path.web}/assets/styleguide/styles"/>
     <property name="path.yaml-standards.executable" value="${path.bin}/yaml-standards"/>
     <property name="phpstan.level" value="4"/>
-    <property name="phpstan.memory-limit" value="512M"/>
+    <property name="phpstan.memory-limit" value="2048M"/>
     <property name="translations.dump.locales" value="en cs" description="This property is @deprecated, see 'domains-info-load' target instead."/>
     <property name="translations.dump.flags" value="--keep"/>
     <property name="yaml-standards.indent-count" value="4"/>

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -62,7 +62,7 @@
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/metadata": "^1.6",
-        "jms/translation-bundle": "^1.4.4",
+        "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "league/flysystem": "^1.0",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -52,7 +52,7 @@
         "incenteev/composer-parameter-handler": "^2.1.3",
         "intervention/image": "^2.3.14",
         "jms/serializer-bundle": "^2.4",
-        "jms/translation-bundle": "^1.4.4",
+        "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "league/flysystem": "^1.0",
         "phing/phing": "^2.16.1",

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1329,7 +1329,7 @@ There you can find links to upgrade notes for other versions too.
     - these constants were removed so you might need to update your application appropriately:
         - `Roles::ROLE_ADMIN_AS_CUSTOMER`
 
-- fixed your version of jms/translation-bundle to 1.4.4 ([#1732](https://github.com/shopsys/shopsys/pull/1732))
+- fix your version of jms/translation-bundle to 1.4.4 in order to prevent problems with translations dumping ([#1732](https://github.com/shopsys/shopsys/pull/1732))
     - see #project-base-diff to update your project
 
 ### Tools

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1329,6 +1329,9 @@ There you can find links to upgrade notes for other versions too.
     - these constants were removed so you might need to update your application appropriately:
         - `Roles::ROLE_ADMIN_AS_CUSTOMER`
 
+- fixed your version of jms/translation-bundle to 1.4.4 ([#1732](https://github.com/shopsys/shopsys/pull/1732))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| New version of JMS/translation-bundle broke dumping translations.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
