### PR TITLE
[project-base] lock composer to version 1.x for 9.0 branch

### DIFF
--- a/project-base/docker/php-fpm/docker-install-composer
+++ b/project-base/docker/php-fpm/docker-install-composer
@@ -14,7 +14,7 @@ then
     exit 1
 fi
 
-php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
+php composer-setup.php --quiet --1 --install-dir=/usr/local/bin --filename=composer
 RESULT=$?
 rm composer-setup.php
 exit $RESULT

--- a/upgrade/UPGRADE-v9.0.4-dev.md
+++ b/upgrade/UPGRADE-v9.0.4-dev.md
@@ -4,3 +4,6 @@ This guide contains instructions to upgrade from version v9.0.3 to v9.0.4-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- lock composer to version 1.x ([#2135](https://github.com/shopsys/shopsys/pull/2135))
+    - see [project-base-diff](https://github.com/shopsys/project-base/commit/) to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Version 9.0.x supports Composer 1 only and this version is now locked during installation.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
