### PR TITLE
design - in popup window with html conntent - call registerNewContent…

### DIFF
--- a/project-base/assets/js/frontend/utils/Window.js
+++ b/project-base/assets/js/frontend/utils/Window.js
@@ -1,6 +1,7 @@
 import { KeyCodes } from 'framework/common/utils/KeyCodes';
 import Timeout from 'framework/common/utils/Timeout';
 import Translator from 'bazinga-translator';
+import Register from 'framework/common/utils/Register';
 
 const defaults = {
     content: '',
@@ -83,7 +84,9 @@ export default class Window {
             this.$activeWindow = null;
         });
 
+        (new Register()).registerNewContent($windowContent);
         this.$window.append($windowContent);
+
         if (this.options.buttonClose) {
             const $windowButtonClose = $('<a href="#" class="window-button-close window-popup__close js-window-button-close" title="' + Translator.trans('Close (Esc)') + '"><i class="svg svg-remove-thin"></i></a>');
             $windowButtonClose


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When accessories in purchase is enabled, and in popup window is html content, we need to call registerNewContent function to enable all js functionaliies - image lazyload, spinbox functions...
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1925  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
