### PR TITLE
[shopsys] bump framework npm package version

### DIFF
--- a/packages/framework/assets/package.json
+++ b/packages/framework/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopsys/framework",
-  "version": "9.0.0-dev.7",
+  "version": "9.0.0-dev.8",
   "description": "Shopsys framework assets files",
   "repository": "https://github.com/shopsys/shopsys",
   "author": "Shopsys",

--- a/project-base/package.json
+++ b/project-base/package.json
@@ -49,7 +49,7 @@
         "webpack-notifier": "^1.6.0"
     },
     "dependencies": {
-        "@shopsys/framework": "9.0.0-dev.7",
+        "@shopsys/framework": "9.0.0-dev.8",
         "codemirror": "^5.49.2",
         "jquery-ui": "^1.12.1",
         "jquery-ui-touch-punch": "^0.2.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| @shopsys/framework npm package is released in version dev.8. This PR changes the version and dependency.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
