### PR TITLE
[shopsys] get product filter from elastic

### DIFF
--- a/packages/framework/easy-coding-standard.yml
+++ b/packages/framework/easy-coding-standard.yml
@@ -84,6 +84,7 @@ parameters:
             - '*/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php'
             # class that is used by OrderPreviewFactory to create OrderPreview
             - '*/src/Model/Order/Preview/OrderPreviewCalculation.php'
+            - '*/src/Model/Product/Filter/Elasticsearch/ProductFilterConfigFactory.php'
 
         Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff:
             - '*/src/Component/DateTimeHelper/Exception/CannotParseDateTimeException.php'

--- a/packages/framework/src/Model/Product/Brand/BrandFacade.php
+++ b/packages/framework/src/Model/Product/Brand/BrandFacade.php
@@ -183,4 +183,14 @@ class BrandFacade
     {
         return $this->brandRepository->getOneByUuid($uuid);
     }
+
+    /**
+     * @param int[] $brandsIds
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     */
+    public function getBrandsForFilterByIds(array $brandsIds, string $locale): array
+    {
+        return $this->brandRepository->getBrandsForFilterByIds($brandsIds, $locale);
+    }
 }

--- a/packages/framework/src/Model/Product/Brand/BrandRepository.php
+++ b/packages/framework/src/Model/Product/Brand/BrandRepository.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Join;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Exception\BrandNotFoundException;
 
 class BrandRepository
@@ -65,5 +66,23 @@ class BrandRepository
         }
 
         return $brand;
+    }
+
+    /**
+     * @param int[] $brandsIds
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     */
+    public function getBrandsForFilterByIds(array $brandsIds, string $locale): array
+    {
+        $brandsQueryBuilder = $this->getBrandRepository()->createQueryBuilder('b')
+            ->select('b, bt')
+            ->join('b.translations', 'bt', Join::WITH, 'bt.locale = :locale')
+            ->where('b.id IN (:brandIds)')
+            ->setParameter('brandIds', $brandsIds)
+            ->setParameter('locale', $locale)
+            ->orderBy('b.name', 'asc');
+
+        return $brandsQueryBuilder->getQuery()->getResult();
     }
 }

