### PR TITLE
[shopsys] removed merging common args monorepo docker-compose

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -1,10 +1,5 @@
 version: "3.4"
 
-x-variables:
-    common_build_args: &common_build_args
-        www_data_uid: 501
-        www_data_gid: 20
-
 services:
     postgres:
         image: postgres:12.1-alpine
@@ -39,7 +34,8 @@ services:
             dockerfile: project-base/docker/php-fpm/Dockerfile
             target: development
             args:
-                <<: *common_build_args
+                www_data_uid: 501
+                www_data_gid: 20
                 project_root: project-base
         container_name: shopsys-framework-php-fpm
         volumes:

--- a/docker/conf/docker-compose-win.yml.dist
+++ b/docker/conf/docker-compose-win.yml.dist
@@ -1,10 +1,5 @@
 version: "3.4"
 
-x-variables:
-    common_build_args: &common_build_args
-        www_data_uid: 1000
-        www_data_gid: 1000
-
 services:
     postgres:
         image: postgres:12.1-alpine
@@ -39,7 +34,8 @@ services:
             dockerfile: project-base/docker/php-fpm/Dockerfile
             target: development
             args:
-                <<: *common_build_args
+                www_data_uid: 1000
+                www_data_gid: 1000
                 project_root: project-base
         container_name: shopsys-framework-php-fpm
         volumes:

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -1,10 +1,5 @@
 version: "3.4"
 
-x-variables:
-    common_build_args: &common_build_args
-        www_data_uid: 1000
-        www_data_gid: 1000
-
 services:
     postgres:
         image: postgres:12.1-alpine
@@ -39,7 +34,8 @@ services:
             dockerfile: project-base/docker/php-fpm/Dockerfile
             target: development
             args:
-                <<: *common_build_args
+                www_data_uid: 1000
+                www_data_gid: 1000
                 project_root: project-base
         container_name: shopsys-framework-php-fpm
         volumes:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| widely used tool `yq` does not properly handle those and throw them away. Apart is no reason to have it when it's used only in one place.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
