### PR TITLE
[shopsys] remove FE API only dependencies from framework

### DIFF
--- a/packages/framework/src/Model/Article/ArticleFacade.php
+++ b/packages/framework/src/Model/Article/ArticleFacade.php
@@ -110,64 +110,6 @@ class ArticleFacade
     }
 
     /**
-     * @param int $domainId
-     * @return int
-     */
-    public function getAllVisibleArticlesCountByDomainId(int $domainId): int
-    {
-        return $this->articleRepository->getAllVisibleArticlesCountByDomainId($domainId);
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $placement
-     * @return int
-     */
-    public function getAllVisibleArticlesCountByDomainIdAndPlacement(int $domainId, string $placement): int
-    {
-        return $this->articleRepository->getAllVisibleArticlesCountByDomainIdAndPlacement($domainId, $placement);
-    }
-
-    /**
-     * @param int $domainId
-     * @param int $limit
-     * @param int $offset
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
-     */
-    public function getVisibleArticlesListByDomainId(
-        int $domainId,
-        int $limit,
-        int $offset
-    ): array {
-        return $this->articleRepository->getVisibleListByDomainId(
-            $domainId,
-            $limit,
-            $offset
-        );
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $placement
-     * @param int $limit
-     * @param int $offset
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
-     */
-    public function getVisibleArticlesListByDomainIdAndPlacement(
-        int $domainId,
-        string $placement,
-        int $limit,
-        int $offset
-    ): array {
-        return $this->articleRepository->getVisibleListByDomainIdAndPlacement(
-            $domainId,
-            $placement,
-            $limit,
-            $offset
-        );
-    }
-
-    /**
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData $articleData
      * @return \Shopsys\FrameworkBundle\Model\Article\Article
      */
@@ -259,15 +201,5 @@ class ArticleFacade
             t('in footer') => Article::PLACEMENT_FOOTER,
             t('without positioning') => Article::PLACEMENT_NONE,
         ];
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $uuid
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article
-     */
-    public function getVisibleByDomainIdAndUuid(int $domainId, string $uuid): Article
-    {
-        return $this->articleRepository->getVisibleByDomainIdAndUuid($domainId, $uuid);
     }
 }

