### PR TITLE
[releaser] added note about posibility of credentials caching while releasing

### DIFF
--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
@@ -95,8 +95,8 @@ final class CreateAndPushGitTagsExceptProjectBaseReleaseWorker extends AbstractS
         }
 
         $this->symfonyStyle->note(sprintf(
-            'When you do not have saved github credentials you may want to cache them temporarily to prevent asking them for each repository.'
-            . ' To do so you may use following command `%s`',
+            'In case you do not have saved GIT credentials you may want to cache them temporarily so you do not need to fill them for each repository.'
+            . ' This can be done by using following command `%s`',
             'git config --global credential.helper "cache --timeout=3600"'
         ));
 

--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
@@ -94,8 +94,11 @@ final class CreateAndPushGitTagsExceptProjectBaseReleaseWorker extends AbstractS
             }
         }
 
-        // temporary cache credentials (for 1 hour) to prevent asking for username and password for each package
-        $this->processRunner->run('git config --global credential.helper "cache --timeout=3600"');
+        $this->symfonyStyle->note(sprintf(
+            'When you do not have saved github credentials you may want to cache them temporarily to prevent asking them for each repository.'
+            . ' To do so you may use following command `%s`',
+            'git config --global credential.helper "cache --timeout=3600"'
+        ));
 
         if (count($packageNamesWithProblems) === 0) {
             foreach ($packageNames as $packageName) {

--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
@@ -94,6 +94,9 @@ final class CreateAndPushGitTagsExceptProjectBaseReleaseWorker extends AbstractS
             }
         }
 
+        // temporary cache credentials (for 1 hour) to prevent asking for username and password for each package
+        $this->processRunner->run('git config --global credential.helper "cache --timeout=3600"');
+
         if (count($packageNamesWithProblems) === 0) {
             foreach ($packageNames as $packageName) {
                 $this->processRunner->run(sprintf('cd %s/%s && git push origin %s', $tempDirectory, $packageName, $versionString));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When running `release` stage you need to fill in username and password for each repository (unless it is not already saved in git config). This PR adds a note how to prevent this state.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
