### PR TITLE
[framework] updated AdministratorFrontSecurityFacade::isAdministratorLogged() to work well if used on frontend

### DIFF
--- a/packages/framework/src/Model/Administrator/Security/AdministratorFrontSecurityFacade.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorFrontSecurityFacade.php
@@ -60,7 +60,10 @@ class AdministratorFrontSecurityFacade
     {
         try {
             $token = $this->getAdministratorToken();
-        } catch (\Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\InvalidTokenException $e) {
+        } catch (
+            \Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\InvalidTokenException |
+            \Symfony\Component\Security\Core\Exception\AuthenticationException $e
+        ) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When method `AdministratorFrontSecurityFacade::isAdministratorLogged()` is called on front-end (eg. in GTM layer), it causes redirect to `front_login` route. And if this calling is in login page, It causes `Too many redirections`. All exceptions catched can be thrown in `AdministratorUserProvider::refreshUser`.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