--- a/packages/framework/src/Model/Product/Filter/Elasticsearch/ProductFilterConfigFactory.php
+++ b/packages/framework/src/Model/Product/Filter/Elasticsearch/ProductFilterConfigFactory.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch;
+
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Category\Category;
+use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
+use Shopsys\FrameworkBundle\Model\Product\Filter\PriceRange;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
+use Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade;
+
+class ProductFilterConfigFactory
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser
+     */
+    protected $currentCustomerUser;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch\ProductFilterElasticFacade
+     */
+    protected $productFilterElasticFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade
+     */
+    protected $flagFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade
+     */
+    protected $brandFacade;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade
+     */
+    protected $parameterFacade;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch\ProductFilterElasticFacade $productFilterElasticFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade $parameterFacade
+     */
+    public function __construct(
+        Domain $domain,
+        CurrentCustomerUser $currentCustomerUser,
+        ProductFilterElasticFacade $productFilterElasticFacade,
+        FlagFacade $flagFacade,
+        BrandFacade $brandFacade,
+        ParameterFacade $parameterFacade
+    ) {
+        $this->domain = $domain;
+        $this->currentCustomerUser = $currentCustomerUser;
+        $this->productFilterElasticFacade = $productFilterElasticFacade;
+        $this->flagFacade = $flagFacade;
+        $this->brandFacade = $brandFacade;
+        $this->parameterFacade = $parameterFacade;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig
+     */
+    public function createForCategory(Category $category): ProductFilterConfig
+    {
+        $elasticFilterData = $this->productFilterElasticFacade->getProductFilterDataInCategory(
+            $category->getId(),
+            $this->currentCustomerUser->getPricingGroup()
+        );
+
+        return new ProductFilterConfig(
+            $this->aggregateParametersData($elasticFilterData),
+            $this->aggregateFlagsData($elasticFilterData),
+            $this->aggregateBrandsData($elasticFilterData),
+            $this->aggregatePriceRangeData($elasticFilterData)
+        );
+    }
+
+    /**
+     * @param string|null $searchText
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig
+     */
+    public function createForSearch(?string $searchText = null): ProductFilterConfig
+    {
+        $elasticFilterData = $this->productFilterElasticFacade->getProductFilterDataForSearch(
+            $searchText,
+            $this->currentCustomerUser->getPricingGroup()
+        );
+
+        return new ProductFilterConfig(
+            [],
+            $this->aggregateFlagsData($elasticFilterData),
+            $this->aggregateBrandsData($elasticFilterData),
+            $this->aggregatePriceRangeData($elasticFilterData)
+        );
+    }
+
+    /**
+     * @param array $elasticFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\PriceRange
+     */
+    protected function aggregatePriceRangeData(array $elasticFilterData): PriceRange
+    {
+        $pricesData = $elasticFilterData['aggregations']['prices']['filter_pricing_group'];
+
+        $minPrice = Money::create((string)($pricesData['min_price']['value'] ?? 0));
+        $maxPrice = Money::create((string)($pricesData['max_price']['value'] ?? 0));
+
+        return new PriceRange($minPrice, $maxPrice);
+    }
+
+    /**
+     * @param array $elasticFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    protected function aggregateFlagsData(array $elasticFilterData): array
+    {
+        $flagsData = $elasticFilterData['aggregations']['flags']['buckets'];
+
+        $flagsIds = array_map(function (array $data) {
+            return $data['key'];
+        }, $flagsData);
+
+        if (count($flagsIds) === 0) {
+            return [];
+        }
+
+        return $this->flagFacade->getFlagsForFilterByIds($flagsIds, $this->domain->getLocale());
+    }
+
+    /**
+     * @param array $elasticFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Brand\Brand[]
+     */
+    protected function aggregateBrandsData(array $elasticFilterData): array
+    {
+        $brandsData = $elasticFilterData['aggregations']['brands']['buckets'];
+
+        $brandsIds = array_map(function (array $data) {
+            return $data['key'];
+        }, $brandsData);
+
+        if (count($brandsIds) === 0) {
+            return [];
+        }
+
+        return $this->brandFacade->getBrandsForFilterByIds($brandsIds, $this->domain->getLocale());
+    }
+
+    /**
+     * @param array $elasticFilterData
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice[]
+     */
+    protected function aggregateParametersData(array $elasticFilterData): array
+    {
+        $parametersData = $elasticFilterData['aggregations']['parameters']['by_parameters']['buckets'];
+
+        $parameterValueIdsIndexedByParameterId = [];
+
+        foreach ($parametersData as $parameter) {
+            $parameterValueIdsIndexedByParameterId[$parameter['key']] = array_map(function ($parameter) {
+                return $parameter['key'];
+            }, $parameter['by_value']['buckets']);
+        }
+
+        if (count($parameterValueIdsIndexedByParameterId) === 0) {
+            return [];
+        }
+
+        return $this->parameterFacade->getParameterFilterChoicesByIds(
+            $parameterValueIdsIndexedByParameterId,
+            $this->domain->getLocale()
+        );
+    }
+}

--- a/packages/framework/src/Model/Product/Filter/Elasticsearch/ProductFilterElasticFacade.php
+++ b/packages/framework/src/Model/Product/Filter/Elasticsearch/ProductFilterElasticFacade.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch;
+
+use Elasticsearch\Client;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex;
+use Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory;
+
+class ProductFilterElasticFacade
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory
+     */
+    protected $filterQueryFactory;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader
+     */
+    protected $indexDefinitionLoader;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
+     */
+    protected $domain;
+
+    /**
+     * @var \Elasticsearch\Client
+     */
+    protected $client;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory
+     * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader $indexDefinitionLoader
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Elasticsearch\Client $client
+     */
+    public function __construct(
+        FilterQueryFactory $filterQueryFactory,
+        IndexDefinitionLoader $indexDefinitionLoader,
+        Domain $domain,
+        Client $client
+    ) {
+        $this->filterQueryFactory = $filterQueryFactory;
+        $this->indexDefinitionLoader = $indexDefinitionLoader;
+        $this->domain = $domain;
+        $this->client = $client;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getIndexName(): string
+    {
+        return $this->indexDefinitionLoader->getIndexDefinition(
+            ProductIndex::getName(),
+            $this->domain->getId()
+        )->getIndexAlias();
+    }
+
+    /**
+     * @param int $categoryId
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return array
+     */
+    public function getProductFilterDataInCategory(int $categoryId, PricingGroup $pricingGroup): array
+    {
+        $baseFilterQuery = $this->filterQueryFactory->create($this->getIndexName())
+            ->filterOnlyVisible($pricingGroup)
+            ->filterOnlySellable()
+            ->filterByCategory([$categoryId]);
+
+        return $this->client->search($baseFilterQuery->getFilterQuery($pricingGroup->getId()));
+    }
+
+    /**
+     * @param string|null $searchText
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @return array
+     */
+    public function getProductFilterDataForSearch(?string $searchText, PricingGroup $pricingGroup): array
+    {
+        $searchText = $searchText ?? '';
+
+        $baseFilterQuery = $this->filterQueryFactory->create($this->getIndexName())
+            ->filterOnlyVisible($pricingGroup)
+            ->filterOnlySellable()
+            ->search($searchText);
+
+        $filterQuery = $baseFilterQuery->getFilterQuery($pricingGroup->getId());
+
+        // Remove parameters from filter on search page
+        unset($filterQuery['body']['aggs']['parameters']);
+
+        return $this->client->search($filterQuery);
+    }
+}

