### PR TITLE
[shopsys] update tests to use tests container to decrease amount of services defined in `services_test.yaml`

### DIFF
--- a/packages/framework/src/Resources/config/services_test.yaml
+++ b/packages/framework/src/Resources/config/services_test.yaml
@@ -11,6 +11,32 @@ services:
         arguments:
             - '%overwrite_domain_url%'
 
+    Shopsys\FrameworkBundle\Model\Feed\FeedRegistry:
+        arguments:
+            $knownTypes: ['daily', 'hourly']
+            $defaultType: 'daily'
+
+    Shopsys\FrameworkBundle\Component\Domain\Domain:
+        factory: ['@Shopsys\FrameworkBundle\Component\Domain\DomainFactory', create]
+        arguments:
+            - '%shopsys.domain_config_filepath%'
+            - '%shopsys.domain_urls_config_filepath%'
+
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Localization\TranslatableListener: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportSubscriber:
+        autoconfigure: false
+
+    Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader:
+        arguments:
+            $indexDefinitionsDirectory: '%shopsys.elasticsearch.structure_dir%'
+            $indexPrefix: 'test_%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
+
+    # @deprecated - services between these two comment blocks are supposed to be removed in next major version
+    # as it is no longer necessary to be defined here - start -------->
+
     Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade: ~
 
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository: ~
@@ -70,20 +96,9 @@ services:
 
     Shopsys\FrameworkBundle\Model\Feed\Delivery\DeliveryFeedItemRepository: ~
 
-    Shopsys\FrameworkBundle\Model\Feed\FeedRegistry:
-        arguments:
-            $knownTypes: ['daily', 'hourly']
-            $defaultType: 'daily'
-
     Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade:
         arguments:
             - '%shopsys.default_db_schema_filepath%'
-
-    Shopsys\FrameworkBundle\Component\Domain\Domain:
-        factory: ['@Shopsys\FrameworkBundle\Component\Domain\DomainFactory', create]
-        arguments:
-            - '%shopsys.domain_config_filepath%'
-            - '%shopsys.domain_urls_config_filepath%'
 
     Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader: ~
 
@@ -163,8 +178,6 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade: ~
-
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade: ~
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser: ~
@@ -172,9 +185,6 @@ services:
     Shopsys\FrameworkBundle\Model\Product\ProductRepository: ~
 
     Shopsys\FrameworkBundle\Model\Script\ScriptFacade: ~
-
-    Shopsys\FrameworkBundle\Model\Localization\TranslatableListener: ~
-
     Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory
 
@@ -204,11 +214,5 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductInputPriceRecalculator: ~
 
-    Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportSubscriber:
-        autoconfigure: false
-
-    Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader:
-        arguments:
-            $indexDefinitionsDirectory: '%shopsys.elasticsearch.structure_dir%'
-            $indexPrefix: 'test_%env(ELASTIC_SEARCH_INDEX_PREFIX)%'
-
+# @deprecated - services between these two comment blocks are supposed to be removed in next major version
+# as it is no longer necessary to be defined here - <-------- end

--- a/project-base/config/services_test.yaml
+++ b/project-base/config/services_test.yaml
@@ -27,46 +27,6 @@ services:
     Symfony\Bridge\Twig\Extension\HttpKernelRuntime:
         arguments: ['@fragment.handler']
 
-    Shopsys\FrameworkBundle\Model\Pricing\PriceConverter: ~
-
     Shopsys\FrameworkBundle\Model\Localization\IntlCurrencyRepository: ~
 
-    Shopsys\FrameworkBundle\Model\Feed\FeedFacade: ~
-
-    Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector: ~
-
-    Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade: ~
-
-    Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory:
-        arguments: ['%router.resource%']
-
-    Shopsys\ReadModelBundle\Image\ImageViewFacade: ~
-
-    Shopsys\ReadModelBundle\Product\Action\ProductActionViewFacade: ~
-
-    Shopsys\FrameworkBundle\Component\Image\ImageFacade:
-        arguments: ['%shopsys.image_url_prefix%']
-
-    Shopsys\FrameworkBundle\Component\Image\ImageLocator:
-        arguments: ['%shopsys.image_dir%']
-
     League\Flysystem\FilesystemInterface: '@main_filesystem'
