### PR TITLE
[project-base] added plugin-proposal-object-rest-spread as babel plugin

### DIFF
--- a/project-base/babel.config.js
+++ b/project-base/babel.config.js
@@ -4,9 +4,10 @@ module.exports = {
             '@babel/preset-env',
             {
                 targets: {
-                    node: 'current',
-                },
-            },
-        ],
+                    node: 'current'
+                }
+            }
+        ]
     ],
+    plugins: ['@babel/plugin-proposal-object-rest-spread']
 };

--- a/project-base/package.json
+++ b/project-base/package.json
@@ -16,6 +16,7 @@
     "devDependencies": {
         "@babel/core": "^7.9.0",
         "@babel/parser": "^7.9.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
         "@babel/preset-env": "^7.9.0",
         "@babel/traverse": "^7.9.0",
         "@symfony/webpack-encore": "^0.28.0",

--- a/project-base/webpack.config.js
+++ b/project-base/webpack.config.js
@@ -31,6 +31,7 @@ Encore
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
     .configureBabel(() => {}, {
+        includeNodeModules: ['@shopsys'],
         useBuiltIns: 'usage',
         corejs: 3
     })

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1380,6 +1380,9 @@ There you can find links to upgrade notes for other versions too.
 
 - fix symfony `dump()` function ([#1745](https://github.com/shopsys/shopsys/pull/1745))
     - see [project-base diff](https://github.com/shopsys/project-base/commit/f1a4c5036a1f3eab202524d2cdc6fa29851468a8) to update your project
+    
+- add compatibility for edge ([#1804](https://github.com/shopsys/shopsys/pull/1804))
+    - see #project-base-diff to update your project
 
 ### Tools
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Our js`s were broken in edge, we added missing babel plugin and fix this problem.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
