### PR TITLE
[framework] FeedExportFactory: fixed casting of $lastSeekId to nullable int

### DIFF
--- a/packages/framework/src/Model/Feed/FeedExportFactory.php
+++ b/packages/framework/src/Model/Feed/FeedExportFactory.php
@@ -86,6 +86,7 @@ class FeedExportFactory
         $feedRenderer = $this->feedRendererFactory->create($feed);
         $feedFilepath = $this->feedPathProvider->getFeedFilepath($feed->getInfo(), $domainConfig);
         $feedLocalFilepath = $this->feedPathProvider->getFeedLocalFilepath($feed->getInfo(), $domainConfig);
+        $lastSeekId = $lastSeekId !== null ? (int)$lastSeekId : $lastSeekId;
 
         return new FeedExport(
             $feed,
@@ -97,7 +98,7 @@ class FeedExportFactory
             $this->em,
             $feedFilepath,
             $feedLocalFilepath,
-            (int)$lastSeekId
+            $lastSeekId
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR fixes retyping `$lastSeekId` from `string\|null` to `int\|null`. At this moment generating feeds don't add begin to feeds (eg. [this](https://github.com/shopsys/shopsys/blob/master/packages/product-feed-heureka-delivery/src/Resources/views/feed.xml.twig#L1-L4)) because [FeedExport class render begin only if $lastSeekId is null](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Feed/FeedExport.php#L141-L143) and `$lastSeekId` is always retyped to int so null never comes and begin is never rendered. This is issue in 9.1 version so I recommend you add this there. Thanks
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| fixes #2039  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
