### PR TITLE
[project-base] generate images_id_seq in data fixtures automatically

### DIFF
--- a/project-base/src/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ImageDataFixture.php
@@ -292,7 +292,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
 
     private function restartImagesIdsDbSequence()
     {
-        $this->em->createNativeQuery('ALTER SEQUENCE images_id_seq RESTART WITH 103', new ResultSetMapping())->execute();
+        $this->em->createNativeQuery('SELECT SETVAL(pg_get_serial_sequence(\'images\', \'id\'), COALESCE((SELECT MAX(id) FROM images) + 1, 1), false)', new ResultSetMapping())->execute();
     }
 
     /**

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -4,3 +4,6 @@ This guide contains instructions to upgrade from version v9.0.1 to v9.0.2-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- generate images_id_seq in data fixtures automatically ([#1918](https://github.com/shopsys/shopsys/pull/1918))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Because I am lazy and It caused errors 
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
