### PR TITLE
[framework] Wrong annotation of return type in getFullPathsIndexedByIdsForDomain

### DIFF
--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -252,7 +252,7 @@ class CategoryFacade
     /**
      * @param int $domainId
      * @param string $locale
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @return string[]
      */
     public function getFullPathsIndexedByIdsForDomain($domainId, $locale)
     {

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -110,7 +110,7 @@ class CategoryRepository extends NestedTreeRepository
     /**
      * @param int $domainId
      * @param string $locale
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @return string[]
      */
     public function getFullPathsIndexedByIdsForDomain($domainId, $locale)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Wrong annotation of return type in `CategoryFacade` and `CategoryRepository` `getFullPathsIndexedByIdsForDomain`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2061
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
