### PR TITLE
[framework] fixed box-upload white line overlapping box

### DIFF
--- a/packages/framework/assets/styles/admin/components/box/upload.less
+++ b/packages/framework/assets/styles/admin/components/box/upload.less
@@ -17,6 +17,7 @@
     }
 
     &__place {
+        position: relative;
         display: flex;
         flex-direction: column;
 


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, reason for the PR| Inside in `&__place` there is `&:after` that have position: absolute. That is white line trough file input. It is not noticeable but it overflows the box. See picture.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)|No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


![image](https://user-images.githubusercontent.com/6003253/97417696-4865dc80-1908-11eb-987b-21c609b49d15.png)
