### PR TITLE
[shopsys] moved setting common entity data to the method

### DIFF
--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -15,7 +15,7 @@ It is a common modification when you need your ecommerce application and ERP sys
 
 Add new `extId` field with Doctrine ORM annotations and a getter for the field into `App\Model\Product\Product` class.
 
-Overwrite constructor for creating `Product` instances.
+Overwrite `setData` method for setting entity data from data object.
 
 ```php
 namespace App\Model\Product;
@@ -39,13 +39,13 @@ class Product extends BaseProduct
 
     /**
      * @param \App\Model\Product\ProductData $productData
-     * @param \App\Model\Product\Product[]|null $variants
      */
-    protected function __construct(BaseProductData $productData, array $variants = null)
+    protected function setData(BaseProductData $productData): void
     {
-        parent::__construct($productData, $variants);
-
+        parent::setData($productData);
+        
         $this->extId = $productData->extId ?? 0;
+
     }
 
     /**

--- a/docs/cookbook/adding-new-attribute-to-an-entity.md
+++ b/docs/cookbook/adding-new-attribute-to-an-entity.md
@@ -219,7 +219,7 @@ class ProductFormTypeExtension extends AbstractTypeExtension
 !!! tip
     If you want to change order for your newly created field, please look at section [Changing order of groups and fields](../extensibility/form-extension.md#changing-order-of-groups-and-fields)
 
-In your `Product` class, overwrite the `edit()` method.
+In your `Product` class, overwrite the `setData()` method.
 
 ```php
 namespace App\Model\Product;
@@ -229,14 +229,10 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
 // ...
 
 /**
- * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain[] $productCategoryDomains
  * @param \App\Model\Product\ProductData $productData
  */
-public function edit(
-    array $productCategoryDomains  
-    BaseProductData $productData,
-) {
-    parent::edit($productCategoryDomains, $productData);
+public function setData(BaseProductData $productData) {
+    parent::setData($productData);
 
     $this->extId = $productData->extId;
 }

--- a/docs/cookbook/create-advanced-grid.md
+++ b/docs/cookbook/create-advanced-grid.md
@@ -35,7 +35,7 @@ class SalesmanData
 }
 ```
 
-### 1.2 Add constructor, `edit` method, and getters to `Salesman` entity
+### 1.2 Add constructor, `edit` and `setData` method, and getters to `Salesman` entity
 ```diff
 // src/Model/Salesman/Salesman.php
 
@@ -46,13 +46,20 @@ class Salesman
 +      */
 +     public function __construct(SalesmanData $salesmanData)
 +     {
-+         $this->edit($salesmanData);
++         $this->setData($salesmanData);
 +     }
 
 +     /**
 +      * @param \App\Model\Salesman\SalesmanData $salesmanData
 +      */
 +     public function edit(SalesmanData $salesmanData)
