### PR TITLE
[framework] sellingTo is now set with the end of day time

### DIFF
--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -20,6 +20,7 @@ use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListAdminFacade;
 use Shopsys\FrameworkBundle\Model\Product\MassAction\ProductMassActionFacade;
 use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Product\ProductData;
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade;
@@ -163,6 +164,7 @@ class ProductController extends AdminBaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $this->setSellingToUntilEndOfDay($productData);
             $this->productFacade->edit($id, $productData);
 
             $this
@@ -209,6 +211,7 @@ class ProductController extends AdminBaseController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $this->setSellingToUntilEndOfDay($productData);
             $product = $this->productFacade->create($productData);
 
             $this
@@ -429,5 +432,15 @@ class ProductController extends AdminBaseController
         }
 
         return true;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductData|null $productData
+     */
+    protected function setSellingToUntilEndOfDay(?ProductData $productData): void
+    {
+        if ($productData->sellingTo !== null) {
+            $productData->sellingTo->modify('+1 day -1 second');
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Product sellingTo has been set to 00:00 hours, so products have been hidden one day earlier than expected. This has been solved now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1924 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
