### PR TITLE
[framework] Enabled caching for DomainRouter and LocalizedRouter

### DIFF
--- a/packages/framework/src/Resources/config/paths.yaml
+++ b/packages/framework/src/Resources/config/paths.yaml
@@ -1,4 +1,6 @@
 parameters:
     shopsys.framework.resources_dir: "%shopsys.framework.root_dir%/src/Resources"
     shopsys.framework.javascript_sources_dir: "%shopsys.framework.resources_dir%/scripts"
+    shopsys.router.domain.cache_dir: "%kernel.cache_dir%/routing/base"
+    shopsys.router.localized.cache_dir: "%kernel.cache_dir%/routing/localized"
     shopsys.var_dir: "/var" # @deprecated This has been added to be backward compatible and will be removed in next major version

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -476,7 +476,9 @@ services:
             - { name: router, priority: 70 }
 
     Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory:
-        arguments: ['%router.resource%']
+        arguments:
+            $routerConfiguration: '%router.resource%'
+            $cacheDir: '%shopsys.router.domain.cache_dir%'
 
     Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataProviderRegistry:
         arguments: [!tagged shopsys.friendly_url_provider]
@@ -485,7 +487,9 @@ services:
         arguments: ['%shopsys.router.friendly_url_router_filepath%']
 
     Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory:
-        arguments: ['%shopsys.router.locale_router_filepath_mask%']
+        arguments:
+            $localeRoutersResourcesFilepathMask: '%shopsys.router.locale_router_filepath_mask%'
+            $cacheDir: '%shopsys.router.localized.cache_dir%'
 
     Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector:
         arguments:

--- a/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/DomainRouterFactoryTest.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactor
 use Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
@@ -59,6 +60,7 @@ class DomainRouterFactoryTest extends TestCase
 
         $delegatingLoaderMock = $this->createMock(DelegatingLoader::class);
         $requestStackMock = $this->createMock(RequestStack::class);
+        $containerMock = $this->createMock(ContainerInterface::class);
 
         $domainRouterFactory = new DomainRouterFactory(
             'routerConfiguration',
@@ -66,7 +68,9 @@ class DomainRouterFactoryTest extends TestCase
             $localizedRouterFactoryMock,
             $friendlyUrlRouterFactoryMock,
             $domain,
-            $requestStackMock
+            $requestStackMock,
+            $containerMock,
+            __DIR__
         );
 
         $router = $domainRouterFactory->getRouter(Domain::THIRD_DOMAIN_ID);

--- a/packages/framework/tests/Unit/Component/Router/LocalizedRouterFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/LocalizedRouterFactoryTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Router\Exception\LocalizedRoutingConfigFileNotFoundException;
 use Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory;
 use Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -16,11 +17,14 @@ class LocalizedRouterFactoryTest extends TestCase
     public function testGetRouterRouterNotResolvedException()
     {
         $delegatingLoaderMock = $this->createMock(DelegatingLoader::class);
+        $containerMock = $this->createMock(ContainerInterface::class);
         $context = new RequestContext();
 
         $localizedRouterFactory = new LocalizedRouterFactory(
             static::LOCALE_ROUTERS_CONFIGURATION_MASK,
-            $delegatingLoaderMock
+            $delegatingLoaderMock,
+            $containerMock,
+            __DIR__
         );
         $this->expectException(LocalizedRoutingConfigFileNotFoundException::class);
         $localizedRouterFactory->getRouter('ru', $context);
@@ -29,6 +33,7 @@ class LocalizedRouterFactoryTest extends TestCase
     public function testGetRouter()
     {
         $delegatingLoaderMock = $this->createMock(DelegatingLoader::class);
+        $containerMock = $this->createMock(ContainerInterface::class);
         $context1 = new RequestContext();
         $context1->setHost('host1');
         $context2 = new RequestContext();
@@ -36,7 +41,9 @@ class LocalizedRouterFactoryTest extends TestCase
 
         $localizedRouterFactory = new LocalizedRouterFactory(
             static::LOCALE_ROUTERS_CONFIGURATION_MASK,
-            $delegatingLoaderMock
+            $delegatingLoaderMock,
+            $containerMock,
+            __DIR__
         );
 
         $router1 = $localizedRouterFactory->getRouter('en', $context1);

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -237,3 +237,12 @@ There you can find links to upgrade notes for other versions too.
     - run `php phing elasticsearch-index-migrate elasticsearch-export` to apply changes in Elasticsearch schema mapping
     - *BC BREAK* single product by UUID is now loaded from Elasticsearch with `productByUuid` resolver
         - if necessary, you can switch to the former resolver `product` in your `Query.types.yaml` file
+
+- provide cache directory to DomainRouterFactory and LocalizedRouterFactory ([#2133](https://github.com/shopsys/shopsys/pull/2133))
+    - the step is necessary in case you have extended following classes:
+        - `Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory`
+        - `Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory`
+    - pass cache directory argument in your `services.yaml` as `$cacheDir`
+        - for this purpose there were introduced 2 new parameters to be used:
+            - `shopsys.router.domain.cache_dir`
+            - `shopsys.router.localized.cache_dir`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Static and localized routes are now cached into file.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2106  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
