### PR TITLE
[framework] fixed checking of empty settings values

### DIFF
--- a/packages/framework/src/Model/Heureka/HeurekaSetting.php
+++ b/packages/framework/src/Model/Heureka/HeurekaSetting.php
@@ -64,7 +64,7 @@ class HeurekaSetting
      */
     public function isHeurekaShopCertificationActivated($domainId)
     {
-        return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId) !== '';
+        return $this->setting->getForDomain(static::HEUREKA_API_KEY, $domainId) !== null;
     }
 
     /**
@@ -73,6 +73,6 @@ class HeurekaSetting
      */
     public function isHeurekaWidgetActivated($domainId)
     {
-        return $this->setting->getForDomain(static::HEUREKA_WIDGET_CODE, $domainId) !== '';
+        return $this->setting->getForDomain(static::HEUREKA_WIDGET_CODE, $domainId) !== null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2035 empty function was removed, but checking for settings values was not properly changed. Based on this value, some fields (ga tracking code or extra checkbox field in order) are rendered. Those values are considered empty when null. This PR fixes usage. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
