### PR TITLE
[framework] fixed multiple binding of product picker events

### DIFF
--- a/packages/framework/assets/js/admin/components/ProductsPickerWindow.js
+++ b/packages/framework/assets/js/admin/components/ProductsPickerWindow.js
@@ -74,8 +74,8 @@ export default class ProductsPickerWindow {
             .click(() => false);
     }
 
-    static init () {
-        $('.js-products-picker-window-add-product').each(function () {
+    static init ($container) {
+        $container.filterAllNodes('.js-products-picker-window-add-product').each(function () {
             // eslint-disable-next-line no-new
             new ProductsPickerWindow($(this));
         });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In this scenario if you choose product as product accessory for example, this product is added to form more than once.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1962 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
