### PR TITLE
[shopsys] added escaping for parenthesis in phpstan.neon

### DIFF
--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -45,7 +45,7 @@ parameters:
             message: '#Call to an undefined method \(Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser&Stringable\)|\(Shopsys\\FrontendApiBundle\\Model\\User\\FrontendApiUser&Symfony\\Component\\Security\\Core\\User\\UserInterface\)::getUuid\(\)\.#'
             path: %currentWorkingDirectory%/src/Model/Customer/User/CurrentCustomerUser.php*
         -
-            message: '#^Unsafe usage of new static().#'
+            message: '#^Unsafe usage of new static\(\).#'
             path: %currentWorkingDirectory%/src/*
     excludes_analyse:
         # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:annotations" command

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -37,7 +37,7 @@ parameters:
             message: '#^Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.$#'
             path: %currentWorkingDirectory%/packages/framework/src/*
         -
-            message: '#^Unsafe usage of new static().#'
+            message: '#^Unsafe usage of new static\(\).#'
             path: %currentWorkingDirectory%/packages/framework/*
         # shopsys/project-base - don't forget to add these rules to phpstan.neon in project-base
         -


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This change has been introduced in phpstan 0.12.33 https://github.com/phpstan/phpstan-src/commit/8479d405a452d915c79792c0d1c54c55dd3a9790
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
