### PR TITLE
[framework] Admin can create new Category URL and remove old automaticly created URL

### DIFF
--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -152,7 +152,6 @@ class CategoryFacade
         }
         $this->em->flush();
         $this->friendlyUrlFacade->saveUrlListFormData('front_product_list', $category->getId(), $categoryData->urls);
-        $this->friendlyUrlFacade->createFriendlyUrls('front_product_list', $category->getId(), $category->getNames());
         $this->imageFacade->manageImages($category, $categoryData->image);
 
         $this->pluginCrudExtensionFacade->saveAllData('category', $category->getId(), $categoryData->pluginData);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Admin can't create own Category URL without Category generated from Category name
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
