### PR TITLE
[shopsys] fixed budles definition

### DIFF
--- a/packages/backend-api/install/config/bundles.php.patch
+++ b/packages/backend-api/install/config/bundles.php.patch
@@ -1,7 +1,7 @@
-@@ -44,4 +44,7 @@
-     Symplify\ConsoleColorDiff\ConsoleColorDiffBundle::class => ['dev' => true, 'test' => true],
-     Symplify\ParameterNameGuard\ParameterNameGuardBundle::class => ['dev' => true, 'test' => true],
-     Symplify\ComposerJsonManipulator\ComposerJsonManipulatorBundle::class => ['dev' => true, 'test' => true],
+@@ -41,4 +41,7 @@
+     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true],
+     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
+     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
 +    Shopsys\BackendApiBundle\ShopsysBackendApiBundle::class => ['all' => true],
 +    Trikoder\Bundle\OAuth2Bundle\TrikoderOAuth2Bundle::class => ['all' => true],
 +    FOS\RestBundle\FOSRestBundle::class => ['all' => true],

--- a/project-base/config/bundles.php
+++ b/project-base/config/bundles.php
@@ -41,7 +41,4 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
-    Symplify\ConsoleColorDiff\ConsoleColorDiffBundle::class => ['dev' => true, 'test' => true],
-    Symplify\ParameterNameGuard\ParameterNameGuardBundle::class => ['dev' => true, 'test' => true],
-    Symplify\ComposerJsonManipulator\ComposerJsonManipulatorBundle::class => ['dev' => true, 'test' => true],
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1862 we extended `budles.php` with 3 more bundles. This change was not needed and even unwanted because it causes error in project-base. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
