### PR TITLE
[framework] fixed currencies menu text

### DIFF
--- a/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
+++ b/packages/framework/src/Model/AdminNavigation/SideMenuBuilder.php
@@ -185,7 +185,7 @@ class SideMenuBuilder
         if ($this->authorizationChecker->isGranted(Roles::ROLE_SUPER_ADMIN)) {
             $currenciesMenuItem = $menu->addChild(
                 'currencies',
-                ['route' => 'admin_currency_list', 'label' => t('Currencies')]
+                ['route' => 'admin_currency_list', 'label' => t('Currencies and rounding')]
             );
             $currenciesMenuItem->setExtra('superadmin', true);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After #1338 was merged, renamed menu entry for currencies (and rounding) was reverted by mistake. Rename was in #1791. This PR changes it back.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
