### PR TITLE
[shopsys] fixed categories sorting in admin

### DIFF
--- a/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
+++ b/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
@@ -1,6 +1,6 @@
-import 'jquery-ui/sortable';
 import 'jquery-ui/ui/widgets/mouse';
 import 'jquery-ui-touch-punch';
+import 'jquery-ui-nested-sortable';
 import Ajax from '../../common/utils/Ajax';
 import FormChangeInfo from './FormChangeInfo';
 import Register from '../../common/utils/Register';
@@ -14,7 +14,7 @@ export default class CategoryTreeSorting {
         this.$saveButton = $saveButton;
 
         const _this = this;
-        this.$rootTree.sortable({
+        this.$rootTree.nestedSortable({
             listType: 'ul',
             handle: '.js-category-tree-item-handle',
             items: '.js-category-tree-item',
@@ -65,7 +65,7 @@ export default class CategoryTreeSorting {
     }
 
     getCategoriesOrderingData () {
-        const data = this.$rootTree.sortable(
+        const data = this.$rootTree.nestedSortable(
             'toArray',
             {
                 excludeRoot: true,

--- a/project-base/package.json
+++ b/project-base/package.json
@@ -56,6 +56,7 @@
         "jquery.cookie": "^1.4.1",
         "magnific-popup": "^1.1.0",
         "minilazyload": "^2.3.3",
+        "nestedSortable": "^1.3.4",
         "slick-carousel": "1.6.0"
     }
 }

--- a/project-base/webpack.config.js
+++ b/project-base/webpack.config.js
@@ -114,6 +114,7 @@ config.resolve.alias = {
     'framework': '@shopsys/framework/js',
     'jquery': path.resolve(path.join(__dirname, 'node_modules', 'jquery')),
     'jquery-ui-styles': path.resolve(path.join(__dirname, 'node_modules', 'jquery-ui')),
-    'bazinga-translator': path.resolve(path.join(__dirname, 'node_modules', 'bazinga-translator'))
+    'bazinga-translator': path.resolve(path.join(__dirname, 'node_modules', 'bazinga-translator')),
+    'jquery-ui-nested-sortable': path.resolve(path.join(__dirname, 'node_modules', 'nestedSortable'))
 };
 module.exports = config;

--- a/upgrade/upgrade-instruction-for-webpack.md
+++ b/upgrade/upgrade-instruction-for-webpack.md
@@ -56,6 +56,7 @@ webpack_encore:
 +        "jquery-ui-touch-punch": "^0.2.3",
 +        "jquery.cookie": "^1.4.1",
 +        "minilazyload": "^2.3.3",
++        "nestedSortable": "^1.3.4",
 +        "slick-carousel": "1.6.0"
 +    },
      "devDependencies": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Sorting categories in administration requires `nestedSorting` plugin to work properly. With this PR this plugin is added and configured.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
