### PR TITLE
[shopsys] redis build-version now includes application environment

### DIFF
--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -119,7 +119,7 @@ These keys are used by API OAuth2. The private key is used to sign tokens and pu
 #### build-version-generate
 
 Generates a Symfony configuration `build-version` variable that is used to distinguish different application builds.
-The variable itself contains current datetime in PHP format `YmdHis` (16 digits, eg. `20190311135223`) and you can use it in any configuration file by `'%build-version%'`.
+The variable itself contains current datetime in PHP format `YmdHis` and application environment (eg. `20190311135223_dev`) so you can use it in any configuration file by `'%build-version%'`.
 
 The variable is generated to file `config/parameters_version.yaml` and this file is excluded from git.
 

--- a/packages/backend-api/install/config/parameters_common.yaml.patch
+++ b/packages/backend-api/install/config/parameters_common.yaml.patch
@@ -1,5 +1,5 @@
 @@ -22,3 +22,4 @@ parameters:
-     build-version: '0000000000000000'
+     build-version: '0000000000000000_%kernel.environment%'
      shopsys.display_timezone: Europe/Prague
      shopsys.image.enable_lazy_load: true
 +    oauth2_encryption_key: '0' #placeholder for correctly running composer post script, replaced by config/oauth2/parameters_oauth.yaml

--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -37,4 +37,4 @@ snc_redis:
     session:
         client: 'session'
         ttl: 604800
-        prefix: '%env(REDIS_PREFIX)%%build-version%session:'
+        prefix: '%env(REDIS_PREFIX)%session:'

--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -29,7 +29,7 @@ snc_redis:
             alias: 'global'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%'
+                prefix: '%env(REDIS_PREFIX)%%build-version%'
         session:
             type: 'phpredis'
             alias: 'session'
@@ -37,4 +37,4 @@ snc_redis:
     session:
         client: 'session'
         ttl: 604800
-        prefix: '%env(REDIS_PREFIX)%session:'
+        prefix: '%env(REDIS_PREFIX)%%build-version%session:'

--- a/project-base/config/parameters_common.yaml
+++ b/project-base/config/parameters_common.yaml
@@ -19,6 +19,6 @@ parameters:
     shopsys.performance_test.feed.min_duration_seconds: 5
     container.autowiring.strict_mode: true
     container.dumper.inline_class_loader: true
-    build-version: '0000000000000000'
+    build-version: '0000000000000000_%kernel.environment%'
     shopsys.display_timezone: Europe/Prague
     shopsys.image.enable_lazy_load: true

--- a/project-base/config/parameters_version.yaml.dist
+++ b/project-base/config/parameters_version.yaml.dist
@@ -1,2 +1,2 @@
 parameters:
-    build-version: '%%version%%'
+    build-version: '%%version%%_%kernel.environment%'

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -42,3 +42,4 @@ There you can find links to upgrade notes for other versions too.
 
 - update your redis build-version to include application environment ([#1985](https://github.com/shopsys/shopsys/pull/#1985))
     - see #project-base-diff to update your project
+    - run `php phing build-version-generate`

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -39,3 +39,6 @@ There you can find links to upgrade notes for other versions too.
 
 - remove customer and his addresses when customer user is deleted ([#1977](https://github.com/shopsys/shopsys/pull/1977))
     - there is no need to update your project in any way, we are just noticing you that customer and his addresses are now removed when all his customer users were deleted
+
+- update your redis build-version to include application environment ([#1985](https://github.com/shopsys/shopsys/pull/#1985))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Application was using same redis tables for each environment and this could result in unexpected problems. This has been solved by adding environment into build-version and using it for all redis tables.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #860 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
