### PR TITLE
[project-base] filterFormMacro.html.twig: display "+" only if counts > 0

### DIFF
--- a/project-base/templates/Front/Content/Product/filterFormMacro.html.twig
+++ b/project-base/templates/Front/Content/Product/filterFormMacro.html.twig
@@ -87,7 +87,8 @@
                                         data-form-id="{{ flagForm.vars.id }}"
                                     >
                                         {% if not flagForm.vars.checked %}
-                                            ({% if filterForm.flags.vars.data is not empty %}+{% endif %}{{ productFilterCountData.countByFlagId[flagForm.vars.value]|default(0) }})
+                                            {% set flagsCount = productFilterCountData.countByFlagId[flagForm.vars.value]|default(0) %}
+                                            ({% if filterForm.flags.vars.data is not empty and flagsCount > 0 %}+{% endif %}{{ flagsCount }})
                                         {% endif %}
                                     </span>
                                 {% endif %}
@@ -153,9 +154,10 @@
                                                     data-form-id="{{ parameterValueForm.vars.id }}"
                                                 >
                                                     {% if not parameterValueForm.vars.checked %}
+                                                        {% set parameterValueCount = productFilterCountData.countByParameterIdAndValueId[parameterId][parameterValueForm.vars.value]|default(0) %}
                                                         (
-                                                            {%- if parameterForm.vars.data is not empty %}+{% endif -%}
-                                                            {{- productFilterCountData.countByParameterIdAndValueId[parameterId][parameterValueForm.vars.value]|default(0) -}}
+                                                            {%- if parameterForm.vars.data is not empty and parameterValueCount > 0 %}+{% endif -%}
+                                                            {{- parameterValueCount -}}
                                                         )
                                                     {% endif %}
                                                 </span>

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -65,3 +65,6 @@ There you can find links to upgrade notes for other versions too.
     -   tail -f $PIPE &
     +   tail -n +1 -f $PIPE &
     ```
+
+- fix displaying '+' sign in product filter ([#2023](https://github.com/shopsys/shopsys/pull/2023))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When the count in the filter was 0, the "+" sign was still displayed and the corresponding checkbox was not disabled (you can test it with demo data in "tv, audio" category by checking "Sencor" brand + "250 kWh/year" for "Annual energy consumption" parameter - see https://prnt.sc/ubmrdd) - that was a bug for flags and parameter values. For brands, this is already ok :slightly_smiling_face: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
