### PR TITLE
[framework] ArticleFormType: fix wrong usage of null coalescing operator

### DIFF
--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -148,7 +148,7 @@ class ArticleFormType extends AbstractType
                 ->add('urls', UrlListType::class, [
                     'label' => t('URL addresses'),
                     'route_name' => 'front_article_detail',
-                    'entity_id' => $options['article'] !== null ?? $options['article']->getId(),
+                    'entity_id' => $options['article']->getId(),
                 ]);
         }
 


### PR DESCRIPTION
- see https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op
- the former way always returns true, which is 1 without using strict types, however, it is just wrong

| Q             | A
| ------------- | ---
|Description, reason for the PR| the operator was used in a bad way. As a result of the bad usage, you can see that all the URLs in article details in admin point to the article with ID 1 now...I found that bug because of smoke tests and using strict types on my project - a function was expecting int but got boolean :facepalm: However, it cost me 1 hour of my life :smile: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
