### PR TITLE
[project-base] fix ProductRenameRedirectPreviousUrlTest when overwrite_domain_url is https

### DIFF
--- a/project-base/tests/App/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
+++ b/project-base/tests/App/Functional/Controller/ProductRenameRedirectPreviousUrlTest.php
@@ -56,13 +56,17 @@ class ProductRenameRedirectPreviousUrlTest extends FunctionalTestCase
 
         $this->productFacade->edit(self::TESTED_PRODUCT_ID, $productData);
 
+        $overwriteDomainUrlParameter = $this->getContainer()->getParameter('overwrite_domain_url');
+
+        $isSecured = parse_url($overwriteDomainUrlParameter, PHP_URL_SCHEME) === 'https';
+
         $overWriteDomainUrl = preg_replace(
             '#^https?://#',
             '',
-            $this->getContainer()->getParameter('overwrite_domain_url')
+            $overwriteDomainUrlParameter
         );
 
-        $client = $this->findClient(true, null, null, [], ['HTTP_HOST' => $overWriteDomainUrl]);
+        $client = $this->findClient(true, null, null, [], ['HTTP_HOST' => $overWriteDomainUrl, 'HTTPS' => $isSecured]);
         $client->request('GET', '/' . $previousFriendlyUrlSlug);
 
         // Should be 301 (moved permanently), because old product urls should be permanently redirected


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR fixes that test when OVERWRITE_DOMAIN_URL is set to secured (https) domain. More description follows
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

When env variable OVERWRITE_DOMAIN_URL is set to value with HTTPS scheme and the test environment is active, this test starts to fail on 
```
Failed asserting that 500 matches expected 301.
```
This is due to an invalid requested domain, so the returned response is 
```
You are trying to access an unknown domain 'https://127.0.0.1:8000'. TEST environment is active, current domain URL is 'http://127.0.0.1:8000'.
``` 

even though the `OVERWRITE_DOMAIN_URL` is set to `https://127.0.0.1:8000` and it's accessible under that URL

It's not a common use-case, but on some native installations, it may cause trouble.