### PR TITLE
[framework] fix version of elasticsearch in composer.json

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -52,7 +52,7 @@
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/persistence": "~1.2.0",
-        "elasticsearch/elasticsearch": "^6.0.1",
+        "elasticsearch/elasticsearch": "^7.6.1",
         "fp/jsformvalidator-bundle": "dev-master",
         "friendsofsymfony/ckeditor-bundle": "^2.1",
         "fzaninotto/faker": "^1.7.1",


### PR DESCRIPTION
- should have been done in https://github.com/shopsys/shopsys/pull/1602

| Q             | A
| ------------- | ---
|Description, reason for the PR| it does not make sense to work with Elasticsearch 7 and require version 6 in composer.json. I believe this was just a mistake in https://github.com/shopsys/shopsys/pull/1602 because only monorepo's composer.json has been updated there
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
