### PR TITLE
[framework] removed SliderFormType excessive ID constraint

### DIFF
--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -41,9 +41,6 @@ class SliderItemFormType extends AbstractType
         if ($options['scenario'] === self::SCENARIO_EDIT) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
-                    'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter article name']),
-                    ],
                     'data' => $options['slider_item']->getId(),
                     'label' => t('ID'),
                 ])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Removed constraint NotBlank for ID, because slider ID cannot be change.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
