### PR TITLE
[project-base] container log now catches all lines from first command output

### DIFF
--- a/project-base/docker/php-fpm/docker-php-entrypoint
+++ b/project-base/docker/php-fpm/docker-php-entrypoint
@@ -11,7 +11,7 @@ PIPE=/tmp/log-pipe
 rm -rf $PIPE
 mkfifo $PIPE
 chmod 666 $PIPE
-tail -f $PIPE &
+tail -n +1 -f $PIPE &
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `tail` used in log-pipe return last 10 lines + all following (option -f), it causes that first command has logged only last 10 lines after start new container. Eg. It is problem for crons in kubernetes (each cron starts new container and whole output is discarted except last 10 lines)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| I don't know <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
