### PR TITLE
[releaser] releaser added warning when merging RC branch

### DIFF
--- a/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
@@ -33,7 +33,7 @@ final class MergeReleaseCandidateBranchReleaseWorker extends AbstractShopsysRele
      */
     public function work(Version $version): void
     {
-        $this->symfonyStyle->note('You need to create a merge commit locally, see https://docs.shopsys.com/en/latest/contributing/merging-on-github/ for detailed instructions.');
+        $this->symfonyStyle->note('You need to create a merge commit locally.');
         $this->symfonyStyle->warning(sprintf(
             'Do not forget to push the "%s" branch!',
             $this->initialBranchName

--- a/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
@@ -34,7 +34,14 @@ final class MergeReleaseCandidateBranchReleaseWorker extends AbstractShopsysRele
     public function work(Version $version): void
     {
         $this->symfonyStyle->note('You need to create a merge commit, see https://docs.shopsys.com/en/latest/contributing/merging-on-github/ for detailed instructions.');
-        $this->symfonyStyle->warning(sprintf('If you are creating the merge commit locally, do not forget to push the "%s" branch!', $this->initialBranchName));
+        $this->symfonyStyle->warning(sprintf(
+            'If you are creating the merge commit locally, do not forget to push the "%s" branch!',
+            $this->initialBranchName
+        ));
+        $this->symfonyStyle->warning(sprintf(
+            'If you are merging it on github do not forget to fetch and checkout initial branch "%s" to prevent conflicts!',
+            $this->initialBranchName
+        ));
         $this->confirm(sprintf('Confirm "%s" branch was merged to "%s"', $this->createBranchName($version), $this->initialBranchName));
 
         if ($this->initialBranchName === 'master') {

--- a/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/MergeReleaseCandidateBranchReleaseWorker.php
@@ -33,16 +33,12 @@ final class MergeReleaseCandidateBranchReleaseWorker extends AbstractShopsysRele
      */
     public function work(Version $version): void
     {
-        $this->symfonyStyle->note('You need to create a merge commit, see https://docs.shopsys.com/en/latest/contributing/merging-on-github/ for detailed instructions.');
+        $this->symfonyStyle->note('You need to create a merge commit locally, see https://docs.shopsys.com/en/latest/contributing/merging-on-github/ for detailed instructions.');
         $this->symfonyStyle->warning(sprintf(
-            'If you are creating the merge commit locally, do not forget to push the "%s" branch!',
+            'Do not forget to push the "%s" branch!',
             $this->initialBranchName
         ));
-        $this->symfonyStyle->warning(sprintf(
-            'If you are merging it on github do not forget to fetch and checkout initial branch "%s" to prevent conflicts!',
-            $this->initialBranchName
-        ));
-        $this->confirm(sprintf('Confirm "%s" branch was merged to "%s"', $this->createBranchName($version), $this->initialBranchName));
+        $this->confirm(sprintf('Confirm "%s" branch was merged and pushed to "%s"', $this->createBranchName($version), $this->initialBranchName));
 
         if ($this->initialBranchName === 'master') {
             $this->symfonyStyle->note('Rest assured, after the master branch is built on Heimdall, it is split automatically (using http://heimdall:8080/view/Tools/job/tool-monorepo-split/)');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When merging release candidate on github may cause troubles in further progress. This PR adds warning to prvent it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
