### PR TITLE
[framework] Added missing exception message about category was not found for product and domain

### DIFF
--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -479,7 +479,7 @@ class CategoryRepository extends NestedTreeRepository
     {
         $productMainCategory = $this->findProductMainCategoryOnDomain($product, $domainId);
         if ($productMainCategory === null) {
-            throw new \Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException();
+            throw new \Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException(sprintf('Main category for product id `%d` and domain id `%d` was not found', $product->getId(), $domainId));
         }
 
         return $productMainCategory;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Hello,
I had a problem in project with non-found category for some products at generating feeds. Console wrote only `ERROR     [cron]` so it was a great debugging 😄 If at little possible, fill the messages for exceptions to avoid dumping vendor packages 😊 
Thanks.

PS: thanks @pk16011990 with this 🙏 

```bash
/var/www/html$ php bin/console shopsys:cron --module="overriddenDailyFeedCronModule" --instance-name=default
12:48:09 INFO      [cron] Start of overriddenDailyFeedCronModule
12:48:37 DEBUG     [cron] Feed "heureka" generated on domain "XXX" into "/web/content/feeds/uQ5TueFNQh_heureka_1.xml".
12:49:20 DEBUG     [cron] Feed "heureka" generated on domain "XXX" into "/web/content/feeds/uQ5TueFNQh_heureka_2.xml".
12:49:52 DEBUG     [cron] Feed "heureka" generated on domain "XXX" into "/web/content/feeds/uQ5TueFNQh_heureka_3.xml".
12:50:16 ERROR     [cron]
12:50:16 ERROR     [cron]
12:50:16 ERROR     [cron]
12:50:16 ERROR     [cron]
12:50:16 ERROR     [cron]
12:50:16 ERROR     [cron]
12:50:16 ERROR     [cron]
^C
/var/www/html$ 
```