### PR TITLE
[frontend-api] removed unnecessary UUID validations from resolvers

### DIFF
--- a/packages/frontend-api/src/Model/Resolver/Article/ArticleResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticleResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Article;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Article\Article;
 use Shopsys\FrameworkBundle\Model\Article\Exception\ArticleNotFoundException;
@@ -61,10 +60,6 @@ class ArticleResolver implements ResolverInterface, AliasedInterface
      */
     public function resolver(string $uuid): Article
     {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
-
         try {
             return $this->articleFacade->getVisibleByDomainIdAndUuid($this->domain->getId(), $uuid);
         } catch (ArticleNotFoundException $articleNotFoundException) {

--- a/packages/frontend-api/src/Model/Resolver/Brand/BrandResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Brand/BrandResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Brand;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Exception\BrandNotFoundException;
@@ -34,10 +33,6 @@ class BrandResolver implements ResolverInterface, AliasedInterface
      */
     public function resolver(string $uuid): Brand
     {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
-
         try {
             return $this->brandFacade->getByUuid($uuid);
         } catch (BrandNotFoundException $brandNotFoundException) {

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Category;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
@@ -34,10 +33,6 @@ class CategoryResolver implements ResolverInterface, AliasedInterface
      */
     public function resolver(string $uuid): Category
     {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
-
         try {
             return $this->categoryFacade->getByUuid($uuid);
         } catch (CategoryNotFoundException $categoryNotFoundException) {

--- a/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Order;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
@@ -99,10 +98,6 @@ class OrderResolver implements ResolverInterface, AliasedInterface
         CustomerUser $customerUser,
         string $uuid
     ): Order {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument \'uuid\' is not valid.');
-        }
-
         return $this->frontendApiOrderFacade->getByUuidAndCustomerUser($uuid, $customerUser);
     }
 }

--- a/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Payment;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentNotFoundException;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
@@ -41,10 +40,6 @@ class PaymentResolver implements ResolverInterface, AliasedInterface
      */
     public function resolver(string $uuid): Payment
     {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
-
         try {
             return $this->paymentFacade->getByUuid($uuid);
         } catch (PaymentNotFoundException $paymentNotFoundException) {

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductByUuidResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductByUuidResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\ProductElasticsearchProvider;
 
@@ -33,10 +32,6 @@ class ProductByUuidResolver implements ResolverInterface, AliasedInterface
      */
     public function resolver(string $uuid): array
     {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
-
         try {
             return $this->productElasticsearchProvider->getVisibleProductArrayByUuid($uuid);
         } catch (ProductNotFoundException $productNotFoundException) {

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\Product;
@@ -54,10 +53,6 @@ class ProductResolver implements ResolverInterface, AliasedInterface
             ),
             E_USER_DEPRECATED
         );
-
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
 
         try {
             return $this->productFacade->getByUuid($uuid);

--- a/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Transport;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Transport\Exception\TransportNotFoundException;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
@@ -41,10 +40,6 @@ class TransportResolver implements ResolverInterface, AliasedInterface
      */
     public function resolver(string $uuid): Transport
     {
-        if (Uuid::isValid($uuid) === false) {
-            throw new UserError('Provided argument is not valid UUID.');
-        }
-
         try {
             return $this->transportFacade->getByUuid($uuid);
         } catch (TransportNotFoundException $transportNotFoundException) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| UUID is validated by the type and it's not necessary to validate them separately in the resolvers anymore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
