### PR TITLE
[framework] fixed error 500 during logout when the user is already logged out

### DIFF
--- a/packages/framework/src/Component/Error/LogoutExceptionSubscriber.php
+++ b/packages/framework/src/Component/Error/LogoutExceptionSubscriber.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Error;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessage;
+use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\LogoutException;
+
+class LogoutExceptionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface
+     */
+    protected $flashBag;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser
+     */
+    protected $currentCustomerUser;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface $flashBag
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        FlashBagInterface $flashBag,
+        CurrentCustomerUser $currentCustomerUser,
+        RouterInterface $router,
+        Domain $domain
+    ) {
+        $this->flashBag = $flashBag;
+        $this->currentCustomerUser = $currentCustomerUser;
+        $this->router = $router;
+        $this->domain = $domain;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException'],
+        ];
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+     */
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        if ($event->getThrowable() instanceof LogoutException || $event->getThrowable()->getPrevious() instanceof LogoutException) {
+            if ($this->currentCustomerUser->findCurrentCustomerUser() !== null) {
+                $domainId = $this->currentCustomerUser->findCurrentCustomerUser()->getDomainId();
+                $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
+
+                $this->flashBag->add(FlashMessage::KEY_ERROR, t('There was an error during logout attempt. If you really want to sign out, please try it again.', [], 'messages', $locale));
+            }
+
+            $redirectUrl = $this->getSafeUrlToRedirect($event->getRequest()->headers->get('referer'));
+
+            $event->setResponse(new RedirectResponse($redirectUrl));
+        }
+    }
+
+    /**
+     * @param string|null $url
+     * @return string
+     */
+    protected function getSafeUrlToRedirect(?string $url): string
+    {
+        if ($url !== null) {
+            $urlParse = parse_url($url);
+            $domainUrl = $this->domain->getUrl();
+            $domainUrlParse = parse_url($domainUrl);
+            $parsedUrl = $urlParse['scheme'] . $urlParse['host'];
+            $parsedDomainUrl = $domainUrlParse['scheme'] . $domainUrlParse['host'];
+
+            if ($parsedUrl === $parsedDomainUrl) {
+                return $url;
+            }
+        }
+
+        return $this->router->generate('front_homepage');
+    }
+}

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2209,6 +2209,9 @@ msgstr "Čím vyšší priorita, tím bude stát zobrazen výše v seznamech. St
 msgid "The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order."
 msgstr "Byla změněna cena zboží <strong>{{ name }}</strong>, které máte v košíku. Prosím, překontrolujte si objednávku."
 
+msgid "There was an error during logout attempt. If you really want to sign out, please try it again."
+msgstr "Během odhlašování došlo k chybě. Pokud se chcete opravdu odhlásit, zkuste to prosím znovu."
+
 msgid "There was an error while saving. The order isn't saved."
 msgstr "Během ukládání došlo k chybě. Pořadí nebylo uloženo."
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2209,6 +2209,9 @@ msgstr ""
 msgid "The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order."
 msgstr ""
 
+msgid "There was an error during logout attempt. If you really want to sign out, please try it again."
+msgstr ""
+
 msgid "There was an error while saving. The order isn't saved."
 msgstr ""
 

--- a/upgrade/UPGRADE-v9.0.1-dev.md
+++ b/upgrade/UPGRADE-v9.0.1-dev.md
@@ -24,3 +24,6 @@ There you can find links to upgrade notes for other versions too.
 - enable automatic deleting of sessions older than 7 days in Redis ([#1842](https://github.com/shopsys/shopsys/pull/1842))
     - see #project-base-diff to update your project
     - you should consider what to do with current sessions, if you want to keep them, set them TTL or delete them
+
+- fix 500 error during logout when the user is already logged out ([#1909](https://github.com/shopsys/shopsys/pull/1909))
+    - you might want to update your translations, because new translation message has been added for Czech and English language only


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Application did end with 500 error page when user was trying to logout, when had not valid CSRF token. This has been fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #769 closes #1559 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
