### PR TITLE
[framework] RegisterExtendedEntitiesCompilerPass: catch MappingException

### DIFF
--- a/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
@@ -25,7 +25,7 @@ class RegisterExtendedEntitiesCompilerPass implements CompilerPassInterface
             if (strpos($class, 'App\\') === 0) {
                 $parentClass = get_parent_class($class);
 
-                if ($parentClass !== false && strpos($parentClass, 'Shopsys\\') === 0) {
+                if ($parentClass !== false && strpos($parentClass, 'Shopsys\\') === 0 && !$annotationReader->isTransient($parentClass)) {
                     $annotationReader->loadMetadataForClass($parentClass, new ClassMetadata($parentClass));
                     $entityExtensionMap[$parentClass] = $class;
                 }


### PR DESCRIPTION
- see https://prnt.sc/scsxyl

| Q             | A
| ------------- | ---
|Description, reason for the PR| if there is a translatable entity in project-base (i.e. it extends AbstractTranslatableEntity), the compiler pass fails on the exception as it is not possible to load metadata for the non-entity. This PR adds a check if parent is a real entity class.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
