### PR TITLE
[frontend-api] Made functional tests independent on domain locales

### DIFF
--- a/project-base/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ProductDataFixture.php
@@ -143,6 +143,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->catnum = '9177759';
         $productData->partno = 'SLE 22F46DM4';
         $productData->ean = '8845781245930';
+        $productData->orderingPriority = 1;
 
         $parameterTranslations = [];
 
@@ -2947,6 +2948,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->catnum = '9176544MS';
         $productData->partno = 'TIC100';
         $productData->ean = '8845781243207';
+        $productData->orderingPriority = 2;
 
         foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
             $locale = $domain->getLocale();
@@ -3062,6 +3064,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->catnum = '9176578';
         $productData->partno = 'T27D590EY';
         $productData->ean = '8845781243205';
+        $productData->orderingPriority = 1;
 
         $parameterTranslations = [];
 
@@ -3148,6 +3151,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->catnum = '7700769';
         $productData->partno = '22MT44D';
         $productData->ean = '8845781245931';
+        $productData->orderingPriority = 1;
 
         $parameterTranslations = [];
 
@@ -3255,6 +3259,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->catnum = '8981537';
         $productData->partno = 'T27D590EY';
         $productData->ean = '8845781245939';
+        $productData->orderingPriority = 1;
 
         $parameterTranslations = [];
 
@@ -3298,6 +3303,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
         $productData->catnum = '8981538';
         $productData->partno = 'T27D590EZ';
         $productData->ean = '8845781245940';
+        $productData->orderingPriority = 1;
 
         $parameterTranslations = [];
 

--- a/project-base/tests/FrontendApiBundle/Functional/Article/GetArticleTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Article/GetArticleTest.php
@@ -48,32 +48,31 @@ class GetArticleTest extends GraphQlTestCase
         $this->assertSame($expectedErrorMessage, $errors[0]['message']);
     }
 
-    /**
-     * @param string $graphQlType
-     * @param array $expectedData
-     * @dataProvider getSpecialArticleDataProvider
-     */
-    public function testGetSpecialArticle(string $graphQlType, array $expectedData): void
+    public function testGetSpecialArticle(): void
     {
-        $response = $this->getResponseContentForQuery($this->getSpecialArticleQuery($graphQlType));
-        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
-        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+        foreach ($this->getSpecialArticleDataProvider() as $dataSet) {
+            list($graphQlType, $expectedData) = $dataSet;
 
-        $this->assertArrayHasKey('uuid', $responseData);
-        $this->assertTrue(Uuid::isValid($responseData['uuid']));
+            $response = $this->getResponseContentForQuery($this->getSpecialArticleQuery($graphQlType));
+            $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+            $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
-        $this->assertKeysAreSameAsExpected(
-            [
-                'name',
-                'placement',
-                'text',
-                'seoH1',
-                'seoTitle',
-                'seoMetaDescription',
-            ],
-            $responseData,
-            $expectedData
-        );
+            $this->assertArrayHasKey('uuid', $responseData);
+            $this->assertTrue(Uuid::isValid($responseData['uuid']));
+
+            $this->assertKeysAreSameAsExpected(
+                [
+                    'name',
+                    'placement',
+                    'text',
+                    'seoH1',
+                    'seoTitle',
+                    'seoMetaDescription',
+                ],
+                $responseData,
+                $expectedData
+            );
+        }
     }
 
     /**
@@ -112,15 +111,16 @@ class GetArticleTest extends GraphQlTestCase
     /**
      * @return array
      */
