### PR TITLE
[shopsys] ImageConfig accepts extended entities

### DIFF
--- a/packages/framework/src/Component/Image/Config/ImageConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfig.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image\Config;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Image;
 
 class ImageConfig
@@ -15,11 +16,25 @@ class ImageConfig
     protected $imageEntityConfigsByClass;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[] $imageEntityConfigsByClass
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
      */
-    public function __construct(array $imageEntityConfigsByClass)
+    protected $entityNameResolver;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[] $imageEntityConfigsByClass
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(array $imageEntityConfigsByClass, EntityNameResolver $entityNameResolver)
     {
-        $this->imageEntityConfigsByClass = $imageEntityConfigsByClass;
+        $this->entityNameResolver = $entityNameResolver;
+
+        $imageEntityConfigsByNormalizedClass = [];
+        foreach ($imageEntityConfigsByClass as $class => $imageEntityConfig) {
+            $normalizedClass = $this->entityNameResolver->resolve($class);
+            $imageEntityConfigsByNormalizedClass[$normalizedClass] = $imageEntityConfig;
+        }
+
+        $this->imageEntityConfigsByClass = $imageEntityConfigsByNormalizedClass;
     }
 
     /**
@@ -137,8 +152,9 @@ class ImageConfig
      */
     public function getImageEntityConfigByClass($class)
     {
-        if (array_key_exists($class, $this->imageEntityConfigsByClass)) {
-            return $this->imageEntityConfigsByClass[$class];
+        $normalizedClass = $this->entityNameResolver->resolve($class);
+        if (array_key_exists($normalizedClass, $this->imageEntityConfigsByClass)) {
+            return $this->imageEntityConfigsByClass[$normalizedClass];
         }
 
         throw new \Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageEntityConfigNotFoundException($class);

--- a/packages/framework/src/Component/Image/Config/ImageConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfig.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image\Config;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Image;
 
@@ -24,10 +25,21 @@ class ImageConfig
      * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[] $imageEntityConfigsByClass
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      */
-    public function __construct(array $imageEntityConfigsByClass, EntityNameResolver $entityNameResolver)
+    public function __construct(array $imageEntityConfigsByClass, ?EntityNameResolver $entityNameResolver = null)
     {
         $this->entityNameResolver = $entityNameResolver;
+        if ($entityNameResolver !== null) {
+            $this->setUpImageEntityConfigsByClass($imageEntityConfigsByClass);
+        } else {
+            $this->imageEntityConfigsByClass = $imageEntityConfigsByClass;
+        }
+    }
 
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig[] $imageEntityConfigsByClass
+     */
+    protected function setUpImageEntityConfigsByClass(array $imageEntityConfigsByClass): void
+    {
         $imageEntityConfigsByNormalizedClass = [];
         foreach ($imageEntityConfigsByClass as $class => $imageEntityConfig) {
             $normalizedClass = $this->entityNameResolver->resolve($class);
@@ -35,6 +47,33 @@ class ImageConfig
         }
 
         $this->imageEntityConfigsByClass = $imageEntityConfigsByNormalizedClass;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function setEntityNameResolver(EntityNameResolver $entityNameResolver): void
+    {
+        if ($this->entityNameResolver !== null && $this->entityNameResolver !== $entityNameResolver) {
+            throw new BadMethodCallException(sprintf(
+                'Method "%s" has been already called and cannot be called multiple times.',
+                __METHOD__
+            ));
+        }
+        if ($this->entityNameResolver === null) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $this->entityNameResolver = $entityNameResolver;
+            $this->setUpImageEntityConfigsByClass($this->imageEntityConfigsByClass);
+        }
     }
 
     /**

--- a/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image\Config;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateMediaException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\WidthAndHeightMissingException;
 use Shopsys\FrameworkBundle\Component\Utils\Utils;
@@ -27,11 +28,18 @@ class ImageConfigLoader
     protected $foundEntityNames;
 
     /**
-     * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver
      */
-    public function __construct(Filesystem $filesystem)
+    protected $entityNameResolver;
+
+    /**
+     * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(Filesystem $filesystem, EntityNameResolver $entityNameResolver)
     {
         $this->filesystem = $filesystem;
+        $this->entityNameResolver = $entityNameResolver;
     }
 
     /**
@@ -56,7 +64,7 @@ class ImageConfigLoader
 
         $preparedConfig = $this->loadFromArray($outputConfig);
 
-        return new ImageConfig($preparedConfig);
+        return new ImageConfig($preparedConfig, $this->entityNameResolver);
     }
 
     /**

--- a/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image\Config;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateMediaException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\WidthAndHeightMissingException;
@@ -36,10 +37,35 @@ class ImageConfigLoader
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      */
-    public function __construct(Filesystem $filesystem, EntityNameResolver $entityNameResolver)
+    public function __construct(Filesystem $filesystem, ?EntityNameResolver $entityNameResolver = null)
     {
         $this->filesystem = $filesystem;
         $this->entityNameResolver = $entityNameResolver;
+    }
+
+    /**
+     * @required
+     * @internal This function will be replaced by constructor injection in next major
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function setEntityNameResolver(EntityNameResolver $entityNameResolver): void
+    {
+        if ($this->entityNameResolver !== null && $this->entityNameResolver !== $entityNameResolver) {
+            throw new BadMethodCallException(sprintf(
+                'Method "%s" has been already called and cannot be called multiple times.',
+                __METHOD__
+            ));
+        }
+        if ($this->entityNameResolver === null) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+            $this->entityNameResolver = $entityNameResolver;
+        }
     }
 
     /**

--- a/packages/framework/tests/Unit/Component/Image/Config/ImageConfigLoaderTest.php
+++ b/packages/framework/tests/Unit/Component/Image/Config/ImageConfigLoaderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Component\Image\Config;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateEntityNameException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateMediaException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateSizeNameException;
@@ -24,7 +25,8 @@ class ImageConfigLoaderTest extends TestCase
     protected function setUp(): void
     {
         $filesystem = new Filesystem();
-        $this->imageConfigLoader = new ImageConfigLoader($filesystem);
+        $entityNameResolver = new EntityNameResolver([]);
+        $this->imageConfigLoader = new ImageConfigLoader($filesystem, $entityNameResolver);
     }
 
     public function testLoadFromArrayDuplicateEntityName()

--- a/packages/framework/tests/Unit/Component/Image/Config/ImageConfigTest.php
+++ b/packages/framework/tests/Unit/Component/Image/Config/ImageConfigTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FrameworkBundle\Unit\Component\Image\Config;
 
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageAdditionalSizeNotFoundException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageEntityConfigNotFoundException;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
@@ -78,10 +79,11 @@ class ImageConfigTest extends TestCase
         ];
 
         $filesystem = new Filesystem();
-        $imageConfigLoader = new ImageConfigLoader($filesystem);
+        $entityNameResolver = new EntityNameResolver([]);
+        $imageConfigLoader = new ImageConfigLoader($filesystem, $entityNameResolver);
         $imageEntityConfigByClass = $imageConfigLoader->loadFromArray($inputConfig);
 
-        return new ImageConfig($imageEntityConfigByClass);
+        return new ImageConfig($imageEntityConfigByClass, $entityNameResolver);
     }
 
     public function testGetEntityName()

--- a/packages/framework/tests/Unit/Component/Image/DirectoryStructureCreatorTest.php
+++ b/packages/framework/tests/Unit/Component/Image/DirectoryStructureCreatorTest.php
@@ -4,6 +4,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Image;
 
 use League\Flysystem\FilesystemInterface;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig;
@@ -32,7 +33,7 @@ class DirectoryStructureCreatorTest extends TestCase
                 []
             ),
         ];
-        $imageConfig = new ImageConfig($imageEntityConfigByClass);
+        $imageConfig = new ImageConfig($imageEntityConfigByClass, new EntityNameResolver([]));
         $filesystemMock = $this->createMock(FilesystemInterface::class);
         $filesystemMock
             ->method('createDir')

--- a/packages/framework/tests/Unit/Component/Image/ImageLocatorTest.php
+++ b/packages/framework/tests/Unit/Component/Image/ImageLocatorTest.php
@@ -4,6 +4,7 @@ namespace Tests\FrameworkBundle\Unit\Component\Image;
 
 use League\Flysystem\FilesystemInterface;
 use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfigDefinition;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfigLoader;
@@ -74,10 +75,11 @@ class ImageLocatorTest extends TestCase
         ];
 
         $filesystem = new Filesystem();
-        $imageConfigLoader = new ImageConfigLoader($filesystem);
+        $entityNameResolver = new EntityNameResolver([]);
+        $imageConfigLoader = new ImageConfigLoader($filesystem, $entityNameResolver);
         $imageEntityConfigByClass = $imageConfigLoader->loadFromArray($inputConfig);
 
-        return new ImageConfig($imageEntityConfigByClass);
+        return new ImageConfig($imageEntityConfigByClass, $entityNameResolver);
     }
 
     public function getRelativeImagePathProvider()

--- a/project-base/config/services_test.yaml
+++ b/project-base/config/services_test.yaml
@@ -44,6 +44,11 @@ services:
 
     Shopsys\ReadModelBundle\Product\Action\ProductActionViewFacade: ~
 
+    Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig:
+        factory: ['@Shopsys\FrameworkBundle\Component\Image\Config\ImageConfigLoader', loadFromYaml]
+        arguments:
+            - '%shopsys.image_config_filepath%'
+
     Shopsys\FrameworkBundle\Component\Image\ImageFacade:
         arguments: ['%shopsys.image_url_prefix%']
 

--- a/project-base/tests/App/Functional/Component/Image/Config/ImageConfigTest.php
+++ b/project-base/tests/App/Functional/Component/Image/Config/ImageConfigTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Component\Image\Config;
+
+use App\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Product\Product as BaseProduct;
+use Tests\App\Test\FunctionalTestCase;
+
+class ImageConfigTest extends FunctionalTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig
+     * @inject
+     */
+    private $imageConfig;
+
+    public function testGetImageConfigForExtendedEntity()
+    {
+        $baseProductImageConfig = $this->imageConfig->getImageEntityConfigByClass(BaseProduct::class);
+        $projectProductImageConfig = $this->imageConfig->getImageEntityConfigByClass(Product::class);
+
+        self::assertEquals($projectProductImageConfig, $baseProductImageConfig);
+    }
+}

--- a/upgrade/UPGRADE-v9.0.1.md
+++ b/upgrade/UPGRADE-v9.0.1.md
@@ -71,3 +71,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fix wrong url of freshly uploaded files in wysiwyg ([#1926](https://github.com/shopsys/shopsys/pull/1926))
     - see [project-base diff](https://github.com/shopsys/project-base/commit/31c3469fb984c6a0224bcbf8db5549a6331afed5) to update your project
+
+- fix ImageConfig does not accept extended entities ([#1777](https://github.com/shopsys/shopsys/pull/1777))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| See #1693... This issue is unfixable on project, because class `ImageClass` contains extra semicolon in annotation (first commit). The extra semicolon fails in phing target annotation fix. Please accept this PR ASAP.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1693 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
