### PR TITLE
[framework] move creation of FilterQuery from facade to factory

### DIFF
--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -215,7 +215,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     ): ProductFilterCountData {
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInCategory(
             $productFilterData,
-            $this->filterQueryFactory->createListableProductsByCategoryWithPriceAndStockFilter($categoryId, $productFilterData)
+            $this->filterQueryFactory->createListableProductsByCategoryIdWithPriceAndStockFilter($categoryId, $productFilterData)
         );
     }
 

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -54,6 +54,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
+     * @deprecated This property will be removed in next major version.
      */
     protected $productFilterDataToQueryTransformer;
 
@@ -63,7 +64,8 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     protected $filterQueryFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader|null
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader
+     * @deprecated This property will be removed in next major version.
      */
     protected $indexDefinitionLoader;
 
@@ -74,9 +76,9 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository $productAccessoryRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterCountDataElasticsearchRepository $productFilterCountDataElasticsearchRepository
-     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer|null $productFilterDataToQueryTransformer
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory
-     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader|null $indexDefinitionLoader
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
      */
     public function __construct(
         ProductRepository $productRepository,
@@ -85,9 +87,9 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         ProductAccessoryRepository $productAccessoryRepository,
         ProductElasticsearchRepository $productElasticsearchRepository,
         ProductFilterCountDataElasticsearchRepository $productFilterCountDataElasticsearchRepository,
-        ?ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer,
+        ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer,
         FilterQueryFactory $filterQueryFactory,
-        ?IndexDefinitionLoader $indexDefinitionLoader = null
+        IndexDefinitionLoader $indexDefinitionLoader
     ) {
         $this->productRepository = $productRepository;
         $this->domain = $domain;

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -148,7 +148,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         int $categoryId
     ): PaginationResult {
-        $filterQuery = $this->filterQueryFactory->createListableProductsInCategory($productFilterData, $orderingModeId, $page, $limit, $categoryId);
+        $filterQuery = $this->filterQueryFactory->createListableProductsByCategoryId($productFilterData, $orderingModeId, $page, $limit, $categoryId);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
@@ -162,7 +162,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     {
         $emptyProductFilterData = new ProductFilterData();
 
-        $filterQuery = $this->filterQueryFactory->createListableProductsForBrand($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
+        $filterQuery = $this->filterQueryFactory->createListableProductsByBrandId($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
@@ -179,7 +179,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $page,
         int $limit
     ): PaginationResult {
-        $filterQuery = $this->filterQueryFactory->createListableProductsForSearchText($productFilterData, $orderingModeId, $page, $limit, $searchText);
+        $filterQuery = $this->filterQueryFactory->createListableProductsBySearchText($productFilterData, $orderingModeId, $page, $limit, $searchText);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
@@ -191,10 +191,12 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     public function getSearchAutocompleteProducts(?string $searchText, int $limit): PaginationResult
     {
+        $searchText = $searchText ?? '';
+
         $emptyProductFilterData = new ProductFilterData();
         $page = 1;
 
-        $filterQuery = $this->filterQueryFactory->createListableProductsForSearchText($emptyProductFilterData, ProductListOrderingConfig::ORDER_BY_RELEVANCE, $page, $limit, $searchText);
+        $filterQuery = $this->filterQueryFactory->createListableProductsBySearchText($emptyProductFilterData, ProductListOrderingConfig::ORDER_BY_RELEVANCE, $page, $limit, $searchText);
 
         $productIds = $this->productElasticsearchRepository->getSortedProductIdsByFilterQuery($filterQuery);
 
@@ -213,7 +215,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     ): ProductFilterCountData {
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInCategory(
             $productFilterData,
-            $this->filterQueryFactory->createProductFilterCount($categoryId, $productFilterData)
+            $this->filterQueryFactory->createListableProductsByCategoryWithPriceAndStockFilter($categoryId, $productFilterData)
         );
     }
 
@@ -229,7 +231,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
 
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInSearch(
             $productFilterData,
-            $this->filterQueryFactory->createProductSearchCount($searchText, $productFilterData)
+            $this->filterQueryFactory->createListableProductsBySearchTextWithPriceAndStockFilter($searchText, $productFilterData)
         );
     }
 
@@ -258,7 +260,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     public function getProductsCountOnCurrentDomain(): int
     {
-        $filterQuery = $this->filterQueryFactory->createSellableAndVisible();
+        $filterQuery = $this->filterQueryFactory->createListable();
 
         return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
     }
@@ -273,7 +275,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
     {
         $emptyProductFilterData = new ProductFilterData();
-        $filterQuery = $this->filterQueryFactory->createListableProductsInCategory(
+        $filterQuery = $this->filterQueryFactory->createListableProductsByCategoryId(
             $emptyProductFilterData,
             $orderingModeId,
             1,
@@ -292,7 +294,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsInCategory() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsByCategoryId() instead.
      */
     protected function createListableProductsInCategoryFilterQuery(
         ProductFilterData $productFilterData,
@@ -301,7 +303,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         int $categoryId
     ): FilterQuery {
-        return $this->filterQueryFactory->createListableProductsInCategory($productFilterData, $orderingModeId, $page, $limit, $categoryId);
+        return $this->filterQueryFactory->createListableProductsByCategoryId($productFilterData, $orderingModeId, $page, $limit, $categoryId);
     }
 
     /**
@@ -311,7 +313,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsForBrand() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsByBrandId() instead.
      */
     protected function createListableProductsForBrandFilterQuery(
         ProductFilterData $productFilterData,
@@ -320,7 +322,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         int $brandId
     ): FilterQuery {
-        return $this->filterQueryFactory->createListableProductsForBrand($productFilterData, $orderingModeId, $page, $limit, $brandId);
+        return $this->filterQueryFactory->createListableProductsByBrandId($productFilterData, $orderingModeId, $page, $limit, $brandId);
     }
 
     /**
@@ -330,7 +332,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param string|null $searchText
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsForSearchText() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsBySearchText() instead.
      */
     protected function createListableProductsForSearchTextFilterQuery(
         ProductFilterData $productFilterData,
@@ -339,7 +341,9 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         ?string $searchText
     ): FilterQuery {
-        return $this->filterQueryFactory->createListableProductsForSearchText($productFilterData, $orderingModeId, $page, $limit, $searchText);
+        $searchText = $searchText ?? '';
+
+        return $this->filterQueryFactory->createListableProductsBySearchText($productFilterData, $orderingModeId, $page, $limit, $searchText);
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -54,7 +54,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
-     * @deprecated This property will be removed in next major version.
+     * @deprecated this property will be removed in next major version
      */
     protected $productFilterDataToQueryTransformer;
 
@@ -65,7 +65,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader
-     * @deprecated This property will be removed in next major version.
+     * @deprecated this property will be removed in next major version
      */
     protected $indexDefinitionLoader;
 
@@ -148,7 +148,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         int $categoryId
     ): PaginationResult {
-        $filterQuery = $this->filterQueryFactory->createListableProductsInCategoryFilterQuery($productFilterData, $orderingModeId, $page, $limit, $categoryId);
+        $filterQuery = $this->filterQueryFactory->createListableProductsInCategory($productFilterData, $orderingModeId, $page, $limit, $categoryId);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
@@ -162,7 +162,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     {
         $emptyProductFilterData = new ProductFilterData();
 
-        $filterQuery = $this->filterQueryFactory->createListableProductsForBrandFilterQuery($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
+        $filterQuery = $this->filterQueryFactory->createListableProductsForBrand($emptyProductFilterData, $orderingModeId, $page, $limit, $brandId);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
@@ -179,7 +179,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $page,
         int $limit
     ): PaginationResult {
-        $filterQuery = $this->filterQueryFactory->createListableProductsForSearchTextFilterQuery($productFilterData, $orderingModeId, $page, $limit, $searchText);
+        $filterQuery = $this->filterQueryFactory->createListableProductsForSearchText($productFilterData, $orderingModeId, $page, $limit, $searchText);
 
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
 
@@ -194,7 +194,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         $emptyProductFilterData = new ProductFilterData();
         $page = 1;
 
-        $filterQuery = $this->filterQueryFactory->createListableProductsForSearchTextFilterQuery($emptyProductFilterData, ProductListOrderingConfig::ORDER_BY_RELEVANCE, $page, $limit, $searchText);
+        $filterQuery = $this->filterQueryFactory->createListableProductsForSearchText($emptyProductFilterData, ProductListOrderingConfig::ORDER_BY_RELEVANCE, $page, $limit, $searchText);
 
         $productIds = $this->productElasticsearchRepository->getSortedProductIdsByFilterQuery($filterQuery);
 
@@ -213,7 +213,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     ): ProductFilterCountData {
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInCategory(
             $productFilterData,
-            $this->filterQueryFactory->createProductFilterCountFilterQuery($categoryId, $productFilterData)
+            $this->filterQueryFactory->createProductFilterCount($categoryId, $productFilterData)
         );
     }
 
@@ -229,7 +229,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
 
         return $this->productFilterCountDataElasticsearchRepository->getProductFilterCountDataInSearch(
             $productFilterData,
-            $this->filterQueryFactory->createProductSearchCountFilterQuery($searchText, $productFilterData)
+            $this->filterQueryFactory->createProductSearchCount($searchText, $productFilterData)
         );
     }
 
@@ -242,7 +242,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
     {
         $emptyProductFilterData = new ProductFilterData();
-        $filterQuery = $this->filterQueryFactory->createFilterQueryWithProductFilterData(
+        $filterQuery = $this->filterQueryFactory->createWithProductFilterData(
             $emptyProductFilterData,
             $orderingModeId,
             1,
@@ -258,7 +258,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      */
     public function getProductsCountOnCurrentDomain(): int
     {
-        $filterQuery = $this->filterQueryFactory->createSellableAndVisibleFilterQuery();
+        $filterQuery = $this->filterQueryFactory->createSellableAndVisible();
 
         return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
     }
@@ -273,7 +273,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
     {
         $emptyProductFilterData = new ProductFilterData();
-        $filterQuery = $this->filterQueryFactory->createListableProductsInCategoryFilterQuery(
+        $filterQuery = $this->filterQueryFactory->createListableProductsInCategory(
             $emptyProductFilterData,
             $orderingModeId,
             1,
@@ -292,7 +292,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsInCategoryFilterQuery() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsInCategory() instead.
      */
     protected function createListableProductsInCategoryFilterQuery(
         ProductFilterData $productFilterData,
@@ -301,7 +301,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         int $categoryId
     ): FilterQuery {
-        return $this->filterQueryFactory->createListableProductsInCategoryFilterQuery($productFilterData, $orderingModeId, $page, $limit, $categoryId);
+        return $this->filterQueryFactory->createListableProductsInCategory($productFilterData, $orderingModeId, $page, $limit, $categoryId);
     }
 
     /**
@@ -311,7 +311,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsForBrandFilterQuery() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsForBrand() instead.
      */
     protected function createListableProductsForBrandFilterQuery(
         ProductFilterData $productFilterData,
@@ -320,7 +320,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         int $brandId
     ): FilterQuery {
-        return $this->filterQueryFactory->createListableProductsForBrandFilterQuery($productFilterData, $orderingModeId, $page, $limit, $brandId);
+        return $this->filterQueryFactory->createListableProductsForBrand($productFilterData, $orderingModeId, $page, $limit, $brandId);
     }
 
     /**
@@ -330,7 +330,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param string|null $searchText
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsForSearchTextFilterQuery() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsForSearchText() instead.
      */
     protected function createListableProductsForSearchTextFilterQuery(
         ProductFilterData $productFilterData,
@@ -339,7 +339,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $limit,
         ?string $searchText
     ): FilterQuery {
-        return $this->filterQueryFactory->createListableProductsForSearchTextFilterQuery($productFilterData, $orderingModeId, $page, $limit, $searchText);
+        return $this->filterQueryFactory->createListableProductsForSearchText($productFilterData, $orderingModeId, $page, $limit, $searchText);
     }
 
     /**
@@ -348,7 +348,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $page
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createFilterQueryWithProductFilterData() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createWithProductFilterData() instead.
      */
     protected function createFilterQueryWithProductFilterData(
         ProductFilterData $productFilterData,
@@ -356,7 +356,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
         int $page,
         int $limit
     ): FilterQuery {
-        return $this->filterQueryFactory->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit);
+        return $this->filterQueryFactory->createWithProductFilterData($productFilterData, $orderingModeId, $page, $limit);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -173,8 +173,8 @@ class FilterQueryFactory
      */
     public function createProductFilterCount(int $categoryId, ProductFilterData $productFilterData): FilterQuery
     {
-        $filterQuery = $this->createSellableAndVisible();
-        $filterQuery->filterByCategory([$categoryId]);
+        $filterQuery = $this->createSellableAndVisible()
+            ->filterByCategory([$categoryId]);
         $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
 
         return $filterQuery;
@@ -187,8 +187,8 @@ class FilterQueryFactory
      */
     public function createProductSearchCount(string $searchText, ProductFilterData $productFilterData): FilterQuery
     {
-        $filterQuery = $this->createSellableAndVisible();
-        $filterQuery->search($searchText);
+        $filterQuery = $this->createSellableAndVisible()
+            ->search($searchText);
         $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
 
         return $filterQuery;

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -67,14 +67,14 @@ class FilterQueryFactory
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsInCategoryFilterQuery(
+    public function createListableProductsInCategory(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
         int $limit,
         int $categoryId
     ): FilterQuery {
-        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+        return $this->createWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->filterByCategory([$categoryId]);
     }
 
@@ -85,13 +85,13 @@ class FilterQueryFactory
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createFilterQueryWithProductFilterData(
+    public function createWithProductFilterData(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
         int $limit
     ): FilterQuery {
-        $filterQuery = $this->createSellableAndVisibleFilterQuery()
+        $filterQuery = $this->createSellableAndVisible()
             ->setPage($page)
             ->setLimit($limit)
             ->applyOrdering($orderingModeId, $this->currentCustomerUser->getPricingGroup());
@@ -113,14 +113,14 @@ class FilterQueryFactory
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsForBrandFilterQuery(
+    public function createListableProductsForBrand(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
         int $limit,
         int $brandId
     ): FilterQuery {
-        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+        return $this->createWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->filterByBrands([$brandId]);
     }
 
@@ -132,7 +132,7 @@ class FilterQueryFactory
      * @param string|null $searchText
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsForSearchTextFilterQuery(
+    public function createListableProductsForSearchText(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
@@ -141,7 +141,7 @@ class FilterQueryFactory
     ): FilterQuery {
         $searchText = $searchText ?? '';
 
-        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+        return $this->createWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->search($searchText);
     }
 
@@ -159,7 +159,7 @@ class FilterQueryFactory
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createSellableAndVisibleFilterQuery(): FilterQuery
+    public function createSellableAndVisible(): FilterQuery
     {
         return $this->create($this->getIndexName())
             ->filterOnlySellable()
@@ -171,9 +171,9 @@ class FilterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createProductFilterCountFilterQuery(int $categoryId, ProductFilterData $productFilterData): FilterQuery
+    public function createProductFilterCount(int $categoryId, ProductFilterData $productFilterData): FilterQuery
     {
-        $filterQuery = $this->createSellableAndVisibleFilterQuery();
+        $filterQuery = $this->createSellableAndVisible();
         $filterQuery->filterByCategory([$categoryId]);
         $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
 
@@ -185,9 +185,9 @@ class FilterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createProductSearchCountFilterQuery(string $searchText, ProductFilterData $productFilterData): FilterQuery
+    public function createProductSearchCount(string $searchText, ProductFilterData $productFilterData): FilterQuery
     {
-        $filterQuery = $this->createSellableAndVisibleFilterQuery();
+        $filterQuery = $this->createSellableAndVisible();
         $filterQuery->search($searchText);
         $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
 

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -67,7 +67,7 @@ class FilterQueryFactory
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsInCategory(
+    public function createListableProductsByCategoryId(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
@@ -91,7 +91,7 @@ class FilterQueryFactory
         int $page,
         int $limit
     ): FilterQuery {
-        $filterQuery = $this->createSellableAndVisible()
+        $filterQuery = $this->createListable()
             ->setPage($page)
             ->setLimit($limit)
             ->applyOrdering($orderingModeId, $this->currentCustomerUser->getPricingGroup());
@@ -113,7 +113,7 @@ class FilterQueryFactory
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsForBrand(
+    public function createListableProductsByBrandId(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
@@ -129,24 +129,23 @@ class FilterQueryFactory
      * @param string $orderingModeId
      * @param int $page
      * @param int $limit
-     * @param string|null $searchText
+     * @param string $searchText
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsForSearchText(
+    public function createListableProductsBySearchText(
         ProductFilterData $productFilterData,
         string $orderingModeId,
         int $page,
         int $limit,
-        ?string $searchText
+        string $searchText
     ): FilterQuery {
-        $searchText = $searchText ?? '';
-
         return $this->createWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
             ->search($searchText);
     }
 
     /**
      * @return string
+     * @internal visibility of this method will be changed to protected in next major version
      */
     public function getIndexName(): string
     {
@@ -159,7 +158,7 @@ class FilterQueryFactory
     /**
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createSellableAndVisible(): FilterQuery
+    public function createListable(): FilterQuery
     {
         return $this->create($this->getIndexName())
             ->filterOnlySellable()
@@ -171,9 +170,9 @@ class FilterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createProductFilterCount(int $categoryId, ProductFilterData $productFilterData): FilterQuery
+    public function createListableProductsByCategoryWithPriceAndStockFilter(int $categoryId, ProductFilterData $productFilterData): FilterQuery
     {
-        $filterQuery = $this->createSellableAndVisible()
+        $filterQuery = $this->createListable()
             ->filterByCategory([$categoryId]);
         $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
 
@@ -185,9 +184,9 @@ class FilterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createProductSearchCount(string $searchText, ProductFilterData $productFilterData): FilterQuery
+    public function createListableProductsBySearchTextWithPriceAndStockFilter(string $searchText, ProductFilterData $productFilterData): FilterQuery
     {
-        $filterQuery = $this->createSellableAndVisible()
+        $filterQuery = $this->createListable()
             ->search($searchText);
         $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
 

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -4,8 +4,60 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Search;
 
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
+use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+
 class FilterQueryFactory
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
+     */
+    protected $filterQueryFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
+     */
+    protected $productFilterDataToQueryTransformer;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser
+     */
+    protected $currentCustomerUser;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader
+     */
+    protected $indexDefinitionLoader;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(
+        FilterQueryFactory $filterQueryFactory,
+        ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer,
+        CurrentCustomerUser $currentCustomerUser,
+        IndexDefinitionLoader $indexDefinitionLoader,
+        Domain $domain
+    ) {
+        $this->filterQueryFactory = $filterQueryFactory;
+        $this->productFilterDataToQueryTransformer = $productFilterDataToQueryTransformer;
+        $this->currentCustomerUser = $currentCustomerUser;
+        $this->indexDefinitionLoader = $indexDefinitionLoader;
+        $this->domain = $domain;
+    }
+
     /**
      * @param string $indexName
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
@@ -13,5 +65,153 @@ class FilterQueryFactory
     public function create(string $indexName): FilterQuery
     {
         return new FilterQuery($indexName);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param int $categoryId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createListableProductsInCategoryFilterQuery(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $categoryId
+    ): FilterQuery {
+        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+            ->filterByCategory([$categoryId]);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createFilterQueryWithProductFilterData(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit
+    ): FilterQuery {
+        $filterQuery = $this->createSellableAndVisibleFilterQuery()
+            ->setPage($page)
+            ->setLimit($limit)
+            ->applyOrdering($orderingModeId, $this->currentCustomerUser->getPricingGroup());
+
+        $filterQuery = $this->productFilterDataToQueryTransformer->addBrandsToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addFlagsToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addParametersToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $filterQuery);
+        $filterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $filterQuery, $this->currentCustomerUser->getPricingGroup());
+
+        return $filterQuery;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param int $brandId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createListableProductsForBrandFilterQuery(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        int $brandId
+    ): FilterQuery {
+        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+            ->filterByBrands([$brandId]);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param string $orderingModeId
+     * @param int $page
+     * @param int $limit
+     * @param string|null $searchText
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createListableProductsForSearchTextFilterQuery(
+        ProductFilterData $productFilterData,
+        string $orderingModeId,
+        int $page,
+        int $limit,
+        ?string $searchText
+    ): FilterQuery {
+        $searchText = $searchText ?? '';
+
+        return $this->createFilterQueryWithProductFilterData($productFilterData, $orderingModeId, $page, $limit)
+            ->search($searchText);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIndexName(): string
+    {
+        return $this->indexDefinitionLoader->getIndexDefinition(
+            ProductIndex::getName(),
+            $this->domain->getId()
+        )->getIndexAlias();
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createSellableAndVisibleFilterQuery(): FilterQuery
+    {
+        return $this->filterQueryFactory->create($this->getIndexName())
+            ->filterOnlySellable()
+            ->filterOnlyVisible($this->currentCustomerUser->getPricingGroup());
+    }
+
+    /**
+     * @param int $categoryId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createProductFilterCountFilterQuery(int $categoryId, ProductFilterData $productFilterData): FilterQuery
+    {
+        $filterQuery = $this->createSellableAndVisibleFilterQuery();
+        $filterQuery->filterByCategory([$categoryId]);
+        $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
+
+        return $filterQuery;
+    }
+
+    /**
+     * @param string|null $searchText
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createProductSearchCountFilterQuery(?string $searchText, ProductFilterData $productFilterData): FilterQuery
+    {
+        $filterQuery = $this->createSellableAndVisibleFilterQuery();
+        $filterQuery->search($searchText);
+        $filterQuery = $this->addPricesAndStockFromFilterDataToQuery($productFilterData, $filterQuery);
+
+        return $filterQuery;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function addPricesAndStockFromFilterDataToQuery(ProductFilterData $productFilterData, FilterQuery $filterQuery): FilterQuery
+    {
+        $filterQuery = $this->productFilterDataToQueryTransformer->addPricesToQuery($productFilterData, $filterQuery, $this->currentCustomerUser->getPricingGroup());
+        $filterQuery = $this->productFilterDataToQueryTransformer->addStockToQuery($productFilterData, $filterQuery);
+
+        return $filterQuery;
     }
 }

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -13,11 +13,6 @@ use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 class FilterQueryFactory
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
-     */
-    protected $filterQueryFactory;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer
      */
     protected $productFilterDataToQueryTransformer;
@@ -38,20 +33,17 @@ class FilterQueryFactory
     protected $domain;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
-        FilterQueryFactory $filterQueryFactory,
         ProductFilterDataToQueryTransformer $productFilterDataToQueryTransformer,
         CurrentCustomerUser $currentCustomerUser,
         IndexDefinitionLoader $indexDefinitionLoader,
         Domain $domain
     ) {
-        $this->filterQueryFactory = $filterQueryFactory;
         $this->productFilterDataToQueryTransformer = $productFilterDataToQueryTransformer;
         $this->currentCustomerUser = $currentCustomerUser;
         $this->indexDefinitionLoader = $indexDefinitionLoader;
@@ -169,7 +161,7 @@ class FilterQueryFactory
      */
     public function createSellableAndVisibleFilterQuery(): FilterQuery
     {
-        return $this->filterQueryFactory->create($this->getIndexName())
+        return $this->create($this->getIndexName())
             ->filterOnlySellable()
             ->filterOnlyVisible($this->currentCustomerUser->getPricingGroup());
     }

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -181,11 +181,11 @@ class FilterQueryFactory
     }
 
     /**
-     * @param string|null $searchText
+     * @param string $searchText
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createProductSearchCountFilterQuery(?string $searchText, ProductFilterData $productFilterData): FilterQuery
+    public function createProductSearchCountFilterQuery(string $searchText, ProductFilterData $productFilterData): FilterQuery
     {
         $filterQuery = $this->createSellableAndVisibleFilterQuery();
         $filterQuery->search($searchText);

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -170,7 +170,7 @@ class FilterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
      */
-    public function createListableProductsByCategoryWithPriceAndStockFilter(int $categoryId, ProductFilterData $productFilterData): FilterQuery
+    public function createListableProductsByCategoryIdWithPriceAndStockFilter(int $categoryId, ProductFilterData $productFilterData): FilterQuery
     {
         $filterQuery = $this->createListable()
             ->filterByCategory([$categoryId]);

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -7,3 +7,11 @@ There you can find links to upgrade notes for other versions too.
 
 - fix path for importing easy coding standard resources ([#2026](https://github.com/shopsys/shopsys/pull/2026))
     - see #project-base-diff to update your project
+
+- ProductOnCurrentDomainElasticFacade has been refactored ([#2036](https://github.com/shopsys/shopsys/pull/2036))
+    - these methods are now deprecated:
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsInCategoryFilterQuery()` use `ProductFilterQueryFactory::createListableProductsInCategory()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsForBrandFilterQuery()` use `ProductFilterQueryFactory::createListableProductsForBrand()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsForSearchTextFilterQuery()` use `ProductFilterQueryFactory::createListableProductsForSearchText()` instead
+        - `ProductOnCurrentDomainElasticFacade::createFilterQueryWithProductFilterData()` use `ProductFilterQueryFactory::createWithProductFilterData()` instead
+        - `ProductOnCurrentDomainElasticFacade::getIndexName()` use `ProductFilterQueryFactory::getIndexName()` instead

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -10,8 +10,8 @@ There you can find links to upgrade notes for other versions too.
 
 - ProductOnCurrentDomainElasticFacade has been refactored ([#2036](https://github.com/shopsys/shopsys/pull/2036))
     - these methods are now deprecated:
-        - `ProductOnCurrentDomainElasticFacade::createListableProductsInCategoryFilterQuery()` use `ProductFilterQueryFactory::createListableProductsInCategory()` instead
-        - `ProductOnCurrentDomainElasticFacade::createListableProductsForBrandFilterQuery()` use `ProductFilterQueryFactory::createListableProductsForBrand()` instead
-        - `ProductOnCurrentDomainElasticFacade::createListableProductsForSearchTextFilterQuery()` use `ProductFilterQueryFactory::createListableProductsForSearchText()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsInCategoryFilterQuery()` use `ProductFilterQueryFactory::createListableProductsByCategoryId()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsForBrandFilterQuery()` use `ProductFilterQueryFactory::createListableProductsByBrandId()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsForSearchTextFilterQuery()` use `ProductFilterQueryFactory::createListableProductsBySearchText()` instead
         - `ProductOnCurrentDomainElasticFacade::createFilterQueryWithProductFilterData()` use `ProductFilterQueryFactory::createWithProductFilterData()` instead
         - `ProductOnCurrentDomainElasticFacade::getIndexName()` use `ProductFilterQueryFactory::getIndexName()` instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ProductOnCurrentDomainElasticFacade had more responsibilities than it should. One of them was creating FilterQuery object and filling it with necessary data. This part has now been moved to factory.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
