### PR TITLE
[framework] ConstantVisibilityRequiredSniff and ForceLateStaticBindingForProtectedConstantsSniff are ignored for sources folders only in project-base

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -45,11 +45,11 @@ parameters:
             - 'utils/*'
 
         Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff:
-            - '*/src/*'
+            - 'project-base/src/*'
             - '*/tests/App/*'
 
         Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff:
-            - '*/src/*'
+            - 'project-base/src/*'
             - '*/tests/App/*'
 
         ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff:

--- a/packages/frontend-api/src/Component/Arguments/PaginatorArgumentsBuilder.php
+++ b/packages/frontend-api/src/Component/Arguments/PaginatorArgumentsBuilder.php
@@ -33,7 +33,7 @@ class PaginatorArgumentsBuilder implements MappingInterface
                 'type' => 'Int',
             ],
             'orderingMode' => [
-                'type' => $config[self::CONFIG_ORDER_TYPE_KEY],
+                'type' => $config[static::CONFIG_ORDER_TYPE_KEY],
             ],
         ];
     }
@@ -44,11 +44,11 @@ class PaginatorArgumentsBuilder implements MappingInterface
      */
     protected function checkMandatoryFields(array $config): void
     {
-        if (array_key_exists(self::CONFIG_ORDER_TYPE_KEY, $config) === false) {
+        if (array_key_exists(static::CONFIG_ORDER_TYPE_KEY, $config) === false) {
             $message = sprintf(
                 'Using the `%s`, the key `%s` defining the GraphQL type of the node is required.',
                 self::class,
-                self::CONFIG_ORDER_TYPE_KEY
+                static::CONFIG_ORDER_TYPE_KEY
             );
             throw new MandatoryArgumentMissingException($message);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| These two sniffs were wrongly set in monorepo. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
