### PR TITLE
[frontend-api] pagination now works with right number of products

### DIFF
--- a/packages/frontend-api/src/Model/Product/ProductFacade.php
+++ b/packages/frontend-api/src/Model/Product/ProductFacade.php
@@ -105,4 +105,16 @@ class ProductFacade
         $productsResult = $this->productElasticsearchRepository->getSortedProductsResultByFilterQuery($filterQuery);
         return $productsResult->getHits();
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @return int
+     */
+    public function getProductsByCategoryCount(Category $category): int
+    {
+        $filterQuery = $this->filterQueryFactory->createListable()
+            ->filterByCategory([$category->getId()]);
+
+        return $this->productElasticsearchRepository->getProductsCountByFilterQuery($filterQuery);
+    }
 }

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -115,7 +115,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
             );
         });
 
-        return $paginator->auto($argument, $this->productFacade->getProductsCountOnCurrentDomain());
+        return $paginator->auto($argument, $this->productFacade->getProductsByCategoryCount($category));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Count of products fo categories has been counted in wrong way. This has been now fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
