### PR TITLE
[project-base] import jquery-ui-touch-punch and add safari support into babel

### DIFF
--- a/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
+++ b/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
@@ -1,5 +1,6 @@
-import 'nestedSortable';
-
+import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import Ajax from '../../common/utils/Ajax';
 import FormChangeInfo from './FormChangeInfo';
 import Register from '../../common/utils/Register';
@@ -13,7 +14,7 @@ export default class CategoryTreeSorting {
         this.$saveButton = $saveButton;
 
         const _this = this;
-        this.$rootTree.nestedSortable({
+        this.$rootTree.sortable({
             listType: 'ul',
             handle: '.js-category-tree-item-handle',
             items: '.js-category-tree-item',
@@ -64,7 +65,7 @@ export default class CategoryTreeSorting {
     }
 
     getCategoriesOrderingData () {
-        const data = this.$rootTree.nestedSortable(
+        const data = this.$rootTree.sortable(
             'toArray',
             {
                 excludeRoot: true,

--- a/packages/framework/assets/js/admin/components/GridDragAndDrop.js
+++ b/packages/framework/assets/js/admin/components/GridDragAndDrop.js
@@ -1,3 +1,6 @@
+import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import formChangeInfo from './FormChangeInfo';
 import Ajax from '../../common/utils/Ajax';
 import Window from '../utils/Window';

--- a/packages/framework/assets/js/admin/components/GridInlineEdit.js
+++ b/packages/framework/assets/js/admin/components/GridInlineEdit.js
@@ -1,3 +1,6 @@
+import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import { KeyCodes } from '../../common/utils/KeyCodes';
 import Ajax from '../../common/utils/Ajax';
 import Register from '../../common/utils/Register';

--- a/packages/framework/assets/js/admin/components/GridMultipleDragAndDrop.js
+++ b/packages/framework/assets/js/admin/components/GridMultipleDragAndDrop.js
@@ -1,3 +1,6 @@
+import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import Ajax from '../../common/utils/Ajax';
 import Window from '../utils/Window';
 import Register from '../../common/utils/Register';

--- a/packages/framework/assets/js/admin/components/SortableValues.js
+++ b/packages/framework/assets/js/admin/components/SortableValues.js
@@ -1,3 +1,6 @@
+import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import Register from '../../common/utils/Register';
 import { escapeHtml } from '../../common/utils/escapeHtml';
 

--- a/packages/framework/assets/js/admin/components/fileUploadPreview.js
+++ b/packages/framework/assets/js/admin/components/fileUploadPreview.js
@@ -1,3 +1,6 @@
+import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import formChangeInfo from './FormChangeInfo';
 import { select, deselect, getSelectedValues } from './choiceControl';
 import Register from '../../common/utils/Register';

--- a/packages/framework/assets/js/admin/components/productsPicker.js
+++ b/packages/framework/assets/js/admin/components/productsPicker.js
@@ -1,5 +1,7 @@
 import 'magnific-popup';
 import 'jquery-ui/sortable';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import FormChangeInfo from './FormChangeInfo';
 import Register from '../../common/utils/Register';
 

--- a/packages/framework/assets/package.json
+++ b/packages/framework/assets/package.json
@@ -17,8 +17,8 @@
     "jquery": "^3.4.1",
     "jquery-hoverintent": "^1.10.1",
     "jquery-ui": "^1.12.1",
+    "jquery-ui-touch-punch": "^0.2.3",
     "magnific-popup": "^1.1.0",
-    "nestedSortable": "^1.3.4",
     "select2": "^4.0.12",
     "waypoints": "^4.0.1"
   },

--- a/project-base/assets/js/admin/admin.js
+++ b/project-base/assets/js/admin/admin.js
@@ -1,6 +1,4 @@
 import '../jQuery/registerJquery';
-import 'jquery-ui/ui/widgets/mouse';
-import 'jquery-ui-touch-punch';
 import registerAdmin from 'framework/admin/registerAdmin';
 import '../loadTranslations';
 

--- a/project-base/assets/js/admin/admin.js
+++ b/project-base/assets/js/admin/admin.js
@@ -1,4 +1,6 @@
 import '../jQuery/registerJquery';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
 import registerAdmin from 'framework/admin/registerAdmin';
 import '../loadTranslations';
 

--- a/project-base/assets/js/frontend.js
+++ b/project-base/assets/js/frontend.js
@@ -1,6 +1,7 @@
-// import 'jquery-ui-touch-punch';
-
 import './jQuery/registerJquery';
+import 'jquery-ui/ui/widgets/mouse';
+import 'jquery-ui-touch-punch';
+
 import tooltip from 'framework/common/bootstrap/tooltip';
 
 import 'framework/common/components';

--- a/project-base/babel.config.js
+++ b/project-base/babel.config.js
@@ -4,7 +4,10 @@ module.exports = {
             '@babel/preset-env',
             {
                 targets: {
-                    node: 'current'
+                    node: 'current',
+                    browsers: [
+                        'safari >= 8'
+                    ]
                 }
             }
         ]

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1533,6 +1533,9 @@ There you can find links to upgrade notes for other versions too.
         - now you can rebuild you less files `npm run dev` and you should see your font on frontend page
     - use full of the webpack, enjoy!
 
+- add support for Safari ([#1811](https://github.com/shopsys/shopsys/pull/1811))
+    - see #project-base-diff to update your project
+
 If you have custom frontend you can skip these tasks:
 - hide variant table header when product is denied for sale ([#1634](https://github.com/shopsys/shopsys/pull/1634))
     - add new condition at product detail file: `templates/Front/Content/Product/detail.html.twig`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We set support for Safari8+ in babel config and import jquery-ui-touch-punch for correct work jquery-ui on touch devices.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
