### PR TITLE
[shopsys] autocompletion for Phing targets

### DIFF
--- a/docs/introduction/autocompletion-for-phing-targets.md
+++ b/docs/introduction/autocompletion-for-phing-targets.md
@@ -1,0 +1,101 @@
+# Autocompletion for Phing Targets
+
+Autocompletion is a functionality through which helps you type commands faster and easier.
+It accomplishes that by presenting possible options when you press the tab key while typing a command.
+This article describes ways how to use autocompletion for Phing targets.
+
+Phing can be run from several locations and on different machines, we summarize here the few most common use-cases.
+
+## Inside the container
+
+When you connect to the container either with `docker-compose exec ... bash`, `docker exec -it ... bash`, or `kubectl exec -it ... bash`,
+you can take advantage of already working autocompletion.
+
+To use, you just type `php phing <tab><tab>` to see all possible completion words.
+Alternatively, you can use `./phing <tab><tab>` to achieve the same behavior.
+
+It's also possible to let autocompletion expand the partially typed target name, so `php phing fri<tab>` became `php phing friendly-urls-generate`.
+
+## Running from the host with Bash
+
+As you can always connect to the container, sometimes it's more convenient to run Phing targets from the host machine.
+It's possible to get autocompletion working, but you have to set it on your machine.
+In this section, you can find the setup guide for Bash.
+
+Create the alias for easier running Phing in the container from your host machine.
+Add following into your profile (usually `~/.bash_profile`, `~/.bashrc`, or `~/.profile` file) to make alias available in newly opened terminal.
+
+```bash
+alias dphing='docker-compose exec php-fpm ./phing'
+```
+
+From now on you can invoke a phing from the container just by running `dphing` from the root of your project folder.
+
+### Linux prerequisites
+
+You need to install `bash-completion` package.
+Exact installation depends on your Linux distribution, but usually, it can be done by running
+
+```bash
+sudo apt install bash-completion
+```
+
+or
+
+```bash
+sudo yum install bash-completion
+```
+
+You may need to add loading of the bash-completion into your profile.
+For more information, please refer to the guide of your Linux distribution.
+
+### MacOS prerequisites
+
+You need to install the necessary package with `brew` command (you need to have [Homebrew](https://brew.sh) installed)
+
+```bash
+brew install bash-completion
+```
+
+Add following into `~/.bash_profile`
+
+```bash
+[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
+```
+
+### Autocomplete script
+
+The last thing is to add the autocomplete script to handle the completion of your previously created `dphing` alias.
+
+Store this file in `/etc/bash_completion.d/dphing` on Linux, or in `/usr/local/etc/bash_completion.d/dphing` on MacOS.
+
+```bash
+_dphing () {
+    local cur prev
+ 
+    COMPREPLY=()
+    buildfile=build.xml
+    _get_comp_words_by_ref cur prev
+ 
+    [ ! -f $buildfile ] && return 0
+
+    COMPREPLY=( $( compgen -W "$( dphing -l | tr -s '\-' | sed s/^-/\|/ | tr -d '\|' \
+        | sed s/\ \ .*\// \
+        | sed s/Buildfile.*// | sed s/Default\ target:// | sed s/Subtargets:// \
+        | sed s/Main\ targets:// \
+        | tr -s ' ' \
+        | sed 's/[^[:print:]]//g' | sed s/\\[.*// | tr '\n' ' ' | tr -s '\n' 2>/dev/null )" \
+        -- "$cur" ) )
+}
+ 
+complete -F _dphing dphing
+```
+
+Restart the terminal for changes to take effect.
+
+From now on, you can just type `dphing <tab><tab>` to see all possible completion words.
+
+It's also possible to let autocompletion expand the partially typed target name, so `dphing fri<tab>` became `dphing friendly-urls-generate`.
+
+!!! note
+    Docker containers have to be running in order to `dphing` and autocompletion work properly.

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -9,6 +9,9 @@ You can list all available Phing targets by running:
 php phing
 ```
 
+!!! note
+    Check out the [Autocompletion for Phing Targets](./autocompletion-for-phing-targets.md) article, where you can find useful info about autocompletion of target names.
+
 ## How Phing targets work
 Phing targets are defined in `build.xml` file.
 Any Phing target can execute a subset of other targets or console commands.

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -18,3 +18,4 @@
 * [Using Form Types](./using-form-types.md)
 * [Friendly URL](./friendly-url.md)
 * [Front-end Breadcrumb Navigation](./front-end-breadcrumb-navigation.md)
+* [Autocompletion for Phing Targets](./autocompletion-for-phing-targets.md)

--- a/docs/introduction/navigation.yml
+++ b/docs/introduction/navigation.yml
@@ -1,5 +1,6 @@
 arrange:
     - index.md
+    - start-building-your-application.md
     - console-commands-for-application-management-phing-targets.md
     - automated-testing.md
     - basics-about-package-architecture.md
@@ -12,8 +13,14 @@ arrange:
     - how-to-set-up-domains-and-locales.md
     - development-workflow-of-project-on-shopsys-framework.md
     - translations.md
+    - working-with-date-time-values.md
     - directories.md
     - cron.md
     - using-form-types.md
     - friendly-url.md
     - front-end-breadcrumb-navigation.md
+    - running-acceptance-tests.md
+    - required-php-configuration.md
+    - shopsys-framework-on-docker.md
+    - monorepo.md
+    - faq-and-common-issues.md

--- a/docs/introduction/navigation.yml
+++ b/docs/introduction/navigation.yml
@@ -19,6 +19,7 @@ arrange:
     - using-form-types.md
     - friendly-url.md
     - front-end-breadcrumb-navigation.md
+    - autocompletion-for-phing-targets.md
     - running-acceptance-tests.md
     - required-php-configuration.md
     - shopsys-framework-on-docker.md

--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -30,6 +30,7 @@ RUN chmod +x /usr/local/bin/docker-install-composer && \
 # autoconf needed by "redis" extension
 RUN apt-get update && \
     apt-get install -y \
+    bash-completion \
     libpng-dev \
     libjpeg-dev \
     libfreetype6-dev \
@@ -76,6 +77,9 @@ ENV LC_ALL en_US.UTF-8
 # copy php.ini configuration
 COPY ${project_root}/docker/php-fpm/php-ini-overrides.ini /usr/local/etc/php/php.ini
 
+# add bash completion for phing
+COPY ${project_root}/docker/php-fpm/phing-completion /etc/bash_completion.d/phing
+
 # overwrite the original entry-point from the PHP Docker image with our own
 COPY ${project_root}/docker/php-fpm/docker-php-entrypoint /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-php-entrypoint
@@ -88,6 +92,9 @@ RUN usermod -m -d /home/www-data www-data && \
 
 # Switch to user
 USER www-data
+
+# enable bash completion
+RUN echo "source /etc/bash_completion" >> ~/.bashrc
 
 RUN mkdir -p /var/www/html/.npm-global
 ENV NPM_CONFIG_PREFIX /var/www/html/.npm-global

--- a/project-base/docker/php-fpm/phing-completion
+++ b/project-base/docker/php-fpm/phing-completion
@@ -1,0 +1,21 @@
+_phing () {
+    local cur prev
+
+    COMPREPLY=()
+    buildfile=build.xml
+    _get_comp_words_by_ref cur prev
+
+    [ ! -f $buildfile ] && return 0
+
+    [[ ${prev} == "php" ]] && [[ ${cur} != "phing" ]] && return
+
+    COMPREPLY=( $( compgen -W "$( ./phing -l | tr -s '\-' | sed s/^-/\|/ | tr -d '\|' \
+        | sed s/\ \ .*\// \
+        | sed s/Buildfile.*// | sed s/Default\ target:// | sed s/Subtargets:// \
+        | sed s/Main\ targets:// \
+        | tr -s ' ' \
+        | sed 's/[^[:print:]]//g' | sed s/\\[.*// | tr '\n' ' ' | tr -s '\n' 2>/dev/null )" \
+        -- "$cur" ) )
+}
+
+complete -F _phing -o default "php" "./phing"

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -135,3 +135,6 @@ There you can find links to upgrade notes for other versions too.
 
 - add brands in frontend API ([#2047](https://github.com/shopsys/shopsys/pull/2047))
     - see #project-base-diff to update your project
+
+- add autocompletion for Phing targets ([#2049](https://github.com/shopsys/shopsys/pull/2049))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In the container is now possible to autocomplete names of the Phing targets. Behavior is documented with hints how to set up autocompletion on the host machine too. Thanks to @pk16011990 for the solution on the host machine.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #776 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
