### PR TITLE
[shopsys] fixed version of symplify/changelog-linker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -173,7 +173,7 @@
     "slevomat/coding-standard": "^6.3.5",
     "sspooky13/yaml-standards": "^5.0.0",
     "symfony/var-dumper": "^4.4.0",
-    "symplify/changelog-linker": "7.3.18",
+    "symplify/changelog-linker": "^7.3.18",
     "symplify/easy-coding-standard": "^7.3.18",
     "symplify/easy-coding-standard-tester": "^7.3.18",
     "symplify/monorepo-builder": "^7.3.18",

--- a/composer.json
+++ b/composer.json
@@ -173,7 +173,7 @@
     "slevomat/coding-standard": "^6.3.5",
     "sspooky13/yaml-standards": "^5.0.0",
     "symfony/var-dumper": "^4.4.0",
-    "symplify/changelog-linker": "7.2.2",
+    "symplify/changelog-linker": "7.3.18",
     "symplify/easy-coding-standard": "^7.3.18",
     "symplify/easy-coding-standard-tester": "^7.3.18",
     "symplify/monorepo-builder": "^7.3.18",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The current state is invalid - `symplify/changelog-linker 7.2` requires class from `simplify/package-builder 7.3`. This result in uncaught error.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
