### PR TITLE
[framework] main_filesystem is now public service for elFinder to work properly

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -83,6 +83,8 @@ services:
     main_filesystem:
         class: League\Flysystem\FilesystemInterface
         factory: ['@Shopsys\FrameworkBundle\Component\Filesystem\MainFilesystemFactory', create]
+        # public service is necessary for ElFinderBundle
+        public: true
 
     Shopsys\FrameworkBundle\Component\Filesystem\MainFilesystemFactory:
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Since Symfony 4, the main_filesystem service was removed when the container was compiled. This can be verified with `./bin/console debug:container main_filesystem`. ElFinder obtain the filesystem service from the container (see `\FM\ElfinderBundle\Configuration\ElFinderConfigurationReader::getFlysystemFilesystem`). This PR makes main_filesystem service public, so it's possible to use $container->get in method mentioned above. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
