### PR TITLE
[framework] IndexExportedEvent is called after elasticsearch export cron module finished

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/AbstractExportChangedCronModule.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractExportChangedCronModule.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 abstract class AbstractExportChangedCronModule implements SimpleCronModuleInterface
 {
@@ -32,21 +34,29 @@ abstract class AbstractExportChangedCronModule implements SimpleCronModuleInterf
     protected $domain;
 
     /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex $index
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade $indexFacade
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface|null $eventDispatcher
      */
     public function __construct(
         AbstractIndex $index,
         IndexFacade $indexFacade,
         IndexDefinitionLoader $indexDefinitionLoader,
-        Domain $domain
+        Domain $domain,
+        ?EventDispatcherInterface $eventDispatcher = null
     ) {
         $this->index = $index;
         $this->indexFacade = $indexFacade;
         $this->indexDefinitionLoader = $indexDefinitionLoader;
         $this->domain = $domain;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -56,11 +66,29 @@ abstract class AbstractExportChangedCronModule implements SimpleCronModuleInterf
     {
     }
 
+    /**
+     * @required
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
+    {
+        if ($this->eventDispatcher !== null && $this->eventDispatcher !== $eventDispatcher) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->eventDispatcher === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->eventDispatcher = $eventDispatcher;
+        }
+    }
+
     public function run()
     {
         foreach ($this->domain->getAllIds() as $domainId) {
             $indexDefinition = $this->indexDefinitionLoader->getIndexDefinition($this->index::getName(), $domainId);
             $this->indexFacade->exportChanged($this->index, $indexDefinition, new NullOutput());
         }
+
+        $this->eventDispatcher->dispatch(new IndexExportedEvent($this->index), IndexExportedEvent::INDEX_EXPORTED);
     }
 }

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportChangedCronModule.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportChangedCronModule.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractExportChangedCronModule;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ProductExportChangedCronModule extends AbstractExportChangedCronModule
 {
@@ -16,13 +17,15 @@ class ProductExportChangedCronModule extends AbstractExportChangedCronModule
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade $indexFacade
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface|null $eventDispatcher
      */
     public function __construct(
         ProductIndex $index,
         IndexFacade $indexFacade,
         IndexDefinitionLoader $indexDefinitionLoader,
-        Domain $domain
+        Domain $domain,
+        ?EventDispatcherInterface $eventDispatcher = null
     ) {
-        parent::__construct($index, $indexFacade, $indexDefinitionLoader, $domain);
+        parent::__construct($index, $indexFacade, $indexDefinitionLoader, $domain, $eventDispatcher);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If I export data to the ES, the data is never set as exported...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
