### PR TITLE
[project-base] added condition for get accessories if module is enabled only

### DIFF
--- a/project-base/templates/Front/Inline/Cart/afterAddWindow.html.twig
+++ b/project-base/templates/Front/Inline/Cart/afterAddWindow.html.twig
@@ -1,7 +1,7 @@
 {{ render(controller('App\\Controller\\Front\\FlashMessageController:indexAction')) }}
 {% import 'Front/Content/Product/productListMacro.html.twig' as productList %}
 
-{% if isModuleEnabled(ACCESSORIES_ON_BUY) %}
+{% if isModuleEnabled(constant('Shopsys\\FrameworkBundle\\Model\\Module\\ModuleList::ACCESSORIES_ON_BUY')) %}
     {% if accessories|length > 0 %}
         <div class="wrap-box margin-top-20 margin-bottom-0">
             <h3 class="wrap-box__title">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The accessories is load with every addProductAjaxAction request now. I added condition into controller for get accessories if module is enabled only. Condition in view is to late in my opinion. 
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
