### PR TITLE
[shopsys] pinned jms/translator bundle to version 1.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
         "jdorn/sql-formatter": "^1.2",
         "jms/metadata": "^1.6",
         "jms/serializer-bundle": "^2.4",
-        "jms/translation-bundle": "^1.5.4",
+        "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "lcobucci/jwt": "^3.3",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -62,7 +62,7 @@
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/metadata": "^1.6",
-        "jms/translation-bundle": "^1.5.4",
+        "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "league/flysystem": "^1.0",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -52,7 +52,7 @@
         "incenteev/composer-parameter-handler": "^2.1.3",
         "intervention/image": "^2.3.14",
         "jms/serializer-bundle": "^2.4",
-        "jms/translation-bundle": "^1.5.4",
+        "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "league/flysystem": "^1.0",
         "phing/phing": "^2.16.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| newest version generate error strtolower() expects parameter 1 to be string, object given in FormExtractor class
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
