### PR TITLE
[releaser] fixed checking builds in after-release stage

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesTravisBuildsReleaseWorker.php
@@ -41,6 +41,11 @@ abstract class AbstractCheckPackagesTravisBuildsReleaseWorker extends AbstractSh
     }
 
     /**
+     * @return string
+     */
+    abstract protected function getCheckingBranchName(): string;
+
+    /**
      * @param \PharIo\Version\Version $version
      */
     public function work(Version $version): void

--- a/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesTravisBuildsReleaseWorker.php
@@ -43,7 +43,7 @@ abstract class AbstractCheckPackagesTravisBuildsReleaseWorker extends AbstractSh
     /**
      * @return string
      */
-    abstract protected function getCheckingBranchName(): string;
+    abstract protected function getBranchName(): string;
 
     /**
      * @param \PharIo\Version\Version $version
@@ -52,7 +52,7 @@ abstract class AbstractCheckPackagesTravisBuildsReleaseWorker extends AbstractSh
     {
         $statusForPackages = $this->travisStatusReporter->getStatusForPackagesByOrganizationAndBranch(
             'shopsys',
-            $this->getCheckingBranchName()
+            $this->getBranchName()
         );
 
         $isPassing = true;

--- a/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesTravisBuildsReleaseWorker.php
@@ -50,7 +50,10 @@ abstract class AbstractCheckPackagesTravisBuildsReleaseWorker extends AbstractSh
      */
     public function work(Version $version): void
     {
-        $statusForPackages = $this->travisStatusReporter->getStatusForPackagesByOrganizationAndBranch('shopsys', $this->initialBranchName);
+        $statusForPackages = $this->travisStatusReporter->getStatusForPackagesByOrganizationAndBranch(
+            'shopsys',
+            $this->getCheckingBranchName()
+        );
 
         $isPassing = true;
 

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesTravisBuildsReleaseWorker.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Shopsys\Releaser\ReleaseWorker\AfterRelease;
 
+use PharIo\Version\Version;
 use Shopsys\Releaser\ReleaseWorker\AbstractCheckPackagesTravisBuildsReleaseWorker;
 use Shopsys\Releaser\Stage;
 
 final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackagesTravisBuildsReleaseWorker
 {
+    /** @var string */
+    private $checkingBranchName;
+
     /**
      * Higher first
      * @return int
@@ -24,5 +28,22 @@ final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackages
     public function getStage(): string
     {
         return Stage::AFTER_RELEASE;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getCheckingBranchName(): string
+    {
+        return $this->checkingBranchName;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $this->checkingBranchName = $version->getVersionString();
+        parent::work($version);
     }
 }

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesTravisBuildsReleaseWorker.php
@@ -33,7 +33,7 @@ final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackages
     /**
      * @return string
      */
-    protected function getCheckingBranchName(): string
+    protected function getBranchName(): string
     {
         return $this->checkingBranchName;
     }

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesTravisBuildsReleaseWorker.php
@@ -11,7 +11,7 @@ use Shopsys\Releaser\Stage;
 final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackagesTravisBuildsReleaseWorker
 {
     /** @var string */
-    private $checkingBranchName;
+    private $releasingBranchName;
 
     /**
      * Higher first
@@ -35,7 +35,7 @@ final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackages
      */
     protected function getBranchName(): string
     {
-        return $this->checkingBranchName;
+        return $this->releasingBranchName;
     }
 
     /**
@@ -43,7 +43,7 @@ final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackages
      */
     public function work(Version $version): void
     {
-        $this->checkingBranchName = $version->getVersionString();
+        $this->releasingBranchName = $version->getVersionString();
         parent::work($version);
     }
 }

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/CheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/CheckPackagesTravisBuildsReleaseWorker.php
@@ -25,4 +25,12 @@ final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackages
     {
         return Stage::RELEASE_CANDIDATE;
     }
+
+    /**
+     * @return string
+     */
+    protected function getCheckingBranchName(): string
+    {
+        return $this->initialBranchName;
+    }
 }

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/CheckPackagesTravisBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/CheckPackagesTravisBuildsReleaseWorker.php
@@ -29,7 +29,7 @@ final class CheckPackagesTravisBuildsReleaseWorker extends AbstractCheckPackages
     /**
      * @return string
      */
-    protected function getCheckingBranchName(): string
+    protected function getBranchName(): string
     {
         return $this->initialBranchName;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In `after-release` stage of releaser there is check for passing builds on travis. The check should validated the released version instead initial branch. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
