### PR TITLE
[shopsys] removed unused imports

### DIFF
--- a/packages/framework/src/Form/Constraints/DeliveryAddressOfCurrentCustomerValidator.php
+++ b/packages/framework/src/Form/Constraints/DeliveryAddressOfCurrentCustomerValidator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Form\Constraints;
 
-use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;

--- a/project-base/tests/App/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
+++ b/project-base/tests/App/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php
@@ -8,7 +8,6 @@ use App\DataFixtures\Demo\AvailabilityDataFixture;
 use App\Model\Product\Product;
 use App\Model\Product\ProductData;
 use Doctrine\ORM\EntityManager;
-use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityCalculation;
 use Shopsys\FrameworkBundle\Model\Product\ProductRepository;

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1357,6 +1357,9 @@ There you can find links to upgrade notes for other versions too.
 - compliance with the principle of encapsulation in the project base ([#1640](https://github.com/shopsys/shopsys/pull/1640))
     - see #project-base-diff to update your project
 
+- remove unused import in `tests/App/Functional/Model/Product/Availability/ProductAvailabilityCalculationTest.php` ([#1779](https://github.com/shopsys/shopsys/pull/1779))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After update of FriendsOfPHP/PHP-CS-Fixer to version 2.16.2, some more unused imports were found thanks to https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4736. This PR removes these unused imports.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
