### PR TITLE
[framework] fixed calculate availability for new product

### DIFF
--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -67,6 +67,10 @@ class ProductAvailabilityCalculation
         if ($this->em->contains($product) === false) {
             $product->markForAvailabilityRecalculation();
 
+            if ($product->isUsingStock()) {
+                return $this->calculateAvailabilityForUsingStockProduct($product);
+            }
+
             return $product->getCalculatedAvailability();
         }
 
@@ -74,15 +78,24 @@ class ProductAvailabilityCalculation
             return $this->calculateMainVariantAvailability($product);
         }
         if ($product->isUsingStock()) {
-            if ($product->getStockQuantity() <= 0
-                && $product->getOutOfStockAction() === Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY
-            ) {
-                return $product->getOutOfStockAvailability();
-            } else {
-                return $this->availabilityFacade->getDefaultInStockAvailability();
-            }
+            return $this->calculateAvailabilityForUsingStockProduct($product);
         } else {
             return $product->getAvailability();
+        }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\Availability
+     */
+    protected function calculateAvailabilityForUsingStockProduct(Product $product): Availability
+    {
+        if ($product->getStockQuantity() <= 0
+            && $product->getOutOfStockAction() === Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY
+        ) {
+            return $product->getOutOfStockAvailability();
+        } else {
+            return $this->availabilityFacade->getDefaultInStockAvailability();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We canceled the default availability setting when availability can't be calculated immediately in # 1659, but new products that use stock can't be created because they need to set some availability because it's a non-null property.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