--- a/packages/framework/src/Model/Article/ArticleRepository.php
+++ b/packages/framework/src/Model/Article/ArticleRepository.php
@@ -4,7 +4,6 @@ namespace Shopsys\FrameworkBundle\Model\Article;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
-use Shopsys\FrameworkBundle\Model\Article\Exception\ArticleNotFoundException;
 
 class ArticleRepository
 {
@@ -97,42 +96,6 @@ class ArticleRepository
     }
 
     /**
-     * @param int $domainId
-     * @param string $placement
-     * @param int $limit
-     * @param int $offset
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
-     */
-    public function getVisibleListByDomainIdAndPlacement(
-        int $domainId,
-        string $placement,
-        int $limit,
-        int $offset
-    ): array {
-        $queryBuilder = $this->getVisibleArticlesByDomainIdAndPlacementSortedByPositionQueryBuilder($domainId, $placement)
-            ->setFirstResult($offset)
-            ->setMaxResults($limit);
-
-        return $queryBuilder->getQuery()->execute();
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $placement
-     * @return int
-     */
-    public function getAllVisibleArticlesCountByDomainIdAndPlacement(int $domainId, string $placement): int
-    {
-        $queryBuilder = $this->getArticlesByDomainIdQueryBuilder($domainId)
-            ->select('COUNT(a)')
-            ->andWhere('a.hidden = false')
-            ->andWhere('a.placement = :placement')
-            ->setParameter('placement', $placement);
-
-        return (int)$queryBuilder->getQuery()->getSingleScalarResult();
-    }
-
-    /**
      * @param int $articleId
      * @return \Shopsys\FrameworkBundle\Model\Article\Article
      */
@@ -177,41 +140,6 @@ class ArticleRepository
 
     /**
      * @param int $domainId
-     * @return int
-     */
-    public function getAllVisibleArticlesCountByDomainId($domainId): int
-    {
-        $queryBuilder = $this->getArticlesByDomainIdQueryBuilder($domainId)
-            ->select('COUNT(a)')
-            ->andWhere('a.hidden = false');
-
-        return (int)$queryBuilder->getQuery()->getSingleScalarResult();
-    }
-
-    /**
-     * @param int $domainId
-     * @param int $limit
-     * @param int $offset
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
-     */
-    public function getVisibleListByDomainId(
-        int $domainId,
-        int $limit,
-        int $offset
-    ): array {
-        $queryBuilder = $this->getAllVisibleQueryBuilder()
-            ->andWhere('a.domainId = :domainId')
-            ->setParameter('domainId', $domainId)
-            ->orderBy('a.placement')
-            ->addOrderBy('a.position')
-            ->setFirstResult($offset)
-            ->setMaxResults($limit);
-
-        return $queryBuilder->getQuery()->execute();
-    }
-
-    /**
-     * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
      */
     public function getAllByDomainId($domainId)
@@ -234,26 +162,5 @@ class ArticleRepository
             ->andWhere('a.placement = :placement')->setParameter('placement', $placement)
             ->orderBy('a.position, a.id');
         return $queryBuilder;
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $uuid
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article
-     */
-    public function getVisibleByDomainIdAndUuid(int $domainId, string $uuid): Article
-    {
-        $article = $this->getAllVisibleQueryBuilder()
-            ->andWhere('a.domainId = :domainId')
-            ->setParameter('domainId', $domainId)
-            ->andWhere('a.uuid = :uuid')
-            ->setParameter('uuid', $uuid)
-            ->getQuery()->getOneOrNullResult();
-
-        if ($article === null) {
-            $message = 'Article with UUID \'' . $uuid . '\' not found.';
-            throw new ArticleNotFoundException($message);
-        }
-        return $article;
     }
 }

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -428,29 +428,6 @@ class OrderFacade
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @param int $limit
-     * @param int $offset
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
-     */
-    public function getCustomerUserOrderLimitedList(
-        CustomerUser $customerUser,
-        int $limit,
-        int $offset
-    ): array {
-        return $this->orderRepository->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @return int
-     */
-    public function getCustomerUserOrderCount(CustomerUser $customerUser): int
-    {
-        return $this->orderRepository->getCustomerUserOrderCount($customerUser);
-    }
-
-    /**
      * @param string $email
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
@@ -467,26 +444,6 @@ class OrderFacade
     public function getById($orderId)
     {
         return $this->orderRepository->getById($orderId);
-    }
-
-    /**
-     * @param string $uuid
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order
-     */
-    public function getByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser): Order
-    {
-        return $this->orderRepository->getByUuidAndCustomerUser($uuid, $customerUser);
-    }
-
-    /**
-     * @param string $uuid
-     * @param string $urlHash
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order
-     */
-    public function getByUuidAndUrlHash(string $uuid, string $urlHash): Order
-    {
-        return $this->orderRepository->getByUuidAndUrlHash($uuid, $urlHash);
     }
 
     /**

--- a/packages/framework/src/Model/Order/OrderRepository.php
+++ b/packages/framework/src/Model/Order/OrderRepository.php
@@ -94,34 +94,6 @@ class OrderRepository
     }
 
     /**
-     * @param string $uuid
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order|null
-     */
-    protected function findByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser)
-    {
-        return $this->createOrderQueryBuilder()
-            ->andWhere('o.uuid = :uuid')->setParameter(':uuid', $uuid)
-            ->andWhere('o.customerUser = :customerUser')->setParameter(':customerUser', $customerUser)
-            ->setMaxResults(1)
-            ->getQuery()->getOneOrNullResult();
-    }
-
-    /**
-     * @param string $uuid
-     * @param string $urlHash
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order|null
-     */
-    protected function findByUuidAndUrlHash(string $uuid, string $urlHash)
-    {
-        return $this->createOrderQueryBuilder()
-            ->andWhere('o.uuid = :uuid')->setParameter(':uuid', $uuid)
-            ->andWhere('o.urlHash = :urlHash')->setParameter(':urlHash', $urlHash)
-            ->setMaxResults(1)
-            ->getQuery()->getOneOrNullResult();
-    }
-
-    /**
      * @param int $id
      * @return \Shopsys\FrameworkBundle\Model\Order\Order
      */
