### PR TITLE
[shopsys] fixed untranslated texts

### DIFF
--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -96,7 +96,7 @@ class AdvertFormType extends AbstractType
                     new Constraints\NotBlank(['message' => 'Please enter name of advertisement area']),
                 ],
                 'label' => t('Name'),
-                'icon_title' => 'Name serves only for internal use within the administration.',
+                'icon_title' => t('Name serves only for internal use within the administration'),
             ])
             ->add('type', ChoiceType::class, [
                 'required' => true,
@@ -125,6 +125,7 @@ class AdvertFormType extends AbstractType
                 'label' => t('Hide advertisement'),
             ])
             ->add('code', TextareaType::class, [
+                'label' => t('Code'),
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([

--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -68,6 +68,7 @@ class CustomerUserFormType extends AbstractType
                 'data' => $customerUser->getId(),
             ]);
             $builderSystemDataGroup->add('domainIcon', DisplayOnlyDomainIconType::class, [
+                'label' => t('Domain'),
                 'data' => $customerUser->getDomainId(),
             ]);
             $pricingGroups = $this->pricingGroupFacade->getByDomainId($customerUser->getDomainId());

--- a/packages/framework/src/Form/Admin/CustomerCommunication/CustomerUserCommunicationFormType.php
+++ b/packages/framework/src/Form/Admin/CustomerCommunication/CustomerUserCommunicationFormType.php
@@ -21,7 +21,10 @@ class CustomerUserCommunicationFormType extends AbstractType
         ]);
 
         $builderSettingsGroup
-            ->add('content', CKEditorType::class, ['required' => false]);
+            ->add('content', CKEditorType::class, [
+                'label' => t('Content'),
+                'required' => false,
+            ]);
 
         $builder
             ->add($builderSettingsGroup)

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
@@ -51,6 +51,7 @@ class PromoCodeFormType extends AbstractType
 
         $builder
             ->add('code', TextType::class, [
+                'label' => t('Code'),
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank([
@@ -71,7 +72,7 @@ class PromoCodeFormType extends AbstractType
                     ]),
                 ],
                 'invalid_message' => 'Please enter whole number.',
-                'label' => 'Discount (%)',
+                'label' => t('Discount (%)'),
             ]);
 
         $builder->add('save', SubmitType::class);

--- a/project-base/assets/js/loadTranslations.js
+++ b/project-base/assets/js/loadTranslations.js
@@ -14,4 +14,4 @@ export default function loadTranslations () {
     });
 }
 
-(new Register()).registerCallback(loadTranslations);
+(new Register()).registerCallback(loadTranslations, 200);

--- a/project-base/src/Form/Admin/ArticleFormTypeExtension.php
+++ b/project-base/src/Form/Admin/ArticleFormTypeExtension.php
@@ -23,7 +23,7 @@ class ArticleFormTypeExtension extends AbstractTypeExtension
             'constraints' => [
                 new Constraints\NotBlank(['message' => 'Please enter date of creation']),
             ],
-            'label' => 'Creation date',
+            'label' => t('Creation date'),
         ]);
         $builder->add($builderArticleDataGroup);
     }

--- a/upgrade/UPGRADE-v9.0.0-dev.md
+++ b/upgrade/UPGRADE-v9.0.0-dev.md
@@ -1431,6 +1431,9 @@ There you can find links to upgrade notes for other versions too.
             + public function deleteById(int $brandId): void
             ```
 
+- fix untranslated texts in admin ([#1841](https://github.com/shopsys/shopsys/pull/1841))
+    - see #project-base-diff to update your project
+
 ### Tools
 
 - apply coding standards checks on your `app` folder ([#1306](https://github.com/shopsys/shopsys/pull/1306))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Several texts in administration were not translated. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
