### PR TITLE
[framework] subscription form removed from error pages

### DIFF
--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -164,7 +164,7 @@ class ErrorPagesFacade
     }
 
     /**
-     * @param mixed $content
+     * @param string $content
      * @return string
      */
     protected function removeContactFrom($content): string

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -8,6 +8,7 @@ use App\Kernel;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -157,8 +158,25 @@ class ErrorPagesFacade
                 $errorPageResponse->getStatusCode()
             );
         }
+        $content = $errorPageResponse->getContent();
 
-        return $errorPageResponse->getContent();
+        return $this->removeContactFrom($content);
+    }
+
+    /**
+     * @param mixed $content
+     * @return string
+     */
+    protected function removeContactFrom($content): string
+    {
+        $crawler = new Crawler($content);
+        $crawler->filter('form[name="subscription_form"]')->each(function (Crawler $crawler) {
+            foreach ($crawler as $node) {
+                $node->parentNode->removeChild($node);
+            }
+        });
+
+        return $crawler->html();
     }
 
     /**

--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -167,7 +167,7 @@ class ErrorPagesFacade
      * @param string $content
      * @return string
      */
-    protected function removeContactFrom($content): string
+    protected function removeContactFrom(string $content): string
     {
         $crawler = new Crawler($content);
         $crawler->filter('form[name="subscription_form"]')->each(function (Crawler $crawler) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We do not want this form on error page sites
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
