### PR TITLE
[docs] updated deprecated uses in a cookbook

### DIFF
--- a/docs/cookbook/adding-a-new-administration-page.md
+++ b/docs/cookbook/adding-a-new-administration-page.md
@@ -11,8 +11,8 @@ Create a class extending `AdminBaseController` in `src/Controller/Admin` directo
 ```php
 namespace App\Controller\Admin;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Symfony\Component\Routing\Annotation\Route;
 
 class DashboardController extends AdminBaseController
 {

--- a/docs/cookbook/create-advanced-grid.md
+++ b/docs/cookbook/create-advanced-grid.md
@@ -318,9 +318,9 @@ namespace App\Controller\Admin;
 -use App\Grid\Salesman\SalesmanGridFactory;
 +use App\Grid\Salesman\SalesmanGridInlineEdit;
 use App\Model\Salesman\SalesmanFacade;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Symfony\Component\Routing\Annotation\Route;
 
 class SalesmanController extends AdminBaseController
 {

--- a/docs/cookbook/create-basic-grid.md
+++ b/docs/cookbook/create-basic-grid.md
@@ -147,8 +147,8 @@ We need to inject (pass through constructor) `SalesmanGridFactory` created earli
 namespace App\Controller\Admin;
 
 use App\Grid\Salesman\SalesmanGridFactory;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Symfony\Component\Routing\Annotation\Route;
 
 class SalesmanController extends AdminBaseController
 {
@@ -389,9 +389,9 @@ namespace App\Controller\Admin;
 
 use App\Grid\Salesman\SalesmanGridFactory;
 + use App\Model\Salesman\SalesmanFacade;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 + use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
 use Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController;
+use Symfony\Component\Routing\Annotation\Route;
 
 class SalesmanController extends AdminBaseController
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `Sensio\Bundle\FrameworkExtraBundle\Configuration\Route` is marked as deprecated and should be replaced by `Symfony\Component\Routing\Annotation\Route` according to its own description.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
