### PR TITLE
[coding-standards] Upgrade dependency on symplify/easy-coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,10 +174,10 @@
     "sspooky13/yaml-standards": "^5.0.0",
     "symfony/var-dumper": "^4.4.0",
     "symplify/changelog-linker": "7.2.2",
-    "symplify/easy-coding-standard": "7.2.2",
-    "symplify/easy-coding-standard-tester": "7.2.2",
-    "symplify/monorepo-builder": "7.2.2",
-    "symplify/package-builder": "7.2.2",
+    "symplify/easy-coding-standard": "^7.3.18",
+    "symplify/easy-coding-standard-tester": "^7.3.18",
+    "symplify/monorepo-builder": "^7.3.18",
+    "symplify/package-builder": "^7.3.18",
     "zalas/phpunit-injector": "^1.4"
   },
   "conflict": {

--- a/packages/backend-api/install/config/bundles.php.patch
+++ b/packages/backend-api/install/config/bundles.php.patch
@@ -1,7 +1,7 @@
-@@ -41,4 +41,7 @@ return [
-     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true],
-     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
-     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
+@@ -44,4 +44,7 @@
+     Symplify\ConsoleColorDiff\ConsoleColorDiffBundle::class => ['dev' => true, 'test' => true],
+     Symplify\ParameterNameGuard\ParameterNameGuardBundle::class => ['dev' => true, 'test' => true],
+     Symplify\ComposerJsonManipulator\ComposerJsonManipulatorBundle::class => ['dev' => true, 'test' => true],
 +    Shopsys\BackendApiBundle\ShopsysBackendApiBundle::class => ['all' => true],
 +    Trikoder\Bundle\OAuth2Bundle\TrikoderOAuth2Bundle::class => ['all' => true],
 +    FOS\RestBundle\FOSRestBundle::class => ['all' => true],

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -18,13 +18,13 @@
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
         "slevomat/coding-standard": "^6.3.5",
         "squizlabs/php_codesniffer": "^3.5.0",
-        "symplify/package-builder": "7.2.2",
-        "symplify/easy-coding-standard": "7.2.2",
+        "symplify/package-builder": "^7.3.18",
+        "symplify/easy-coding-standard": "^7.3.18",
         "symfony/finder": "^4.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symplify/easy-coding-standard-tester": "7.2.2"
+        "symplify/easy-coding-standard-tester": "^7.3.18"
     },
     "autoload": {
         "psr-4": {

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -1,6 +1,4 @@
 imports:
-    # for PSR-2 description, see: http://www.php-fig.org/psr/psr-2/
-    - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/psr2.yaml' }
     # some checkers use BetterPhpdocParser services which must be configured (file renamed in symplify/better-phpdoc-parser v5.4.14)
     - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yml', ignore_errors: true }
     - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yaml', ignore_errors: true }
@@ -174,6 +172,8 @@ services:
         maxCount: 30
 
 parameters:
+    sets:
+        - 'psr2'
     line_ending: '\n'
     exclude_files:
         - '*/tests/Unit/**/wrong/*'

--- a/project-base/config/bundles.php
+++ b/project-base/config/bundles.php
@@ -41,4 +41,7 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
+    Symplify\ConsoleColorDiff\ConsoleColorDiffBundle::class => ['dev' => true, 'test' => true],
+    Symplify\ParameterNameGuard\ParameterNameGuardBundle::class => ['dev' => true, 'test' => true],
+    Symplify\ComposerJsonManipulator\ComposerJsonManipulatorBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/symfony.lock
+++ b/symfony.lock
@@ -828,6 +828,9 @@
     "symfony/polyfill-mbstring": {
         "version": "v1.12.0"
     },
+    "symfony/polyfill-php70": {
+        "version": "v1.17.1"
+    },
     "symfony/polyfill-php72": {
         "version": "v1.12.0"
     },
@@ -835,7 +838,7 @@
         "version": "v1.12.0"
     },
     "symfony/polyfill-php80": {
-        "version": "v1.17.0"
+        "version": "v1.17.1"
     },
     "symfony/process": {
         "version": "v3.4.32"
@@ -1014,6 +1017,12 @@
     "symplify/coding-standard": {
         "version": "v5.4.16"
     },
+    "symplify/composer-json-manipulator": {
+        "version": "v7.3.18"
+    },
+    "symplify/console-color-diff": {
+        "version": "v7.3.18"
+    },
     "symplify/easy-coding-standard": {
         "version": "v5.4.13"
     },
@@ -1025,6 +1034,12 @@
     },
     "symplify/package-builder": {
         "version": "v5.4.16"
+    },
+    "symplify/parameter-name-guard": {
+        "version": "v7.3.18"
+    },
+    "symplify/phpstan-extensions": {
+        "version": "v7.3.18"
     },
     "symplify/set-config-resolver": {
         "version": "v7.2.3"

--- a/utils/releaser/src/ReleaseWorker/AbstractCheckUncommittedChangesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractCheckUncommittedChangesReleaseWorker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\Releaser\ReleaseWorker;
 
 use PharIo\Version\Version;
-use Symplify\MonorepoBuilder\Release\Message;
 
 abstract class AbstractCheckUncommittedChangesReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesOnPackagistReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesOnPackagistReleaseWorker.php
@@ -7,8 +7,8 @@ namespace Shopsys\Releaser\ReleaseWorker\AfterRelease;
 use PharIo\Version\Version;
 use Shopsys\Releaser\Packagist\PackageProvider;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class CheckPackagesOnPackagistReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/Message.php
+++ b/utils/releaser/src/ReleaseWorker/Message.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker;
+
+final class Message
+{
+    /**
+     * @var string
+     */
+    public const SUCCESS = 'All good!';
+}

--- a/utils/releaser/src/ReleaseWorker/Release/CheckChangelogForTodaysDateReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CheckChangelogForTodaysDateReleaseWorker.php
@@ -10,8 +10,8 @@ use Nette\Utils\Strings;
 use PharIo\Version\Version;
 use Shopsys\Releaser\FileManipulator\ChangelogFileManipulator;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class CheckChangelogForTodaysDateReleaseWorker extends AbstractShopsysReleaseWorker

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/CheckNewDoctrineReleaseReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/CheckNewDoctrineReleaseReleaseWorker.php
@@ -8,8 +8,8 @@ use Nette\Utils\Strings;
 use PharIo\Version\Version;
 use Shopsys\Releaser\Guzzle\ApiCaller;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class CheckNewDoctrineReleaseReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ResolveDocsTodoReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ResolveDocsTodoReleaseWorker.php
@@ -7,9 +7,9 @@ namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
 use Nette\Utils\Strings;
 use PharIo\Version\Version;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
 use Symfony\Component\Finder\Finder;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class ResolveDocsTodoReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetFrameworkBundleVersionReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetFrameworkBundleVersionReleaseWorker.php
@@ -8,8 +8,8 @@ use Nette\Utils\FileSystem;
 use PharIo\Version\Version;
 use Shopsys\Releaser\FileManipulator\FrameworkBundleVersionFileManipulator;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class SetFrameworkBundleVersionReleaseWorker extends AbstractShopsysReleaseWorker

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetMutualDependenciesToVersionReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/SetMutualDependenciesToVersionReleaseWorker.php
@@ -7,10 +7,10 @@ namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
 use PharIo\Version\Version;
 use Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
 use Symplify\MonorepoBuilder\DependencyUpdater;
 use Symplify\MonorepoBuilder\Package\PackageNamesProvider;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class SetMutualDependenciesToVersionReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/TestYourBranchLocallyReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/TestYourBranchLocallyReleaseWorker.php
@@ -6,8 +6,8 @@ namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
 
 use PharIo\Version\Version;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class TestYourBranchLocallyReleaseWorker extends AbstractShopsysReleaseWorker
 {

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -10,8 +10,8 @@ use Shopsys\Releaser\FileManipulator\GeneralUpgradeFileManipulator;
 use Shopsys\Releaser\FileManipulator\MonorepoUpgradeFileManipulator;
 use Shopsys\Releaser\FileManipulator\VersionUpgradeFileManipulator;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\Release\Message;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Twig\Environment;
 

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ValidateConflictsInComposerJsonReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ValidateConflictsInComposerJsonReleaseWorker.php
@@ -8,9 +8,9 @@ use PharIo\Version\Version;
 use Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider;
 use Shopsys\Releaser\IntervalEvaluator;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
-use Symplify\MonorepoBuilder\FileSystem\JsonFileManager;
-use Symplify\MonorepoBuilder\Release\Message;
+use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
 
 final class ValidateConflictsInComposerJsonReleaseWorker extends AbstractShopsysReleaseWorker
 {
@@ -20,7 +20,7 @@ final class ValidateConflictsInComposerJsonReleaseWorker extends AbstractShopsys
     private $composerJsonFilesProvider;
 
     /**
-     * @var \Symplify\MonorepoBuilder\FileSystem\JsonFileManager
+     * @var \Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager
      */
     private $jsonFileManager;
 
@@ -36,7 +36,7 @@ final class ValidateConflictsInComposerJsonReleaseWorker extends AbstractShopsys
 
     /**
      * @param \Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider $composerJsonFilesProvider
-     * @param \Symplify\MonorepoBuilder\FileSystem\JsonFileManager $jsonFileManager
+     * @param \Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager $jsonFileManager
      * @param \Shopsys\Releaser\IntervalEvaluator $intervalEvaluator
      */
     public function __construct(

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ValidateRequireFormatInComposerJsonReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ValidateRequireFormatInComposerJsonReleaseWorker.php
@@ -8,11 +8,11 @@ use Nette\Utils\Strings;
 use PharIo\Version\Version;
 use Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider;
 use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Message;
 use Shopsys\Releaser\Stage;
 use Symfony\Component\Finder\SplFileInfo;
-use Symplify\MonorepoBuilder\FileSystem\JsonFileManager;
+use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
 use Symplify\MonorepoBuilder\Package\PackageNamesProvider;
-use Symplify\MonorepoBuilder\Release\Message;
 
 final class ValidateRequireFormatInComposerJsonReleaseWorker extends AbstractShopsysReleaseWorker
 {
@@ -22,7 +22,7 @@ final class ValidateRequireFormatInComposerJsonReleaseWorker extends AbstractSho
     private $composerJsonFilesProvider;
 
     /**
-     * @var \Symplify\MonorepoBuilder\FileSystem\JsonFileManager
+     * @var \Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager
      */
     private $jsonFileManager;
 
@@ -38,7 +38,7 @@ final class ValidateRequireFormatInComposerJsonReleaseWorker extends AbstractSho
 
     /**
      * @param \Shopsys\Releaser\FilesProvider\ComposerJsonFilesProvider $composerJsonFilesProvider
-     * @param \Symplify\MonorepoBuilder\FileSystem\JsonFileManager $jsonFileManager
+     * @param \Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager $jsonFileManager
      * @param \Symplify\MonorepoBuilder\Package\PackageNamesProvider $packageNamesProvider
      */
     public function __construct(


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| Upgrading [coding-standards] dependecy to "symplify/easy-coding-standard": "^7.3.18", needed for Symfony 5 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1859 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
