### PR TITLE
[framework] categories with empty name are now considered not visible

### DIFF
--- a/packages/framework/src/Model/Category/CategoryVisibilityRepository.php
+++ b/packages/framework/src/Model/Category/CategoryVisibilityRepository.php
@@ -109,7 +109,7 @@ class CategoryVisibilityRepository
                 SET visible = (
                     cd.enabled = TRUE
                     AND
-                    ct.name IS NOT NULL
+                    (ct.name IS NOT NULL OR ct.name != '')
                     AND
                     parent_cd.visible = TRUE
                 )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When importing data from IS, it might happen easily that you persist empty string for your category name. Thanks to the original condition (`ct.name IS NOT NULL`), such a category is considered visible then, because it is not null indeed, however, that is just wrong. This PR improves the condition for category visibility calculation - category with the empty name should not be visible as well. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

It might be a good idea to inspect the codebase for similar conditions :thinking: 
