### PR TITLE
[framework] do not call unnecessary elasticsearch queries

### DIFF
--- a/packages/read-model/src/Product/Detail/ProductDetailViewElasticsearchFactory.php
+++ b/packages/read-model/src/Product/Detail/ProductDetailViewElasticsearchFactory.php
@@ -118,20 +118,13 @@ class ProductDetailViewElasticsearchFactory
             $parameterViews[] = $this->parameterViewFactory->createFromParameterArray($parameterArray);
         }
 
-        $accessories = $this->listedProductViewFactory->createFromProductsArray(
-            $this->productElasticsearchProvider->getSellableProductArrayByIds($productArray['accessories'])
-        );
-        $variants = $this->listedProductViewFactory->createFromProductsArray(
-            $this->productElasticsearchProvider->getSellableProductArrayByIds($productArray['variants'])
-        );
-
         return $this->createInstance(
             $productArray,
             $this->imageViewFacade->getAllImagesByEntityId(Product::class, $productArray['id']),
             $parameterViews,
             $this->brandViewFactory->createFromProductArray($productArray),
-            $accessories,
-            $variants
+            $this->getListedProductViewsByProductIds($productArray['accessories']),
+            $this->getListedProductViewsByProductIds($productArray['variants'])
         );
     }
 
@@ -204,5 +197,20 @@ class ProductDetailViewElasticsearchFactory
         }
 
         return $seoMetaDescription;
+    }
+
+    /**
+     * @param int[] $productIds
+     * @return \Shopsys\ReadModelBundle\Product\Listed\ListedProductView[]
+     */
+    protected function getListedProductViewsByProductIds(array $productIds): array
+    {
+        if (count($productIds) === 0) {
+            return [];
+        }
+
+        return $this->listedProductViewFactory->createFromProductsArray(
+            $this->productElasticsearchProvider->getSellableProductArrayByIds($productIds)
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After implementing product detail from Elasticsearch there are unnecessary calls to Elasticsearch if accessories or variants are not set to product. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
