### PR TITLE
[framework] BestsellingProductFormType now uses constant for rendering product list

### DIFF
--- a/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
+++ b/packages/framework/src/Form/Admin/BestsellingProduct/BestsellingProductFormType.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle\Form\Admin\BestsellingProduct;
 
 use Shopsys\FrameworkBundle\Form\Constraints;
 use Shopsys\FrameworkBundle\Form\ProductType;
+use Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\BestsellingProductFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -31,7 +32,7 @@ class BestsellingProductFormType extends AbstractType
             ])
             ->add('save', SubmitType::class);
 
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < BestsellingProductFacade::MAX_RESULTS_ADMIN; $i++) {
             $builder->get('products')
                 ->add($i, ProductType::class, [
                     'required' => false,

--- a/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductFacade.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/BestsellingProductFacade.php
@@ -8,9 +8,13 @@ use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 
 class BestsellingProductFacade
 {
+    /**
+     * @deprecated This constant will be removed in next major version. There was need to change its visibility that would cause BC break
+     */
     protected const MAX_RESULTS = 10;
     protected const ORDERS_CREATED_AT_LIMIT = '-1 month';
     public const MAX_SHOW_RESULTS = 3;
+    public const MAX_RESULTS_ADMIN = 10;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\AutomaticBestsellingProductRepository
@@ -66,13 +70,13 @@ class BestsellingProductFacade
             $category,
             $pricingGroup,
             new DateTime(static::ORDERS_CREATED_AT_LIMIT),
-            static::MAX_RESULTS
+            static::MAX_RESULTS_ADMIN
         );
 
         return $this->bestsellingProductCombinator->combineManualAndAutomaticProducts(
             $manualProductsIndexedByPosition,
             $automaticProducts,
-            static::MAX_RESULTS
+            static::MAX_RESULTS_ADMIN
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When changing limit for bestselling products in admin, developer needed to overwrite both BestsellingProductFormType and BestsellingProductFacade. This has now been resolved using one constant for both classes.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1889 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
