### PR TITLE
[framework] do not run checks for cart modifications on cart delete

### DIFF
--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -195,7 +195,9 @@ class CartFacade
 
     public function deleteCartOfCurrentCustomerUser()
     {
-        $cart = $this->findCartOfCurrentCustomerUser();
+        $customerUserIdentifier = $this->customerUserIdentifierFactory->get();
+
+        $cart = $this->cartRepository->findByCustomerUserIdentifier($customerUserIdentifier);
 
         if ($cart !== null) {
             $this->deleteCart($cart);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Cart is deleted after creating of an order. On cart delete, checks for cart modifications are run. At this point some checks can fail, because ordered products are sellout already. Customer then see warning flash message on sent page. More info can be found in reported issue #2082
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2082  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
