### PR TITLE
[project-base] logo on homepage is link and is not wrapped in H1 

### DIFF
--- a/project-base/templates/Front/Content/Default/index.html.twig
+++ b/project-base/templates/Front/Content/Default/index.html.twig
@@ -12,12 +12,6 @@
     {{- title -}}
 {% endblock %}
 
-{% block logo %}
-    <h1 class="logo">
-        <img src="{{ asset('public/frontend/images/logo.svg') }}" alt="{{ 'Online shop'|trans }}">
-    </h1>
-{% endblock %}
-
 {% block main_content %}
 
     {% if sliderItems is not empty %}

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -53,3 +53,7 @@ There you can find links to upgrade notes for other versions too.
 - allow multiple elasticsearch hosts ([#2240](https://github.com/shopsys/shopsys/pull/2240))
     - now it's possible to set multiple elasticsearch hosts like `'["elasticsearch:9200", "elasticsearch2:9200"]'`
     - `Elasticsearch\ClientBuilder` is now created with a different factory, you may want to check your overridden service definition (see PR for details)
+
+- unify logo rendering on homepage and subpages ([#2048](https://github.com/shopsys/shopsys/pull/2048))
+    - on homepage is no longer H1 element, consider adding it in your custom design
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Linked logo on homepage is consistent with the rest of the web, removed unnecessary code, and just image inside H1 has no semantic information so H1 wrapper is removed from logo allowing the H1 to be included  in the content
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... closes #2243
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
