### PR TITLE
[framework] fixed parameter name in remove item from order confirm window

### DIFF
--- a/packages/framework/assets/js/admin/components/OrderItems.js
+++ b/packages/framework/assets/js/admin/components/OrderItems.js
@@ -89,7 +89,7 @@ export default class OrderItems {
 
             // eslint-disable-next-line no-new
             new Window({
-                content: Translator.trans('Do you really want to remove item "<i>%itemName%</i>" from the order?', { '%itemName%': itemName }),
+                content: Translator.trans('Do you really want to remove item "<i>%itemName%</i>" from the order?', { 'itemName': itemName }),
                 buttonCancel: true,
                 buttonContinue: true,
                 eventContinue: () => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Parameters in JS `Translator.trans` function need to have names without percent symbol.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
