### PR TITLE
[project-base] tail logs unbuffered

### DIFF
--- a/project-base/docker/php-fpm/docker-php-entrypoint
+++ b/project-base/docker/php-fpm/docker-php-entrypoint
@@ -11,7 +11,7 @@ PIPE=/tmp/log-pipe
 rm -rf $PIPE
 mkfifo $PIPE
 chmod 666 $PIPE
-tail -n +1 -f $PIPE &
+stdbuf -o0 tail -n +1 -f $PIPE &
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -208,3 +208,6 @@ There you can find links to upgrade notes for other versions too.
 
 - enable logging in tests ([#2113](https://github.com/shopsys/shopsys/pull/2113))
     - see #project-base-diff to update your project
+
+- avoid missing or delayed logs ([#2103](https://github.com/shopsys/shopsys/pull/2103))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| By default, `tail` command output is buffered by 8KB when it runs in the background. Because of this, some logs can be missed or there can be delayed to see logs. More information can be found here:https://superuser.com/questions/742238/piping-tail-f-into-awk/1123674#1123674 and https://unix.stackexchange.com/questions/46723/flush-tail-f-buffer
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
