### PR TITLE
[framework] changed default locale in test to domain locale

### DIFF
--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -112,9 +112,6 @@ Some parts of these instructions are already prepared for the locales `en` and `
 Set up the locale of the domain in `config/domains.yaml`.
 This configuration file contains pieces of information about the domain ID, the domain identifier for the domain tabs in the administration, and the domain locale.
 
-!!! note
-    Changing locales for domain may cause tests to start failing. It is necessary to [configure default locale](#38-default-application-locale) properly to fix it.
-
 #### 3.2 Frontend routes
 Create a file with the frontend routes for the added locale if this file is not already created for this locale.
 Create this file in the directory `config/shopsys-routing` with the name `routing_front_xx.yaml` where `xx` replace for the code of added locale.
@@ -175,10 +172,13 @@ An example for domain that uses English language:
 
 #### 3.8 Default application locale
 In most cases, when working with multilanguage attributes, you do not need to specify any locale as it is set automatically from the request so you can just use e.g. `Product::getName()` and you get the proper translation.
-However, sometimes, there is no request (i.e. in CLI commands or in tests) so you need to tell your application, which locale should be used - either using a parameter in the method (`Product::getName('es')`) or by setting a default application locale.
+However, sometimes, there is no request (i.e. in CLI commands) so you need to tell your application, which locale should be used - either using a parameter in the method (`Product::getName('es')`) or by setting a default application locale.
 
 To change the default application locale, set `locale` parameter to you desired locale (e.g. `es` for Spanish) in your [`parameters_common.yaml`](https://github.com/shopsys/shopsys/blob/master/project-base/config/parameters_common.yaml).
 The value is then used for setting [`default_locale` Symfony parameter](https://symfony.com/doc/3.4/translation/locale.html#setting-a-default-locale) (see your [`config/packages/translation.yaml`](https://github.com/shopsys/shopsys/blob/master/project-base/config/packages/translation.yaml) config).
+
+!!!note
+    Default application locale in test environment is set to first domain locale except administration where is respected [`admin_locale` setting](#36-locale-in-administration)
 
 ### 4. Change the url address for an existing domain
 

--- a/packages/framework/src/Model/Administration/AdministrationFacade.php
+++ b/packages/framework/src/Model/Administration/AdministrationFacade.php
@@ -26,6 +26,12 @@ class AdministrationFacade
      */
     public function isInAdmin(): bool
     {
-        return preg_match('/^admin_/', $this->requestStack->getMasterRequest()->attributes->get('_route')) === 1;
+        $masterRequest = $this->requestStack->getMasterRequest();
+
+        if ($masterRequest === null) {
+            return false;
+        }
+
+        return preg_match('/^admin_/', $masterRequest->attributes->get('_route')) === 1;
     }
 }

--- a/packages/framework/src/Resources/config/services_test.yaml
+++ b/packages/framework/src/Resources/config/services_test.yaml
@@ -27,14 +27,18 @@ services:
     # @deprecated Registering this service is necessary to avoid BC break. It will be removed in next major version.
     Shopsys\FrameworkBundle\Model\Localization\TranslatableListener:
         class: Tests\FrameworkBundle\Test\TestTranslatableListener
+        arguments:
+            $adminLocale: '%shopsys.admin_locale%'
 
     prezent_doctrine_translatable.listener:
         class: Tests\FrameworkBundle\Test\TestTranslatableListener
         tags:
             - 'doctrine.event_subscriber'
         arguments:
-            - '@prezent_doctrine_translatable.metadata_factory'
-            - '@Shopsys\FrameworkBundle\Component\Domain\Domain'
+            $factory: '@prezent_doctrine_translatable.metadata_factory'
+            $domain: '@Shopsys\FrameworkBundle\Component\Domain\Domain'
+            $administrationFacade: '@Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade'
+            $adminLocale: '%shopsys.admin_locale%'
 
     Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportSubscriber:
         autoconfigure: false

--- a/packages/framework/src/Resources/config/services_test.yaml
+++ b/packages/framework/src/Resources/config/services_test.yaml
@@ -24,6 +24,10 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade: ~
 
+    # @deprecated Registering this service is necessary to avoid BC break. It will be removed in next major version.
+    Shopsys\FrameworkBundle\Model\Localization\TranslatableListener:
+        class: Tests\FrameworkBundle\Test\TestTranslatableListener
+
     prezent_doctrine_translatable.listener:
         class: Tests\FrameworkBundle\Test\TestTranslatableListener
         tags:

--- a/packages/framework/src/Resources/config/services_test.yaml
+++ b/packages/framework/src/Resources/config/services_test.yaml
@@ -24,7 +24,13 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade: ~
 
-    Shopsys\FrameworkBundle\Model\Localization\TranslatableListener: ~
+    prezent_doctrine_translatable.listener:
+        class: Tests\FrameworkBundle\Test\TestTranslatableListener
+        tags:
+            - 'doctrine.event_subscriber'
+        arguments:
+            - '@prezent_doctrine_translatable.metadata_factory'
+            - '@Shopsys\FrameworkBundle\Component\Domain\Domain'
 
     Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportSubscriber:
         autoconfigure: false

--- a/packages/framework/tests/Test/TestTranslatableListener.php
+++ b/packages/framework/tests/Test/TestTranslatableListener.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\FrameworkBundle\Test;
 
+use Exception;
 use Metadata\MetadataFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
 use Shopsys\FrameworkBundle\Model\Localization\TranslatableListener;
 
 class TestTranslatableListener extends TranslatableListener
@@ -16,19 +18,49 @@ class TestTranslatableListener extends TranslatableListener
     protected $domain;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade
+     */
+    protected $administrationFacade;
+
+    /**
+     * @var string
+     */
+    protected $adminLocale;
+
+    /**
      * @param \Metadata\MetadataFactory $factory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade $administrationFacade
+     * @param string $adminLocale
      */
-    public function __construct(MetadataFactory $factory, Domain $domain)
+    public function __construct(MetadataFactory $factory, Domain $domain, AdministrationFacade $administrationFacade, string $adminLocale)
     {
         parent::__construct($factory);
         $this->domain = $domain;
+        $this->administrationFacade = $administrationFacade;
+        $this->adminLocale = $adminLocale;
     }
 
     /**
      * @return string
      */
     public function getCurrentLocale()
+    {
+        try {
+            if ($this->administrationFacade->isInAdmin()) {
+                return $this->adminLocale;
+            }
+        } catch (Exception $exception) {
+            return $this->getFirstDomainLocale();
+        }
+
+        return $this->getFirstDomainLocale();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFirstDomainLocale(): string
     {
         return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
     }

--- a/packages/framework/tests/Test/TestTranslatableListener.php
+++ b/packages/framework/tests/Test/TestTranslatableListener.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Test;
+
+use Metadata\MetadataFactory;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Localization\TranslatableListener;
+
+class TestTranslatableListener extends TranslatableListener
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @param \Metadata\MetadataFactory $factory
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     */
+    public function __construct(MetadataFactory $factory, Domain $domain)
+    {
+        parent::__construct($factory);
+        $this->domain = $domain;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentLocale()
+    {
+        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+    }
+}

--- a/packages/framework/tests/Test/TestTranslatableListener.php
+++ b/packages/framework/tests/Test/TestTranslatableListener.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\FrameworkBundle\Test;
 
-use Exception;
 use Metadata\MetadataFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
@@ -46,12 +45,8 @@ class TestTranslatableListener extends TranslatableListener
      */
     public function getCurrentLocale()
     {
-        try {
-            if ($this->administrationFacade->isInAdmin()) {
-                return $this->adminLocale;
-            }
-        } catch (Exception $exception) {
-            return $this->getFirstDomainLocale();
+        if ($this->administrationFacade->isInAdmin()) {
+            return $this->adminLocale;
         }
 
         return $this->getFirstDomainLocale();

--- a/project-base/config/packages/test/prezent_doctrine_translatable.yaml
+++ b/project-base/config/packages/test/prezent_doctrine_translatable.yaml
@@ -1,3 +1,0 @@
-prezent_doctrine_translatable:
-    # in tests there is no default locale set
-    fallback_locale: "%locale%"

--- a/project-base/tests/App/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/App/Functional/Model/Cart/CartFacadeTest.php
@@ -17,12 +17,6 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     use SymfonyTestContainer;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
-     * @inject
-     */
-    private $translatableListener;
-
-    /**
      * @var \Shopsys\FrameworkBundle\Model\Cart\CartFactory
      * @inject
      */
@@ -175,10 +169,6 @@ class CartFacadeTest extends TransactionFunctionalTestCase
 
     public function testCanDeleteCartItem()
     {
-        // Set currentLocale in TranslatableListener as it done in real request
-        // because CartWatcherFacade works with entity translations.
-        $this->translatableListener->setCurrentLocale('cs');
-
         $customerUserIdentifier = new CustomerUserIdentifier('secretSessionHash');
 
         /** @var \App\Model\Product\Product $product1 */

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -68,3 +68,8 @@ There you can find links to upgrade notes for other versions too.
 
 - fix displaying '+' sign in product filter ([#2023](https://github.com/shopsys/shopsys/pull/2023))
     - see #project-base-diff to update your project
+
+- remove setting domain locale in `CartFacadeTest` ([#2037](https://github.com/shopsys/shopsys/pull/2037))
+    - in tests is used extended class of `Shopsys\FrameworkBundle\Model\Localization\TranslatableListener`
+    - removed `config/packages/test/prezent_doctrine_translatable.yaml`
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Tests are running from CLI without having locale set. It results in using default locale configured in `parameters.locale` variable.<br>This PR make tests to be running with first domain locale.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
