### PR TITLE
[project-base] enabled logging in tests

### DIFF
--- a/project-base/config/packages/test/monolog.yaml
+++ b/project-base/config/packages/test/monolog.yaml
@@ -1,16 +1,37 @@
-# disable logging in tests
 monolog:
+    channels: ["cron", "slow"]
     handlers:
         main:
-            type: "null"
-            excluded_404s: false
+            type: fingers_crossed
+            buffer_size: 1000
+            action_level: warning
+            handler: nested
+            excluded_404s:
+                - ^/
         nested:
-            type: "null"
+            type: stream
+            path: "%shopsys.log_stream%"
+            level: warning
         cron:
-            type: "null"
+            type: stream
+            path: "%shopsys.log_stream%"
+            channels: cron
+            level: warning
         slow:
-            type: "null"
+            type: stream
+            path: "%shopsys.log_stream%"
+            channels: slow
+            level: warning
+        # display cron.DEBUG messages in console for -v, -vv and -vvv verbosities
         cron_console_output:
-            type: "null"
+            type: console
+            verbosity_levels:
+                VERBOSITY_NORMAL: WARNING
+                VERBOSITY_VERBOSE: NOTICE
+                VERBOSITY_VERY_VERBOSE: INFO
+                VERBOSITY_DEBUG: DEBUG
+            channels: cron
+            # stop propagation to the second "console" handler so that message is not printed twice
+            bubble: false
         console_output:
-            type: "null"
+            type: console

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -205,3 +205,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fix cleaning of old redis cache ([#2096](https://github.com/shopsys/shopsys/pull/2096))
     - see #project-base-diff to update your project
+
+- enable logging in tests ([#2113](https://github.com/shopsys/shopsys/pull/2113))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Logging in tests was disabled which lead to harder debugging of problems with tests. Now we have enabled logging of level WARNING or higher, so only important informations are logged.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
