### PR TITLE
[shopsys] Creating instance of data object with DataFactory::createInstance() method

### DIFF
--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -133,12 +133,20 @@ use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory as BaseProductDataF
 class ProductDataFactory extends BaseProductDataFactory
 {
     /**
+     * @return \App\Model\Product\ProductData
+     */
+    protected function createInstance(): BaseProductData
+    {
+        return new ProductData();
+    }
+
+    /**
      * @param \App\Model\Product\Product $product
      * @return \App\Model\Product\ProductData
      */
     public function createFromProduct(BaseProduct $product): BaseProductData
     {
-        $productData = new ProductData();
+        $productData = $this->createInstance();
         $this->fillFromProduct($productData, $product);
         $productData->extId = $product->getExtId() ?? 0;
 
@@ -150,7 +158,7 @@ class ProductDataFactory extends BaseProductDataFactory
      */
     public function create(): BaseProductData
     {
-        $productData = new ProductData();
+        $productData = $this->createInstance();
         $this->fillNew($productData);
         $productData->extId = 0;
 
@@ -252,7 +260,7 @@ class ProductDataFactory extends BaseProductDataFactory
      */
     public function createFromProduct(BaseProduct $product): BaseProductData
     {
-        $productData = new ProductData();
+        $productData = $this->createInstance();
         $this->fillFromProduct($productData, $product);
         $productData->extId = $product->getExtId();
 

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlDataFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlDataFactory.php
@@ -7,9 +7,17 @@ class FriendlyUrlDataFactory implements FriendlyUrlDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlData
      */
-    public function create(): FriendlyUrlData
+    protected function createInstance(): FriendlyUrlData
     {
         return new FriendlyUrlData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlData
+     */
+    public function create(): FriendlyUrlData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -19,7 +27,7 @@ class FriendlyUrlDataFactory implements FriendlyUrlDataFactoryInterface
      */
     public function createFromIdAndName(int $id, string $name): FriendlyUrlData
     {
-        $friendlyUrlData = $this->create();
+        $friendlyUrlData = $this->createInstance();
         $friendlyUrlData->id = $id;
         $friendlyUrlData->name = $name;
 

--- a/packages/framework/src/Component/UploadedFile/UploadedFileDataFactory.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileDataFactory.php
@@ -24,9 +24,17 @@ class UploadedFileDataFactory implements UploadedFileDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileData
      */
-    public function create(): UploadedFileData
+    public function createInstance(): UploadedFileData
     {
         return new UploadedFileData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileData
+     */
+    public function create(): UploadedFileData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -36,7 +44,7 @@ class UploadedFileDataFactory implements UploadedFileDataFactoryInterface
      */
     public function createByEntity(object $entity, string $type = UploadedFileTypeConfig::DEFAULT_TYPE_NAME): UploadedFileData
     {
-        $uploadedFileData = $this->create();
+        $uploadedFileData = $this->createInstance();
 
         $this->fillByUploadedFiles($uploadedFileData, $this->uploadedFileFacade->getUploadedFilesByEntity($entity, $type));
 

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -193,7 +193,7 @@ class AdministratorController extends AdminBaseController
      */
     public function newAction(Request $request)
     {
-        $form = $this->createForm(AdministratorFormType::class, $this->administratorDataFactory->createInstance(), [
+        $form = $this->createForm(AdministratorFormType::class, $this->administratorDataFactory->create(), [
             'scenario' => AdministratorFormType::SCENARIO_CREATE,
             'administrator' => null,
         ]);

--- a/packages/framework/src/Controller/Admin/AdministratorController.php
+++ b/packages/framework/src/Controller/Admin/AdministratorController.php
@@ -193,7 +193,7 @@ class AdministratorController extends AdminBaseController
      */
     public function newAction(Request $request)
     {
-        $form = $this->createForm(AdministratorFormType::class, $this->administratorDataFactory->create(), [
+        $form = $this->createForm(AdministratorFormType::class, $this->administratorDataFactory->createInstance(), [
             'scenario' => AdministratorFormType::SCENARIO_CREATE,
             'administrator' => null,
         ]);

--- a/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
@@ -7,9 +7,17 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData
      */
-    public function create(): AdministratorData
+    protected function createInstance(): AdministratorData
     {
         return new AdministratorData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData
+     */
+    public function create(): AdministratorData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
      */
     public function createFromAdministrator(Administrator $administrator): AdministratorData
     {
-        $administratorData = new AdministratorData();
+        $administratorData = $this->createInstance();
         $this->fillFromAdministrator($administratorData, $administrator);
         return $administratorData;
     }

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactory.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactory.php
@@ -9,7 +9,7 @@ class AdministratorRoleDataFactory implements AdministratorRoleDataFactoryInterf
     /**
      * @inheritDoc
      */
-    public function create(): AdministratorRoleData
+    public function createInstance(): AdministratorRoleData
     {
         return new AdministratorRoleData();
     }
@@ -17,9 +17,17 @@ class AdministratorRoleDataFactory implements AdministratorRoleDataFactoryInterf
     /**
      * @inheritDoc
      */
+    public function create(): AdministratorRoleData
+    {
+        return $this->createInstance();
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function createFromAdministratorRole(AdministratorRole $administratorRole): AdministratorRoleData
     {
-        $administratorRoleData = new AdministratorRoleData();
+        $administratorRoleData = $this->createInstance();
         $this->fillFromAdministratorRole($administratorRoleData, $administratorRole);
 
         return $administratorRoleData;

--- a/packages/framework/src/Model/Advert/AdvertDataFactory.php
+++ b/packages/framework/src/Model/Advert/AdvertDataFactory.php
@@ -39,9 +39,17 @@ class AdvertDataFactory implements AdvertDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Advert\AdvertData
      */
-    public function create(): AdvertData
+    protected function createInstance(): AdvertData
     {
         return new AdvertData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Advert\AdvertData
+     */
+    public function create(): AdvertData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -50,7 +58,7 @@ class AdvertDataFactory implements AdvertDataFactoryInterface
      */
     public function createFromAdvert(Advert $advert): AdvertData
     {
-        $advertData = new AdvertData();
+        $advertData = $this->createInstance();
         $this->fillFromAdvert($advertData, $advert);
         return $advertData;
     }

--- a/packages/framework/src/Model/Article/ArticleDataFactory.php
+++ b/packages/framework/src/Model/Article/ArticleDataFactory.php
@@ -39,12 +39,20 @@ class ArticleDataFactory implements ArticleDataFactoryInterface
     }
 
     /**
+     * @return \Shopsys\FrameworkBundle\Model\Article\ArticleData
+     */
+    protected function createInstance(): ArticleData
+    {
+        return new ArticleData();
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Article\Article $article
      * @return \Shopsys\FrameworkBundle\Model\Article\ArticleData
      */
     public function createFromArticle(Article $article): ArticleData
     {
-        $articleData = new ArticleData();
+        $articleData = $this->createInstance();
         $this->fillFromArticle($articleData, $article);
 
         return $articleData;
@@ -55,7 +63,7 @@ class ArticleDataFactory implements ArticleDataFactoryInterface
      */
     public function create(): ArticleData
     {
-        $articleData = new ArticleData();
+        $articleData = $this->createInstance();
         $this->fillNew($articleData);
 
         return $articleData;

--- a/packages/framework/src/Model/Category/CategoryDataFactory.php
+++ b/packages/framework/src/Model/Category/CategoryDataFactory.php
@@ -73,12 +73,20 @@ class CategoryDataFactory implements CategoryDataFactoryInterface
     }
 
     /**
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryData
+     */
+    protected function createInstance(): CategoryData
+    {
+        return new CategoryData();
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @return \Shopsys\FrameworkBundle\Model\Category\CategoryData
      */
     public function createFromCategory(Category $category): CategoryData
     {
-        $categoryData = new CategoryData();
+        $categoryData = $this->createInstance();
         $this->fillFromCategory($categoryData, $category);
 
         return $categoryData;
@@ -89,7 +97,7 @@ class CategoryDataFactory implements CategoryDataFactoryInterface
      */
     public function create(): CategoryData
     {
-        $categoryData = new CategoryData();
+        $categoryData = $this->createInstance();
         $this->fillNew($categoryData);
 
         return $categoryData;

--- a/packages/framework/src/Model/ContactForm/ContactFormSettingsDataFactory.php
+++ b/packages/framework/src/Model/ContactForm/ContactFormSettingsDataFactory.php
@@ -20,11 +20,19 @@ class ContactFormSettingsDataFactory implements ContactFormSettingsDataFactoryIn
     }
 
     /**
+     * @return \Shopsys\FrameworkBundle\Model\ContactForm\ContactFormSettingsData
+     */
+    protected function createInstance(): ContactFormSettingsData
+    {
+        return new ContactFormSettingsData();
+    }
+
+    /**
      * @inheritDoc
      */
     public function createFromSettingsByDomainId(int $domainId): ContactFormSettingsData
     {
-        $contactFormSettingsData = new ContactFormSettingsData();
+        $contactFormSettingsData = $this->createInstance();
         $contactFormSettingsData->mainText = $this->contactFormSettingsFacade->getMainText($domainId);
 
         return $contactFormSettingsData;

--- a/packages/framework/src/Model/Country/CountryDataFactory.php
+++ b/packages/framework/src/Model/Country/CountryDataFactory.php
@@ -22,9 +22,17 @@ class CountryDataFactory implements CountryDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Country\CountryData
      */
+    protected function createInstance(): CountryData
+    {
+        return new CountryData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Country\CountryData
+     */
     public function create(): CountryData
     {
-        $countryData = new CountryData();
+        $countryData = $this->createInstance();
         $this->fillNew($countryData);
 
         return $countryData;
@@ -36,7 +44,7 @@ class CountryDataFactory implements CountryDataFactoryInterface
      */
     public function createFromCountry(Country $country): CountryData
     {
-        $countryData = new CountryData();
+        $countryData = $this->createInstance();
         $this->fillFromCountry($countryData, $country);
 
         return $countryData;

--- a/packages/framework/src/Model/Customer/BillingAddressDataFactory.php
+++ b/packages/framework/src/Model/Customer/BillingAddressDataFactory.php
@@ -7,9 +7,17 @@ class BillingAddressDataFactory implements BillingAddressDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData
      */
-    public function create(): BillingAddressData
+    protected function createInstance(): BillingAddressData
     {
         return new BillingAddressData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData
+     */
+    public function create(): BillingAddressData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class BillingAddressDataFactory implements BillingAddressDataFactoryInterface
      */
     public function createFromBillingAddress(BillingAddress $billingAddress): BillingAddressData
     {
-        $billingAddressData = $this->create();
+        $billingAddressData = $this->createInstance();
         $this->fillFromBillingAddress($billingAddressData, $billingAddress);
 
         return $billingAddressData;

--- a/packages/framework/src/Model/Customer/CustomerDataFactory.php
+++ b/packages/framework/src/Model/Customer/CustomerDataFactory.php
@@ -9,9 +9,17 @@ class CustomerDataFactory implements CustomerDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\CustomerData
      */
-    public function create(): CustomerData
+    protected function createInstance(): CustomerData
     {
         return new CustomerData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\CustomerData
+     */
+    public function create(): CustomerData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -20,7 +28,7 @@ class CustomerDataFactory implements CustomerDataFactoryInterface
      */
     public function createForDomain(int $domainId): CustomerData
     {
-        $customerData = $this->create();
+        $customerData = $this->createInstance();
         $customerData->domainId = $domainId;
 
         return $customerData;
@@ -32,7 +40,7 @@ class CustomerDataFactory implements CustomerDataFactoryInterface
      */
     public function createFromCustomer(Customer $customer): CustomerData
     {
-        $customerData = $this->create();
+        $customerData = $this->createInstance();
         $customerData->billingAddress = $customer->getBillingAddress();
         $customerData->deliveryAddresses = $customer->getDeliveryAddresses();
         $customerData->domainId = $customer->getDomainId();

--- a/packages/framework/src/Model/Customer/DeliveryAddressDataFactory.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddressDataFactory.php
@@ -7,9 +7,17 @@ class DeliveryAddressDataFactory implements DeliveryAddressDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData
      */
-    public function create(): DeliveryAddressData
+    protected function createInstance(): DeliveryAddressData
     {
         return new DeliveryAddressData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData
+     */
+    public function create(): DeliveryAddressData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class DeliveryAddressDataFactory implements DeliveryAddressDataFactoryInterface
      */
     public function createFromDeliveryAddress(DeliveryAddress $deliveryAddress): DeliveryAddressData
     {
-        $deliveryAddressData = new DeliveryAddressData();
+        $deliveryAddressData = $this->createInstance();
         $this->fillFromDeliveryAddress($deliveryAddressData, $deliveryAddress);
 
         return $deliveryAddressData;

--- a/packages/framework/src/Model/Customer/User/CustomerUserDataFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserDataFactory.php
@@ -23,9 +23,17 @@ class CustomerUserDataFactory implements CustomerUserDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData
      */
-    public function create(): CustomerUserData
+    protected function createInstance(): CustomerUserData
     {
         return new CustomerUserData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData
+     */
+    public function create(): CustomerUserData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -35,7 +43,7 @@ class CustomerUserDataFactory implements CustomerUserDataFactoryInterface
      */
     public function createForCustomer(Customer $customer): CustomerUserData
     {
-        $customerUserData = $this->create();
+        $customerUserData = $this->createInstance();
         $customerUserData->customer = $customer;
         return $customerUserData;
     }
@@ -47,7 +55,7 @@ class CustomerUserDataFactory implements CustomerUserDataFactoryInterface
      */
     public function createForDomainId(int $domainId): CustomerUserData
     {
-        $customerUserData = $this->create();
+        $customerUserData = $this->createInstance();
         $this->fillForDomainId($customerUserData, $domainId);
 
         return $customerUserData;
@@ -70,7 +78,7 @@ class CustomerUserDataFactory implements CustomerUserDataFactoryInterface
      */
     public function createFromCustomerUser(CustomerUser $customerUser): CustomerUserData
     {
-        $customerUserData = $this->create();
+        $customerUserData = $this->createInstance();
         $this->fillFromUser($customerUserData, $customerUser);
 
         return $customerUserData;

--- a/packages/framework/src/Model/Customer/User/CustomerUserRefreshTokenChainDataFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserRefreshTokenChainDataFactory.php
@@ -9,8 +9,16 @@ class CustomerUserRefreshTokenChainDataFactory implements CustomerUserRefreshTok
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainData
      */
-    public function create(): CustomerUserRefreshTokenChainData
+    protected function createInstance(): CustomerUserRefreshTokenChainData
     {
         return new CustomerUserRefreshTokenChainData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainData
+     */
+    public function create(): CustomerUserRefreshTokenChainData
+    {
+        return $this->createInstance();
     }
 }

--- a/packages/framework/src/Model/Customer/User/CustomerUserUpdateDataFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserUpdateDataFactory.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle\Model\Customer\User;
 
 use Shopsys\FrameworkBundle\Component\Utils\Utils;
 use Shopsys\FrameworkBundle\Model\Customer\BillingAddress;
+use Shopsys\FrameworkBundle\Model\Customer\BillingAddressData;
 use Shopsys\FrameworkBundle\Model\Customer\BillingAddressDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Customer\CustomerFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress;
@@ -52,11 +53,25 @@ class CustomerUserUpdateDataFactory implements CustomerUserUpdateDataFactoryInte
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $billingAddressData
+     * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData $deliveryAddressData
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData $customerUserData
+     * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateData
+     */
+    protected function createInstance(
+        BillingAddressData $billingAddressData,
+        DeliveryAddressData $deliveryAddressData,
+        CustomerUserData $customerUserData
+    ): CustomerUserUpdateData {
+        return new CustomerUserUpdateData($billingAddressData, $deliveryAddressData, $customerUserData);
+    }
+
+    /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateData
      */
     public function create(): CustomerUserUpdateData
     {
-        return new CustomerUserUpdateData(
+        return $this->createInstance(
             $this->billingAddressDataFactory->create(),
             $this->deliveryAddressDataFactory->create(),
             $this->customerUserDataFactory->create()
@@ -70,13 +85,11 @@ class CustomerUserUpdateDataFactory implements CustomerUserUpdateDataFactoryInte
      */
     public function createFromCustomerUser(CustomerUser $customerUser): CustomerUserUpdateData
     {
-        $customerUserUpdateData = new CustomerUserUpdateData(
+        return $this->createInstance(
             $this->billingAddressDataFactory->createFromBillingAddress($customerUser->getCustomer()->getBillingAddress()),
             $this->getDeliveryAddressDataFromCustomerUser($customerUser),
             $this->customerUserDataFactory->createFromCustomerUser($customerUser)
         );
-
-        return $customerUserUpdateData;
     }
 
     /**

--- a/packages/framework/src/Model/Mail/MailTemplateDataFactory.php
+++ b/packages/framework/src/Model/Mail/MailTemplateDataFactory.php
@@ -23,9 +23,17 @@ class MailTemplateDataFactory implements MailTemplateDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData
      */
+    protected function createInstance(): MailTemplateData
+    {
+        return new MailTemplateData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateData
+     */
     public function create(): MailTemplateData
     {
-        $mailTemplateData = new MailTemplateData();
+        $mailTemplateData = $this->createInstance();
         $mailTemplateData->attachments = $this->uploadedFileDataFactory->create();
 
         return $mailTemplateData;
@@ -37,7 +45,7 @@ class MailTemplateDataFactory implements MailTemplateDataFactoryInterface
      */
     public function createFromMailTemplate(MailTemplate $mailTemplate): MailTemplateData
     {
-        $mailTemplateData = new MailTemplateData();
+        $mailTemplateData = $this->createInstance();
         $this->fillFromMailTemplate($mailTemplateData, $mailTemplate);
         $mailTemplateData->attachments = $this->uploadedFileDataFactory->createByEntity($mailTemplate);
 

--- a/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemDataFactory.php
@@ -22,9 +22,17 @@ class OrderItemDataFactory implements OrderItemDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData
      */
-    public function create(): OrderItemData
+    protected function createInstance(): OrderItemData
     {
         return new OrderItemData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData
+     */
+    public function create(): OrderItemData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -33,7 +41,7 @@ class OrderItemDataFactory implements OrderItemDataFactoryInterface
      */
     public function createFromOrderItem(OrderItem $orderItem): OrderItemData
     {
-        $orderItemData = new OrderItemData();
+        $orderItemData = $this->createInstance();
         $this->fillFromOrderItem($orderItemData, $orderItem);
         $this->addFieldsByOrderItemType($orderItemData, $orderItem);
 

--- a/packages/framework/src/Model/Order/OrderDataFactory.php
+++ b/packages/framework/src/Model/Order/OrderDataFactory.php
@@ -23,9 +23,17 @@ class OrderDataFactory implements OrderDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Order\OrderData
      */
-    public function create(): OrderData
+    protected function createInstance(): OrderData
     {
         return new OrderData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Order\OrderData
+     */
+    public function create(): OrderData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -34,7 +42,7 @@ class OrderDataFactory implements OrderDataFactoryInterface
      */
     public function createFromOrder(Order $order): OrderData
     {
-        $orderData = new OrderData();
+        $orderData = $this->createInstance();
         $this->fillFromOrder($orderData, $order);
 
         return $orderData;

--- a/packages/framework/src/Model/Order/PromoCode/PromoCodeDataFactory.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCodeDataFactory.php
@@ -7,9 +7,17 @@ class PromoCodeDataFactory implements PromoCodeDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeData
      */
-    public function create(): PromoCodeData
+    protected function createInstance(): PromoCodeData
     {
         return new PromoCodeData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeData
+     */
+    public function create(): PromoCodeData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class PromoCodeDataFactory implements PromoCodeDataFactoryInterface
      */
     public function createFromPromoCode(PromoCode $promoCode): PromoCodeData
     {
-        $promoCodeData = new PromoCodeData();
+        $promoCodeData = $this->createInstance();
         $this->fillFromPromoCode($promoCodeData, $promoCode);
 
         return $promoCodeData;

--- a/packages/framework/src/Model/Order/Status/OrderStatusDataFactory.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatusDataFactory.php
@@ -22,9 +22,17 @@ class OrderStatusDataFactory implements OrderStatusDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData
      */
+    protected function createInstance(): OrderStatusData
+    {
+        return new OrderStatusData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData
+     */
     public function create(): OrderStatusData
     {
-        $orderStatusData = new OrderStatusData();
+        $orderStatusData = $this->createInstance();
         $this->fillNew($orderStatusData);
         return $orderStatusData;
     }
@@ -45,7 +53,7 @@ class OrderStatusDataFactory implements OrderStatusDataFactoryInterface
      */
     public function createFromOrderStatus(OrderStatus $orderStatus): OrderStatusData
     {
-        $orderStatusData = new OrderStatusData();
+        $orderStatusData = $this->createInstance();
         $this->fillFromOrderStatus($orderStatusData, $orderStatus);
 
         return $orderStatusData;

--- a/packages/framework/src/Model/Payment/PaymentDataFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentDataFactory.php
@@ -67,9 +67,17 @@ class PaymentDataFactory implements PaymentDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Payment\PaymentData
      */
+    protected function createInstance(): PaymentData
+    {
+        return new PaymentData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Payment\PaymentData
+     */
     public function create(): PaymentData
     {
-        $paymentData = new PaymentData();
+        $paymentData = $this->createInstance();
         $this->fillNew($paymentData);
 
         return $paymentData;
@@ -99,7 +107,7 @@ class PaymentDataFactory implements PaymentDataFactoryInterface
      */
     public function createFromPayment(Payment $payment): PaymentData
     {
-        $paymentData = new PaymentData();
+        $paymentData = $this->createInstance();
         $this->fillFromPayment($paymentData, $payment);
 
         return $paymentData;

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestDataFactory.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestDataFactory.php
@@ -7,9 +7,25 @@ class PersonalDataAccessRequestDataFactory implements PersonalDataAccessRequestD
     /**
      * @return \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestData
      */
+    protected function createInstance(): PersonalDataAccessRequestData
+    {
+        return new PersonalDataAccessRequestData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestData
+     */
+    public function create(): PersonalDataAccessRequestData
+    {
+        return $this->createInstance();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestData
+     */
     public function createForExport(): PersonalDataAccessRequestData
     {
-        $personalDataAccessRequestData = new PersonalDataAccessRequestData();
+        $personalDataAccessRequestData = $this->createInstance();
         $personalDataAccessRequestData->type = PersonalDataAccessRequest::TYPE_EXPORT;
 
         return $personalDataAccessRequestData;
@@ -20,7 +36,7 @@ class PersonalDataAccessRequestDataFactory implements PersonalDataAccessRequestD
      */
     public function createForDisplay(): PersonalDataAccessRequestData
     {
-        $personalDataAccessRequestData = new PersonalDataAccessRequestData();
+        $personalDataAccessRequestData = $this->createInstance();
         $personalDataAccessRequestData->type = PersonalDataAccessRequest::TYPE_DISPLAY;
 
         return $personalDataAccessRequestData;

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyDataFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyDataFactory.php
@@ -7,9 +7,17 @@ class CurrencyDataFactory implements CurrencyDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData
      */
-    public function create(): CurrencyData
+    protected function createInstance(): CurrencyData
     {
         return new CurrencyData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData
+     */
+    public function create(): CurrencyData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class CurrencyDataFactory implements CurrencyDataFactoryInterface
      */
     public function createFromCurrency(Currency $currency): CurrencyData
     {
-        $currencyData = new CurrencyData();
+        $currencyData = $this->createInstance();
         $this->fillFromCurrency($currencyData, $currency);
 
         return $currencyData;

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupDataFactory.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupDataFactory.php
@@ -7,9 +7,17 @@ class PricingGroupDataFactory implements PricingGroupDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData
      */
-    public function create(): PricingGroupData
+    protected function createInstance(): PricingGroupData
     {
         return new PricingGroupData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData
+     */
+    public function create(): PricingGroupData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class PricingGroupDataFactory implements PricingGroupDataFactoryInterface
      */
     public function createFromPricingGroup(PricingGroup $pricingGroup): PricingGroupData
     {
-        $pricingGroupData = new PricingGroupData();
+        $pricingGroupData = $this->createInstance();
         $this->fillFromPricingGroup($pricingGroupData, $pricingGroup);
 
         return $pricingGroupData;

--- a/packages/framework/src/Model/Pricing/Vat/VatDataFactory.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatDataFactory.php
@@ -7,9 +7,17 @@ class VatDataFactory implements VatDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData
      */
-    public function create(): VatData
+    protected function createInstance(): VatData
     {
         return new VatData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData
+     */
+    public function create(): VatData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class VatDataFactory implements VatDataFactoryInterface
      */
     public function createFromVat(Vat $vat): VatData
     {
-        $vatData = new VatData();
+        $vatData = $this->createInstance();
         $this->fillFromVat($vatData, $vat);
 
         return $vatData;

--- a/packages/framework/src/Model/Product/Availability/AvailabilityDataFactory.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityDataFactory.php
@@ -22,9 +22,17 @@ class AvailabilityDataFactory implements AvailabilityDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData
      */
+    protected function createInstance(): AvailabilityData
+    {
+        return new AvailabilityData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData
+     */
     public function create(): AvailabilityData
     {
-        $availabilityData = new AvailabilityData();
+        $availabilityData = $this->createInstance();
         $this->fillNew($availabilityData);
         return $availabilityData;
     }
@@ -45,7 +53,7 @@ class AvailabilityDataFactory implements AvailabilityDataFactoryInterface
      */
     public function createFromAvailability(Availability $availability): AvailabilityData
     {
-        $availabilityData = new AvailabilityData();
+        $availabilityData = $this->createInstance();
         $this->fillFromAvailability($availabilityData, $availability);
 
         return $availabilityData;

--- a/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
@@ -66,9 +66,17 @@ class BrandDataFactory implements BrandDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData
      */
+    protected function createInstance(): BrandData
+    {
+        return new BrandData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData
+     */
     public function create(): BrandData
     {
-        $brandData = new BrandData();
+        $brandData = $this->createInstance();
         $this->fillNew($brandData);
 
         return $brandData;
@@ -96,7 +104,7 @@ class BrandDataFactory implements BrandDataFactoryInterface
      */
     public function createFromBrand(Brand $brand): BrandData
     {
-        $brandData = new BrandData();
+        $brandData = $this->createInstance();
         $this->fillFromBrand($brandData, $brand);
 
         return $brandData;

--- a/packages/framework/src/Model/Product/Flag/FlagDataFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagDataFactory.php
@@ -22,9 +22,17 @@ class FlagDataFactory implements FlagDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData
      */
+    protected function createInstance(): FlagData
+    {
+        return new FlagData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData
+     */
     public function create(): FlagData
     {
-        $flagData = new FlagData();
+        $flagData = $this->createInstance();
         $this->fillNew($flagData);
         return $flagData;
     }
@@ -45,7 +53,7 @@ class FlagDataFactory implements FlagDataFactoryInterface
      */
     public function createFromFlag(Flag $flag): FlagData
     {
-        $flagData = new FlagData();
+        $flagData = $this->createInstance();
         $this->fillFromFlag($flagData, $flag);
 
         return $flagData;

--- a/packages/framework/src/Model/Product/Parameter/ParameterDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterDataFactory.php
@@ -22,9 +22,17 @@ class ParameterDataFactory implements ParameterDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData
      */
+    protected function createInstance(): ParameterData
+    {
+        return new ParameterData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData
+     */
     public function create(): ParameterData
     {
-        $parameterData = new ParameterData();
+        $parameterData = $this->createInstance();
         $this->fillNew($parameterData);
         return $parameterData;
     }
@@ -45,7 +53,7 @@ class ParameterDataFactory implements ParameterDataFactoryInterface
      */
     public function createFromParameter(Parameter $parameter): ParameterData
     {
-        $parameterData = new ParameterData();
+        $parameterData = $this->createInstance();
         $this->fillFromParameter($parameterData, $parameter);
 
         return $parameterData;

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueDataFactory.php
@@ -7,9 +7,17 @@ class ParameterValueDataFactory implements ParameterValueDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData
      */
-    public function create(): ParameterValueData
+    protected function createInstance(): ParameterValueData
     {
         return new ParameterValueData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValueData
+     */
+    public function create(): ParameterValueData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class ParameterValueDataFactory implements ParameterValueDataFactoryInterface
      */
     public function createFromParameterValue(ParameterValue $parameterValue): ParameterValueData
     {
-        $parameterValueData = new ParameterValueData();
+        $parameterValueData = $this->createInstance();
         $this->fillFromParameterValue($parameterValueData, $parameterValue);
 
         return $parameterValueData;

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueDataFactory.php
@@ -20,9 +20,17 @@ class ProductParameterValueDataFactory implements ProductParameterValueDataFacto
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData
      */
-    public function create(): ProductParameterValueData
+    protected function createInstance(): ProductParameterValueData
     {
         return new ProductParameterValueData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData
+     */
+    public function create(): ProductParameterValueData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -31,7 +39,7 @@ class ProductParameterValueDataFactory implements ProductParameterValueDataFacto
      */
     public function createFromProductParameterValue(ProductParameterValue $productParameterValue): ProductParameterValueData
     {
-        $productParameterValueData = new ProductParameterValueData();
+        $productParameterValueData = $this->createInstance();
         $this->fillFromProductParameterValue($productParameterValueData, $productParameterValue);
 
         return $productParameterValueData;

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -121,9 +121,17 @@ class ProductDataFactory implements ProductDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\ProductData
      */
+    protected function createInstance(): ProductData
+    {
+        return new ProductData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\ProductData
+     */
     public function create(): ProductData
     {
-        $productData = new ProductData();
+        $productData = $this->createInstance();
         $this->fillNew($productData);
 
         return $productData;
@@ -167,7 +175,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
      */
     public function createFromProduct(Product $product): ProductData
     {
-        $productData = new ProductData();
+        $productData = $this->createInstance();
         $this->fillFromProduct($productData, $product);
 
         return $productData;

--- a/packages/framework/src/Model/Product/Unit/UnitDataFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitDataFactory.php
@@ -22,9 +22,17 @@ class UnitDataFactory implements UnitDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData
      */
+    protected function createInstance(): UnitData
+    {
+        return new UnitData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData
+     */
     public function create(): UnitData
     {
-        $unitData = new UnitData();
+        $unitData = $this->createInstance();
         $this->fillNew($unitData);
         return $unitData;
     }
@@ -45,7 +53,7 @@ class UnitDataFactory implements UnitDataFactoryInterface
      */
     public function createFromUnit(Unit $unit): UnitData
     {
-        $unitData = new UnitData();
+        $unitData = $this->createInstance();
         $this->fillFromUnit($unitData, $unit);
 
         return $unitData;

--- a/packages/framework/src/Model/Script/ScriptDataFactory.php
+++ b/packages/framework/src/Model/Script/ScriptDataFactory.php
@@ -7,9 +7,17 @@ class ScriptDataFactory implements ScriptDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Script\ScriptData
      */
-    public function create(): ScriptData
+    protected function createInstance(): ScriptData
     {
         return new ScriptData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Script\ScriptData
+     */
+    public function create(): ScriptData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -18,7 +26,7 @@ class ScriptDataFactory implements ScriptDataFactoryInterface
      */
     public function createFromScript(Script $script): ScriptData
     {
-        $scriptData = new ScriptData();
+        $scriptData = $this->createInstance();
         $this->fillFromScript($scriptData, $script);
 
         return $scriptData;

--- a/packages/framework/src/Model/Slider/SliderItemDataFactory.php
+++ b/packages/framework/src/Model/Slider/SliderItemDataFactory.php
@@ -39,9 +39,17 @@ class SliderItemDataFactory implements SliderItemDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Slider\SliderItemData
      */
-    public function create(): SliderItemData
+    protected function createInstance(): SliderItemData
     {
         return new SliderItemData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Slider\SliderItemData
+     */
+    public function create(): SliderItemData
+    {
+        return $this->createInstance();
     }
 
     /**
@@ -50,7 +58,7 @@ class SliderItemDataFactory implements SliderItemDataFactoryInterface
      */
     public function createFromSliderItem(SliderItem $sliderItem): SliderItemData
     {
-        $sliderItemData = new SliderItemData();
+        $sliderItemData = $this->createInstance();
         $this->fillFromSliderItem($sliderItemData, $sliderItem);
 
         return $sliderItemData;

--- a/packages/framework/src/Model/Transport/TransportDataFactory.php
+++ b/packages/framework/src/Model/Transport/TransportDataFactory.php
@@ -67,9 +67,17 @@ class TransportDataFactory implements TransportDataFactoryInterface
     /**
      * @return \Shopsys\FrameworkBundle\Model\Transport\TransportData
      */
+    protected function createInstance(): TransportData
+    {
+        return new TransportData();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Transport\TransportData
+     */
     public function create(): TransportData
     {
-        $transportData = new TransportData();
+        $transportData = $this->createInstance();
         $this->fillNew($transportData);
 
         return $transportData;
@@ -99,7 +107,7 @@ class TransportDataFactory implements TransportDataFactoryInterface
      */
     public function createFromTransport(Transport $transport): TransportData
     {
-        $transportData = new TransportData();
+        $transportData = $this->createInstance();
         $this->fillFromTransport($transportData, $transport);
 
         return $transportData;

--- a/packages/product-feed-google/src/Model/Product/GoogleProductDomainDataFactory.php
+++ b/packages/product-feed-google/src/Model/Product/GoogleProductDomainDataFactory.php
@@ -7,8 +7,16 @@ class GoogleProductDomainDataFactory implements GoogleProductDomainDataFactoryIn
     /**
      * @return \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData
      */
-    public function create(): GoogleProductDomainData
+    protected function createInstance(): GoogleProductDomainData
     {
         return new GoogleProductDomainData();
+    }
+
+    /**
+     * @return \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData
+     */
+    public function create(): GoogleProductDomainData
+    {
+        return $this->createInstance();
     }
 }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDataFactory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryDataFactory.php
@@ -7,8 +7,16 @@ class HeurekaCategoryDataFactory implements HeurekaCategoryDataFactoryInterface
     /**
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData
      */
-    public function create(): HeurekaCategoryData
+    protected function createInstance(): HeurekaCategoryData
     {
         return new HeurekaCategoryData();
+    }
+
+    /**
+     * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData
+     */
+    public function create(): HeurekaCategoryData
+    {
+        return $this->createInstance();
     }
 }

--- a/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomainDataFactory.php
+++ b/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomainDataFactory.php
@@ -7,8 +7,16 @@ class HeurekaProductDomainDataFactory implements HeurekaProductDomainDataFactory
     /**
      * @return \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData
      */
-    public function create(): HeurekaProductDomainData
+    protected function createInstance(): HeurekaProductDomainData
     {
         return new HeurekaProductDomainData();
+    }
+
+    /**
+     * @return \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData
+     */
+    public function create(): HeurekaProductDomainData
+    {
+        return $this->createInstance();
     }
 }

--- a/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomainDataFactory.php
+++ b/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomainDataFactory.php
@@ -7,8 +7,16 @@ class ZboziProductDomainDataFactory implements ZboziProductDomainDataFactoryInte
     /**
      * @return \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData
      */
-    public function create(): ZboziProductDomainData
+    protected function createInstance(): ZboziProductDomainData
     {
         return new ZboziProductDomainData();
+    }
+
+    /**
+     * @return \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData
+     */
+    public function create(): ZboziProductDomainData
+    {
+        return $this->createInstance();
     }
 }

--- a/packages/read-model/src/Product/Action/ProductActionViewFactory.php
+++ b/packages/read-model/src/Product/Action/ProductActionViewFactory.php
@@ -12,13 +12,30 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 class ProductActionViewFactory
 {
     /**
+     * @param int $id
+     * @param bool $sellingDenied
+     * @param bool $isMainVariant
+     * @param string $detailUrl
+     * @return \Shopsys\ReadModelBundle\Product\Action\ProductActionView
+     */
+    protected function create(int $id, bool $sellingDenied, bool $isMainVariant, string $detailUrl): ProductActionView
+    {
+        return new ProductActionView(
+            $id,
+            $sellingDenied,
+            $isMainVariant,
+            $detailUrl
+        );
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param string $absoluteUrl
      * @return \Shopsys\ReadModelBundle\Product\Action\ProductActionView
      */
     public function createFromProduct(Product $product, string $absoluteUrl): ProductActionView
     {
-        return new ProductActionView(
+        return $this->create(
             $product->getId(),
             $product->isSellingDenied(),
             $product->isMainVariant(),
@@ -32,7 +49,7 @@ class ProductActionViewFactory
      */
     public function createFromArray(array $productArray): ProductActionView
     {
-        return new ProductActionView(
+        return $this->create(
             $productArray['id'],
             $productArray['selling_denied'],
             $productArray['is_main_variant'],

--- a/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
@@ -42,6 +42,30 @@ class ListedProductViewFactory
     }
 
     /**
+     * @param int $id
+     * @param string $name
+     * @param string|null $shortDescription
+     * @param string $availability
+     * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice $sellingPrice
+     * @param array $flagIds
+     * @param \Shopsys\ReadModelBundle\Product\Action\ProductActionView $action
+     * @param \Shopsys\ReadModelBundle\Image\ImageView|null $image
+     * @return \Shopsys\ReadModelBundle\Product\Listed\ListedProductView
+     */
+    protected function create(
+        int $id,
+        string $name,
+        ?string $shortDescription,
+        string $availability,
+        ProductPrice $sellingPrice,
+        array $flagIds,
+        ProductActionView $action,
+        ?ImageView $image
+    ): ListedProductView {
+        return new ListedProductView($id, $name, $shortDescription, $availability, $sellingPrice, $flagIds, $action, $image);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param \Shopsys\ReadModelBundle\Image\ImageView|null $imageView
      * @param \Shopsys\ReadModelBundle\Product\Action\ProductActionView $productActionView
@@ -49,7 +73,7 @@ class ListedProductViewFactory
      */
     public function createFromProduct(Product $product, ?ImageView $imageView, ProductActionView $productActionView): ListedProductView
     {
-        return new ListedProductView(
+        return $this->create(
             $product->getId(),
             $product->getName(),
             $product->getShortDescription($this->domain->getId()),
@@ -70,7 +94,7 @@ class ListedProductViewFactory
      */
     public function createFromArray(array $productArray, ?ImageView $imageView, ProductActionView $productActionView, PricingGroup $pricingGroup): ListedProductView
     {
-        return new ListedProductView(
+        return $this->create(
             $productArray['id'],
             $productArray['name'],
             $productArray['short_description'],

--- a/project-base/src/Model/Administrator/AdministratorDataFactory.php
+++ b/project-base/src/Model/Administrator/AdministratorDataFactory.php
@@ -4,28 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Administrator;
 
-use Shopsys\FrameworkBundle\Model\Administrator\Administrator as BaseAdministrator;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorData as BaseAdministratorData;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory as BaseAdministratorDataFactory;
 
+/**
+ * @method \App\Model\Administrator\AdministratorData create()
+ * @method \App\Model\Administrator\AdministratorData createFromAdministrator(\App\Model\Administrator\Administrator $administrator)
+ */
 class AdministratorDataFactory extends BaseAdministratorDataFactory
 {
     /**
      * @return \App\Model\Administrator\AdministratorData
      */
-    public function create(): BaseAdministratorData
+    public function createInstance(): BaseAdministratorData
     {
         return new AdministratorData();
-    }
-
-    /**
-     * @param \App\Model\Administrator\Administrator $administrator
-     * @return \App\Model\Administrator\AdministratorData
-     */
-    public function createFromAdministrator(BaseAdministrator $administrator): BaseAdministratorData
-    {
-        $administratorData = new AdministratorData();
-        $this->fillFromAdministrator($administratorData, $administrator);
-        return $administratorData;
     }
 }

--- a/project-base/src/Model/Article/ArticleDataFactory.php
+++ b/project-base/src/Model/Article/ArticleDataFactory.php
@@ -4,35 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Article;
 
-use DateTime;
-use Shopsys\FrameworkBundle\Model\Article\Article as BaseArticle;
 use Shopsys\FrameworkBundle\Model\Article\ArticleData as BaseArticleData;
 use Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory as BaseArticleDataFactory;
 
+/**
+ * @method \App\Model\Article\ArticleData create()
+ * @method \App\Model\Article\ArticleData createFromArticle(\App\Model\Article\Article $article)
+ */
 class ArticleDataFactory extends BaseArticleDataFactory
 {
     /**
-     * @param \App\Model\Article\Article $article
      * @return \App\Model\Article\ArticleData
      */
-    public function createFromArticle(BaseArticle $article): BaseArticleData
+    protected function createInstance(): BaseArticleData
     {
-        $articleData = new ArticleData();
-        $this->fillFromArticle($articleData, $article);
-
-        $articleData->createdAt = $article->getCreatedAt() ?? new DateTime();
-
-        return $articleData;
-    }
-
-    /**
-     * @return \App\Model\Article\ArticleData
-     */
-    public function create(): BaseArticleData
-    {
-        $articleData = new ArticleData();
-        $this->fillNew($articleData);
-
-        return $articleData;
+        return new ArticleData();
     }
 }

--- a/project-base/src/Model/Category/CategoryDataFactory.php
+++ b/project-base/src/Model/Category/CategoryDataFactory.php
@@ -4,32 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Category;
 
-use Shopsys\FrameworkBundle\Model\Category\Category as BaseCategory;
 use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
 use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactory as BaseCategoryDataFactory;
 
+/**
+ * @method \App\Model\Category\CategoryData createFromCategory(\App\Model\Category\Category $category)
+ * @method \App\Model\Category\CategoryData create()
+ */
 class CategoryDataFactory extends BaseCategoryDataFactory
 {
     /**
-     * @param \App\Model\Category\Category $category
      * @return \App\Model\Category\CategoryData
      */
-    public function createFromCategory(BaseCategory $category): BaseCategoryData
+    protected function createInstance(): BaseCategoryData
     {
-        $categoryData = new CategoryData();
-        $this->fillFromCategory($categoryData, $category);
-
-        return $categoryData;
-    }
-
-    /**
-     * @return \App\Model\Category\CategoryData
-     */
-    public function create(): BaseCategoryData
-    {
-        $categoryData = new CategoryData();
-        $this->fillNew($categoryData);
-
-        return $categoryData;
+        return new CategoryData();
     }
 }

--- a/project-base/src/Model/Customer/User/CustomerUserDataFactory.php
+++ b/project-base/src/Model/Customer/User/CustomerUserDataFactory.php
@@ -4,65 +4,22 @@ declare(strict_types=1);
 
 namespace App\Model\Customer\User;
 
-use Shopsys\FrameworkBundle\Model\Customer\Customer;
-use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser as BaseUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData as BaseUserData;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactory as BaseUserDataFactory;
-use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade;
 
+/**
+ * @method \App\Model\Customer\User\CustomerUserData create()
+ * @method \App\Model\Customer\User\CustomerUserData createForCustomer(\Shopsys\FrameworkBundle\Model\Customer\Customer $customer)
+ * @method \App\Model\Customer\User\CustomerUserData createForDomainId(int $domainId)
+ * @method \App\Model\Customer\User\CustomerUserData createFromCustomerUser(\App\Model\Customer\User\CustomerUser $customerUser)
+ */
 class CustomerUserDataFactory extends BaseUserDataFactory
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade $pricingGroupSettingFacade
-     */
-    public function __construct(PricingGroupSettingFacade $pricingGroupSettingFacade)
-    {
-        parent::__construct($pricingGroupSettingFacade);
-    }
-
-    /**
      * @return \App\Model\Customer\User\CustomerUserData
      */
-    public function create(): BaseUserData
+    protected function createInstance(): BaseUserData
     {
         return new CustomerUserData();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\Customer $customer
-     *
-     * @return \App\Model\Customer\User\CustomerUserData
-     */
-    public function createForCustomer(Customer $customer): BaseUserData
-    {
-        $customerUserData = $this->create();
-        $customerUserData->customer = $customer;
-        return $customerUserData;
-    }
-
-    /**
-     * @param int $domainId
-     *
-     * @return \App\Model\Customer\User\CustomerUserData
-     */
-    public function createForDomainId(int $domainId): BaseUserData
-    {
-        $customerUserData = $this->create();
-        $this->fillForDomainId($customerUserData, $domainId);
-
-        return $customerUserData;
-    }
-
-    /**
-     * @param \App\Model\Customer\User\CustomerUser $customerUser
-     *
-     * @return \App\Model\Customer\User\CustomerUserData
-     */
-    public function createFromCustomerUser(BaseUser $customerUser): BaseUserData
-    {
-        $customerUserData = $this->create();
-        $this->fillFromUser($customerUserData, $customerUser);
-
-        return $customerUserData;
     }
 }

--- a/project-base/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/project-base/src/Model/Order/Item/OrderItemDataFactory.php
@@ -4,30 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Order\Item;
 
-use Shopsys\FrameworkBundle\Model\Order\Item\OrderItem as BaseOrderItem;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData as BaseOrderItemData;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory as BaseOrderItemDataFactory;
 
+/**
+ * @method \App\Model\Order\Item\OrderItemData create()
+ * @method \App\Model\Order\Item\OrderItemData createFromOrderItem(\App\Model\Order\Item\OrderItem $orderItem)
+ */
 class OrderItemDataFactory extends BaseOrderItemDataFactory
 {
     /**
      * @return \App\Model\Order\Item\OrderItemData
      */
-    public function create(): BaseOrderItemData
+    protected function createInstance(): BaseOrderItemData
     {
         return new OrderItemData();
-    }
-
-    /**
-     * @param \App\Model\Order\Item\OrderItem $orderItem
-     * @return \App\Model\Order\Item\OrderItemData
-     */
-    public function createFromOrderItem(BaseOrderItem $orderItem): BaseOrderItemData
-    {
-        $orderItemData = new OrderItemData();
-        $this->fillFromOrderItem($orderItemData, $orderItem);
-        $this->addFieldsByOrderItemType($orderItemData, $orderItem);
-
-        return $orderItemData;
     }
 }

--- a/project-base/src/Model/Order/OrderDataFactory.php
+++ b/project-base/src/Model/Order/OrderDataFactory.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Order;
 
-use Shopsys\FrameworkBundle\Model\Order\Order as BaseOrder;
 use Shopsys\FrameworkBundle\Model\Order\OrderData as BaseOrderData;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory as BaseOrderDataFactory;
 
+/**
+ * @method \App\Model\Order\OrderData create()
+ * @method \App\Model\Order\OrderData createFromOrder(\App\Model\Order\Order $order)
+ */
 class OrderDataFactory extends BaseOrderDataFactory
 {
     /**
      * @return \App\Model\Order\OrderData
      */
-    public function create(): BaseOrderData
+    protected function createInstance(): BaseOrderData
     {
         return new OrderData();
-    }
-
-    /**
-     * @param \App\Model\Order\Order $order
-     * @return \App\Model\Order\OrderData
-     */
-    public function createFromOrder(BaseOrder $order): BaseOrderData
-    {
-        $orderData = new OrderData();
-        $this->fillFromOrder($orderData, $order);
-
-        return $orderData;
-    }
-
-    /**
-     * @param \App\Model\Order\OrderData $orderData
-     * @param \App\Model\Order\Order $order
-     */
-    protected function fillFromOrder(BaseOrderData $orderData, BaseOrder $order)
-    {
-        parent::fillFromOrder($orderData, $order);
     }
 }

--- a/project-base/src/Model/Payment/PaymentDataFactory.php
+++ b/project-base/src/Model/Payment/PaymentDataFactory.php
@@ -6,12 +6,15 @@ namespace App\Model\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
-use Shopsys\FrameworkBundle\Model\Payment\Payment as BasePayment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory as BasePaymentDataFactory;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 
+/**
+ * @method \App\Model\Payment\PaymentData create()
+ * @method \App\Model\Payment\PaymentData createFromPayment(\App\Model\Payment\Payment $payment)
+ */
 class PaymentDataFactory extends BasePaymentDataFactory
 {
     /**
@@ -32,23 +35,8 @@ class PaymentDataFactory extends BasePaymentDataFactory
     /**
      * @return \App\Model\Payment\PaymentData
      */
-    public function create(): BasePaymentData
+    protected function createInstance(): BasePaymentData
     {
-        $paymentData = new PaymentData();
-        $this->fillNew($paymentData);
-
-        return $paymentData;
-    }
-
-    /**
-     * @param \App\Model\Payment\Payment $payment
-     * @return \App\Model\Payment\PaymentData
-     */
-    public function createFromPayment(BasePayment $payment): BasePaymentData
-    {
-        $paymentData = new PaymentData();
-        $this->fillFromPayment($paymentData, $payment);
-
-        return $paymentData;
+        return new PaymentData();
     }
 }

--- a/project-base/src/Model/Product/Brand/BrandDataFactory.php
+++ b/project-base/src/Model/Product/Brand/BrandDataFactory.php
@@ -7,11 +7,14 @@ namespace App\Model\Product\Brand;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
-use Shopsys\FrameworkBundle\Model\Product\Brand\Brand as BaseBrand;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandData as BaseBrandData;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactory as BaseBrandDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 
+/**
+ * @method \App\Model\Product\Brand\BrandData create()
+ * @method \App\Model\Product\Brand\BrandData createFromBrand(\App\Model\Product\Brand\Brand $brand)
+ */
 class BrandDataFactory extends BaseBrandDataFactory
 {
     /**
@@ -32,23 +35,8 @@ class BrandDataFactory extends BaseBrandDataFactory
     /**
      * @return \App\Model\Product\Brand\BrandData
      */
-    public function create(): BaseBrandData
+    protected function createInstance(): BaseBrandData
     {
-        $brandData = new BrandData();
-        $this->fillNew($brandData);
-
-        return $brandData;
-    }
-
-    /**
-     * @param \App\Model\Product\Brand\Brand $brand
-     * @return \App\Model\Product\Brand\BrandData
-     */
-    public function createFromBrand(BaseBrand $brand): BaseBrandData
-    {
-        $brandData = new BrandData();
-        $this->fillFromBrand($brandData, $brand);
-
-        return $brandData;
+        return new BrandData();
     }
 }

--- a/project-base/src/Model/Product/ProductDataFactory.php
+++ b/project-base/src/Model/Product/ProductDataFactory.php
@@ -4,32 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Product;
 
-use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
 use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory as BaseProductDataFactory;
 
+/**
+ * @method \App\Model\Product\ProductData create()
+ * @method \App\Model\Product\ProductData createFromProduct(\App\Model\Product\Product $product)
+ */
 class ProductDataFactory extends BaseProductDataFactory
 {
     /**
      * @return \App\Model\Product\ProductData
      */
-    public function create(): BaseProductData
+    protected function createInstance(): BaseProductData
     {
-        $productData = new ProductData();
-        $this->fillNew($productData);
-
-        return $productData;
-    }
-
-    /**
-     * @param \App\Model\Product\Product $product
-     * @return \App\Model\Product\ProductData
-     */
-    public function createFromProduct(BaseProduct $product): BaseProductData
-    {
-        $productData = new ProductData();
-        $this->fillFromProduct($productData, $product);
-
-        return $productData;
+        return new ProductData();
     }
 }

--- a/project-base/src/Model/Transport/TransportDataFactory.php
+++ b/project-base/src/Model/Transport/TransportDataFactory.php
@@ -4,32 +4,20 @@ declare(strict_types=1);
 
 namespace App\Model\Transport;
 
-use Shopsys\FrameworkBundle\Model\Transport\Transport as BaseTransport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;
 use Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory as BaseTransportDataFactory;
 
+/**
+ * @method \App\Model\Transport\TransportData create()
+ * @method \App\Model\Transport\TransportData createFromTransport(\App\Model\Transport\Transport $transport)
+ */
 class TransportDataFactory extends BaseTransportDataFactory
 {
     /**
      * @return \App\Model\Transport\TransportData
      */
-    public function create(): BaseTransportData
+    protected function createInstance(): BaseTransportData
     {
-        $transportData = new TransportData();
-        $this->fillNew($transportData);
-
-        return $transportData;
-    }
-
-    /**
-     * @param \App\Model\Transport\Transport $transport
-     * @return \App\Model\Transport\TransportData $transportData
-     */
-    public function createFromTransport(BaseTransport $transport): BaseTransportData
-    {
-        $transportData = new TransportData();
-        $this->fillFromTransport($transportData, $transport);
-
-        return $transportData;
+        return new TransportData();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Extending data factories is not straightforward enough and sometimes require more methods to be overwritten. This PR brings more comfort for developer when extending data factories.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1397  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
