### PR TITLE
[framework] new entity extensions are now registered immediately

### DIFF
--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExten
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProductFeedConfigsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProjectFrameworkClassExtensionsCompilerPass;
+use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -40,6 +41,8 @@ class ShopsysFrameworkBundle extends Bundle
         $environment = $container->getParameter('kernel.environment');
         if ($environment === EnvironmentType::DEVELOPMENT) {
             $container->addCompilerPass(new RegisterProjectFrameworkClassExtensionsCompilerPass());
+            $container->addResource(new DirectoryResource($container->getParameter('kernel.root_dir') . '/Component'));
+            $container->addResource(new DirectoryResource($container->getParameter('kernel.root_dir') . '/Model'));
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was problem, that container cache was not invalidated when changes were made in Model classes, like new entity class extending framework entity. This extended entity was not registered until cache was cleared, which could lead in several problems e.g. unable to generate database migrations.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
