### PR TITLE
[project-base] Automatically delete sessions after 7 days of user inactivity

### DIFF
--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -36,4 +36,5 @@ snc_redis:
             dsn: 'redis://%redis_host%'
     session:
         client: 'session'
+        ttl: 604800
         prefix: '%env(REDIS_PREFIX)%session:'

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -11,3 +11,7 @@ There you can find links to upgrade notes for other versions too.
 
 - fix not working upload of files in wysiwyg editor ([#1899](https://github.com/shopsys/shopsys/pull/1899))
     - see #project-base-diff to update your project
+
+- enable automatic deleting of sessions older than 7 days in Redis ([#1842](https://github.com/shopsys/shopsys/pull/1842))
+    - see #project-base-diff to update your project
+    - you should consider what to do with current sessions, if you want to keep them, set them TTL or delete them


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Session were never deleted from Redis and this caused some high disk space usage. This is fixed by this PR.
|New feature| No 
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No 
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Delete a session after 24 hours of user inactivity, because the session stays on the server forever and takes up memory space. 
