### PR TITLE
[framework] change password in facade now do explicit flush operation

### DIFF
--- a/packages/framework/src/Model/Customer/User/CustomerUserPasswordFacade.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserPasswordFacade.php
@@ -117,5 +117,7 @@ class CustomerUserPasswordFacade
         $encoder = $this->encoderFactory->getEncoder($customerUser);
         $passwordHash = $encoder->encodePassword($password, null);
         $customerUser->setPasswordHash($passwordHash);
+
+        $this->em->flush($customerUser);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Method in facade can be easily used separately in controller. For example moving change password into separate customer section. Mostly facades do a flush after changing data. The necessity to call an explicit flush after calling the facade method can be easily overlooked and cause troubles. Not mentioning the flush should not be called in controller (at least in my mind 😄)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
