### PR TITLE
[project-base] use __DIR__ instead of dirname(__FILE__)

### DIFF
--- a/project-base/phing
+++ b/project-base/phing
@@ -6,7 +6,7 @@
  * $Id: 3da5a2758ca689a6ee49defabcda5efa6dd70a97 $
  */
 
-$phingPhpFilepath = dirname(__FILE__) . '/vendor/phing/phing/bin/phing.php';
+$phingPhpFilepath = __DIR__ . '/vendor/phing/phing/bin/phing.php';
 
 if (!file_exists($phingPhpFilepath)) {
     echo "Error: $phingPhpFilepath not found.\n";

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -4,3 +4,6 @@ This guide contains instructions to upgrade from version v9.0.1 to v9.0.2-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- use __DIR__ instead of dirname(__FILE__) ([#1939](https://github.com/shopsys/shopsys/pull/1939))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is better to use __DIR__
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
