### PR TITLE
[shopsys] frontend API tests are always run on CI in monorepo

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -100,4 +100,4 @@ kubectl rollout status --namespace=${JOB_NAME} deployment/webserver-php-fpm --wa
 PHP_FPM_POD=$(kubectl get pods --namespace=${JOB_NAME} -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
 
 # Run phing build targets for build of the application
-kubectl exec ${PHP_FPM_POD} --namespace=${JOB_NAME} -- ./phing -D production.confirm.action=y backend-api-install backend-api-oauth-keys-generate test-db-create test-dirs-create checks-ci
+kubectl exec ${PHP_FPM_POD} --namespace=${JOB_NAME} -- ./phing -D production.confirm.action=y backend-api-install backend-api-oauth-keys-generate frontend-api-enable test-db-create test-dirs-create checks-ci

--- a/project-base/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php
@@ -19,11 +19,17 @@ class ProductImagesTest extends GraphQlTestCase
      */
     private $productFacade;
 
+    /**
+     * @var mixed
+     */
+    private $webserverUrl;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->product = $this->productFacade->getById(1);
+        $this->webserverUrl = $this->getContainer()->getParameter('overwrite_domain_url');
     }
 
     public function testFirstProductWithAllImages(): void
@@ -49,7 +55,7 @@ class ProductImagesTest extends GraphQlTestCase
         "product": {
             "images": [
                 {
-                    "url": "http://webserver:8080/content-test/images/product/default/1.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/default/1.jpg",
                     "type": null,
                     "size": "default",
                     "width": 410,
@@ -57,7 +63,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/galleryThumbnail/1.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/galleryThumbnail/1.jpg",
                     "type": null,
                     "size": "galleryThumbnail",
                     "width": null,
@@ -65,7 +71,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/list/1.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/list/1.jpg",
                     "type": null,
                     "size": "list",
                     "width": 150,
@@ -73,7 +79,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/thumbnail/1.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/thumbnail/1.jpg",
                     "type": null,
                     "size": "thumbnail",
                     "width": 50,
@@ -81,7 +87,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/original/1.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/original/1.jpg",
                     "type": null,
                     "size": "original",
                     "width": null,
@@ -89,7 +95,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/default/64.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/default/64.jpg",
                     "type": null,
                     "size": "default",
                     "width": 410,
@@ -97,7 +103,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/galleryThumbnail/64.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/galleryThumbnail/64.jpg",
                     "type": null,
                     "size": "galleryThumbnail",
                     "width": null,
@@ -105,7 +111,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/list/64.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/list/64.jpg",
                     "type": null,
                     "size": "list",
                     "width": 150,
@@ -113,7 +119,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/thumbnail/64.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/thumbnail/64.jpg",
                     "type": null,
                     "size": "thumbnail",
                     "width": 50,
@@ -121,7 +127,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/original/64.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/original/64.jpg",
                     "type": null,
                     "size": "original",
                     "width": null,
@@ -159,7 +165,7 @@ class ProductImagesTest extends GraphQlTestCase
         "product": {
             "images": [
                 {
-                    "url": "http://webserver:8080/content-test/images/product/list/1.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/list/1.jpg",
                     "type": null,
                     "size": "list",
                     "width": 150,
@@ -167,7 +173,7 @@ class ProductImagesTest extends GraphQlTestCase
                     "position": null
                 },
                 {
-                    "url": "http://webserver:8080/content-test/images/product/list/64.jpg",
+                    "url": "' . $this->webserverUrl . '/content-test/images/product/list/64.jpg",
                     "type": null,
                     "size": "list",
                     "width": 150,

--- a/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php
@@ -8,6 +8,18 @@ use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class PaymentsTest extends GraphQlTestCase
 {
+    /**
+     * @var mixed
+     */
+    private $webserverUrl;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->webserverUrl = $this->getContainer()->getParameter('overwrite_domain_url');
+    }
+
     public function testPayments(): void
     {
         $query = '
@@ -46,8 +58,8 @@ class PaymentsTest extends GraphQlTestCase
                             'vatAmount' => '0.00',
                         ],
                         'images' => [
-                            ['url' => 'http://webserver:8080/content-test/images/payment/default/53.jpg'],
-                            ['url' => 'http://webserver:8080/content-test/images/payment/original/53.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/payment/default/53.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/payment/original/53.jpg'],
                         ],
                         'transports' => [
                             ['name' => t('PPL', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
@@ -65,8 +77,8 @@ class PaymentsTest extends GraphQlTestCase
                             'vatAmount' => '0.00',
                         ],
                         'images' => [
-                            ['url' => 'http://webserver:8080/content-test/images/payment/default/55.jpg'],
-                            ['url' => 'http://webserver:8080/content-test/images/payment/original/55.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/payment/default/55.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/payment/original/55.jpg'],
                         ],
                         'transports' => [
                             ['name' => t('Czech post', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
@@ -83,8 +95,8 @@ class PaymentsTest extends GraphQlTestCase
                             'vatAmount' => '0.00',
                         ],
                         'images' => [
-                            ['url' => 'http://webserver:8080/content-test/images/payment/default/54.jpg'],
-                            ['url' => 'http://webserver:8080/content-test/images/payment/original/54.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/payment/default/54.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/payment/original/54.jpg'],
                         ],
                         'transports' => [
                             ['name' => t('Personal collection', [], 'dataFixtures', $this->getLocaleForFirstDomain())],

--- a/project-base/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php
@@ -8,6 +8,18 @@ use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class TransportsTest extends GraphQlTestCase
 {
+    /**
+     * @var mixed
+     */
+    private $webserverUrl;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->webserverUrl = $this->getContainer()->getParameter('overwrite_domain_url');
+    }
+
     public function testPayments(): void
     {
         $query = '
@@ -46,8 +58,8 @@ class TransportsTest extends GraphQlTestCase
                             'vatAmount' => $this->getPriceWithVatConvertedToDomainDefaultCurrency('21.00'),
                         ],
                         'images' => [
-                            ['url' => 'http://webserver:8080/content-test/images/transport/default/56.jpg'],
-                            ['url' => 'http://webserver:8080/content-test/images/transport/original/56.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/transport/default/56.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/transport/original/56.jpg'],
                         ],
                         'payments' => [
                             ['name' => t('Cash on delivery', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
@@ -64,8 +76,8 @@ class TransportsTest extends GraphQlTestCase
                             'vatAmount' => $this->getPriceWithVatConvertedToDomainDefaultCurrency('42.00'),
                         ],
                         'images' => [
-                            ['url' => 'http://webserver:8080/content-test/images/transport/default/57.jpg'],
-                            ['url' => 'http://webserver:8080/content-test/images/transport/original/57.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/transport/default/57.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/transport/original/57.jpg'],
                         ],
                         'payments' => [
                             ['name' => t('Credit card', [], 'dataFixtures', $this->getLocaleForFirstDomain())],
@@ -82,8 +94,8 @@ class TransportsTest extends GraphQlTestCase
                             'vatAmount' => '0.00',
                         ],
                         'images' => [
-                            ['url' => 'http://webserver:8080/content-test/images/transport/default/58.jpg'],
-                            ['url' => 'http://webserver:8080/content-test/images/transport/original/58.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/transport/default/58.jpg'],
+                            ['url' => $this->webserverUrl . '/content-test/images/transport/original/58.jpg'],
                         ],
                         'payments' => [
                             ['name' => t('Credit card', [], 'dataFixtures', $this->getLocaleForFirstDomain())],

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -24,3 +24,6 @@ There you can find links to upgrade notes for other versions too.
         - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductsOnCurrentDomain()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsOnCurrentDomain()` instead
         - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface::getProductsByCategory()` use `Shopsys\FrontendApiBundle\Model\Product\ProductFacade::getProductsByCategory()` instead
         - `Shopsys\FrameworkBundle\Component\Image\ImageFacade::getImagesByEntityIdAndNameIndexedById()` use `Shopsys\FrontendApiBundle\Component\Image\ImageFacade::getImagesByEntityIdAndNameIndexedById()` instead
+
+- fix webserver URL in frontend API tests ([#2045](https://github.com/shopsys/shopsys/pull/2045))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Currently tests were not run by default and sometimes there would be helpful. This PR also fixes problems with image urls on our current CI.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
