### PR TITLE
[frontend-api] string inputs are always trimmed

### DIFF
--- a/packages/frontend-api/src/Model/Customer/User/CustomerUserDataFactory.php
+++ b/packages/frontend-api/src/Model/Customer/User/CustomerUserDataFactory.php
@@ -46,7 +46,7 @@ class CustomerUserDataFactory
 
         foreach ($input as $key => $value) {
             if (property_exists(get_class($customerUserData), $key)) {
-                $customerUserData->{$key} = $value !== null ? trim($value) : null;
+                $customerUserData->{$key} = $value !== null ? $value : null;
             }
         }
 

--- a/packages/frontend-api/src/Model/GraphqlConfigurator.php
+++ b/packages/frontend-api/src/Model/GraphqlConfigurator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model;
+
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\Type;
+use Shopsys\FrontendApiBundle\Model\ScalarType\StringType;
+
+class GraphqlConfigurator
+{
+    public function applyExtraConfiguration(): void
+    {
+        $this->overrideStandardTypes();
+    }
+
+    protected function overrideStandardTypes(): void
+    {
+        $types = Type::getStandardTypes();
+        // Prevents multiple overriding in tests as standard types stays overridden even on new booted kernel
+        if ($types[Type::STRING] instanceof StringType) {
+            return;
+        }
+
+        GraphQL::overrideStandardTypes([
+            Type::STRING => new StringType(),
+        ]);
+    }
+}

--- a/packages/frontend-api/src/Model/Mutation/Newsletter/NewsletterMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Newsletter/NewsletterMutation.php
@@ -43,7 +43,7 @@ class NewsletterMutation implements MutationInterface, AliasedInterface
         $validator->validate();
 
         $input = $argument['input'];
