### PR TITLE
[shopsys] made parameters overridable by ENV variables

### DIFF
--- a/.ci/build_kubernetes.sh
+++ b/.ci/build_kubernetes.sh
@@ -16,9 +16,6 @@ cp project-base/config/parameters.yaml.dist project-base/config/parameters.yaml
 yq write --inplace project-base/config/domains_urls.yaml domains_urls[0].url http://${FIRST_DOMAIN_HOSTNAME}:${NGINX_INGRESS_CONTROLLER_HOST_PORT}
 yq write --inplace project-base/config/domains_urls.yaml domains_urls[1].url http://${SECOND_DOMAIN_HOSTNAME}:${NGINX_INGRESS_CONTROLLER_HOST_PORT}
 
-# Change "overwrite_domain_url" parameter for Selenium tests as containers "webserver" and "php-fpm" are bundled together in a pod "webserver-php-fpm"
-yq write --inplace project-base/config/parameters_test.yaml parameters.overwrite_domain_url http://webserver-php-fpm:8080
-
 # Pull or build Docker images for the current commit
 DOCKER_IMAGE_TAG=ci-commit-${GIT_COMMIT}
 DOCKER_ELASTIC_IMAGE_TAG=ci-elasticsearch-7
@@ -55,6 +52,8 @@ DOCKER_ELASTIC_IMAGE=${DOCKER_USERNAME}/elasticsearch:${DOCKER_ELASTIC_IMAGE_TAG
 PATH_CONFIG_DIRECTORY='/var/www/html/project-base/config'
 GOOGLE_CLOUD_STORAGE_BUCKET_NAME=''
 GOOGLE_CLOUD_PROJECT_ID=''
+# Change "OVERWRITE_DOMAIN_URL" parameter for Selenium tests as containers "webserver" and "php-fpm" are bundled together in a pod "webserver-php-fpm"
+OVERWRITE_DOMAIN_URL='http://webserver-php-fpm:8080'
 
 FILES=$( find project-base/kubernetes -type f )
 VARS=(
@@ -65,6 +64,7 @@ VARS=(
     PATH_CONFIG_DIRECTORY
     GOOGLE_CLOUD_STORAGE_BUCKET_NAME
     GOOGLE_CLOUD_PROJECT_ID
+    OVERWRITE_DOMAIN_URL
 )
 
 for FILE in $FILES; do

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,6 @@
         "guzzlehttp/guzzle": "^6.3",
         "helios-ag/fm-elfinder-bundle": "^10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
-        "incenteev/composer-parameter-handler": "^2.1.3",
         "intervention/image": "^2.3.14",
         "jdorn/sql-formatter": "^1.2",
         "jms/metadata": "^1.6",
@@ -186,12 +185,14 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "cp -n project-base/config/parameters.yaml.dist project-base/config/parameters.yaml || echo '[skiped] parameters.yaml exists'",
+            "cp -n project-base/config/parameters_test.yaml.dist project-base/config/parameters_test.yaml || echo '[skiped] parameters_test.yaml exists'",
             "App\\Environment::checkEnvironment",
             "@auto-scripts"
         ],
         "post-update-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "cp -n project-base/config/parameters.yaml.dist project-base/config/parameters.yaml || echo '[skiped] parameters.yaml exists'",
+            "cp -n project-base/config/parameters_test.yaml.dist project-base/config/parameters_test.yaml || echo '[skiped] parameters_test.yaml exists'",
             "App\\Environment::checkEnvironment",
             "@auto-scripts"
         ],