++     {
++         $this->setData($salesmanData);
++     }
++
++      * @param \App\Model\Salesman\SalesmanData $salesmanData
++      */
++     public function setData(SalesmanData $salesmanData)
 +     {
 +         $this->name = $salesmanData->name;
 +         $this->registeredAt = $salesmanData->registeredAt;

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -116,7 +116,6 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
      */
     public function __construct(AdministratorData $administratorData)
     {
-        $this->setData($administratorData);
         $this->lastActivity = new DateTime();
         $this->gridLimits = new ArrayCollection();
         $this->loginToken = '';
@@ -124,6 +123,7 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
         $this->multidomainLoginToken = '';
         $this->multidomainLoginTokenExpiration = new DateTime();
         $this->roles = new ArrayCollection();
+        $this->setData($administratorData);
     }
 
     /**

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -116,9 +116,7 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
      */
     public function __construct(AdministratorData $administratorData)
     {
-        $this->email = $administratorData->email;
-        $this->realName = $administratorData->realName;
-        $this->username = $administratorData->username;
+        $this->setData($administratorData);
         $this->lastActivity = new DateTime();
         $this->gridLimits = new ArrayCollection();
         $this->loginToken = '';
@@ -132,6 +130,14 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $administratorData
      */
     public function edit(AdministratorData $administratorData): void
+    {
+        $this->setData($administratorData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $administratorData
+     */
+    protected function setData(AdministratorData $administratorData): void
     {
         $this->email = $administratorData->email;
         $this->realName = $administratorData->realName;

--- a/packages/framework/src/Model/Advert/Advert.php
+++ b/packages/framework/src/Model/Advert/Advert.php
@@ -76,19 +76,21 @@ class Advert
      */
     public function __construct(AdvertData $advert)
     {
-        $this->domainId = $advert->domainId;
-        $this->name = $advert->name;
-        $this->type = $advert->type;
-        $this->code = $advert->code;
-        $this->link = $advert->link;
-        $this->positionName = $advert->positionName;
-        $this->hidden = $advert->hidden;
+        $this->setData($advert);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertData $advert
      */
     public function edit(AdvertData $advert)
+    {
+        $this->setData($advert);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertData $advert
+     */
+    protected function setData(AdvertData $advert): void
     {
         $this->domainId = $advert->domainId;
         $this->name = $advert->name;

--- a/packages/framework/src/Model/Article/Article.php
+++ b/packages/framework/src/Model/Article/Article.php
@@ -99,20 +99,22 @@ class Article implements OrderableEntityInterface
     public function __construct(ArticleData $articleData)
     {
         $this->domainId = $articleData->domainId;
-        $this->name = $articleData->name;
-        $this->text = $articleData->text;
-        $this->seoTitle = $articleData->seoTitle;
-        $this->seoMetaDescription = $articleData->seoMetaDescription;
-        $this->seoH1 = $articleData->seoH1;
-        $this->placement = $articleData->placement;
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
-        $this->hidden = $articleData->hidden;
+        $this->setData($articleData);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
      */
     public function edit(ArticleData $articleData)
+    {
+        $this->setData($articleData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
+     */
+    protected function setData(ArticleData $articleData): void
     {
         $this->name = $articleData->name;
         $this->text = $articleData->text;

--- a/packages/framework/src/Model/Category/Category.php
+++ b/packages/framework/src/Model/Category/Category.php
@@ -99,10 +99,9 @@ class Category extends AbstractTranslatableEntity
         $this->domains = new ArrayCollection();
         $this->children = new ArrayCollection();
 
-        $this->setData($categoryData);
         $this->createDomains($categoryData);
-
         $this->uuid = $categoryData->uuid ?: Uuid::uuid4()->toString();
+        $this->setData($categoryData);
     }
 
     /**
@@ -110,9 +109,8 @@ class Category extends AbstractTranslatableEntity
      */
     public function edit(CategoryData $categoryData)
     {
-        $this->setParent($categoryData->parent);
-        $this->setTranslations($categoryData);
         $this->setDomains($categoryData);
+        $this->setData($categoryData);
     }
 
     /**

--- a/packages/framework/src/Model/Category/Category.php
+++ b/packages/framework/src/Model/Category/Category.php
@@ -95,12 +95,11 @@ class Category extends AbstractTranslatableEntity
      */
     public function __construct(CategoryData $categoryData)
     {
-        $this->setParent($categoryData->parent);
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
         $this->children = new ArrayCollection();
 
-        $this->setTranslations($categoryData);
+        $this->setData($categoryData);
         $this->createDomains($categoryData);
 
         $this->uuid = $categoryData->uuid ?: Uuid::uuid4()->toString();
@@ -114,6 +113,15 @@ class Category extends AbstractTranslatableEntity
         $this->setParent($categoryData->parent);
         $this->setTranslations($categoryData);
         $this->setDomains($categoryData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryData $categoryData
+     */
+    protected function setData(CategoryData $categoryData): void
+    {
+        $this->setParent($categoryData->parent);
+        $this->setTranslations($categoryData);
     }
 
     /**

--- a/packages/framework/src/Model/Country/Country.php
+++ b/packages/framework/src/Model/Country/Country.php
@@ -54,9 +54,26 @@ class Country extends AbstractTranslatableEntity
     {
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
-        $this->setTranslations($countryData);
         $this->createDomains($countryData);
+        $this->setData($countryData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Country\CountryData $countryData
+     */
+    public function edit(CountryData $countryData): void
+    {
+        $this->setDomains($countryData);
+        $this->setData($countryData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Country\CountryData $countryData
+     */
+    protected function setData(CountryData $countryData): void
+    {
         $this->code = $countryData->code;
+        $this->setTranslations($countryData);
     }
 
     /**
@@ -85,16 +102,6 @@ class Country extends AbstractTranslatableEntity
     public function isEnabled(int $domainId): bool
     {
         return $this->getCountryDomain($domainId)->isEnabled();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Country\CountryData $countryData
-     */
-    public function edit(CountryData $countryData): void
-    {
-        $this->code = $countryData->code;
-        $this->setTranslations($countryData);
-        $this->setDomains($countryData);
     }
 
     /**

--- a/packages/framework/src/Model/Customer/BillingAddress.php
+++ b/packages/framework/src/Model/Customer/BillingAddress.php
@@ -88,23 +88,22 @@ class BillingAddress
      */
     public function __construct(BillingAddressData $billingAddressData)
     {
-        $this->street = $billingAddressData->street;
-        $this->city = $billingAddressData->city;
-        $this->postcode = $billingAddressData->postcode;
-        $this->companyCustomer = $billingAddressData->companyCustomer;
-        if ($this->companyCustomer) {
-            $this->companyName = $billingAddressData->companyName;
-            $this->companyNumber = $billingAddressData->companyNumber;
-            $this->companyTaxNumber = $billingAddressData->companyTaxNumber;
-        }
-        $this->country = $billingAddressData->country;
         $this->customer = $billingAddressData->customer;
+        $this->setData($billingAddressData);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $billingAddressData
      */
     public function edit(BillingAddressData $billingAddressData)
+    {
+        $this->setData($billingAddressData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData $billingAddressData
+     */
+    protected function setData(BillingAddressData $billingAddressData): void
     {
         $this->street = $billingAddressData->street;
         $this->city = $billingAddressData->city;

--- a/packages/framework/src/Model/Customer/Customer.php
+++ b/packages/framework/src/Model/Customer/Customer.php
@@ -47,8 +47,8 @@ class Customer
      */
     public function __construct(CustomerData $customerData)
     {
-        $this->setData($customerData);
         $this->domainId = $customerData->domainId;
+        $this->setData($customerData);
     }
 
     /**

--- a/packages/framework/src/Model/Customer/DeliveryAddress.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddress.php
@@ -91,8 +91,8 @@ class DeliveryAddress
      */
     public function __construct(DeliveryAddressData $deliveryAddressData)
     {
-        $this->setData($deliveryAddressData);
         $this->customer = $deliveryAddressData->customer;
+        $this->setData($deliveryAddressData);
     }
 
     /**

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -137,27 +137,31 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, Serializab
      */
     public function __construct(CustomerUserData $customerUserData)
     {
-        $this->firstName = $customerUserData->firstName;
-        $this->lastName = $customerUserData->lastName;
+        $this->domainId = $customerUserData->domainId;
+        $this->setData($customerUserData);
+        $this->setEmail($customerUserData->email);
+        $this->customer = $customerUserData->customer;
+        $this->uuid = $customerUserData->uuid ?: Uuid::uuid4()->toString();
+        $this->refreshTokenChain = new ArrayCollection();
         if ($customerUserData->createdAt !== null) {
             $this->createdAt = $customerUserData->createdAt;
         } else {
             $this->createdAt = new \DateTime();
         }
-        $this->domainId = $customerUserData->domainId;
-        $this->pricingGroup = $customerUserData->pricingGroup;
-        $this->telephone = $customerUserData->telephone;
-        $this->setEmail($customerUserData->email);
-        $this->customer = $customerUserData->customer;
-        $this->defaultDeliveryAddress = $customerUserData->defaultDeliveryAddress;
-        $this->uuid = $customerUserData->uuid ?: Uuid::uuid4()->toString();
-        $this->refreshTokenChain = new ArrayCollection();
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData $customerUserData
      */
     public function edit(CustomerUserData $customerUserData)
+    {
+        $this->setData($customerUserData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData $customerUserData
+     */
+    protected function setData(CustomerUserData $customerUserData): void
     {
         $this->firstName = $customerUserData->firstName;
         $this->lastName = $customerUserData->lastName;

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -138,7 +138,6 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, Serializab
     public function __construct(CustomerUserData $customerUserData)
     {
         $this->domainId = $customerUserData->domainId;
-        $this->setData($customerUserData);
         $this->setEmail($customerUserData->email);
         $this->customer = $customerUserData->customer;
         $this->uuid = $customerUserData->uuid ?: Uuid::uuid4()->toString();
@@ -148,6 +147,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, Serializab
         } else {
             $this->createdAt = new \DateTime();
         }
+        $this->setData($customerUserData);
     }
 
     /**

--- a/packages/framework/src/Model/Order/PromoCode/PromoCode.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCode.php
@@ -40,14 +40,21 @@ class PromoCode
      */
     public function __construct(PromoCodeData $promoCodeData)
     {
-        $this->code = $promoCodeData->code;
-        $this->percent = (string)$promoCodeData->percent;
+        $this->setData($promoCodeData);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeData $promoCodeData
      */
     public function edit(PromoCodeData $promoCodeData): void
+    {
+        $this->setData($promoCodeData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeData $promoCodeData
+     */
+    protected function setData(PromoCodeData $promoCodeData): void
     {
         $this->code = $promoCodeData->code;
         $this->percent = (string)$promoCodeData->percent;

--- a/packages/framework/src/Model/Order/Status/OrderStatus.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatus.php
@@ -51,6 +51,22 @@ class OrderStatus extends AbstractTranslatableEntity
     {
         $this->translations = new ArrayCollection();
         $this->setType($type);
+        $this->setData($orderStatusData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $orderStatusData
+     */
+    public function edit(OrderStatusData $orderStatusData)
+    {
+        $this->setData($orderStatusData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $orderStatusData
+     */
+    protected function setData(OrderStatusData $orderStatusData): void
+    {
         $this->setTranslations($orderStatusData);
     }
 
@@ -112,14 +128,6 @@ class OrderStatus extends AbstractTranslatableEntity
         } else {
             throw new \Shopsys\FrameworkBundle\Model\Order\Status\Exception\InvalidOrderStatusTypeException($type);
         }
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData $orderStatusData
-     */
-    public function edit(OrderStatusData $orderStatusData)
-    {
-        $this->setTranslations($orderStatusData);
     }
 
     public function checkForDelete()

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -105,14 +105,31 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
         $this->transports = new ArrayCollection();
-        $this->hidden = $paymentData->hidden;
+        $this->setData($paymentData);
         $this->deleted = false;
-        $this->setTranslations($paymentData);
         $this->createDomains($paymentData);
         $this->prices = new ArrayCollection();
-        $this->czkRounding = $paymentData->czkRounding;
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->uuid = $paymentData->uuid ?: Uuid::uuid4()->toString();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $paymentData
+     */
+    public function edit(PaymentData $paymentData)
+    {
+        $this->setData($paymentData);
+        $this->setDomains($paymentData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $paymentData
+     */
+    protected function setData(PaymentData $paymentData): void
+    {
+        $this->hidden = $paymentData->hidden;
+        $this->czkRounding = $paymentData->czkRounding;
+        $this->setTranslations($paymentData);
     }
 
     /**
@@ -175,17 +192,6 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
         foreach ($paymentData->instructions as $locale => $instructions) {
             $this->translation($locale)->setInstructions($instructions);
         }
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentData $paymentData
-     */
-    public function edit(PaymentData $paymentData)
-    {
-        $this->hidden = $paymentData->hidden;
-        $this->czkRounding = $paymentData->czkRounding;
-        $this->setTranslations($paymentData);
-        $this->setDomains($paymentData);
     }
 
     /**

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -105,12 +105,12 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
         $this->transports = new ArrayCollection();
-        $this->setData($paymentData);
         $this->deleted = false;
         $this->createDomains($paymentData);
         $this->prices = new ArrayCollection();
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->uuid = $paymentData->uuid ?: Uuid::uuid4()->toString();
+        $this->setData($paymentData);
     }
 
     /**
@@ -118,8 +118,8 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
      */
     public function edit(PaymentData $paymentData)
     {
-        $this->setData($paymentData);
         $this->setDomains($paymentData);
+        $this->setData($paymentData);
     }
 
     /**

--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -71,9 +71,25 @@ class Currency
      */
     public function __construct(CurrencyData $currencyData)
     {
+        $this->setData($currencyData);
+        $this->exchangeRate = $currencyData->exchangeRate;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
+     */
+    public function edit(CurrencyData $currencyData)
+    {
+        $this->setData($currencyData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
+     */
+    protected function setData(CurrencyData $currencyData): void
+    {
         $this->name = $currencyData->name;
         $this->code = $currencyData->code;
-        $this->exchangeRate = $currencyData->exchangeRate;
         $this->minFractionDigits = $currencyData->minFractionDigits;
         $this->setRoundingType($currencyData->roundingType);
     }
@@ -156,16 +172,5 @@ class Currency
             self::ROUNDING_TYPE_FIFTIES,
             self::ROUNDING_TYPE_INTEGER,
         ];
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData $currencyData
-     */
-    public function edit(CurrencyData $currencyData)
-    {
-        $this->name = $currencyData->name;
-        $this->code = $currencyData->code;
-        $this->minFractionDigits = $currencyData->minFractionDigits;
-        $this->setRoundingType($currencyData->roundingType);
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/Currency.php
+++ b/packages/framework/src/Model/Pricing/Currency/Currency.php
@@ -71,8 +71,8 @@ class Currency
      */
     public function __construct(CurrencyData $currencyData)
     {
-        $this->setData($currencyData);
         $this->exchangeRate = $currencyData->exchangeRate;
+        $this->setData($currencyData);
     }
 
     /**

--- a/packages/framework/src/Model/Pricing/Group/PricingGroup.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroup.php
@@ -39,8 +39,24 @@ class PricingGroup
      */
     public function __construct(PricingGroupData $pricingGroupData, $domainId)
     {
-        $this->name = $pricingGroupData->name;
         $this->domainId = $domainId;
+        $this->setData($pricingGroupData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $pricingGroupData
+     */
+    public function edit(PricingGroupData $pricingGroupData)
+    {
+        $this->setData($pricingGroupData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $pricingGroupData
+     */
+    protected function setData(PricingGroupData $pricingGroupData): void
+    {
+        $this->name = $pricingGroupData->name;
     }
 
     /**
@@ -65,13 +81,5 @@ class PricingGroup
     public function getDomainId()
     {
         return $this->domainId;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupData $pricingGroupData
-     */
-    public function edit(PricingGroupData $pricingGroupData)
-    {
-        $this->name = $pricingGroupData->name;
     }
 }

--- a/packages/framework/src/Model/Pricing/Vat/Vat.php
+++ b/packages/framework/src/Model/Pricing/Vat/Vat.php
@@ -56,9 +56,25 @@ class Vat
      */
     public function __construct(VatData $vatData, int $domainId)
     {
-        $this->name = $vatData->name;
+        $this->setData($vatData);
         $this->percent = $vatData->percent;
         $this->domainId = $domainId;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $vatData
+     */
+    public function edit(VatData $vatData)
+    {
+        $this->setData($vatData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $vatData
+     */
+    protected function setData(VatData $vatData): void
+    {
+        $this->name = $vatData->name;
     }
 
     /**
@@ -91,14 +107,6 @@ class Vat
     public function getReplaceWith()
     {
         return $this->replaceWith;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatData $vatData
-     */
-    public function edit(VatData $vatData)
-    {
-        $this->name = $vatData->name;
     }
 
     /**

--- a/packages/framework/src/Model/Pricing/Vat/Vat.php
+++ b/packages/framework/src/Model/Pricing/Vat/Vat.php
@@ -56,9 +56,9 @@ class Vat
      */
     public function __construct(VatData $vatData, int $domainId)
     {
-        $this->setData($vatData);
         $this->percent = $vatData->percent;
         $this->domainId = $domainId;
+        $this->setData($vatData);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Availability/Availability.php
+++ b/packages/framework/src/Model/Product/Availability/Availability.php
@@ -44,6 +44,22 @@ class Availability extends AbstractTranslatableEntity
     public function __construct(AvailabilityData $availabilityData)
     {
         $this->translations = new ArrayCollection();
+        $this->setData($availabilityData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData $availabilityData
+     */
+    public function edit(AvailabilityData $availabilityData)
+    {
+        $this->setData($availabilityData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData $availabilityData
+     */
+    protected function setData(AvailabilityData $availabilityData): void
+    {
         $this->setTranslations($availabilityData);
         $this->dispatchTime = $availabilityData->dispatchTime;
     }
@@ -81,15 +97,6 @@ class Availability extends AbstractTranslatableEntity
     protected function createTranslation()
     {
         return new AvailabilityTranslation();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData $availabilityData
-     */
-    public function edit(AvailabilityData $availabilityData)
-    {
-        $this->setTranslations($availabilityData);
-        $this->dispatchTime = $availabilityData->dispatchTime;
     }
 
     /**

--- a/packages/framework/src/Model/Product/Brand/Brand.php
+++ b/packages/framework/src/Model/Product/Brand/Brand.php
@@ -51,12 +51,29 @@ class Brand extends AbstractTranslatableEntity
      */
     public function __construct(BrandData $brandData)
     {
-        $this->name = $brandData->name;
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
 
-        $this->setTranslations($brandData);
+        $this->setData($brandData);
         $this->createDomains($brandData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData $brandData
+     */
+    public function edit(BrandData $brandData)
+    {
+        $this->setData($brandData);
+        $this->setDomains($brandData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData $brandData
+     */
+    protected function setData(BrandData $brandData): void
+    {
+        $this->name = $brandData->name;
+        $this->setTranslations($brandData);
     }
 
     /**
@@ -73,16 +90,6 @@ class Brand extends AbstractTranslatableEntity
     public function getName()
     {
         return $this->name;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandData $brandData
-     */
-    public function edit(BrandData $brandData)
-    {
-        $this->name = $brandData->name;
-        $this->setTranslations($brandData);
-        $this->setDomains($brandData);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Brand/Brand.php
+++ b/packages/framework/src/Model/Product/Brand/Brand.php
@@ -54,8 +54,8 @@ class Brand extends AbstractTranslatableEntity
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
 
-        $this->setData($brandData);
         $this->createDomains($brandData);
+        $this->setData($brandData);
     }
 
     /**
@@ -63,8 +63,8 @@ class Brand extends AbstractTranslatableEntity
      */
     public function edit(BrandData $brandData)
     {
-        $this->setData($brandData);
         $this->setDomains($brandData);
+        $this->setData($brandData);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Flag/Flag.php
+++ b/packages/framework/src/Model/Product/Flag/Flag.php
@@ -51,6 +51,22 @@ class Flag extends AbstractTranslatableEntity
     public function __construct(FlagData $flagData)
     {
         $this->translations = new ArrayCollection();
+        $this->setData($flagData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData $flagData
+     */
+    public function edit(FlagData $flagData)
+    {
+        $this->setData($flagData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData $flagData
+     */
+    protected function setData(FlagData $flagData): void
+    {
         $this->setTranslations($flagData);
         $this->rgbColor = $flagData->rgbColor;
         $this->visible = $flagData->visible;
@@ -105,15 +121,5 @@ class Flag extends AbstractTranslatableEntity
     protected function createTranslation()
     {
         return new FlagTranslation();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagData $flagData
-     */
-    public function edit(FlagData $flagData)
-    {
-        $this->setTranslations($flagData);
-        $this->rgbColor = $flagData->rgbColor;
-        $this->visible = $flagData->visible;
     }
 }

--- a/packages/framework/src/Model/Product/Parameter/Parameter.php
+++ b/packages/framework/src/Model/Product/Parameter/Parameter.php
@@ -44,6 +44,22 @@ class Parameter extends AbstractTranslatableEntity
     public function __construct(ParameterData $parameterData)
     {
         $this->translations = new ArrayCollection();
+        $this->setData($parameterData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $parameterData
+     */
+    public function edit(ParameterData $parameterData)
+    {
+        $this->setData($parameterData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $parameterData
+     */
+    protected function setData(ParameterData $parameterData): void
+    {
         $this->setTranslations($parameterData);
         $this->visible = $parameterData->visible;
     }
@@ -89,14 +105,5 @@ class Parameter extends AbstractTranslatableEntity
     protected function createTranslation()
     {
         return new ParameterTranslation();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $parameterData
-     */
-    public function edit(ParameterData $parameterData)
-    {
-        $this->setTranslations($parameterData);
-        $this->visible = $parameterData->visible;
     }
 }

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -293,16 +293,10 @@ class Product extends AbstractTranslatableEntity
         $this->catnum = $productData->catnum;
         $this->partno = $productData->partno;
         $this->ean = $productData->ean;
-        $this->sellingFrom = $productData->sellingFrom;
-        $this->sellingTo = $productData->sellingTo;
-        $this->sellingDenied = $productData->sellingDenied;
-        $this->hidden = $productData->hidden;
-        $this->unit = $productData->unit;
+        $this->setData($productData);
         $this->setAvailabilityAndStock($productData);
         $this->calculatedAvailability = $this->availability;
-        $this->recalculateAvailability = true;
         $this->calculatedVisibility = false;
-        $this->setTranslations($productData);
         $this->createDomains($productData);
         $this->productCategoryDomains = new ArrayCollection();
         $this->flags = new ArrayCollection($productData->flags);
@@ -311,8 +305,6 @@ class Product extends AbstractTranslatableEntity
         $this->calculatedHidden = true;
         $this->calculatedSellingDenied = true;
         $this->exportProduct = true;
-        $this->brand = $productData->brand;
-        $this->orderingPriority = $productData->orderingPriority;
 
         $this->variants = new ArrayCollection();
         if ($variants === null) {
@@ -323,6 +315,48 @@ class Product extends AbstractTranslatableEntity
         }
 
         $this->uuid = $productData->uuid ?: Uuid::uuid4()->toString();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain[] $productCategoryDomains
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     */
+    public function edit(
+        array $productCategoryDomains,
+        ProductData $productData
+    ) {
+        $this->setData($productData);
+
+        $this->editFlags($productData->flags);
+        $this->setDomains($productData);
+
+        if (!$this->isVariant()) {
+            $this->setProductCategoryDomains($productCategoryDomains);
+        }
+        if (!$this->isMainVariant()) {
+            $this->setAvailabilityAndStock($productData);
+            $this->catnum = $productData->catnum;
+            $this->partno = $productData->partno;
+            $this->ean = $productData->ean;
+        }
+
+        $this->markForVisibilityRecalculation();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     */
+    protected function setData(ProductData $productData): void
+    {
+        $this->sellingFrom = $productData->sellingFrom;
+        $this->sellingTo = $productData->sellingTo;
+        $this->sellingDenied = $productData->sellingDenied;
+        $this->hidden = $productData->hidden;
+        $this->brand = $productData->brand;
+        $this->unit = $productData->unit;
+        $this->recalculateAvailability = true;
+        $this->setTranslations($productData);
+        $this->orderingPriority = $productData->orderingPriority;
     }
 
     /**
@@ -342,40 +376,6 @@ class Product extends AbstractTranslatableEntity
     public static function createMainVariant(ProductData $productData, array $variants)
     {
         return new static($productData, $variants);
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain[] $productCategoryDomains
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
-     */
-    public function edit(
-        array $productCategoryDomains,
-        ProductData $productData
-    ) {
-        $this->sellingFrom = $productData->sellingFrom;
-        $this->sellingTo = $productData->sellingTo;
-        $this->sellingDenied = $productData->sellingDenied;
-        $this->recalculateAvailability = true;
-        $this->hidden = $productData->hidden;
-        $this->editFlags($productData->flags);
-        $this->brand = $productData->brand;
-        $this->unit = $productData->unit;
-        $this->setTranslations($productData);
-        $this->setDomains($productData);
-
-        if (!$this->isVariant()) {
-            $this->setProductCategoryDomains($productCategoryDomains);
-        }
-        if (!$this->isMainVariant()) {
-            $this->setAvailabilityAndStock($productData);
-            $this->catnum = $productData->catnum;
-            $this->partno = $productData->partno;
-            $this->ean = $productData->ean;
-        }
-
-        $this->orderingPriority = $productData->orderingPriority;
-
-        $this->markForVisibilityRecalculation();
     }
 
     /**

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -293,7 +293,6 @@ class Product extends AbstractTranslatableEntity
         $this->catnum = $productData->catnum;
         $this->partno = $productData->partno;
         $this->ean = $productData->ean;
-        $this->setData($productData);
         $this->setAvailabilityAndStock($productData);
         $this->calculatedAvailability = $this->availability;
         $this->calculatedVisibility = false;
@@ -315,6 +314,7 @@ class Product extends AbstractTranslatableEntity
         }
 
         $this->uuid = $productData->uuid ?: Uuid::uuid4()->toString();
+        $this->setData($productData);
     }
 
     /**
@@ -325,7 +325,6 @@ class Product extends AbstractTranslatableEntity
         array $productCategoryDomains,
         ProductData $productData
     ) {
-        $this->setData($productData);
 
         $this->editFlags($productData->flags);
         $this->setDomains($productData);
@@ -339,6 +338,7 @@ class Product extends AbstractTranslatableEntity
             $this->partno = $productData->partno;
             $this->ean = $productData->ean;
         }
+        $this->setData($productData);
 
         $this->markForVisibilityRecalculation();
     }

--- a/packages/framework/src/Model/Product/Unit/Unit.php
+++ b/packages/framework/src/Model/Product/Unit/Unit.php
@@ -37,6 +37,22 @@ class Unit extends AbstractTranslatableEntity
     public function __construct(UnitData $unitData)
     {
         $this->translations = new ArrayCollection();
+        $this->setData($unitData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $unitData
+     */
+    public function edit(UnitData $unitData)
+    {
+        $this->setData($unitData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $unitData
+     */
+    protected function setData(UnitData $unitData): void
+    {
         $this->setTranslations($unitData);
     }
 
@@ -73,13 +89,5 @@ class Unit extends AbstractTranslatableEntity
     protected function createTranslation()
     {
         return new UnitTranslation();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitData $unitData
-     */
-    public function edit(UnitData $unitData)
-    {
-        $this->setTranslations($unitData);
     }
 }

--- a/packages/framework/src/Model/Script/Script.php
+++ b/packages/framework/src/Model/Script/Script.php
@@ -49,6 +49,22 @@ class Script
      */
     public function __construct(ScriptData $scriptData)
     {
+        $this->setData($scriptData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptData $scriptData
+     */
+    public function edit(ScriptData $scriptData)
+    {
+        $this->setData($scriptData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptData $scriptData
+     */
+    protected function setData(ScriptData $scriptData): void
+    {
         $this->name = $scriptData->name;
         $this->code = $scriptData->code;
         $this->placement = $scriptData->placement;
@@ -84,15 +100,5 @@ class Script
     public function getPlacement()
     {
         return $this->placement;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptData $scriptData
-     */
-    public function edit(ScriptData $scriptData)
-    {
-        $this->name = $scriptData->name;
-        $this->code = $scriptData->code;
-        $this->placement = $scriptData->placement;
     }
 }

--- a/packages/framework/src/Model/Slider/SliderItem.php
+++ b/packages/framework/src/Model/Slider/SliderItem.php
@@ -61,16 +61,21 @@ class SliderItem implements OrderableEntityInterface
      */
     public function __construct(SliderItemData $sliderItemData)
     {
-        $this->domainId = $sliderItemData->domainId;
-        $this->name = $sliderItemData->name;
-        $this->link = $sliderItemData->link;
-        $this->hidden = $sliderItemData->hidden;
+        $this->setData($sliderItemData);
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemData $sliderItemData
      */
     public function edit(SliderItemData $sliderItemData)
+    {
+        $this->setData($sliderItemData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemData $sliderItemData
+     */
+    protected function setData(SliderItemData $sliderItemData): void
     {
         $this->domainId = $sliderItemData->domainId;
         $this->name = $sliderItemData->name;

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -97,12 +97,12 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
         $this->createDomains($transportData);
-        $this->setData($transportData);
         $this->deleted = false;
         $this->prices = new ArrayCollection();
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->payments = new ArrayCollection();
         $this->uuid = $transportData->uuid ?: Uuid::uuid4()->toString();
+        $this->setData($transportData);
     }
 
     /**

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -96,10 +96,9 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
     {
         $this->translations = new ArrayCollection();
         $this->domains = new ArrayCollection();
-        $this->hidden = $transportData->hidden;
-        $this->deleted = false;
-        $this->setTranslations($transportData);
         $this->createDomains($transportData);
+        $this->setData($transportData);
+        $this->deleted = false;
         $this->prices = new ArrayCollection();
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->payments = new ArrayCollection();
@@ -111,9 +110,17 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
      */
     public function edit(TransportData $transportData)
     {
+        $this->setDomains($transportData);
+        $this->setData($transportData);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportData $transportData
+     */
+    protected function setData(TransportData $transportData): void
+    {
         $this->hidden = $transportData->hidden;
         $this->setTranslations($transportData);
-        $this->setDomains($transportData);
     }
 
     /**

--- a/packages/product-feed-google/src/Model/Product/GoogleProductDomain.php
+++ b/packages/product-feed-google/src/Model/Product/GoogleProductDomain.php
@@ -47,15 +47,21 @@ class GoogleProductDomain
      */
     public function __construct(GoogleProductDomainData $googleProductDomainData)
     {
-        $this->product = $googleProductDomainData->product;
-        $this->show = $googleProductDomainData->show;
-        $this->domainId = $googleProductDomainData->domainId;
+        $this->setData($googleProductDomainData);
     }
 
     /**
      * @param \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData $googleProductDomainData
      */
     public function edit(GoogleProductDomainData $googleProductDomainData)
+    {
+        $this->setData($googleProductDomainData);
+    }
+
+    /**
+     * @param \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData $googleProductDomainData
+     */
+    protected function setData(GoogleProductDomainData $googleProductDomainData): void
     {
         $this->product = $googleProductDomainData->product;
         $this->show = $googleProductDomainData->show;

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
@@ -54,8 +54,7 @@ class HeurekaCategory
     public function __construct(HeurekaCategoryData $heurekaCategoryData)
     {
         $this->id = $heurekaCategoryData->id;
-        $this->name = $heurekaCategoryData->name;
-        $this->fullName = $heurekaCategoryData->fullName;
+        $this->setData($heurekaCategoryData);
         $this->categories = new ArrayCollection($heurekaCategoryData->categories);
     }
 
@@ -64,9 +63,17 @@ class HeurekaCategory
      */
     public function edit(HeurekaCategoryData $heurekaCategoryData)
     {
+        $this->setData($heurekaCategoryData);
+        $this->editCategories($heurekaCategoryData->categories);
+    }
+
+    /**
+     * @param \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData $heurekaCategoryData
+     */
+    protected function setData(HeurekaCategoryData $heurekaCategoryData): void
+    {
         $this->name = $heurekaCategoryData->name;
         $this->fullName = $heurekaCategoryData->fullName;
-        $this->editCategories($heurekaCategoryData->categories);
     }
 
     /**

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
@@ -54,8 +54,8 @@ class HeurekaCategory
     public function __construct(HeurekaCategoryData $heurekaCategoryData)
     {
         $this->id = $heurekaCategoryData->id;
-        $this->setData($heurekaCategoryData);
         $this->categories = new ArrayCollection($heurekaCategoryData->categories);
+        $this->setData($heurekaCategoryData);
     }
 
     /**
@@ -63,8 +63,8 @@ class HeurekaCategory
      */
     public function edit(HeurekaCategoryData $heurekaCategoryData)
     {
-        $this->setData($heurekaCategoryData);
         $this->editCategories($heurekaCategoryData->categories);
+        $this->setData($heurekaCategoryData);
     }
 
     /**

--- a/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomain.php
+++ b/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomain.php
@@ -48,15 +48,21 @@ class HeurekaProductDomain
      */
     public function __construct(HeurekaProductDomainData $heurekaProductDomainData)
     {
-        $this->product = $heurekaProductDomainData->product;
-        $this->cpc = $heurekaProductDomainData->cpc;
-        $this->domainId = $heurekaProductDomainData->domainId;
+        $this->setData($heurekaProductDomainData);
     }
 
     /**
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData $heurekaProductDomainData
      */
     public function edit(HeurekaProductDomainData $heurekaProductDomainData)
+    {
+        $this->setData($heurekaProductDomainData);
+    }
+
+    /**
+     * @param \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData $heurekaProductDomainData
+     */
+    protected function setData(HeurekaProductDomainData $heurekaProductDomainData): void
     {
         $this->product = $heurekaProductDomainData->product;
         $this->cpc = $heurekaProductDomainData->cpc;

--- a/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomain.php
+++ b/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomain.php
@@ -62,17 +62,21 @@ class ZboziProductDomain
      */
     public function __construct(ZboziProductDomainData $zboziProductDomainData)
     {
-        $this->product = $zboziProductDomainData->product;
-        $this->show = $zboziProductDomainData->show;
-        $this->cpc = $zboziProductDomainData->cpc;
-        $this->cpcSearch = $zboziProductDomainData->cpcSearch;
-        $this->domainId = $zboziProductDomainData->domainId;
+        $this->setData($zboziProductDomainData);
     }
 
     /**
      * @param \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData $zboziProductDomainData
      */
     public function edit(ZboziProductDomainData $zboziProductDomainData)
+    {
+        $this->setData($zboziProductDomainData);
+    }
+
+    /**
+     * @param \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData $zboziProductDomainData
+     */
+    protected function setData(ZboziProductDomainData $zboziProductDomainData): void
     {
         $this->product = $zboziProductDomainData->product;
         $this->show = $zboziProductDomainData->show;

--- a/project-base/src/Model/Administrator/Administrator.php
+++ b/project-base/src/Model/Administrator/Administrator.php
@@ -16,6 +16,7 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorData as BaseAdminis
  *     @ORM\Index(columns={"username"})
  *   }
  * )
+ * @method setData(\App\Model\Administrator\AdministratorData $administratorData)
  */
 class Administrator extends BaseAdministrator
 {

--- a/project-base/src/Model/Administrator/Administrator.php
+++ b/project-base/src/Model/Administrator/Administrator.php
@@ -16,7 +16,6 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorData as BaseAdminis
  *     @ORM\Index(columns={"username"})
  *   }
  * )
- * @method setData(\App\Model\Administrator\AdministratorData $administratorData)
  */
 class Administrator extends BaseAdministrator
 {
@@ -34,5 +33,13 @@ class Administrator extends BaseAdministrator
     public function edit(BaseAdministratorData $administratorData): void
     {
         parent::edit($administratorData);
+    }
+
+    /**
+     * @param \App\Model\Administrator\AdministratorData $administratorData
+     */
+    protected function setData(BaseAdministratorData $administratorData): void
+    {
+        parent::setData($administratorData);
     }
 }

--- a/project-base/src/Model/Article/Article.php
+++ b/project-base/src/Model/Article/Article.php
@@ -28,8 +28,6 @@ class Article extends BaseArticle
     public function __construct(BaseArticleData $articleData)
     {
         parent::__construct($articleData);
-
-        $this->createdAt = $articleData->createdAt ?? new DateTime();
     }
 
     /**
@@ -38,7 +36,14 @@ class Article extends BaseArticle
     public function edit(BaseArticleData $articleData)
     {
         parent::edit($articleData);
+    }
 
+    /**
+     * @param \App\Model\Article\ArticleData $articleData
+     */
+    protected function setData(BaseArticleData $articleData): void
+    {
+        parent::setData($articleData);
         $this->createdAt = $articleData->createdAt ?? new DateTime();
     }
 

--- a/project-base/src/Model/Category/Category.php
+++ b/project-base/src/Model/Category/Category.php
@@ -21,7 +21,6 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
  * @method setTranslations(\App\Model\Category\CategoryData $categoryData)
  * @method setDomains(\App\Model\Category\CategoryData $categoryData)
  * @method createDomains(\App\Model\Category\CategoryData $categoryData)
- * @method setData(\App\Model\Category\CategoryData $categoryData)
  */
 class Category extends BaseCategory
 {
@@ -39,5 +38,13 @@ class Category extends BaseCategory
     public function edit(BaseCategoryData $categoryData)
     {
         parent::edit($categoryData);
+    }
+
+    /**
+     * @param \App\Model\Category\CategoryData $categoryData
+     */
+    protected function setData(BaseCategoryData $categoryData): void
+    {
+        parent::setData($categoryData);
     }
 }

--- a/project-base/src/Model/Category/Category.php
+++ b/project-base/src/Model/Category/Category.php
@@ -21,6 +21,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
  * @method setTranslations(\App\Model\Category\CategoryData $categoryData)
  * @method setDomains(\App\Model\Category\CategoryData $categoryData)
  * @method createDomains(\App\Model\Category\CategoryData $categoryData)
+ * @method setData(\App\Model\Category\CategoryData $categoryData)
  */
 class Category extends BaseCategory
 {

--- a/project-base/src/Model/Customer/User/CustomerUser.php
+++ b/project-base/src/Model/Customer/User/CustomerUser.php
@@ -19,7 +19,6 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData as BaseUserData
  *     }
  * )
  * @ORM\Entity
- * @method setData(\App\Model\Customer\User\CustomerUserData $customerUserData)
  */
 class CustomerUser extends BaseUser
 {
@@ -38,5 +37,13 @@ class CustomerUser extends BaseUser
     public function edit(BaseUserData $customerUserData)
     {
         parent::edit($customerUserData);
+    }
+
+    /**
+     * @param \App\Model\Customer\User\CustomerUserData $customerUserData
+     */
+    protected function setData(BaseUserData $customerUserData): void
+    {
+        parent::setData($customerUserData);
     }
 }

--- a/project-base/src/Model/Customer/User/CustomerUser.php
+++ b/project-base/src/Model/Customer/User/CustomerUser.php
@@ -19,6 +19,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData as BaseUserData
  *     }
  * )
  * @ORM\Entity
+ * @method setData(\App\Model\Customer\User\CustomerUserData $customerUserData)
  */
 class CustomerUser extends BaseUser
 {

--- a/project-base/src/Model/Payment/Payment.php
+++ b/project-base/src/Model/Payment/Payment.php
@@ -19,7 +19,6 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
  * @method setTranslations(\App\Model\Payment\PaymentData $paymentData)
  * @method setDomains(\App\Model\Payment\PaymentData $paymentData)
  * @method createDomains(\App\Model\Payment\PaymentData $paymentData)
- * @method setData(\App\Model\Payment\PaymentData $paymentData)
  */
 class Payment extends BasePayment
 {
@@ -37,5 +36,13 @@ class Payment extends BasePayment
     public function edit(BasePaymentData $paymentData)
     {
         parent::edit($paymentData);
+    }
+
+    /**
+     * @param \App\Model\Payment\PaymentData $paymentData
+     */
+    protected function setData(BasePaymentData $paymentData): void
+    {
+        parent::setData($paymentData);
     }
 }

--- a/project-base/src/Model/Payment/Payment.php
+++ b/project-base/src/Model/Payment/Payment.php
@@ -19,6 +19,7 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentData as BasePaymentData;
  * @method setTranslations(\App\Model\Payment\PaymentData $paymentData)
  * @method setDomains(\App\Model\Payment\PaymentData $paymentData)
  * @method createDomains(\App\Model\Payment\PaymentData $paymentData)
+ * @method setData(\App\Model\Payment\PaymentData $paymentData)
  */
 class Payment extends BasePayment
 {

--- a/project-base/src/Model/Product/Brand/Brand.php
+++ b/project-base/src/Model/Product/Brand/Brand.php
@@ -14,7 +14,6 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandData as BaseBrandData;
  * @method setTranslations(\App\Model\Product\Brand\BrandData $brandData)
  * @method setDomains(\App\Model\Product\Brand\BrandData $brandData)
  * @method createDomains(\App\Model\Product\Brand\BrandData $brandData)
- * @method setData(\App\Model\Product\Brand\BrandData $brandData)
  */
 class Brand extends BaseBrand
 {
@@ -32,5 +31,13 @@ class Brand extends BaseBrand
     public function edit(BaseBrandData $brandData)
     {
         parent::edit($brandData);
+    }
+
+    /**
+     * @param \App\Model\Product\Brand\BrandData $brandData
+     */
+    protected function setData(BaseBrandData $brandData): void
+    {
+        parent::setData($brandData);
     }
 }

--- a/project-base/src/Model/Product/Brand/Brand.php
+++ b/project-base/src/Model/Product/Brand/Brand.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandData as BaseBrandData;
  * @method setTranslations(\App\Model\Product\Brand\BrandData $brandData)
  * @method setDomains(\App\Model\Product\Brand\BrandData $brandData)
  * @method createDomains(\App\Model\Product\Brand\BrandData $brandData)
+ * @method setData(\App\Model\Product\Brand\BrandData $brandData)
  */
 class Brand extends BaseBrand
 {

--- a/project-base/src/Model/Product/Product.php
+++ b/project-base/src/Model/Product/Product.php
@@ -30,7 +30,6 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
  * @method refreshVariants(\App\Model\Product\Product[] $currentVariants)
  * @method addNewVariants(\App\Model\Product\Product[] $currentVariants)
  * @method unsetRemovedVariants(\App\Model\Product\Product[] $currentVariants)
- * @method setData(\App\Model\Product\ProductData $productData)
  */
 class Product extends BaseProduct
 {
@@ -52,5 +51,13 @@ class Product extends BaseProduct
         BaseProductData $productData
     ) {
         parent::edit($productCategoryDomains, $productData);
+    }
+
+    /**
+     * @param \App\Model\Product\ProductData $productData
+     */
+    protected function setData(BaseProductData $productData): void
+    {
+        parent::setData($productData);
     }
 }

--- a/project-base/src/Model/Product/Product.php
+++ b/project-base/src/Model/Product/Product.php
@@ -30,6 +30,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
  * @method refreshVariants(\App\Model\Product\Product[] $currentVariants)
  * @method addNewVariants(\App\Model\Product\Product[] $currentVariants)
  * @method unsetRemovedVariants(\App\Model\Product\Product[] $currentVariants)
+ * @method setData(\App\Model\Product\ProductData $productData)
  */
 class Product extends BaseProduct
 {

--- a/project-base/src/Model/Transport/Transport.php
+++ b/project-base/src/Model/Transport/Transport.php
@@ -19,7 +19,6 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;
  * @method addPayment(\App\Model\Payment\Payment $payment)
  * @method setPayments(\App\Model\Payment\Payment[] $payments)
  * @method removePayment(\App\Model\Payment\Payment $payment)
- * @method setData(\App\Model\Transport\TransportData $transportData)
  */
 class Transport extends BaseTransport
 {
@@ -37,5 +36,13 @@ class Transport extends BaseTransport
     public function edit(BaseTransportData $transportData)
     {
         parent::edit($transportData);
+    }
+
+    /**
+     * @param \App\Model\Transport\TransportData $transportData
+     */
+    protected function setData(BaseTransportData $transportData): void
+    {
+        parent::setData($transportData);
     }
 }

--- a/project-base/src/Model/Transport/Transport.php
+++ b/project-base/src/Model/Transport/Transport.php
@@ -19,6 +19,7 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportData as BaseTransportData;
  * @method addPayment(\App\Model\Payment\Payment $payment)
  * @method setPayments(\App\Model\Payment\Payment[] $payments)
  * @method removePayment(\App\Model\Payment\Payment $payment)
+ * @method setData(\App\Model\Transport\TransportData $transportData)
  */
 class Transport extends BaseTransport
 {

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -39,3 +39,6 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateAvailability`
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculatePrice`
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateVisibility`
+
+- moved setting of common entity data to new method ([#1976](https://github.com/shopsys/shopsys/pull/1976))
+    - see #project-base-diff1 and #project-base-diff2 to update your project

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -41,4 +41,4 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Product\Product::$recalculateVisibility`
 
 - moved setting of common entity data to new method ([#1976](https://github.com/shopsys/shopsys/pull/1976))
-    - see #project-base-diff1 and #project-base-diff2 to update your project
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We have many duplicated logic in entities. This PR extracts common parts into separate methodd.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1746  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
