### PR TITLE
[frontend-api] Added resolvers for orders

### DIFF
--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -428,6 +428,29 @@ class OrderFacade
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
+     */
+    public function getCustomerUserOrderLimitedList(
+        CustomerUser $customerUser,
+        int $limit,
+        int $offset
+    ): array {
+        return $this->orderRepository->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return int
+     */
+    public function getCustomerUserOrderCount(CustomerUser $customerUser): int
+    {
+        return $this->orderRepository->getCustomerUserOrderCount($customerUser);
+    }
+
+    /**
      * @param string $email
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Order\Order[]

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -470,6 +470,26 @@ class OrderFacade
     }
 
     /**
+     * @param string $uuid
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function getByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser): Order
+    {
+        return $this->orderRepository->getByUuidAndCustomerUser($uuid, $customerUser);
+    }
+
+    /**
+     * @param string $uuid
+     * @param string $urlHash
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function getByUuidAndUrlHash(string $uuid, string $urlHash): Order
+    {
+        return $this->orderRepository->getByUuidAndUrlHash($uuid, $urlHash);
+    }
+
+    /**
      * @param string $urlHash
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Order\Order

--- a/packages/framework/src/Model/Order/OrderRepository.php
+++ b/packages/framework/src/Model/Order/OrderRepository.php
@@ -178,6 +178,40 @@ class OrderRepository
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
+     */
+    public function getCustomerUserOrderLimitedList(CustomerUser $customerUser, int $limit, int $offset): array
+    {
+        return $this->createOrderQueryBuilder()
+            ->andWhere('o.customerUser = :customerUser')
+            ->setParameter('customerUser', $customerUser)
+            ->orderBy('o.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return int
+     */
+    public function getCustomerUserOrderCount(CustomerUser $customerUser): int
+    {
+        return $this->em->createQueryBuilder()
+            ->select('count(o.id)')
+            ->from(Order::class, 'o')
+            ->where('o.deleted = FALSE')
+            ->andWhere('o.customerUser = :customerUser')
+            ->setParameter('customerUser', $customerUser)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
      * @param string $email
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Order\Order[]

--- a/packages/framework/src/Model/Order/OrderRepository.php
+++ b/packages/framework/src/Model/Order/OrderRepository.php
@@ -94,6 +94,34 @@ class OrderRepository
     }
 
     /**
+     * @param string $uuid
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order|null
+     */
+    protected function findByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser)
+    {
+        return $this->createOrderQueryBuilder()
+            ->andWhere('o.uuid = :uuid')->setParameter(':uuid', $uuid)
+            ->andWhere('o.customerUser = :customerUser')->setParameter(':customerUser', $customerUser)
+            ->setMaxResults(1)
+            ->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @param string $uuid
+     * @param string $urlHash
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order|null
+     */
+    protected function findByUuidAndUrlHash(string $uuid, string $urlHash)
+    {
+        return $this->createOrderQueryBuilder()
+            ->andWhere('o.uuid = :uuid')->setParameter(':uuid', $uuid)
+            ->andWhere('o.urlHash = :urlHash')->setParameter(':urlHash', $urlHash)
+            ->setMaxResults(1)
+            ->getQuery()->getOneOrNullResult();
+    }
+
+    /**
      * @param int $id
      * @return \Shopsys\FrameworkBundle\Model\Order\Order
      */
@@ -103,6 +131,44 @@ class OrderRepository
 
         if ($order === null) {
             throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException('Order with ID ' . $id . ' not found.');
+        }
+
+        return $order;
+    }
+
+    /**
+     * @param string $uuid
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function getByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser): Order
+    {
+        $order = $this->findByUuidAndCustomerUser($uuid, $customerUser);
+
+        if ($order === null) {
+            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException(sprintf(
+                'Order with UUID \'%s\' not found.',
+                $uuid
+            ));
+        }
+
+        return $order;
+    }
+
+    /**
+     * @param string $uuid
+     * @param string $urlHash
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function getByUuidAndUrlHash(string $uuid, string $urlHash): Order
+    {
+        $order = $this->findByUuidAndUrlHash($uuid, $urlHash);
+
+        if ($order === null) {
+            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException(sprintf(
+                'Order with UUID \'%s\' not found.',
+                $uuid
+            ));
         }
 
         return $order;
@@ -241,7 +307,10 @@ class OrderRepository
             ->getQuery()->getOneOrNullResult();
 
         if ($order === null) {
-            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException();
+            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException(sprintf(
+                'Order with urlHash "%s" was not found.',
+                $urlHash
+            ));
         }
 
         return $order;

--- a/packages/frontend-api/apiary.apib
+++ b/packages/frontend-api/apiary.apib
@@ -1808,3 +1808,330 @@ Returns customer user new personal data
             }
         }
     }
+
+## List of customer user orders [/graphql{?customer_user_orders}]
+
+### POST [POST]
+
+Returns list of customer user orders that can be paginated using `first`, `last`, `before` and `after` keywords.
+By default this list is limited to first 10 orders.
+You can read more about Connection specification in [connections article](https://relay.dev/graphql/connections.htm).
+
+- Request (application/json)
+
+    - Headers
+        Authorization: Bearer --ACCESS-TOKEN--
+
+    - Body
+        {
+            orders(first: 2) {
+                edges {
+                    node {
+                        uuid
+                        number
+                        urlHash
+                        creationDate
+                        status
+                        totalPrice {
+                            priceWithVat
+                        }
+                        items {
+                            name
+                        }
+                        transport {
+                            name
+                        }
+                        payment {
+                            name
+                        }
+                        companyName
+                        companyNumber
+                        companyTaxNumber
+                        firstName
+                        lastName
+                        email
+                        street
+                        city
+                        postcode
+                        country
+                        differentDeliveryAddress
+                        note
+                    }
+                }
+            }
+        }
+
+
+- Response 200 (application/json; charset=utf-8)
+
+    {
+        "data": {
+            "orders": {
+                "edges": [
+                    {
+                        "node": {
+                            "uuid": "2f310e40-5104-4bd3-1337-0ebd9fe7324e",
+                            "number": "1095328621",
+                            "urlHash": "ckbikWM3atXE471u0xvg0SqQP4gbwgbNjQ89de8qirbyzDQ74i",
+                            "creationDate": "2020-07-20T20:46:26+00:00",
+                            "status": "New",
+                            "totalPrice": {
+                                "priceWithVat": "76.580000"
+                            },
+                            "items": [
+                                {
+                                    "name": "Pot holder, black"
+                                },
+                                {
+                                    "name": "Credit card"
+                                },
+                                {
+                                    "name": "Personal collection"
+                                }
+                            ],
+                            "transport": {
+                                "name": "Personal collection"
+                            },
+                            "payment": {
+                                "name": "Credit card"
+                            },
+                            "companyName": null,
+                            "companyNumber": null,
+                            "companyTaxNumber": null,
+                            "firstName": "Iva",
+                            "lastName": "Jačková",
+                            "email": "no-reply@shopsys.com",
+                            "street": "Druhá 2",
+                            "city": "Ostrava",
+                            "postcode": "71300",
+                            "country": "CZ",
+                            "differentDeliveryAddress": false,
+                            "note": null
+                        }
+                    },
+                    {
+                        "node": {
+                            "uuid": "f236f5ac-6d0d-4074-a666-7b878e7a6937",
+                            "number": "1595328622",
+                            "urlHash": "fpb0c5Aasmw71CLkltLwZVm3h2efkfjMr3hsRkvgxupjYj31QO",
+                            "creationDate": "2020-07-19T04:02:31+00:00",
+                            "status": "New",
+                            "totalPrice": {
+                                "priceWithVat": "83.580000"
+                            },
+                            "items": [
+                                {
+                                    "name": "CD-R 210MB"
+                                },
+                                {
+                                    "name": "Cash on delivery"
+                                },
+                                {
+                                    "name": "Czech post"
+                                }
+                            ],
+                            "transport": {
+                                "name": "Czech post"
+                            },
+                            "payment": {
+                                "name": "Cash on delivery"
+                            },
+                            "companyName": null,
+                            "companyNumber": null,
+                            "companyTaxNumber": null,
+                            "firstName": "Jan",
+                            "lastName": "Adamovský",
+                            "email": "no-reply@shopsys.com",
+                            "street": "Třetí 3",
+                            "city": "Ostrava",
+                            "postcode": "71200",
+                            "country": "CZ",
+                            "differentDeliveryAddress": false,
+                            "note": null
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+## Order detail (authorized) [/graphql{?order_detail_authorized}]
+
+### POST [POST]
+
+Returns order filtered using UUID and access token
+
+- Request (application/json)
+
+    - Headers
+        Authorization: Bearer --ACCESS-TOKEN--
+
+    - Body
+        {
+            order(uuid: "2f310e40-51O4-4bde-8517-0ebd9fe7324e") {
+                uuid
+                number
+                urlHash
+                creationDate
+                status
+                totalPrice {
+                    priceWithVat
+                }
+                items {
+                    name
+                }
+                transport {
+                    name
+                }
+                payment {
+                    name
+                }
+                companyName
+                companyNumber
+                companyTaxNumber
+                firstName
+                lastName
+                email
+                street
+                city
+                postcode
+                country
+                differentDeliveryAddress
+                note
+            }
+        }
+
+
+- Response 200 (application/json; charset=utf-8)
+    {
+        "data": {
+            "order": {
+                "uuid": "2f310e40-51O4-4bde-8517-0ebd9fe7324e",
+                "number": "1595328621",
+                "urlHash": "cKbikWM3ktXe471u0xvgOSqQP4rbwgbNjQ89de8qirbyzDQ74i",
+                "creationDate": "2020-07-20T20:46:26+00:00",
+                "status": "New",
+                "totalPrice": {
+                    "priceWithVat": "76.580000"
+                },
+                "items": [
+                    {
+                        "name": "Pot holder, black"
+                    },
+                    {
+                        "name": "Credit card"
+                    },
+                    {
+                        "name": "Personal collection"
+                    }
+                ],
+                "transport": {
+                    "name": "Personal collection"
+                },
+                "payment": {
+                    "name": "Credit card"
+                },
+                "companyName": null,
+                "companyNumber": null,
+                "companyTaxNumber": null,
+                "firstName": "Iva",
+                "lastName": "Jačková",
+                "email": "no-reply@shopsys.com",
+                "street": "Druhá 2",
+                "city": "Ostrava",
+                "postcode": "71300",
+                "country": "CZ",
+                "differentDeliveryAddress": false,
+                "note": null
+            }
+        }
+    }
+
+## Order detail (unauthorized) [/graphql{?order_detail_unauthorized}]
+
+### POST [POST]
+
+Returns order filtered using url hash
+
+- Request (application/json)
+
+    - Body
+        {
+            order(urlHash:"cKbikWM3ktXe471u0xvgOSqQP4rbwgbNjQ89de8qirbyzDQ74i") {
+                uuid
+                number
+                urlHash
+                creationDate
+                status
+                totalPrice {
+                    priceWithVat
+                }
+                items {
+                    name
+                }
+                transport {
+                    name
+                }
+                payment {
+                    name
+                }
+                companyName
+                companyNumber
+                companyTaxNumber
+                firstName
+                lastName
+                email
+                street
+                city
+                postcode
+                country
+                differentDeliveryAddress
+                note
+            }
+        }
+
+
+- Response 200 (application/json; charset=utf-8)
+    {
+        "data": {
+            "order": {
+                "uuid": "2f310e40-51O4-4bde-8517-0ebd9fe7324e",
+                "number": "1595328621",
+                "urlHash": "cKbikWM3ktXe471u0xvgOSqQP4rbwgbNjQ89de8qirbyzDQ74i",
+                "creationDate": "2020-07-20T20:46:26+00:00",
+                "status": "New",
+                "totalPrice": {
+                    "priceWithVat": "76.580000"
+                },
+                "items": [
+                    {
+                        "name": "Pot holder, black"
+                    },
+                    {
+                        "name": "Credit card"
+                    },
+                    {
+                        "name": "Personal collection"
+                    }
+                ],
+                "transport": {
+                    "name": "Personal collection"
+                },
+                "payment": {
+                    "name": "Credit card"
+                },
+                "companyName": null,
+                "companyNumber": null,
+                "companyTaxNumber": null,
+                "firstName": "Iva",
+                "lastName": "Jačková",
+                "email": "no-reply@shopsys.com",
+                "street": "Druhá 2",
+                "city": "Ostrava",
+                "postcode": "71300",
+                "country": "CZ",
+                "differentDeliveryAddress": false,
+                "note": null
+            }
+        }
+    }

--- a/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Order;
+
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Error\UserError;
+use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
+use Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException;
+use Shopsys\FrameworkBundle\Model\Order\Order;
+use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+
+class OrderResolver implements ResolverInterface, AliasedInterface
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser
+     */
+    protected $currentCustomerUser;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
+     */
+    protected $orderFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        CurrentCustomerUser $currentCustomerUser,
+        OrderFacade $orderFacade,
+        Domain $domain
+    ) {
+        $this->orderFacade = $orderFacade;
+        $this->currentCustomerUser = $currentCustomerUser;
+        $this->domain = $domain;
+    }
+
+    /**
+     * @param string|null $uuid
+     * @param string|null $urlHash
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function resolver(?string $uuid = null, ?string $urlHash = null): Order
+    {
+        $customerUser = $this->currentCustomerUser->findCurrentCustomerUser();
+
+        try {
+            if ($uuid !== null && $customerUser !== null) {
+                return $this->getOrderForCustomerUserByUuid($customerUser, $uuid);
+            } elseif ($urlHash !== null) {
+                return $this->orderFacade->getByUrlHashAndDomain($urlHash, $this->domain->getId());
+            }
+        } catch (OrderNotFoundException $orderNotFoundException) {
+            throw new UserError($orderNotFoundException->getMessage());
+        }
+
+        throw new UserError('You need to be logged in or provide argument \'urlHash\'.');
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases(): array
+    {
+        return [
+            'resolver' => 'order',
+        ];
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    protected function getOrderForCustomerUserByUuid(
+        CustomerUser $customerUser,
+        string $uuid
+    ): Order {
+        if (Uuid::isValid($uuid) === false) {
+            throw new UserError('Provided argument \'uuid\' is not valid.');
+        }
+
+        return $this->orderFacade->getByUuidAndCustomerUser($uuid, $customerUser);
+    }
+}
+

--- a/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Resolver\Order;
+
+use Overblog\GraphQLBundle\Definition\Argument;
+use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Error\UserError;
+use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
+use Overblog\GraphQLBundle\Relay\Connection\Paginator;
+use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+
+class OrdersResolver implements ResolverInterface, AliasedInterface
+{
+    protected const DEFAULT_FIRST_LIMIT = 10;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser
+     */
+    protected $currentCustomerUser;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
+     */
+    protected $orderFacade;
+
+    /**
+     * @var \Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder
+     */
+    protected $connectionBuilder;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
+     */
+    public function __construct(CurrentCustomerUser $currentCustomerUser, OrderFacade $orderFacade)
+    {
+        $this->currentCustomerUser = $currentCustomerUser;
+        $this->orderFacade = $orderFacade;
+        $this->connectionBuilder = new ConnectionBuilder();
+    }
+
+    /**
+     * @param \Overblog\GraphQLBundle\Definition\Argument $argument
+     * @return \Overblog\GraphQLBundle\Relay\Connection\ConnectionInterface|object
+     */
+    public function resolve(Argument $argument)
+    {
+        $this->setDefaultFirstOffsetIfNecessary($argument);
+
+        $customerUser = $this->currentCustomerUser->findCurrentCustomerUser();
+        if (!$customerUser) {
+            throw new UserError('Token is not valid.');
+        }
+
+        $paginator = new Paginator(function ($offset, $limit) use ($customerUser) {
+            return $this->orderFacade->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
+        });
+
+        return $paginator->auto($argument, $this->orderFacade->getCustomerUserOrderCount($customerUser));
+    }
+
+    /**
+     * @param \Overblog\GraphQLBundle\Definition\Argument $argument
+     */
+    protected function setDefaultFirstOffsetIfNecessary(Argument $argument): void
+    {
+        if ($argument->offsetExists('first') === false
+            && $argument->offsetExists('last') === false
+        ) {
+            $argument->offsetSet('first', static::DEFAULT_FIRST_LIMIT);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAliases(): array
+    {
+        return [
+            'resolve' => 'orders',
+        ];
+    }
+}

--- a/packages/frontend-api/src/Resources/config/graphql-types/Pagination/OrderDecoratorConnection.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/Pagination/OrderDecoratorConnection.types.yaml
@@ -1,0 +1,3 @@
+OrderConnectionDecorator:
+    type: object
+    decorator: true

--- a/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yaml
@@ -54,3 +54,8 @@ QueryDecorator:
                 type: 'CurrentCustomerUser!'
                 resolve: "@=resolver('currentCustomerUser')"
                 description: "Returns currently logged in customer user"
+            orders:
+                type: "OrderConnection"
+                argsBuilder: "Relay::Connection"
+                resolve: "@=resolver('orders', [args])"
+                description: "Returns list of order that can be paginated using `first`, `last`, `before` and `after` keywords"

--- a/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yaml
@@ -58,4 +58,13 @@ QueryDecorator:
                 type: "OrderConnection"
                 argsBuilder: "Relay::Connection"
                 resolve: "@=resolver('orders', [args])"
-                description: "Returns list of order that can be paginated using `first`, `last`, `before` and `after` keywords"
+                description: "Returns list of orders that can be paginated using `first`, `last`, `before` and `after` keywords"
+            order:
+                type: 'Order'
+                resolve: "@=resolver('order', [args['uuid'], args['urlHash']])"
+                args:
+                    uuid:
+                        type: "Uuid"
+                    urlHash:
+                        type: "String"
+                description: "Returns order filtered using UUID or urlHash"

--- a/project-base/config/graphql/types/Pagination/OrderConnection.types.yaml
+++ b/project-base/config/graphql/types/Pagination/OrderConnection.types.yaml
@@ -1,0 +1,6 @@
+OrderConnection:
+    type: relay-connection
+    config:
+        nodeType: Order
+    inherits:
+        - 'OrderConnectionDecorator'

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Order;
+
+use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
+
+class GetOrderAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
+     * @inject
+     */
+    private $orderFacade;
+
+    public function testGetOrder(): void
+    {
+        foreach ($this->getOrderDataForCurrentlyLoggedCustomerUserProvider() as $dataSet) {
+            list($uuid, $expectedOrderData) = $dataSet;
+
+            $graphQlType = 'order';
+            $response = $this->getResponseContentForQuery($this->getOrderQuery($uuid));
+            $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+            $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+
+            $this->assertArrayHasKey('status', $responseData);
+            $this->assertSame($expectedOrderData['status'], $responseData['status']);
+
+            $this->assertArrayHasKey('totalPrice', $responseData);
+            $this->assertArrayHasKey('priceWithVat', $responseData['totalPrice']);
+            $this->assertSame($expectedOrderData['totalPriceWithVat'], $responseData['totalPrice']['priceWithVat']);
+        }
+    }
+
+    public function testGetOrderReturnsError(): void
+    {
+        $order = $this->getOrderOfNotCurrentlyLoggedCustomerUser();
+        $expectedErrorMessage = 'Order with UUID \'' . $order->getUuid() . '\' not found.';
+
+        $response = $this->getResponseContentForQuery($this->getOrderQuery($order->getUuid()));
+        $this->assertResponseContainsArrayOfErrors($response);
+        $errors = $this->getErrorsFromResponse($response);
+
+        $this->assertArrayHasKey(0, $errors);
+        $this->assertArrayHasKey('message', $errors[0]);
+        $this->assertSame($expectedErrorMessage, $errors[0]['message']);
+    }
+
+    /**
+     * @return array
+     */
+    private function getOrderDataForCurrentlyLoggedCustomerUserProvider(): array
+    {
+        $data = [];
+        $orderIds = [1, 2, 3];
+        foreach ($orderIds as $orderId) {
+            $order = $this->orderFacade->getById($orderId);
+            $data[] = [
+                $order->getUuid(),
+                [
+                    'status' => $order->getStatus()->getName(),
+                    'totalPriceWithVat' => $order->getTotalPriceWithVat()->getAmount(),
+                ],
+            ];
+        }
+        return $data;
+    }
+
+    /**
+     * @param string $uuid
+     * @return string
+     */
+    private function getOrderQuery(string $uuid): string
+    {
+        return '
+            {
+                order (uuid:"' . $uuid . '") {
+                    status
+                    totalPrice {
+                        priceWithVat
+                    }
+                }
+            }
+        ';
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    private function getOrderOfNotCurrentlyLoggedCustomerUser(): \Shopsys\FrameworkBundle\Model\Order\Order
+    {
+        return $this->orderFacade->getById(7);
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsUnauthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsUnauthenticatedCustomerUserTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Order;
+
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class GetOrderAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
+     * @inject
+     */
+    private $orderFacade;
+
+    public function testGetOrder(): void
+    {
+        foreach ($this->getOrderDataProvider() as $dataSet) {
+            list($urlHash, $expectedOrderData) = $dataSet;
+
+            $graphQlType = 'order';
+            $response = $this->getResponseContentForQuery($this->getOrderQuery($urlHash));
+            $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+            $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+
+            $this->assertArrayHasKey('status', $responseData);
+            $this->assertSame($expectedOrderData['status'], $responseData['status']);
+
+            $this->assertArrayHasKey('totalPrice', $responseData);
+            $this->assertArrayHasKey('priceWithVat', $responseData['totalPrice']);
+            $this->assertSame($expectedOrderData['totalPriceWithVat'], $responseData['totalPrice']['priceWithVat']);
+        }
+    }
+
+    public function testGetOrderReturnsError(): void
+    {
+        foreach ($this->getIncorrectOrderDataProvider() as $dataSet) {
+            list($urlHash, $expectedErrorMessage) = $dataSet;
+
+            $response = $this->getResponseContentForQuery($this->getOrderQuery($urlHash));
+            $this->assertResponseContainsArrayOfErrors($response);
+            $errors = $this->getErrorsFromResponse($response);
+
+            $this->assertArrayHasKey(0, $errors);
+            $this->assertArrayHasKey('message', $errors[0]);
+            $this->assertSame($expectedErrorMessage, $errors[0]['message']);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getOrderDataProvider(): array
+    {
+        $data = [];
+        $orderIds = [7, 8, 9];
+        foreach ($orderIds as $orderId) {
+            $order = $this->orderFacade->getById($orderId);
+            $data[] = [
+                $order->getUrlHash(),
+                [
+                    'status' => $order->getStatus()->getName(),
+                    'totalPriceWithVat' => $order->getTotalPriceWithVat()->getAmount(),
+                ],
+            ];
+        }
+        return $data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getIncorrectOrderDataProvider(): array
+    {
+        return [
+            [
+                null,
+                'You need to be logged in or provide argument \'urlHash\'.',
+            ],
+            [
+                'foo',
+                'Order with urlHash "foo" was not found.',
+            ],
+        ];
+    }
+
+    /**
+     * @param string|null $urlHash
+     * @return string
+     */
+    private function getOrderQuery(?string $urlHash = null): string
+    {
+        if ($urlHash !== null) {
+            $graphQlTypeWithFilters = 'order (urlHash:"' . $urlHash . '")';
+        } else {
+            $graphQlTypeWithFilters = 'order';
+        }
+
+        return '
+            {
+                ' . $graphQlTypeWithFilters . ' {
+                    status
+                    totalPrice {
+                        priceWithVat
+                    }
+                }
+            }
+        ';
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Order;
+
+use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
+
+class GetOrdersAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
+{
+    /**
+     * @param string $query
+     * @param array $expectedOrdersData
+     * @dataProvider getOrdersDataProvider
+     */
+    public function testGetAllCustomerUserOrders(string $query, array $expectedOrdersData): void
+    {
+        $graphQlType = 'orders';
+        $response = $this->getResponseContentForQuery($query);
+        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+
+        $this->assertArrayHasKey('edges', $responseData);
+        $this->assertCount(count($expectedOrdersData), $responseData['edges']);
+
+        foreach ($responseData['edges'] as $edge) {
+            $this->assertArrayHasKey('node', $edge);
+
+            $expectedOrderData = array_shift($expectedOrdersData);
+            $this->assertArrayHasKey('status', $edge['node']);
+            $this->assertSame($expectedOrderData['status'], $edge['node']['status']);
+
+            $this->assertArrayHasKey('totalPrice', $edge['node']);
+            $this->assertArrayHasKey('priceWithVat', $edge['node']['totalPrice']);
+            $this->assertSame($expectedOrderData['priceWithVat'], $edge['node']['totalPrice']['priceWithVat']);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getOrdersDataProvider(): array
+    {
+        return [
+            [
+                $this->getOrdersWithoutFilterQuery(),
+                $this->getExpectedUserOrders(),
+            ],
+            [
+                $this->getFirstOrdersQuery(2),
+                array_slice($this->getExpectedUserOrders(), 0, 2),
+            ],
+            [
+                $this->getFirstOrdersQuery(1),
+                array_slice($this->getExpectedUserOrders(), 0, 1),
+            ],
+            [
+                $this->getLastOrdersQuery(1),
+                array_slice($this->getExpectedUserOrders(), 5, 1),
+            ],
+            [
+                $this->getLastOrdersQuery(2),
+                array_slice($this->getExpectedUserOrders(), 4, 2),
+            ],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    private function getOrdersWithoutFilterQuery(): string
+    {
+        return '
+            {
+                orders {
+                    edges {
+                        node {
+                            status
+                            totalPrice {
+                                priceWithVat
+                            }
+                        }
+                    }
+                }
+            }
+        ';
+    }
+
+    /**
+     * @param int $numberOfOrders
+     * @return string
+     */
+    private function getFirstOrdersQuery(int $numberOfOrders): string
+    {
+        return '
+            {
+                orders (first:' . $numberOfOrders . ') {
+                    edges {
+                        node {
+                            status
+                            totalPrice {
+                                priceWithVat
+                            }
+                        }
+                    }
+                }
+            }
+        ';
+    }
+
+    /**
+     * @param int $numberOfOrders
+     * @return string
+     */
+    private function getLastOrdersQuery(int $numberOfOrders): string
+    {
+        return '
+            {
+                orders (last:' . $numberOfOrders . ') {
+                    edges {
+                        node {
+                            status
+                            totalPrice {
+                                priceWithVat
+                            }
+                        }
+                    }
+                }
+            }
+        ';
+    }
+
+    /**
+     * @return array
+     */
+    private function getExpectedUserOrders(): array
+    {
+        return [
+            [
+                'status' => 'In Progress',
+                'priceWithVat' => '153.640000',
+            ],
+            [
+                'status' => 'Done',
+                'priceWithVat' => '4308.320000',
+            ],
+            [
+                'status' => 'New',
+                'priceWithVat' => '83.580000',
+            ],
+            [
+                'status' => 'Done',
+                'priceWithVat' => '245.970000',
+            ],
+            [
+                'status' => 'New',
+                'priceWithVat' => '76.580000',
+            ],
+            [
+                'status' => 'New',
+                'priceWithVat' => '1012.420000',
+            ],
+        ];
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsUnauthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsUnauthenticatedCustomerUserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Order;
+
+use Tests\FrontendApiBundle\Test\GraphQlTestCase;
+
+class GetOrdersAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
+{
+    public function testGetAllCustomerUserOrders(): void
+    {
+        $response = $this->getResponseContentForQuery($this->getOrdersWithoutFilterQuery());
+        $this->assertResponseContainsArrayOfErrors($response);
+        $errors = $this->getErrorsFromResponse($response);
+
+        $this->assertArrayHasKey(0, $errors);
+        $this->assertArrayHasKey('message', $errors[0]);
+        $this->assertSame(
+            'Token is not valid.',
+            $errors[0]['message']
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getOrdersWithoutFilterQuery(): string
+    {
+        return '
+            {
+                orders {
+                    edges {
+                        node {
+                            status
+                            totalPrice {
+                                priceWithVat
+                            }
+                        }
+                    }
+                }
+            }
+        ';
+    }
+}

--- a/project-base/tests/FrontendApiBundle/Test/GraphQlWithLoginTestCase.php
+++ b/project-base/tests/FrontendApiBundle/Test/GraphQlWithLoginTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Test;
 
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class GraphQlWithLoginTestCase extends GraphQlTestCase
@@ -18,9 +19,15 @@ abstract class GraphQlWithLoginTestCase extends GraphQlTestCase
 
     protected function setUp(): void
     {
+        $this->client = $this->findClient(true);
+        $this->domain = $this->client->getContainer()->get(Domain::class);
+        $this->em = $this->client->getContainer()->get('doctrine.orm.entity_manager');
+        $this->overwriteDomainUrl = $this->getContainer()->getParameter('overwrite_domain_url');
+
+        $this->domain->switchDomainById(Domain::FIRST_DOMAIN_ID);
+
         $this->runCheckTestEnabledOnCurrentDomain();
 
-        $this->client = $this->findClient(true);
         $this->accessToken = $this->getAccessToken(static::DEFAULT_USER_EMAIL, static::DEFAULT_USER_PASSWORD);
 
         parent::setUp();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR adds posibility to retreive order list or single order for given customer user or combination of uuid and urls hash.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
