### PR TITLE
[shopsys] temporary fileupload is now uploaded to abstract filesystem

### DIFF
--- a/packages/framework/assets/js/admin/components/FileUpload.js
+++ b/packages/framework/assets/js/admin/components/FileUpload.js
@@ -20,7 +20,7 @@ export default class FileUpload {
         this.lastUploadItemId = null;
         this.$uploader = $uploader;
 
-        this.$uploader.closest('form').submit(() => this.onFormSubmit());
+        this.$uploader.closest('form').submit((event) => this.onFormSubmit(event));
         this.initUploadedFiles();
         this.initUploader();
     }

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -33,6 +33,7 @@ parameters:
             - '*/tests/Unit/Component/Image/ImageLocatorTest.php'
             - '*/tests/Unit/Component/Image/Config/ImageConfigLoaderTest.php'
             - '*/tests/Unit/Component/Image/Config/ImageConfigTest.php'
+            - '*/src/Form/Constraints/FileAbstractFilesystemValidator.php'
 
         ObjectCalisthenics\Sniffs\Metrics\PropertyPerClassLimitSniff:
             - '*/src/Model/Order/Order.php'
@@ -86,3 +87,6 @@ parameters:
 
         PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff.Underscore:
             - '*/src/Component/Filesystem/Flysystem/VolumeDriver.php'
+
+        PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff.MaxExceeded:
+            - '*/src/Form/Constraints/FileAbstractFilesystemValidator.php'

--- a/packages/framework/src/Component/FileUpload/DeleteOldUploadedFilesCronModule.php
+++ b/packages/framework/src/Component/FileUpload/DeleteOldUploadedFilesCronModule.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\FileUpload;
+
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+use Symfony\Bridge\Monolog\Logger;
+
+class DeleteOldUploadedFilesCronModule implements SimpleCronModuleInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
+     */
+    protected $fileUpload;
+
+    /**
+     * @var \Symfony\Bridge\Monolog\Logger
+     */
+    protected $logger;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
+     */
+    public function __construct(FileUpload $fileUpload)
+    {
+        $this->fileUpload = $fileUpload;
+    }
+
+    /**
+     * @param \Symfony\Bridge\Monolog\Logger $logger
+     */
+    public function setLogger(Logger $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function run(): void
+    {
+        $count = $this->fileUpload->deleteOldUploadedFiles();
+
+        $this->logger->info($count . ' files were deleted.');
+    }
+}

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -2,15 +2,17 @@
 
 namespace Shopsys\FrameworkBundle\Component\FileUpload;
 
