### PR TITLE
[framework] categories in admin are now loaded using admin locale

### DIFF
--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -17,6 +17,7 @@ use Shopsys\FrameworkBundle\Form\UrlListType;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryData;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -53,21 +54,29 @@ class CategoryFormType extends AbstractType
     private $pluginCrudExtensionFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Localization\Localization
+     */
+    private $localization;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade
      * @param \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginCrudExtensionFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         CategoryFacade $categoryFacade,
         Domain $domain,
         SeoSettingFacade $seoSettingFacade,
-        PluginCrudExtensionFacade $pluginCrudExtensionFacade
+        PluginCrudExtensionFacade $pluginCrudExtensionFacade,
+        Localization $localization
     ) {
         $this->categoryFacade = $categoryFacade;
         $this->domain = $domain;
         $this->seoSettingFacade = $seoSettingFacade;
         $this->pluginCrudExtensionFacade = $pluginCrudExtensionFacade;
+        $this->localization = $localization;
     }
 
     /**
@@ -104,9 +113,9 @@ class CategoryFormType extends AbstractType
         }
 
         if ($options['category'] !== null) {
-            $parentChoices = $this->categoryFacade->getTranslatedAllWithoutBranch($options['category'], $this->domain->getCurrentDomainConfig());
+            $parentChoices = $this->categoryFacade->getAllTranslatedWithoutBranch($options['category'], $this->localization->getAdminLocale());
         } else {
-            $parentChoices = $this->categoryFacade->getTranslatedAll($this->domain->getCurrentDomainConfig());
+            $parentChoices = $this->categoryFacade->getAllTranslated($this->localization->getAdminLocale());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter;
 
+use BadMethodCallException;
 use Doctrine\ORM\QueryBuilder;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Localization\Localization as LocalizationAlias;
 use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
@@ -22,18 +25,45 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
     protected $categoryFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain|null
+     * @deprecated This will be removed in next major version
      */
     protected $domain;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @var \Shopsys\FrameworkBundle\Model\Localization\Localization|null
      */
-    public function __construct(CategoryFacade $categoryFacade, Domain $domain)
-    {
+    protected $localization;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain|null $domain
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization|null $localization
+     */
+    public function __construct(
+        CategoryFacade $categoryFacade,
+        ?Domain $domain = null,
+        ?LocalizationAlias $localization = null
+    ) {
         $this->categoryFacade = $categoryFacade;
         $this->domain = $domain;
+        $this->localization = $localization;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setLocalization(Localization $localization): void
+    {
+        if ($this->localization !== null && $this->localization !== $localization) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->localization === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->localization = $localization;
+        }
     }
 
     /**
@@ -71,7 +101,7 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
         return [
             'expanded' => false,
             'multiple' => false,
-            'choices' => $this->categoryFacade->getTranslatedAll($this->domain->getCurrentDomainConfig()),
+            'choices' => $this->categoryFacade->getAllTranslated($this->localization->getAdminLocale()),
             'choice_label' => function (Category $category) {
                 $padding = str_repeat("\u{00a0}", ($category->getLevel() - 1) * 2);
                 return $padding . $category->getName();

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -215,10 +215,20 @@ class CategoryFacade
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @deprecated This method will be removed in next major version. It has been replaced by getAllTranslated
      */
     public function getTranslatedAll(DomainConfig $domainConfig)
     {
         return $this->categoryRepository->getTranslatedAll($domainConfig);
+    }
+
+    /**
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     */
+    public function getAllTranslated(string $locale): array
+    {
+        return $this->categoryRepository->getAllTranslated($locale);
     }
 
     /**
@@ -324,10 +334,21 @@ class CategoryFacade
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @deprecated This method will be removed in next major version. It has been replaced by getAllTranslatedWithoutBranch
      */
     public function getTranslatedAllWithoutBranch(Category $category, DomainConfig $domainConfig)
     {
         return $this->categoryRepository->getTranslatedAllWithoutBranch($category, $domainConfig);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     */
+    public function getAllTranslatedWithoutBranch(Category $category, string $locale): array
+    {
+        return $this->categoryRepository->getAllTranslatedWithoutBranch($category, $locale);
     }
 
     /**

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -160,11 +160,29 @@ class CategoryRepository extends NestedTreeRepository
      * @param \Shopsys\FrameworkBundle\Model\Category\Category $categoryBranch
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @deprecated This method will be removed in next major version. It has been replaced by getAllTranslatedWithoutBranch
      */
     public function getTranslatedAllWithoutBranch(Category $categoryBranch, DomainConfig $domainConfig)
     {
         $queryBuilder = $this->getAllQueryBuilder();
         $this->addTranslation($queryBuilder, $domainConfig->getLocale());
+
+        return $queryBuilder->andWhere('c.lft < :branchLft OR c.rgt > :branchRgt')
+            ->setParameter('branchLft', $categoryBranch->getLft())
+            ->setParameter('branchRgt', $categoryBranch->getRgt())
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $categoryBranch
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     */
+    public function getAllTranslatedWithoutBranch(Category $categoryBranch, string $locale): array
+    {
+        $queryBuilder = $this->getAllQueryBuilder();
+        $this->addTranslation($queryBuilder, $locale);
 
         return $queryBuilder->andWhere('c.lft < :branchLft OR c.rgt > :branchRgt')
             ->setParameter('branchLft', $categoryBranch->getLft())
@@ -560,6 +578,7 @@ class CategoryRepository extends NestedTreeRepository
     /**
      * @param  \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @deprecated This method will be removed in next major version. It has been replaced by getAllTranslated
      */
     public function getTranslatedAll(DomainConfig $domainConfig)
     {
@@ -568,5 +587,17 @@ class CategoryRepository extends NestedTreeRepository
 
         return $queryBuilder->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     */
+    public function getAllTranslated(string $locale): array
+    {
+        $queryBuilder = $this->getAllQueryBuilder();
+        $this->addTranslation($queryBuilder, $locale);
+
+        return $queryBuilder->getQuery()->getResult();
     }
 }

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -25,3 +25,14 @@ There you can find links to upgrade notes for other versions too.
 
 - fixed displaying errors in popup window ([#1970](https://github.com/shopsys/shopsys/pull/1970))
     - see #project-base-diff to update your project
+
+- categories in admin are now loaded using admin locale ([#1982](https://github.com/shopsys/shopsys/pull/1982))
+    - `CategoryRepository::getTranslatedAllWithoutBranch()` is deprecated, use `CategoryRepository::getAllTranslatedWithoutBranch()` instead
+    - `CategoryRepository::getTranslatedAll` is deprecated, use `CategoryRepository::getAllTranslated()` instead
+    - `CategoryFacade::getTranslatedAllWithoutBranch()` is deprecated, use `CategoryFacade::getAllTranslatedWithoutBranch()` instead
+    - `CategoryFacade::getTranslatedAll` is deprecated, use `CategoryFacade::getAllTranslated()` instead
+    - `ProductCategoryFilter::__construct()` has changed its interface and argument Domain will be removed in next major
+    ```diff
+    -   public function __construct(CategoryFacade $categoryFacade, Domain $domain = null)
+    +   public function __construct(CategoryFacade $categoryFacade, ?Domain $domain = null, ?LocalizationAlias $localization = null)
+    ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Domain locale has been used for loading categories in admin instead of admin locale, this has been fixed now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1729 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
