### PR TITLE
[framework] Able to show debug toolbar on production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
         "overblog/graphiql-bundle": "^0.1",
         "overblog/graphql-bundle": "^0.12",
+        "phar-io/version": "^2.0",
         "phing/phing": "^2.16.1",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable": "^1.2",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -68,6 +68,7 @@
         "league/flysystem": "^1.0",
         "litipk/php-bignumbers": "^0.8",
         "nikic/php-parser": "^4.0",
+        "phar-io/version": "^2.0",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable": "^1.2",
         "prezent/doctrine-translatable-bundle": "^1.0.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In PR #1502 was introducing change that needs `PharIo\Version` package to parse version. That package was only installed as dependency on another package. Because we need sometimes to debug our applications on CI server or on Development server (where are not installed dev packages), It was really annoying that we need always to run `php phing composer-dev` to be able to show debug toolbar. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
