### PR TITLE
[project-base] windowForm: fix initialization of JS validation

### DIFF
--- a/project-base/templates/Front/Content/Login/windowForm.html.twig
+++ b/project-base/templates/Front/Content/Login/windowForm.html.twig
@@ -1,4 +1,3 @@
-{{ init_js_validation(null, false) }}
 {{ form_start(form, {attr: {class: 'js-front-login-window'}}) }}
     {{ form_errors(form) }}
 
@@ -34,3 +33,4 @@
     </div>
 
 {{ form_end(form) }}
+{{ init_js_validation(form, false) }}

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -11,3 +11,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fix not working upload of files in wysiwyg editor ([#1899](https://github.com/shopsys/shopsys/pull/1899))
     - see #project-base-diff to update your project
+
+- fix login form validation is initialized too early ([#1906](https://github.com/shopsys/shopsys/pull/1906))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
- a given form should be provided to init_js_validation function as the first parameter, otherwise, it triggers the validation init for all forms on the page - and if they are not rendered yet, it actually breaks the JS validation for them

| Q             | A
| ------------- | ---
|Description, reason for the PR| On our project, the window form is rendered directly in the site header and the original way of the js validation init has actually broken the JS validation of the other forms on the page. Kudos to @pk16011990 that helped me to find the underlying problem :pray: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
