### PR TITLE
[shopsys] added missing upgrade notes for 1827

### DIFF
--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -57,3 +57,11 @@ There you can find links to upgrade notes for other versions too.
 
 - move npm-global directory to project in order to make it included in Docker volumes ([#2024](https://github.com/shopsys/shopsys/pull/2024))
     - see #project-base-diff to update your project
+
+- update `docker/php-fpm/docker-php-entrypoint` to show all lines from first command output ([#1827](https://github.com/shopsys/shopsys/pull/1827))
+    ```diff
+        mkfifo $PIPE
+        chmod 666 $PIPE
+    -   tail -f $PIPE &
+    +   tail -n +1 -f $PIPE &
+    ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in #1827 are missing upgrade notes. This PR adding them
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