+use BadMethodCallException;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\String\TransformString;
-use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FileUpload
 {
     protected const TEMPORARY_DIRECTORY = 'fileUploads';
+    protected const DELETE_OLD_FILES_SECONDS = 86400;
 
     /**
      * @var string
@@ -33,11 +35,6 @@ class FileUpload
     protected $fileNamingConvention;
 
     /**
-     * @var \Symfony\Component\Filesystem\Filesystem
-     */
-    protected $localFilesystem;
-
-    /**
      * @var \League\Flysystem\MountManager
      */
     protected $mountManager;
@@ -48,30 +45,51 @@ class FileUpload
     protected $filesystem;
 
     /**
+     * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface|null
+     */
+    protected $parameterBag;
+
+    /**
      * @param string $temporaryDir
      * @param string $uploadedFileDir
      * @param string $imageDir
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileNamingConvention $fileNamingConvention
-     * @param \Symfony\Component\Filesystem\Filesystem $symfonyFilesystem
      * @param \League\Flysystem\MountManager $mountManager
      * @param \League\Flysystem\FilesystemInterface $filesystem
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface|null $parameterBag
      */
     public function __construct(
         $temporaryDir,
         $uploadedFileDir,
         $imageDir,
         FileNamingConvention $fileNamingConvention,
-        Filesystem $symfonyFilesystem,
         MountManager $mountManager,
-        FilesystemInterface $filesystem
+        FilesystemInterface $filesystem,
+        ?ParameterBagInterface $parameterBag = null
     ) {
         $this->temporaryDir = $temporaryDir;
         $this->uploadedFileDir = $uploadedFileDir;
         $this->imageDir = $imageDir;
         $this->fileNamingConvention = $fileNamingConvention;
-        $this->localFilesystem = $symfonyFilesystem;
         $this->mountManager = $mountManager;
         $this->filesystem = $filesystem;
+        $this->parameterBag = $parameterBag;
+    }
+
+    /**
+     * @required
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setEventDispatcher(ParameterBagInterface $parameterBag): void
+    {
+        if ($this->parameterBag !== null && $this->parameterBag !== $parameterBag) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->parameterBag === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->parameterBag = $parameterBag;
+        }
     }
 
     /**
@@ -85,7 +103,7 @@ class FileUpload
         }
 
         $temporaryFilename = $this->getTemporaryFilename($file->getClientOriginalName());
-        $file->move($this->getTemporaryDirectory(), $temporaryFilename);
+        $this->mountManager->move('local://' . $file->getRealPath(), 'main://' . $this->getTemporaryDirectory() . '/' . $temporaryFilename);
 
         return $temporaryFilename;
     }
@@ -99,8 +117,8 @@ class FileUpload
         if (!empty($filename)) {
             $filepath = $this->getTemporaryFilepath($filename);
             try {
-                $this->localFilesystem->remove($filepath);
-            } catch (\Symfony\Component\Filesystem\Exception\IOException $ex) {
+                $this->filesystem->delete($filepath);
+            } catch (\League\Flysystem\FileNotFoundException $ex) {
                 return false;
             }
         }
@@ -123,6 +141,15 @@ class FileUpload
     public function getTemporaryFilepath($temporaryFilename)
     {
         return $this->getTemporaryDirectory() . '/' . TransformString::safeFilename($temporaryFilename);
+    }
+
+    /**
+     * @param string $temporaryFilename
+     * @return string
+     */
+    public function getAbsoluteTemporaryFilepath($temporaryFilename)
+    {
+        return $this->parameterBag->get('kernel.root_dir') . $this->getTemporaryDirectory() . '/' . TransformString::safeFilename($temporaryFilename);
     }
 
     /**
@@ -209,11 +236,30 @@ class FileUpload
                     $this->filesystem->delete($targetFilename);
                 }
 
-                $this->mountManager->move('local://' . $sourceFilepath, 'main://' . $targetFilename);
+                $this->mountManager->move('main://' . $sourceFilepath, 'main://' . $targetFilename);
             } catch (\Symfony\Component\Filesystem\Exception\IOException $ex) {
                 $message = 'Failed to rename file from temporary directory to entity';
                 throw new \Shopsys\FrameworkBundle\Component\FileUpload\Exception\MoveToEntityFailedException($message, $ex);
             }
         }
+    }
+
+    /**
+     * @return int Count of deleted files
+     */
+    public function deleteOldUploadedFiles(): int
+    {
+        $deletedCounter = 0;
+        $currentTimestamp = time();
+        $uploadedFiles = $this->filesystem->listContents($this->getTemporaryDirectory());
+
+        foreach ($uploadedFiles as $uploadedFile) {
+            if ($uploadedFile['type'] === 'file' && $currentTimestamp - $uploadedFile['timestamp'] >= static::DELETE_OLD_FILES_SECONDS) {
+                $this->filesystem->delete($uploadedFile['path']);
+                $deletedCounter++;
+            }
+        }
+
+        return $deletedCounter;
     }
 }

