### PR TITLE
[shopsys] fixed wrong generated demodata for different number of domains than 2

### DIFF
--- a/project-base/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/OrderDataFixture.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\DataFixtures\Demo;
 
+use DateTime;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
-use Faker\Generator;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
@@ -26,11 +26,6 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRepository
      */
     private $customerUserRepository;
-
-    /**
-     * @var \Faker\Generator
-     */
-    private $faker;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Order\OrderFacade
@@ -59,7 +54,6 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRepository $customerUserRepository
-     * @param \Faker\Generator $faker
      * @param \Shopsys\FrameworkBundle\Model\Order\OrderFacade $orderFacade
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory
      * @param \App\Model\Order\OrderDataFactory $orderDataFactory
@@ -68,7 +62,6 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
      */
     public function __construct(
         CustomerUserRepository $customerUserRepository,
-        Generator $faker,
         OrderFacade $orderFacade,
         OrderPreviewFactory $orderPreviewFactory,
         OrderDataFactoryInterface $orderDataFactory,
@@ -76,7 +69,6 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         CurrencyFacade $currencyFacade
     ) {
         $this->customerUserRepository = $customerUserRepository;
-        $this->faker = $faker;
         $this->orderFacade = $orderFacade;
         $this->orderPreviewFactory = $orderPreviewFactory;
         $this->orderDataFactory = $orderDataFactory;
@@ -126,7 +118,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -3 day'))->setTime(12, 40, 22);
         $this->createOrder(
             $orderData,
             [
@@ -151,7 +143,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -11 day'))->setTime(4, 34, 19);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
         $this->createOrder(
             $orderData,
@@ -179,7 +171,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -3 day'))->setTime(18, 27, 36);
         $this->createOrder(
             $orderData,
             [
@@ -204,7 +196,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -1 day'))->setTime(18, 30, 01);
         $this->createOrder(
             $orderData,
             [
@@ -228,7 +220,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -2 day'))->setTime(1, 46, 6);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::SUPERADMINISTRATOR);
         $this->createOrder(
             $orderData,
@@ -255,7 +247,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -12 day'))->setTime(0, 49, 0);
         $this->createOrder(
             $orderData,
             [
@@ -284,7 +276,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -13 day'))->setTime(23, 35, 15);
         $this->createOrder(
             $orderData,
             [
@@ -309,7 +301,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -5 day'))->setTime(9, 11, 59);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::SUPERADMINISTRATOR);
         $this->createOrder(
             $orderData,
@@ -335,7 +327,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -14 day'))->setTime(12, 54, 07);
         $this->createOrder(
             $orderData,
             [
@@ -359,7 +351,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -7 day'))->setTime(7, 2, 31);
         $this->createOrder(
             $orderData,
             [
@@ -382,7 +374,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -7 day'))->setTime(11, 28, 20);
         $this->createOrder(
             $orderData,
             [
@@ -407,7 +399,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -10 day'))->setTime(18, 3, 36);
         $this->createOrder(
             $orderData,
             [
@@ -431,7 +423,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -10 day'))->setTime(23, 47, 11);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
         $this->createOrder(
             $orderData,
@@ -456,7 +448,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -10 day'))->setTime(8, 14, 8);
         $this->createOrder(
             $orderData,
             [
@@ -482,7 +474,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -11 day'))->setTime(4, 43, 25);
         $this->createOrder(
             $orderData,
             [
@@ -510,7 +502,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -5 day'))->setTime(3, 3, 12);
         $this->createOrder(
             $orderData,
             [
@@ -548,7 +540,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -13 day'))->setTime(17, 34, 40);
         $orderData->createdAsAdministrator = $this->getReference(AdministratorDataFixture::ADMINISTRATOR);
         $this->createOrder(
             $orderData,
@@ -592,7 +584,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->note = 'Doufám, že vše dorazí v pořádku a co nejdříve :)';
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-2 week', 'now');
+        $orderData->createdAt = (new DateTime('now -6 day'))->setTime(5, 7, 38);
         $this->createOrder(
             $orderData,
             [
@@ -628,7 +620,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-1 week', 'now');
+        $orderData->createdAt = (new DateTime('now -1 day'))->setTime(22, 51, 55);
         $this->createOrder(
             $orderData,
             [
@@ -668,7 +660,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->note = 'Prosím o dodání do pátku. Děkuji.';
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-1 week', 'now');
+        $orderData->createdAt = (new DateTime('now -4 day'))->setTime(21, 23, 5);
         $this->createOrder(
             $orderData,
             [
@@ -698,7 +690,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-1 week', 'now');
+        $orderData->createdAt = (new DateTime('now -4 day'))->setTime(11, 14, 2);
         $this->createOrder(
             $orderData,
             [
@@ -723,7 +715,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         $orderData->deliveryAddressSameAsBillingAddress = true;
         $orderData->domainId = $domainId;
         $orderData->currency = $domainDefaultCurrency;
-        $orderData->createdAt = $this->faker->dateTimeBetween('-1 week', 'now');
+        $orderData->createdAt = (new DateTime('now -7 day'))->setTime(11, 10, 47);
         $this->createOrder(
             $orderData,
             [

--- a/project-base/tests/FrontendApiBundle/Functional/Article/GetArticleTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Article/GetArticleTest.php
@@ -36,10 +36,10 @@ class GetArticleTest extends GraphQlTestCase
 
     public function testGetArticleReturnsError(): void
     {
-        $article = $this->getArticleOnDifferentDomain();
-        $expectedErrorMessage = 'Article with UUID \'' . $article->getUuid() . '\' not found.';
+        $wrongUuid = '123e4567-e89b-12d3-a456-426614174000';
+        $expectedErrorMessage = 'Article with UUID \'' . $wrongUuid . '\' not found.';
 
-        $response = $this->getResponseContentForQuery($this->getArticleQuery($article->getUuid()));
+        $response = $this->getResponseContentForQuery($this->getArticleQuery($wrongUuid));
         $this->assertResponseContainsArrayOfErrors($response);
         $errors = $this->getErrorsFromResponse($response);
 
@@ -201,13 +201,5 @@ class GetArticleTest extends GraphQlTestCase
                 }
             }
         ';
-    }
-
-    /**
-     * @return \Shopsys\FrameworkBundle\Model\Article\Article
-     */
-    private function getArticleOnDifferentDomain(): Article
-    {
-        return $this->articleFacade->getById(6);
     }
 }

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -138,3 +138,6 @@ There you can find links to upgrade notes for other versions too.
 
 - add autocompletion for Phing targets ([#2049](https://github.com/shopsys/shopsys/pull/2049))
     - see #project-base-diff to update your project
+
+- made tests to be domain independent ([#2051](https://github.com/shopsys/shopsys/pull/2051))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Wher we are not running exactly 2 domain the faker will generate different created date to order so some tests will fail (when they are dependent on sorted orders). This PR removes faker for datetime.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
