### PR TITLE
[project-base] Load javascripts after content is loaded

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -58,7 +58,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome:3.11
+        image: selenium/standalone-chrome:3.141.5
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -58,7 +58,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome:3.11
+        image: selenium/standalone-chrome:3.141.5
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome:3.11
+        image: selenium/standalone-chrome:3.141.5
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"

--- a/docs/introduction/running-acceptance-tests.md
+++ b/docs/introduction/running-acceptance-tests.md
@@ -31,8 +31,8 @@ In your `docker-compose.yml`, use `standalone-chrome-debug` image for `selenium-
 
 ```diff
   selenium-server:
--    image: selenium/standalone-chrome:3.11
-+    image: selenium/standalone-chrome-debug:3.11
+-    image: selenium/standalone-chrome:3.141.5
++    image: selenium/standalone-chrome-debug:3.141.5
      container_name: shopsys-framework-acceptance-tests
          ports:
              - "4400:4444"

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -4,6 +4,7 @@ imports:
 parameters:
     # Use Shopsys validator factory for fp/jsformvalidator-bundle
     fp_js_form_validator.factory.class: Shopsys\FrameworkBundle\Form\JsFormValidatorFactory
+    fp_js_form_validator.twig_extension.class: Shopsys\FrameworkBundle\Twig\JsFormValidatorTwigExtension
 
     # Use Shopsys routing for knplabs/knp-menu-bundle that ignores missing parameters in routes
     knp_menu.factory_extension.routing.class: Shopsys\FrameworkBundle\Model\AdminNavigation\RoutingExtension

--- a/packages/framework/src/Resources/config/services/twig.yaml
+++ b/packages/framework/src/Resources/config/services/twig.yaml
@@ -10,6 +10,7 @@ services:
 
     Shopsys\FrameworkBundle\Twig\:
         resource: '../../Twig/'
+        exclude: '../../Twig/{JsFormValidatorTwigExtension.php}'
 
     Shopsys\FrameworkBundle\Twig\DomainExtension:
         arguments:

--- a/packages/framework/src/Twig/JsFormValidatorTwigExtension.php
+++ b/packages/framework/src/Twig/JsFormValidatorTwigExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Twig;
+
+use Fp\JsFormValidatorBundle\Twig\Extension\JsFormValidatorTwigExtension as BaseJsFormValidatorTwigExtension;
+
+class JsFormValidatorTwigExtension extends BaseJsFormValidatorTwigExtension
+{
+    /**
+     * @inheritDoc
+     */
+    public function getJsValidator($form = null, $onLoad = true, $wrapped = true)
+    {
+        // onLoad can not be registered in the jsModel, because following listener below is called after onLoad event
+        $jsModels = parent::getJsValidator($form, false, false);
+        if ($jsModels === '') {
+            return '';
+        }
+
+        // Following addListener is copy-paste from FpJsFormValidator.js
+        $jsModels = '
+            (function () {
+                var runJsModel = function () {' . $jsModels . '};
+                if (typeof FpJsFormValidator !== "undefined" ) {
+                    runJsModel();
+                } else {
+                    var addListener = document.addEventListener || document.attachEvent;
+                    var removeListener = document.removeEventListener || document.detachEvent;
+                    var eventName = document.addEventListener ? "DOMContentLoaded" : "onreadystatechange";
+                    addListener.call(document, eventName, function (callee) {
+                        removeListener.call(this, eventName, callee, false);
+                        runJsModel();
+                    }, false);
+                }
+            })();';
+
+        if ($wrapped) {
+            $jsModels = '<script type="text/javascript">' . $jsModels . '</script>';
+        }
+
+        return $jsModels;
+    }
+}

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome:3.11
+        image: selenium/standalone-chrome:3.141.5
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"

--- a/project-base/docker/conf/docker-compose-win.yml.dist
+++ b/project-base/docker/conf/docker-compose-win.yml.dist
@@ -56,7 +56,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome:3.11
+        image: selenium/standalone-chrome:3.141.5
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -54,7 +54,7 @@ services:
             - "1600:80"
 
     selenium-server:
-        image: selenium/standalone-chrome:3.11
+        image: selenium/standalone-chrome:3.141.5
         container_name: shopsys-framework-acceptance-tests
         ports:
             - "4400:4444"

