### PR TITLE
[shopsys] move doctrine metadata and annotations cache to file instead of redis

### DIFF
--- a/packages/framework/src/Component/Doctrine/Cache/FallbackCacheFactory.php
+++ b/packages/framework/src/Component/Doctrine/Cache/FallbackCacheFactory.php
@@ -7,6 +7,9 @@ use Doctrine\Common\Cache\RedisCache;
 use Exception;
 use Redis;
 
+/**
+ * @deprecated Class will be removed in next major version as it is not necessary anymore
+ */
 class FallbackCacheFactory
 {
     /**

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -113,16 +113,14 @@ services:
             - { method: setRedis, arguments: ['@snc_redis.doctrine_query'] }
 
     shopsys.doctrine.cache_driver.metadata_cache:
-        class: Doctrine\Common\Cache\CacheProvider
-        factory: ['@Shopsys\FrameworkBundle\Component\Doctrine\Cache\FallbackCacheFactory', 'create']
+        class: Doctrine\Common\Cache\PhpFileCache
         arguments:
-            - '@snc_redis.doctrine_metadata'
+            - '%kernel.cache_dir%/metadata'
 
     shopsys.framework.cache_driver.annotations_cache:
-        class: Doctrine\Common\Cache\CacheProvider
-        factory: ['@Shopsys\FrameworkBundle\Component\Doctrine\Cache\FallbackCacheFactory', 'create']
+        class: Doctrine\Common\Cache\PhpFileCache
         arguments:
-            - '@snc_redis.framework_annotations'
+            - '%kernel.cache_dir%/annotations'
 
     Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider: ~
 
@@ -133,6 +131,7 @@ services:
         tags:
             - { name: knp_menu.menu_builder, method: createMenu, alias: admin_side_menu }
 
+    # @deprecated Class will be removed in next major version as it is not necessary anymore
     Shopsys\FrameworkBundle\Component\Doctrine\Cache\FallbackCacheFactory: ~
 
     Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchConfig: ~

--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -6,24 +6,12 @@ snc_redis:
             dsn: 'redis://%redis_host%'
             options:
                 prefix: '%env(REDIS_PREFIX)%%build-version%:cache:bestselling_products:'
-        doctrine_metadata:
-            type: 'phpredis'
-            alias: 'doctrine_metadata'
-            dsn: 'redis://%redis_host%'
-            options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:metadata:'
         doctrine_query:
             type: 'phpredis'
             alias: 'doctrine_query'
             dsn: 'redis://%redis_host%'
             options:
                 prefix: '%env(REDIS_PREFIX)%%build-version%:cache:doctrine:query:'
-        framework_annotations:
-            type: 'phpredis'
-            alias: 'framework_annotations'
-            dsn: 'redis://%redis_host%'
-            options:
-                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:framework:annotations:'
         # client is used exclusively for cleaning old versions of redis caches and should not be used for anything else
         global:
             type: 'phpredis'

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -214,3 +214,8 @@ There you can find links to upgrade notes for other versions too.
 
 - disable javascript validation for product filter form ([#2104](https://github.com/shopsys/shopsys/pull/2104))
     - see #project-base-diff to update your project
+
+- move doctrine metadata and annotations cache to file instead of redis ([#2107](https://github.com/shopsys/shopsys/pull/2107))
+    - class `Shopsys\FrameworkBundle\Component\Doctrine\Cache\FallbackCacheFactory` is deprecated and will be removed in next major version
+        - in case you need it in your project you should implement it by yourself
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Every HTTP request do a lot of requests to Redis cache. This dramatically increases Redis CPU usage and may kill Redis. With OPcache configured for production, performance should be similar
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
