### PR TITLE
[framework] fix ErrorExtractor::getAllErrorsAsArray()

### DIFF
--- a/packages/framework/src/Component/FlashMessage/ErrorExtractor.php
+++ b/packages/framework/src/Component/FlashMessage/ErrorExtractor.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Component\FlashMessage;
 
-use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 class ErrorExtractor
 {
     /**
-     * @param \Symfony\Component\Form\Form $form
+     * @param \Symfony\Component\Form\FormInterface $form
      * @param array $errorFlashMessages
      * @return string[]
      */
-    public function getAllErrorsAsArray(Form $form, array $errorFlashMessages)
+    public function getAllErrorsAsArray(FormInterface $form, array $errorFlashMessages): array
     {
         $errors = $errorFlashMessages;
         foreach ($form->getErrors(true) as $error) {

--- a/packages/framework/src/Component/FlashMessage/ErrorExtractor.php
+++ b/packages/framework/src/Component/FlashMessage/ErrorExtractor.php
@@ -3,18 +3,17 @@
 namespace Shopsys\FrameworkBundle\Component\FlashMessage;
 
 use Symfony\Component\Form\Form;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 
 class ErrorExtractor
 {
     /**
      * @param \Symfony\Component\Form\Form $form
-     * @param \Symfony\Component\HttpFoundation\Session\Flash\FlashBag $flashMessageBag
+     * @param array $errorFlashMessages
      * @return string[]
      */
-    public function getAllErrorsAsArray(Form $form, FlashBag $flashMessageBag)
+    public function getAllErrorsAsArray(Form $form, array $errorFlashMessages)
     {
-        $errors = $flashMessageBag->get(FlashMessage::KEY_ERROR);
+        $errors = $errorFlashMessages;
         foreach ($form->getErrors(true) as $error) {
             /* @var $error \Symfony\Component\Form\FormError */
             $errors[] = $error->getMessage();

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1212,7 +1212,7 @@ There you can find links to upgrade notes for other versions too.
         - `ErrorExtractor::getAllErrorsAsArray()`
             ```diff           
             -   public function getAllErrorsAsArray(Form $form, Bag $flashMessageBag)
-            +   public function getAllErrorsAsArray(Form $form, array $errorFlashMessages)
+            +   public function getAllErrorsAsArray(FormInterface $form, array $errorFlashMessages): array
             ```
         - `Grid::__construct()`
             ```diff           

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1212,7 +1212,7 @@ There you can find links to upgrade notes for other versions too.
         - `ErrorExtractor::getAllErrorsAsArray()`
             ```diff           
             -   public function getAllErrorsAsArray(Form $form, Bag $flashMessageBag)
-            +   public function getAllErrorsAsArray(Form $form, FlashBag $flashMessageBag)
+            +   public function getAllErrorsAsArray(Form $form, array $errorFlashMessages)
             ```
         - `Grid::__construct()`
             ```diff           


### PR DESCRIPTION
- according to the usage of the method, the second parameter should be an array
- the bug was introduced in https://github.com/shopsys/shopsys/pull/1704
(3761f8e930931aa7a661fe3c0202ac77fa7cbe71)

| Q             | A
| ------------- | ---
|Description, reason for the PR| there is a conflict in method interface and it's usage. I had two options - change the method's interface to fit the usages, or fix the usages. I chose the first one as it seemed easier to use it this way. If you want to fix the problem another way, I am ok with it :slightly_smiling_face: Maybe `FlashMessageTrait` could provide a getter for `\Symfony\Component\HttpFoundation\Session\Flash\FlashBag` instance :thinking: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