--- a/packages/framework/src/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AddConstraintValidatorsPass implements CompilerPassInterface
+{
+    private $validatorFactoryServiceId;
+
+    private $constraintValidatorTag;
+
+    /**
+     * @param string $validatorFactoryServiceId
+     * @param string $constraintValidatorTag
+     */
+    public function __construct(
+        string $validatorFactoryServiceId = 'validator.validator_factory',
+        string $constraintValidatorTag = 'validator.constraint_validator'
+    ) {
+        $this->validatorFactoryServiceId = $validatorFactoryServiceId;
+        $this->constraintValidatorTag = $constraintValidatorTag;
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($this->validatorFactoryServiceId)) {
+            return;
+        }
+
+        $validators = [];
+        foreach ($container->findTaggedServiceIds($this->constraintValidatorTag, true) as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+
+            if (isset($attributes[0]['alias'])) {
+                $validators[$attributes[0]['alias']] = new Reference($id);
+            }
+
+            $validators[$definition->getClass()] = new Reference($id);
+            $validators[$id] = new Reference($id);
+        }
+
+        $container
+            ->getDefinition($this->validatorFactoryServiceId)
+            ->replaceArgument(0, ServiceLocatorTagPass::register($container, $validators));
+    }
+}

--- a/packages/framework/src/Form/Constraints/FileAbstractFilesystemValidator.php
+++ b/packages/framework/src/Form/Constraints/FileAbstractFilesystemValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form\Constraints;
+
+use League\Flysystem\MountManager;
+use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\File\File as FileObject;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\FileValidator;
+
+class FileAbstractFilesystemValidator extends FileValidator
+{
+    /**
+     * @var \League\Flysystem\MountManager
+     */
+    private $mountManager;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
+     */
+    private $fileUpload;
+
+    /**
+     * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface
+     */
+    private $parameterBag;
+
+    /**
+     * @param \League\Flysystem\MountManager $mountManager
+     * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
+     */
+    public function __construct(
+        MountManager $mountManager,
+        FileUpload $fileUpload,
+        ParameterBagInterface $parameterBag
+    ) {
+        $this->mountManager = $mountManager;
+        $this->fileUpload = $fileUpload;
+        $this->parameterBag = $parameterBag;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $abstractPath = $this->fileUpload->getTemporaryFilepath($value->getFilename());
+
+        if ($this->mountManager->has('main://' . $abstractPath)) {
+            $localFileUniqueName = $this->fileUpload->getTemporaryFilepath(uniqid() . $value->getFilename());
+            $localPath = $this->parameterBag->get('shopsys.root_dir') . $localFileUniqueName;
+            $this->mountManager->copy('main://' . $abstractPath, 'local://' . $localPath);
+
+            parent::validate(new FileObject($localPath), $constraint);
+
+            $this->mountManager->delete('local://' . $localPath);
+        } else {
+            $this->context->buildViolation('This file could not be found. Please remove it and try to upload it again.')
+                ->setCode((string)UPLOAD_ERR_NO_FILE)
+                ->addViolation();
+        }
+    }
+}

--- a/packages/framework/src/Form/Constraints/ImageAbstractFilesystemValidator.php
+++ b/packages/framework/src/Form/Constraints/ImageAbstractFilesystemValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form\Constraints;
+
+use League\Flysystem\MountManager;
+use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\File\File as FileObject;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\ImageValidator;
+
+class ImageAbstractFilesystemValidator extends ImageValidator
+{
+    /**
+     * @var \League\Flysystem\MountManager
+     */
+    private $mountManager;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
+     */
+    private $fileUpload;
+
+    /**
+     * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface
+     */
+    private $parameterBag;
+
+    /**
+     * @param \League\Flysystem\MountManager $mountManager
+     * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
+     */
+    public function __construct(
+        MountManager $mountManager,
+        FileUpload $fileUpload,
+        ParameterBagInterface $parameterBag
+    ) {
+        $this->mountManager = $mountManager;
+        $this->fileUpload = $fileUpload;
+        $this->parameterBag = $parameterBag;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $abstractPath = $this->fileUpload->getTemporaryFilepath($value->getFilename());
+        if ($this->mountManager->has('main://' . $abstractPath)) {
+            $localFileUniqueName = $this->fileUpload->getTemporaryFilepath(uniqid() . $value->getFilename());
+            $localPath = $this->parameterBag->get('shopsys.root_dir') . $localFileUniqueName;
+
+            $this->mountManager->copy('main://' . $abstractPath, 'local://' . $localPath);
+
+            parent::validate(new FileObject($localPath), $constraint);
+
+            $this->mountManager->delete('local://' . $localPath);
+        } else {
+            $this->context->buildViolation('This image could not be found. Please remove it and try to upload it again.')
+                ->setCode((string)UPLOAD_ERR_NO_FILE)
+                ->addViolation();
+        }
+    }
+}

