### PR TITLE
[shopsys] Moved methods used only by FE API from framework facades to FE API facades

### DIFF
--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -229,6 +229,7 @@ class ImageFacade
      * @param string $entityName
      * @param string|null $type
      * @return \Shopsys\FrameworkBundle\Component\Image\Image[]
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Component\Image\ImageFacade::getImagesByEntityIdAndNameIndexedById()
      */
     public function getImagesByEntityIdAndNameIndexedById(int $entityId, string $entityName, $type)
     {

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -499,9 +499,18 @@ class ProductFacade
      * @param int $domainId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getSellableByUuid()
      */
     public function getSellableByUuid(string $uuid, int $domainId, PricingGroup $pricingGroup): Product
     {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getSellableByUuid().',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return $this->productRepository->getSellableByUuid($uuid, $domainId, $pricingGroup);
     }
 

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -236,58 +236,6 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     }
 
     /**
-     * @param int $limit
-     * @param int $offset
-     * @param string $orderingModeId
-     * @return array
-     */
-    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
-    {
-        $emptyProductFilterData = new ProductFilterData();
-        $filterQuery = $this->filterQueryFactory->createWithProductFilterData(
-            $emptyProductFilterData,
-            $orderingModeId,
-            1,
-            $limit
-        )->setFrom($offset);
-
-        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
-        return $productsResult->getHits();
-    }
-
-    /**
-     * @return int
-     */
-    public function getProductsCountOnCurrentDomain(): int
-    {
-        $filterQuery = $this->filterQueryFactory->createListable();
-
-        return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
-     * @param int $limit
-     * @param int $offset
-     * @param string $orderingModeId
-     * @return array
-     */
-    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
-    {
-        $emptyProductFilterData = new ProductFilterData();
-        $filterQuery = $this->filterQueryFactory->createListableProductsByCategoryId(
-            $emptyProductFilterData,
-            $orderingModeId,
-            1,
-            $limit,
-            $category->getId()
-        )->setFrom($offset);
-
-        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
-        return $productsResult->getHits();
-    }
-
-    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
      * @param string $orderingModeId
      * @param int $page
@@ -370,5 +318,60 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
     protected function getIndexName(): string
     {
         return $this->filterQueryFactory->getIndexName();
+    }
+
+    /**
+     * @return int
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsCountOnCurrentDomain()
+     */
+    public function getProductsCountOnCurrentDomain(): int
+    {
+        $filterQuery = $this->filterQueryFactory->createListable();
+
+        return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
+    }
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsOnCurrentDomain()
+     */
+    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $filterQuery = $this->filterQueryFactory->createWithProductFilterData(
+            $emptyProductFilterData,
+            $orderingModeId,
+            1,
+            $limit
+        )->setFrom($offset);
+
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
+        return $productsResult->getHits();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsByCategory()
+     */
+    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $filterQuery = $this->filterQueryFactory->createListableProductsByCategoryId(
+            $emptyProductFilterData,
+            $orderingModeId,
+            1,
+            $limit,
+            $category->getId()
+        )->setFrom($offset);
+
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
+        return $productsResult->getHits();
     }
 }

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -152,70 +152,6 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
-     * @param int $limit
-     * @param int $offset
-     * @param string $orderingModeId
-     * @return array
-     */
-    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
-    {
-        $queryBuilder = $this->productRepository->getAllListableTranslatedAndOrderedQueryBuilderByCategory(
-            $this->domain->getId(),
-            $this->domain->getLocale(),
-            $orderingModeId,
-            $this->currentCustomerUser->getPricingGroup(),
-            $category
-        );
-
-        $queryBuilder->setFirstResult($offset)
-            ->setMaxResults($limit);
-        $query = $queryBuilder->getQuery();
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SortableNullsWalker::class);
-
-        return $query->execute();
-    }
-
-    /**
-     * @param int $limit
-     * @param int $offset
-     * @param string $orderingModeId
-     * @return array
-     */
-    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
-    {
-        $queryBuilder = $this->productRepository->getAllListableTranslatedAndOrderedQueryBuilder(
-            $this->domain->getId(),
-            $this->domain->getLocale(),
-            $orderingModeId,
-            $this->currentCustomerUser->getPricingGroup()
-        );
-
-        $queryBuilder->setFirstResult($offset)
-            ->setMaxResults($limit);
-        $query = $queryBuilder->getQuery();
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SortableNullsWalker::class);
-
-        return $query->execute();
-    }
-
-    /**
-     * @return int
-     */
-    public function getProductsCountOnCurrentDomain(): int
-    {
-        $queryBuilder = $this->productRepository->getAllListableQueryBuilder(
-            $this->domain->getId(),
-            $this->currentCustomerUser->getPricingGroup()
-        );
-
-        return $queryBuilder
-            ->select('count(p.id)')
-            ->getQuery()
-            ->getSingleScalarResult();
-    }
-
-    /**
      * @param string $orderingModeId
      * @param int $page
      * @param int $limit
@@ -355,5 +291,72 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
             $this->domain->getId(),
             $this->currentCustomerUser->getPricingGroup()
         );
+    }
+
+    /**
+     * @return int
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsCountOnCurrentDomain()
+     */
+    public function getProductsCountOnCurrentDomain(): int
+    {
+        $queryBuilder = $this->productRepository->getAllListableQueryBuilder(
+            $this->domain->getId(),
+            $this->currentCustomerUser->getPricingGroup()
+        );
+
+        return $queryBuilder
+            ->select('count(p.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsOnCurrentDomain()
+     */
+    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
+    {
+        $queryBuilder = $this->productRepository->getAllListableTranslatedAndOrderedQueryBuilder(
+            $this->domain->getId(),
+            $this->domain->getLocale(),
+            $orderingModeId,
+            $this->currentCustomerUser->getPricingGroup()
+        );
+
+        $queryBuilder->setFirstResult($offset)
+            ->setMaxResults($limit);
+        $query = $queryBuilder->getQuery();
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SortableNullsWalker::class);
+
+        return $query->execute();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsByCategory()
+     */
+    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
+    {
+        $queryBuilder = $this->productRepository->getAllListableTranslatedAndOrderedQueryBuilderByCategory(
+            $this->domain->getId(),
+            $this->domain->getLocale(),
+            $orderingModeId,
+            $this->currentCustomerUser->getPricingGroup(),
+            $category
+        );
+
+        $queryBuilder->setFirstResult($offset)
+            ->setMaxResults($limit);
+        $query = $queryBuilder->getQuery();
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SortableNullsWalker::class);
+
+        return $query->execute();
     }
 }

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacadeInterface.php
@@ -113,6 +113,7 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param int $offset
      * @param string $orderingModeId
      * @return array
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsByCategory()
      */
     public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array;
 