--- a/project-base/kubernetes/deployments/selenium-server.yml
+++ b/project-base/kubernetes/deployments/selenium-server.yml
@@ -11,7 +11,7 @@ spec:
         spec:
             containers:
                 -   name: selenium
-                    image: selenium/standalone-chrome:3.11
+                    image: selenium/standalone-chrome:3.141.5
                     ports:
                         -   name: selenium
                             containerPort: 4444

--- a/project-base/templates/Front/Layout/base.html.twig
+++ b/project-base/templates/Front/Layout/base.html.twig
@@ -14,8 +14,6 @@
         {{ encore_entry_link_tags( entryDirectoryPrint ) }}
 
         {{ render(controller('App\\Controller\\Front\\HeurekaController:embedWidgetAction')) }}
-        {{ encore_entry_script_tags('frontend') }}
-        {% block javascripts %}{% endblock %}
 
         <title>{% block title %}Shopsys Framework{% endblock %} {{ getSeoTitleAddOn() }}</title>
     </head>
@@ -27,7 +25,8 @@
 
         {% block html_body %}{% endblock %}
 
-        {% block javascripts_bottom %}{% endblock %}
+        {{ encore_entry_script_tags('frontend') }}
+        {% block javascripts %}{% endblock %}
         {{ getAllPagesAfterContentScripts()|raw }}
 
         {{ js_validator_config() }}

--- a/project-base/templates/Front/Layout/base.html.twig
+++ b/project-base/templates/Front/Layout/base.html.twig
@@ -14,6 +14,7 @@
         {{ encore_entry_link_tags( entryDirectoryPrint ) }}
 
         {{ render(controller('App\\Controller\\Front\\HeurekaController:embedWidgetAction')) }}
+        {% block javascripts %}{% endblock %}
 
         <title>{% block title %}Shopsys Framework{% endblock %} {{ getSeoTitleAddOn() }}</title>
     </head>
@@ -26,7 +27,7 @@
         {% block html_body %}{% endblock %}
 
         {{ encore_entry_script_tags('frontend') }}
-        {% block javascripts %}{% endblock %}
+        {% block javascripts_bottom %}{% endblock %}
         {{ getAllPagesAfterContentScripts()|raw }}
 
         {{ js_validator_config() }}

--- a/project-base/tests/App/Acceptance/acceptance/CustomerRegistrationCest.php
+++ b/project-base/tests/App/Acceptance/acceptance/CustomerRegistrationCest.php
@@ -25,6 +25,9 @@ class CustomerRegistrationCest
         $me->wantTo('successfully register new customer');
         $me->amOnPage('/');
         $layoutPage->clickOnRegistration();
+
+        $me->reloadPage();
+
         $registrationPage->register('Roman', 'Štěpánek', 'no-reply.16@shopsys.com', 'user123', 'user123');
         $me->wait(self::MINIMUM_FORM_SUBMIT_WAIT_TIME);
         $me->seeTranslationFrontend('You have been successfully registered.');

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -174,5 +174,9 @@ There you can find links to upgrade notes for other versions too.
 - fixed standards on new release of FriendsOfPHP/PHP-CS-Fixer ([#2094](https://github.com/shopsys/shopsys/pull/2094))
     - run `php phing standards-fix` to apply fixes
 
+- load javascripts after content is loaded ([#1879](https://github.com/shopsys/shopsys/pull/1879))
+    - if you set the parameter `fp_js_form_validator.twig_extension.class` to a custom class, please adjust this class according to [#1879](https://github.com/shopsys/shopsys/pull/1879)
+    - see #project-base-diff to update your project
+
 - allow placing scripts in administration after content([#2086](https://github.com/shopsys/shopsys/pull/2086))
     - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Javascripts are blocking page to be loaded fast. This PR moves scripts at the bottom of page to speed up page loading
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Lighthouse (on localhost) speed comparison:

Before
<img width="795" alt="Snímek obrazovky 2020-05-31 v 16 30 00" src="https://user-images.githubusercontent.com/1482966/83354882-fa9a7780-a35b-11ea-8efa-12605e69a6f5.png">
After
<img width="773" alt="Snímek obrazovky 2020-05-31 v 16 30 23" src="https://user-images.githubusercontent.com/1482966/83354888-08e89380-a35c-11ea-80d3-293ff1ca5e81.png">

