### PR TITLE
[framework] Product::setProductCategoryDomains() fix

### DIFF
--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -634,17 +634,38 @@ class Product extends AbstractTranslatableEntity
      */
     public function setProductCategoryDomains(array $productCategoryDomains)
     {
-        $this->productCategoryDomains->clear();
-
-        foreach ($productCategoryDomains as $productCategoryDomain) {
-            $this->productCategoryDomains->add($productCategoryDomain);
+        foreach ($this->productCategoryDomains as $productCategoryDomain) {
+            if ($this->isProductCategoryDomainInArray($productCategoryDomain, $productCategoryDomains) === false) {
+                $this->productCategoryDomains->removeElement($productCategoryDomain);
+            }
         }
-
+        foreach ($productCategoryDomains as $productCategoryDomain) {
+            if ($this->isProductCategoryDomainInArray($productCategoryDomain, $this->productCategoryDomains->toArray()) === false) {
+                $this->productCategoryDomains->add($productCategoryDomain);
+            }
+        }
         if ($this->isMainVariant()) {
             foreach ($this->getVariants() as $variant) {
                 $variant->copyProductCategoryDomains($productCategoryDomains);
             }
         }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain $searchProductCategoryDomain
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain[] $productCategoryDomains
+     * @return bool
+     */
+    protected function isProductCategoryDomainInArray(ProductCategoryDomain $searchProductCategoryDomain, array $productCategoryDomains): bool
+    {
+        foreach ($productCategoryDomains as $productCategoryDomain) {
+            if ($productCategoryDomain->getCategory() === $searchProductCategoryDomain->getCategory()
+                && $productCategoryDomain->getDomainId() === $searchProductCategoryDomain->getDomainId()
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
- the method now adds the new elements only when they are not present in the current data
- this solution prevents the application from possible duplicate key errors
- original problem: when flush without parameter is called on entity manager, elements
that are removed from collection are scheduled for DELETE, however,
INSERT queries are executed before DELETE, so the application fails here
- the behavior is connected with `orphanremoval=true` and `cascade={"persist"}` settings of `Product::$productCategoryDomains`

| Q             | A
| ------------- | ---
|Description, reason for the PR| the application might fail on duplicate key error when flush without parameter is called during the product editing
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Original authors of this fix are @pk16011990 and @machicek so kudos to them! :+1: 

:warning: Btw, someone should really examine the other collections in the application - there might be a similar problem. :warning: 

