### PR TITLE
[shopsys] added missing upgrades for webpack and css

### DIFF
--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1410,6 +1410,26 @@ There you can find links to upgrade notes for other versions too.
 - javascript assets are managed by webpack and npm ([#1545](https://github.com/shopsys/shopsys/pull/1545), [#1645](https://github.com/shopsys/shopsys/pull/1645))
     - please read [upgrade instruction for webpack](./upgrade-instruction-for-webpack.md)
 
+- css and other assets are managed by webpack ([#1725](https://github.com/shopsys/shopsys/pull/1725))
+    - see #project-base-diff to update your project
+    - move content from `src/resources/styles/front` to `assets/styles/frontend`
+    - move content from `src/resources/styles/admin` to `assets/styles/admin`
+    - move content from `src/resources/svg` to `assets/styles/frontend/svg`
+    - move content from `web/assets/frontend/fonts` to `assets/public/frontend/fonts`
+    - move content from `web/assets/frontend/images` to `assets/public/frontend/images`
+    - move content from `web/assets/admin/fonts` to `assets/public/frontend/fonts`
+    - move content from `web/assets/admin/images` to `assets/public/frontend/images`
+    - move content from `web/assets/styleguide/images` to `assets/public/styleguide/images`
+    - you should remove the `grunt` target from your `build.xml` file
+    - add `styles_directory` into your domains config (you can get inspired in [project-base/config/domains.yml  ](https://github.com/shopsys/shopsys/blob/master/project-base/config/domains.yml))
+    - change all `asset` function call in your templates
+      ```diff
+        - asset('assets/**/*.*')
+        + asset('public/**/*.*')
+      ```
+    - remove `getCssVersion()` function call from your templates
+    - use full of the webpack, enjoy!
+
 If you have custom frontend you can skip these tasks:
 - hide variant table header when product is denied for sale ([#1634](https://github.com/shopsys/shopsys/pull/1634))
     - add new condition at product detail file: `templates/Front/Content/Product/detail.html.twig`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We forgot for upgrade notes in #1725 ...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