-    public function getSpecialArticleDataProvider(): array
+    private function getSpecialArticleDataProvider(): array
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         return [
             [
                 'termsAndConditionsArticle',
                 [
-                    'name' => 'Terms and conditions',
+                    'name' => t('Terms and conditions', [], 'dataFixtures', $firstDomainLocale),
                     'placement' => Article::PLACEMENT_FOOTER,
-                    'text' => 'Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.',
+                    'text' => t('Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.', [], 'dataFixtures', $firstDomainLocale),
                     'seoH1' => null,
                     'seoTitle' => null,
                     'seoMetaDescription' => null,
@@ -129,9 +129,9 @@ class GetArticleTest extends GraphQlTestCase
             [
                 'privacyPolicyArticle',
                 [
-                    'name' => 'Privacy policy',
+                    'name' => t('Privacy policy', [], 'dataFixtures', $firstDomainLocale),
                     'placement' => Article::PLACEMENT_NONE,
-                    'text' => 'Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.',
+                    'text' => t('Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.', [], 'dataFixtures', $firstDomainLocale),
                     'seoH1' => null,
                     'seoTitle' => null,
                     'seoMetaDescription' => null,
@@ -140,9 +140,9 @@ class GetArticleTest extends GraphQlTestCase
             [
                 'cookiesArticle',
                 [
-                    'name' => 'Information about cookies',
+                    'name' => t('Information about cookies', [], 'dataFixtures', $firstDomainLocale),
                     'placement' => Article::PLACEMENT_NONE,
-                    'text' => 'Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.',
+                    'text' => t('Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.', [], 'dataFixtures', $firstDomainLocale),
                     'seoH1' => null,
                     'seoTitle' => null,
                     'seoMetaDescription' => null,

--- a/project-base/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php
@@ -5,43 +5,43 @@ declare(strict_types=1);
 namespace Tests\FrontendApiBundle\Functional\Article;
 
 use Ramsey\Uuid\Uuid;
+use Shopsys\FrameworkBundle\Model\Article\Article;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class GetArticlesTest extends GraphQlTestCase
 {
-    /**
-     * @param string $query
-     * @param array $expectedArticlesData
-     * @dataProvider getArticlesDataProvider
-     */
-    public function testGetArticles(string $query, array $expectedArticlesData): void
+    public function testGetArticles(): void
     {
-        $graphQlType = 'articles';
-        $response = $this->getResponseContentForQuery($query);
-        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
-        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+        foreach ($this->getArticlesDataProvider() as $dataSet) {
+            list($query, $expectedArticlesData) = $dataSet;
 
-        $this->assertArrayHasKey('edges', $responseData);
-        $this->assertCount(count($expectedArticlesData), $responseData['edges']);
+            $graphQlType = 'articles';
+            $response = $this->getResponseContentForQuery($query);
+            $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+            $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
-        foreach ($responseData['edges'] as $edge) {
-            $this->assertArrayHasKey('node', $edge);
+            $this->assertArrayHasKey('edges', $responseData);
+            $this->assertCount(count($expectedArticlesData), $responseData['edges']);
 
-            $this->assertArrayHasKey('uuid', $edge['node']);
-            $this->assertTrue(Uuid::isValid($edge['node']['uuid']));
+            foreach ($responseData['edges'] as $edge) {
+                $this->assertArrayHasKey('node', $edge);
 
-            $this->assertKeysAreSameAsExpected(
-                [
-                    'name',
-                    'placement',
-                    'text',
-                    'seoH1',
-                    'seoTitle',
-                    'seoMetaDescription',
-                ],
-                $edge['node'],
-                array_shift($expectedArticlesData)
-            );
+                $this->assertArrayHasKey('uuid', $edge['node']);
+                $this->assertTrue(Uuid::isValid($edge['node']['uuid']));
+
+                $this->assertKeysAreSameAsExpected(
+                    [
+                        'name',
+                        'placement',
+                        'text',
+                        'seoH1',
+                        'seoTitle',
+                        'seoMetaDescription',
+                    ],
+                    $edge['node'],
+                    array_shift($expectedArticlesData)
+                );
+            }
         }
     }
 
@@ -61,7 +61,7 @@ class GetArticlesTest extends GraphQlTestCase
     /**
      * @return array
      */
-    public function getArticlesDataProvider(): array
+    private function getArticlesDataProvider(): array
     {
         return [
             [
@@ -85,15 +85,15 @@ class GetArticlesTest extends GraphQlTestCase
                 array_slice($this->getExpectedArticles(), 3, 2),
             ],
             [
-                $this->getFirstArticlesQuery(1, 'topMenu'),
+                $this->getFirstArticlesQuery(1, Article::PLACEMENT_TOP_MENU),
                 array_slice($this->getExpectedArticles(), 3, 1),
             ],
             [
-                $this->getLastArticlesQuery(1, 'topMenu'),
+                $this->getLastArticlesQuery(1, Article::PLACEMENT_TOP_MENU),
                 array_slice($this->getExpectedArticles(), 4, 1),
             ],
             [
-                $this->getAllArticlesQuery('topMenu'),
+                $this->getAllArticlesQuery(Article::PLACEMENT_TOP_MENU),
                 array_slice($this->getExpectedArticles(), 3, 2),
             ],
             [
@@ -202,46 +202,47 @@ class GetArticlesTest extends GraphQlTestCase
      */
     private function getExpectedArticles(): array
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         return [
             [
-                'name' => 'Terms and conditions',
-                'placement' => 'footer',
-                'text' => 'Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.',
+                'name' => t('Terms and conditions', [], 'dataFixtures', $firstDomainLocale),
+                'placement' => Article::PLACEMENT_FOOTER,
+                'text' => t('Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.', [], 'dataFixtures', $firstDomainLocale),
                 'seoH1' => null,
                 'seoTitle' => null,
                 'seoMetaDescription' => null,
             ],
             [
-                'name' => 'Privacy policy',
-                'placement' => 'none',
-                'text' => 'Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.',
+                'name' => t('Privacy policy', [], 'dataFixtures', $firstDomainLocale),
+                'placement' => Article::PLACEMENT_NONE,
+                'text' => t('Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.', [], 'dataFixtures', $firstDomainLocale),
                 'seoH1' => null,
                 'seoTitle' => null,
                 'seoMetaDescription' => null,
             ],
             [
-                'name' => 'Information about cookies',
-                'placement' => 'none',
-                'text' => 'Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.',
+                'name' => t('Information about cookies', [], 'dataFixtures', $firstDomainLocale),
+                'placement' => Article::PLACEMENT_NONE,
+                'text' => t('Morbi posuere mauris dolor, quis accumsan dolor ullamcorper eget. Phasellus at elementum magna, et pretium neque. Praesent tristique lorem mi, eget varius quam aliquam eget. Vivamus ultrices interdum nisi, sed placerat lectus fermentum non. Phasellus ac quam vitae nisi aliquam vestibulum. Sed rhoncus tortor a arcu sagittis placerat. Nulla lectus nunc, ultrices ac faucibus sed, accumsan nec diam. Nam auctor neque quis tincidunt tempus. Nunc eget risus tristique, lobortis metus vitae, pellentesque leo. Vivamus placerat turpis ac dolor vehicula tincidunt. Sed venenatis, ante id ultrices convallis, lacus elit porttitor dolor, non porta risus ipsum ac justo. Integer id pretium quam, id placerat nulla.', [], 'dataFixtures', $firstDomainLocale),
                 'seoH1' => null,
                 'seoTitle' => null,
                 'seoMetaDescription' => null,
             ],
             [
-                'name' => 'News',
-                'placement' => 'topMenu',
-                'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis nisi, tincidunt sollicitudin augue eu, laoreet blandit sem. Donec rutrum augue a elit imperdiet, eu vehicula tortor porta. Vivamus pulvinar sem non auctor dictum. Morbi eleifend semper enim, eu faucibus tortor posuere vitae. Donec tincidunt ipsum ullamcorper nisi accumsan tincidunt. Aenean sed velit massa. Nullam interdum eget est ut convallis. Vestibulum et mauris condimentum, rutrum sem congue, suscipit arcu.\\nSed tristique vehicula ipsum, ut vulputate tortor feugiat eu. Vivamus convallis quam vulputate faucibus facilisis. Curabitur tincidunt pulvinar leo, eu dapibus augue lacinia a. Fusce sed tincidunt nunc. Morbi a nisi a odio pharetra laoreet nec eget quam. In in nisl tortor. Ut fringilla vitae lectus eu venenatis. Nullam interdum sed odio a posuere. Fusce pellentesque dui vel tortor blandit, a dictum nunc congue.',
+                'name' => t('News', [], 'dataFixtures', $firstDomainLocale),
+                'placement' => Article::PLACEMENT_TOP_MENU,
+                'text' => t('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis nisi, tincidunt sollicitudin augue eu, laoreet blandit sem. Donec rutrum augue a elit imperdiet, eu vehicula tortor porta. Vivamus pulvinar sem non auctor dictum. Morbi eleifend semper enim, eu faucibus tortor posuere vitae. Donec tincidunt ipsum ullamcorper nisi accumsan tincidunt. Aenean sed velit massa. Nullam interdum eget est ut convallis. Vestibulum et mauris condimentum, rutrum sem congue, suscipit arcu.\\nSed tristique vehicula ipsum, ut vulputate tortor feugiat eu. Vivamus convallis quam vulputate faucibus facilisis. Curabitur tincidunt pulvinar leo, eu dapibus augue lacinia a. Fusce sed tincidunt nunc. Morbi a nisi a odio pharetra laoreet nec eget quam. In in nisl tortor. Ut fringilla vitae lectus eu venenatis. Nullam interdum sed odio a posuere. Fusce pellentesque dui vel tortor blandit, a dictum nunc congue.', [], 'dataFixtures', $firstDomainLocale),
                 'seoH1' => null,
                 'seoTitle' => null,
                 'seoMetaDescription' => null,
             ],
             [
-                'name' => 'Shopping guide',
-                'placement' => 'topMenu',
-                'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis nisi, tincidunt sollicitudin augue eu, laoreet blandit sem. Donec rutrum augue a elit imperdiet, eu vehicula tortor porta. Vivamus pulvinar sem non auctor dictum. Morbi eleifend semper enim, eu faucibus tortor posuere vitae. Donec tincidunt ipsum ullamcorper nisi accumsan tincidunt. Aenean sed velit massa. Nullam interdum eget est ut convallis. Vestibulum et mauris condimentum, rutrum sem congue, suscipit arcu.\\nSed tristique vehicula ipsum, ut vulputate tortor feugiat eu. Vivamus convallis quam vulputate faucibus facilisis. Curabitur tincidunt pulvinar leo, eu dapibus augue lacinia a. Fusce sed tincidunt nunc. Morbi a nisi a odio pharetra laoreet nec eget quam. In in nisl tortor. Ut fringilla vitae lectus eu venenatis. Nullam interdum sed odio a posuere. Fusce pellentesque dui vel tortor blandit, a dictum nunc congue.',
-                'seoH1' => 'Shopping guide to improve your shopping experience',
-                'seoTitle' => 'Shopping guide for quick shopping',
-                'seoMetaDescription' => 'Shopping guide - Tips and tricks how to quickly find what you are looking for',
+                'name' => t('Shopping guide', [], 'dataFixtures', $firstDomainLocale),
+                'placement' => Article::PLACEMENT_TOP_MENU,
+                'text' => t('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus felis nisi, tincidunt sollicitudin augue eu, laoreet blandit sem. Donec rutrum augue a elit imperdiet, eu vehicula tortor porta. Vivamus pulvinar sem non auctor dictum. Morbi eleifend semper enim, eu faucibus tortor posuere vitae. Donec tincidunt ipsum ullamcorper nisi accumsan tincidunt. Aenean sed velit massa. Nullam interdum eget est ut convallis. Vestibulum et mauris condimentum, rutrum sem congue, suscipit arcu.\\nSed tristique vehicula ipsum, ut vulputate tortor feugiat eu. Vivamus convallis quam vulputate faucibus facilisis. Curabitur tincidunt pulvinar leo, eu dapibus augue lacinia a. Fusce sed tincidunt nunc. Morbi a nisi a odio pharetra laoreet nec eget quam. In in nisl tortor. Ut fringilla vitae lectus eu venenatis. Nullam interdum sed odio a posuere. Fusce pellentesque dui vel tortor blandit, a dictum nunc congue.', [], 'dataFixtures', $firstDomainLocale),
+                'seoH1' => t('Shopping guide to improve your shopping experience', [], 'dataFixtures', $firstDomainLocale),
+                'seoTitle' => t('Shopping guide for quick shopping', [], 'dataFixtures', $firstDomainLocale),
+                'seoMetaDescription' => t('Shopping guide - Tips and tricks how to quickly find what you are looking for', [], 'dataFixtures', $firstDomainLocale),
             ],
         ];
     }

--- a/project-base/tests/FrontendApiBundle/Functional/Category/CategoriesTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Category/CategoriesTest.php
@@ -18,14 +18,15 @@ class CategoriesTest extends GraphQlTestCase
             }
         ';
 
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $arrayExpected = [
             'data' => [
                 'categories' => [
-                    ['name' => 'Electronics'],
-                    ['name' => 'Books'],
-                    ['name' => 'Toys'],
-                    ['name' => 'Garden tools'],
-                    ['name' => 'Food'],
+                    ['name' => t('Electronics', [], 'dataFixtures', $firstDomainLocale)],
+                    ['name' => t('Books', [], 'dataFixtures', $firstDomainLocale)],
+                    ['name' => t('Toys', [], 'dataFixtures', $firstDomainLocale)],
+                    ['name' => t('Garden tools', [], 'dataFixtures', $firstDomainLocale)],
+                    ['name' => t('Food', [], 'dataFixtures', $firstDomainLocale)],
                 ],
             ],
         ];
@@ -46,15 +47,16 @@ class CategoriesTest extends GraphQlTestCase
             }
         ';
 
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expected = [
-            'name' => 'Electronics',
+            'name' => t('Electronics', [], 'dataFixtures', $firstDomainLocale),
             'children' => [
-                ['name' => 'TV, audio'],
-                ['name' => 'Cameras & Photo'],
-                ['name' => 'Printers'],
-                ['name' => 'Personal Computers & accessories'],
-                ['name' => 'Mobile Phones'],
-                ['name' => 'Coffee Machines'],
+                ['name' => t('TV, audio', [], 'dataFixtures', $firstDomainLocale)],
+                ['name' => t('Cameras & Photo', [], 'dataFixtures', $firstDomainLocale)],
+                ['name' => t('Printers', [], 'dataFixtures', $firstDomainLocale)],
+                ['name' => t('Personal Computers & accessories', [], 'dataFixtures', $firstDomainLocale)],
+                ['name' => t('Mobile Phones', [], 'dataFixtures', $firstDomainLocale)],
+                ['name' => t('Coffee Machines', [], 'dataFixtures', $firstDomainLocale)],
             ],
         ];
 

--- a/project-base/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
@@ -83,10 +83,11 @@ mutation {
     }
 }';
 
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expectedViolationMessages = [
-            0 => 'First name cannot be longer than 100 characters',
-            1 => 'Last name cannot be longer than 100 characters',
-            2 => 'Telephone number cannot be longer than 30 characters',
+            0 => t('First name cannot be longer than {{ limit }} characters', ['{{ limit }}' => 100], 'validators', $firstDomainLocale),
+            1 => t('Last name cannot be longer than {{ limit }} characters', ['{{ limit }}' => 100], 'validators', $firstDomainLocale),
+            2 => t('Telephone number cannot be longer than {{ limit }} characters', ['{{ limit }}' => 30], 'validators', $firstDomainLocale),
         ];
 
         $response = $this->getResponseContentForQuery($query);

--- a/project-base/tests/FrontendApiBundle/Functional/Order/AbstractOrderTestCase.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/AbstractOrderTestCase.php
@@ -16,9 +16,10 @@ class AbstractOrderTestCase extends GraphQlTestCase
      */
     protected function getExpectedOrderItems(): array
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         return [
             0 => [
-                'name' => '22" Sencor SLE 22F46DM4 HELLO KITTY',
+                'name' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '139.96',
                     'priceWithoutVat' => '115.67',
@@ -31,10 +32,10 @@ class AbstractOrderTestCase extends GraphQlTestCase
                 ],
                 'quantity' => 10,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             1 => [
-                'name' => 'Cash on delivery',
+                'name' => t('Cash on delivery', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '2.00',
                     'priceWithoutVat' => '2.00',
@@ -50,7 +51,7 @@ class AbstractOrderTestCase extends GraphQlTestCase
                 'unit' => null,
             ],
             2 => [
-                'name' => 'Czech post',
+                'name' => t('Czech post', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '4.84',
                     'priceWithoutVat' => '4.00',

--- a/project-base/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php
@@ -8,16 +8,17 @@ class CompanyFieldsAreValidatedTest extends AbstractOrderTestCase
 {
     public function testValidationErrorWhenCompanyBehalfIsTrueAndFieldsAreMissing(): void
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expectedValidations = [
             'input.companyName' => [
                 0 => [
-                    'message' => 'Please enter company name',
+                    'message' => t('Please enter company name', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.companyNumber' => [
                 0 => [
-                    'message' => 'Please enter identification number',
+                    'message' => t('Please enter identification number', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],

--- a/project-base/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php
@@ -8,40 +8,41 @@ class DeliveryFieldsAreValidatedTest extends AbstractOrderTestCase
 {
     public function testValidationErrorWhenCompanyBehalfIsTrueAndFieldsAreMissing(): void
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expectedValidations = [
             'input.deliveryFirstName' => [
                 0 => [
-                    'message' => 'Please enter first name of contact person',
+                    'message' => t('Please enter first name of contact person', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryLastName' => [
                 0 => [
-                    'message' => 'Please enter last name of contact person',
+                    'message' => t('Please enter last name of contact person', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryStreet' => [
                 0 => [
-                    'message' => 'Please enter street',
+                    'message' => t('Please enter street', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryCity' => [
                 0 => [
-                    'message' => 'Please enter city',
+                    'message' => t('Please enter city', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryPostcode' => [
                 0 => [
-                    'message' => 'Please enter zip code',
+                    'message' => t('Please enter zip code', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryCountry' => [
                 0 => [
-                    'message' => 'Please choose country',
+                    'message' => t('Please choose country', [], 'validators', $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],

--- a/project-base/tests/FrontendApiBundle/Functional/Order/FullOrderTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/FullOrderTest.php
@@ -8,16 +8,17 @@ class FullOrderTest extends AbstractOrderTestCase
 {
     public function testCreateFullOrder(): void
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expected = [
             'data' => [
                 'CreateOrder' => [
                     'transport' => [
-                        'name' => 'Czech post',
+                        'name' => t('Czech post', [], 'dataFixtures', $firstDomainLocale),
                     ],
                     'payment' => [
-                        'name' => 'Cash on delivery',
+                        'name' => t('Cash on delivery', [], 'dataFixtures', $firstDomainLocale),
                     ],
-                    'status' => 'New',
+                    'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
                     'totalPrice' => [
                         'priceWithVat' => '1406.44',
                         'priceWithoutVat' => '1162.69',

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
@@ -8,38 +8,37 @@ use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
 
 class GetOrdersAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
 {
-    /**
-     * @param string $query
-     * @param array $expectedOrdersData
-     * @dataProvider getOrdersDataProvider
-     */
-    public function testGetAllCustomerUserOrders(string $query, array $expectedOrdersData): void
+    public function testGetAllCustomerUserOrders(): void
     {
-        $graphQlType = 'orders';
-        $response = $this->getResponseContentForQuery($query);
-        $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
-        $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
+        foreach ($this->getOrdersDataProvider() as $dataSet) {
+            list($query, $expectedOrdersData) = $dataSet;
 
-        $this->assertArrayHasKey('edges', $responseData);
-        $this->assertCount(count($expectedOrdersData), $responseData['edges']);
+            $graphQlType = 'orders';
+            $response = $this->getResponseContentForQuery($query);
+            $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
+            $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
-        foreach ($responseData['edges'] as $edge) {
-            $this->assertArrayHasKey('node', $edge);
+            $this->assertArrayHasKey('edges', $responseData);
+            $this->assertCount(count($expectedOrdersData), $responseData['edges']);
 
-            $expectedOrderData = array_shift($expectedOrdersData);
-            $this->assertArrayHasKey('status', $edge['node']);
-            $this->assertSame($expectedOrderData['status'], $edge['node']['status']);
+            foreach ($responseData['edges'] as $edge) {
+                $this->assertArrayHasKey('node', $edge);
 
-            $this->assertArrayHasKey('totalPrice', $edge['node']);
-            $this->assertArrayHasKey('priceWithVat', $edge['node']['totalPrice']);
-            $this->assertSame($expectedOrderData['priceWithVat'], $edge['node']['totalPrice']['priceWithVat']);
+                $expectedOrderData = array_shift($expectedOrdersData);
+                $this->assertArrayHasKey('status', $edge['node']);
+                $this->assertSame($expectedOrderData['status'], $edge['node']['status']);
+
+                $this->assertArrayHasKey('totalPrice', $edge['node']);
+                $this->assertArrayHasKey('priceWithVat', $edge['node']['totalPrice']);
+                $this->assertSame($expectedOrderData['priceWithVat'], $edge['node']['totalPrice']['priceWithVat']);
+            }
         }
     }
 
     /**
      * @return array
      */
-    public function getOrdersDataProvider(): array
+    private function getOrdersDataProvider(): array
     {
         return [
             [
@@ -135,29 +134,30 @@ class GetOrdersAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
      */
     private function getExpectedUserOrders(): array
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         return [
             [
-                'status' => 'In Progress',
+                'status' => t('In Progress', [], 'dataFixtures', $firstDomainLocale),
                 'priceWithVat' => '153.640000',
             ],
             [
-                'status' => 'Done',
+                'status' => t('Done', [], 'dataFixtures', $firstDomainLocale),
                 'priceWithVat' => '4308.320000',
             ],
             [
-                'status' => 'New',
+                'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
                 'priceWithVat' => '83.580000',
             ],
             [
-                'status' => 'Done',
+                'status' => t('Done', [], 'dataFixtures', $firstDomainLocale),
                 'priceWithVat' => '245.970000',
             ],
             [
-                'status' => 'New',
+                'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
                 'priceWithVat' => '76.580000',
             ],
             [
-                'status' => 'New',
+                'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
                 'priceWithVat' => '1012.420000',
             ],
         ];

--- a/project-base/tests/FrontendApiBundle/Functional/Order/MinimalOrderTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/MinimalOrderTest.php
@@ -8,16 +8,17 @@ class MinimalOrderTest extends AbstractOrderTestCase
 {
     public function testCreateMinimalOrderMutation(): void
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expected = [
             'data' => [
                 'CreateOrder' => [
                     'transport' => [
-                        'name' => 'Czech post',
+                        'name' => t('Czech post', [], 'dataFixtures', $firstDomainLocale),
                     ],
                     'payment' => [
-                        'name' => 'Cash on delivery',
+                        'name' => t('Cash on delivery', [], 'dataFixtures', $firstDomainLocale),
                     ],
-                    'status' => 'New',
+                    'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
                     'totalPrice' => [
                         'priceWithVat' => '1406.44',
                         'priceWithoutVat' => '1162.69',

--- a/project-base/tests/FrontendApiBundle/Functional/Order/MultipleProductsInOrderTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/MultipleProductsInOrderTest.php
@@ -10,16 +10,17 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
 {
     public function testCreateFullOrder(): void
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expected = [
             'data' => [
                 'CreateOrder' => [
                     'transport' => [
-                        'name' => 'Czech post',
+                        'name' => t('Czech post', [], 'dataFixtures', $firstDomainLocale),
                     ],
                     'payment' => [
-                        'name' => 'Cash on delivery',
+                        'name' => t('Cash on delivery', [], 'dataFixtures', $firstDomainLocale),
                     ],
-                    'status' => 'New',
+                    'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
                     'totalPrice' => [
                         'priceWithVat' => '4964.44',
                         'priceWithoutVat' => '4103.19',
@@ -80,9 +81,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
      */
     protected function getExpectedOrderItems(): array
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         return [
             0 => [
-                'name' => '22" Sencor SLE 22F46DM4 HELLO KITTY',
+                'name' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '139.96',
                     'priceWithoutVat' => '115.67',
@@ -95,10 +97,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 ],
                 'quantity' => 10,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             1 => [
-                'name' => '100 Czech crowns ticket',
+                'name' => t('100 Czech crowns ticket', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '4.84',
                     'priceWithoutVat' => '4.00',
@@ -111,10 +113,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 ],
                 'quantity' => 100,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             2 => [
-                'name' => '27” Hyundai T27D590EY',
+                'name' => t('27” Hyundai T27D590EY', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '300.03',
                     'priceWithoutVat' => '247.96',
@@ -127,10 +129,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 ],
                 'quantity' => 1,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             3 => [
-                'name' => '27” Hyundai T27D590EZ',
+                'name' => t('27” Hyundai T27D590EZ', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '309.71',
                     'priceWithoutVat' => '255.96',
@@ -143,10 +145,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 ],
                 'quantity' => 2,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             4 => [
-                'name' => '30” Hyundai 22MT44D',
+                'name' => t('30” Hyundai 22MT44D', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '193.55',
                     'priceWithoutVat' => '159.96',
@@ -159,10 +161,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 ],
                 'quantity' => 5,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             5 => [
-                'name' => '32" Philips 32PFL4308',
+                'name' => t('32" Philips 32PFL4308', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '395.60',
                     'priceWithoutVat' => '326.94',
@@ -175,10 +177,10 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 ],
                 'quantity' => 3,
                 'vatRate' => '21.0000',
-                'unit' => 'pcs',
+                'unit' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
             ],
             6 => [
-                'name' => 'Cash on delivery',
+                'name' => t('Cash on delivery', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '2.00',
                     'priceWithoutVat' => '2.00',
@@ -194,7 +196,7 @@ class MultipleProductsInOrderTest extends AbstractOrderTestCase
                 'unit' => null,
             ],
             7 => [
-                'name' => 'Czech post',
+                'name' => t('Czech post', [], 'dataFixtures', $firstDomainLocale),
                 'unitPrice' => [
                     'priceWithVat' => '4.84',
                     'priceWithoutVat' => '4.00',

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Product;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
@@ -39,7 +38,7 @@ class ProductTest extends GraphQlTestCase
         $arrayExpected = [
             'data' => [
                 'product' => [
-                    'name' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'name' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], 'dataFixtures', $this->getLocaleForFirstDomain()),
                 ],
             ],
         ];
@@ -85,7 +84,7 @@ class ProductTest extends GraphQlTestCase
      */
     private function getExpectedProductDetailWithAllAttributes(): array
     {
-        $firstDomainLocale = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $shortDescription = t(
             'Television LED, 55 cm diagonal, 1920x1080 Full HD, DVB-T MPEG4 tuner with USB recording and playback',
             [],

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Product;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
@@ -52,21 +51,22 @@ class ProductVariantTest extends GraphQlTestCase
             }
         ';
 
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $arrayExpected = [
             'data' => [
                 'product' => [
                     '__typename' => 'MainVariant',
-                    'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
-                    'shortDescription' => t('Television monitor IPS, 16: 9, 5M: 1, 200cd/m2, 5ms GTG, FullHD 1920x1080, DVB-S2/T2/C, 2x HDMI, USB, SCART, 2 x 5W speakers, energ. Class A', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $firstDomainLocale),
+                    'shortDescription' => t('Television monitor IPS, 16: 9, 5M: 1, 200cd/m2, 5ms GTG, FullHD 1920x1080, DVB-S2/T2/C, 2x HDMI, USB, SCART, 2 x 5W speakers, energ. Class A', [], 'dataFixtures', $firstDomainLocale),
                     'variants' => [
                         [
-                            'name' => t('51,5” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                            'name' => t('51,5” Hyundai 22HD44D', [], 'dataFixtures', $firstDomainLocale),
                         ],
                         [
-                            'name' => t('60” Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                            'name' => t('60” Hyundai 22HD44D', [], 'dataFixtures', $firstDomainLocale),
                         ],
                         [
-                            'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                            'name' => t('Hyundai 22HD44D', [], 'dataFixtures', $firstDomainLocale),
                         ],
                     ],
                 ],
@@ -93,14 +93,15 @@ class ProductVariantTest extends GraphQlTestCase
             }
         ';
 
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $arrayExpected = [
             'data' => [
                 'product' => [
                     '__typename' => 'Variant',
-                    'name' => t('27” Hyundai T27D590EY', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
-                    'shortDescription' => t('TV LED, 100Hz, diagonal 80cm 100Hz, Full HD 1920 x 1080, DVB-T / C, 2x HDMI, USB, CI +, VGA, SCART, speakers 16W, energy. Class A +', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                    'name' => t('27” Hyundai T27D590EY', [], 'dataFixtures', $firstDomainLocale),
+                    'shortDescription' => t('TV LED, 100Hz, diagonal 80cm 100Hz, Full HD 1920 x 1080, DVB-T / C, 2x HDMI, USB, CI +, VGA, SCART, speakers 16W, energy. Class A +', [], 'dataFixtures', $firstDomainLocale),
                     'mainVariant' => [
-                        'name' => t('32” Hyundai 32PFL4400', [], 'dataFixtures', $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale()),
+                        'name' => t('32” Hyundai 32PFL4400', [], 'dataFixtures', $firstDomainLocale),
                     ],
                 ],
             ],

--- a/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Product;
 
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class ProductsTest extends GraphQlTestCase
 {
     public function testFirstFiveProductsWithName(): void
     {
-        $firstDomainLocale = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $query = '
             query {
                 products (first: 5) {
@@ -48,11 +47,11 @@ class ProductsTest extends GraphQlTestCase
         $this->assertEquals($productsExpected, $queryResult, json_encode($queryResult));
     }
 
-    public function testNineteenthProductWithAllAttributes(): void
+    public function testFifthProductWithAllAttributes(): void
     {
         $query = '
             query {
-                products (first: 1, after: "YXJyYXljb25uZWN0aW9uOjE3") {
+                products (first: 1, after: "YXJyYXljb25uZWN0aW9uOjM=") {
                     edges {
                         node {
                             name
@@ -83,7 +82,7 @@ class ProductsTest extends GraphQlTestCase
             }
         ';
 
-        $arrayExpected = $this->getExpectedDataForNineteenthProduct();
+        $arrayExpected = $this->getExpectedDataForFifthProduct();
 
         $graphQlType = 'products';
         $response = $this->getResponseContentForQuery($query);
@@ -104,14 +103,14 @@ class ProductsTest extends GraphQlTestCase
     /**
      * @return array
      */
-    private function getExpectedDataForNineteenthProduct(): array
+    private function getExpectedDataForFifthProduct(): array
     {
-        $firstDomainLocale = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         $arrayExpected = [
             [
-                'name' => t('Canon EOS 700D', [], 'dataFixtures', $firstDomainLocale),
-                'shortDescription' => t('Canon EOS 700D + EF-S 18-55 mm + 75-300 mm DC III DC III Quality digital camera with CMOS sensor with a resolution of 18 megapixels, which is to take the top photo in a professional style. Innovative DIGIC 5 image processing delivers powerful in any situation. A high sensitivity range up to ISO 12800 lets you capture great images even in dim light', [], 'dataFixtures', $firstDomainLocale),
-                'link' => $this->getLocalizedPathOnFirstDomainByRouteName('front_product_detail', ['id' => 8]),
+                'name' => t('30” Hyundai 22MT44D', [], 'dataFixtures', $firstDomainLocale),
+                'shortDescription' => t('Television monitor LED 16: 9, 5M: 1, 250cd/m2, 9.5ms, 1366x768', [], 'dataFixtures', $firstDomainLocale),
+                'link' => $this->getLocalizedPathOnFirstDomainByRouteName('front_product_detail', ['id' => 77]),
                 'unit' => [
                     'name' => t('pcs', [], 'dataFixtures', $firstDomainLocale),
                 ],
@@ -121,14 +120,14 @@ class ProductsTest extends GraphQlTestCase
                 'stockQuantity' => 100,
                 'categories' => [
                     [
-                        'name' => t('Cameras & Photo', [], 'dataFixtures', $firstDomainLocale),
+                        'name' => t('TV, audio', [], 'dataFixtures', $firstDomainLocale),
                     ],
                 ],
                 'flags' => [],
                 'price' => [
-                    'priceWithVat' => $this->getPriceWithVatConvertedToDomainDefaultCurrency('24990'),
-                    'priceWithoutVat' => $this->getPriceWithoutVatConvertedToDomainDefaultCurrency('24990'),
-                    'vatAmount' => $this->getPriceWithoutVatConvertedToDomainDefaultCurrency('0.00'),
+                    'priceWithVat' => $this->getPriceWithVatConvertedToDomainDefaultCurrency('4838.75'),
+                    'priceWithoutVat' => $this->getPriceWithoutVatConvertedToDomainDefaultCurrency('3999'),
+                    'vatAmount' => $this->getPriceWithoutVatConvertedToDomainDefaultCurrency('839.75'),
                 ],
             ],
         ];
@@ -160,13 +159,14 @@ class ProductsTest extends GraphQlTestCase
      */
     private function getExpectedDataForLastProduct(): string
     {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
         return '{
     "data": {
         "products": {
             "edges": [
                 {
                     "node": {
-                        "name": "ZN-8009 steam iron Ferrato stainless steel 2200 Watt Blue"
+                        "name": "' . t('ZN-8009 steam iron Ferrato stainless steel 2200 Watt Blue', [], 'dataFixtures', $firstDomainLocale) . '"
                     }
                 }
             ]

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -73,3 +73,6 @@ There you can find links to upgrade notes for other versions too.
     - in tests is used extended class of `Shopsys\FrameworkBundle\Model\Localization\TranslatableListener`
     - removed `config/packages/test/prezent_doctrine_translatable.yaml`
     - see #project-base-diff to update your project
+
+- fix frontend-api tests when domain locales are changed ([#2019](https://github.com/shopsys/shopsys/pull/2019))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Current state of functional tests in [frontend api](https://github.com/shopsys/frontend-api) is not suitable for changing locales on domain. When doing so the FEAPI tests will start failing. This PR will make the tests more stable
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