-
-    Shopsys\FrameworkBundle\Component\Router\CurrentDomainRouter:
-        tags:
-            - { name: router, priority: 70 }
-
-    Shopsys\FrameworkBundle\Model\Localization\Localization:
-        arguments:
-            $adminLocale: '%shopsys.admin_locale%'
-
-    CommerceGuys\Intl\Currency\CurrencyRepositoryInterface:
-        class: Shopsys\FrameworkBundle\Model\Localization\IntlCurrencyRepository
-
-    Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory: ~
-
-    Shopsys\FrameworkBundle\Twig\NumberFormatterExtension: ~
-
-    Shopsys\FrameworkBundle\Model\Pricing\Rounding: ~
-
-    Shopsys\FrontendApiBundle\Model\Token\TokenFacade: ~

--- a/project-base/tests/App/Functional/EntityExtension/EntityExtensionTest.php
+++ b/project-base/tests/App/Functional/EntityExtension/EntityExtensionTest.php
@@ -72,7 +72,7 @@ class EntityExtensionTest extends TransactionFunctionalTestCase
             ProductTranslation::class => ExtendedProductTranslation::class,
         ];
 
-        $applicationEntityExtensionMap = static::bootKernel()->getContainer()->getParameter('shopsys.entity_extension.map');
+        $applicationEntityExtensionMap = $this->getContainer()->getParameter('shopsys.entity_extension.map');
 
         foreach ($applicationEntityExtensionMap as $baseClass => $extendedClass) {
             if (!array_key_exists($baseClass, $entityExtensionMap)) {

--- a/project-base/tests/App/Performance/Feed/AllFeedsTest.php
+++ b/project-base/tests/App/Performance/Feed/AllFeedsTest.php
@@ -45,7 +45,7 @@ class AllFeedsTest extends KernelTestCase
             'debug' => EnvironmentType::isDebug(EnvironmentType::TEST),
         ]);
 
-        $container = static::bootKernel()->getContainer();
+        $container = static::$container;
         $container->get(Domain::class)
             ->switchDomainById(Domain::FIRST_DOMAIN_ID);
 
@@ -89,7 +89,7 @@ class AllFeedsTest extends KernelTestCase
 
         $this->exportJmeterCsvReport(
             $performanceTestSamples,
-            static::bootKernel()->getContainer()->getParameter('shopsys.root_dir') . '/build/stats/performance-tests-feeds.csv'
+            static::$container->getParameter('shopsys.root_dir') . '/build/stats/performance-tests-feeds.csv'
         );
 
         $this->assertSamplesAreSuccessful($performanceTestSamples);
@@ -115,9 +115,9 @@ class AllFeedsTest extends KernelTestCase
     public function getAllFeedGenerationData()
     {
         /** @var \Shopsys\FrameworkBundle\Model\Feed\FeedRegistry $feedRegistry */
-        $feedRegistry = static::bootKernel()->getContainer()->get(FeedRegistry::class);
+        $feedRegistry = static::$container->get(FeedRegistry::class);
         /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
-        $domain = static::bootKernel()->getContainer()->get(Domain::class);
+        $domain = static::$container->get(Domain::class);
         $dailyFeedGenerationData = $this->getFeedGenerationData(
             $feedRegistry->getFeeds('daily'),
             $domain->getAll(),
@@ -184,7 +184,7 @@ class AllFeedsTest extends KernelTestCase
         $this->setUp();
 
         /** @var \Symfony\Component\Routing\RouterInterface $router */
-        $router = static::bootKernel()->getContainer()->get('router');
+        $router = static::$container->get('router');
 
         $uri = $router->generate(
             self::ROUTE_NAME_GENERATE_FEED,
@@ -198,7 +198,7 @@ class AllFeedsTest extends KernelTestCase
         $auth->authenticateRequest($request);
 
         /** @var \Doctrine\ORM\EntityManager $entityManager */
-        $entityManager = static::bootKernel()->getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager = static::$container->get('doctrine.orm.entity_manager');
 
         $startTime = microtime(true);
         $entityManager->beginTransaction();

--- a/project-base/tests/App/Performance/Page/AllPagesTest.php
+++ b/project-base/tests/App/Performance/Page/AllPagesTest.php
@@ -33,7 +33,7 @@ class AllPagesTest extends KernelTestCase
             'debug' => EnvironmentType::isDebug(EnvironmentType::TEST),
         ]);
 
-        self::$kernel->getContainer()->get(Domain::class)
+        static::$container->get(Domain::class)
             ->switchDomainById(Domain::FIRST_DOMAIN_ID);
     }
 
