### PR TITLE
[shopsys] required symfony/http-kernel in 4.4.13 or higher due to security issue

### DIFF
--- a/packages/backend-api/composer.json
+++ b/packages/backend-api/composer.json
@@ -35,7 +35,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/http-foundation": "^4.4",
-        "symfony/http-kernel": "^4.4"
+        "symfony/http-kernel": "^4.4.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/packages/form-types-bundle/composer.json
+++ b/packages/form-types-bundle/composer.json
@@ -21,7 +21,7 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/form": "^4.4",
         "symfony/framework-bundle": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/options-resolver": "^4.4",
         "symfony/translation": "^4.4"
     },

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -32,7 +32,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/http-foundation": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/routing": "^4.4"
     },
     "require-dev": {

--- a/packages/google-cloud-bundle/composer.json
+++ b/packages/google-cloud-bundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/options-resolver": "^4.4"
     },
     "require-dev": {

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -32,7 +32,7 @@
         "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/filesystem": "^3.4|^4.0",
         "symfony/framework-bundle": "^3.4|^4.0",
-        "symfony/http-kernel": "^3.4|^4.0",
+        "symfony/http-kernel": "^3.4|^4.4.13",
         "symfony/templating": "^3.4|^4.0"
     },
     "require-dev": {

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -35,7 +35,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/form": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/translation": "^4.4"
     },
     "require-dev": {

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -30,7 +30,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/framework-bundle": "^4.4",
-        "symfony/http-kernel": "^4.4"
+        "symfony/http-kernel": "^4.4.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -38,7 +38,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/form": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/translation": "^4.4"
     },
     "require-dev": {

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -35,7 +35,7 @@
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/form": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/translation": "^4.4"
     },
     "require-dev": {

--- a/packages/read-model/composer.json
+++ b/packages/read-model/composer.json
@@ -28,7 +28,7 @@
         "shopsys/plugin-interface": "9.0.x-dev",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Required fixed version of `symfony/http-kernel` due to https://github.com/advisories/GHSA-754h-5r27-7x3r
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
