### PR TITLE
[project-base] improved clearing cache behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,9 +194,9 @@
             "@auto-scripts"
         ],
         "auto-scripts": {
+            "php phing clean": "script",
             "shopsys:domains-urls:configure": "symfony-cmd",
             "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd",
-            "cache:clear --no-warmup": "symfony-cmd",
             "security-checker security:check": "script"
         }
     },

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -134,9 +134,9 @@
             "@auto-scripts"
         ],
         "auto-scripts": {
+            "php phing clean": "script",
             "shopsys:domains-urls:configure": "symfony-cmd",
             "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd",
-            "cache:clear --no-warmup": "symfony-cmd",
             "security-checker security:check": "script"
         }
     },

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -127,7 +127,7 @@ COPY --chown=www-data:www-data / /var/www/html
 
 RUN composer install --optimize-autoloader --no-interaction --no-progress --no-dev
 
-RUN php phing build-deploy-part-1-db-independent
+RUN php phing build-deploy-part-1-db-independent clean
 
 ########################################################################################################################
 
@@ -140,3 +140,5 @@ RUN composer install --optimize-autoloader --no-interaction --no-progress --dev
 RUN php phing composer-dev dirs-create test-dirs-create assets npm standards tests-unit tests-acceptance-build
 
 RUN ./bin/console shopsys:environment:change prod
+
+RUN php phing clean

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -206,6 +206,9 @@ There you can find links to upgrade notes for other versions too.
     - be aware, if you already have such paths (`hledani/`, `search/`) in your application
     - the change might cause problems with your SEO as well
 
+- clear cache before any other commands in composer and after docker image is built ([#1820](https://github.com/shopsys/shopsys/pull/1820))
+    - see #project-base-diff to update your project
+
 ### Database migrations
 - [#1757](https://github.com/shopsys/shopsys/pull/1757)
     - orders have nullable field `origin` to distinguish origin of the order


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Cache is now cleared before any other commands in composer scripts and does not rely on working application. Built Docker image does not contain cache generated on build. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1002 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

_Note: why it's necessary to clear the cache first? 
For example, after #1606 it's necessary to clear cache after composer update. But if any symfony command is run before clearing cache, application try to use old cache with incompatible method definition and fails on `Declaration of Redis_ca5fc0f::multi() should be compatible with Redis::multi($mode = NULL) in /var/www/html/project-base/var/cache/prod/ContainerWnR8ZiQ/Redis_ca5fc0f.php`_ 

_Note2: In Linux Kernel 3.10 with XFS filesystem and Overlay storage, this change results in an un-buildable image due to error in Linux kernel. (see https://github.com/moby/moby/issues/10294#issuecomment-223909234)_