-        $email = trim($input['email']);
+        $email = $input['email'];
         $this->newsletterFacade->addSubscribedEmail($email, $this->domain->getId());
 
         return [

--- a/packages/frontend-api/src/Model/ScalarType/PasswordType.php
+++ b/packages/frontend-api/src/Model/ScalarType/PasswordType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\ScalarType;
+
+use GraphQL\Language\AST\StringValueNode;
+
+class PasswordType
+{
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function serialize(string $value): string
+    {
+        return $value;
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function parseValue(string $value): string
+    {
+        return $value;
+    }
+
+    /**
+     * @param \GraphQL\Language\AST\StringValueNode $valueNode
+     * @return string
+     */
+    public static function parseLiteral(StringValueNode $valueNode): string
+    {
+        return $valueNode->value;
+    }
+}

--- a/packages/frontend-api/src/Model/ScalarType/StringType.php
+++ b/packages/frontend-api/src/Model/ScalarType/StringType.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\ScalarType;
+
+use GraphQL\Type\Definition\StringType as BaseStringType;
+
+class StringType extends BaseStringType
+{
+    /**
+     * @param \GraphQL\Language\AST\Node $valueNode
+     * @param array|null $variables
+     * @return string|null
+     */
+    public function parseLiteral($valueNode, ?array $variables = null)
+    {
+        $value = parent::parseLiteral($valueNode, $variables);
+        if ($value === null) {
+            return null;
+        }
+        return trim($value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public function parseValue($value)
+    {
+        return trim(parent::parseValue($value));
+    }
+}

--- a/packages/frontend-api/src/Resources/config/graphql-types/ChangePasswordInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ChangePasswordInputDecorator.types.yaml
@@ -10,7 +10,7 @@ ChangePasswordInputDecorator:
                     -   NotBlank:
                             message: "Please enter your email address"
             oldPassword:
-                type: "String!"
+                type: "Password!"
                 description: "Current customer user password."
                 validation:
                     -   NotBlank:
@@ -19,7 +19,7 @@ ChangePasswordInputDecorator:
                             min: 6
                             minMessage: "Old password must be at least {{ limit }} characters long"
             newPassword:
-                type: "String!"
+                type: "Password!"
                 description: "New customer user password."
                 validation:
                     -   NotBlank:

--- a/packages/frontend-api/src/Resources/config/graphql-types/ChangePersonalDataInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ChangePersonalDataInputDecorator.types.yaml
@@ -8,7 +8,6 @@ ChangePersonalDataInputDecorator:
                 description: "Customer user first name"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter first name"
                     -   Length:
                             max: 100
@@ -18,7 +17,6 @@ ChangePersonalDataInputDecorator:
                 description: "Customer user last name"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter last name"
                     -   Length:
                             max: 100
@@ -28,7 +26,6 @@ ChangePersonalDataInputDecorator:
                 description: "Date and time when the order was created"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter telephone number"
                     -   Length:
                             max: 30

--- a/packages/frontend-api/src/Resources/config/graphql-types/LoginInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/LoginInputDecorator.types.yaml
@@ -7,5 +7,5 @@ LoginInputDecorator:
                 type: "String!"
                 description: "The user email."
             password:
-                type: "String!"
+                type: "Password!"
                 description: "The user password."

--- a/packages/frontend-api/src/Resources/config/graphql-types/NewsletterSubscriptionDataInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/NewsletterSubscriptionDataInputDecorator.types.yaml
@@ -8,7 +8,6 @@ NewsletterSubscriptionDataInputDecorator:
                 type: "String!"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter email"
                     -   Email:
                             message: "Please enter valid email"

--- a/packages/frontend-api/src/Resources/config/graphql-types/OrderInput/OrderInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/OrderInput/OrderInputDecorator.types.yaml
@@ -11,7 +11,6 @@ OrderInputDecorator:
                 description: "The customer's first name"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter first name"
                     -   Length:
                             max: 100
@@ -21,7 +20,6 @@ OrderInputDecorator:
                 description: "The customer's last name"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter last name"
                     -   Length:
                             max: 100
@@ -31,7 +29,6 @@ OrderInputDecorator:
                 description: "The customer's email address"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter email"
                     -   Email:
                             message: "Please enter valid email"
@@ -43,7 +40,6 @@ OrderInputDecorator:
                 description: "The customer's telephone number"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter telephone number"
                     -   Length:
                             max: 30
@@ -57,7 +53,6 @@ OrderInputDecorator:
                 description: "The customer’s company name (required when onCompanyBehalf is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter company name"
                             groups: "onCompanyBehalf"
                     -   Length:
@@ -69,7 +64,6 @@ OrderInputDecorator:
                 description: "The customer’s company identification number (required when onCompanyBehalf is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter identification number"
                             groups: "onCompanyBehalf"
                     -   Length:
@@ -90,7 +84,6 @@ OrderInputDecorator:
                 description: "Billing address street name (will be on the tax invoice)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter street"
                     -   Length:
                             max: 100
@@ -100,7 +93,6 @@ OrderInputDecorator:
                 description: "Billing address city name (will be on the tax invoice)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter city"
                     -   Length:
                             max: 100
@@ -111,7 +103,6 @@ OrderInputDecorator:
                 description: "Billing address zip code (will be on the tax invoice)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter zip code"
                     -   Length:
                             max: 30
@@ -122,7 +113,6 @@ OrderInputDecorator:
                 description: "Billing address country code (Country will be on the tax invoice)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please choose country"
                     -   \Shopsys\FrameworkBundle\Form\Constraints\Country: ~
 
@@ -134,7 +124,6 @@ OrderInputDecorator:
                 description: "First name of the contact person for delivery (required when differentDeliveryAddress is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter first name of contact person"
                             groups: "differentDeliveryAddress"
                     -   Length:
@@ -146,7 +135,6 @@ OrderInputDecorator:
                 description: "Last name of the contact person for delivery (required when differentDeliveryAddress is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter last name of contact person"
                             groups: "differentDeliveryAddress"
                     -   Length:
@@ -174,7 +162,6 @@ OrderInputDecorator:
                 description: "Street name for delivery (required when differentDeliveryAddress is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter street"
                             groups: "differentDeliveryAddress"
                     -   Length:
@@ -186,7 +173,6 @@ OrderInputDecorator:
                 description: "City name for delivery (required when differentDeliveryAddress is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter city"
                             groups: "differentDeliveryAddress"
                     -   Length:
@@ -198,7 +184,6 @@ OrderInputDecorator:
                 description: "Zip code for delivery (required when differentDeliveryAddress is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter zip code"
                             groups: "differentDeliveryAddress"
                     -   Length:
@@ -210,7 +195,6 @@ OrderInputDecorator:
                 description: "Country code for delivery (required when differentDeliveryAddress is true)"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please choose country"
                             groups: "differentDeliveryAddress"
                     -   Shopsys\FrameworkBundle\Form\Constraints\Country:

--- a/packages/frontend-api/src/Resources/config/graphql-types/RegistrationDataInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/RegistrationDataInputDecorator.types.yaml
@@ -36,7 +36,7 @@ RegistrationDataInputDecorator:
                     -   Shopsys\FrameworkBundle\Form\Constraints\UniqueEmail:
                             message: "This email is already registered"
             password:
-                type: "String!"
+                type: "Password!"
                 description: "Customer user password."
                 validation:
                     -   NotBlank:

--- a/packages/frontend-api/src/Resources/config/graphql-types/RegistrationDataInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/RegistrationDataInputDecorator.types.yaml
@@ -9,7 +9,6 @@ RegistrationDataInputDecorator:
                 description: "Customer user first name"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter first name"
                     -   Length:
                             max: 100
@@ -19,7 +18,6 @@ RegistrationDataInputDecorator:
                 description: "Customer user last name"
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter last name"
                     -   Length:
                             max: 100
@@ -29,7 +27,6 @@ RegistrationDataInputDecorator:
                 description: "Customer user email."
                 validation:
                     -   NotBlank:
-                            normalizer: "trim"
                             message: "Please enter email"
                     -   Email:
                             message: "Please enter valid email"

--- a/packages/frontend-api/src/Resources/config/graphql-types/ScalarType/PasswordDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ScalarType/PasswordDecorator.types.yaml
@@ -1,0 +1,7 @@
+PasswordDecorator:
+    type: custom-scalar
+    config:
+        description: "Represents and encapsulates a string for password"
+        serialize: ["Shopsys\\FrontendApiBundle\\Model\\ScalarType\\PasswordType", "serialize"]
+        parseValue: ["Shopsys\\FrontendApiBundle\\Model\\ScalarType\\PasswordType", "parseValue"]
+        parseLiteral: ["Shopsys\\FrontendApiBundle\\Model\\ScalarType\\PasswordType", "parseLiteral"]

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -32,3 +32,5 @@ services:
 
     Shopsys\FrontendApiBundle\Model\User\FrontendApiUserFactoryInterface:
         alias: Shopsys\FrontendApiBundle\Model\User\FrontendApiUserFactory
+
+    Shopsys\FrontendApiBundle\Model\GraphqlConfigurator: ~

--- a/project-base/config/graphql/types/ScalarType/Password.types.yaml
+++ b/project-base/config/graphql/types/ScalarType/Password.types.yaml
@@ -1,0 +1,4 @@
+Password:
+    type: custom-scalar
+    inherits:
+        - 'PasswordDecorator'

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -228,3 +228,6 @@ There you can find links to upgrade notes for other versions too.
     - `EnvironmentFileSetting::getEnvironment()` has now its `$console` parameter nullable and will be fully removed in next major
     - `TEST` environment can now be used in CLI
     - `DomainFactoryOverwritingDomainUrl` is now replacing `DomainFactory` in `ACCEPTANCE` environment instead of `TEST`
+
+- add automatic string trimming and new Password type in frontend API ([#2127](https://github.com/shopsys/shopsys/pull/2127))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| All string input is trimmed. To prevent trimming passwords there was introduced a new type `Password` which do not manipulate with the values.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2111  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