@@ -61,7 +61,7 @@ class AllPagesTest extends KernelTestCase
     {
         $this->doTestPagesWithProgress(
             $this->getRequestDataSets('~^admin_~'),
-            self::$kernel->getContainer()->getParameter('shopsys.root_dir') . '/build/stats/performance-tests-admin.csv'
+            static::$container->getParameter('shopsys.root_dir') . '/build/stats/performance-tests-admin.csv'
         );
     }
 
@@ -69,7 +69,7 @@ class AllPagesTest extends KernelTestCase
     {
         $this->doTestPagesWithProgress(
             $this->getRequestDataSets('~^front~'),
-            self::$kernel->getContainer()->getParameter('shopsys.root_dir') . '/build/stats/performance-tests-front.csv'
+            static::$container->getParameter('shopsys.root_dir') . '/build/stats/performance-tests-front.csv'
         );
     }
 
@@ -87,7 +87,7 @@ class AllPagesTest extends KernelTestCase
         }
 
         $routeConfigCustomizer = new RouteConfigCustomizer($requestDataSetGenerators);
-        $routeConfigCustomization = new RouteConfigCustomization(self::$kernel->getContainer());
+        $routeConfigCustomization = new RouteConfigCustomization(static::$container);
         $routeConfigCustomization->customizeRouteConfigs($routeConfigCustomizer);
 
         $routeConfigCustomizer->customize(function (RouteConfig $config, RouteInfo $info) use ($routeNamePattern) {
@@ -178,7 +178,7 @@ class AllPagesTest extends KernelTestCase
     {
         $this->setUp();
 
-        $requestDataSet->executeCallsDuringTestExecution(static::$kernel->getContainer());
+        $requestDataSet->executeCallsDuringTestExecution(static::$container);
 
         $uri = $this->getRouterAdapter()->generateUri($requestDataSet);
 
@@ -186,7 +186,7 @@ class AllPagesTest extends KernelTestCase
         $requestDataSet->getAuth()->authenticateRequest($request);
 
         /** @var \Doctrine\ORM\EntityManager $entityManager */
-        $entityManager = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager = static::$container->get('doctrine.orm.entity_manager');
 
         $startTime = microtime(true);
         $entityManager->beginTransaction();
@@ -269,7 +269,7 @@ class AllPagesTest extends KernelTestCase
      */
     private function getRouterAdapter()
     {
-        $router = static::$kernel->getContainer()->get('router');
+        $router = static::$container->get('router');
         $routerAdapter = new SymfonyRouterAdapter($router);
 
         return $routerAdapter;
@@ -302,7 +302,7 @@ class AllPagesTest extends KernelTestCase
      */
     private function createPerformanceTestSampleQualifier()
     {
-        $container = self::$kernel->getContainer();
+        $container = static::$container;
 
         return new PerformanceTestSampleQualifier(
             $container->getParameter('shopsys.performance_test.page.duration_milliseconds.warning'),

--- a/project-base/tests/App/Smoke/Http/HttpSmokeTest.php
+++ b/project-base/tests/App/Smoke/Http/HttpSmokeTest.php
@@ -15,7 +15,7 @@ class HttpSmokeTest extends HttpSmokeTestCase
     {
         parent::setUp();
 
-        self::$kernel->getContainer()->get(Domain::class)
+        static::$container->get(Domain::class)
             ->switchDomainById(Domain::FIRST_DOMAIN_ID);
     }
 
@@ -24,7 +24,7 @@ class HttpSmokeTest extends HttpSmokeTestCase
      */
     protected function customizeRouteConfigs(RouteConfigCustomizer $routeConfigCustomizer)
     {
-        $routeConfigCustomization = new RouteConfigCustomization(self::$kernel->getContainer());
+        $routeConfigCustomization = new RouteConfigCustomization(static::$container);
         $routeConfigCustomization->customizeRouteConfigs($routeConfigCustomizer);
     }
 
@@ -35,7 +35,7 @@ class HttpSmokeTest extends HttpSmokeTestCase
     protected function handleRequest(Request $request)
     {
         /** @var \Doctrine\ORM\EntityManager $entityManager */
-        $entityManager = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+        $entityManager = static::$container->get('doctrine.orm.entity_manager');
 
         $entityManager->beginTransaction();
         ob_start();

--- a/project-base/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -36,7 +36,7 @@ class RouteConfigCustomization
      */
     public function __construct(ContainerInterface $container)
     {
-        $this->container = $container;
+        $this->container = $container->get('test.service_container');
     }
 
     /**
@@ -129,6 +129,7 @@ class RouteConfigCustomization
                         . '(Routes are protected by RouteCsrfProtector.)';
                     $config->changeDefaultRequestDataSet($debugNote)
                         ->addCallDuringTestExecution(function (RequestDataSet $requestDataSet, ContainerInterface $container) {
+                            $container = $container->get('test.service_container');
                             /** @var \Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector $routeCsrfProtector */
                             $routeCsrfProtector = $container->get(RouteCsrfProtector::class);
                             /** @var \Symfony\Component\Security\Csrf\CsrfTokenManager $csrfTokenManager */

--- a/project-base/tests/App/Test/Codeception/Helper/SymfonyHelper.php
+++ b/project-base/tests/App/Test/Codeception/Helper/SymfonyHelper.php
@@ -42,6 +42,6 @@ class SymfonyHelper extends Module
      */
     public function grabServiceFromContainer($serviceId)
     {
-        return $this->kernel->getContainer()->get($serviceId);
+        return $this->kernel->getContainer()->get('test.service_container')->get($serviceId);
     }
 }

--- a/project-base/tests/App/Test/FunctionalTestCase.php
+++ b/project-base/tests/App/Test/FunctionalTestCase.php
@@ -96,7 +96,7 @@ abstract class FunctionalTestCase extends WebTestCase implements ServiceContaine
      */
     protected function getContainer()
     {
-        return $this->findClient()->getContainer();
+        return $this->findClient()->getContainer()->get('test.service_container');
     }
 
     /**
@@ -113,7 +113,7 @@ abstract class FunctionalTestCase extends WebTestCase implements ServiceContaine
      */
     public function createContainer(): ContainerInterface
     {
-        return $this->getContainer();
+        return $this->getContainer()->get('test.service_container');
     }
 
     /**

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -20,3 +20,6 @@ There you can find links to upgrade notes for other versions too.
 
 - call static method as static ([#1937](https://github.com/shopsys/shopsys/pull/1937))
     - see #project-base-diff to update your project
+
+- update tests to use tests container to decrease amount of services defined in `services_test.yaml` ([#](https://github.com/shopsys/shopsys/pull/))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With Symfony 4.1 came new test container that includes all defined services in `services.yaml`. There are some restrictions like services not used in any other service are removed from this container. That is reason why some services must be kept. This PR has been inspired by #1661.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #907 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
