### PR TITLE
[framework] remove final from relevant classes

### DIFF
--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
-final class ShopsysFrameworkDataCollector extends DataCollector
+class ShopsysFrameworkDataCollector extends DataCollector
 {
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain

--- a/packages/framework/src/Component/Doctrine/MoneyType.php
+++ b/packages/framework/src/Component/Doctrine/MoneyType.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 
-final class MoneyType extends Type
+class MoneyType extends Type
 {
     /**
      * {@inheritDoc}

--- a/packages/framework/src/Component/Money/Exception/InvalidNumericArgumentException.php
+++ b/packages/framework/src/Component/Money/Exception/InvalidNumericArgumentException.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\Money\Exception;
 use Exception;
 use Throwable;
 
-final class InvalidNumericArgumentException extends Exception implements MoneyException
+class InvalidNumericArgumentException extends Exception implements MoneyException
 {
     /**
      * @param string $value

--- a/packages/framework/src/Component/Money/Exception/UnsupportedTypeException.php
+++ b/packages/framework/src/Component/Money/Exception/UnsupportedTypeException.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\Money\Exception;
 use InvalidArgumentException;
 use Throwable;
 
-final class UnsupportedTypeException extends InvalidArgumentException implements MoneyException
+class UnsupportedTypeException extends InvalidArgumentException implements MoneyException
 {
     /**
      * @param mixed $value

--- a/packages/framework/src/Component/Money/Money.php
+++ b/packages/framework/src/Component/Money/Money.php
@@ -8,7 +8,7 @@ use JsonSerializable;
 use Litipk\BigNumbers\Decimal;
 use Shopsys\FrameworkBundle\Component\Money\Exception\UnsupportedTypeException;
 
-final class Money implements JsonSerializable
+class Money implements JsonSerializable
 {
     /**
      * @var \Litipk\BigNumbers\Decimal

--- a/packages/framework/src/Form/Transformers/CopyTotalPricesOfOrderItemTransformer.php
+++ b/packages/framework/src/Form/Transformers/CopyTotalPricesOfOrderItemTransformer.php
@@ -8,7 +8,7 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
-final class CopyTotalPricesOfOrderItemTransformer implements DataTransformerInterface
+class CopyTotalPricesOfOrderItemTransformer implements DataTransformerInterface
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData|null $value

--- a/packages/framework/src/Form/Transformers/NumericToMoneyTransformer.php
+++ b/packages/framework/src/Form/Transformers/NumericToMoneyTransformer.php
@@ -8,7 +8,7 @@ use Shopsys\FrameworkBundle\Component\Money\Money;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
-final class NumericToMoneyTransformer implements DataTransformerInterface
+class NumericToMoneyTransformer implements DataTransformerInterface
 {
     /**
      * @var int

--- a/packages/framework/src/Migrations/Version20181114102106.php
+++ b/packages/framework/src/Migrations/Version20181114102106.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
-final class Version20181114102106 extends AbstractMigration
+class Version20181114102106 extends AbstractMigration
 {
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema

--- a/packages/framework/src/Migrations/Version20181114120915.php
+++ b/packages/framework/src/Migrations/Version20181114120915.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
-final class Version20181114120915 extends AbstractMigration
+class Version20181114120915 extends AbstractMigration
 {
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema

--- a/packages/framework/src/Migrations/Version20181114134959.php
+++ b/packages/framework/src/Migrations/Version20181114134959.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
-final class Version20181114134959 extends AbstractMigration
+class Version20181114134959 extends AbstractMigration
 {
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Shopsys Framework uses class extendability like main way, how to override it. However few classes break is with their `final` definition. And it is inconsistent (3 DB migrations are final and others not). I didn't solve classes in tests, coding standards package and utils. Maybe it can be watched by automatic sniff like protected property, because protected property in final class is funny and sad in one time... 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
