### PR TITLE
[project-base] fixed path to tests in phpstan.neon

### DIFF
--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -28,7 +28,7 @@ parameters:
             path: %currentWorkingDirectory%/tests/*
         -
             message: '#^Service "test.service_container" is not registered in the container.$#'
-            path: %currentWorkingDirectory%/*/tests/*
+            path: %currentWorkingDirectory%/tests/*
         -
             message: '#^Service "snc_redis.test" is not registered in the container.$#'
             path: %currentWorkingDirectory%/tests/App/Functional/Component/Redis/Redis*FacadeTest.php

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -28,6 +28,5 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff and update your `yaml-standards.yaml` file
     - run `php phing standards-fix` to fix your `yaml` files
 
-- add phpstan-symfony extension ([#1961](https://github.com/shopsys/shopsys/pull/1961))
-    - see #project-base-diff to update your project
-
+- add phpstan-symfony extension ([#1961](https://github.com/shopsys/shopsys/pull/1961)) and ([#1974](https://github.com/shopsys/shopsys/pull/1974))
+    - see #project-base-diff1 and #project-base-diff2 to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Wrong path has been used in implementation of phpstan-symfony, this is now fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
