### PR TITLE
[framework] optimization: flush the whole identity map when an order is created

### DIFF
--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -263,7 +263,6 @@ class OrderFacade
     {
         $orderNumber = (string)$this->orderNumberSequenceRepository->getNextNumber();
         $orderUrlHash = $this->orderHashGeneratorRepository->getUniqueHash();
-        $toFlush = [];
 
         $this->setOrderDataAdministrator($orderData);
 
@@ -273,13 +272,11 @@ class OrderFacade
             $orderUrlHash,
             $customerUser
         );
-        $toFlush[] = $order;
 
         $this->fillOrderItems($order, $orderPreview);
 
         foreach ($order->getItems() as $orderItem) {
             $this->em->persist($orderItem);
-            $toFlush[] = $orderItem;
         }
 
         $order->setTotalPrice(
@@ -287,7 +284,7 @@ class OrderFacade
         );
 
         $this->em->persist($order);
-        $this->em->flush($toFlush);
+        $this->em->flush();
 
         return $order;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| For a long time, I thought that for improving performance, you should always flush just the relevenat entities, not the whole identity map. However, during optimizations on my project, I found out, that the previous is probably not 100 % true. When you have the new entities in the identity map only (e.g. when creating a new order), then flush without parameters is much faster. This single change really helped me on the project - it **decreased the flush time from 2.75s to 955ms**! It would be great if you had time for exploring this behavior further and maybe change other pieces of code that call flush with an array of new entities :thinking: 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
