### PR TITLE
[project-base] set cors handle in FE API

### DIFF
--- a/project-base/config/packages/shopsys_frontend_api.yaml
+++ b/project-base/config/packages/shopsys_frontend_api.yaml
@@ -1,4 +1,7 @@
 overblog_graphql:
+    security:
+        # for more flexibility use https://github.com/nelmio/NelmioCorsBundle
+        handle_cors: true
     definitions:
         schema:
             query: Query


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If we want to consume FE API from another url address (static cdn or other) we run into a problem with cors headers. This PR enables cors headers in the FE API by default.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
