### PR TITLE
[shopsys] fp/jsformvalidator-bundle is pinned to minor 1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
     "egeloen/ordered-form": "^3.0",
     "elasticsearch/elasticsearch": "^6.0.1",
     "friendsofphp/php-cs-fixer": "^2.14.0",
-    "fp/jsformvalidator-bundle": "^1.5.1",
+    "fp/jsformvalidator-bundle": "~1.5.1",
     "fzaninotto/faker": "^1.7.1",
     "gedmo/doctrine-extensions": "^2.4.34",
     "google/cloud-storage": "^1.10",

--- a/packages/coding-standards/src/CsFixer/OrmJoinColumnRequireNullableFixer.php
+++ b/packages/coding-standards/src/CsFixer/OrmJoinColumnRequireNullableFixer.php
@@ -11,7 +11,6 @@ use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -55,7 +55,7 @@
         "egeloen/ckeditor-bundle": "^4.0.6",
         "egeloen/ordered-form": "^3.0",
         "elasticsearch/elasticsearch": "^6.0.1",
-        "fp/jsformvalidator-bundle": "^1.5.1",
+        "fp/jsformvalidator-bundle": "~1.5.1",
         "fzaninotto/faker": "^1.7.1",
         "gedmo/doctrine-extensions": "^2.4.34",
         "guzzlehttp/guzzle": "^6.3",

--- a/packages/framework/src/Model/Order/Status/Grid/OrderStatusInlineEdit.php
+++ b/packages/framework/src/Model/Order/Status/Grid/OrderStatusInlineEdit.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Order\Status\Grid;
 
 use Shopsys\FrameworkBundle\Component\Grid\InlineEdit\AbstractGridInlineEdit;
 use Shopsys\FrameworkBundle\Form\Admin\Order\Status\OrderStatusFormType;
-use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade;
 use Symfony\Component\Form\FormFactoryInterface;

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -50,7 +50,7 @@
         "doctrine/doctrine-migrations-bundle": "^1.3.0",
         "doctrine/persistence": "~1.2.0",
         "egeloen/ckeditor-bundle": "^4.0.6",
-        "fp/jsformvalidator-bundle": "^1.5.1",
+        "fp/jsformvalidator-bundle": "~1.5.1",
         "fzaninotto/faker": "^1.7.1",
         "helios-ag/fm-elfinder-bundle": "^9.2",
         "heureka/overeno-zakazniky": "^2.0.6",

--- a/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
+++ b/project-base/src/Shopsys/ShopBundle/Controller/Front/ErrorController.php
@@ -3,7 +3,6 @@
 namespace Shopsys\ShopBundle\Controller\Front;
 
 use Exception;
-use Shopsys\Environment;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\UnableToResolveDomainException;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;

--- a/upgrade/UPGRADE-v7.3.4-dev.md
+++ b/upgrade/UPGRADE-v7.3.4-dev.md
@@ -4,3 +4,14 @@ This guide contains instructions to upgrade from version v7.3.3 to v7.3.4-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+## [shopsys/framework]
+
+### Application
+
+- pin version of `fp/jsformvalidator-bundle` to `~1.5.1` as next minor is not meant to be used with Symfony 3 ([#1790](https://github.com/shopsys/shopsys/pull/1790))
+    ```diff
+    # composer.json
+    -   "fp/jsformvalidator-bundle": "^1.5.1",
+    +   "fp/jsformvalidator-bundle": "~1.5.1",
+    ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| New minor version (1.6) of `fp/jsformvalidator-bundle` should be used with Symfony 4 only. This PR pin version of `fp/jsformvalidator-bundle` to 1.5 minor. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
