### PR TITLE
[framework] hide "Uploading..." flash message on error

### DIFF
--- a/packages/framework/assets/js/admin/components/FileUpload.js
+++ b/packages/framework/assets/js/admin/components/FileUpload.js
@@ -125,6 +125,7 @@ export default class FileUpload {
         new Window({
             content: Translator.trans('Error occurred while uploading file: %message%', { 'message': message })
         });
+        this.$status.parent().hide();
     }
 
     onFallbackMode () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When upload failed on some error, flash message "Uploading..." was not removed and might confuse users. This was fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes/No