--- a/packages/framework/src/Model/Product/Flag/FlagFacade.php
+++ b/packages/framework/src/Model/Product/Flag/FlagFacade.php
@@ -118,4 +118,14 @@ class FlagFacade
     {
         $this->eventDispatcher->dispatch(new FlagEvent($flag), $eventType);
     }
+
+    /**
+     * @param int[] $flagsIds
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    public function getFlagsForFilterByIds(array $flagsIds, string $locale): array
+    {
+        return $this->flagRepository->getFlagsForFilterByIds($flagsIds, $locale);
+    }
 }

--- a/packages/framework/src/Model/Product/Flag/FlagRepository.php
+++ b/packages/framework/src/Model/Product/Flag/FlagRepository.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr\Join;
 use Shopsys\FrameworkBundle\Model\Product\Flag\Exception\FlagNotFoundException;
 
 class FlagRepository
@@ -58,5 +59,24 @@ class FlagRepository
     public function getAll()
     {
         return $this->getFlagRepository()->findBy([], ['id' => 'asc']);
+    }
+
+    /**
+     * @param int[] $flagsIds
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag\Flag[]
+     */
+    public function getFlagsForFilterByIds(array $flagsIds, string $locale): array
+    {
+        $flagsQueryBuilder = $this->getFlagRepository()->createQueryBuilder('f')
+            ->select('f, ft')
+            ->join('f.translations', 'ft', Join::WITH, 'ft.locale = :locale')
+            ->where('f.id IN (:flagsIds)')
+            ->andWhere('f.visible = true')
+            ->orderBy('ft.name', 'asc')
+            ->setParameter('flagsIds', $flagsIds)
+            ->setParameter('locale', $locale);
+
+        return $flagsQueryBuilder->getQuery()->getResult();
     }
 }

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -282,4 +282,44 @@ class ParameterRepository
 
         return $productParameterValuesIndexedByProductIdAndParameterName;
     }
