### PR TITLE
OrderPriceCalculation incorrect rounding for czech crowns

### DIFF
--- a/packages/framework/src/Model/Order/OrderPriceCalculation.php
+++ b/packages/framework/src/Model/Order/OrderPriceCalculation.php
@@ -75,7 +75,7 @@ class OrderPriceCalculation
         }
 
         $priceWithVat = $orderTotalPrice->getPriceWithVat();
-        $roundedPriceWithVat = $priceWithVat->round(0);
+        $roundedPriceWithVat = $this->rounding->roundPriceWithVatByCurrency($priceWithVat, $currency);
 
         $roundingPrice = $this->rounding->roundPriceWithVatByCurrency(
             $roundedPriceWithVat->subtract($priceWithVat),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|`OrderPriceCalculation::calculateOrderRoundingPrice` method behaves incorrectly when you add `roundPriceWithVatByCurrency` rounding `none`. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

What happens is that we have added `none` rounding to `Rounding::roundPriceWithVatByCurrency` and this part of code behaves incorrectly. For example when I have price 100,47, `$roundedPriceWithVat` is 0,47 and then `$roundingPrice` type `none` is not taken into consideration.
```
$priceWithVat = $orderTotalPrice->getPriceWithVat();
$roundedPriceWithVat = $priceWithVat->round(0);

$roundingPrice = $this->rounding->roundPriceWithVatByCurrency($roundedPriceWithVat->subtract($priceWithVat), $currency);
```
 After I change how the `$roundedPriceWithVat` is calculated in the first place, this resolves the rounding strangeness.

Also, I have noticed that in method `calculateOrderRoundingPrice` is very strange if statement that behaves differently for some payments in CZK currency.
```
if (!$payment->isCzkRounding() || $currency->getCode() !== Currency::CODE_CZK) {
     return null;
}
```