### PR TITLE
[framework] cache domain router

### DIFF
--- a/packages/framework/src/Component/Router/DomainRouterFactory.php
+++ b/packages/framework/src/Component/Router/DomainRouterFactory.php
@@ -50,12 +50,18 @@ class DomainRouterFactory
     protected $requestStack;
 
     /**
+     * @var string
+     */
+    protected $cacheDir;
+
+    /**
      * @param mixed $routerConfiguration
      * @param \Symfony\Component\Config\Loader\LoaderInterface $configLoader
      * @param \Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory $localizedRouterFactory
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory $friendlyUrlRouterFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @param string $cacheDir
      */
     public function __construct(
         $routerConfiguration,
@@ -63,7 +69,8 @@ class DomainRouterFactory
         LocalizedRouterFactory $localizedRouterFactory,
         FriendlyUrlRouterFactory $friendlyUrlRouterFactory,
         Domain $domain,
-        RequestStack $requestStack
+        RequestStack $requestStack,
+        string $cacheDir
     ) {
         $this->routerConfiguration = $routerConfiguration;
         $this->configLoader = $configLoader;
@@ -71,6 +78,7 @@ class DomainRouterFactory
         $this->domain = $domain;
         $this->friendlyUrlRouterFactory = $friendlyUrlRouterFactory;
         $this->requestStack = $requestStack;
+        $this->cacheDir = $cacheDir;
     }
 
     /**
@@ -109,7 +117,10 @@ class DomainRouterFactory
         return new Router(
             $this->configLoader,
             $this->routerConfiguration,
-            ['resource_type' => 'service'],
+            [
+                'resource_type' => 'service',
+                'cache_dir' => $this->cacheDir . '/routing/base' . $domainConfig->getId(),
+            ],
             $this->getRequestContextByDomainConfig($domainConfig)
         );
     }

--- a/packages/framework/src/Component/Router/LocalizedRouterFactory.php
+++ b/packages/framework/src/Component/Router/LocalizedRouterFactory.php
@@ -27,14 +27,21 @@ class LocalizedRouterFactory
     protected $routersByLocaleAndHost;
 
     /**
+     * @var string
+     */
+    protected $cacheDir;
+
+    /**
      * @param string $localeRoutersResourcesFilepathMask
      * @param \Symfony\Component\Config\Loader\LoaderInterface $configLoader
+     * @param string $cacheDir
      */
-    public function __construct($localeRoutersResourcesFilepathMask, LoaderInterface $configLoader)
+    public function __construct($localeRoutersResourcesFilepathMask, LoaderInterface $configLoader, string $cacheDir)
     {
         $this->configLoader = $configLoader;
         $this->localeRoutersResourcesFilepathMask = $localeRoutersResourcesFilepathMask;
         $this->routersByLocaleAndHost = [];
+        $this->cacheDir = $cacheDir;
     }
 
     /**
@@ -56,7 +63,7 @@ class LocalizedRouterFactory
             $this->routersByLocaleAndHost[$locale][$context->getHost()] = new Router(
                 $this->configLoader,
                 $this->getLocaleRouterResourceByLocale($locale),
-                [],
+                ['cache_dir' => $this->cacheDir . '/routing/locale_' . $locale],
                 $context
             );
         }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -477,7 +477,9 @@ services:
             - { name: router, priority: 70 }
 
     Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory:
-        arguments: ['%router.resource%']
+        arguments:
+            $routerConfiguration: '%router.resource%'
+            $cacheDir: '%kernel.cache_dir%'
 
     Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataProviderRegistry:
         arguments: [!tagged shopsys.friendly_url_provider]
@@ -486,7 +488,9 @@ services:
         arguments: ['%shopsys.router.friendly_url_router_filepath%']
 
     Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory:
-        arguments: ['%shopsys.router.locale_router_filepath_mask%']
+        arguments:
+            $localeRoutersResourcesFilepathMask: '%shopsys.router.locale_router_filepath_mask%'
+            $cacheDir: '%kernel.cache_dir%'
 
     Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector:
         arguments:

--- a/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
@@ -66,7 +66,8 @@ class DomainRouterFactoryTest extends TestCase
             $localizedRouterFactoryMock,
             $friendlyUrlRouterFactoryMock,
             $domain,
-            $requestStackMock
+            $requestStackMock,
+            __DIR__
         );
 
         $router = $domainRouterFactory->getRouter(Domain::THIRD_DOMAIN_ID);

--- a/packages/framework/tests/Unit/Component/Router/LocalizedRouterFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/LocalizedRouterFactoryTest.php
@@ -20,7 +20,8 @@ class LocalizedRouterFactoryTest extends TestCase
 
         $localizedRouterFactory = new LocalizedRouterFactory(
             static::LOCALE_ROUTERS_CONFIGURATION_MASK,
-            $delegatingLoaderMock
+            $delegatingLoaderMock,
+            __DIR__
         );
         $this->expectException(LocalizedRoutingConfigFileNotFoundException::class);
         $localizedRouterFactory->getRouter('ru', $context);
@@ -36,7 +37,8 @@ class LocalizedRouterFactoryTest extends TestCase
 
         $localizedRouterFactory = new LocalizedRouterFactory(
             static::LOCALE_ROUTERS_CONFIGURATION_MASK,
-            $delegatingLoaderMock
+            $delegatingLoaderMock,
+            __DIR__
         );
 
         $router1 = $localizedRouterFactory->getRouter('en', $context1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Domain router was not cached. This PR save BasicRouter and LocalizedRouter to cache and increase performance on every page
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

