### PR TITLE
[framework] design - admin title button wrap bar only if contains buttons

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Content/Administrator/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Administrator/list.html.twig
@@ -4,9 +4,11 @@
 {% block h1 %}{{ 'Administrators overview'|trans }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ url('admin_administrator_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>{{ 'Create new administrator'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_administrator_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>{{ 'Create new administrator'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Advert/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Advert/list.html.twig
@@ -4,9 +4,11 @@
 {% block h1 %}{{ 'Advertising system'|trans }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ url('admin_advert_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>{{ 'Create new advertising'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_advert_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>{{ 'Create new advertising'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Article/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Article/list.html.twig
@@ -4,9 +4,11 @@
 {% block h1 %}{{ 'Articles overview'|trans }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ url('admin_article_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>{{ 'Create new article'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_article_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>{{ 'Create new article'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Category/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Category/list.html.twig
@@ -4,10 +4,12 @@
 {% block title %}- {{ 'Categories'|trans }}{% endblock %}
 {% block h1 %}{{ 'Categories'|trans }}{% endblock %}
 {% block btn %}
-    <a href="{{ url('admin_category_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>
-        {{ 'Create new category'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_category_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>
+            {{ 'Create new category'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Country/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Country/list.html.twig
@@ -5,10 +5,12 @@
 {% block h1 %}{{ 'Countries overview'|trans }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ url('admin_country_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>
-        {{ 'Create new country'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_country_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>
+            {{ 'Create new country'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Customer/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Customer/list.html.twig
@@ -4,10 +4,12 @@
 {% block h1 %}{{ 'Customers overview'|trans }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ url('admin_customer_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>
-        {{ 'Create new customer'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_customer_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>
+            {{ 'Create new customer'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Product/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/list.html.twig
@@ -3,24 +3,26 @@
 {% block title %}- {{ 'Products overview'|trans }}{% endblock %}
 {% block h1 %}{{ 'Products overview'|trans }}{% endblock %}
 {% block btn %}
-    {% if productCanBeCreated %}
-        <a href="{{ url('admin_product_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-            <i class="btn__icon">+</i>{{ 'Create new product'|trans }}
-        </a>
-        <a href="{{ url('admin_product_createvariant') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-            <i class="btn__icon">+</i>{{ 'Create variant'|trans }}
-        </a>
-    {% else %}
-        <span class="btn btn--primary btn--plus wrap-bar__btn btn--disabled">
-            <i class="btn__icon">+</i>{{ 'Create new product'|trans }}
-        </span>
-        <span class="btn btn--primary btn--plus wrap-bar__btn btn--disabled">
-            <i class="btn__icon">+</i>{{ 'Create variant'|trans }}
-        </span>
-        <a href="{{ url('admin_default_dashboard') }}" class="btn-link-style wrap-bar__btn">
-            {{ 'Fill missing settings to enable creating products. More information here.'|trans }}
-        </a>
-    {% endif %}
+    <div class="wrap-bar__buttons">
+        {% if productCanBeCreated %}
+            <a href="{{ url('admin_product_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+                <i class="btn__icon">+</i>{{ 'Create new product'|trans }}
+            </a>
+            <a href="{{ url('admin_product_createvariant') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+                <i class="btn__icon">+</i>{{ 'Create variant'|trans }}
+            </a>
+        {% else %}
+            <span class="btn btn--primary btn--plus wrap-bar__btn btn--disabled">
+                <i class="btn__icon">+</i>{{ 'Create new product'|trans }}
+            </span>
+            <span class="btn btn--primary btn--plus wrap-bar__btn btn--disabled">
+                <i class="btn__icon">+</i>{{ 'Create variant'|trans }}
+            </span>
+            <a href="{{ url('admin_default_dashboard') }}" class="btn-link-style wrap-bar__btn">
+                {{ 'Fill missing settings to enable creating products. More information here.'|trans }}
+            </a>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/PromoCode/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/PromoCode/list.html.twig
@@ -8,10 +8,12 @@
 {% endblock %}
 
 {% block btn %}
-    <div class="wrap-bar">
-        <a href="{{ url('admin_promocode_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-            <i class="btn__icon">+</i>
-            {{ 'Create promo code'|trans }}
-        </a>
+    <div class="wrap-bar__buttons">
+        <div class="wrap-bar">
+            <a href="{{ url('admin_promocode_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+                <i class="btn__icon">+</i>
+                {{ 'Create promo code'|trans }}
+            </a>
+        </div>
     </div>
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Content/Script/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Script/list.html.twig
@@ -3,10 +3,12 @@
 {% block title %}- {{ 'Scripts overview'|trans }}{% endblock %}
 {% block h1 %}{{ 'Scripts overview'|trans }}{% endblock %}
 {% block btn %}
-    <a href="{{ url('admin_script_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>
-        {{ 'Create new script'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_script_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>
+            {{ 'Create new script'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Content/Slider/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Slider/list.html.twig
@@ -4,9 +4,11 @@
 {% block h1 %}{{ 'Slider pages'|trans }}{% endblock %}
 
 {% block btn %}
-    <a href="{{ url('admin_slider_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
-        <i class="btn__icon">+</i>{{ 'Create new page'|trans }}
-    </a>
+    <div class="wrap-bar__buttons">
+        <a href="{{ url('admin_slider_new') }}" class="btn btn--primary btn--plus wrap-bar__btn">
+            <i class="btn__icon">+</i>{{ 'Create new page'|trans }}
+        </a>
+    </div>
 {% endblock %}
 
 {% block main_content %}

--- a/packages/framework/src/Resources/views/Admin/Layout/layoutWithPanel.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/layoutWithPanel.html.twig
@@ -24,9 +24,7 @@
                     <h1 class="wrap-bar__heading">
                         {% block h1 %}{{ 'Administration'|trans }}{% endblock %}
                     </h1>
-                    <div class="wrap-bar__buttons">
-                        {% block btn %}{% endblock %}
-                    </div>
+                    {% block btn %}{% endblock %}
                 </div>
                 {% block visibility_info %}{% endblock %}
             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Beside page title in administration there are empty blocks, which make title smaller. Now we are generating right block only if contains buttons.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1887  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
