### PR TITLE
[project-base] more reliable FE API tests

### DIFF
--- a/project-base/tests/FrontendApiBundle/Functional/Category/CategoriesTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Category/CategoriesTest.php
@@ -46,8 +46,6 @@ class CategoriesTest extends GraphQlTestCase
             }
         ';
 
-        $output = $this->getResponseContentForQuery($query);
-
         $expected = [
             'name' => 'Electronics',
             'children' => [
@@ -60,6 +58,13 @@ class CategoriesTest extends GraphQlTestCase
             ],
         ];
 
-        $this->assertEquals($expected, $output['data']['categories'][0]);
+        $graphQlType = 'categories';
+        $response = $this->getResponseContentForQuery($query);
+
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+
+        $this->assertArrayHasKey(0, $responseData);
+        $this->assertEquals($expected, $responseData[0]);
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Customer/User/ChangePasswordTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Customer/User/ChangePasswordTest.php
@@ -58,11 +58,14 @@ mutation {
             0 => 'New password must be at least 6 characters long',
         ];
 
-        $responseData = $this->getResponseContentForQuery($query)['errors'][0]['extensions']['validation'];
+        $response = $this->getResponseContentForQuery($query);
+        $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
+        $responseData = $this->getErrorsExtensionValidationFromResponse($response);
 
         $i = 0;
         foreach ($responseData as $responseRow) {
             foreach ($responseRow as $validationError) {
+                $this->assertArrayHasKey('message', $validationError);
                 $this->assertEquals($expectedViolationMessages[$i], $validationError['message']);
                 $i++;
             }

--- a/project-base/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
@@ -89,11 +89,14 @@ mutation {
             2 => 'Telephone number cannot be longer than 30 characters',
         ];
 
-        $responseData = $this->getResponseContentForQuery($query)['errors'][0]['extensions']['validation'];
+        $response = $this->getResponseContentForQuery($query);
+        $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
+        $responseData = $this->getErrorsExtensionValidationFromResponse($response);
 
         $i = 0;
         foreach ($responseData as $responseRow) {
             foreach ($responseRow as $validationError) {
+                $this->assertArrayHasKey('message', $validationError);
                 $this->assertEquals($expectedViolationMessages[$i], $validationError['message']);
                 $i++;
             }

--- a/project-base/tests/FrontendApiBundle/Functional/Login/LoginTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Login/LoginTest.php
@@ -17,9 +17,15 @@ class LoginTest extends GraphQlTestCase
 
     public function testLoginMutation(): void
     {
-        $responseData = $this->getResponseContentForQuery($this->getLoginQuery())['data']['Login'];
+        $graphQlType = 'Login';
+        $response = $this->getResponseContentForQuery($this->getLoginQuery());
+
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+
         $this->assertArrayHasKey('accessToken', $responseData);
         $this->assertIsString($responseData['accessToken']);
+
         $this->assertArrayHasKey('refreshToken', $responseData);
         $this->assertIsString($responseData['refreshToken']);
 
@@ -29,9 +35,18 @@ class LoginTest extends GraphQlTestCase
             $this->fail('Token is not valid');
         }
 
-        $authorizationResponseData = $this->getResponseContentForQuery($this->getLoginQuery(), [], ['HTTP_Authorization' => sprintf('Bearer %s', $responseData['accessToken'])])['data']['Login'];
+        $authorizationResponse = $this->getResponseContentForQuery(
+            $this->getLoginQuery(),
+            [],
+            ['HTTP_Authorization' => sprintf('Bearer %s', $responseData['accessToken'])]
+        );
+
+        $this->assertResponseContainsArrayOfDataForGraphQlType($authorizationResponse, $graphQlType);
+        $authorizationResponseData = $this->getResponseDataForGraphQlType($authorizationResponse, $graphQlType);
+
         $this->assertArrayHasKey('accessToken', $authorizationResponseData);
         $this->assertIsString($authorizationResponseData['accessToken']);
+
         $this->assertArrayHasKey('refreshToken', $authorizationResponseData);
         $this->assertIsString($authorizationResponseData['refreshToken']);
     }

--- a/project-base/tests/FrontendApiBundle/Functional/Logout/LogoutTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Logout/LogoutTest.php
@@ -10,7 +10,10 @@ class LogoutTest extends GraphQlWithLoginTestCase
 {
     public function testLogoutMutation()
     {
-        $isLogoutSuccess = $this->getResponseContentForQuery($this->getLogoutQuery())['data']['Logout'];
+        $response = $this->getResponseContentForQuery($this->getLogoutQuery());
+        $this->assertArrayHasKey('data', $response);
+        $this->assertArrayHasKey('Logout', $response['data']);
+        $isLogoutSuccess = $response['data']['Logout'];
         $this->assertTrue($isLogoutSuccess);
     }
 

--- a/project-base/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php
@@ -25,8 +25,9 @@ class CompanyFieldsAreValidatedTest extends AbstractOrderTestCase
 
         $orderMutation = $this->getOrderMutation(__DIR__ . '/Resources/companyFieldsAreValidated.graphql');
 
-        $responseData = $this->getResponseContentForQuery($orderMutation);
+        $response = $this->getResponseContentForQuery($orderMutation);
+        $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
 
-        $this->assertEquals($expectedValidations, $responseData['errors'][0]['extensions']['validation']);
+        $this->assertEquals($expectedValidations, $this->getErrorsExtensionValidationFromResponse($response));
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php
@@ -49,8 +49,9 @@ class DeliveryFieldsAreValidatedTest extends AbstractOrderTestCase
 
         $orderMutation = $this->getOrderMutation(__DIR__ . '/Resources/deliveryFieldsAreValidated.graphql');
 
-        $responseData = $this->getResponseContentForQuery($orderMutation);
+        $response = $this->getResponseContentForQuery($orderMutation);
+        $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
 
-        $this->assertEquals($expectedValidations, $responseData['errors'][0]['extensions']['validation']);
+        $this->assertEquals($expectedValidations, $this->getErrorsExtensionValidationFromResponse($response));
     }
 }

