### PR TITLE
requests are transactional only in admin

### DIFF
--- a/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
+++ b/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
@@ -33,7 +33,10 @@ class TransactionalMasterRequestListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if ($event->isMasterRequest() && !$this->inTransaction) {
+        if ($event->isMasterRequest()
+            && $this->isAdminRoute($event->getRequest()->get('_route'))
+            && !$this->inTransaction
+        ) {
             $this->em->beginTransaction();
             $this->inTransaction = true;
         }
@@ -59,5 +62,14 @@ class TransactionalMasterRequestListener
             $this->em->rollback();
             $this->inTransaction = false;
         }
+    }
+
+    /**
+     * @param string $route
+     * @return bool
+     */
+    protected function isAdminRoute(string $route): bool
+    {
+        return strpos($route, 'admin_') === 0;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On large projects, we need to use database replication. Currently, we need to remove Transactional requests for Frontend, because transactions are automatically queried to "Master" instance. For more information, you can read [this](https://github.com/doctrine/dbal/blob/2.12.x/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php#L19)
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
