### PR TITLE
[shopsys] disable codeac.io by default so it is not run on branches until it is set properly

### DIFF
--- a/.codeac.yml
+++ b/.codeac.yml
@@ -1,0 +1,31 @@
+version: '1'
+
+tools:
+    bandit:
+        enabled: false
+    detekt:
+        enabled: false
+    eslint:
+        enabled: false
+    ethlint:
+        enabled: false
+    hadolint:
+        enabled: false
+    npmAudit:
+        enabled: false
+    phpmd:
+        enabled: false
+    phpstan:
+        enabled: false
+    pylint:
+        enabled: false
+    revive:
+        enabled: false
+    rubocop:
+        enabled: false
+    scsslint:
+        enabled: false
+    tfsec:
+        enabled: false
+    tslint:
+        enabled: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We wanna try codeac, but we want to prevent it to run on all branches before it is set correctly. This PR should ensure that.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
