### PR TITLE
[framework] Locale flags now use asset packages to retrieve its URL

### DIFF
--- a/packages/framework/src/Twig/LocalizationExtension.php
+++ b/packages/framework/src/Twig/LocalizationExtension.php
@@ -53,9 +53,10 @@ class LocalizationExtension extends AbstractExtension
      */
     public function getLocaleFlagHtml($locale, $showTitle = true)
     {
-        $src = $this->assetPackages->getUrl('public/admin/images/flags/' . $locale . '.png');
+        $filepath = 'public/admin/images/flags/' . $locale . '.png';
+        $src = $this->assetPackages->getUrl($filepath);
 
-        if (file_exists($this->webDir . $src) === false) {
+        if (file_exists($this->webDir . '/' . $filepath) === false) {
             return strtoupper($locale);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When project use configuration framework.assets.base_urls eg. for using of CDN, locale flags in administraions don't work. Tested filepath looks like `/var/www/html/src/../webhttp://cdn.example.test:8000/public/admin/images/flags/cs.png`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
