### PR TITLE
[framework] fix Authenticator definition

### DIFF
--- a/packages/framework/src/Resources/config/services.yml
+++ b/packages/framework/src/Resources/config/services.yml
@@ -498,11 +498,6 @@ services:
     Shopsys\FrameworkBundle\Model\Security\Authenticator:
         arguments:
             - '@security.token_storage'
-            - '@Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher'
-
-    Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher:
-        arguments:
-            - '@event_dispatcher'
 
     Shopsys\FrameworkBundle\Component\Filesystem\FilepathComparator: ~
 


### PR DESCRIPTION
- explicit definition of "EventDispatcherInterface $eventDispatcher" argument causes production application build to fail because TraceableEventDispatcher requires Stopwatch in its constructor and the dependency is not installed in production

| Q             | A
| ------------- | ---
|Description, reason for the PR| I am not able to install application in production env (`composer install --no-dev` fails on `Cannot autowire service "Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher": argument "$stopwatch" of method Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher::__construct()" has type "Symfony\Component\Stopwatch\Stopwatch" but this class was not found.`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1597  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
