### PR TITLE
[framework] Phing: domain info load target now does not include errors in output properties

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -444,13 +444,13 @@
     </target>
 
     <target name="domains-info-load" description="Load info about domains configuration into Phing properties." hidden="true">
-        <exec executable="${path.php.executable}" passthru="true" outputProperty="domains-info.ids">
+        <exec executable="${path.php.executable}" outputProperty="domains-info.ids" error="${dev.null}">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:domains:info"/>
             <arg value="--oneline"/>
         </exec>
 
-        <exec executable="${path.php.executable}" passthru="true" outputProperty="domains-info.locales">
+        <exec executable="${path.php.executable}" outputProperty="domains-info.locales" error="${dev.null}">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:domains:info"/>
             <arg value="locale"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Solution in #1844 is not good as in translation-dump target it does not load the properties at all (visible confusion). This PR only redirects error output
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