@@ -219,17 +220,7 @@
         "symfony": {
             "allow-contrib": true,
             "require": "^4.4.0"
-        },
-        "incenteev-parameters": [
-            {
-                "file": "project-base/config/parameters.yaml",
-                "keep-outdated": true
-            },
-            {
-                "file": "project-base/config/parameters_test.yaml",
-                "keep-outdated": true
-            }
-        ]
+        }
     },
     "replace": {
         "shopsys/backend-api": "self.version",

--- a/docs/cookbook/dumping-and-importing-the-database.md
+++ b/docs/cookbook/dumping-and-importing-the-database.md
@@ -30,7 +30,7 @@ Then you can import the dump:
 psql --quiet --username=database_user --host=database_host target_database_name < dump.sql
 ```
 
-Replace `database_user`, `database_host` and `target_database_name` with the correct values (from your `config/parameters.yaml`).
+Replace `database_user`, `database_host` and `target_database_name` with the correct values (from your `.env.local`).
 The command will prompt you for the user's password.
 
 ## Importing database into a new database
@@ -49,5 +49,5 @@ Then you can import the dump:
 psql --quiet --username=database_user --host=database_host target_database_name < dump.sql
 ```
 
-Replace `database_user`, `database_host` and `target_database_name` with the correct values (from your `config/parameters.yaml`).
+Replace `database_user`, `database_host` and `target_database_name` with the correct values (from your `.env.local`).
 The command will prompt you for the user's password.

--- a/docs/installation/application-configuration.md
+++ b/docs/installation/application-configuration.md
@@ -1,51 +1,10 @@
 # Application Configuration
 
-The application is configurable by [Symfony configuration files](https://symfony.com/doc/4.4/configuration.html#configuration-parameters) or via environment variables which allows you to overwrite them.
+The application is configurable by [Symfony configuration files](https://symfony.com/doc/4.4/configuration.html#configuration-parameters) or via [environment variables](https://symfony.com/doc/4.4/configuration.html#configuration-environments) which allows you to overwrite them.
 
-- [Configuration by parameters](#configuration-by-parameters)
-- [Configuration by environment variables](#configuration-by-environment-variables)
+## Configuration parameters
 
-## Configuration by parameters
-
-For operating Shopsys Framework it is needed to have correctly set connections to external services via `parameters.yaml` config.
-From the clean project, during composer installation process it will prompt you to set the values of parameters (`config/parameters.yaml`):
-
-| Name                                     | Description                                                                                                  |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `database_host`                          | access data of your PostgreSQL database                                                                      |
-| `database_port`                          | ...                                                                                                          |
-| `database_name`                          | ...                                                                                                          |
-| `database_user`                          | ...                                                                                                          |
-| `database_password`                      | ...                                                                                                          |
-| `elasticsearch_host`                     | host of your Elasticsearch                                                                                   |
-| `redis_host`                             | host of your Redis storage (credentials are not supported right now)                                         |
-| `mailer_transport`                       | access data of your mail server                                                                              |
-| `mailer_host`                            | ...                                                                                                          |
-| `mailer_user`                            | ...                                                                                                          |
-| `mailer_password`                        | ...                                                                                                          |
-| `mailer_disable_delivery`                | set to `true` if you don't want to send any emails                                                          |
-| `mailer_master_email_address`            | set if you want to send all emails to one address (useful for development)                                  |
-| `mailer_delivery_whitelist`              | set as array with regex text items if you want to have master email but allow sending to specific addresses |
-| `secret`                                 | randomly generated secret token                                                                              |
-| `trusted_proxies`                        | proxies that are trusted to pass traffic, used mainly for production                                         |
-
-Composer will then prompt you to set parameters for testing environment (`config/parameters_test.yaml`):
-
-| Name                               | Description                                                                   |
-| ---------------------------------- | ----------------------------------------------------------------------------- |
-| `test_database_host`               | access data of your PostgreSQL database for tests                             |
-| `test_database_port`               | ...                                                                           |
-| `test_database_name`               | ...                                                                           |
-| `test_database_user`               | ...                                                                           |
-| `test_database_password`           | ...                                                                           |
-| `overwrite_domain_url`             | overwrites URL of all domains for acceptance testing (set to `~` to disable)  |
-| `selenium_server_host`             | with native installation the selenium server is on `localhost`                |
-| `test_mailer_transport`            | access data of your mail server for tests                                     |
-| `test_mailer_host`                 | ...                                                                           |
-| `test_mailer_user`                 | ...                                                                           |
-| `test_mailer_password`             | ...                                                                           |
-| `shopsys.content_dir_name`         | web/content-test/ directory is used instead of web/content/ during the tests  |
-
+For operating Shopsys Framework it is needed to have correctly set connections to external services via ENV variables.
 
 !!! note
     All default values use default ports for all external services like PostgreSQL database, elasticsearch, redis, ...
@@ -53,19 +12,44 @@ Composer will then prompt you to set parameters for testing environment (`config
 !!! tip
     Host values can be modified or can be aliased for your Operating System via `/etc/hosts` or `C:\Windows\System32\drivers\etc\hosts`
 
-## Configuration by environment variables
 
 Environment variables are really handy to configure the right setting in the desired application environment.
 You may want to set some settings in a different way (such as production, test, or CI servers).
 [Setting environment variables](/introduction/setting-environment-variables) depends on environment of your application.
 
+!!! tip
+    To improve performance you can optionally run `composer dump-env`. [See Symfony documentation for further information.](https://symfony.com/doc/4.4/configuration.html#configuring-environment-variables-in-production)
+
 ### Application
 
-| Name                                   | Default | Description                                                                          |
-| -------------------------------------- | ------- | ------------------------------------------------------------------------------------ |
-| `REDIS_PREFIX`                         | `''`    | separates more projects that use the same redis service                              |
-| `ELASTIC_SEARCH_INDEX_PREFIX`          | `''`    | separates more projects that use the same elasticsearch service                      |
-| `IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK`  | `'0'`   | set to `true` if you want to allow administrators to log in with default credentials |
+!!! note
+    To propagate the change of `MAILER_DELIVERY_WHITELIST`, `MAILER_DISABLE_DELIVERY` and `MAILER_MASTER_EMAIL_ADDRESS` cache must be cleaned. 
+
+| Name                                   | Default                              | Description                                                                          |
+| -------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------ |
+| `DATABASE_HOST`                        | `'postgres'`                         | access data of your PostgreSQL database                                              |
+| `DATABASE_PORT`                        | `null`                               | ...                                                                                  |
+| `DATABASE_NAME`                        | `'shopsys'`                          | ...                                                                                  |
+| `DATABASE_USER`                        | `'root'`                             | ...                                                                                  |
+| `DATABASE_PASSWORD`                    | `'root'`                             | ...                                                                                  |
+| `ELASTICSEARCH_HOST`                   | `'elasticsearch:9200'`               | host of your Elasticsearch                                                           |
+| `REDIS_HOST`                           | `'redis'`                            | host of your Redis storage (credentials are not supported right now)                 |
+| `REDIS_PREFIX`                         | `''`                                 | separates more projects that use the same redis service                              |
+| `MAILER_TRANSPORT`                     | `'smtp'`                             | access data of your mail server                                                      |
+| `MAILER_HOST`                          | `'smtp-server'`                      | ...                                                                                  |
+| `MAILER_USER`                          | `null`                               | ...                                                                                  |
+| `MAILER_PASSWORD`                      | `null`                               | ...                                                                                  |
+| `MAILER_DELIVERY_WHITELIST`            | `'/@shopsys\.com$/'`                 | regex text items if you want to have master email but allow sending to specific addresses (set as text separated by comma for multiple values) |
+| `MAILER_DISABLE_DELIVERY`              | `false`                              | set to `true` if you don't want to send any emails                                   |
+| `MAILER_MASTER_EMAIL_ADDRESS`          | `'no-reply@shopsys.com'`             | set if you want to send all emails to one address (useful for development)           |
+| `APP_SECRET`                           | `'ThisTokenIsNotSoSecretChangeIt'`   | randomly generated secret token                                                      |
+| `ELASTIC_SEARCH_INDEX_PREFIX`          | `''`                                 | separates more projects that use the same elasticsearch service                      |
+| `IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK`  | `'0'`                                | set to `true` if you want to allow administrators to log in with default credentials |
+| `OVERWRITE_DOMAIN_URL`                 | `'http://webserver:8080'`            | overwrites URL of all domains for acceptance testing (set to `~` to disable)         |
+| `SELENIUM_SERVER_HOST`                 | `'selenium-server'`                  | with native installation the selenium server is on `localhost`                       |
+| `SHOPSYS_CONTENT_DIR_NAME`             | `'content-test'`                     | web/content-test/ directory is used instead of web/content/ during the tests         |
+| `TRUSTED_PROXIES`                      | `'127.0.0.1'`                        | proxies that are trusted to pass traffic, used mainly for production (set as text separated by comma for multiple values) |
+
 
 ### Google Cloud Bundle
 

--- a/docs/installation/installation-using-docker-on-production-server.md
+++ b/docs/installation/installation-using-docker-on-production-server.md
@@ -275,7 +275,7 @@ echo $'domains_urls:
 ' >  config/domains_urls.yaml
 ```
 
-Then we check whether `mailer_master_email_address` property in [`parameters.yaml.dist`](https://github.com/shopsys/shopsys/blob/master/project-base/config/parameters.yaml.dist) is set correctly.
+Then we check whether ENV variable `MAILER_MASTER_EMAIL_ADDRESS` in [`.env` or `.env.local`](https://github.com/shopsys/shopsys/blob/master/project-base/.env) is set correctly.
 
 After the project is setup correctly, we launch the build of php-fpm container by docker build command that will build image with composer, npm packages and created assets.
 

--- a/docs/introduction/running-acceptance-tests.md
+++ b/docs/introduction/running-acceptance-tests.md
@@ -55,10 +55,10 @@ For running acceptance tests you need to install [Google Chrome browser](https:/
 You must choose compatible versions of Google Chrome and ChromeDriver.
 As Chrome browser has auto-update enabled by default this may require you to update ChromeDriver from time to time.
 
-When installing Shopsys Framework natively, it is important to update parameters in `config/parameters_test.yaml`:
+When installing Shopsys Framework natively, it is important to update parameters in `.env.test.local`:
 
-* `overwrite_domain_url: ~` (disables domain URL overwriting in `TEST` environment)
-* `selenium_server_host: 127.0.0.1`
+* `OVERWRITE_DOMAIN_URL=` (disables domain URL overwriting in `TEST` environment)
+* `SELENIUM_SERVER_HOST=127.0.0.1`
 
 ### Installing Google Chrome browser
 Download and install Google Chrome browser from <https://www.google.com/chrome/browser/desktop/>

--- a/docs/introduction/running-acceptance-tests.md
+++ b/docs/introduction/running-acceptance-tests.md
@@ -10,10 +10,10 @@ docker exec -it shopsys-framework-php-fpm bash
 
 !!! note
     For `selenium-server` to be able to connect to you `webserver` container and access your application, all domains should have URL set to `http://webserver:8000`.
-    This is done via parameter `%overwrite_domain_url%` defined in `config/parameters_test.yaml`.
+    This is done via ENV `OVERWRITE_DOMAIN_URL` defined in `.env.test` or `.env.test.local`.
     Everything should be configured for you by default but it is important to keep the domain URL overwriting in mind when dealing with acceptance tests.
 
-If you are logged into your `php-fpm` container and have the `%overwrite_domain_url%` parameter properly set,
+If you are logged into your `php-fpm` container and have the `OVERWRITE_DOMAIN_URL` ENV properly set,
 you can run acceptance tests:
 ```sh
 php phing tests-acceptance

--- a/packages/framework/src/Twig/MailerSettingExtension.php
+++ b/packages/framework/src/Twig/MailerSettingExtension.php
@@ -41,9 +41,11 @@ class MailerSettingExtension extends AbstractExtension
     public function __construct(ContainerInterface $container, Environment $twigEnvironment)
     {
         $this->container = $container;
+
+        $this->mailerWhitelistExpressions = $this->container->getParameter('mailer_delivery_whitelist');
         $this->isDeliveryDisabled = $this->container->getParameter('mailer_disable_delivery');
         $this->mailerMasterEmailAddress = $this->container->getParameter('mailer_master_email_address');
-        $this->mailerWhitelistExpressions = $this->container->getParameter('mailer_delivery_whitelist');
+
         $this->twigEnvironment = $twigEnvironment;
     }
 

--- a/project-base/.env
+++ b/project-base/.env
@@ -14,5 +14,23 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK='0'
-REDIS_PREFIX=''
+DATABASE_HOST=postgres
+DATABASE_PORT=5432
+DATABASE_NAME=shopsys
+DATABASE_USER=root
+DATABASE_PASSWORD=root
+ELASTICSEARCH_HOST='elasticsearch:9200'
 ELASTIC_SEARCH_INDEX_PREFIX=''
+REDIS_HOST=redis
+REDIS_PREFIX=''
+
+MAILER_TRANSPORT=smtp
+MAILER_HOST=smtp-server
+MAILER_USER=
+MAILER_PASSWORD=
+MAILER_DELIVERY_WHITELIST=/@shopsys\.com$/
+MAILER_DISABLE_DELIVERY=0
+MAILER_MASTER_EMAIL_ADDRESS=no-reply@shopsys.com
+
+APP_SECRET=ThisTokenIsNotSoSecretChangeIt
+TRUSTED_PROXIES=127.0.0.1

--- a/project-base/.env.test
+++ b/project-base/.env.test
@@ -1,1 +1,6 @@
 # define your env variables for the test environment here
+
+DATABASE_NAME=shopsys-test
+SELENIUM_SERVER_HOST=selenium-server
+OVERWRITE_DOMAIN_URL=http://webserver:8080
+SHOPSYS_CONTENT_DIR_NAME=content-test

--- a/project-base/build/codeception.yml
+++ b/project-base/build/codeception.yml
@@ -6,7 +6,8 @@ paths:
     data: ../tests/App/Acceptance/data
     support: ../tests/App/Test/Codeception
 params:
-    - ../config/parameters_test.yaml
+    - ../.env
+    - ../.env.test
 settings:
     colors: true
     memory_limit: 1024M

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -49,7 +49,6 @@
         "fzaninotto/faker": "^1.7.1",
         "helios-ag/fm-elfinder-bundle": "^10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
-        "incenteev/composer-parameter-handler": "^2.1.3",
         "intervention/image": "^2.3.14",
         "jms/serializer-bundle": "^2.4",
         "jms/translation-bundle": "1.4.4",
@@ -126,12 +125,14 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "cp -n config/parameters.yaml.dist config/parameters.yaml || echo '[skiped] parameters.yaml exists'",
+            "cp -n config/parameters_test.yaml.dist config/parameters_test.yaml || echo '[skiped] parameters_test.yaml exists'",
             "App\\Environment::checkEnvironment",
             "@auto-scripts"
         ],
         "post-update-cmd": [
-            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "cp -n config/parameters.yaml.dist config/parameters.yaml || echo '[skiped] parameters.yaml exists'",
+            "cp -n config/parameters_test.yaml.dist config/parameters_test.yaml || echo '[skiped] parameters_test.yaml exists'",
             "App\\Environment::checkEnvironment",
             "@auto-scripts"
         ],
@@ -162,16 +163,6 @@
         "symfony": {
             "allow-contrib": true,
             "require": "^4.4"
-        },
-        "incenteev-parameters": [
-            {
-                "file": "config/parameters.yaml",
-                "keep-outdated": true
-            },
-            {
-                "file": "config/parameters_test.yaml",
-                "keep-outdated": true
-            }
-        ]
+        }
     }
 }

--- a/project-base/config/bootstrap.php
+++ b/project-base/config/bootstrap.php
@@ -19,7 +19,7 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     $path = dirname(__DIR__).'/.env';
-    $dotenv = new Dotenv(false);
+    $dotenv = new Dotenv(true);
 
     // load all the .env files
     if (method_exists($dotenv, 'loadEnv')) {

--- a/project-base/config/parameters.yaml.dist
+++ b/project-base/config/parameters.yaml.dist
@@ -1,22 +1,21 @@
+# @deprecated
+# This file is kept to provide a backward compatibility for parameters set in services.
+# All values should be set with ENV variables exclusively.
+# This file will be removed in the next major, when all occurrences of parameters will be replaced.
+
 parameters:
-    database_host: postgres
-    database_port: ~
-    database_name: shopsys
-    database_user: root
-    database_password: root
-
-    elasticsearch_host: elasticsearch:9200
-
-    redis_host: redis
-
-    mailer_transport: smtp
-    mailer_host: smtp-server
-    mailer_user: ~
-    mailer_password: ~
+    database_host: '%env(DATABASE_HOST)%'
+    database_port: '%env(DATABASE_PORT)%'
+    database_name: '%env(DATABASE_NAME)%'
+    database_user: '%env(DATABASE_USER)%'
+    database_password: '%env(DATABASE_PASSWORD)%'
+    elasticsearch_host: '%env(ELASTICSEARCH_HOST)%'
+    redis_host: '%env(REDIS_HOST)%'
+    mailer_transport: '%env(MAILER_TRANSPORT)%'
+    mailer_host: '%env(MAILER_HOST)%'
+    mailer_user: '%env(MAILER_USER)%'
+    mailer_password: '%env(MAILER_PASSWORD)%'
     mailer_disable_delivery: false
     mailer_master_email_address: no-reply@shopsys.com
     mailer_delivery_whitelist: [/@shopsys\.com$/]
-
-    secret: ThisTokenIsNotSoSecretChangeIt
-    trusted_proxies:
-        - "127.0.0.1"
+    secret: '%env(APP_SECRET)%'

--- a/project-base/config/parameters_test.yaml.dist
+++ b/project-base/config/parameters_test.yaml.dist
@@ -1,16 +1,19 @@
+# @deprecated
+# This file is kept to provide a backward compatibility for parameters set in services.
+# All values should be set with ENV variables exclusively.
+# This file will be removed in the next major, when all occurrences of parameters will be replaced.
+
 parameters:
-    test_database_host: postgres
-    test_database_port: ~
-    test_database_name: shopsys-test
-    test_database_user: root
-    test_database_password: root
+    selenium_server_host: '%env(SELENIUM_SERVER_HOST)%'
+    overwrite_domain_url: '%env(OVERWRITE_DOMAIN_URL)%'
+    shopsys.content_dir_name: '%env(SHOPSYS_CONTENT_DIR_NAME)%'
 
-    selenium_server_host: selenium-server
-    overwrite_domain_url: http://webserver:8080
-
-    test_mailer_transport: smtp
-    test_mailer_host: smtp-server
-    test_mailer_user: ~
-    test_mailer_password: ~
-
-    shopsys.content_dir_name: 'content-test'
+    test_database_host: '%env(DATABASE_HOST)%'
+    test_database_port: '%env(DATABASE_PORT)%'
+    test_database_name: '%env(DATABASE_NAME)%'
+    test_database_user: '%env(DATABASE_USER)%'
+    test_database_password: '%env(DATABASE_PASSWORD)%'
+    test_mailer_transport: '%env(MAILER_TRANSPORT)%'
+    test_mailer_host: '%env(MAILER_HOST)%'
+    test_mailer_user: '%env(MAILER_USER)%'
+    test_mailer_password: '%env(MAILER_PASSWORD)%'

--- a/project-base/config/parameters_test.yaml.dist
+++ b/project-base/config/parameters_test.yaml.dist
@@ -4,7 +4,6 @@
 # This file will be removed in the next major, when all occurrences of parameters will be replaced.
 
 parameters:
-    selenium_server_host: '%env(SELENIUM_SERVER_HOST)%'
     overwrite_domain_url: '%env(OVERWRITE_DOMAIN_URL)%'
     shopsys.content_dir_name: '%env(SHOPSYS_CONTENT_DIR_NAME)%'
 

--- a/project-base/kubernetes/deployments/webserver-php-fpm.yml
+++ b/project-base/kubernetes/deployments/webserver-php-fpm.yml
@@ -76,6 +76,8 @@ spec:
                             value: "{{GOOGLE_CLOUD_STORAGE_BUCKET_NAME}}"
                         -   name: GOOGLE_CLOUD_PROJECT_ID
                             value: "{{GOOGLE_CLOUD_PROJECT_ID}}"
+                        -   name: OVERWRITE_DOMAIN_URL
+                            value: "{{OVERWRITE_DOMAIN_URL}}"
             containers:
                 -   image: "{{DOCKER_PHP_FPM_IMAGE}}"
                     name: php-fpm
@@ -96,6 +98,8 @@ spec:
                             value: "{{GOOGLE_CLOUD_STORAGE_BUCKET_NAME}}"
                         -   name: GOOGLE_CLOUD_PROJECT_ID
                             value: "{{GOOGLE_CLOUD_PROJECT_ID}}"
+                        -   name: OVERWRITE_DOMAIN_URL
+                            value: "{{OVERWRITE_DOMAIN_URL}}"
                 -   image: nginx:1.13.10-alpine
                     name: webserver
                     ports:

--- a/project-base/src/Kernel.php
+++ b/project-base/src/Kernel.php
@@ -88,6 +88,8 @@ class Kernel extends BaseKernel
         if (file_exists($confDir . '/parameters_version.yaml')) {
             $loader->load($confDir . '/parameters_version.yaml');
         }
+
+        $this->configureSwiftMailer($container);
     }
 
     /**
@@ -101,5 +103,37 @@ class Kernel extends BaseKernel
         $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    protected function configureSwiftMailer(ContainerBuilder $container): void
+    {
+        $envMailerDeliveryWhitelist = getenv('MAILER_DELIVERY_WHITELIST');
+        if ($envMailerDeliveryWhitelist !== false) {
+            $mailerDeliveryWhitelist = explode(',', $envMailerDeliveryWhitelist);
+            $container->setParameter('mailer_delivery_whitelist', $mailerDeliveryWhitelist);
+        }
+
+        $envMailerDisableDelivery = getenv('MAILER_DISABLE_DELIVERY');
+        if ($envMailerDisableDelivery !== false) {
+            $castedEnvMailerDisableDelivery = (bool)(filter_var(
+                $envMailerDisableDelivery,
+                FILTER_VALIDATE_BOOLEAN
+            ) ?: filter_var(
+                $envMailerDisableDelivery,
+                FILTER_VALIDATE_INT
+            ) ?: filter_var(
+                $envMailerDisableDelivery,
+                FILTER_VALIDATE_FLOAT
+            ));
+            $container->setParameter('mailer_disable_delivery', $castedEnvMailerDisableDelivery);
+        }
+
+        $envMailerMasterEmailAddress = getenv('MAILER_MASTER_EMAIL_ADDRESS');
+        if ($envMailerMasterEmailAddress !== false) {
+            $container->setParameter('mailer_master_email_address', $envMailerMasterEmailAddress);
+        }
     }
 }

--- a/project-base/symfony.lock
+++ b/project-base/symfony.lock
@@ -292,9 +292,6 @@
     "illuminate/support": {
         "version": "v5.8.35"
     },
-    "incenteev/composer-parameter-handler": {
-        "version": "v2.1.3"
-    },
     "intervention/image": {
         "version": "2.5.1"
     },

--- a/project-base/tests/App/Acceptance/acceptance.suite.yml
+++ b/project-base/tests/App/Acceptance/acceptance.suite.yml
@@ -32,7 +32,7 @@ modules:
             populate: true
             cleanup: true
         Tests\App\Test\Codeception\Module\StrictWebDriver:
-            host: "%selenium_server_host%"
+            host: '%SELENIUM_SERVER_HOST%'
             port: 4444
             url: ~
             browser: chrome

--- a/symfony.lock
+++ b/symfony.lock
@@ -277,9 +277,6 @@
     "heureka/overeno-zakazniky": {
         "version": "v2.0.6"
     },
-    "incenteev/composer-parameter-handler": {
-        "version": "v2.1.3"
-    },
     "intervention/image": {
         "version": "2.5.0"
     },

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -144,3 +144,7 @@ There you can find links to upgrade notes for other versions too.
 
 - add additional data to Product frontend API type ([#2057](https://github.com/shopsys/shopsys/pull/2057))
     - see #project-base-diff to update your project
+
+- made parameters overridable by ENV variables ([#2055](https://github.com/shopsys/shopsys/pull/2055))
+    - how to configure your application with ENV variables can be found [in our docs](https://docs.shopsys.com/en/latest/installation/application-configuration/)
+    - see #project-base-diff to update your project

--- a/upgrade/upgrading-monorepo.md
+++ b/upgrade/upgrading-monorepo.md
@@ -13,6 +13,11 @@ Typical upgrade sequence should be:
 
 ***Note:** During the execution of `build-demo-dev phing target`, there will be installed 3-rd party software as dependencies of Shopsys Framework by [composer](https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies) and [npm](https://docs.npmjs.com/about-the-public-npm-registry) with licenses that are described in document [Open Source License Acknowledgements and Third-Party Copyrights](https://github.com/shopsys/shopsys/blob/7.3/open-source-license-acknowledgements-and-third-party-copyrights.md)*
 
+## [From v9.0.3 to v9.1.0-dev]
+
+- allow overriding parameters with ENV variables ([#2055](https://github.com/shopsys/shopsys/pull/2055)))
+     - remove `config/parameters.yaml` and `config/parameters_test.yaml` then run `composer install`
+
 ## [From v9.0.3 to v9.0.4-dev]
 
 ## [From v9.0.2 to v9.0.3]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to be able change parameters via ENV variables to easier change setting of application in any environment. This PR allows developers to override all parameters in `parameters.yaml` by ENV variables. This PR also unifies usage of parameters in different environment (dev, test, prod).
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

The original PR (#1615) was braking backward compatibility.