### PR TITLE
[shopsys] save generated error pages via flysystem adapter

### DIFF
--- a/project-base/config/paths.yaml
+++ b/project-base/config/paths.yaml
@@ -7,7 +7,7 @@ parameters:
     shopsys.domain_images_dir: '/web%shopsys.domain_images_url_prefix%'
     shopsys.domain_images_url_prefix: '/%shopsys.content_dir_name%/admin/images/domain'
     shopsys.domain_urls_config_filepath: '%shopsys.root_dir%/config/domains_urls.yaml'
-    shopsys.error_pages_dir: '%shopsys.root_dir%/var/errorPages/'
+    shopsys.error_pages_dir: '/var/errorPages/'
     shopsys.feed_dir: '/web%shopsys.feed_url_prefix%'
     shopsys.feed_url_prefix: '/%shopsys.content_dir_name%/feeds/'
     shopsys.filemanager_upload_dir: '%shopsys.web_dir%/%shopsys.filemanager_upload_web_dir%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Until now, generated error pages were saved into local var dir. It contradicts the principles of [12-factor app](https://12factor.net/processes). That is problem when someone has production in cluster because he couldn't upgrade error pages via cron. This PR is changing this behaviour and uses flysystem adapter for saving error pages. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1628 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