@@ -131,44 +103,6 @@ class OrderRepository
 
         if ($order === null) {
             throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException('Order with ID ' . $id . ' not found.');
-        }
-
-        return $order;
-    }
-
-    /**
-     * @param string $uuid
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order
-     */
-    public function getByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser): Order
-    {
-        $order = $this->findByUuidAndCustomerUser($uuid, $customerUser);
-
-        if ($order === null) {
-            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException(sprintf(
-                'Order with UUID \'%s\' not found.',
-                $uuid
-            ));
-        }
-
-        return $order;
-    }
-
-    /**
-     * @param string $uuid
-     * @param string $urlHash
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order
-     */
-    public function getByUuidAndUrlHash(string $uuid, string $urlHash): Order
-    {
-        $order = $this->findByUuidAndUrlHash($uuid, $urlHash);
-
-        if ($order === null) {
-            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException(sprintf(
-                'Order with UUID \'%s\' not found.',
-                $uuid
-            ));
         }
 
         return $order;
@@ -241,40 +175,6 @@ class OrderRepository
             ->orderBy('o.createdAt', 'DESC')
             ->setParameter('customerUser', $customerUser)
             ->getQuery()->execute();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @param int $limit
-     * @param int $offset
-     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
-     */
-    public function getCustomerUserOrderLimitedList(CustomerUser $customerUser, int $limit, int $offset): array
-    {
-        return $this->createOrderQueryBuilder()
-            ->andWhere('o.customerUser = :customerUser')
-            ->setParameter('customerUser', $customerUser)
-            ->orderBy('o.createdAt', 'DESC')
-            ->setFirstResult($offset)
-            ->setMaxResults($limit)
-            ->getQuery()
-            ->execute();
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
-     * @return int
-     */
-    public function getCustomerUserOrderCount(CustomerUser $customerUser): int
-    {
-        return $this->em->createQueryBuilder()
-            ->select('count(o.id)')
-            ->from(Order::class, 'o')
-            ->where('o.deleted = FALSE')
-            ->andWhere('o.customerUser = :customerUser')
-            ->setParameter('customerUser', $customerUser)
-            ->getQuery()
-            ->getSingleScalarResult();
     }
 
     /**

--- a/packages/frontend-api/src/Model/Article/ArticleFacade.php
+++ b/packages/frontend-api/src/Model/Article/ArticleFacade.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Article;
+
+use Shopsys\FrameworkBundle\Model\Article\Article;
+
+class ArticleFacade
+{
+    /**
+     * @var \Shopsys\FrontendApiBundle\Model\Article\ArticleRepository
+     */
+    protected $articleRepository;
+
+    /**
+     * @param \Shopsys\FrontendApiBundle\Model\Article\ArticleRepository $articleRepository
+     */
+    public function __construct(ArticleRepository $articleRepository)
+    {
+        $this->articleRepository = $articleRepository;
+    }
+
+    /**
+     * @param int $domainId
+     * @return int
+     */
+    public function getAllVisibleArticlesCountByDomainId(int $domainId): int
+    {
+        return $this->articleRepository->getAllVisibleArticlesCountByDomainId($domainId);
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $placement
+     * @return int
+     */
+    public function getAllVisibleArticlesCountByDomainIdAndPlacement(int $domainId, string $placement): int
+    {
+        return $this->articleRepository->getAllVisibleArticlesCountByDomainIdAndPlacement($domainId, $placement);
+    }
+
+    /**
+     * @param int $domainId
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
+     */
+    public function getVisibleArticlesListByDomainId(
+        int $domainId,
+        int $limit,
+        int $offset
+    ): array {
+        return $this->articleRepository->getVisibleListByDomainId(
+            $domainId,
+            $limit,
+            $offset
+        );
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $placement
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
+     */
+    public function getVisibleArticlesListByDomainIdAndPlacement(
+        int $domainId,
+        string $placement,
+        int $limit,
+        int $offset
+    ): array {
+        return $this->articleRepository->getVisibleListByDomainIdAndPlacement(
+            $domainId,
+            $placement,
+            $limit,
+            $offset
+        );
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Article\Article
+     */
+    public function getVisibleByDomainIdAndUuid(int $domainId, string $uuid): Article
+    {
+        return $this->articleRepository->getVisibleByDomainIdAndUuid($domainId, $uuid);
+    }
+}

--- a/packages/frontend-api/src/Model/Article/ArticleRepository.php
+++ b/packages/frontend-api/src/Model/Article/ArticleRepository.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Article;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Model\Article\Article;
+use Shopsys\FrameworkBundle\Model\Article\ArticleRepository as FrameworkArticleRepository;
+use Shopsys\FrameworkBundle\Model\Article\Exception\ArticleNotFoundException;
+
+class ArticleRepository
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleRepository
+     */
+    protected $articleRepository;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleRepository $articleRepository
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     */
+    public function __construct(FrameworkArticleRepository $articleRepository, EntityManagerInterface $em)
+    {
+        $this->articleRepository = $articleRepository;
+        $this->em = $em;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $placement
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
+     */
+    public function getVisibleListByDomainIdAndPlacement(
+        int $domainId,
+        string $placement,
+        int $limit,
+        int $offset
+    ): array {
+        $queryBuilder = $this->getVisibleArticlesByDomainIdAndPlacementSortedByPositionQueryBuilder($domainId, $placement)
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        return $queryBuilder->getQuery()->execute();
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $placement
+     * @return \Doctrine\ORM\QueryBuilder
+     * @deprecated This method will be removed in next major version. It will be replaced by \Shopsys\FrameworkBundle\Model\Article\ArticleRepository::getVisibleArticlesByDomainIdAndPlacementSortedByPositionQueryBuilder() which will change its visibility to public.
+     */
+    protected function getVisibleArticlesByDomainIdAndPlacementSortedByPositionQueryBuilder(
+        int $domainId,
+        string $placement
+    ): QueryBuilder {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. It will be replaced by \Shopsys\FrameworkBundle\Model\Article\ArticleRepository::getVisibleArticlesByDomainIdAndPlacementSortedByPositionQueryBuilder() which will change its visibility to public.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        $queryBuilder = $this->articleRepository->getVisibleArticlesByDomainIdQueryBuilder($domainId)
+            ->andWhere('a.placement = :placement')->setParameter('placement', $placement)
+            ->orderBy('a.position, a.id');
+        return $queryBuilder;
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $placement
+     * @return int
+     */
+    public function getAllVisibleArticlesCountByDomainIdAndPlacement(int $domainId, string $placement): int
+    {
+        $queryBuilder = $this->getArticlesByDomainIdQueryBuilder($domainId)
+            ->select('COUNT(a)')
+            ->andWhere('a.hidden = false')
+            ->andWhere('a.placement = :placement')
+            ->setParameter('placement', $placement);
+
+        return (int)$queryBuilder->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param int $domainId
+     * @return \Doctrine\ORM\QueryBuilder
+     * @deprecated This method will be removed in next major version. It will be replaced by \Shopsys\FrameworkBundle\Model\Article\ArticleRepository::getArticlesByDomainIdQueryBuilder() which will change its visibility to public.
+     */
+    protected function getArticlesByDomainIdQueryBuilder($domainId)
+    {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. It will be replaced by \Shopsys\FrameworkBundle\Model\Article\ArticleRepository::getArticlesByDomainIdQueryBuilder() which will change its visibility to public.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return $this->em->createQueryBuilder()
+            ->select('a')
+            ->from(Article::class, 'a')
+            ->where('a.domainId = :domainId')->setParameter('domainId', $domainId);
+    }
+
+    /**
+     * @param int $domainId
+     * @return int
+     */
+    public function getAllVisibleArticlesCountByDomainId($domainId): int
+    {
+        $queryBuilder = $this->getArticlesByDomainIdQueryBuilder($domainId)
+            ->select('COUNT(a)')
+            ->andWhere('a.hidden = false');
+
+        return (int)$queryBuilder->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param int $domainId
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Article\Article[]
+     */
+    public function getVisibleListByDomainId(
+        int $domainId,
+        int $limit,
+        int $offset
+    ): array {
+        $queryBuilder = $this->getAllVisibleQueryBuilder()
+            ->andWhere('a.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
+            ->orderBy('a.placement')
+            ->addOrderBy('a.position')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        return $queryBuilder->getQuery()->execute();
+    }
+
+    /**
+     * @return \Doctrine\ORM\QueryBuilder
+     * @deprecated This method will be removed in next major version. It will be replaced by \Shopsys\FrameworkBundle\Model\Article\ArticleRepository::getAllVisibleQueryBuilder() which will change its visibility to public.
+     */
+    protected function getAllVisibleQueryBuilder()
+    {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. It will be replaced by \Shopsys\FrameworkBundle\Model\Article\ArticleRepository::getAllVisibleQueryBuilder() which will change its visibility to public.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return $this->em->createQueryBuilder()
+            ->select('a')
+            ->from(Article::class, 'a')
+            ->where('a.hidden = false');
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $uuid
+     * @return \Shopsys\FrameworkBundle\Model\Article\Article
+     */
+    public function getVisibleByDomainIdAndUuid(int $domainId, string $uuid): Article
+    {
+        $article = $this->getAllVisibleQueryBuilder()
+            ->andWhere('a.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
+            ->andWhere('a.uuid = :uuid')
+            ->setParameter('uuid', $uuid)
+            ->getQuery()->getOneOrNullResult();
+
+        if ($article === null) {
+            $message = 'Article with UUID \'' . $uuid . '\' not found.';
+            throw new ArticleNotFoundException($message);
+        }
+        return $article;
+    }
+}

--- a/packages/frontend-api/src/Model/Order/OrderFacade.php
+++ b/packages/frontend-api/src/Model/Order/OrderFacade.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Order;
+
+use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
+use Shopsys\FrameworkBundle\Model\Order\Order;
+
+class OrderFacade
+{
+    /**
+     * @var \Shopsys\FrontendApiBundle\Model\Order\OrderRepository
+     */
+    protected $orderRepository;
+
+    /**
+     * @param \Shopsys\FrontendApiBundle\Model\Order\OrderRepository $orderRepository
+     */
+    public function __construct(OrderRepository $orderRepository)
+    {
+        $this->orderRepository = $orderRepository;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
+     */
+    public function getCustomerUserOrderLimitedList(
+        CustomerUser $customerUser,
+        int $limit,
+        int $offset
+    ): array {
+        return $this->orderRepository->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return int
+     */
+    public function getCustomerUserOrderCount(CustomerUser $customerUser): int
+    {
+        return $this->orderRepository->getCustomerUserOrderCount($customerUser);
+    }
+
+    /**
+     * @param string $uuid
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function getByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser): Order
+    {
+        return $this->orderRepository->getByUuidAndCustomerUser($uuid, $customerUser);
+    }
+}

--- a/packages/frontend-api/src/Model/Order/OrderRepository.php
+++ b/packages/frontend-api/src/Model/Order/OrderRepository.php
@@ -25,6 +25,7 @@ class OrderRepository
 
     /**
      * @return \Doctrine\ORM\QueryBuilder
+     * @internal This will be replaced by \Shopsys\FrameworkBundle\Model\Order::getOrderRepository() with visibility set to public
      */
     protected function createOrderQueryBuilder()
     {

--- a/packages/frontend-api/src/Model/Order/OrderRepository.php
+++ b/packages/frontend-api/src/Model/Order/OrderRepository.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Order;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
+use Shopsys\FrameworkBundle\Model\Order\Order;
+
+class OrderRepository
+{
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $em;
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager
+     */
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->em = $entityManager;
+    }
+
+    /**
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    protected function createOrderQueryBuilder()
+    {
+        return $this->em->createQueryBuilder()
+            ->select('o')
+            ->from(Order::class, 'o')
+            ->where('o.deleted = FALSE');
+    }
+
+    /**
+     * @param string $uuid
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order|null
+     */
+    protected function findByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser)
+    {
+        return $this->createOrderQueryBuilder()
+            ->andWhere('o.uuid = :uuid')->setParameter(':uuid', $uuid)
+            ->andWhere('o.customerUser = :customerUser')->setParameter(':customerUser', $customerUser)
+            ->setMaxResults(1)
+            ->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @param string $uuid
+     * @param string $urlHash
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order|null
+     */
+    protected function findByUuidAndUrlHash(string $uuid, string $urlHash)
+    {
+        return $this->createOrderQueryBuilder()
+            ->andWhere('o.uuid = :uuid')->setParameter(':uuid', $uuid)
+            ->andWhere('o.urlHash = :urlHash')->setParameter(':urlHash', $urlHash)
+            ->setMaxResults(1)
+            ->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * @param string $uuid
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order
+     */
+    public function getByUuidAndCustomerUser(string $uuid, CustomerUser $customerUser): Order
+    {
+        $order = $this->findByUuidAndCustomerUser($uuid, $customerUser);
+
+        if ($order === null) {
+            throw new \Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException(sprintf(
+                'Order with UUID \'%s\' not found.',
+                $uuid
+            ));
+        }
+
+        return $order;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @param int $limit
+     * @param int $offset
+     * @return \Shopsys\FrameworkBundle\Model\Order\Order[]
+     */
+    public function getCustomerUserOrderLimitedList(CustomerUser $customerUser, int $limit, int $offset): array
+    {
+        return $this->createOrderQueryBuilder()
+            ->andWhere('o.customerUser = :customerUser')
+            ->setParameter('customerUser', $customerUser)
+            ->orderBy('o.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @return int
+     */
+    public function getCustomerUserOrderCount(CustomerUser $customerUser): int
+    {
+        return $this->em->createQueryBuilder()
+            ->select('count(o.id)')
+            ->from(Order::class, 'o')
+            ->where('o.deleted = FALSE')
+            ->andWhere('o.customerUser = :customerUser')
+            ->setParameter('customerUser', $customerUser)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+}

--- a/packages/frontend-api/src/Model/Resolver/Article/ArticleResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticleResolver.php
@@ -10,15 +10,15 @@ use Overblog\GraphQLBundle\Error\UserError;
 use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Article\Article;
-use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
 use Shopsys\FrameworkBundle\Model\Article\Exception\ArticleNotFoundException;
 use Shopsys\FrameworkBundle\Model\Cookies\CookiesFacade;
 use Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade;
+use Shopsys\FrontendApiBundle\Model\Article\ArticleFacade;
 
 class ArticleResolver implements ResolverInterface, AliasedInterface
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade
+     * @var \Shopsys\FrontendApiBundle\Model\Article\ArticleFacade
      */
     protected $articleFacade;
 
@@ -38,7 +38,7 @@ class ArticleResolver implements ResolverInterface, AliasedInterface
     protected $cookiesFacade;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
+     * @param \Shopsys\FrontendApiBundle\Model\Article\ArticleFacade $articleFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Model\Cookies\CookiesFacade $cookiesFacade

--- a/packages/frontend-api/src/Model/Resolver/Article/ArticlesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticlesResolver.php
@@ -10,14 +10,14 @@ use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
+use Shopsys\FrontendApiBundle\Model\Article\ArticleFacade;
 
 class ArticlesResolver implements ResolverInterface, AliasedInterface
 {
     protected const DEFAULT_FIRST_LIMIT = 10;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Article\ArticleFacade
+     * @var \Shopsys\FrontendApiBundle\Model\Article\ArticleFacade
      */
     protected $articleFacade;
 
@@ -32,7 +32,7 @@ class ArticlesResolver implements ResolverInterface, AliasedInterface
     protected $connectionBuilder;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Article\ArticleFacade $articleFacade
+     * @param \Shopsys\FrontendApiBundle\Model\Article\ArticleFacade $articleFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(ArticleFacade $articleFacade, Domain $domain)

--- a/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Order\Exception\OrderNotFoundException;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+use Shopsys\FrontendApiBundle\Model\Order\OrderFacade as FrontendApiOrderFacade;
 
 class OrderResolver implements ResolverInterface, AliasedInterface
 {
@@ -33,18 +34,26 @@ class OrderResolver implements ResolverInterface, AliasedInterface
     protected $domain;
 
     /**
+     * @var \Shopsys\FrontendApiBundle\Model\Order\OrderFacade
+     */
+    protected $frontendApiOrderFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrontendApiBundle\Model\Order\OrderFacade $frontendApiOrderFacade
      */
     public function __construct(
         CurrentCustomerUser $currentCustomerUser,
         OrderFacade $orderFacade,
-        Domain $domain
+        Domain $domain,
+        FrontendApiOrderFacade $frontendApiOrderFacade
     ) {
         $this->orderFacade = $orderFacade;
         $this->currentCustomerUser = $currentCustomerUser;
         $this->domain = $domain;
+        $this->frontendApiOrderFacade = $frontendApiOrderFacade;
     }
 
     /**
@@ -92,6 +101,6 @@ class OrderResolver implements ResolverInterface, AliasedInterface
             throw new UserError('Provided argument \'uuid\' is not valid.');
         }
 
-        return $this->orderFacade->getByUuidAndCustomerUser($uuid, $customerUser);
+        return $this->frontendApiOrderFacade->getByUuidAndCustomerUser($uuid, $customerUser);
     }
 }

--- a/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
@@ -12,6 +12,7 @@ use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
+use Shopsys\FrontendApiBundle\Model\Order\OrderFacade as FrontendApiOrderFacade;
 
 class OrdersResolver implements ResolverInterface, AliasedInterface
 {
@@ -33,14 +34,24 @@ class OrdersResolver implements ResolverInterface, AliasedInterface
     protected $connectionBuilder;
 
     /**
+     * @var \Shopsys\FrontendApiBundle\Model\Order\OrderFacade
+     */
+    protected $frontendApiOrderFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
+     * @param \Shopsys\FrontendApiBundle\Model\Order\OrderFacade $frontendApiOrderFacade
      */
-    public function __construct(CurrentCustomerUser $currentCustomerUser, OrderFacade $orderFacade)
-    {
+    public function __construct(
+        CurrentCustomerUser $currentCustomerUser,
+        OrderFacade $orderFacade,
+        FrontendApiOrderFacade $frontendApiOrderFacade
+    ) {
         $this->currentCustomerUser = $currentCustomerUser;
         $this->orderFacade = $orderFacade;
         $this->connectionBuilder = new ConnectionBuilder();
+        $this->frontendApiOrderFacade = $frontendApiOrderFacade;
     }
 
     /**
@@ -57,10 +68,10 @@ class OrdersResolver implements ResolverInterface, AliasedInterface
         }
 
         $paginator = new Paginator(function ($offset, $limit) use ($customerUser) {
-            return $this->orderFacade->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
+            return $this->frontendApiOrderFacade->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
         });
 
-        return $paginator->auto($argument, $this->orderFacade->getCustomerUserOrderCount($customerUser));
+        return $paginator->auto($argument, $this->frontendApiOrderFacade->getCustomerUserOrderCount($customerUser));
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
@@ -11,8 +11,7 @@ use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
-use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
-use Shopsys\FrontendApiBundle\Model\Order\OrderFacade as FrontendApiOrderFacade;
+use Shopsys\FrontendApiBundle\Model\Order\OrderFacade;
 
 class OrdersResolver implements ResolverInterface, AliasedInterface
 {
@@ -24,7 +23,7 @@ class OrdersResolver implements ResolverInterface, AliasedInterface
     protected $currentCustomerUser;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
+     * @var \Shopsys\FrontendApiBundle\Model\Order\OrderFacade
      */
     protected $orderFacade;
 
@@ -34,24 +33,16 @@ class OrdersResolver implements ResolverInterface, AliasedInterface
     protected $connectionBuilder;
 
     /**
-     * @var \Shopsys\FrontendApiBundle\Model\Order\OrderFacade
-     */
-    protected $frontendApiOrderFacade;
-
-    /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
-     * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
-     * @param \Shopsys\FrontendApiBundle\Model\Order\OrderFacade $frontendApiOrderFacade
+     * @param \Shopsys\FrontendApiBundle\Model\Order\OrderFacade $orderFacade
      */
     public function __construct(
         CurrentCustomerUser $currentCustomerUser,
-        OrderFacade $orderFacade,
-        FrontendApiOrderFacade $frontendApiOrderFacade
+        OrderFacade $orderFacade
     ) {
         $this->currentCustomerUser = $currentCustomerUser;
         $this->orderFacade = $orderFacade;
         $this->connectionBuilder = new ConnectionBuilder();
-        $this->frontendApiOrderFacade = $frontendApiOrderFacade;
     }
 
     /**
@@ -68,10 +59,10 @@ class OrdersResolver implements ResolverInterface, AliasedInterface
         }
 
         $paginator = new Paginator(function ($offset, $limit) use ($customerUser) {
-            return $this->frontendApiOrderFacade->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
+            return $this->orderFacade->getCustomerUserOrderLimitedList($customerUser, $limit, $offset);
         });
 
-        return $paginator->auto($argument, $this->frontendApiOrderFacade->getCustomerUserOrderCount($customerUser));
+        return $paginator->auto($argument, $this->orderFacade->getCustomerUserOrderCount($customerUser));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When working on FE API we have added some methods to framework classes that should not be there. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
