### PR TITLE
fix cleaning of old redis cache

### DIFF
--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -24,6 +24,7 @@ snc_redis:
             dsn: 'redis://%redis_host%'
             options:
                 prefix: '%env(REDIS_PREFIX)%%build-version%:cache:framework:annotations:'
+        # client is used exclusively for cleaning old versions of redis caches and should not be used for anything else
         global:
             type: 'phpredis'
             alias: 'global'

--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -29,7 +29,7 @@ snc_redis:
             alias: 'global'
             dsn: 'redis://%redis_host%'
             options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%'
+                prefix: '%env(REDIS_PREFIX)%'
         session:
             type: 'phpredis'
             alias: 'session'

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -202,3 +202,6 @@ There you can find links to upgrade notes for other versions too.
             - it should not cause any trouble as filtering product from Elasticsearch was edited to filter variants out, so it behaves same as earlier
             - when you have some of related functionality extended you should probably want to filter variants out by yourself
                 - method `FilterQuery::filterOutVariants()` was introduced for this purposes
+
+- fix cleaning of old redis cache ([#2096](https://github.com/shopsys/shopsys/pull/2096))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On our project, after upgrading to `9.0.2`, old redis cache is not removed after calling `shopsys:redis:clean-cache-old`. Removing the build version from the prefix fixes the problem, but TBH, I am not sure whether this is ok and whether this modification does not break anything else
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
