### PR TITLE
[framework] fix ordering of slider items in administration

### DIFF
--- a/packages/framework/assets/js/admin/components/GridDragAndDrop.js
+++ b/packages/framework/assets/js/admin/components/GridDragAndDrop.js
@@ -6,9 +6,9 @@ import Translator from 'bazinga-translator';
 
 export default class GridDragAndDrop {
 
-    constructor () {
+    constructor ($content) {
         const _this = this;
-        $('.js-drag-and-drop-grid-rows').sortable({
+        $content.find('.js-drag-and-drop-grid-rows').sortable({
             cursor: 'move',
             handle: '.cursor-move',
             items: '.js-grid-row',
@@ -17,12 +17,12 @@ export default class GridDragAndDrop {
             update: (event) => _this.onUpdate(event)
         });
 
-        $('.js-grid').each(function () {
+        $content.find('.js-grid').each(function () {
             const $grid = $(this);
             _this.initGrid($grid);
         });
 
-        this.unifyMultipleGrids();
+        this.unifyMultipleGrids($content);
     }
 
     initGrid ($grid) {
@@ -55,10 +55,10 @@ export default class GridDragAndDrop {
         }
     }
 
-    unifyMultipleGrids () {
-        const $gridSaveButtons = $('.js-drag-and-drop-grid-submit');
-        const $gridsOnPage = $('.js-grid[data-drag-and-drop-ordering-entity-class]');
-        const $saveAllButton = $('.js-drag-and-drop-grid-submit-all');
+    unifyMultipleGrids ($content) {
+        const $gridSaveButtons = $content.find('.js-drag-and-drop-grid-submit');
+        const $gridsOnPage = $content.find('.js-grid[data-drag-and-drop-ordering-entity-class]');
+        const $saveAllButton = $content.find('.js-drag-and-drop-grid-submit-all');
 
         if ($saveAllButton.length === 1) {
             $gridSaveButtons.hide();
@@ -87,7 +87,7 @@ export default class GridDragAndDrop {
 
         const _this = this;
         Ajax.ajax({
-            loaderElement: '.js-drag-and-drop-grid-submit, js-drag-and-drop-grid-submit-all',
+            loaderElement: $grid.find('.js-drag-and-drop-grid-submit, js-drag-and-drop-grid-submit-all'),
             url: $grid.data('drag-and-drop-url-save-ordering'),
             type: 'POST',
             data: data,
@@ -122,9 +122,9 @@ export default class GridDragAndDrop {
         return rowIds;
     }
 
-    static init () {
+    static init ($content) {
         // eslint-disable-next-line no-new
-        new GridDragAndDrop();
+        new GridDragAndDrop($content);
     }
 }
 

--- a/packages/framework/assets/js/admin/components/GridMultipleDragAndDrop.js
+++ b/packages/framework/assets/js/admin/components/GridMultipleDragAndDrop.js
@@ -5,23 +5,23 @@ import Translator from 'bazinga-translator';
 
 export default class GridMultipleDragAndDrop {
 
-    constructor () {
-        this.toggleRowHolders();
+    constructor ($content) {
+        this.toggleRowHolders($content);
 
         const _this = this;
-        $('.js-multiple-grids-save-all-button').click((event) => this.saveOrdering(event));
-        $('.js-multiple-grids-rows-unified').sortable({
+        $content.find('.js-multiple-grids-save-all-button').click((event) => this.saveOrdering($content, event));
+        $content.find('.js-multiple-grids-rows-unified').sortable({
             cursor: 'move',
             handle: '.cursor-move',
             items: '.js-grid-row, .js-grid-row-holder',
             placeholder: 'in-drop-place',
             revert: 200,
-            change: () => _this.onUpdate(),
-            update: () => _this.onUpdate()
+            change: () => _this.onUpdate($content),
+            update: () => _this.onUpdate($content)
         });
     }
 
-    saveOrdering (event) {
+    saveOrdering ($content, event) {
         const $saveButton = $(event.target);
         const $grids = $saveButton.closest('.js-multiple-grids-rows-unified').find('.js-grid');
         const data = {
@@ -29,7 +29,7 @@ export default class GridMultipleDragAndDrop {
         };
 
         Ajax.ajax({
-            loaderElement: '.js-multiple-grids-save-all-button',
+            loaderElement: $content.find('.js-multiple-grids-save-all-button'),
             url: $saveButton.data('drag-and-drop-url-save-ordering'),
             type: 'POST',
             data: data,
@@ -67,22 +67,22 @@ export default class GridMultipleDragAndDrop {
         return rowIdsIndexedByGridId;
     }
 
-    toggleRowHolders () {
-        $('.js-multiple-grids-rows-unified .js-grid').each(function () {
+    toggleRowHolders ($content) {
+        $content.find('.js-multiple-grids-rows-unified .js-grid').each(function () {
             const gridRowsCount = $(this).find('.js-grid-row:not(.ui-sortable-helper):not(.js-grid-row-holder), .in-drop-place').length;
             const $rowHolder = $(this).find('.js-grid-row-holder');
             $rowHolder.toggle(gridRowsCount === 0);
         });
     }
 
-    onUpdate () {
-        $('.js-multiple-grids-save-all-button').removeClass('btn--disabled');
-        this.toggleRowHolders();
+    onUpdate ($content) {
+        $content.find('.js-multiple-grids-save-all-button').removeClass('btn--disabled');
+        this.toggleRowHolders($content);
     }
 
-    static init () {
+    static init ($content) {
         // eslint-disable-next-line no-new
-        new GridMultipleDragAndDrop();
+        new GridMultipleDragAndDrop($content);
     }
 }
 

--- a/packages/framework/src/Controller/Admin/SliderController.php
+++ b/packages/framework/src/Controller/Admin/SliderController.php
@@ -76,7 +76,8 @@ class SliderController extends AdminBaseController
             ->select('s')
             ->from(SliderItem::class, 's')
             ->where('s.domainId = :selectedDomainId')
-            ->setParameter('selectedDomainId', $this->adminDomainTabsFacade->getSelectedDomainId());
+            ->setParameter('selectedDomainId', $this->adminDomainTabsFacade->getSelectedDomainId())
+            ->orderBy('s.position');
         $dataSource = new QueryBuilderDataSource($queryBuilder, 's.id');
 
         $grid = $this->gridFactory->create('sliderItemList', $dataSource);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Slider items were wrongly ordered in admin. Also there was increasing number of ajax calls, this has been solved by initializing sortable grids only for particular content.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
