### PR TITLE
[framework] select2 is no longer hidden under bottom bar in administration

### DIFF
--- a/packages/framework/assets/js/admin/components/initSelect2.js
+++ b/packages/framework/assets/js/admin/components/initSelect2.js
@@ -2,10 +2,19 @@ import Register from '../../common/utils/Register';
 import 'select2/dist/js/select2.full';
 
 export function initSelect2 ($container) {
+    const select2BottomMaxOffset = 250;
+
     $container.filterAllNodes('select').select2({
         minimumResultsForSearch: 5,
         width: 'computedstyle'
+    }).on('select2:open', function () {
+        const $select2Container = $('.select2-container').last();
+        const bottom = $select2Container[0].getBoundingClientRect().bottom;
+        if (($(window).outerHeight() - bottom) < select2BottomMaxOffset) {
+            $select2Container.find('.select2-dropdown').removeClass('select2-dropdown--below').addClass('select2-dropdown--above');
+        }
     });
+
 }
 
 (new Register()).registerCallback(initSelect2, 'initSelect2');

--- a/packages/framework/assets/styles/admin/libs/select2/select2-custom.less
+++ b/packages/framework/assets/styles/admin/libs/select2/select2-custom.less
@@ -60,7 +60,6 @@
 
 .select2-dropdown {
     border: 2px solid @color-border;
-    z-index: 1000;
 
     &--in-window {
         z-index: 11000;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When is some selectbox placed at the bottom of the content in the administration, it will hide under bar at the bottom of page. Select2 is supposed to recognize such behavior and display select options to the top, but it is not working well and PR created to force position of options (https://github.com/select2/select2/pull/4618) has not been accepted by author for four years. This PR introduces fix, that will force such behavior.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
