### PR TITLE
[product-feed-heureka] rename method "convertToShopEntities" to "convertToHeurekaCategoriesData"

### DIFF
--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php
@@ -35,7 +35,7 @@ class HeurekaCategoryDownloader
     {
         $xmlCategoryDataObjects = $this->loadXml()->xpath('/HEUREKA//CATEGORY[CATEGORY_FULLNAME]');
 
-        return $this->convertToShopEntities($xmlCategoryDataObjects);
+        return $this->convertToHeurekaCategoriesData($xmlCategoryDataObjects);
     }
 
     /**
@@ -54,7 +54,7 @@ class HeurekaCategoryDownloader
      * @param \SimpleXMLElement[] $xmlCategoryDataObjects
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData[]
      */
-    protected function convertToShopEntities(array $xmlCategoryDataObjects)
+    protected function convertToHeurekaCategoriesData(array $xmlCategoryDataObjects)
     {
         $heurekaCategoriesData = [];
 

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1342,6 +1342,9 @@ There you can find links to upgrade notes for other versions too.
     - email template variable has been changed from `{e-mail}` to `{email}`, update your email templates accordingly
     - run `php phing translations-dump` and check, if some translations are needed to be translated
 
+- method name in `HeurekaCategoryDownloader` has been changed ([#1740](https://github.com/shopsys/shopsys/pull/1740))
+    - `HeurekaCategoryDownloader::convertToShopEntities()` has been renamed to `HeurekaCategoryDownloader::convertToHeurekaCategoriesData()` update your project appropriately
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Originally created by @pk16011990. The method name was wrong, so it has been changed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
