### PR TITLE
[framework] fixed phpstan error due to not existent class from different package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,7 @@
         "codeception/phpunit-wrapper": "^8.0",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "nette/utils": "^3.0",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.19",
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -96,7 +96,7 @@
         "webmozart/assert": "^1.4"
     },
     "require-dev": {
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.19",
         "phpunit/phpunit": "^8.0",
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -42,9 +42,6 @@ parameters:
             message: '#^Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.$#'
             path: %currentWorkingDirectory%/src/*
         -
-            message: '#Class Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser not found\.#'
-            path: %currentWorkingDirectory%/src/Model/Customer/User/CurrentCustomerUser.php*
-        -
             message: '#Call to an undefined method \(Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser&Stringable\)|\(Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser&Symfony\\Component\\Security\\Core\\User\\UserInterface\)::getUuid\(\)\.#'
             path: %currentWorkingDirectory%/src/Model/Customer/User/CurrentCustomerUser.php*
         -

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -42,6 +42,12 @@ parameters:
             message: '#^Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.$#'
             path: %currentWorkingDirectory%/src/*
         -
+            message: '#Class Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser not found\.#'
+            path: %currentWorkingDirectory%/src/Model/Customer/User/CurrentCustomerUser.php*
+        -
+            message: '#Call to an undefined method \(Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser&Stringable\)|\(Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser&Symfony\\Component\\Security\\Core\\User\\UserInterface\)::getUuid\(\)\.#'
+            path: %currentWorkingDirectory%/src/Model/Customer/User/CurrentCustomerUser.php*
+        -
             message: '#^Unsafe usage of new static().#'
             path: %currentWorkingDirectory%/src/*
     excludes_analyse:

--- a/packages/framework/src/Model/Customer/User/CurrentCustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CurrentCustomerUser.php
@@ -64,7 +64,7 @@ class CurrentCustomerUser
 
         $user = $token->getUser();
 
-        if ($user instanceof FrontendApiUser) {
+        if (class_exists('\Shopsys\FrontendApiBundle\Model\User\FrontendApiUser') && $user instanceof FrontendApiUser) {
             return $this->customerUserFacade->getByUuid($user->getUuid());
         }
 

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -109,7 +109,7 @@
         "codeception/module-db": "^1.0",
         "codeception/module-webdriver": "^1.0",
         "codeception/phpunit-wrapper": "^8.0",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.19",
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In the framework we are working with FrontendApi class only in case, that bundle is installed. PHPStan ignores class_exists condition and throws an error about not the existing class. This has been resolved in this PR.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
