### PR TITLE
[shopsys] do not require short list syntax

### DIFF
--- a/packages/framework/src/Component/Paginator/QueryPaginator.php
+++ b/packages/framework/src/Component/Paginator/QueryPaginator.php
@@ -99,7 +99,7 @@ class QueryPaginator implements PaginatorInterface
             $parametersAssoc[$parameter->getName()] = $parameter->getValue();
         }
 
-        [, $flatenedParameters] = SQLParserUtils::expandListParameters(
+        list(, $flatenedParameters) = SQLParserUtils::expandListParameters(
             $query->getDQL(),
             $parametersAssoc,
             []

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -145,3 +145,7 @@ parameters:
         # @deprecated File is excluded as the comments are already missing and deprecated methods will not be in next major
         SlevomatCodingStandard\Sniffs\Commenting\DeprecatedAnnotationDeclarationSniff:
             - '*/tests/App/Test/Codeception/Module/StrictWebDriver.php'
+
+        # @deprecated This will be moved from project-base to coding-standards package in next major version
+        # rule breaks jms/translation-budle as it fails on this usage: `[, $b] = $var`
+        PhpCsFixer\Fixer\ListNotation\ListSyntaxFixer: ~

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -121,7 +121,7 @@ There you can find links to upgrade notes for other versions too.
             use `Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFactory::getIdsForProducts()` instead
     - see #project-base-diff to update your project
 
-- added more coding standards ([#2035](https://github.com/shopsys/shopsys/pull/2035))
+- added more coding standards ([#2035](https://github.com/shopsys/shopsys/pull/2035), [#2052](https://github.com/shopsys/shopsys/pull/2052))
     - the most of the rules have their own fixer, run `php phing ecs-fix` to resolve them
         - you need to run `ecs-fix` multiple times unless it is OK, because of the amount of changes
     - disallowed usage of `empty()` is one which must be fixed manually


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2035 was required checker/fixer for short list syntaxt. Unfortunatelly there is a bug in `jmstranslation-bundle` which does not work well with it (https://github.com/schmittjoh/JMSTranslationBundle/issues/506) and `phing translations-dump` started failing because of that.<br>This PR adds ignore for this rule. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
