### PR TITLE
[framework] added array_key_exists condition into to NotNullableColumnsFinder method

### DIFF
--- a/packages/framework/src/Component/Doctrine/NotNullableColumnsFinder.php
+++ b/packages/framework/src/Component/Doctrine/NotNullableColumnsFinder.php
@@ -52,6 +52,10 @@ class NotNullableColumnsFinder
     {
         $notNullableAssociationNames = [];
         foreach ($classMetadataInfo->getAssociationMappings() as $associationMapping) {
+            if (array_key_exists('joinColumns', $associationMapping) === false) {
+                continue;
+            }
+
             if ($associationMapping['joinColumns'][0]['nullable'] === false) {
                 $notNullableAssociationNames[] = $associationMapping['joinColumns'][0]['name'];
             }

--- a/packages/framework/tests/Unit/Component/Doctrine/NotNullableColumnsFinderTest.php
+++ b/packages/framework/tests/Unit/Component/Doctrine/NotNullableColumnsFinderTest.php
@@ -33,22 +33,10 @@ class NotNullableColumnsFinderTest extends TestCase
                     return 'not_nullable_field';
                 }
             });
-        $associationMapping1['joinColumns'] = [
-            [
-                'nullable' => true,
-                'name' => 'nullable_association',
-            ],
-        ];
-        $associationMapping2['joinColumns'] = [
-            [
-                'nullable' => false,
-                'name' => 'not_nullable_association',
-            ],
-        ];
-        $associationMappings = [$associationMapping1, $associationMapping2];
+
         $classMetadataInfoMock
             ->method('getAssociationMappings')
-            ->willReturn($associationMappings);
+            ->willReturn($this->getAssociationMappings());
 
         $expectedResult = [
             'EntityName' => [
@@ -61,6 +49,30 @@ class NotNullableColumnsFinderTest extends TestCase
         $actualResult = $notNullableColumnsFinder->getAllNotNullableColumnNamesIndexedByTableName([$classMetadataInfoMock]);
 
         $this->assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @return array
+     */
+    private function getAssociationMappings(): array
+    {
+        $associationMapping1['joinColumns'] = [
+            [
+                'nullable' => true,
+                'name' => 'nullable_association',
+            ],
+        ];
+        $associationMapping2['joinColumns'] = [
+            [
+                'nullable' => false,
+                'name' => 'not_nullable_association',
+            ],
+        ];
+
+        // this array can simulate bidirectional association
+        $associationMapping3 = [];
+
+        return [$associationMapping1, $associationMapping2, $associationMapping3];
     }
 
     public function testGetAllNotNullableColumnNamesIndexedByTableNameException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixed issue
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1759 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
