### PR TITLE
[project-base] added email length validation in SubscriptionFormType

### DIFF
--- a/project-base/src/Form/Front/Newsletter/SubscriptionFormType.php
+++ b/project-base/src/Form/Front/Newsletter/SubscriptionFormType.php
@@ -28,6 +28,9 @@ class SubscriptionFormType extends AbstractType
                 'required' => true,
                 'constraints' => [
                     new Constraints\NotBlank(),
+                    new Constraints\Length(
+                        ['max' => 255, 'maxMessage' => 'Email cannot be longer than {{ limit }} characters']
+                    ),
                     new Email(),
                 ],
             ])

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -252,3 +252,6 @@ There you can find links to upgrade notes for other versions too.
 
 - add ACCEPTANCE file to .gitignore ([#2145](https://github.com/shopsys/shopsys/pull/2145))
     - see #project-base-diff to update your project
+    
+- add email length validation in SubscriptionFormType ([#2120](https://github.com/shopsys/shopsys/pull/2120))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| add email length validation in SubscriptionFormType
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
