### PR TITLE
[monorepo] add frontend_api.yaml to .gitignore for monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /project-base/package-lock.json
 /project-base/migrations-lock.yml
 /project-base/.phpunit.result.cache
+/project-base/config/packages/frontend_api.yaml
 /.env.local
 /.env.local.php
 /.env.*.local


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In monorepo we don't want to commit file `frontend_api.yaml`, which enables FE API. This file needs to be commited only for projects build on top of the SSFW 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
