### PR TITLE
[framework] MessageFactoryInterface:createMessage(): rename $personalData parameter

### DIFF
--- a/packages/framework/src/Model/Mail/MessageFactoryInterface.php
+++ b/packages/framework/src/Model/Mail/MessageFactoryInterface.php
@@ -6,8 +6,8 @@ interface MessageFactoryInterface
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplate $template
-     * @param mixed $personalData
+     * @param mixed $data
      * @return \Shopsys\FrameworkBundle\Model\Mail\MessageData
      */
-    public function createMessage(MailTemplate $template, $personalData);
+    public function createMessage(MailTemplate $template, $data);
 }


### PR DESCRIPTION
- the name of the parameter is less specific (and less confusing) now

| Q             | A
| ------------- | ---
|Description, reason for the PR| the specific parameter name did not make sense as the interface itself is very general
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