+
+    /**
+     * @param int[] $parameterIds
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter[]
+     */
+    public function getVisibleParametersByIds(array $parameterIds, string $locale): array
+    {
+        $parametersQueryBuilder = $this->getParameterRepository()->createQueryBuilder('p')
+            ->select('p, pt')
+            ->join('p.translations', 'pt', Join::WITH, 'pt.locale = :locale')
+            ->where('p.id IN (:parameterIds)')
+            ->andWhere('p.visible = true')
+            ->setParameter('parameterIds', $parameterIds)
+            ->setParameter('locale', $locale)
+            ->orderBy('pt.name', 'asc');
+
+        return $parametersQueryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * @param int[] $parameterValueIds
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue[]
+     */
+    public function getParameterValuesByIds(array $parameterValueIds): array
+    {
+        $parameterValues = $this->getParameterValueRepository()->createQueryBuilder('pv')
+            ->where('pv.id IN (:parameterValueIds)')
+            ->setParameter('parameterValueIds', $parameterValueIds)
+            ->getQuery()->getResult();
+
+        $parameterValuesIndexedById = [];
+
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue $parameterValue */
+        foreach ($parameterValues as $parameterValue) {
+            $parameterValuesIndexedById[$parameterValue->getId()] = $parameterValue;
+        }
+
+        return $parameterValuesIndexedById;
+    }
 }

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -543,6 +543,49 @@ class FilterQuery
     }
 
     /**
+     * Applies all filters for filter
+     * For flags, brands, stock, parameters, min and max price
+     * Parameters aggregation have nested structure in result [parameter_id][parameter_value_id]
+     *
+     * @param int $pricingGroupId
+     * @return array
+     */
+    public function getFilterQuery(int $pricingGroupId): array
+    {
+        $query = $this->getAbsoluteNumbersWithParametersQuery();
+
+        $query['body']['aggs']['prices'] = [
+            'nested' => [
+                'path' => 'prices',
+            ],
+            'aggs' => [
+                'filter_pricing_group' => [
+                    'filter' => [
+                        'term' => [
+                            'prices.pricing_group_id' => $pricingGroupId,
+                        ],
+                    ],
+                    'aggs' => [
+                        'min_price' => [
+                            'min' => [
+                                'field' => 'prices.price_with_vat',
+                            ],
+                        ],
+                        'max_price' => [
+                            'max' => [
+                                'field' => 'prices.price_with_vat',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+
+        ];
+
+        return $query;
+    }
+
+    /**
      * Answers question "If I add this flag, how many products will be added?"
      * We are looking for count of products that meet all filters and don't have any of already selected flags
      *

--- a/project-base/src/Controller/Front/ProductController.php
+++ b/project-base/src/Controller/Front/ProductController.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Module\ModuleFacade;
 use Shopsys\FrameworkBundle\Model\Module\ModuleList;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
-use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory;
+use Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch\ProductFilterConfigFactory;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade;
@@ -30,7 +30,7 @@ class ProductController extends FrontBaseController
     public const PRODUCTS_PER_PAGE = 12;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch\ProductFilterConfigFactory
      */
     private $productFilterConfigFactory;
 
@@ -99,7 +99,7 @@ class ProductController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory $productFilterConfigFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch\ProductFilterConfigFactory $productFilterConfigFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade $productListOrderingModeForListFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade $productListOrderingModeForBrandFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade $productListOrderingModeForSearchFacade
@@ -324,11 +324,7 @@ class ProductController extends FrontBaseController
      */
     private function createProductFilterConfigForCategory(Category $category)
     {
-        return $this->productFilterConfigFactory->createForCategory(
-            $this->domain->getId(),
-            $this->domain->getLocale(),
-            $category
-        );
+        return $this->productFilterConfigFactory->createForCategory($category);
     }
 
     /**
@@ -337,11 +333,7 @@ class ProductController extends FrontBaseController
      */
     private function createProductFilterConfigForSearch($searchText)
     {
-        return $this->productFilterConfigFactory->createForSearch(
-            $this->domain->getId(),
-            $this->domain->getLocale(),
-            $searchText
-        );
+        return $this->productFilterConfigFactory->createForSearch($searchText);
     }
 
     /**

--- a/project-base/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
+++ b/project-base/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php
@@ -22,7 +22,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends ParameterTransa
     use SymfonyTestContainer;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\Elasticsearch\ProductFilterConfigFactory
      * @inject
      */
     protected $productFilterConfigFactory;
@@ -66,11 +66,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends ParameterTransa
             /** @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $expectedCountData */
             $expectedCountData = $dataProvider[2];
 
-            $filterConfig = $this->productFilterConfigFactory->createForCategory(
-                $this->domain->getId(),
-                $this->domain->getLocale(),
-                $category
-            );
+            $filterConfig = $this->productFilterConfigFactory->createForCategory($category);
             $countData = $this->productOnCurrentDomainFacade->getProductFilterCountDataInCategory(
                 $category->getId(),
                 $filterConfig,
@@ -109,11 +105,7 @@ abstract class ProductOnCurrentDomainFacadeCountDataTest extends ParameterTransa
             /** @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData $expectedCountData */
             $expectedCountData = $dataProvider[2];
 
-            $filterConfig = $this->productFilterConfigFactory->createForSearch(
-                $this->domain->getId(),
-                $this->domain->getLocale(),
-                $searchText
-            );
+            $filterConfig = $this->productFilterConfigFactory->createForSearch($searchText);
             $countData = $this->productOnCurrentDomainFacade->getProductFilterCountDataForSearch(
                 $searchText,
                 $filterConfig,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Product list page is slow with a lot of products in database. This PR gets parameters and other IDs for product filter from Elasticsearch and then loads entities from database with basic SQL.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
