### PR TITLE
[frontend-api] fixed ChangePasswordTest for FE API

### DIFF
--- a/project-base/tests/FrontendApiBundle/Functional/Customer/User/ChangePasswordTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Customer/User/ChangePasswordTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Customer\User;
 
-use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
 
-class ChangePasswordTest extends GraphQlTestCase
+class ChangePasswordTest extends GraphQlWithLoginTestCase
 {
     public function testChangePassword(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ChaangePasswordTest was running without provided access token
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
