### PR TITLE
[project-base] fixed standards on new release of FriendsOfPHP/PHP-CS-Fixer

### DIFF
--- a/project-base/src/Controller/Front/ErrorController.php
+++ b/project-base/src/Controller/Front/ErrorController.php
@@ -120,7 +120,7 @@ class ErrorController extends FrontBaseController
 
         return $this->render($this->getTemplatePath($code, $format), [
             'status_code' => $code,
-            'status_text' => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',
+            'status_text' => Response::$statusTexts[$code] ?? '',
             'exception' => $exception,
             'logger' => $logger,
         ]);

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -170,3 +170,6 @@ There you can find links to upgrade notes for other versions too.
 - remove hirak/prestissimo from Dockerfile ([#2089](https://github.com/shopsys/shopsys/pull/2089))
     - make sure you have composer 2 installed (`composer --version`)
     - see #project-base-diff to update your project 
+
+- fixed standards on new release of FriendsOfPHP/PHP-CS-Fixer ([#2094](https://github.com/shopsys/shopsys/pull/2094))
+    - run `php phing standards-fix` to apply fixes


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR fixes standards which were not applied correctly because of bug in FriendsOfPHP/PHP-CS-Fixer
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
