### PR TITLE
[project-base] Free memory after each functional test

### DIFF
--- a/project-base/config/bootstrap.php
+++ b/project-base/config/bootstrap.php
@@ -56,3 +56,11 @@ $_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+
+/**
+ * With the increasing number of tests and the new version of php unite 8 (see https://github.com/sebastianbergmann/phpunit/issues/3915),
+ * memory requirements have increased and the memory limit needs to be increased.
+ */
+if($_SERVER['APP_ENV'] === 'test'){
+    ini_set('memory_limit', '768MB');
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Functional tests consume about 500MB memory. It causes fail after add few new tests on project. Problem is probably combination of #1704 (injecting services by TestContainer - this PR caused double memory useage!) and PhpUnit (https://github.com/sebastianbergmann/phpunit/issues/3915). I found small part of leaked memory - injected services into all test's instance. It is only 15% in my case, but it is better then nothing. Next precaution I suggest increase memory limit in tests.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
