### PR TITLE
[coding-standards] pinned version of slevomat/coding-standard to ~6.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",
-        "slevomat/coding-standard": "^6.1",
+        "slevomat/coding-standard": "~6.2.0",
         "sspooky13/yaml-standards": "^5.0.0",
         "symfony/var-dumper": "^4.4.0",
         "symfony/web-server-bundle": "^4.4.0",

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -16,7 +16,7 @@
         "friendsofphp/php-cs-fixer": "^2.14.0",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
-        "slevomat/coding-standard": "^6.1",
+        "slevomat/coding-standard": "~6.2.0",
         "squizlabs/php_codesniffer": "^3.5.0",
         "symplify/package-builder": "7.2.2",
         "symplify/easy-coding-standard": "7.2.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With [slevomat/coding-standard v6.3.0](https://github.com/slevomat/coding-standard/releases/tag/6.3.0) release classes from SlevomatCodingStandard namespace are no longer autoloaded (see https://github.com/slevomat/coding-standard/pull/969). This PR locks the version to previous minor until fixed in slevomat/coding-standard.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
