### PR TITLE
[framework] prevent duplicating of admin side menu

### DIFF
--- a/packages/framework/assets/js/admin/components/Product.js
+++ b/packages/framework/assets/js/admin/components/Product.js
@@ -24,6 +24,7 @@ export default class Product {
         const $productDetailNavigation = $('.js-product-detail-navigation');
         const $webContent = $('.web__content');
 
+        $productDetailNavigation.empty();
         $('.form-group__title, .form-full__title').each(function () {
             const $title = $(this);
             const $titleClone = $title.clone();

--- a/packages/framework/assets/js/admin/components/Product.js
+++ b/packages/framework/assets/js/admin/components/Product.js
@@ -2,7 +2,7 @@ import constant from '../utils/constant';
 import Register from '../../common/utils/Register';
 
 export default class Product {
-    static init () {
+    static init ($container) {
         const usingStockSelection = $('#product_form_displayAvailabilityGroup_usingStock input[type="radio"]');
         const $outOfStockActionSelection = $('select[name="product_form[displayAvailabilityGroup][stockGroup][outOfStockAction]"]');
 
@@ -17,14 +17,13 @@ export default class Product {
         Product.toggleIsUsingStock(usingStockSelection.filter(':checked').val() === '1');
         Product.toggleIsUsingAlternateAvailability($outOfStockActionSelection.val() === constant('\\Shopsys\\FrameworkBundle\\Model\\Product\\Product::OUT_OF_STOCK_ACTION_SET_ALTERNATE_AVAILABILITY'));
 
-        Product.initializeSideNavigation();
+        Product.initializeSideNavigation($container);
     }
 
-    static initializeSideNavigation () {
-        const $productDetailNavigation = $('.js-product-detail-navigation');
+    static initializeSideNavigation ($container) {
+        const $productDetailNavigation = $container.find('.js-product-detail-navigation');
         const $webContent = $('.web__content');
 
-        $productDetailNavigation.empty();
         $('.form-group__title, .form-full__title').each(function () {
             const $title = $(this);
             const $titleClone = $title.clone();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When page has changed the side menu is aappended to current one. Thir PR empty already rendered side menu and append it into empty element.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1907  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
