### PR TITLE
[framework] reconfigured NotLogFakeHttpExceptionsErrorListener service

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -535,15 +535,15 @@ services:
             - '@twig'
             - '%kernel.debug%'
 
-    Shopsys\FrameworkBundle\Component\Error\NotLogFakeHttpExceptionsErrorListener: '@twig.exception_listener'
+    Shopsys\FrameworkBundle\Component\Error\NotLogFakeHttpExceptionsErrorListener: '@exception_listener'
 
-    twig.exception_listener:
+    exception_listener:
         class: Shopsys\FrameworkBundle\Component\Error\NotLogFakeHttpExceptionsErrorListener
         tags:
             - { name: 'kernel.event_subscriber' }
             - { name: 'monolog.logger', channel: 'request' }
         arguments:
-            - '%twig.exception_listener.controller%'
+            - '%kernel.error_controller%'
             - '@?logger'
             - '%kernel.debug%'
             - '@Shopsys\FrameworkBundle\Component\Error\ErrorIdProvider'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After upgrade to Symfony 4  `NotLogFakeHttpExceptionsErrorListener` was not configured properly and is not taken into account as ErrorListener. Resulting in missing ErrorID in log entries. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


In the 3.4 version, the listener was configured with Twig, which was deprecated in 4.x version.
`NotLogFakeHttpExceptionsErrorListener` now replaces Symfony's default service `exception_listener`
