### PR TITLE
[shopsys] allow placing scripts in administration after content

### DIFF
--- a/packages/framework/assets/js/admin/components/MeasuringScript.js
+++ b/packages/framework/assets/js/admin/components/MeasuringScript.js
@@ -3,17 +3,18 @@ import Register from '../../common/utils/Register';
 export default class MeasuringScript {
 
     constructor ($container) {
-        this.$embedOnlyInOrderSentPageCheckbox = $container.filterAllNodes('input[name="script_form[placement]"]');
+        const $placementSelectBox = $container.filterAllNodes('.js-measure-script-placement-choice');
 
-        if (this.$embedOnlyInOrderSentPageCheckbox.length > 0) {
-            this.toggleScriptVariables();
-            this.$embedOnlyInOrderSentPageCheckbox.on('change', () => this.toggleScriptVariables());
-        }
+        this.toggleMessageInfo($placementSelectBox.val(), $container);
+
+        $placementSelectBox.on('change', event => {
+            this.toggleMessageInfo($(event.target).val(), $container);
+        });
     }
 
-    toggleScriptVariables () {
-        const isChecked = this.$embedOnlyInOrderSentPageCheckbox.prop('checked');
-        $('#js-order-sent-page-variables').toggle(isChecked);
+    toggleMessageInfo (value, $container) {
+        $container.filterAllNodes('.js-script-placement-info').hide();
+        $container.filterAllNodes('.js-script-placement-info-' + value).show();
     }
 
     static init ($container) {

--- a/packages/framework/src/Controller/Admin/ScriptController.php
+++ b/packages/framework/src/Controller/Admin/ScriptController.php
@@ -137,6 +137,7 @@ class ScriptController extends AdminBaseController
         $grid->setTheme('@ShopsysFramework/Admin/Content/Script/listGrid.html.twig', [
             'PLACEMENT_ORDER_SENT_PAGE' => Script::PLACEMENT_ORDER_SENT_PAGE,
             'PLACEMENT_ALL_PAGES' => Script::PLACEMENT_ALL_PAGES,
+            'PLACEMENT_ALL_PAGES_AFTER_CONTENT' => Script::PLACEMENT_ALL_PAGES_AFTER_CONTENT,
         ]);
 
         return $this->render('@ShopsysFramework/Admin/Content/Script/list.html.twig', [

--- a/packages/framework/src/Form/Admin/Script/ScriptFormType.php
+++ b/packages/framework/src/Form/Admin/Script/ScriptFormType.php
@@ -2,10 +2,10 @@
 
 namespace Shopsys\FrameworkBundle\Form\Admin\Script;
 
-use Shopsys\FrameworkBundle\Form\Transformers\ScriptPlacementToBooleanTransformer;
 use Shopsys\FrameworkBundle\Model\Script\ScriptData;
+use Shopsys\FrameworkBundle\Model\Script\ScriptFacade;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -15,6 +15,19 @@ use Symfony\Component\Validator\Constraints;
 
 class ScriptFormType extends AbstractType
 {
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Script\ScriptFacade
+     */
+    protected $scriptFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptFacade $scriptFacade
+     */
+    public function __construct(ScriptFacade $scriptFacade)
+    {
+        $this->scriptFacade = $scriptFacade;
+    }
+
     /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
      * @param array $options
@@ -35,9 +48,13 @@ class ScriptFormType extends AbstractType
                     'class' => 'height-150',
                 ],
             ])
-            ->add($builder
-                ->create('placement', CheckboxType::class, ['required' => false])
-                ->addModelTransformer(new ScriptPlacementToBooleanTransformer()))
+            ->add('placement', ChoiceType::class, [
+                'required' => true,
+                'choices' => $this->scriptFacade->getAvailablePlacementChoices(),
+                'attr' => [
+                    'class' => 'js-measure-script-placement-choice',
+                ],
+            ])
             ->add('save', SubmitType::class);
     }
 

--- a/packages/framework/src/Form/Transformers/ScriptPlacementToBooleanTransformer.php
+++ b/packages/framework/src/Form/Transformers/ScriptPlacementToBooleanTransformer.php
@@ -6,6 +6,9 @@ use Shopsys\FrameworkBundle\Model\Script\Script;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
+/**
+ * @deprecated No replacement suggested as it's not necessary anymore
+ */
 class ScriptPlacementToBooleanTransformer implements DataTransformerInterface
 {
     /**

--- a/packages/framework/src/Model/Script/Script.php
+++ b/packages/framework/src/Model/Script/Script.php
@@ -12,6 +12,7 @@ class Script
 {
     public const PLACEMENT_ORDER_SENT_PAGE = 'placementOrderSentPage';
     public const PLACEMENT_ALL_PAGES = 'placementAllPages';
+    public const PLACEMENT_ALL_PAGES_AFTER_CONTENT = 'placementAllPagesAfterContent';
     public const GOOGLE_ANALYTICS_TRACKING_ID_SETTING_NAME = 'googleAnalyticsTrackingId';
 
     /**

--- a/packages/framework/src/Model/Script/ScriptFacade.php
+++ b/packages/framework/src/Model/Script/ScriptFacade.php
@@ -127,17 +127,19 @@ class ScriptFacade
 
     /**
      * @return string[]
+     * @deprecated use getAllPagesBeforeContentScriptCodes() instead
      */
     public function getAllPagesScriptCodes()
     {
-        $allPagesScripts = $this->scriptRepository->getScriptsByPlacement(Script::PLACEMENT_ALL_PAGES);
-        $scriptCodes = [];
+        @trigger_error(
+            sprintf(
+                'The "%s()" method is deprecated and will be removed in the next major. Use "getAllPagesBeforeContentScriptCodes()" instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
 
-        foreach ($allPagesScripts as $script) {
-            $scriptCodes[] = $script->getCode();
-        }
-
-        return $scriptCodes;
+        return $this->getAllPagesBeforeContentScriptCodes();
     }
 
     /**
@@ -146,14 +148,14 @@ class ScriptFacade
      */
     public function getOrderSentPageScriptCodesWithReplacedVariables(Order $order)
     {
-        $scripts = $this->scriptRepository->getScriptsByPlacement(Script::PLACEMENT_ORDER_SENT_PAGE);
-        $scriptCodes = [];
+        $scriptCodes = $this->getScriptCodesByPlacement(Script::PLACEMENT_ORDER_SENT_PAGE);
 
-        foreach ($scripts as $script) {
-            $scriptCodes[] = $this->replaceVariables($script->getCode(), $order);
+        $scriptCodesWithReplacedVariables = [];
+        foreach ($scriptCodes as $scriptCode) {
+            $scriptCodesWithReplacedVariables[] = $this->replaceVariables($scriptCode, $order);
         }
 
-        return $scriptCodes;
+        return $scriptCodesWithReplacedVariables;
     }
 
     /**
@@ -196,5 +198,49 @@ class ScriptFacade
         ];
 
         return strtr($code, $variableReplacements);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllPagesBeforeContentScriptCodes(): array
+    {
+        return $this->getScriptCodesByPlacement(Script::PLACEMENT_ALL_PAGES);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllPagesAfterContentScriptCodes(): array
+    {
+        return $this->getScriptCodesByPlacement(Script::PLACEMENT_ALL_PAGES_AFTER_CONTENT);
+    }
+
+    /**
+     * @param string $placement
+     * @return string[]
+     */
+    protected function getScriptCodesByPlacement(string $placement): array
+    {
+        $scripts = $this->scriptRepository->getScriptsByPlacement($placement);
+        $scriptCodes = [];
+
+        foreach ($scripts as $script) {
+            $scriptCodes[] = $script->getCode();
+        }
+
+        return $scriptCodes;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAvailablePlacementChoices(): array
+    {
+        return [
+            t('After content (all pages)') => Script::PLACEMENT_ALL_PAGES_AFTER_CONTENT,
+            t('Order confirmation page') => Script::PLACEMENT_ORDER_SENT_PAGE,
+            t('Before content (all pages)') => Script::PLACEMENT_ALL_PAGES,
+        ];
     }
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -154,6 +154,9 @@ msgstr "Reklama <strong>{{ name }}</strong> byla smazána"
 msgid "Advertising system"
 msgstr "Reklamní systém"
 
+msgid "After content (all pages)"
+msgstr "Po obsahu (na všech stránkách)"
+
 msgid "All domains"
 msgstr "Všechny domény"
 
@@ -267,6 +270,9 @@ msgstr "Jelikož dostupnost \"%name%\" je používána ještě u některých pro
 
 msgid "Because status \"%name%\" is used with other orders also, you have to choose a new status which will replace the existing one. Which status you want to set to these orders? When changing this, there won't be emails sent to customers."
 msgstr "Jelikož stav \"%name%\" je používán ještě u některých objednávek, musíte zvolit, jaký stav bude použit místo něj. Jaký stav chcete těmto objednávkám nastavit? Při této změně stavu nebude odeslán e-mail zákazníkům."
+
+msgid "Before content (all pages)"
+msgstr "Před obsahem (na všech stránkách)"
 
 msgid "Best-selling products of category <strong><a href=\"{{ url }}\">{{ name }}</a></strong> set."
 msgstr "Bylo nastaveno nejprodávanější zboží kategorie <strong><a href=\"{{ url }}\">{{ name }}</a></strong>"
@@ -1945,6 +1951,9 @@ msgstr "Skript <strong>{{ name }}</strong> byl smazán"
 msgid "Script name"
 msgstr "Název skriptu"
 
+msgid "Script placement"
+msgstr "Umístění skriptu"
+
 msgid "Script will be placed at the beginning of the page, after tag <body>."
 msgstr "Skript bude vložen na začátek stránky, za tag <body>."
 
@@ -2226,6 +2235,9 @@ msgstr "Tento e-mail byl odeslán z kontaktního formuláře umístěného pod p
 
 msgid "This item can be set in product detail of a specific variant"
 msgstr "Tuto položku můžete nastavit na kartě konkrétní varianty"
+
+msgid "This may significantly impact site performance and should be avoided whenever possible."
+msgstr "Toto nastavení může významně ovlivnit výkon webu a nemělo by se používat, pokud to není nutné."
 
 msgid "This status can't be deleted, because there is a functionality bounded to it - it identifies orders that were not successfully processed."
 msgstr "Tento stav není možné smazat, jelikož je na něj navázána funkčnost - určuje objednávky, které nebyly úspěšně vyřízeny."

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -154,6 +154,9 @@ msgstr ""
 msgid "Advertising system"
 msgstr ""
 
+msgid "After content (all pages)"
+msgstr ""
+
 msgid "All domains"
 msgstr ""
 
@@ -266,6 +269,9 @@ msgid "Because availability \"%name%\" is used with other products also, you hav
 msgstr ""
 
 msgid "Because status \"%name%\" is used with other orders also, you have to choose a new status which will replace the existing one. Which status you want to set to these orders? When changing this, there won't be emails sent to customers."
+msgstr ""
+
+msgid "Before content (all pages)"
 msgstr ""
 
 msgid "Best-selling products of category <strong><a href=\"{{ url }}\">{{ name }}</a></strong> set."
@@ -1945,6 +1951,9 @@ msgstr ""
 msgid "Script name"
 msgstr ""
 
+msgid "Script placement"
+msgstr ""
+
 msgid "Script will be placed at the beginning of the page, after tag <body>."
 msgstr ""
 
@@ -2225,6 +2234,9 @@ msgid "This email was sent from the contact form located below the panel of cate
 msgstr ""
 
 msgid "This item can be set in product detail of a specific variant"
+msgstr ""
+
+msgid "This may significantly impact site performance and should be avoided whenever possible."
 msgstr ""
 
 msgid "This status can't be deleted, because there is a functionality bounded to it - it identifies orders that were not successfully processed."

--- a/packages/framework/src/Resources/views/Admin/Content/Script/detail.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Script/detail.html.twig
@@ -4,7 +4,6 @@
 {% block h1 %}{% endblock %}
 
 {% block main_content %}
-    <div class="in-message in-message--block">{{ 'Script will be placed at the beginning of the page, after tag <body>.'|trans }} </div>
 
     {{ form_start(form) }}
         {{ form_errors(form) }}
@@ -13,7 +12,7 @@
 
         {{ form_row(form.name, { label: 'Name'|trans}) }}
         {{ form_row(form.code, { label: 'Code'|trans, attr: {class: 'measuring-code-input'} }) }}
-        {{ form_row(form.placement, { label: 'Add only to order confirmation page'|trans}) }}
+        {{ form_row(form.placement, { label: 'Script placement'|trans}) }}
         {% embed '@ShopsysFramework/Admin/Inline/FixedBar/fixedBar.html.twig' %}
             {% block fixed_bar_content %}
                 <a href="{{ url('admin_script_list') }}" class="btn-link-style">{{ 'Back to overview'|trans }}</a>
@@ -21,7 +20,15 @@
             {% endblock %}
         {% endembed %}
     {{ form_end(form) }}
-    <div id="js-order-sent-page-variables">
+
+    <div class="wrap-bar js-script-placement-info js-script-placement-info-{{ constant('Shopsys\\FrameworkBundle\\Model\\Script\\Script::PLACEMENT_ALL_PAGES') }}">
+        <div class="in-message in-message--block in-message--warning">
+            {{ 'Script will be placed at the beginning of the page, after tag <body>.'|trans }}
+            {{ 'This may significantly impact site performance and should be avoided whenever possible.'|trans }}
+        </div>
+    </div>
+
+    <div class="js-script-placement-info js-script-placement-info-{{ constant('Shopsys\\FrameworkBundle\\Model\\Script\\Script::PLACEMENT_ORDER_SENT_PAGE') }} {# @deprecated #}js-order-sent-page-variables">
         <table class="table-main">
             <thead>
                 <tr>

--- a/packages/framework/src/Resources/views/Admin/Content/Script/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Script/listGrid.html.twig
@@ -8,6 +8,8 @@
     {% if value == PLACEMENT_ORDER_SENT_PAGE %}
         {{ 'Order confirmation page'|trans }}
     {% elseif value == PLACEMENT_ALL_PAGES %}
-        {{ 'All pages'|trans }}
+        {{ 'Before content (all pages)'|trans }}
+    {% elseif value == PLACEMENT_ALL_PAGES_AFTER_CONTENT %}
+        {{ 'After content (all pages)'|trans }}
     {% endif %}
 {% endblock %}

--- a/packages/framework/src/Twig/ScriptsExtension.php
+++ b/packages/framework/src/Twig/ScriptsExtension.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Twig;
+
+use Shopsys\FrameworkBundle\Model\Order\Order;
+use Shopsys\FrameworkBundle\Model\Script\ScriptFacade;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class ScriptsExtension extends AbstractExtension
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Script\ScriptFacade
+     */
+    protected $scriptFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptFacade $scriptFacade
+     */
+    public function __construct(
+        ScriptFacade $scriptFacade
+    ) {
+        $this->scriptFacade = $scriptFacade;
+    }
+
+    /**
+     * @return \Twig\TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('getAllPagesBeforeContentScripts', [$this, 'getAllPagesBeforeContentScripts']),
+            new TwigFunction('getAllPagesAfterContentScripts', [$this, 'getAllPagesAfterContentScripts']),
+            new TwigFunction('getOrderSentPageScripts', [$this, 'getOrderSentPageScripts']),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getAllPagesBeforeContentScripts(): string
+    {
+        return $this->joinScriptsCodes($this->scriptFacade->getAllPagesBeforeContentScriptCodes());
+    }
+
+    /**
+     * @return string
+     */
+    public function getAllPagesAfterContentScripts(): string
+    {
+        return $this->joinScriptsCodes($this->scriptFacade->getAllPagesAfterContentScriptCodes());
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Order $order
+     * @return string
+     */
+    public function getOrderSentPageScripts(Order $order): string
+    {
+        return $this->joinScriptsCodes($this->scriptFacade->getOrderSentPageScriptCodesWithReplacedVariables($order));
+    }
+
+    /**
+     * @param string[] $scriptCodes
+     * @return string
+     */
+    protected function joinScriptsCodes(array $scriptCodes): string
+    {
+        return implode("\n", $scriptCodes);
+    }
+}

--- a/project-base/src/Controller/Front/ScriptController.php
+++ b/project-base/src/Controller/Front/ScriptController.php
@@ -33,13 +33,6 @@ class ScriptController extends FrontBaseController
         $this->domain = $domain;
     }
 
-    public function embedAllPagesScriptsAction()
-    {
-        return $this->render('Front/Inline/MeasuringScript/scripts.html.twig', [
-            'scriptsCodes' => $this->scriptFacade->getAllPagesScriptCodes(),
-        ]);
-    }
-
     public function embedAllPagesGoogleAnalyticsScriptAction()
     {
         if (!$this->scriptFacade->isGoogleAnalyticsActivated($this->domain->getId())) {
@@ -48,16 +41,6 @@ class ScriptController extends FrontBaseController
 
         return $this->render('Front/Inline/MeasuringScript/googleAnalytics.html.twig', [
             'trackingId' => $this->scriptFacade->getGoogleAnalyticsTrackingId($this->domain->getId()),
-        ]);
-    }
-
-    /**
-     * @param \App\Model\Order\Order $order
-     */
-    public function embedOrderSentPageScriptsAction(Order $order)
-    {
-        return $this->render('Front/Inline/MeasuringScript/scripts.html.twig', [
-            'scriptsCodes' => $this->scriptFacade->getOrderSentPageScriptCodesWithReplacedVariables($order),
         ]);
     }
 

--- a/project-base/templates/Front/Content/Order/sent.html.twig
+++ b/project-base/templates/Front/Content/Order/sent.html.twig
@@ -13,7 +13,7 @@
 
 {% block main_content %}
 
-    {{ render(controller('App\\Controller\\Front\\ScriptController:embedOrderSentPageScriptsAction', {order: order})) }}
+    {{ getOrderSentPageScripts(order)|raw }}
     {{ render(controller('App\\Controller\\Front\\ScriptController:embedOrderSentPageGoogleAnalyticsScriptAction', {order: order})) }}
 
     <div class="web__line">

--- a/project-base/templates/Front/Layout/base.html.twig
+++ b/project-base/templates/Front/Layout/base.html.twig
@@ -22,12 +22,13 @@
 
     <body class="web">
 
-        {{ render(controller('App\\Controller\\Front\\ScriptController:embedAllPagesScriptsAction')) }}
+        {{ getAllPagesBeforeContentScripts()|raw }}
         {{ render(controller('App\\Controller\\Front\\ScriptController:embedAllPagesGoogleAnalyticsScriptAction')) }}
 
         {% block html_body %}{% endblock %}
 
         {% block javascripts_bottom %}{% endblock %}
+        {{ getAllPagesAfterContentScripts()|raw }}
 
         {{ js_validator_config() }}
         {{ init_js_validation() }}

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -173,3 +173,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fixed standards on new release of FriendsOfPHP/PHP-CS-Fixer ([#2094](https://github.com/shopsys/shopsys/pull/2094))
     - run `php phing standards-fix` to apply fixes
+
+- allow placing scripts in administration after content([#2086](https://github.com/shopsys/shopsys/pull/2086))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Scripts (various javascript) created in administration can be now placed after content to avoid negative impact on page performance. Rendering scripts was also changer from rendering controller to calling function to improve page performance.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

