### PR TITLE
[framework] JS validation: fix creating of prototype of compound item in collection

### DIFF
--- a/packages/framework/assets/js/common/validation/customizeFpValidator.js
+++ b/packages/framework/assets/js/common/validation/customizeFpValidator.js
@@ -17,7 +17,7 @@ FpJsFormValidator.preparePrototype = function (prototype, name) {
 
     if (typeof prototype.children === 'object') {
         for (let childName in prototype.children) {
-            prototype[childName] = this.preparePrototype(prototype.children[childName], name);
+            prototype.children[childName] = this.preparePrototype(prototype.children[childName], name);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When compound item has property with reserved name (eg. `id`), it causes broken FpJsElement.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