--- a/project-base/tests/FrontendApiBundle/Functional/Order/DynamicFieldsInOrderTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/DynamicFieldsInOrderTest.php
@@ -10,14 +10,21 @@ class DynamicFieldsInOrderTest extends AbstractOrderTestCase
     {
         $orderMutation = $this->getOrderMutation(__DIR__ . '/Resources/dynamicFieldsInOrder.graphql');
 
-        $responseData = $this->getResponseContentForQuery($orderMutation)['data']['CreateOrder'];
+        $graphQlType = 'CreateOrder';
+        $response = $this->getResponseContentForQuery($orderMutation);
+
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
         $this->assertArrayHasKey('uuid', $responseData);
         $this->assertIsString($responseData['uuid']);
+
         $this->assertArrayHasKey('number', $responseData);
         $this->assertIsString($responseData['number']);
+
         $this->assertArrayHasKey('urlHash', $responseData);
         $this->assertIsString($responseData['urlHash']);
+
         $this->assertArrayHasKey('creationDate', $responseData);
         $this->assertIsString($responseData['creationDate']);
     }

--- a/project-base/tests/FrontendApiBundle/Functional/Order/RequiredFieldsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/RequiredFieldsTest.php
@@ -26,9 +26,11 @@ class RequiredFieldsTest extends AbstractOrderTestCase
 
         $orderMutation = $this->getOrderMutation(__DIR__ . '/Resources/requiredFields.graphql');
 
-        $responseData = $this->getResponseContentForQuery($orderMutation)['errors'];
+        $response = $this->getResponseContentForQuery($orderMutation);
+        $this->assertResponseContainsArrayOfErrors($response);
 
-        foreach ($responseData as $key => $responseRow) {
+        foreach ($this->getErrorsFromResponse($response) as $key => $responseRow) {
+            $this->assertArrayHasKey('message', $responseRow);
             $this->assertEquals($expectedViolationMessages[$key], $responseRow['message']);
         }
     }

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -32,9 +32,16 @@ class ProductsTest extends GraphQlTestCase
             ['name' => t('30” Hyundai 22MT44D', [], 'dataFixtures', $firstDomainLocale)],
         ];
 
