### PR TITLE
[framework] select distinct product for vat replace

### DIFF
--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -664,7 +664,7 @@ class ProductRepository
     public function getProductIteratorForReplaceVat()
     {
         $query = $this->em->createQuery('
-            SELECT p
+            SELECT DISTINCT p
             FROM ' . Product::class . ' p
             JOIN ' . ProductDomain::class . ' pd WITH pd.product = p
             JOIN pd.vat v


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| doctrine fails to hydrate non-unique rows when used iterator. error when running cron Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| #1968 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