@@ -121,11 +122,13 @@ interface ProductOnCurrentDomainFacadeInterface
      * @param int $offset
      * @param string $orderingModeId
      * @return array
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsOnCurrentDomain()
      */
     public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array;
 
     /**
      * @return int
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsCountOnCurrentDomain()
      */
     public function getProductsCountOnCurrentDomain(): int;
 }

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -642,9 +642,18 @@ class ProductRepository
      * @param int $domainId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     * @deprecated This method will be removed in next major version. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductRepository::getSellableByUuid()
      */
     public function getSellableByUuid(string $uuid, int $domainId, PricingGroup $pricingGroup): Product
     {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. It was used only in FE API, so it has been replaced by \Shopsys\FrontendApiBundle\Model\Product\ProductRepository::getSellableByUuid().',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         $qb = $this->getAllSellableQueryBuilder($domainId, $pricingGroup);
         $qb->andWhere('p.uuid = :uuid');
         $qb->setParameter('uuid', $uuid);

--- a/packages/frontend-api/src/Component/Constraints/ProductCanBeOrderedValidator.php
+++ b/packages/frontend-api/src/Component/Constraints/ProductCanBeOrderedValidator.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
+use Shopsys\FrontendApiBundle\Model\Product\ProductFacade as FrontendApiProductFacade;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -16,6 +18,7 @@ class ProductCanBeOrderedValidator extends ConstraintValidator
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
+     * @deprecated This property will be removed in next major version as it is no longer in use
      */
     protected $productFacade;
 
@@ -35,21 +38,55 @@ class ProductCanBeOrderedValidator extends ConstraintValidator
     protected $currentCustomerUser;
 
     /**
+     * @var \Shopsys\FrontendApiBundle\Model\Product\ProductFacade|null
+     */
+    protected $frontendApiProductFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductFacade $productFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade $productCachedAttributesFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductFacade|null $frontendApiProductFacade
      */
     public function __construct(
         ProductFacade $productFacade,
         ProductCachedAttributesFacade $productCachedAttributesFacade,
         Domain $domain,
-        CurrentCustomerUser $currentCustomerUser
+        CurrentCustomerUser $currentCustomerUser,
+        ?FrontendApiProductFacade $frontendApiProductFacade = null
     ) {
         $this->productFacade = $productFacade;
         $this->productCachedAttributesFacade = $productCachedAttributesFacade;
         $this->domain = $domain;
         $this->currentCustomerUser = $currentCustomerUser;
+        $this->frontendApiProductFacade = $frontendApiProductFacade;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductFacade $frontendApiProductFacade
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setFrontendApiProductFacade(FrontendApiProductFacade $frontendApiProductFacade): void
+    {
+        if ($this->frontendApiProductFacade !== null && $this->frontendApiProductFacade !== $frontendApiProductFacade) {
+            throw new BadMethodCallException(sprintf(
+                'Method "%s" has been already called and cannot be called multiple times.',
+                __METHOD__
+            ));
+        }
+        if ($this->frontendApiProductFacade === null) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $this->frontendApiProductFacade = $frontendApiProductFacade;
+        }
     }
 
     /**
@@ -69,7 +106,7 @@ class ProductCanBeOrderedValidator extends ConstraintValidator
         $vatAmount = $value['unitPrice']['vatAmount'];
 
         try {
-            $productEntity = $this->productFacade->getSellableByUuid(
+            $productEntity = $this->frontendApiProductFacade->getSellableByUuid(
                 $uuid,
                 $this->domain->getId(),
                 $this->currentCustomerUser->getPricingGroup()

--- a/packages/frontend-api/src/Component/Image/ImageFacade.php
+++ b/packages/frontend-api/src/Component/Image/ImageFacade.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\Image;
+
+use Shopsys\FrameworkBundle\Component\Image\ImageRepository;
+
+class ImageFacade
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Image\ImageRepository
+     */
+    protected $imageRepository;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageRepository $imageRepository
+     */
+    public function __construct(ImageRepository $imageRepository)
+    {
+        $this->imageRepository = $imageRepository;
+    }
+
+    /**
+     * @param int $entityId
+     * @param string $entityName
+     * @param string|null $type
+     * @return \Shopsys\FrameworkBundle\Component\Image\Image[]
+     */
+    public function getImagesByEntityIdAndNameIndexedById(int $entityId, string $entityName, ?string $type): array
+    {
+        return $this->imageRepository->getImagesByEntityIndexedById(
+            $entityName,
+            $entityId,
+            $type
+        );
+    }
+}