--- a/packages/framework/src/Model/Mail/MailTemplateAttachmentFilepathProvider.php
+++ b/packages/framework/src/Model/Mail/MailTemplateAttachmentFilepathProvider.php
@@ -45,7 +45,9 @@ class MailTemplateAttachmentFilepathProvider
      */
     public function getTemporaryFilepath(UploadedFile $uploadedFile): string
     {
-        $temporaryFilepath = TransformString::removeDriveLetterFromPath($this->fileUpload->getTemporaryFilepath($uploadedFile->getFilename()));
+        $temporaryFilepath = TransformString::removeDriveLetterFromPath(
+            $this->fileUpload->getAbsoluteTemporaryFilepath($uploadedFile->getFilename())
+        );
 
         if (!$this->mountManager->has('local://' . $temporaryFilepath)) {
             $uploadedFilePath = $this->uploadedFileFacade->getAbsoluteUploadedFileFilepath($uploadedFile);

--- a/packages/framework/src/Resources/config/directories.yaml
+++ b/packages/framework/src/Resources/config/directories.yaml
@@ -10,6 +10,7 @@ parameters:
         - '%kernel.project_dir%/var/lock'
         - '%kernel.project_dir%/var/log'
         - '%kernel.project_dir%/var/errorPages'
+        - '%kernel.project_dir%/var/uploadedFiles'
         - '%shopsys.web_dir%/assets/admin/styles'
         - '%shopsys.web_dir%/assets/frontend/styles'
         - '%shopsys.web_dir%/assets/scripts'

--- a/packages/framework/src/Resources/config/paths.yaml
+++ b/packages/framework/src/Resources/config/paths.yaml
@@ -1,3 +1,4 @@
 parameters:
     shopsys.framework.resources_dir: "%shopsys.framework.root_dir%/src/Resources"
     shopsys.framework.javascript_sources_dir: "%shopsys.framework.resources_dir%/scripts"
+    shopsys.var_dir: "/var" # @deprecated This has been added to be backward compatible and will be removed in next major version

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -217,7 +217,7 @@ services:
     Shopsys\FrameworkBundle\Component\FileUpload\FileNamingConvention: ~
 
     Shopsys\FrameworkBundle\Component\FileUpload\FileUpload:
-        arguments: ['%kernel.cache_dir%', '%shopsys.uploaded_file_dir%', '%shopsys.image_dir%']
+        arguments: ['%shopsys.var_dir%', '%shopsys.uploaded_file_dir%', '%shopsys.image_dir%']
 
     Shopsys\FrameworkBundle\Component\FileUpload\DoctrineListener:
         tags:
@@ -971,9 +971,14 @@ services:
 
     Shopsys\FrameworkBundle\Model\Pricing\PriceConverter: ~
 
-
     Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainDataFactory
 
     Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainFactory
+
+    Symfony\Component\Validator\Constraints\ImageValidator:
+        class: Shopsys\FrameworkBundle\Form\Constraints\ImageAbstractFilesystemValidator
+
+    Symfony\Component\Validator\Constraints\FileValidator:
+        class: Shopsys\FrameworkBundle\Form\Constraints\FileAbstractFilesystemValidator

--- a/packages/framework/src/Resources/config/services/cron.yaml
+++ b/packages/framework/src/Resources/config/services/cron.yaml
@@ -3,3 +3,8 @@ services:
         autowire: true
         autoconfigure: true
         public: false
+
+    # @deprecated This has been added to be backward compatible and will be removed in next major version
+    Shopsys\FrameworkBundle\Component\FileUpload\DeleteOldUploadedFilesCronModule:
+        tags:
+            - { name: shopsys.cron, hours: '5', minutes: '0', readableName: 'Delete old temporary uploaded files' }

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -4,6 +4,7 @@ namespace Shopsys\FrameworkBundle;
 
 use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\LazyRedisCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterCronModulesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterExtendedEntitiesCompilerPass;
@@ -35,6 +36,7 @@ class ShopsysFrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterProductFeedConfigsCompilerPass());
         $container->addCompilerPass(new LazyRedisCompilerPass());
         $container->addCompilerPass(new RegisterExtendedEntitiesCompilerPass());
+        $container->addCompilerPass(new AddConstraintValidatorsPass());
 
         $container->registerForAutoconfiguration(AbstractIndex::class)->addTag('elasticsearch.index');
 

--- a/packages/framework/tests/Unit/Component/Image/ImageFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Image/ImageFactoryTest.php
@@ -14,7 +14,6 @@ use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
 use Shopsys\FrameworkBundle\Component\Image\Image;
 use Shopsys\FrameworkBundle\Component\Image\ImageFactory;
 use Shopsys\FrameworkBundle\Component\Image\Processing\ImageProcessor;
-use Symfony\Component\Filesystem\Filesystem;
 
 class ImageFactoryTest extends TestCase
 {
@@ -83,10 +82,9 @@ class ImageFactoryTest extends TestCase
     private function getFileUpload(): FileUpload
     {
         $fileNamingConvention = new FileNamingConvention();
-        $filesystem = new Filesystem();
         $mountManager = new MountManager();
         $abstractFilesystem = $this->createMock(FilesystemInterface::class);
 
-        return new FileUpload('temporaryDir', 'uploadedFileDir', 'imageDir', $fileNamingConvention, $filesystem, $mountManager, $abstractFilesystem);
+        return new FileUpload('temporaryDir', 'uploadedFileDir', 'imageDir', $fileNamingConvention, $mountManager, $abstractFilesystem);
     }
 }

--- a/project-base/config/paths.yaml
+++ b/project-base/config/paths.yaml
@@ -33,3 +33,4 @@ parameters:
     shopsys.data_fixtures_images.resources_dir: '%shopsys.data_fixtures.resources_dir%/images/'
     shopsys.elasticsearch.structure_dir: '%shopsys.resources_dir%/definition/'
     shopsys.json_entrypoints_path: '%kernel.project_dir%/web/build/entrypoints.json'
+    shopsys.var_dir: '/var'

--- a/project-base/config/services/cron.yaml
+++ b/project-base/config/services/cron.yaml
@@ -52,6 +52,10 @@ services:
         tags:
             - { name: shopsys.cron, hours: '4', minutes: '0', readableName: 'Generate Sitemap' }
 
+    Shopsys\FrameworkBundle\Component\FileUpload\DeleteOldUploadedFilesCronModule:
+        tags:
+            - { name: shopsys.cron, hours: '5', minutes: '0', readableName: 'Delete old temporary uploaded files' }
+
     # This module should run as last because it creates multiple kernels and fake requests.
     Shopsys\FrameworkBundle\Component\Error\ErrorPageCronModule:
         tags:

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -19,3 +19,6 @@ There you can find links to upgrade notes for other versions too.
 
 - call static method as static ([#1937](https://github.com/shopsys/shopsys/pull/1937))
     - see #project-base-diff to update your project
+
+- update your project to upload temporary files to abstract filesystem ([#1955](https://github.com/shopsys/shopsys/pull/1955))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With more replicas of PHP-FPM is possible to run on another replica before uploaded file is saved to abstract filesystem. This has been now solved.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1917 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
