### PR TITLE
[framework] fixed typo in framework composer.json file

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -102,7 +102,7 @@
         "phpstan/phpstan-phpunit": "^0.12",
         "shopsys/coding-standards": "9.0.x-dev",
         "sspooky13/yaml-standards": "^5.0.0",
-        "symfony/var-dumper": "^4.4",
+        "symfony/var-dumper": "^4.4"
     },
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| From #1817 there is a typo in composer.json file resulting in non-installable package. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
