### PR TITLE
[shopsys] timezone for running crons

### DIFF
--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -13,6 +13,8 @@ If you want to show Cron overview table for non-superadmin users you need add pa
 
 ## Default Cron Commands
 There is some prepared configuration in a file [`config/services/cron.yaml`](https://github.com/shopsys/project-base/blob/master/config/services/cron.yaml) in `project-base`.
+!!! note
+    Hours set in [`config/services/cron.yaml`](https://github.com/shopsys/project-base/blob/master/config/services/cron.yaml) are consider to be in timezone set in `shopsys.cron_timezone` parameter in [`config/parameters_common.yaml`](https://github.com/shopsys/project-base/blob/master/config/parameters_common.yaml) file.
 
 ## Running Cron Jobs
 Do not forget to set up a cron on your server to execute [`php phing cron`](../introduction/console-commands-for-application-management-phing-targets.md#cron) every 5 minutes.

--- a/docs/introduction/working-with-date-time-values.md
+++ b/docs/introduction/working-with-date-time-values.md
@@ -38,3 +38,18 @@ This date should be visible near the article.
 Due to limitations of PHP, the value is in variable of the `DateTime` type with zero time (midnight).
 Presenting such date back to the user results into date shift (one day back), because this "midnight DateTime" is converted to the display timezone.
 Storing the dates in the database as a DateTime type prevents it.
+
+## Filling the dates programmatically
+
+When storing dates in different way than using application forms (e.g. from 3rd party application), it is necessary to convert them into UTC timezone.
+This can be done like this:
+```php
+$dateFormOtherSource = '2020-08-24 18:30:02';
+$dateTime = new \DateTime($dateFormOtherSource, new \DateTimeZone('Europe/Prague'));
+$dateTime->setTimezone(new \DateTimeZone('UTC'));
+```
+
+## When to use Date
+
+As described in previous paragraph, the best way to store date is to use `DateTime`.
+There is one exception to that and it is storing of historical data like birthdays, historical events etc.

--- a/packages/backend-api/install/config/parameters_common.yaml.patch
+++ b/packages/backend-api/install/config/parameters_common.yaml.patch
@@ -1,5 +1,5 @@
-@@ -22,3 +22,4 @@ parameters:
-     build-version: '0000000000000000_%kernel.environment%'
+@@ -23,3 +23,4 @@ parameters:
      shopsys.display_timezone: Europe/Prague
+     shopsys.cron_timezone: Europe/Prague
      shopsys.image.enable_lazy_load: true
 +    oauth2_encryption_key: '0' #placeholder for correctly running composer post script, replaced by config/oauth2/parameters_oauth.yaml

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -2,8 +2,10 @@
 
 namespace Shopsys\FrameworkBundle\Command;
 
+use BadMethodCallException;
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
@@ -12,6 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CronCommand extends Command
 {
@@ -35,17 +38,41 @@ class CronCommand extends Command
     private $mutexFactory;
 
     /**
+     * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface|null
+     */
+    private $parameterBag;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Cron\CronFacade $cronFacade
      * @param \Shopsys\FrameworkBundle\Component\Cron\MutexFactory $mutexFactory
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface|null $parameterBag
      */
     public function __construct(
         CronFacade $cronFacade,
-        MutexFactory $mutexFactory
+        MutexFactory $mutexFactory,
+        ?ParameterBagInterface $parameterBag = null
     ) {
         $this->cronFacade = $cronFacade;
         $this->mutexFactory = $mutexFactory;
+        $this->parameterBag = $parameterBag;
 
         parent::__construct();
+    }
+
+    /**
+     * @required
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setParameterBag(ParameterBagInterface $parameterBag): void
+    {
+        if ($this->parameterBag !== null && $this->parameterBag !== $parameterBag) {
+            throw new BadMethodCallException(sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__));
+        }
+        if ($this->parameterBag === null) {
+            @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.', __METHOD__), E_USER_DEPRECATED);
+            $this->parameterBag = $parameterBag;
+        }
     }
 
     protected function configure()
@@ -162,7 +189,7 @@ class CronCommand extends Command
      */
     private function getCurrentRoundedTime()
     {
-        $time = new DateTime(null);
+        $time = new DateTime('now', $this->getCronTimeZone());
         $time->modify('-' . $time->format('s') . ' sec');
         $time->modify('-' . ($time->format('i') % 5) . ' min');
 
@@ -198,5 +225,16 @@ class CronCommand extends Command
         );
 
         return $chosenInstanceName;
+    }
+
+    /**
+     * @return \DateTimeZone
+     */
+    private function getCronTimeZone(): DateTimeZone
+    {
+        $cronTimezone = $this->parameterBag->get('shopsys.cron_timezone');
+        $cronTimezone = $cronTimezone ?? date_default_timezone_get();
+
+        return new DateTimeZone($cronTimezone);
     }
 }

--- a/packages/framework/src/Resources/config/parameters_common.yaml
+++ b/packages/framework/src/Resources/config/parameters_common.yaml
@@ -11,6 +11,9 @@ parameters:
     # All time values are displayed in this timezone (default is PHP timezone)
     shopsys.display_timezone: ~
 
+    # Hours defined in cron.yaml correspond to this timezone (default is PHP timezone)
+    shopsys.cron_timezone: ~
+
     # Default extended classes mapping
     shopsys.entity_extension.map: {}
 

--- a/project-base/config/parameters_common.yaml
+++ b/project-base/config/parameters_common.yaml
@@ -21,4 +21,5 @@ parameters:
     container.dumper.inline_class_loader: true
     build-version: '0000000000000000_%kernel.environment%'
     shopsys.display_timezone: Europe/Prague
+    shopsys.cron_timezone: Europe/Prague
     shopsys.image.enable_lazy_load: true

--- a/upgrade/UPGRADE-v9.0.2-dev.md
+++ b/upgrade/UPGRADE-v9.0.2-dev.md
@@ -43,3 +43,6 @@ There you can find links to upgrade notes for other versions too.
 - update your redis build-version to include application environment ([#1985](https://github.com/shopsys/shopsys/pull/#1985))
     - see #project-base-diff to update your project
     - run `php phing build-version-generate`
+
+- set timezone for your crons ([#2000](https://github.com/shopsys/shopsys/pull/2000))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With introduction of setting all dates and times in UTC timezone, problems with running crons in desired times has occurred.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1924 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
