### PR TITLE
[framework] better extensibility of article form type

### DIFF
--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Form\GroupType;
 use Shopsys\FrameworkBundle\Form\UrlListType;
 use Shopsys\FrameworkBundle\Model\Article\Article;
 use Shopsys\FrameworkBundle\Model\Article\ArticleData;
+use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -34,15 +35,23 @@ class ArticleFormType extends AbstractType
     private $domain;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade
+     */
+    private $articleFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
      */
     public function __construct(
         SeoSettingFacade $seoSettingFacade,
-        Domain $domain
+        Domain $domain,
+        ArticleFacade $articleFacade
     ) {
         $this->seoSettingFacade = $seoSettingFacade;
         $this->domain = $domain;
+        $this->articleFacade = $articleFacade;
     }
 
     /**
@@ -66,11 +75,7 @@ class ArticleFormType extends AbstractType
                 ])
                 ->add('placement', ChoiceType::class, [
                     'required' => true,
-                    'choices' => [
-                        t('in upper menu') => Article::PLACEMENT_TOP_MENU,
-                        t('in footer') => Article::PLACEMENT_FOOTER,
-                        t('without positioning') => Article::PLACEMENT_NONE,
-                    ],
+                    'choices' => $this->articleFacade->getAvailablePlacementChoices(),
                     'placeholder' => t('-- Choose article position --'),
                     'constraints' => [
                         new Constraints\NotBlank(['message' => 'Please choose article placement']),

--- a/packages/framework/src/Model/Article/ArticleFacade.php
+++ b/packages/framework/src/Model/Article/ArticleFacade.php
@@ -186,4 +186,16 @@ class ArticleFacade
     {
         return $this->articleRepository->getAllByDomainId($domainId);
     }
+
+    /**
+     * @return string[]
+     */
+    public function getAvailablePlacementChoices(): array
+    {
+        return [
+            t('in upper menu') => Article::PLACEMENT_TOP_MENU,
+            t('in footer') => Article::PLACEMENT_FOOTER,
+            t('without positioning') => Article::PLACEMENT_NONE,
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If I want to add a new placement for articles, I have to extend the entire form because of one field. I've created a method that returns this field, and to add one (or more) placement, just overload this method
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
