### PR TITLE
[framework] deprecated notice is triggered when deprecated method is called

### DIFF
--- a/packages/framework/src/Component/Elasticsearch/IndexDefinition.php
+++ b/packages/framework/src/Component/Elasticsearch/IndexDefinition.php
@@ -117,6 +117,8 @@ class IndexDefinition
      */
     public function getLegacyIndexAlias(): string
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->indexPrefix . $this->getIndexName() . $this->getDomainId();
     }
 

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -219,6 +219,8 @@ class CategoryFacade
      */
     public function getTranslatedAll(DomainConfig $domainConfig)
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use getAllTranslated() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->categoryRepository->getTranslatedAll($domainConfig);
     }
 
@@ -338,6 +340,8 @@ class CategoryFacade
      */
     public function getTranslatedAllWithoutBranch(Category $category, DomainConfig $domainConfig)
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use getAllTranslatedWithoutBranch() instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->categoryRepository->getTranslatedAllWithoutBranch($category, $domainConfig);
     }
 

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -164,6 +164,8 @@ class CategoryRepository extends NestedTreeRepository
      */
     public function getTranslatedAllWithoutBranch(Category $categoryBranch, DomainConfig $domainConfig)
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use getAllTranslatedWithoutBranch() instead.', __METHOD__), E_USER_DEPRECATED);
+
         $queryBuilder = $this->getAllQueryBuilder();
         $this->addTranslation($queryBuilder, $domainConfig->getLocale());
 
@@ -581,6 +583,8 @@ class CategoryRepository extends NestedTreeRepository
      */
     public function getTranslatedAll(DomainConfig $domainConfig)
     {
+        @trigger_error(sprintf('The %s() method is deprecated and will be removed in the next major. Use getAllTranslated() instead.', __METHOD__), E_USER_DEPRECATED);
+
         $queryBuilder = $this->getAllQueryBuilder();
         $this->addTranslation($queryBuilder, $domainConfig->getLocale());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We have added @deprecated annotation to deprecated methods, but triggering deprecated notice was missing. This has been now added to alert users they should update their code before next major.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
