### PR TITLE
[framework] added validation of images extensions so only jpg, jpeg, gif and png are allowed

### DIFF
--- a/packages/framework/src/Component/Image/Processing/ImageProcessor.php
+++ b/packages/framework/src/Component/Image/Processing/ImageProcessor.php
@@ -16,6 +16,8 @@ class ImageProcessor
     public const EXTENSION_JPG = 'jpg';
     public const EXTENSION_PNG = 'png';
     public const EXTENSION_GIF = 'gif';
+    public const SUPPORTED_EXTENSIONS = [self::EXTENSION_JPG, self::EXTENSION_JPEG, self::EXTENSION_GIF, self::EXTENSION_PNG];
+    public const SUPPORTED_IMAGE_MIME_TYPES = 'image/jpeg|image/gif|image/png';
 
     /**
      * @var string[]

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Form\Admin\Slider;
 
 use Shopsys\FormTypesBundle\YesNoType;
+use Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor;
 use Shopsys\FrameworkBundle\Form\DisplayOnlyType;
 use Shopsys\FrameworkBundle\Form\DomainType;
 use Shopsys\FrameworkBundle\Form\GroupType;
@@ -109,6 +110,7 @@ class SliderItemFormType extends AbstractType
                 'label' => t('Upload image'),
                 'entity' => $options['slider_item'],
                 'info_text' => t('You can upload following formats: PNG, JPG'),
+                'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],
             ]);
 
         $builder

--- a/packages/framework/src/Form/Constraints/FileAllowedExtension.php
+++ b/packages/framework/src/Form/Constraints/FileAllowedExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Form\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class FileAllowedExtension extends Constraint
+{
+    /**
+     * @var string
+     */
+    public $message = 'File extension {{ value }} is not between allowed extension. Allowed extensions are {{ extensions }}.';
+
+    /**
+     * @var array
+     */
+    public $extensions;
+
+    public function getRequiredOptions()
+    {
+        return [
+            'extensions',
+        ];
+    }
+
+    public function getDefaultOption()
+    {
+        return 'extensions';
+    }
+}

--- a/packages/framework/src/Form/Constraints/FileAllowedExtensionValidator.php
+++ b/packages/framework/src/Form/Constraints/FileAllowedExtensionValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Shopsys\FrameworkBundle\Form\Constraints;
+
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class FileAllowedExtensionValidator extends ConstraintValidator
+{
+    /**
+     * @param string|\Symfony\Component\HttpFoundation\File\File $value
+     * @param \Symfony\Component\Validator\Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof FileAllowedExtension) {
+            throw new \Symfony\Component\Validator\Exception\UnexpectedTypeException($constraint, FileAllowedExtension::class);
+        }
+
+        if (!$value instanceof File) {
+            throw new \Symfony\Component\Validator\Exception\InvalidArgumentException('Value must be instance of ' . File::class);
+        }
+
+        if (!is_array($constraint->extensions)) {
+            throw new \Symfony\Component\Validator\Exception\ConstraintDefinitionException('Extensions parameter of FileAllowedExtensionsValidator must be array.');
+        }
+
+        if (!in_array(strtolower($value->getExtension()), $constraint->extensions, true)) {
+            $this->context->addViolation(
+                $constraint->message,
+                [
+                    '{{ value }}' => $this->formatValue($value->getExtension()),
+                    '{{ extensions }}' => $this->formatValue(implode(', ', $constraint->extensions)),
+                ]
+            );
+        }
+    }
+}

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -79,7 +79,7 @@ class ImageUploadType extends AbstractType
             'image_type' => null,
             'multiple' => null,
             'image_entity_class' => null,
-            'extensions' => [ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_PNG, ImageProcessor::EXTENSION_GIF],
+            'extensions' => ImageProcessor::SUPPORTED_EXTENSIONS,
         ]);
 
         $resolver->setNormalizer(
@@ -138,7 +138,7 @@ class ImageUploadType extends AbstractType
             'multiple' => $this->isMultiple($options),
             'mapped' => false,
             'attr' => [
-                'accept' => 'image/gif|image/jpeg|image/png',
+                'accept' => ImageProcessor::SUPPORTED_IMAGE_MIME_TYPES,
             ],
         ]);
     }

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -6,6 +6,8 @@ use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadData;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor;
+use Shopsys\FrameworkBundle\Form\Constraints\FileAllowedExtension;
 use Shopsys\FrameworkBundle\Form\Transformers\ImagesIdsToImagesTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -15,6 +17,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ImageUploadType extends AbstractType
@@ -76,7 +79,24 @@ class ImageUploadType extends AbstractType
             'image_type' => null,
             'multiple' => null,
             'image_entity_class' => null,
+            'extensions' => [ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_PNG, ImageProcessor::EXTENSION_GIF],
         ]);
+
+        $resolver->setNormalizer(
+            'file_constraints',
+            function (Options $options, $fileConstraints) {
+                if ($options['extensions'] === null || $options['extensions'] === []) {
+                    return $fileConstraints;
+                }
+
+                return array_merge(
+                    [
+                        new FileAllowedExtension(['extensions' => $options['extensions']]),
+                    ],
+                    $fileConstraints
+                );
+            }
+        );
     }
 
     /**

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -138,7 +138,7 @@ class ImageUploadType extends AbstractType
             'multiple' => $this->isMultiple($options),
             'mapped' => false,
             'attr' => [
-                'accept' => 'image/*',
+                'accept' => 'image/gif|image/jpeg|image/png',
             ],
         ]);
     }

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -58,6 +58,9 @@ msgstr "Pole musí obsahovat {{ needle }}."
 msgid "Fields must not be identical"
 msgstr "Pole se musí shodovat."
 
+msgid "File extension {{ value }} is not between allowed extension. Allowed extensions are {{ extensions }}."
+msgstr "Přípona souboru {{ value }} není mezi povolenými příponami. Povolené přípony jsou {{ extensions }}."
+
 msgid "File extension {{ value }} is too long. It should have {{ limit }} character or less."
 msgstr "Přípona souboru {{ value }} je příliš dlouhá. Měla by mít {{ limit }} znaků nebo méně."
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -58,6 +58,9 @@ msgstr ""
 msgid "Fields must not be identical"
 msgstr ""
 
+msgid "File extension {{ value }} is not between allowed extension. Allowed extensions are {{ extensions }}."
+msgstr ""
+
 msgid "File extension {{ value }} is too long. It should have {{ limit }} character or less."
 msgstr ""
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Uploading image with wrong extension leaded to error 500. This validation prevents such situations.
|New feature| Yes<!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
