### PR TITLE
[framework] renamed rounding related menu entries

### DIFF
--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -145,9 +145,9 @@ class SideMenuBuilder
         $menu->setExtra('icon', 'tag');
 
         $menu->addChild('pricing_groups', ['route' => 'admin_pricinggroup_list', 'label' => t('Pricing groups')]);
-        $menu->addChild('vat', ['route' => 'admin_vat_list', 'label' => t('VAT and rounding')]);
+        $menu->addChild('vat', ['route' => 'admin_vat_list', 'label' => t('VAT')]);
         $menu->addChild('free_transport_and_payment', ['route' => 'admin_transportandpayment_freetransportandpaymentlimit', 'label' => t('Free shipping and payment')]);
-        $menu->addChild('currencies', ['route' => 'admin_currency_list', 'label' => t('Currencies')]);
+        $menu->addChild('currencies', ['route' => 'admin_currency_list', 'label' => t('Currencies and rounding')]);
         $promoCodesMenu = $menu->addChild('promo_codes', ['route' => 'admin_promocode_list', 'label' => t('Promo codes')]);
         $promoCodesMenu->addChild('new', ['route' => 'admin_promocode_new', 'label' => t('New promo code'), 'display' => false]);
         $promoCodesMenu->addChild('edit', ['route' => 'admin_promocode_edit', 'label' => t('Editing promo code'), 'display' => false]);

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -553,8 +553,8 @@ msgstr "Cron se serviceId `%serviceId%` byl naplánován"
 msgid "Cropping"
 msgstr "Ořezávání"
 
-msgid "Currencies"
-msgstr "Měny"
+msgid "Currencies and rounding"
+msgstr "Měny a zaokrouhlování"
 
 msgid "Currency <strong>{{ name }}</strong> deleted"
 msgstr "Měna <strong>{{ name }}</strong> byla smazána"
@@ -2337,9 +2337,6 @@ msgstr "DPH <strong>{{ name }}</strong> bylo smazáno"
 
 msgid "VAT <strong>{{ name }}</strong> deleted and replaced by <strong>{{ newName }}</strong>."
 msgstr "DPH <strong>{{ name }}</strong> bylo smazáno a bylo nahrazeno <strong>{{ newName }}</strong>."
-
-msgid "VAT and rounding"
-msgstr "DPH a zaokrouhlování"
 
 msgid "VAT rate (%)"
 msgstr "Výše DPH (%)"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -553,7 +553,7 @@ msgstr ""
 msgid "Cropping"
 msgstr ""
 
-msgid "Currencies"
+msgid "Currencies and rounding"
 msgstr ""
 
 msgid "Currency <strong>{{ name }}</strong> deleted"
@@ -2336,9 +2336,6 @@ msgid "VAT <strong>{{ name }}</strong> deleted"
 msgstr ""
 
 msgid "VAT <strong>{{ name }}</strong> deleted and replaced by <strong>{{ newName }}</strong>."
-msgstr ""
-
-msgid "VAT and rounding"
 msgstr ""
 
 msgid "VAT rate (%)"

--- a/packages/framework/src/Resources/views/Admin/Content/Currency/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Currency/list.html.twig
@@ -1,7 +1,7 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
 
-{% block title %}- {{ 'Currencies'|trans }}{% endblock %}
-{% block h1 %}{{ 'Currencies'|trans }}{% endblock %}
+{% block title %}- {{ 'Currencies and rounding'|trans }}{% endblock %}
+{% block h1 %}{{ 'Currencies and rounding'|trans }}{% endblock %}
 
 {% block main_content %}
     <div class="wrap-divider wrap-divider--bottom">

--- a/packages/framework/src/Resources/views/Admin/Content/Vat/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Vat/list.html.twig
@@ -1,7 +1,7 @@
 {% extends '@ShopsysFramework/Admin/Layout/layoutWithPanel.html.twig' %}
 
-{% block title %}- {{ 'VAT and rounding'|trans }}{% endblock %}
-{% block h1 %}{{ 'VAT and rounding'|trans }}{% endblock %}
+{% block title %}- {{ 'VAT'|trans }}{% endblock %}
+{% block h1 %}{{ 'VAT'|trans }}{% endblock %}
 
 {% block main_content %}
     {{ render(controller('ShopsysFrameworkBundle:Admin/Domain:domainTabs')) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1487 roundings was moved to currencies and global rounding was removed. This PR renames menu entries and headers on related pages. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes (removed translations) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


`VAT and roundings` renamed to `VAT` as it no longer contains rounding settings.
`Currencies` renamed to `Currencies and rounding` as rounding was moved to currency setting.