### PR TITLE
[project-base] fix dump function

### DIFF
--- a/project-base/app/autoload.php
+++ b/project-base/app/autoload.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
+$symfonyDumpFunctionPath = 'vendor/symfony/var-dumper/Resources/functions/dump.php';
+
+file_exists(__DIR__ . '/../' . $symfonyDumpFunctionPath) ? require_once __DIR__ . '/../' . $symfonyDumpFunctionPath : require_once __DIR__ . '/../../' . $symfonyDumpFunctionPath;
+
 /* @var \Composer\Autoload\ClassLoader $loader */
 $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../vendor/autoload.php';
 

--- a/project-base/app/autoload.php
+++ b/project-base/app/autoload.php
@@ -6,7 +6,13 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $symfonyDumpFunctionPath = 'vendor/symfony/var-dumper/Resources/functions/dump.php';
 
-file_exists(__DIR__ . '/../' . $symfonyDumpFunctionPath) ? require_once __DIR__ . '/../' . $symfonyDumpFunctionPath : require_once __DIR__ . '/../../' . $symfonyDumpFunctionPath;
+if (file_exists(__DIR__ . '/../' . $symfonyDumpFunctionPath)) {
+    require_once __DIR__ . '/../' . $symfonyDumpFunctionPath;
+}
+
+if (file_exists(__DIR__ . '/../../' . $symfonyDumpFunctionPath)) {
+    require_once __DIR__ . '/../../' . $symfonyDumpFunctionPath;
+}
 
 /* @var \Composer\Autoload\ClassLoader $loader */
 $loader = file_exists(__DIR__ . '/../vendor/autoload.php') ? require __DIR__ . '/../vendor/autoload.php' : require __DIR__ . '/../../vendor/autoload.php';

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1384,6 +1384,9 @@ There you can find links to upgrade notes for other versions too.
 - fix validation of addresses in customer section ([#1797](https://github.com/shopsys/shopsys/pull/1797)
     - see #project-base-diff to update you
 
+- fix symfony `dump()` function ([#1745](https://github.com/shopsys/shopsys/pull/1745))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are using shorter `d()` function for dumping some content, but most people out of Shopsys do not know about this function and they are trying to use Symfony built-in function `dump()` which is not working properly because of same function from Nette/Tracy package that is load instead of Symfony's function. A lot of people will be able to debug now :)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1535 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
