### PR TITLE
[shopsys] dropped support for PHP versions lower  than 7.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-bcmath": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
@@ -208,7 +208,7 @@
         "component-dir": "project-base/web/components",
         "sort-packages": true,
         "platform": {
-            "php": "7.2"
+            "php": "7.4.1"
         }
     },
     "extra": {

--- a/docs/docker/docker-troubleshooting.md
+++ b/docs/docker/docker-troubleshooting.md
@@ -164,8 +164,8 @@ When `composer install` or `composer update` fails on an error with exceeding th
 Docker images may fail to build during `docker-compose up -d` due to invalid reference format, eg.:
 ```no-highlight
 Building php-fpm
-Step 1/41 : FROM php:7.2-fpm-stretch as base
-ERROR: Service 'php-fpm' failed to build: Error parsing reference: "php:7.2-fpm-stretch as base" is not a valid repository/tag: invalid reference format
+Step 1/41 : FROM php:7.4-fpm-buster as base
+ERROR: Service 'php-fpm' failed to build: Error parsing reference: "php:7.4-fpm-buster as base" is not a valid repository/tag: invalid reference format
 ```
 This is because you have a version of Docker which does not support [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).
 

--- a/docs/installation/application-requirements.md
+++ b/docs/installation/application-requirements.md
@@ -4,7 +4,7 @@ To be able to install, develop and run Shopsys Framework, the system should have
 ## Linux / MacOS / WSL
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PostgreSQL 12.1](https://wiki.postgresql.org/wiki/Detailed_installation_guides)
-* [PHP 7.2 - 7.4](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
+* [PHP 7.4.1 or higher](http://php.net/manual/en/install.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 * [Composer](https://getcomposer.org/doc/00-intro.md#globally)
 * [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
 * [Redis](https://redis.io/topics/quickstart)
@@ -18,7 +18,7 @@ To be able to install, develop and run Shopsys Framework, the system should have
 ## Windows
 * [GIT](https://git-scm.com/download/win)
 * [PostgreSQL 12.1](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
-* [PHP 7.2 - 7.4](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
+* [PHP 7.4.1 or higher](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows)
 * [Node.js with npm](https://nodejs.org/en/download/) (npm is automatically installed when you install Node.js)
 * [Redis](https://github.com/MicrosoftArchive/redis/releases)

--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -8,7 +8,7 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 ## Requirements
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.unix.php)
-    * At least version **7.2 or higher**
+    * At least version **7.4.1 or higher**
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * [Docker](https://docs.docker.com/engine/installation/)
     * At least version **17.05 or higher** so it supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -13,7 +13,7 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for relatively fast 
 ## Requirements
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.macosx.php)
-    * At least version **7.2 or higher**
+    * At least version **7.4.1 or higher**
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * [Docker for Mac](https://docs.docker.com/engine/installation/)
     * Docker-sync suggests ([in known issue](https://github.com/EugenMayer/docker-sync/issues/517)) to use Docker for Mac in version 17.09.1-ce-mac42 (21090)

--- a/docs/installation/installation-using-docker-windows-10-pro-higher.md
+++ b/docs/installation/installation-using-docker-windows-10-pro-higher.md
@@ -20,7 +20,7 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for relatively fast 
 ## Requirements
 * [GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 * [PHP](http://php.net/manual/en/install.windows.php)
-    * At least version **7.2 or higher**
+    * At least version **7.4.1 or higher**
 * [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
     * Docker for Windows requires at least 6.5 GB of memory, but this is only required to run `composer install` and `composer update` which would result in `Killed` status if not enough memory would be available (we recommend to set at least 2.5 GB RAM, 1 CPU and 4 GB Swap in `Docker -> Preferences… -> Resources -> ADVANCED`)
     * Version of Docker Engine should be at least **17.05 or higher** so it supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -26,7 +26,7 @@ For more detailed information about the Shopsys Framework, please see [Shopsys F
 - [How can I create Front-end Breadcrumb navigation?](#how-can-i-create-front-end-breadcrumb-navigation)
 - [Do you have any tips how to debug emails during development in Docker?](#do-you-have-any-tips-how-to-debug-emails-during-development-in-docker)
 - [Can I see what is really happening in the Codeception acceptance tests when using Docker?](#can-i-see-what-is-really-happening-in-the-codeception-acceptance-tests-when-using-docker)
-- [Why is there a faked PHP 7.2 platform in the Composer config?](#why-is-there-a-faked-php-72-platform-in-the-composer-config)
+- [Why is there a faked PHP 7.4.1 platform in the Composer config?](#why-is-there-a-faked-php-741-platform-in-the-composer-config)
 - [How to make PHPStorm and PHPStan understand that I use extended classes?](#how-to-make-phpstorm-and-phpstan-understand-that-i-use-extended-classes)
 - [SMTP container cannot send email with error "Helo command rejected: need fully-qualified hostname"](#smtp-container-cannot-send-email-with-error-helo-command-rejected-need-fully-qualified-hostname)
 
@@ -152,9 +152,9 @@ See [Outgoing emails](https://github.com/djfarrelly/MailDev#outgoing-email) in t
 ## Can I see what is really happening in the Codeception acceptance tests when using Docker?
 Yes, you can! Check [the quick guide](./running-acceptance-tests.md#how-to-watch-what-is-going-on-in-the-selenium-browser).
 
-## Why is there a faked PHP 7.2 platform in the Composer config?
-As a general rule, packages and libraries that depend on PHP 7.2 will work as expected even on PHP 7.4 (any higher 7.x version), but not vice versa.
-Mainteiners of PHP are focusing on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration73.incompatible.php) introduced in PHP 7.3, in practice it doesn't cause issues).
+## Why is there a faked PHP 7.4.1 platform in the Composer config?
+As a general rule, packages and libraries that depend on PHP 7.4.1 will work as expected even on any higher 7.x version, but not vice versa.
+Maintainers of PHP are focusing on backward-compatibility (even if there were [some incompatible changes](https://www.php.net/manual/en/migration74.incompatible.php) introduced in PHP 7.4, in practice it doesn't cause issues).
 
 Using [the `config.platform.php` option](https://getcomposer.org/doc/06-config.md#platform) in `composer.json` allows us to force Composer to install such dependencies, that work for all supported versions of PHP by Shopsys Framework.
 These dependencies are locked during each release of SSFW so users that install it can download exact versions of all libraries and tools that were tested and proved working.

--- a/docs/introduction/start-building-your-application.md
+++ b/docs/introduction/start-building-your-application.md
@@ -125,7 +125,7 @@ To do so, remove the `config.platform.php` option from your `composer.json`:
          "preferred-install": "dist",
 -        "component-dir": "project-base/web/components",
 -        "platform": {
--            "php": "7.2"
+-            "php": "7.4.1"
 -        }
 +        "component-dir": "project-base/web/components"
      },
@@ -138,28 +138,28 @@ If you're interested in why we use the forced PHP version in the first place, re
 ---
 
 On the other hand, if you're planning to run your project in production on a natively installed PHP, you should respect the version installed on that server.
-We recommend to use the same version in your `php-fpm`'s `Dockerfile`, so that developers using Docker run the app in the same environment.
+We recommend using the same version in your `php-fpm`'s `Dockerfile`, so that developers using Docker run the app in the same environment.
 After all, your production server is the one that matters the most.
 
 First, run `php -v` on your server to find our the exact version, for example:
 ``` no-highlight
-PHP 7.2.19-0ubuntu0.18.04.1 (cli) (built: Jun  4 2019 14:48:12) ( NTS )
-Copyright (c) 1997-2018 The PHP Group
-Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
-    with Zend OPcache v7.2.19-0ubuntu0.18.04.1, Copyright (c) 1999-2018, by Zend Technologies
+PHP 7.4.12 (cli) (built: Oct  29 2020 18:37:21) ( NTS )
+Copyright (c) The PHP Group
+Zend Engine v3.4.0, Copyright (c) Zend Technologies
+    with Zend OPcache v7.4.12, Copyright (c), by Zend Technologies
 ```
 Then change the version in your `docker/php-fpm/Dockerfile`:
 ```diff
 - FROM php:7.4-fpm-buster as base
-+ FROM php:7.2.19-fpm-stretch as base
++ FROM php:7.4.12-fpm-buster as base
 ```
 After running `docker-compose up -d --build` you'll have the application running on the same PHP.
 
 Now you can modify the version in your `composer.json` as well so all packages will always be installed in a compatible version.
 ```diff
          "platform": {
--            "php": "7.2"
-+            "php": "7.2.19"
+-            "php": "7.4.1"
++            "php": "7.4.12"
          }
 ```
 To apply the new setting, execute `composer update` and commit the changes.

--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -109,7 +109,7 @@ https://github.com/elastic/elasticsearch/blob/v6.3.2/LICENSE.txt
 Copyright 2009-2018 Elasticsearch
 
 ### Php
-Image: `php:7.2-fpm-stretch`  
+Image: `php:7.4-fpm-buster`  
 License: The PHP License  
 http://php.net/license/  
 Copyright (c) 1999 - 2018 The PHP Group. All rights reserved.

--- a/packages/backend-api/.travis.yml
+++ b/packages/backend-api/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/backend-api/composer.json
+++ b/packages/backend-api/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^2.7",

--- a/packages/form-types-bundle/.travis.yml
+++ b/packages/form-types-bundle/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 install:

--- a/packages/form-types-bundle/composer.json
+++ b/packages/form-types-bundle/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/form": "^4.4",

--- a/packages/framework/.travis.yml
+++ b/packages/framework/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-bcmath": "*",
         "ext-ctype": "*",
         "ext-curl": "*",

--- a/packages/frontend-api/.travis.yml
+++ b/packages/frontend-api/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "lcobucci/jwt": "^3.3",
         "overblog/graphql-bundle": "^0.13",
         "overblog/graphiql-bundle": "^0.2",

--- a/packages/google-cloud-bundle/.travis.yml
+++ b/packages/google-cloud-bundle/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/google-cloud-bundle/composer.json
+++ b/packages/google-cloud-bundle/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "google/cloud-storage": "^1.10",
         "shopsys/form-types-bundle": "9.1.x-dev",
         "shopsys/framework": "9.1.x-dev",

--- a/packages/plugin-interface/.travis.yml
+++ b/packages/plugin-interface/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 install:

--- a/packages/plugin-interface/composer.json
+++ b/packages/plugin-interface/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "symfony/monolog-bridge": "^4.4.0"
     },
     "require-dev": {

--- a/packages/product-feed-google/.travis.yml
+++ b/packages/product-feed-google/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^2.7",

--- a/packages/product-feed-heureka-delivery/.travis.yml
+++ b/packages/product-feed-heureka-delivery/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "shopsys/doctrine-orm": "^2.7.2",
         "shopsys/form-types-bundle": "9.1.x-dev",
         "shopsys/framework": "9.1.x-dev",

--- a/packages/product-feed-heureka/.travis.yml
+++ b/packages/product-feed-heureka/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-pdo": "*",

--- a/packages/product-feed-zbozi/.travis.yml
+++ b/packages/product-feed-zbozi/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "doctrine/dbal": "^2.7",

--- a/packages/read-model/.travis.yml
+++ b/packages/read-model/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/read-model/composer.json
+++ b/packages/read-model/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "shopsys/form-types-bundle": "9.1.x-dev",
         "shopsys/framework": "9.1.x-dev",
         "shopsys/migrations": "9.1.x-dev",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4.1",
         "ext-bcmath": "*",
         "ext-ctype": "*",
         "ext-curl": "*",
@@ -148,7 +148,7 @@
         "component-dir": "web/components",
         "sort-packages": true,
         "platform": {
-            "php": "7.2"
+            "php": "7.4.1"
         }
     },
     "extra": {

--- a/project-base/symfony.lock
+++ b/project-base/symfony.lock
@@ -348,6 +348,15 @@
     "kriswallsmith/assetic": {
         "version": "v1.4.0"
     },
+    "laminas/laminas-code": {
+        "version": "3.4.1"
+    },
+    "laminas/laminas-eventmanager": {
+        "version": "3.3.0"
+    },
+    "laminas/laminas-zendframework-bridge": {
+        "version": "1.1.1"
+    },
     "lcobucci/jwt": {
         "version": "3.3.2"
     },
@@ -356,6 +365,9 @@
     },
     "league/flysystem-cached-adapter": {
         "version": "1.0.9"
+    },
+    "league/mime-type-detection": {
+        "version": "1.5.1"
     },
     "litipk/php-bignumbers": {
         "version": "0.8.6"
@@ -450,7 +462,7 @@
         "version": "2.16.1"
     },
     "php": {
-        "version": "7.2"
+        "version": "7.4.1"
     },
     "php-cs-fixer/diff": {
         "version": "v1.3.0"
@@ -487,6 +499,9 @@
     },
     "phpstan/phpstan-phpunit": {
         "version": "0.11.2"
+    },
+    "phpstan/phpstan-symfony": {
+        "version": "0.12.11"
     },
     "phpunit/php-code-coverage": {
         "version": "6.1.4"
@@ -1145,6 +1160,9 @@
     },
     "vasek-purchart/console-errors-bundle": {
         "version": "1.0.1"
+    },
+    "webimpress/safe-writer": {
+        "version": "2.1.0"
     },
     "webmozart/assert": {
         "version": "1.5.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -330,6 +330,15 @@
     "knplabs/knp-menu-bundle": {
         "version": "v2.3.0"
     },
+    "laminas/laminas-code": {
+        "version": "3.4.1"
+    },
+    "laminas/laminas-eventmanager": {
+        "version": "3.3.0"
+    },
+    "laminas/laminas-zendframework-bridge": {
+        "version": "1.1.1"
+    },
     "lcobucci/jwt": {
         "version": "3.3.1"
     },
@@ -341,6 +350,9 @@
     },
     "league/flysystem-cached-adapter": {
         "version": "1.0.9"
+    },
+    "league/mime-type-detection": {
+        "version": "1.5.1"
     },
     "league/oauth2-server": {
         "version": "7.2.0"
@@ -426,7 +438,7 @@
         "version": "2.16.1"
     },
     "php": {
-        "version": "7.2"
+        "version": "7.4.1"
     },
     "php-cs-fixer/diff": {
         "version": "v1.3.0"
@@ -1080,6 +1092,9 @@
     "vasek-purchart/console-errors-bundle": {
         "version": "1.0.1"
     },
+    "webimpress/safe-writer": {
+        "version": "2.1.0"
+    },
     "webmozart/assert": {
         "version": "1.5.0"
     },
@@ -1098,13 +1113,7 @@
     "zalas/phpunit-injector": {
         "version": "v1.2.7"
     },
-    "zendframework/zend-code": {
-        "version": "3.4.0"
-    },
     "zendframework/zend-diactoros": {
         "version": "1.8.7"
-    },
-    "zendframework/zend-eventmanager": {
-        "version": "3.2.1"
     }
 }

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -186,3 +186,7 @@ There you can find links to upgrade notes for other versions too.
 
 - increase reliability and decrease maintainability of acceptance tests ([#2099](https://github.com/shopsys/shopsys/pull/2099))
     - see #project-base-diff to update your project
+
+- drop support for lower PHP versions than 7.4.1 ([#2109](https://github.com/shopsys/shopsys/pull/2109))
+    - see #project-base-diff to update your project 
+    - update your dependencies with `composer update` after you set `platform.php` in `composer.json` to the required version


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| From now on, only PHP 7.4.1 or higher is supported by Shopsys Framework. Explanation follows.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| May <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| No


In general, it's not a good idea to run an application on an unsupported version of the PHP.
PHP 7.2 is no longer actively supported and security support stops in a few days.
PHP 7.3 will stop being actively supported in nearly a month (even though security support will remain for another year).
(source https://www.php.net/supported-versions.php)

Many used libraries release new versions with PHP 7.4+ compatibility only, which forces us to keep older versions without important fixes or new features available. We count on the projects to use the newer version and drop support for lower versions by themselves, but it's not something we're happy about.
Because of all that makes maintaining the Shopsys Framework and mostly projects based on SSFW unnecessarily harder and without any added value (on the contrary in fact). 

Since v9.0.0 PHP 7.4 is a default version used if you use provided [Dockerfile](https://github.com/shopsys/shopsys/blob/v9.0.0/project-base/docker/php-fpm/Dockerfile), so your code should be more than ready.