### PR TITLE
[framework] datepicker.js assigns options per instance

### DIFF
--- a/packages/framework/assets/js/common/components/datePicker.js
+++ b/packages/framework/assets/js/common/components/datePicker.js
@@ -27,7 +27,7 @@ $.datepicker.setDefaults($.datepicker.regional['cs']);
 export default function datePicker ($container) {
     $container.filterAllNodes('.js-date-picker').each(function () {
         // Loads regional settings for current locale
-        const options = $.datepicker.regional[global.locale] || $.datepicker.regional[''];
+        const options = Object.assign({}, $.datepicker.regional[global.locale] || $.datepicker.regional['']);
 
         // Date format is fixed so that it is understood by back-end
         options.dateFormat = constant('\\Shopsys\\FrameworkBundle\\Form\\DatePickerType::FORMAT_JS');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If there are more datepicker on the page, the settings are copied among themselves. For example, I have two datepicker for the first set max date to today and the second not. At this point, the second datepicker has max date set and should not have. This PR is copy of #1541 as we were not able to manage it and change previous branch as needed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
