### PR TITLE
[shopsys] fixed services in releaser

### DIFF
--- a/utils/releaser/config/services.yaml
+++ b/utils/releaser/config/services.yaml
@@ -19,17 +19,18 @@ services:
         resource: "../src"
         exclude: "../src/Exception"
 
-    GuzzleHttp\Client: ~
+    GuzzleHttp\ClientInterface:
+        class: GuzzleHttp\Client
+
     Symfony\Component\Console\Helper\QuestionHelper: ~
 
     Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider:
         arguments:
             - ['packages', 'project-base']
 
-    Twig_Environment:
-        class: Twig\Environment
+    Twig\Environment: ~
 
-    Twig_LoaderInterface:
+    Twig\Loader\LoaderInterface:
         class: Twig\Loader\FilesystemLoader
         arguments:
             - ['upgrade/template']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We didn't update services in releaser after upgrade to symfony4. This PR fix it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
