### PR TITLE
[shopsys] added psr/event-dispatcher in order to prevent phpstan to repport missing class errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,6 +169,7 @@
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",
+        "psr/event-dispatcher": "^1.0.0",
         "slevomat/coding-standard": "^6.3.5",
         "sspooky13/yaml-standards": "^5.0.0",
         "symfony/var-dumper": "^4.4.0",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -100,6 +100,7 @@
         "phpunit/phpunit": "^8.0",
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
+        "psr/event-dispatcher": "^1.0.0",
         "shopsys/coding-standards": "9.1.x-dev",
         "sspooky13/yaml-standards": "^5.0.0",
         "symfony/var-dumper": "^4.4"

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -112,6 +112,7 @@
         "phpstan/phpstan-doctrine": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^8.0",
+        "psr/event-dispatcher": "^1.0.0",
         "shopsys/coding-standards": "9.1.x-dev",
         "shopsys/http-smoke-testing": "9.1.x-dev",
         "sspooky13/yaml-standards": "^5.0.0",

--- a/symfony.lock
+++ b/symfony.lock
@@ -518,6 +518,9 @@
     "psr/container": {
         "version": "1.0.0"
     },
+    "psr/event-dispatcher": {
+        "version": "1.0.0"
+    },
     "psr/http-message": {
         "version": "1.0.1"
     },

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -4,3 +4,7 @@ This guide contains instructions to upgrade from version v9.0.0 to v9.1.0-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+## Application
+- add `psr/event-dispatcher` to your composer dependencies in order to prevent PHPStan errors in Event classes ([#1894](https://github.com/shopsys/shopsys/pull/1894))
+    - add `"psr/event-dispatcher": "^1.0.0",` to `require-dev` section in your `composer.json` file


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| New version of PHPStan 0.12.29 started to cause `Reflection error: Psr\EventDispatcher\StoppableEventInterface not found. ` in classes extending `\Symfony\Contracts\EventDispatcher\Event`. This has been fixed by adding such classes to project in dev environment.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
