### PR TITLE
[framework] ProductAvailabilityCalculation: fix property annotation

### DIFF
--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -16,7 +16,7 @@ class ProductAvailabilityCalculation
     protected $availabilityFacade;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator
      */
     protected $productSellingDeniedRecalculator;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Seems like a little typo but it has kind of huge impact - it breaks the functionality of annotations fixer - it is not able to get the property type properly and it results in adding `@property  $productSellingDeniedRecalculator` (ie. the type is missing completely) property annotation into my extended class. Of course, phpstan has a problem with such an annotation so we end up in a cycle of failing annotations-fix <-> phpstan . In combination with https://github.com/shopsys/shopsys/issues/1958, it is really unpleasant 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)|No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
