### PR TITLE
[shopsys] fixed JavaScript translations generation

### DIFF
--- a/packages/backend-api/install/build.xml.patch
+++ b/packages/backend-api/install/build.xml.patch
@@ -1,19 +1,10 @@
-@@ -6,6 +6,7 @@
-     <property name="check-and-fix-annotations" value="true"/>
-     <property name="path.root" value="${project.basedir}"/>
-     <property name="path.vendor" value="${path.root}/vendor"/>
-+    <property name="path.backend-api" value="${path.vendor}/shopsys/backend-api"/>
-     <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
-     <property name="path.framework.assets" value="node_modules/@shopsys/framework"/>
-     <property name="path.frontend-api" value="${path.vendor}/shopsys/frontend-api"/>
-@@ -14,5 +15,10 @@
+@@ -14,5 +14,9 @@
 
      <import file="${path.framework}/build.xml"/>
      <import file="${path.frontend-api}/build.xml"/>
 +    <import file="${path.backend-api}/build.xml"/>
-+
+
 +    <target name="composer-dev" depends="shopsys_framework.composer-dev,backend-api-oauth-keys-generate" description="Installs dependencies for development and generate OAuth keys."/>
 +
 +    <target name="composer-prod" depends="shopsys_framework.composer-prod,backend-api-oauth-keys-generate" description="Installs dependencies for production and generate OAuth keys."/>
-
  </project>

--- a/packages/framework/assets/js/admin/utils/Window.js
+++ b/packages/framework/assets/js/admin/utils/Window.js
@@ -7,8 +7,6 @@ const defaults = {
     buttonClose: true,
     buttonCancel: false,
     buttonContinue: false,
-    textContinue: Translator.trans('Yes'),
-    textCancel: Translator.trans('No'),
     urlContinue: '#',
     wide: false,
     cssClass: '',
@@ -32,7 +30,11 @@ export default class Window {
     constructor (inputOptions) {
         this.$activeWindow = null;
 
-        this.options = $.extend(defaults, inputOptions);
+        this.options = $.extend(
+            { textContinue: Translator.trans('Yes'), textCancel: Translator.trans('No') },
+            defaults,
+            inputOptions
+        );
 
         if (this.$activeWindow !== null) {
             this.$activeWindow.trigger('windowFastClose');

--- a/project-base/assets/js/frontend/utils/Window.js
+++ b/project-base/assets/js/frontend/utils/Window.js
@@ -7,8 +7,6 @@ const defaults = {
     buttonClose: true,
     buttonCancel: false,
     buttonContinue: false,
-    textContinue: Translator.trans('Yes'),
-    textCancel: Translator.trans('No'),
     textHeading: '',
     urlContinue: '#',
     cssClass: 'window-popup--standard',
@@ -40,7 +38,11 @@ export default class Window {
     constructor (inputOptions) {
         this.$activeWindow = null;
 
-        this.options = $.extend(defaults, inputOptions);
+        this.options = $.extend(
+            { textContinue: Translator.trans('Yes'), textCancel: Translator.trans('No') },
+            defaults,
+            inputOptions
+        );
 
         if (this.$activeWindow !== null) {
             this.$activeWindow.trigger('windowFastClose');

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -7,7 +7,7 @@
     <property name="path.root" value="${project.basedir}"/>
     <property name="path.vendor" value="${path.root}/vendor"/>
     <property name="path.framework" value="${path.vendor}/shopsys/framework"/>
-    <property name="path.framework.assets" value="node_modules/@shopsys/framework"/>
+    <property name="path.framework.assets" value="${path.root}/node_modules/@shopsys/framework"/>
     <property name="path.frontend-api" value="${path.vendor}/shopsys/frontend-api"/>
 
     <property name="phpstan.level" value="4"/>

--- a/project-base/webpack.config.js
+++ b/project-base/webpack.config.js
@@ -60,7 +60,7 @@ Encore
                 sources.getFrameworkVendorDir() + '/src/Resources/translations/*.po',
                 './translations/*.po',
             ];
-            const outputDirForExportedTranslations = Encore.isProduction() ? './web/build/' : './assets/js/';
+            const outputDirForExportedTranslations = './assets/js/';
 
             try {
                 processTrans(dirWithJsFiles, dirWithTranslations, outputDirForExportedTranslations);

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -13,6 +13,10 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 
 - add missing elasticsearch host to production docker-compose.yml file ([#1861](https://github.com/shopsys/shopsys/pull/1861))
+    - see #project-base-diff to update your project
 
 - fix login form validation is initialized too early ([#1906](https://github.com/shopsys/shopsys/pull/1906))
+    - see #project-base-diff to update your project
+
+- fix exporting of JavaScript translations ([#1880](https://github.com/shopsys/shopsys/pull/1880))
     - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are loading translations befor content load callback in `Window.js` classes - at this moment the translations wasn't load, because translations are loaded in content load callback with the highest priority. Next, we are having bad framework javascript's path in `project-base/build.xml` and we are having unnecessary path to translations in `webpack.config.js`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1875  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
