### PR TITLE
[project-base] fixed phpstan.neon

### DIFF
--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -6,19 +6,19 @@ parameters:
         -
             # We need to have undefined variable for testing purposes
             message: '#^Undefined variable: \$undefined$#'
-            path: %currentWorkingDirectory%/project-base/src/Controller/Test/ErrorHandlerController.php
+            path: %currentWorkingDirectory%/src/Controller/Test/ErrorHandlerController.php
         -
             # We need to have undefined variable for testing purposes
             message: '#^Expression "\$undefined\[42\]" on a separate line does not do anything\.$#'
-            path: %currentWorkingDirectory%/project-base/src/Controller/Test/ErrorHandlerController.php
+            path: %currentWorkingDirectory%/src/Controller/Test/ErrorHandlerController.php
         -
             # Ignore annotations in generated code
             message: '#^PHPDoc tag @(param|return) has invalid value (.|\n)+ expected type at offset \d+$#'
-            path: %currentWorkingDirectory%/project-base/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php
+            path: %currentWorkingDirectory%/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php
         -
             # Ignore annotations in generated code
             message: '#^PHPDoc tag @throws with type .+ is not subtype of Throwable$#'
-            path: %currentWorkingDirectory%/project-base/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php
+            path: %currentWorkingDirectory%/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php
 includes:
     - vendor/phpstan/phpstan-doctrine/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With upgrading to symfony4 we made a mistake in phpstan file in project-base. This PR fixed it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
