### PR TITLE
[releaser] releaser fixed npm command

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ReleaseNewNodeModulePackageVersion.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ReleaseNewNodeModulePackageVersion.php
@@ -42,7 +42,7 @@ class ReleaseNewNodeModulePackageVersion extends AbstractShopsysReleaseWorker
 npm login
 # pass your credentials (login, password, email)
 
-npm release
+npm publish
 
 # set new version attribute to %s in project-base/package.json
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The command for releasing of new npm package is wrong. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
