### PR TITLE
[framework] fix condition for plus numbers of parameters in the product filter

### DIFF
--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -652,15 +652,14 @@ class FilterQuery
                 ],
                 'query' => [
                     'bool' => [
-                        'must' => $this->match,
                         'filter' => $this->filters,
-                        'must_not' => [
+                        'must' => [
                             [
                                 'nested' => [
                                     'path' => 'parameters',
                                     'query' => [
                                         'bool' => [
-                                            'must' => [
+                                            'must_not' => [
                                                 'terms' => [
                                                     'parameters.parameter_value_id' => $selectedValuesIds,
                                                 ],


### PR DESCRIPTION
In the product filter on the frontend it was wrong to calculate the plus value of the parameters with multiple values for unselected parameter values, the reason being the reverse condition for the choice of elastic. For a more detailed description and explanation I am available on the slack.

| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes