### PR TITLE
[framework] fixed copying images when creating variants

### DIFF
--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -462,7 +462,7 @@ class ImageFacade
                     $sourceImage,
                     ImageConfig::ORIGINAL_SIZE_NAME
                 ),
-                'local://' . TransformString::removeDriveLetterFromPath(
+                'main://' . TransformString::removeDriveLetterFromPath(
                     $this->fileUpload->getTemporaryFilepath($sourceImage->getFilename())
                 )
             );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Temporary files must be created on abstract filesystem. Related to #1955.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2134  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes