### PR TITLE
[framework] spinbox plus now works correctly with min value

### DIFF
--- a/project-base/assets/js/frontend/components/spinbox.js
+++ b/project-base/assets/js/frontend/components/spinbox.js
@@ -32,30 +32,37 @@ export default class Spinbox {
     }
 
     static plus () {
-        let value = $.trim($(this).val());
-        let max = $(this).data('spinbox-max');
-
-        if (value.match(/^\d+$/)) {
-            value = parseInt(value) + 1;
-            if (max !== undefined && max < value) {
-                value = max;
-            }
-            $(this).val(value);
-            $(this).change();
-        }
+        Spinbox.changeValue($(this), '+');
     }
 
     static minus () {
-        let value = $.trim($(this).val());
-        let min = $(this).data('spinbox-min');
+        Spinbox.changeValue($(this), '-');
+    }
+
+    static changeValue (input, action) {
+        let value = $.trim(input.val());
+        const min = input.data('spinbox-min');
+        const max = input.data('spinbox-max');
 
         if (value.match(/^\d+$/)) {
-            value = parseInt(value) - 1;
+            value = parseInt(value);
+
+            if (action === '+') {
+                value += 1;
+            } else {
+                value -= 1;
+            }
+
             if (min !== undefined && min > value) {
                 value = min;
             }
-            $(this).val(value);
-            $(this).change();
+
+            if (max !== undefined && max < value) {
+                value = max;
+            }
+
+            input.val(value);
+            input.change();
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Spinbox was not using minimal value, when incrementing number and maximal value when decreasing number. The calculation is now same for both actions and spinbox should now work correctly.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1516 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
