### PR TITLE
[frontend-api] frontend API now correctly uses methods from frontend API facades instead of framework ones

### DIFF
--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -12,6 +12,7 @@ use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 use Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface;
+use Shopsys\FrontendApiBundle\Model\Product\ProductFacade;
 
 class ProductsResolver implements ResolverInterface, AliasedInterface
 {
@@ -23,6 +24,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     * @deprecated This property will be removed in next major version
      */
     protected $productOnCurrentDomainFacade;
 
@@ -32,13 +34,21 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
     protected $connectionBuilder;
 
     /**
+     * @var \Shopsys\FrontendApiBundle\Model\Product\ProductFacade
+     */
+    protected $productFacade;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductFacade $productFacade
      */
     public function __construct(
-        ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
+        ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade,
+        ProductFacade $productFacade
     ) {
         $this->productOnCurrentDomainFacade = $productOnCurrentDomainFacade;
         $this->connectionBuilder = new ConnectionBuilder();
+        $this->productFacade = $productFacade;
     }
 
     /**
@@ -50,14 +60,14 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
         $this->setDefaultFirstOffsetIfNecessary($argument);
 
         $paginator = new Paginator(function ($offset, $limit) {
-            return $this->productOnCurrentDomainFacade->getProductsOnCurrentDomain(
+            return $this->productFacade->getProductsOnCurrentDomain(
                 $limit,
                 $offset,
                 ProductListOrderingConfig::ORDER_BY_PRIORITY
             );
         });
 
-        return $paginator->auto($argument, $this->productOnCurrentDomainFacade->getProductsCountOnCurrentDomain());
+        return $paginator->auto($argument, $this->productFacade->getProductsCountOnCurrentDomain());
     }
 
     /**
@@ -70,7 +80,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
         $this->setDefaultFirstOffsetIfNecessary($argument);
 
         $paginator = new Paginator(function ($offset, $limit) use ($category) {
-            return $this->productOnCurrentDomainFacade->getProductsByCategory(
+            return $this->productFacade->getProductsByCategory(
                 $category,
                 $limit,
                 $offset,
@@ -78,7 +88,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
             );
         });
 
-        return $paginator->auto($argument, $this->productOnCurrentDomainFacade->getProductsCountOnCurrentDomain());
+        return $paginator->auto($argument, $this->productFacade->getProductsCountOnCurrentDomain());
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
+use BadMethodCallException;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
@@ -34,21 +35,47 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
     protected $connectionBuilder;
 
     /**
-     * @var \Shopsys\FrontendApiBundle\Model\Product\ProductFacade
+     * @var \Shopsys\FrontendApiBundle\Model\Product\ProductFacade|null
      */
     protected $productFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
-     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductFacade $productFacade
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductFacade|null $productFacade
      */
     public function __construct(
         ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade,
-        ProductFacade $productFacade
+        ?ProductFacade $productFacade = null
     ) {
         $this->productOnCurrentDomainFacade = $productOnCurrentDomainFacade;
         $this->connectionBuilder = new ConnectionBuilder();
         $this->productFacade = $productFacade;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductFacade $productFacade
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setProductFacade(ProductFacade $productFacade): void
+    {
+        if ($this->productFacade !== null && $this->productFacade !== $productFacade) {
+            throw new BadMethodCallException(sprintf(
+                'Method "%s" has been already called and cannot be called multiple times.',
+                __METHOD__
+            ));
+        }
+        if ($this->productFacade === null) {
+            @trigger_error(
+                sprintf(
+                    'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                    __METHOD__
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $this->productFacade = $productFacade;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In refactoring of ProductOnCurrentDomainFacade we forgot to update frontend API resolvers. This has been fixed here.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
