### PR TITLE
[framework] fixed renamig files in elfinder

### DIFF
--- a/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
+++ b/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
@@ -121,7 +121,7 @@ class VolumeDriver extends Driver
      */
     protected function rmTmb($stat)
     {
-        $path = $stat['realpath'];
+        $path = $this->tmbPath . DIRECTORY_SEPARATOR . $this->tmbname($stat);
         if ($this->tmbURL) {
             $thumbnailName = $this->gettmb($path, $stat);
             $stat['tmb'] = $thumbnailName ? $thumbnailName : 1;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| While renaming file via elfinder there was warning about undefined index in VolumeDriver. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
