### PR TITLE
[shopsys] Upgrade PHP to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "ramsey/uuid": "^3.8",
         "roave/better-reflection": "^3.5",
         "sensiolabs/security-checker": "^6.0",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/ordered-form": "^4.0",
         "shopsys/postgres-search-bundle": "^0.2",
         "snc/redis-bundle": "^2.1.8",

--- a/docs/installation/application-requirements.md
+++ b/docs/installation/application-requirements.md
@@ -4,7 +4,7 @@ To be able to install, develop and run Shopsys Framework, the system should have
 ## Linux / MacOS / WSL
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PostgreSQL 12.1](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
-* [PHP 7.2 - 7.3](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
+* [PHP 7.2 - 7.4](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 * [Composer](https://getcomposer.org/doc/00-intro.md#globally)
 * [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
 * [Redis](https://redis.io/topics/quickstart)
@@ -18,7 +18,7 @@ To be able to install, develop and run Shopsys Framework, the system should have
 ## Windows
 * [GIT](https://git-scm.com/download/win)
 * [PostgreSQL 12.1](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
-* [PHP 7.2 - 7.3](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
+* [PHP 7.2 - 7.4](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows)
 * [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
 * [Redis](https://github.com/MicrosoftArchive/redis/releases)

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -153,7 +153,7 @@ See [Outgoing emails](https://github.com/djfarrelly/MailDev#outgoing-email) in t
 Yes, you can! Check [the quick guide](./running-acceptance-tests.md#how-to-watch-what-is-going-on-in-the-selenium-browser).
 
 ## Why is there a faked PHP 7.2 platform in the Composer config?
-As a general rule, packages and libraries that depend on PHP 7.2 will work as expected even on PHP 7.3 (any higher 7.x version), but not vice versa.
+As a general rule, packages and libraries that depend on PHP 7.2 will work as expected even on PHP 7.4 (any higher 7.x version), but not vice versa.
 Mainteiners of PHP are focusing on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration73.incompatible.php) introduced in PHP 7.3, in practice it doesn't cause issues).
 
 Using [the `config.platform.php` option](https://getcomposer.org/doc/06-config.md#platform) in `composer.json` allows us to force Composer to install such dependencies, that work for all supported versions of PHP by Shopsys Framework.

--- a/docs/introduction/shopsys-framework-on-docker.md
+++ b/docs/introduction/shopsys-framework-on-docker.md
@@ -68,7 +68,7 @@ kind of recipe by which final image is cooked.
 
 Dockerfile example command:
 ```dockerfile
-FROM php:7.3-fpm-stretch
+FROM php:7.4-fpm-buster
 ```
 
 !!! note

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -150,7 +150,7 @@ Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
 ```
 Then change the version in your `docker/php-fpm/Dockerfile`:
 ```diff
-- FROM php:7.3-fpm-stretch as base
+- FROM php:7.4-fpm-buster as base
 + FROM php:7.2.19-fpm-stretch as base
 ```
 After running `docker-compose up -d --build` you'll have the application running on the same PHP.

--- a/packages/backend-api/.travis.yml
+++ b/packages/backend-api/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/coding-standards/.travis.yml
+++ b/packages/coding-standards/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/form-types-bundle/.travis.yml
+++ b/packages/form-types-bundle/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 install:
     - composer install

--- a/packages/framework/.travis.yml
+++ b/packages/framework/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -74,7 +74,7 @@
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8",
         "roave/better-reflection": "^3.5",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/form-types-bundle": "9.0.x-dev",
         "shopsys/migrations": "9.0.x-dev",
         "shopsys/ordered-form": "^4.0",

--- a/packages/frontend-api/.travis.yml
+++ b/packages/frontend-api/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/google-cloud-bundle/.travis.yml
+++ b/packages/google-cloud-bundle/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/http-smoke-testing/.travis.yml
+++ b/packages/http-smoke-testing/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 env:
     - DEPENDENCIES=""

--- a/packages/migrations/.travis.yml
+++ b/packages/migrations/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/plugin-interface/.travis.yml
+++ b/packages/plugin-interface/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 install:
     - composer install

--- a/packages/product-feed-google/.travis.yml
+++ b/packages/product-feed-google/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -27,7 +27,7 @@
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/persistence": "~1.2.0",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/form-types-bundle": "9.0.x-dev",
         "shopsys/framework": "9.0.x-dev",
         "shopsys/migrations": "9.0.x-dev",

--- a/packages/product-feed-heureka-delivery/.travis.yml
+++ b/packages/product-feed-heureka-delivery/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.2",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/form-types-bundle": "9.0.x-dev",
         "shopsys/framework": "9.0.x-dev",
         "shopsys/migrations": "9.0.x-dev",

--- a/packages/product-feed-heureka/.travis.yml
+++ b/packages/product-feed-heureka/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -30,7 +30,7 @@
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/persistence": "~1.2.0",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/form-types-bundle": "9.0.x-dev",
         "shopsys/framework": "9.0.x-dev",
         "shopsys/migrations": "9.0.x-dev",

--- a/packages/product-feed-zbozi/.travis.yml
+++ b/packages/product-feed-zbozi/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -27,7 +27,7 @@
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/persistence": "~1.2.0",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/form-types-bundle": "9.0.x-dev",
         "shopsys/framework": "9.0.x-dev",
         "shopsys/migrations": "9.0.x-dev",

--- a/packages/read-model/.travis.yml
+++ b/packages/read-model/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
     - 7.2
     - 7.3
+    - 7.4
 
 cache:
     directories:

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -60,7 +60,7 @@
         "prezent/doctrine-translatable-bundle": "^1.0.3",
         "sensio/framework-extra-bundle": "^5.2",
         "sensiolabs/security-checker": "^6.0",
-        "shopsys/doctrine-orm": "^2.6.2",
+        "shopsys/doctrine-orm": "^2.6.6",
         "shopsys/google-cloud-bundle": "9.0.x-dev",
         "shopsys/postgres-search-bundle": "^0.2",
         "shopsys/migrations": "9.0.x-dev",

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm-stretch as base
+FROM php:7.4-fpm-buster as base
 
 ARG project_root=.
 
@@ -44,7 +44,7 @@ RUN apt-get update && \
     apt-get clean
 
 # "gd" extension needs to have specified jpeg and freetype dir for jpg/jpeg images support
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 
 # install necessary tools for running application
 RUN docker-php-ext-install \

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -188,6 +188,9 @@ There you can find links to upgrade notes for other versions too.
 
     - run `docker-compose up -d` so the new image is pulled and used
 
+- upgrade PHP to version 7.4 ([#1737](https://github.com/shopsys/shopsys/pull/1737))
+    - see #project-base-diff to update your project
+
 ### Configuration
 - add trailing slash to all your localized paths for `front_product_search` route ([#1067](https://github.com/shopsys/shopsys/pull/1067))
     - be aware, if you already have such paths (`hledani/`, `search/`) in your application


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Beyond nine mountains and nine forests there was introduced new version of PHP language in version 7.4. After a while, the whole world began to whisper about the news this version brings. it wasn't long before the power of this version began to emerge. And soon this power will also appear in the Shopsys framework.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

- https://github.com/shopsys/doctrine-orm package was updated to [v2.6.6](https://github.com/shopsys/doctrine-orm/releases)
- PR with fix was merged into fp/jsformvalidator-bundle (https://github.com/formapro/JsFormValidatorBundle/pull/158)
- ocramius/proxy-manager is installed in version 2.2.3 due to php platform set to 7.2 and in PHP7.4 this version throws deprecations.
- jakub-onderka/php-parallel-lint throws deprecation, but as its abandoned, it should be replaced with https://github.com/php-parallel-lint/PHP-Parallel-Lint (will be done in a separate PR)