### PR TITLE
[framework] test environment is no longer wrongly detected as prod

### DIFF
--- a/project-base/app/getEnvironment.php
+++ b/project-base/app/getEnvironment.php
@@ -6,4 +6,4 @@ namespace App;
 
 require_once __DIR__ . '/autoload.php';
 
-file_put_contents('php://output', Environment::getEnvironment(true));
+file_put_contents('php://output', Environment::getEnvironment(false));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Test environment was wrongly detected as production and it caused production-protection phing target to warn user, that he is in production environment when it was not true.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