--- a/packages/frontend-api/src/Model/Product/ProductFacade.php
+++ b/packages/frontend-api/src/Model/Product/ProductFacade.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Product;
 
+use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory;
+use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository;
 
 class ProductFacade
 {
@@ -15,11 +19,28 @@ class ProductFacade
     protected $productRepository;
 
     /**
-     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductRepository $productRepository
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
      */
-    public function __construct(ProductRepository $productRepository)
-    {
+    protected $filterQueryFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository
+     */
+    protected $productElasticsearchRepository;
+
+    /**
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductRepository $productRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
+     */
+    public function __construct(
+        ProductRepository $productRepository,
+        FilterQueryFactory $filterQueryFactory,
+        ProductElasticsearchRepository $productElasticsearchRepository
+    ) {
         $this->productRepository = $productRepository;
+        $this->filterQueryFactory = $filterQueryFactory;
+        $this->productElasticsearchRepository = $productElasticsearchRepository;
     }
 
     /**
@@ -31,5 +52,57 @@ class ProductFacade
     public function getSellableByUuid(string $uuid, int $domainId, PricingGroup $pricingGroup): Product
     {
         return $this->productRepository->getSellableByUuid($uuid, $domainId, $pricingGroup);
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductsCountOnCurrentDomain(): int
+    {
+        $filterQuery = $this->filterQueryFactory->createListable();
+
+        return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
+    }
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     */
+    public function getProductsOnCurrentDomain(int $limit, int $offset, string $orderingModeId): array
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $filterQuery = $this->filterQueryFactory->createWithProductFilterData(
+            $emptyProductFilterData,
+            $orderingModeId,
+            1,
+            $limit
+        )->setFrom($offset);
+
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
+        return $productsResult->getHits();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param int $limit
+     * @param int $offset
+     * @param string $orderingModeId
+     * @return array
+     */
+    public function getProductsByCategory(Category $category, int $limit, int $offset, string $orderingModeId): array
+    {
+        $emptyProductFilterData = new ProductFilterData();
+        $filterQuery = $this->filterQueryFactory->createListableProductsByCategoryId(
+            $emptyProductFilterData,
+            $orderingModeId,
+            1,
+            $limit,
+            $category->getId()
+        )->setFrom($offset);
+
+        $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
+        return $productsResult->getHits();
     }
 }

--- a/packages/frontend-api/src/Model/Product/ProductFacade.php
+++ b/packages/frontend-api/src/Model/Product/ProductFacade.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+
+class ProductFacade
+{
+    /**
+     * @var \Shopsys\FrontendApiBundle\Model\Product\ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductRepository $productRepository
+     */
+    public function __construct(ProductRepository $productRepository)
+    {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * @param string $uuid
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     */
+    public function getSellableByUuid(string $uuid, int $domainId, PricingGroup $pricingGroup): Product
+    {
+        return $this->productRepository->getSellableByUuid($uuid, $domainId, $pricingGroup);
+    }
+}

--- a/packages/frontend-api/src/Model/Product/ProductRepository.php
+++ b/packages/frontend-api/src/Model/Product/ProductRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Product;
+
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Product\ProductRepository as FrameworkProductRepository;
+
+class ProductRepository
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
+     */
+    protected $productRepository;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
+     */
+    public function __construct(FrameworkProductRepository $productRepository)
+    {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * @param string $uuid
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product
+     */
+    public function getSellableByUuid(string $uuid, int $domainId, PricingGroup $pricingGroup): Product
+    {
+        $qb = $this->productRepository->getAllSellableQueryBuilder($domainId, $pricingGroup);
+        $qb->andWhere('p.uuid = :uuid');
+        $qb->setParameter('uuid', $uuid);
+
+        $product = $qb->getQuery()->getOneOrNullResult();
+
+        if ($product === null) {
+            throw new \Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException(sprintf('Product with UUID "%s" does not exist.', $uuid));
+        }
+
+        return $product;
+    }
+}

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Image;
 
+use BadMethodCallException;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -14,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
+use Shopsys\FrontendApiBundle\Component\Image\ImageFacade as FrontendApiImageFacade;
 
 class ImagesResolver implements ResolverInterface
 {
@@ -38,18 +40,52 @@ class ImagesResolver implements ResolverInterface
     protected $domain;
 
     /**
+     * @var \Shopsys\FrontendApiBundle\Component\Image\ImageFacade|null
+     */
+    protected $frontendApiImageFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
      * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig $imageConfig
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrontendApiBundle\Component\Image\ImageFacade|null $frontendApiImageFacade
      */
     public function __construct(
         ImageFacade $imageFacade,
         ImageConfig $imageConfig,
-        Domain $domain
+        Domain $domain,
+        ?FrontendApiImageFacade $frontendApiImageFacade = null
     ) {
         $this->imageFacade = $imageFacade;
         $this->imageConfig = $imageConfig;
         $this->domain = $domain;
+        $this->frontendApiImageFacade = $frontendApiImageFacade;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrontendApiBundle\Component\Image\ImageFacade $frontendApiImageFacade
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setFrontendApiImageFacade(FrontendApiImageFacade $frontendApiImageFacade): void
+    {
+        if ($this->frontendApiImageFacade !== null && $this->frontendApiImageFacade !== $frontendApiImageFacade) {
+            throw new BadMethodCallException(sprintf(
+                'Method "%s" has been already called and cannot be called multiple times.',
+                __METHOD__
+            ));
+        }
+        if ($this->frontendApiImageFacade === null) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $this->frontendApiImageFacade = $frontendApiImageFacade;
+        }
     }
 
     /**
@@ -107,7 +143,7 @@ class ImagesResolver implements ResolverInterface
     protected function resolveByEntityId(int $entityId, string $entityName, ?string $type, ?string $size): array
     {
         $sizeConfigs = $this->getSizeConfigs($type, $size, $entityName);
-        $images = $this->imageFacade->getImagesByEntityIdAndNameIndexedById($entityId, $entityName, $type);
+        $images = $this->frontendApiImageFacade->getImagesByEntityIdAndNameIndexedById($entityId, $entityName, $type);
 
         return $this->getResolvedImages($images, $sizeConfigs);
     }

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -5,7 +5,7 @@ services:
         public: false
 
     Shopsys\FrontendApiBundle\:
-        resource: '../../**/*{Facade,Factory,Mutation,Resolver,Validator}.php'
+        resource: '../../**/*{Facade,Factory,Mutation,Repository,Resolver,Validator}.php'
 
     resolverMaps:
         namespace: Shopsys\FrontendApiBundle\

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -15,3 +15,8 @@ There you can find links to upgrade notes for other versions too.
         - `ProductOnCurrentDomainElasticFacade::createListableProductsForSearchTextFilterQuery()` use `ProductFilterQueryFactory::createListableProductsBySearchText()` instead
         - `ProductOnCurrentDomainElasticFacade::createFilterQueryWithProductFilterData()` use `ProductFilterQueryFactory::createWithProductFilterData()` instead
         - `ProductOnCurrentDomainElasticFacade::getIndexName()` use `ProductFilterQueryFactory::getIndexName()` instead
+
+- remove FE API only dependencies from framework ([#2041](https://github.com/shopsys/shopsys/pull/2041))
+    - this methods has been marked as deprecated and will be removed in next major version:
+        - `Shopsys\FrameworkBundle\Model\Product\ProductFacade::getSellableByUuid()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getSellableByUuid()` instead
+        - `Shopsys\FrameworkBundle\Model\Product\ProductRepository::getSellableByUuid()` use `Shopsys\FrontendApiBundle\Model\Product\ProductRepository::getSellableByUuid()` instead

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -20,3 +20,6 @@ There you can find links to upgrade notes for other versions too.
     - this methods has been marked as deprecated and will be removed in next major version:
         - `Shopsys\FrameworkBundle\Model\Product\ProductFacade::getSellableByUuid()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getSellableByUuid()` instead
         - `Shopsys\FrameworkBundle\Model\Product\ProductRepository::getSellableByUuid()` use `Shopsys\FrontendApiBundle\Model\Product\ProductRepository::getSellableByUuid()` instead
+        - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductFilterCountDataForSearch()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductFilterCountDataForSearch()` instead
+        - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductsOnCurrentDomain()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsOnCurrentDomain()` instead
+        - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductsByCategory()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsByCategory()` instead

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -23,3 +23,4 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductFilterCountDataForSearch()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductFilterCountDataForSearch()` instead
         - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductsOnCurrentDomain()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsOnCurrentDomain()` instead
         - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductsByCategory()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsByCategory()` instead
+        - `Shopsys\FrameworkBundle\Component\Image\ImageFacade::getImagesByEntityIdAndNameIndexedById()` use `Shopsys\FrontendApiBundle\Component\Image\ImageFacade::getImagesByEntityIdAndNameIndexedById()` instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We added in previous versions some methods in framework, that were used only by FE API. Some of those methods even lead to BC break. All these were moved to FE API to remove not necessary methods from framework.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
