### PR TITLE
[shopsys] added livereload plugin for webpack

### DIFF
--- a/docs/frontend/npm-and-webpack.md
+++ b/docs/frontend/npm-and-webpack.md
@@ -74,6 +74,11 @@ Therefore we can use `npm run watch` for development.
 This command checks if a file has changed and if it does, changes are propagated into the resulting bundle.
 The `npm run watch` command launches the webpack in development mode, which means creating source maps to help you debug your project.
 
+### Livereload
+
+The watch command is linked to the [livereload plugin](https://github.com/statianzo/webpack-livereload-plugin).
+The [livereload plugin](https://github.com/statianzo/webpack-livereload-plugin) plugin will refresh your page the moment you change any asset. 
+
 ## Constants and translations
 
 In previous versions, the constants were automatically replaced from the backend to the frontend.

--- a/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
@@ -22,5 +22,9 @@
 
         {{ js_validator_config() }}
         {{ init_js_validation() }}
+
+        {% if app.environment == 'dev' %}
+            <script async src="//localhost:35729/livereload.js"></script>
+        {% endif %}
     </body>
 </html>

--- a/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/base.html.twig
@@ -23,7 +23,7 @@
         {{ js_validator_config() }}
         {{ init_js_validation() }}
 
-        {% if app.environment == 'dev' %}
+        {% if app.environment is same as('dev') %}
             <script async src="//localhost:35729/livereload.js"></script>
         {% endif %}
     </body>

--- a/project-base/package.json
+++ b/project-base/package.json
@@ -46,6 +46,7 @@
         "stylelint-webpack-plugin": "^1.2.3",
         "svgo": "1.2.2",
         "webfonts-generator": "^0.4.0",
+        "webpack-livereload-plugin": "^2.3.0",
         "webpack-notifier": "^1.6.0"
     },
     "dependencies": {

--- a/project-base/templates/Front/Layout/base.html.twig
+++ b/project-base/templates/Front/Layout/base.html.twig
@@ -32,7 +32,7 @@
         {{ js_validator_config() }}
         {{ init_js_validation() }}
 
-        {% if app.environment == 'dev' %}
+        {% if app.environment is same as('dev') %}
             <script async src="//localhost:35729/livereload.js"></script>
         {% endif %}
     </body>

--- a/project-base/templates/Front/Layout/base.html.twig
+++ b/project-base/templates/Front/Layout/base.html.twig
@@ -31,5 +31,9 @@
 
         {{ js_validator_config() }}
         {{ init_js_validation() }}
+
+        {% if app.environment == 'dev' %}
+            <script async src="//localhost:35729/livereload.js"></script>
+        {% endif %}
     </body>
 </html>

--- a/project-base/webpack.config.js
+++ b/project-base/webpack.config.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const StylelintPlugin = require('stylelint-webpack-plugin');
 const sources = require('./assets/js/bin/helpers/sources');
+const LiveReloadPlugin = require('webpack-livereload-plugin');
 
 if (!Encore.isRuntimeEnvironmentConfigured()) {
     Encore.configureRuntimeEnvironment(process.env.NODE_ENV || 'dev');
@@ -73,6 +74,7 @@ Encore
         { from: 'node_modules/@shopsys/framework/public/admin', to: '../../web/public/admin', force: true },
         { from: 'assets/public', to: '../../web/public', ignore: ['assets/public/admin/svg/**/*'], force: true }
     ]))
+    .addPlugin(new LiveReloadPlugin())
 ;
 
 const domainFile = './config/domains.yaml';

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1567,6 +1567,9 @@ There you can find links to upgrade notes for other versions too.
 - add support for Safari ([#1811](https://github.com/shopsys/shopsys/pull/1811))
     - see #project-base-diff to update your project
 
+- add LiveRload for Webpack ([#1807](https://github.com/shopsys/shopsys/pull/1807))
+    - see #project-base-diff to update your project
+
 If you have custom frontend you can skip these tasks:
 - hide variant table header when product is denied for sale ([#1634](https://github.com/shopsys/shopsys/pull/1634))
     - add new condition at product detail file: `templates/Front/Content/Product/detail.html.twig`

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1567,7 +1567,7 @@ There you can find links to upgrade notes for other versions too.
 - add support for Safari ([#1811](https://github.com/shopsys/shopsys/pull/1811))
     - see #project-base-diff to update your project
 
-- add LiveRload for Webpack ([#1807](https://github.com/shopsys/shopsys/pull/1807))
+- add LiveReload for Webpack ([#1807](https://github.com/shopsys/shopsys/pull/1807))
     - see #project-base-diff to update your project
 
 If you have custom frontend you can skip these tasks:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We put back liverload plugin after upgrade to webpack encore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1694
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
