### PR TITLE
[framework] fixed accessories locale dependent information

### DIFF
--- a/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
@@ -75,9 +75,9 @@ class ListedProductViewFactory
     {
         return $this->create(
             $product->getId(),
-            $product->getName(),
+            $product->getName($this->domain->getLocale()),
             $product->getShortDescription($this->domain->getId()),
-            $product->getCalculatedAvailability()->getName(),
+            $product->getCalculatedAvailability()->getName($this->domain->getLocale()),
             $this->productCachedAttributesFacade->getProductSellingPrice($product),
             $this->getFlagIdsForProduct($product),
             $productActionView,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When I switched locales on doman (`cs` for 1st domain, `en` for 2nd one) the product title on product detail in section accessories is in wrong locale. Even the functional test fails.<br>This solution is more like a hotfix to me. IMHO there are a risk of more similar usages which we do not know about yet.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Failing test:

```
Tests\ReadModelBundle\Functional\Product\Listed\ListedProductViewFacadeTest::testGetAllAccessories
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Kabel HDMI A - HDMI A M/M 2m zlacene konektory High Speed HD'
+'Kabel HDMI A - HDMI A M/M 2m gold-plated connectors High Speed HD'

/var/www/html/project-base/tests/ReadModelBundle/Functional/Product/Listed/ListedProductViewFacadeTest.php:40
```