### PR TITLE
[releaser] fixed names of required heimdall tools for releasing new version

### DIFF
--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagReleaseWorker.php
@@ -41,7 +41,7 @@ final class CreateAndPushGitTagReleaseWorker extends AbstractShopsysReleaseWorke
         if ($this->initialBranchName === 'master') {
             $this->symfonyStyle->note('Rest assured, after you push the tagged master branch, the new tag will be propagated to packagist once the project is built and split on Heimdall automatically.');
         } else {
-            $this->symfonyStyle->note(sprintf('After you push the tag, you need use to split the "%s" branch using "tool-monorepo-split-branch" on Heimdall (http://heimdall:8080/view/Tools/job/tool-monorepo-split-branch/)', $this->initialBranchName));
+            $this->symfonyStyle->note(sprintf('After you push the tag, you need use to split the "%s" branch using "tool-monorepo-split" on Heimdall (http://heimdall:8080/view/Tools/job/tool-monorepo-split/)', $this->initialBranchName));
             $this->symfonyStyle->note('Rest assured, after you split the branch, the new tag will be propagated to packagist automatically.');
             $this->confirm('Confirm the branch is split.');
         }

--- a/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
@@ -40,7 +40,7 @@ final class MergeReleaseCandidateBranchReleaseWorker extends AbstractShopsysRele
         if ($this->initialBranchName === 'master') {
             $this->symfonyStyle->note('Rest assured, after the master branch is built on Heimdall, it is split automatically (using http://heimdall:8080/view/Tools/job/tool-monorepo-split/)');
         } else {
-            $this->symfonyStyle->note(sprintf('You need split the "%s" branch it using "tool-monorepo-split-branch" on Heimdall (http://heimdall:8080/view/Tools/job/tool-monorepo-split-branch/)', $this->initialBranchName));
+            $this->symfonyStyle->note(sprintf('You need split the "%s" branch it using "tool-monorepo-force-split-branch" on Heimdall (http://heimdall:8080/view/Tools/job/tool-monorepo-force-split-branch/)', $this->initialBranchName));
         }
         $this->confirm('Confirm the branch is split.');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In `release` stage of `monorepo-builder release` is recommneding wrong tools to run. These names are fixed to proper one in this PR
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
