### PR TITLE
[framework] throwable is now available in logger context when a cron fails on error

### DIFF
--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -127,7 +127,9 @@ class CronFacade
             );
         } catch (Throwable $throwable) {
             $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
-            $this->logger->addError('End of ' . $cronModuleConfig->getServiceId() . ' because of error');
+            $this->logger->addError('End of ' . $cronModuleConfig->getServiceId() . ' because of error', [
+                'throwable' => $throwable,
+            ]);
             throw $throwable;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When a cron module fails on error, in logs, we just see that it failed but it is difficult to find out why (I usually need to run the module again manually and see the output). Thanks to this modification, there should be all the necessary information included in the log entry.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
