### PR TITLE
[shopsys] PHPStan limit maximum number of processes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 parameters:
-
+    # limit maximum concurrent job count to prevent server overload
+    parallel:
+        maximumNumberOfProcesses: 5
     treatPhpDocTypesAsCertain: false
 
     ignoreErrors:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Add PHPStan limit for concurrent jobs so CI server is not overloaded.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
