### PR TITLE
[shopsys] fix upgrade notes for https://github.com/shopsys/shopsys/pull/1777

### DIFF
--- a/upgrade/UPGRADE-v9.0.1.md
+++ b/upgrade/UPGRADE-v9.0.1.md
@@ -71,6 +71,3 @@ There you can find links to upgrade notes for other versions too.
 
 - fix wrong url of freshly uploaded files in wysiwyg ([#1926](https://github.com/shopsys/shopsys/pull/1926))
     - see [project-base diff](https://github.com/shopsys/project-base/commit/31c3469fb984c6a0224bcbf8db5549a6331afed5) to update your project
-
-- fix ImageConfig does not accept extended entities ([#1777](https://github.com/shopsys/shopsys/pull/1777))
-    - see #project-base-diff to update your project

--- a/upgrade/UPGRADE-v9.0.2.md
+++ b/upgrade/UPGRADE-v9.0.2.md
@@ -50,3 +50,6 @@ There you can find links to upgrade notes for other versions too.
 
 - add acceptance test for testing sending order as logged customer ([#2011](https://github.com/shopsys/shopsys/pull/2011))
     - see [project-base-diff](https://github.com/shopsys/project-base/commit/09340a81e0223f3922d0964e0632711113163f06) to update your project
+
+- fix ImageConfig does not accept extended entities ([#1777](https://github.com/shopsys/shopsys/pull/1777))
+    - see [project-base-diff](https://github.com/shopsys/project-base/commit/0d1ed01dc743fc2e5c1acd0d8f3434743f4dd890) to update your project


### PR DESCRIPTION
- added a link to project-base diff
- the instruction moved from UPGRADE-v9.0.1.md to UPGRADE-v9.0.2.md as
the modification was actaully released in 9.0.2

| Q             | A
| ------------- | ---
|Description, reason for the PR| it was really confusing for us that the newly added `ImageConfigTest` was failing and it took some time until we realized that the modification is not present in `9.0.1` version :smile: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
