### PR TITLE
[shopsys] cache friendly url slugs for generator into redis

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlCacheKeyProvider.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlCacheKeyProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
+
+class FriendlyUrlCacheKeyProvider
+{
+    /**
+     * @param string $routeName
+     * @param int $domainId
+     * @param int $entityId
+     * @return string
+     */
+    public function getMainFriendlyUrlSlugCacheKey(string $routeName, int $domainId, int $entityId): string
+    {
+        return sprintf(
+            '%s_%s_%s',
+            $routeName,
+            $domainId,
+            $entityId
+        );
+    }
+}

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\MethodGenerateIsNotSupportedException;
@@ -12,6 +13,7 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouteCompiler;
+use Symfony\Contracts\Cache\CacheInterface;
 
 class FriendlyUrlGenerator extends BaseUrlGenerator
 {
@@ -21,16 +23,40 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
     protected $friendlyUrlRepository;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider|null
+     */
+    protected ?FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider;
+
+    /**
+     * @var \Symfony\Contracts\Cache\CacheInterface|null
+     */
+    protected ?CacheInterface $mainFriendlyUrlSlugCache;
+
+    /**
      * @param \Symfony\Component\Routing\RequestContext $context
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository
+     * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider|null $friendlyUrlCacheKeyProvider
+     * @param \Symfony\Contracts\Cache\CacheInterface|null $mainFriendlyUrlSlugCache
      */
     public function __construct(
         RequestContext $context,
-        FriendlyUrlRepository $friendlyUrlRepository
+        FriendlyUrlRepository $friendlyUrlRepository,
+        ?FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider = null,
+        ?CacheInterface $mainFriendlyUrlSlugCache = null
     ) {
+        if ($mainFriendlyUrlSlugCache === null) {
+            $deprecationMessage = sprintf(
+                'The argument "$mainFriendlyUrlSlugCache" is not provided by constructor in "%s". In the next major it will be required.',
+                self::class
+            );
+            @trigger_error($deprecationMessage, E_USER_DEPRECATED);
+        }
+
         parent::__construct(new RouteCollection(), $context, null);
 
         $this->friendlyUrlRepository = $friendlyUrlRepository;
+        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
+        $this->mainFriendlyUrlSlugCache = $mainFriendlyUrlSlugCache;
     }
 
     /**
@@ -60,18 +86,24 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
         $entityId = $parameters['id'];
         unset($parameters['id']);
 
-        try {
-            $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl(
-                $domainConfig->getId(),
-                $routeName,
-                $entityId
+        $domainId = $domainConfig->getId();
+
+        if ($this->mainFriendlyUrlSlugCache !== null) {
+            $slug = $this->mainFriendlyUrlSlugCache->get(
+                $this->friendlyUrlCacheKeyProvider->getMainFriendlyUrlSlugCacheKey(
+                    $routeName,
+                    $domainId,
+                    (int)$entityId
+                ),
+                function () use ($domainId, $routeName, $entityId) {
+                    return $this->getSlug($domainId, $routeName, $entityId);
+                }
             );
-        } catch (FriendlyUrlNotFoundException $e) {
-            $message = 'Unable to generate a URL for the named route "' . $routeName . '" as such route does not exist.';
-            throw new RouteNotFoundException($message, 0, $e);
+        } else {
+            $slug = $this->getSlug($domainId, $routeName, $entityId);
         }
 
-        return $this->getGeneratedUrl($routeName, $route, $friendlyUrl, $parameters, $referenceType);
+        return $this->getGeneratedUrlBySlug($routeName, $route, $slug, $parameters, $referenceType);
     }
 
     /**
@@ -107,6 +139,43 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
     }
 
     /**
+     * @param string $routeName
+     * @param \Symfony\Component\Routing\Route $route
+     * @param string $slug
+     * @param array $parameters
+     * @param int $referenceType
+     * @return string
+     */
+    public function getGeneratedUrlBySlug(
+        string $routeName,
+        Route $route,
+        string $slug,
+        array $parameters,
+        int $referenceType
+    ): string {
+        $compiledRoute = RouteCompiler::compile($route);
+
+        $tokens = [
+            [
+                0 => 'text',
+                1 => '/' . $slug,
+            ],
+        ];
+
+        return $this->doGenerate(
+            $compiledRoute->getVariables(),
+            $route->getDefaults(),
+            $route->getRequirements(),
+            $tokens,
+            $parameters,
+            $routeName,
+            $referenceType,
+            $compiledRoute->getHostTokens(),
+            $route->getSchemes()
+        );
+    }
+
+    /**
      * Not supported method
      *
      * @param mixed $routeName
@@ -116,5 +185,55 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
     public function generate($routeName, $parameters = [], $referenceType = self::ABSOLUTE_PATH)
     {
         throw new MethodGenerateIsNotSupportedException();
+    }
+
+    /**
+     * @param int $domainId
+     * @param string $routeName
+     * @param int $entityId
+     * @return string
+     */
+    protected function getSlug(int $domainId, string $routeName, $entityId): string
+    {
+        try {
+            $friendlyUrl = $this->friendlyUrlRepository->getMainFriendlyUrl(
+                $domainId,
+                $routeName,
+                $entityId
+            );
+            return $friendlyUrl->getSlug();
+        } catch (FriendlyUrlNotFoundException $e) {
+            $message = 'Unable to generate a URL for the named route "' . $routeName . '" as such route does not exist.';
+            throw new RouteNotFoundException($message, 0, $e);
+        }
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setFriendlyUrlCacheKeyProvider(FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider): void
+    {
+        if (
+            $this->friendlyUrlCacheKeyProvider !== null
+            && $this->friendlyUrlCacheKeyProvider !== $friendlyUrlCacheKeyProvider
+        ) {
+            throw new BadMethodCallException(
+                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
+            );
+        }
+        if ($this->friendlyUrlCacheKeyProvider !== null) {
+            return;
+        }
+
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
     }
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRouterFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRouterFactory.php
@@ -2,9 +2,11 @@
 
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
+use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Contracts\Cache\CacheInterface;
 
 class FriendlyUrlRouterFactory
 {
@@ -24,18 +26,34 @@ class FriendlyUrlRouterFactory
     protected $friendlyUrlRouterResourceFilepath;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider|null
+     */
+    protected ?FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider;
+
+    /**
+     * @var \Symfony\Contracts\Cache\CacheInterface|null
+     */
+    protected ?CacheInterface $mainFriendlyUrlSlugCache;
+
+    /**
      * @param mixed $friendlyUrlRouterResourceFilepath
      * @param \Symfony\Component\Config\Loader\LoaderInterface $configLoader
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository
+     * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider|null $friendlyUrlCacheKeyProvider
+     * @param \Symfony\Contracts\Cache\CacheInterface|null $mainFriendlyUrlSlugCache
      */
     public function __construct(
         $friendlyUrlRouterResourceFilepath,
         LoaderInterface $configLoader,
-        FriendlyUrlRepository $friendlyUrlRepository
+        FriendlyUrlRepository $friendlyUrlRepository,
+        ?FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider = null,
+        ?CacheInterface $mainFriendlyUrlSlugCache = null
     ) {
         $this->friendlyUrlRouterResourceFilepath = $friendlyUrlRouterResourceFilepath;
         $this->configLoader = $configLoader;
         $this->friendlyUrlRepository = $friendlyUrlRepository;
+        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
+        $this->mainFriendlyUrlSlugCache = $mainFriendlyUrlSlugCache;
     }
 
     /**
@@ -48,10 +66,44 @@ class FriendlyUrlRouterFactory
         return new FriendlyUrlRouter(
             $context,
             $this->configLoader,
-            new FriendlyUrlGenerator($context, $this->friendlyUrlRepository),
+            new FriendlyUrlGenerator(
+                $context,
+                $this->friendlyUrlRepository,
+                $this->friendlyUrlCacheKeyProvider,
+                $this->mainFriendlyUrlSlugCache
+            ),
             new FriendlyUrlMatcher($this->friendlyUrlRepository),
             $domainConfig,
             $this->friendlyUrlRouterResourceFilepath
         );
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setFriendlyUrlCacheKeyProvider(FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider): void
+    {
+        if (
+            $this->friendlyUrlCacheKeyProvider !== null
+            && $this->friendlyUrlCacheKeyProvider !== $friendlyUrlCacheKeyProvider
+        ) {
+            throw new BadMethodCallException(
+                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
+            );
+        }
+        if ($this->friendlyUrlCacheKeyProvider !== null) {
+            return;
+        }
+
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
     }
 }

--- a/project-base/config/packages/framework.yaml
+++ b/project-base/config/packages/framework.yaml
@@ -21,3 +21,8 @@ framework:
         collect: false
     assets: ~
     error_controller: 'App\Controller\Front\ErrorController::showAction'
+    cache:
+        pools:
+            main_friendly_url_slug_cache:
+                adapter: cache.adapter.redis
+                provider: snc_redis.main_friendly_url_slugs

--- a/project-base/config/packages/snc_redis.yaml
+++ b/project-base/config/packages/snc_redis.yaml
@@ -23,6 +23,12 @@ snc_redis:
             type: 'phpredis'
             alias: 'session'
             dsn: 'redis://%redis_host%'
+        main_friendly_url_slugs:
+            type: 'phpredis'
+            alias: 'main_friendly_url_slugs'
+            dsn: 'redis://%redis_host%'
+            options:
+                prefix: '%env(REDIS_PREFIX)%%build-version%:cache:main_friendly_url_slugs:'
     session:
         client: 'session'
         ttl: 604800

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -263,3 +263,7 @@ There you can find links to upgrade notes for other versions too.
     - you may want to update your own native queries in similar way
     - don't forget that parameters in the `executeStatement()` call should have a type explicitly defined (see PR for examples)
     - see #project-base-diff to update your project
+
+- set redis client to cache friendly url slugs ([#2146](https://github.com/shopsys/shopsys/pull/2146))
+    - see #project-base-diff to update your project
+        - you need to define new cache pool `main_friendly_url_slug_cache` which will be automatically passed in `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory` constructors argument named `$mainFriendlyUrlSlugCache`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Each friendly URL created in twig recieved slug from database. This PR adds slugs to be cached in redis to reduce queries.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