-        $edges = $this->getResponseContentForQuery($query)['data']['products']['edges'];
+        $graphQlType = 'products';
+        $response = $this->getResponseContentForQuery($query);
+
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+        $this->assertArrayHasKey('edges', $responseData);
+
         $queryResult = [];
-        foreach ($edges as $edge) {
+        foreach ($responseData['edges'] as $edge) {
+            $this->assertArrayHasKey('node', $edge);
             $queryResult[] = $edge['node'];
         }
 
@@ -78,9 +85,16 @@ class ProductsTest extends GraphQlTestCase
 
         $arrayExpected = $this->getExpectedDataForNineteenthProduct();
 
-        $edges = $this->getResponseContentForQuery($query)['data']['products']['edges'];
+        $graphQlType = 'products';
+        $response = $this->getResponseContentForQuery($query);
+
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+        $this->assertArrayHasKey('edges', $responseData);
+
         $queryResult = [];
-        foreach ($edges as $edge) {
+        foreach ($responseData['edges'] as $edge) {
+            $this->assertArrayHasKey('node', $edge);
             $queryResult[] = $edge['node'];
         }
 

--- a/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
+++ b/project-base/tests/FrontendApiBundle/Test/GraphQlTestCase.php
@@ -139,4 +139,66 @@ abstract class GraphQlTestCase extends FunctionalTestCase
     {
         return $this->overwriteDomainUrl . $uri;
     }
+
+    /**
+     * @param array $response
+     * @return array
+     */
+    protected function getErrorsFromResponse(array $response): array
+    {
+        return $response['errors'];
+    }
+
+    /**
+     * @param array $response
+     * @return array
+     */
+    protected function getErrorsExtensionValidationFromResponse(array $response): array
+    {
+        return $this->getErrorsFromResponse($response)[0]['extensions']['validation'];
+    }
+
+    /**
+     * @param array $response
+     * @param string $graphQlType
+     * @return array
+     */
+    protected function getResponseDataForGraphQlType(array $response, string $graphQlType): array
+    {
+        return $response['data'][$graphQlType];
+    }
+
+    /**
+     * @param array $response
+     * @param string $graphQlType
+     */
+    protected function assertResponseContainsArrayOfDataForGraphQlType(array $response, string $graphQlType): void
+    {
+        $this->assertArrayHasKey('data', $response);
+        $this->assertArrayHasKey($graphQlType, $response['data']);
+        $this->assertIsArray($response['data'][$graphQlType]);
+    }
+
+    /**
+     * @param array $response
+     */
+    protected function assertResponseContainsArrayOfErrors(array $response): void
+    {
+        $this->assertArrayHasKey('errors', $response);
+        $this->assertIsArray($response['errors']);
+    }
+
+    /**
+     * @param array $response
+     */
+    protected function assertResponseContainsArrayOfExtensionValidationErrors(array $response): void
+    {
+        $this->assertResponseContainsArrayOfErrors($response);
+        $errors = $this->getErrorsFromResponse($response);
+
+        $this->assertArrayHasKey(0, $errors);
+        $this->assertArrayHasKey('extensions', $errors[0]);
+        $this->assertArrayHasKey('validation', $errors[0]['extensions']);
+        $this->assertIsArray($errors[0]['extensions']['validation']);
+    }
 }

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -1,0 +1,11 @@
+# [Upgrade from v9.0.1 to v9.1.0-dev](https://github.com/shopsys/shopsys/compare/v9.0.1...master)
+
+This guide contains instructions to upgrade from version v9.0.1 to v9.1.0-dev.
+
+**Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/master/UPGRADE.md) about upgrading.**
+There you can find links to upgrade notes for other versions too.
+
+## Application
+
+- make Frontend API tests more reliable ([#1913](https://github.com/shopsys/shopsys/pull/1913))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| FE API tests end by throwing error (undefined index) instead of failure.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

TODO:
- [x] Add assertion to rest of testing classes
- [x] Think about refactoring this assertion - it is same on many places.