### PR TITLE
[shopsys] fix Window.js - default options are not overridden by jQuery.extend function anymore

### DIFF
--- a/packages/framework/assets/js/admin/utils/Window.js
+++ b/packages/framework/assets/js/admin/utils/Window.js
@@ -30,11 +30,7 @@ export default class Window {
     constructor (inputOptions) {
         this.$activeWindow = null;
 
-        this.options = $.extend(
-            { textContinue: Translator.trans('Yes'), textCancel: Translator.trans('No') },
-            defaults,
-            inputOptions
-        );
+        this.options = { textContinue: Translator.trans('Yes'), textCancel: Translator.trans('No'), ...defaults, ...inputOptions };
 
         if (this.$activeWindow !== null) {
             this.$activeWindow.trigger('windowFastClose');

--- a/project-base/assets/js/frontend/utils/Window.js
+++ b/project-base/assets/js/frontend/utils/Window.js
@@ -38,11 +38,7 @@ export default class Window {
     constructor (inputOptions) {
         this.$activeWindow = null;
 
-        this.options = $.extend(
-            { textContinue: Translator.trans('Yes'), textCancel: Translator.trans('No') },
-            defaults,
-            inputOptions
-        );
+        this.options = { textContinue: Translator.trans('Yes'), textCancel: Translator.trans('No'), ...defaults, ...inputOptions };
 
         if (this.$activeWindow !== null) {
             this.$activeWindow.trigger('windowFastClose');

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -62,3 +62,6 @@ There you can find links to upgrade notes for other versions too.
 
 - add variant visibility on product detail ([#771](https://github.com/shopsys/shopsys/pull/771))
     - see #project-base-diff to update your project
+
+- fix Window.js - default options are not overridden by jQuery.extend function anymore ([#1892](https://github.com/shopsys/shopsys/pull/1892))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| when using `$.extend`, the first parameter is populated with the result of the function (see https://api.jquery.com/jQuery.extend/). That means, when new Window is created with some options that override the defaults, another Window that is created after the first one has default options affected by the settings of the first Window
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

### steps to reproduce (demodata)
1. Go to homepage
1. Click on "Add to cart" (for any product in "Special offers")
1. Close the window
1. Fill in a mail into the subscription form, check the checkbox "I agree with privacy policy" and submit the form.

You see the popup window with information, that you have been successfully subscribed to the newsletter, and the window contains "Add to cart" button because it was saved as a default option for Window when you added the product to cart :slightly_smiling_face: 

https://prnt.sc/syk6v1
