### PR TITLE
[framework] added link into breadcrumb item in admin if uri is not null

### DIFF
--- a/packages/framework/src/Resources/views/Admin/Inline/Breadcrumb/breadcrumb.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Breadcrumb/breadcrumb.html.twig
@@ -7,7 +7,13 @@
         {% elseif loop.last %}
             <span class="in-breadcrumb__item in-breadcrumb__item--actual">{{ breadcrumbOverrider.lastItemOverridden ? breadcrumbOverrider.lastItemLabel : item.label }}</span>
         {% else %}
+            {% if item.uri is not null %}
+                <a href="{{ item.uri }}">
+            {% endif %}
             <span class="in-breadcrumb__item">{{ item.label }}</span>
+            {% if item.uri is not null %}
+                </a>
+            {% endif %}
         {% endif %}
 
         {% if not loop.last %}

--- a/packages/framework/src/Resources/views/Admin/Inline/Breadcrumb/breadcrumb.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Breadcrumb/breadcrumb.html.twig
@@ -8,11 +8,9 @@
             <span class="in-breadcrumb__item in-breadcrumb__item--actual">{{ breadcrumbOverrider.lastItemOverridden ? breadcrumbOverrider.lastItemLabel : item.label }}</span>
         {% else %}
             {% if item.uri is not null %}
-                <a href="{{ item.uri }}">
-            {% endif %}
-            <span class="in-breadcrumb__item">{{ item.label }}</span>
-            {% if item.uri is not null %}
-                </a>
+                <a href="{{ item.uri }}"><span class="in-breadcrumb__item">{{ item.label }}</span></a>
+            {% else %}
+                <span class="in-breadcrumb__item">{{ item.label }}</span>
             {% endif %}
         {% endif %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We have breadcrumb navigation in the administration, but if there is a link to the route, this navigation will not display the link. This PR adds a link to the navigation.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
