### PR TITLE
[shopsys] fixed filtering of products in frontend API

### DIFF
--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -366,6 +366,18 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     }
 
     /**
+     * @return int
+     */
+    public function getProductsCountOnCurrentDomain(): int
+    {
+        $filterQuery = $this->filterQueryFactory->create($this->getIndexName())
+            ->filterOnlySellable()
+            ->filterOnlyVisible($this->currentCustomerUser->getPricingGroup());
+
+        return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @param int $limit
      * @param int $offset

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -200,6 +200,24 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
     }
 
     /**
+     * @return int
+     */
+    public function getProductsCountOnCurrentDomain(): int
+    {
+        $queryBuilder = $this->productRepository->getAllListableQueryBuilder(
+            $this->domain->getId(),
+            $this->currentCustomerUser->getPricingGroup()
+        );
+
+        $this->productRepository->addTranslation($queryBuilder, $this->domain->getLocale());
+
+        return $queryBuilder
+            ->select('count(p.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
      * @param string $orderingModeId
      * @param int $page
      * @param int $limit

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -209,8 +209,6 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
             $this->currentCustomerUser->getPricingGroup()
         );
 
-        $this->productRepository->addTranslation($queryBuilder, $this->domain->getLocale());
-
         return $queryBuilder
             ->select('count(p.id)')
             ->getQuery()

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
@@ -123,4 +123,9 @@ interface ProductOnCurrentDomainFacadeInterface
      * @return array
      */
     public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array;
+
+    /**
+     * @return int
+     */
+    public function getProductsCountOnCurrentDomain(): int;
 }

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -188,4 +188,15 @@ class ProductElasticsearchRepository
     {
         return (int)$result['hits']['total']['value'];
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return int
+     */
+    public function getProductsCountByFilterQuery(FilterQuery $filterQuery): int
+    {
+        $result = $this->client->search($filterQuery->getQuery());
+
+        return $this->extractTotalCount($result);
+    }
 }

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -16,6 +16,9 @@ use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
 class ProductsResolver implements ResolverInterface, AliasedInterface
 {
     protected const DEFAULT_FIRST_LIMIT = 10;
+    /**
+     * @deprecated This will be removed in next major release
+     */
     protected const EDGE_COUNT = 2;
 
     /**
@@ -44,6 +47,8 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function resolve(Argument $argument)
     {
+        $this->setDefaultFirstOffsetIfNecessary($argument);
+
         $paginator = new Paginator(function ($offset, $limit) {
             return $this->productOnCurrentDomainFacade->getProductsOnCurrentDomain(
                 $limit,
@@ -62,36 +67,25 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function resolveByCategory(Argument $argument, Category $category)
     {
-        if ($argument->offsetExists('last')) {
-            $limit = (int)$argument->offsetGet('last');
-            $cursor = $argument->offsetGet('before');
-            $offset = max((int)$this->connectionBuilder->cursorToOffset($cursor) - $limit, 0);
-        } else {
-            $this->setDefaultFirstOffsetIfNecessary($argument);
-            $limit = (int)$argument->offsetGet('first');
-            $cursor = $argument->offsetGet('after');
-            $offset = (int)$this->connectionBuilder->cursorToOffset($cursor);
-        }
+        $this->setDefaultFirstOffsetIfNecessary($argument);
 
-        $products = $this->productOnCurrentDomainFacade->getProductsByCategory(
-            $category,
-            $limit + static::EDGE_COUNT,
-            $offset,
-            ProductListOrderingConfig::ORDER_BY_PRIORITY
-        );
-        $paginator = new Paginator(function () use ($products) {
-            return $products;
+        $paginator = new Paginator(function ($offset, $limit) use ($category) {
+            return $this->productOnCurrentDomainFacade->getProductsByCategory(
+                $category,
+                $limit,
+                $offset,
+                ProductListOrderingConfig::ORDER_BY_PRIORITY
+            );
         });
 
-        return $paginator->auto($argument, count($products));
+        return $paginator->auto($argument, $this->productOnCurrentDomainFacade->getProductsCountOnCurrentDomain());
     }
-
     /**
      * @param \Overblog\GraphQLBundle\Definition\Argument $argument
      */
     protected function setDefaultFirstOffsetIfNecessary(Argument $argument): void
     {
-        if ($argument->offsetExists('first') === false) {
+        if ($argument->offsetExists('first') === false && $argument->offsetExists('last') === false) {
             $argument->offsetSet('first', static::DEFAULT_FIRST_LIMIT);
         }
     }

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -44,28 +44,15 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function resolve(Argument $argument)
     {
-        if ($argument->offsetExists('last')) {
-            $limit = (int)$argument->offsetGet('last');
-            $cursor = $argument->offsetGet('before');
-            $offset = max((int)$this->connectionBuilder->cursorToOffset($cursor) - $limit, 0);
-        } else {
-            $this->setDefaultFirstOffsetIfNecessary($argument);
-            $limit = (int)$argument->offsetGet('first');
-            $cursor = $argument->offsetGet('after');
-            $offset = (int)$this->connectionBuilder->cursorToOffset($cursor);
-        }
-
-        $products = $this->productOnCurrentDomainFacade->getProductsOnCurrentDomain(
-            $limit + static::EDGE_COUNT,
-            $offset,
-            ProductListOrderingConfig::ORDER_BY_PRIORITY
-        );
-
-        $paginator = new Paginator(function () use ($products) {
-            return $products;
+        $paginator = new Paginator(function ($offset, $limit) {
+            return $this->productOnCurrentDomainFacade->getProductsOnCurrentDomain(
+                $limit,
+                $offset,
+                ProductListOrderingConfig::ORDER_BY_PRIORITY
+            );
         });
 
-        return $paginator->auto($argument, count($products));
+        return $paginator->auto($argument, $this->productOnCurrentDomainFacade->getProductsCountOnCurrentDomain());
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -80,6 +80,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
 
         return $paginator->auto($argument, $this->productOnCurrentDomainFacade->getProductsCountOnCurrentDomain());
     }
+
     /**
      * @param \Overblog\GraphQLBundle\Definition\Argument $argument
      */

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -121,4 +121,43 @@ class ProductsTest extends GraphQlTestCase
 
         return $arrayExpected;
     }
+
+    public function testLastProduct(): void
+    {
+        $query = '
+            query {
+                products (last: 1) {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        ';
+
+        $jsonExpected = $this->getExpectedDataForLastProduct();
+
+        $this->assertQueryWithExpectedJson($query, $jsonExpected);
+    }
+
+    /**
+     * @return string
+     */
+    private function getExpectedDataForLastProduct(): string
+    {
+        return '{
+    "data": {
+        "products": {
+            "edges": [
+                {
+                    "node": {
+                        "name": "ZN-8009 steam iron Ferrato stainless steel 2200 Watt Blue"
+                    }
+                }
+            ]
+        }
+    }
+}';
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Keyword last was working wrong way. This was caused by wrong implementation of Paginator. This has been solved in this PR.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
