### PR TITLE
[shopsys] fixed fraction digits of prices in FEAPI

### DIFF
--- a/packages/frontend-api/src/Component/Price/MoneyFormatterHelper.php
+++ b/packages/frontend-api/src/Component/Price/MoneyFormatterHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\Price;
+
+use Shopsys\FrameworkBundle\Component\Money\Money;
+
+class MoneyFormatterHelper
+{
+    protected const MAX_FRACTION_DIGITS = 6;
+    protected const DECIMAL_POINT = '.';
+    protected const THOUSANDS_SEPARATOR = '';
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money $money
+     * @return string
+     */
+    public static function formatWithMaxFractionDigits(Money $money): string
+    {
+        return number_format(
+            $money->getAmount(),
+            static::MAX_FRACTION_DIGITS,
+            static::DECIMAL_POINT,
+            static::THOUSANDS_SEPARATOR
+        );
+    }
+}

--- a/packages/frontend-api/src/Model/ScalarType/MoneyType.php
+++ b/packages/frontend-api/src/Model/ScalarType/MoneyType.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrontendApiBundle\Model\ScalarType;
 
 use GraphQL\Language\AST\StringValueNode;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper;
 
 class MoneyType
 {
@@ -15,7 +16,7 @@ class MoneyType
      */
     public static function serialize(Money $value): string
     {
-        return $value->getAmount();
+        return MoneyFormatterHelper::formatWithMaxFractionDigits($value);
     }
 
     /**

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\FrontendApiBundle\Functional\Order;
 
 use Shopsys\FrameworkBundle\Model\Order\Order;
+use Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper;
 use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
 
 class GetOrderAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
@@ -14,6 +15,12 @@ class GetOrderAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
      * @inject
      */
     private $orderFacade;
+
+    /**
+     * @var \Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper
+     * @inject
+     */
+    private $moneyFormatterHelper;
 
     public function testGetOrder(): void
     {
@@ -61,7 +68,9 @@ class GetOrderAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
                 $order->getUuid(),
                 [
                     'status' => $order->getStatus()->getName(),
-                    'totalPriceWithVat' => $order->getTotalPriceWithVat()->getAmount(),
+                    'totalPriceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(
+                        $order->getTotalPriceWithVat()
+                    ),
                 ],
             ];
         }

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsUnauthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrderAsUnauthenticatedCustomerUserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Order;
 
+use Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class GetOrderAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
@@ -13,6 +14,12 @@ class GetOrderAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
      * @inject
      */
     private $orderFacade;
+
+    /**
+     * @var \Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper
+     * @inject
+     */
+    private $moneyFormatterHelper;
 
     public function testGetOrder(): void
     {
@@ -61,7 +68,9 @@ class GetOrderAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
                 $order->getUrlHash(),
                 [
                     'status' => $order->getStatus()->getName(),
-                    'totalPriceWithVat' => $order->getTotalPriceWithVat()->getAmount(),
+                    'totalPriceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(
+                        $order->getTotalPriceWithVat()
+                    ),
                 ],
             ];
         }

--- a/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Order;
 
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper;
 use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
 
 class GetOrdersAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
 {
+    /**
+     * @var \Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper
+     * @inject
+     */
+    private $moneyFormatterHelper;
+
     public function testGetAllCustomerUserOrders(): void
     {
         foreach ($this->getOrdersDataProvider() as $dataSet) {
@@ -135,30 +143,31 @@ class GetOrdersAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
     private function getExpectedUserOrders(): array
     {
         $firstDomainLocale = $this->getLocaleForFirstDomain();
+        $domainId = $this->domain->getId();
         return [
             [
                 'status' => t('In Progress', [], 'dataFixtures', $firstDomainLocale),
-                'priceWithVat' => '153.640000',
+                'priceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(Money::create('153.64')),
             ],
             [
                 'status' => t('Done', [], 'dataFixtures', $firstDomainLocale),
-                'priceWithVat' => '4308.320000',
+                'priceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(Money::create('4308.32')),
             ],
             [
                 'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
-                'priceWithVat' => '83.580000',
+                'priceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(Money::create('83.58')),
             ],
             [
                 'status' => t('Done', [], 'dataFixtures', $firstDomainLocale),
-                'priceWithVat' => '245.970000',
+                'priceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(Money::create('245.97')),
             ],
             [
                 'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
-                'priceWithVat' => '76.580000',
+                'priceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(Money::create('76.58')),
             ],
             [
                 'status' => t('New [adjective]', [], 'dataFixtures', $firstDomainLocale),
-                'priceWithVat' => '1012.420000',
+                'priceWithVat' => MoneyFormatterHelper::formatWithMaxFractionDigits(Money::create('1012.42')),
             ],
         ];
     }

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -141,3 +141,6 @@ There you can find links to upgrade notes for other versions too.
 
 - made tests to be domain independent ([#2051](https://github.com/shopsys/shopsys/pull/2051))
     - see #project-base-diff to update your project
+
+- fixed fraction digits of prices in frontend API ([#2062](https://github.com/shopsys/shopsys/pull/2062))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Frontend API does not respects fraction digits per currency.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
