### PR TITLE
[framework] fixed loading of multi design templates

### DIFF
--- a/packages/framework/src/Component/Domain/Multidomain/Twig/FilesystemLoader.php
+++ b/packages/framework/src/Component/Domain/Multidomain/Twig/FilesystemLoader.php
@@ -13,14 +13,16 @@ class FilesystemLoader extends BaseFilesystemLoader
     protected $domain;
 
     /**
+     * @param array $paths
      * @param string|null $rootPath
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain|null $domain
      */
     public function __construct(
+        array $paths = [],
         ?string $rootPath = null,
         ?Domain $domain = null
     ) {
-        parent::__construct([], $rootPath);
+        parent::__construct($paths, $rootPath);
 
         $this->domain = $domain;
         $this->assertDomainDependency();

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterMultiDesignFilesystemLoaderCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterMultiDesignFilesystemLoaderCompilerPass.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
+
+use Shopsys\FrameworkBundle\Component\Domain\Multidomain\Twig\FilesystemLoader;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterMultiDesignFilesystemLoaderCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.native_filesystem');
+        $twigFilesystemLoaderDefinition->setClass(FilesystemLoader::class);
+        $twigFilesystemLoaderDefinition->setAutowired(true);
+    }
+}

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterMultiDesignFilesystemLoaderCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterMultiDesignFilesystemLoaderCompilerPass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
 
 use Shopsys\FrameworkBundle\Component\Domain\Multidomain\Twig\FilesystemLoader;
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -18,5 +19,10 @@ class RegisterMultiDesignFilesystemLoaderCompilerPass implements CompilerPassInt
         $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.native_filesystem');
         $twigFilesystemLoaderDefinition->setClass(FilesystemLoader::class);
         $twigFilesystemLoaderDefinition->setAutowired(true);
+
+        $environment = $container->getParameter('kernel.environment');
+        if ($environment === EnvironmentType::TEST) {
+            $twigFilesystemLoaderDefinition->setPublic(true);
+        }
     }
 }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -542,16 +542,6 @@ services:
     twig.stringloader:
         class: Twig\Loader\ArrayLoader
 
-    Shopsys\FrameworkBundle\Component\Domain\Multidomain\Twig\FilesystemLoader: '@twig.loader.filesystem'
-
-    twig.loader.filesystem:
-        class: Shopsys\FrameworkBundle\Component\Domain\Multidomain\Twig\FilesystemLoader
-        arguments:
-            $locator: '@templating.locator'
-            $parser: '@templating.name_parser'
-            $rootPath: '%kernel.project_dir%'
-            $domain: '@Shopsys\FrameworkBundle\Component\Domain\Domain'
-
     Shopsys\FrameworkBundle\Form\Constraints\UniqueEmailValidator:
         tags:
             - { name: validator.constraint_validator, alias: Shopsys\FrameworkBundle\Form\Constraints\UniqueEmailValidator }

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidators
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\LazyRedisCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterCronModulesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterExtendedEntitiesCompilerPass;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterMultiDesignFilesystemLoaderCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExtensionsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProductFeedConfigsCompilerPass;
@@ -37,6 +38,7 @@ class ShopsysFrameworkBundle extends Bundle
         $container->addCompilerPass(new LazyRedisCompilerPass());
         $container->addCompilerPass(new RegisterExtendedEntitiesCompilerPass());
         $container->addCompilerPass(new AddConstraintValidatorsPass());
+        $container->addCompilerPass(new RegisterMultiDesignFilesystemLoaderCompilerPass());
 
         $container->registerForAutoconfiguration(AbstractIndex::class)->addTag('elasticsearch.index');
 

--- a/project-base/templates/Front/Tests/twigLoader.custom.html.twig
+++ b/project-base/templates/Front/Tests/twigLoader.custom.html.twig
@@ -1,0 +1,1 @@
+Hello world custom

--- a/project-base/templates/Front/Tests/twigLoader.html.twig
+++ b/project-base/templates/Front/Tests/twigLoader.html.twig
@@ -1,0 +1,1 @@
+Hello world

--- a/project-base/tests/App/Functional/Twig/FilesystemLoaderTest.php
+++ b/project-base/tests/App/Functional/Twig/FilesystemLoaderTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Twig;
+
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Tests\App\Test\FunctionalTestCase;
+
+class FilesystemLoaderTest extends FunctionalTestCase
+{
+    public function testLoadingMultiDesignTemplate()
+    {
+        $twigFilesystemLoader = $this->getContainer()->get('twig.loader.native_filesystem');
+        $setting = $this->createMock(Setting::class);
+        $twig = $this->getContainer()->get('twig');
+
+        $domainConfigWithoutCustomDesignId = new DomainConfig(
+            1,
+            'http://webserver:8080',
+            'domain1',
+            'en',
+            'sa',
+            ''
+        );
+
+        $domainConfigWithCustomDesignId = new DomainConfig(
+            2,
+            'http://webserver:8080',
+            'domain2',
+            'en',
+            'sa',
+            'custom'
+        );
+
+        $domain = new Domain([$domainConfigWithoutCustomDesignId, $domainConfigWithCustomDesignId], $setting);
+
+        $twigReflection = new \ReflectionClass($twigFilesystemLoader);
+        $domainReflection = $twigReflection->getProperty('domain');
+        $domainReflection->setAccessible(true);
+        $domainReflection->setValue($twigFilesystemLoader, $domain);
+
+        $domain->switchDomainById(1);
+        $fileOutput = $twig->render('Front/Tests/twigLoader.html.twig');
+        $this->assertSame('Hello world', trim($fileOutput));
+
+        $domain->switchDomainById(2);
+        $fileOutput = $twig->render('Front/Tests/twigLoader.html.twig');
+        $this->assertSame('Hello world custom', trim($fileOutput));
+
+        $domainReflection->setValue($twigFilesystemLoader, $this->domain);
+        $domainReflection->setAccessible(false);
+    }
+}

--- a/upgrade/UPGRADE-v9.0.3-dev.md
+++ b/upgrade/UPGRADE-v9.0.3-dev.md
@@ -27,3 +27,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fix webserver URL in frontend API tests ([#2045](https://github.com/shopsys/shopsys/pull/2045))
     - see #project-base-diff to update your project
+
+- fix loading of multi design templates ([#2050](https://github.com/shopsys/shopsys/pull/2050))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With upgrade on Symfony 4 there has been changes in FilesystemLoaders and it caused our FilesystemLoader to not be used anymore. This PR fixes that and adds test to check, if it is working correctly in the future.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2042  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
