### PR TITLE
[shopsys] fixed typo in annotations

### DIFF
--- a/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
+++ b/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
@@ -95,7 +95,8 @@ class EntityManagerDecorator extends BaseEntityManagerDecorator
     }
 
     /**
-     * {@inheritdoc}
+     * @param string $className
+     * @return \Doctrine\Common\Persistence\ObjectRepository
      */
     public function getRepository($className)
     {

--- a/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
+++ b/packages/product-feed-heureka/tests/Unit/HeurekaFeedItemTest.php
@@ -44,7 +44,7 @@ class HeurekaFeedItemTest extends TestCase
     private $categoryFacadeMock;
 
     /**
-     * @var \Shopsys\ProductFeed\HeurekaBundle\Model\FeedItem\HeurekaFeedItemFactory::__construct
+     * @var \Shopsys\ProductFeed\HeurekaBundle\Model\FeedItem\HeurekaFeedItemFactory
      */
     private $heurekaFeedItemFactory;
 

--- a/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
+++ b/packages/product-feed-zbozi/tests/Unit/ZboziFeedItemTest.php
@@ -44,7 +44,7 @@ class ZboziFeedItemTest extends TestCase
     private $categoryFacadeMock;
 
     /**
-     * @var \Shopsys\ProductFeed\ZboziBundle\Model\FeedItem\ZboziFeedItemFactory::__construct
+     * @var \Shopsys\ProductFeed\ZboziBundle\Model\FeedItem\ZboziFeedItemFactory
      */
     private $zboziFeedItemFactory;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes errors in annotation found by new version of PHPStan 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

`packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php` 
 fails on 
```
Method Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator::getRepository()
should return Doctrine\Common\Persistence\ObjectRepository<T> 
but returns Doctrine\Common\Persistence\ObjectRepository<object>.
```

Maybe it's a bug in phpstan-doctrine (without phpstan-doctrine, the error is not reported). Added phpdoc is the same as it's in the original interface.
