### PR TITLE
[project-base] removed hirak/prestissimo from build

### DIFF
--- a/project-base/docker/php-fpm/Dockerfile
+++ b/project-base/docker/php-fpm/Dockerfile
@@ -99,9 +99,6 @@ RUN echo "source /etc/bash_completion" >> ~/.bashrc
 RUN mkdir -p /var/www/html/.npm-global
 ENV NPM_CONFIG_PREFIX /var/www/html/.npm-global
 
-# hirak/prestissimo makes the install of Composer dependencies faster by parallel downloading
-RUN composer global require hirak/prestissimo
-
 # set COMPOSER_MEMORY_LIMIT to -1 (i.e. unlimited - this is a hotfix until https://github.com/shopsys/shopsys/issues/634 is solved)
 ENV COMPOSER_MEMORY_LIMIT=-1
 

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -168,5 +168,5 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 
 - remove hirak/prestissimo from Dockerfile ([#2089](https://github.com/shopsys/shopsys/pull/2089))
-    - make sure you have composer 2 installed
+    - make sure you have composer 2 installed (`composer --version`)
     - see #project-base-diff to update your project 

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -166,3 +166,7 @@ There you can find links to upgrade notes for other versions too.
 
 - add adverts in frontend API ([#2068](https://github.com/shopsys/shopsys/pull/2068))
     - see #project-base-diff to update your project
+
+- remove hirak/prestissimo from Dockerfile ([#2089](https://github.com/shopsys/shopsys/pull/2089))
+    - make sure you have composer 2 installed
+    - see #project-base-diff to update your project 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| it's no longer necessary since composer v2
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
