### PR TITLE
[shopsys] fixed import path in ecs configurations

### DIFF
--- a/packages/backend-api/easy-coding-standard.yml
+++ b/packages/backend-api/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -1,7 +1,7 @@
 imports:
     # some checkers use BetterPhpdocParser services which must be configured (file renamed in symplify/better-phpdoc-parser v5.4.14)
-    - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yml', ignore_errors: true }
-    - { resource: '%vendor_dir%/symplify/better-phpdoc-parser/config/config.yaml', ignore_errors: true }
+    - { resource: 'vendor/symplify/better-phpdoc-parser/config/config.yml', ignore_errors: true }
+    - { resource: 'vendor/symplify/better-phpdoc-parser/config/config.yaml', ignore_errors: true }
 
 services:
     _defaults:

--- a/packages/form-types-bundle/easy-coding-standard.yml
+++ b/packages/form-types-bundle/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~

--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in these namespaces

--- a/packages/frontend-api/easy-coding-standard.yml
+++ b/packages/frontend-api/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/packages/google-cloud-bundle/easy-coding-standard.yml
+++ b/packages/google-cloud-bundle/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~

--- a/packages/http-smoke-testing/easy-coding-standard.yml
+++ b/packages/http-smoke-testing/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~

--- a/packages/migrations/easy-coding-standard.yml
+++ b/packages/migrations/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~

--- a/packages/plugin-interface/easy-coding-standard.yml
+++ b/packages/plugin-interface/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff: ~

--- a/packages/product-feed-google/easy-coding-standard.yml
+++ b/packages/product-feed-google/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/packages/product-feed-heureka-delivery/easy-coding-standard.yml
+++ b/packages/product-feed-heureka-delivery/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/packages/product-feed-zbozi/easy-coding-standard.yml
+++ b/packages/product-feed-zbozi/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/packages/read-model/easy-coding-standard.yml
+++ b/packages/read-model/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true }
 
 services:
     # this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: '%vendor_dir%/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
+    - { resource: 'vendor/shopsys/coding-standards/easy-coding-standard.yml', ignore_errors: true  }
 
 services:
     PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer: ~

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -4,3 +4,6 @@ This guide contains instructions to upgrade from version v9.0.2 to v9.0.3-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- fix path for importing easy coding standard resources ([#2026](https://github.com/shopsys/shopsys/pull/2026))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| According to cahnge in symplify package there is no longer possible to use `%vendor_dir%`. The usages should be replaced via path. See https://github.com/symplify/symplify/pull/1752
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2012  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
