### PR TITLE
Do not use private in constraints

### DIFF
--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -13,6 +13,7 @@ services:
                             - Shopsys\FrameworkBundle\Component
                             - Shopsys\FrameworkBundle\Controller
                             - Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch
+                            - Shopsys\FrameworkBundle\Form\Constraints
                             - Shopsys\FrameworkBundle\Form\Transformer
                             - Shopsys\FrameworkBundle\Twig
 

--- a/packages/framework/src/Form/Constraints/CountryValidator.php
+++ b/packages/framework/src/Form/Constraints/CountryValidator.php
@@ -20,7 +20,7 @@ class CountryValidator extends ConstraintValidator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade

--- a/packages/framework/src/Form/Constraints/EmailValidator.php
+++ b/packages/framework/src/Form/Constraints/EmailValidator.php
@@ -37,7 +37,7 @@ class EmailValidator extends ConstraintValidator
      * @param string $value
      * @return bool
      */
-    private function isEmail($value)
+    protected function isEmail($value)
     {
         $atom = "[-a-z0-9!#$%&'*+/=?^_`{|}~]"; // RFC 5322 unquoted characters in local-part
         $alpha = "a-z\x80-\xFF"; // superset of IDN

--- a/packages/framework/src/Form/Constraints/FileAbstractFilesystemValidator.php
+++ b/packages/framework/src/Form/Constraints/FileAbstractFilesystemValidator.php
@@ -16,17 +16,17 @@ class FileAbstractFilesystemValidator extends FileValidator
     /**
      * @var \League\Flysystem\MountManager
      */
-    private $mountManager;
+    protected $mountManager;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
      */
-    private $fileUpload;
+    protected $fileUpload;
 
     /**
      * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface
      */
-    private $parameterBag;
+    protected $parameterBag;
 
     /**
      * @param \League\Flysystem\MountManager $mountManager

--- a/packages/framework/src/Form/Constraints/ImageAbstractFilesystemValidator.php
+++ b/packages/framework/src/Form/Constraints/ImageAbstractFilesystemValidator.php
@@ -16,17 +16,17 @@ class ImageAbstractFilesystemValidator extends ImageValidator
     /**
      * @var \League\Flysystem\MountManager
      */
-    private $mountManager;
+    protected $mountManager;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload
      */
-    private $fileUpload;
+    protected $fileUpload;
 
     /**
      * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface
      */
-    private $parameterBag;
+    protected $parameterBag;
 
     /**
      * @param \League\Flysystem\MountManager $mountManager

--- a/packages/framework/src/Form/Constraints/NotSelectedDomainToShowValidator.php
+++ b/packages/framework/src/Form/Constraints/NotSelectedDomainToShowValidator.php
@@ -12,7 +12,7 @@ class NotSelectedDomainToShowValidator extends ConstraintValidator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Form/Constraints/UniqueCollectionValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueCollectionValidator.php
@@ -52,7 +52,7 @@ class UniqueCollectionValidator extends ConstraintValidator
      * @param mixed $value2
      * @return bool
      */
-    private function areValuesEqual(UniqueCollection $constraint, $value1, $value2)
+    protected function areValuesEqual(UniqueCollection $constraint, $value1, $value2)
     {
         if ($constraint->allowEmpty) {
             if ($value1 === null || $value2 === null) {
@@ -72,7 +72,7 @@ class UniqueCollectionValidator extends ConstraintValidator
      * @param mixed $value2
      * @return bool
      */
-    private function areValuesEqualInFields(array $fields, $value1, $value2)
+    protected function areValuesEqualInFields(array $fields, $value1, $value2)
     {
         foreach ($fields as $field) {
             $fieldValue1 = $this->getFieldValue($value1, $field);
@@ -91,7 +91,7 @@ class UniqueCollectionValidator extends ConstraintValidator
      * @param string $field
      * @return mixed
      */
-    private function getFieldValue($value, $field)
+    protected function getFieldValue($value, $field)
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 

--- a/packages/framework/src/Form/Constraints/UniqueEmailValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueEmailValidator.php
@@ -13,12 +13,12 @@ class UniqueEmailValidator extends ConstraintValidator
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade
      */
-    private $customerUserFacade;
+    protected $customerUserFacade;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade $customerUserFacade

--- a/packages/framework/src/Form/Constraints/UniqueSlugsOnDomainsValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueSlugsOnDomainsValidator.php
@@ -15,12 +15,12 @@ class UniqueSlugsOnDomainsValidator extends ConstraintValidator
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
-    private $domain;
+    protected $domain;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
      */
-    private $domainRouterFactory;
+    protected $domainRouterFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -50,7 +50,7 @@ class UniqueSlugsOnDomainsValidator extends ConstraintValidator
      * @param array $values
      * @param \Shopsys\FrameworkBundle\Form\Constraints\UniqueSlugsOnDomains $constraint
      */
-    private function validateDuplication(array $values, UniqueSlugsOnDomains $constraint)
+    protected function validateDuplication(array $values, UniqueSlugsOnDomains $constraint)
     {
         $slugsCountByDomainId = $this->getSlugsCountIndexedByDomainId($values);
         foreach ($slugsCountByDomainId as $domainId => $countBySlug) {
@@ -72,7 +72,7 @@ class UniqueSlugsOnDomainsValidator extends ConstraintValidator
      * @param array $values
      * @param \Shopsys\FrameworkBundle\Form\Constraints\UniqueSlugsOnDomains $constraint
      */
-    private function validateExists($values, UniqueSlugsOnDomains $constraint)
+    protected function validateExists($values, UniqueSlugsOnDomains $constraint)
     {
         foreach ($values as $urlData) {
             $domainId = $urlData[UrlListData::FIELD_DOMAIN];
@@ -99,7 +99,7 @@ class UniqueSlugsOnDomainsValidator extends ConstraintValidator
      * @param array $values
      * @return int[][]
      */
-    private function getSlugsCountIndexedByDomainId(array $values)
+    protected function getSlugsCountIndexedByDomainId(array $values)
     {
         $slugsCountByDomainId = [];
         foreach ($values as $urlData) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| Validators can be extended since #1955 and private properties or methods don't do it easier.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
