### PR TITLE
[framework] updated Currency::setRoundingType() for easier extension in project-base

### DIFF
--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -139,7 +139,7 @@ class Currency
      */
     protected function setRoundingType(string $roundingType): void
     {
-        if (in_array($roundingType, self::getRoundingTypes(), true) === true) {
+        if (in_array($roundingType, static::getRoundingTypes(), true) === true) {
             $this->roundingType = $roundingType;
         } else {
             throw new InvalidRoundingTypeException($roundingType);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In order to add new rouding type I need to override functions `getRoundingTypes` and `setRoundingType` . This PR resolves problem, so overriding function `getRoundingTypes` is enough to make it work. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
