### PR TITLE
[framework] fixed AdministratorFacade::changePassword() method

### DIFF
--- a/packages/framework/src/Model/Administrator/AdministratorFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFacade.php
@@ -166,7 +166,7 @@ class AdministratorFacade
     public function changePassword($administratorUsername, $newPassword)
     {
         $administrator = $this->administratorRepository->getByUserName($administratorUsername);
-        $administrator->setPasswordHash($newPassword);
+        $this->setPassword($administrator, $newPassword);
         $this->em->flush($administrator);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Method is used in `shopsys:administrator:change-password` command, but it was not working until now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
