### PR TITLE
[shopsys] doctrine money type now requires sql comment hint

### DIFF
--- a/packages/framework/src/Component/Doctrine/MoneyType.php
+++ b/packages/framework/src/Component/Doctrine/MoneyType.php
@@ -56,4 +56,13 @@ final class MoneyType extends Type
             throw ConversionException::conversionFailedFormat($value, $this->getName(), 'numeric', $e);
         }
     }
+
+    /**
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     * @return bool
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/project-base/config/packages/doctrine.yaml
+++ b/project-base/config/packages/doctrine.yaml
@@ -14,7 +14,6 @@ doctrine:
         types:
             money:
                 class: \Shopsys\FrameworkBundle\Component\Doctrine\MoneyType
-                commented: false
             tsvector:
                 class: \Intaro\PostgresSearchBundle\DBAL\TsvectorType
                 commented: false

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1131,6 +1131,7 @@ There you can find links to upgrade notes for other versions too.
 - update your application to symfony4 ([#1704](https://github.com/shopsys/shopsys/pull/1704))
     
     - see #project-base-diff to update your project
+    - see also #project-base-diff from [#1764](https://github.com/shopsys/shopsys/pull/1764)
     
     - minimum memory requirements for installation using Docker on MacOS and Windows has changed, please read  [Installation Using Docker for MacOS](docs/installation/installation-using-docker-macos.md) or [Installation Using Docker for Windows 10 Pro and higher](docs/installation/installation-using-docker-windows-10-pro-higher.md)
     


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1704 was deprecation about _implicitly marked type as commented_* resolved with setting the commented attribute to false. That resulted in strange behavior when generating new migrations with Money type. This PR re-enables SQL comment hints with `MoneyType::requiresSQLCommentHint()` method. (The type itself should be aware of the need of SQL comment hint)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

\* `User Deprecated: The type "money" was implicitly marked as commented due to the configuration. This is deprecated and will be removed in DoctrineBundle 2.0. Either set the "commented" attribute in the configuration to "false" or mark the type as commented in "Shopsys\FrameworkBundle\Component\Doctrine\MoneyType::requiresSQLCommentHint()."`