### PR TITLE
[shopsys] ignored phpcs-cache file for git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /nbproject
 /vendor
 /.php_cs.cache
+/.phpcs-cache
 /.docker-sync
 .DS_Store
 /composer.lock


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Every time I work with the projetct file `.phpcs-cache` is created. I do not want to exclude or delete it before every commit so I added it to `.gitignore` to prevent commiting it accidentally.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
