### PR TITLE
[shopsys] use DBAL native queries for DML instead of ORM Native SQL

### DIFF
--- a/docs/model/introduction-to-model-architecture.md
+++ b/docs/model/introduction-to-model-architecture.md
@@ -137,26 +137,28 @@ class CartRepository
      */
     public function deleteOldCartsForUnregisteredCustomerUsers($daysLimit)
     {
-        $nativeQuery = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'DELETE FROM cart_items WHERE cart_id IN (
                 SELECT C.id
                 FROM carts C
                 WHERE C.modified_at <= :timeLimit AND customer_user_id IS NULL)',
-            new ResultSetMapping()
+            [
+                'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
+            ],
+            [
+                'timeLimit' => Types::DATETIME_MUTABLE,
+            ]
         );
 
-        $nativeQuery->execute([
-            'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
-        ]);
-
-        $nativeQuery = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'DELETE FROM carts WHERE modified_at <= :timeLimit AND customer_user_id IS NULL',
-            new ResultSetMapping()
+            [
+                'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
+            ],
+            [
+                'timeLimit' => Types::DATETIME_MUTABLE,
+            ]
         );
-
-        $nativeQuery->execute([
-            'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
-        ]);
     }
 
     // ...

--- a/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
+++ b/packages/framework/src/Component/DataFixture/AbstractNativeFixture.php
@@ -6,6 +6,9 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\ResultSetMapping;
 
+/**
+ * @deprecated Class is obsolete and will be removed in the next major
+ */
 abstract class AbstractNativeFixture extends AbstractFixture
 {
     /**
@@ -29,6 +32,14 @@ abstract class AbstractNativeFixture extends AbstractFixture
      */
     protected function executeNativeQuery($sql, ?array $parameters = null)
     {
+        @trigger_error(
+            sprintf(
+                'The "%s" class is deprecated and will be removed in the next major.',
+                self::class
+            ),
+            E_USER_DEPRECATED
+        );
+
         $nativeQuery = $this->entityManager->createNativeQuery($sql, new ResultSetMapping());
         return $nativeQuery->execute($parameters);
     }

--- a/packages/framework/src/Component/Domain/DomainDbFunctionsFacade.php
+++ b/packages/framework/src/Component/Domain/DomainDbFunctionsFacade.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Component\Domain;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 
 class DomainDbFunctionsFacade
 {
@@ -49,7 +48,7 @@ class DomainDbFunctionsFacade
             $domainIdsByLocaleSqlClauses[] = $sql;
         }
 
-        $query = $this->em->createNativeQuery(
+        return $this->em->getConnection()->executeStatement(
             'CREATE OR REPLACE FUNCTION get_domain_ids_by_locale(locale text) RETURNS SETOF integer AS $$
             BEGIN
                 CASE
@@ -57,11 +56,8 @@ class DomainDbFunctionsFacade
                     ELSE RETURN;
                 END CASE;
             END
-            $$ LANGUAGE plpgsql IMMUTABLE;',
-            new ResultSetMapping()
+            $$ LANGUAGE plpgsql IMMUTABLE;'
         );
-
-        return $query->execute();
     }
 
     protected function createLocaleByDomainIdFunction()
@@ -73,7 +69,7 @@ class DomainDbFunctionsFacade
                 . ' THEN RETURN \'' . $domainConfig->getLocale() . '\';';
         }
 
-        $query = $this->em->createNativeQuery(
+        return $this->em->getConnection()->executeStatement(
             'CREATE OR REPLACE FUNCTION get_domain_locale(domain_id integer) RETURNS text AS $$
             BEGIN
                 CASE
@@ -81,10 +77,7 @@ class DomainDbFunctionsFacade
                     ELSE RAISE EXCEPTION \'Domain with ID % does not exists\', domain_id;
                 END CASE;
             END
-            $$ LANGUAGE plpgsql IMMUTABLE;',
-            new ResultSetMapping()
+            $$ LANGUAGE plpgsql IMMUTABLE;'
         );
-
-        return $query->execute();
     }
 }

--- a/packages/framework/src/Component/Domain/DomainUrlReplacer.php
+++ b/packages/framework/src/Component/Domain/DomainUrlReplacer.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Component\Domain;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlQuoter;
 use Shopsys\FrameworkBundle\Component\Doctrine\StringColumnsFinder;
 
@@ -54,7 +53,7 @@ class DomainUrlReplacer
                 $domainConfigUrl
             );
 
-            $this->em->createNativeQuery($urlReplacementSql, new ResultSetMapping())->execute();
+            $this->em->getConnection()->executeStatement($urlReplacementSql);
         }
     }
 

--- a/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityDataCreator.php
+++ b/packages/framework/src/Component/Domain/Multidomain/MultidomainEntityDataCreator.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Component\Domain\Multidomain;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 use Shopsys\FrameworkBundle\Component\Doctrine\SqlQuoter;
 
 class MultidomainEntityDataCreator
@@ -71,16 +71,19 @@ class MultidomainEntityDataCreator
         $quotedColumnNames = $this->sqlQuoter->quoteIdentifiers($columnNames);
         $quotedColumnNamesSql = implode(', ', $quotedColumnNames);
         $quotedTableName = $this->sqlQuoter->quoteIdentifier($tableName);
-        $query = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'INSERT INTO ' . $quotedTableName . ' (domain_id, ' . $quotedColumnNamesSql . ')
             SELECT :newDomainId, ' . $quotedColumnNamesSql . '
             FROM ' . $quotedTableName . '
             WHERE domain_id = :templateDomainId',
-            new ResultSetMapping()
+            [
+                'newDomainId' => $newDomainId,
+                'templateDomainId' => $templateDomainId,
+            ],
+            [
+                'newDomainId' => Types::INTEGER,
+                'templateDomainId' => Types::INTEGER,
+            ]
         );
-        $query->execute([
-            'newDomainId' => $newDomainId,
-            'templateDomainId' => $templateDomainId,
-        ]);
     }
 }

--- a/packages/framework/src/Component/Setting/SettingValueRepository.php
+++ b/packages/framework/src/Component/Setting/SettingValueRepository.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Component\Setting;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 
 class SettingValueRepository
 {
@@ -43,7 +43,7 @@ class SettingValueRepository
      */
     public function copyAllMultidomainSettings($fromDomainId, $toDomainId)
     {
-        $query = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'INSERT INTO setting_values (name, value, type, domain_id)
             SELECT name, value, type, :toDomainId
             FROM setting_values
@@ -54,12 +54,16 @@ class SettingValueRepository
                     WHERE domain_id IS NOT NULL
                         AND domain_id != :commonDomainId
                 )',
-            new ResultSetMapping()
+            [
+                'toDomainId' => $toDomainId,
+                'fromDomainId' => $fromDomainId,
+                'commonDomainId' => SettingValue::DOMAIN_ID_COMMON,
+            ],
+            [
+                'toDomainId' => Types::INTEGER,
+                'fromDomainId' => Types::INTEGER,
+                'commonDomainId' => Types::INTEGER,
+            ]
         );
-        $query->execute([
-            'toDomainId' => $toDomainId,
-            'fromDomainId' => $fromDomainId,
-            'commonDomainId' => SettingValue::DOMAIN_ID_COMMON,
-        ]);
     }
 }

--- a/packages/framework/src/Model/Cart/CartRepository.php
+++ b/packages/framework/src/Model/Cart/CartRepository.php
@@ -3,8 +3,8 @@
 namespace Shopsys\FrameworkBundle\Model\Cart;
 
 use DateTime;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifier;
 
 class CartRepository
@@ -51,26 +51,28 @@ class CartRepository
      */
     public function deleteOldCartsForUnregisteredCustomerUsers($daysLimit)
     {
-        $nativeQuery = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'DELETE FROM cart_items WHERE cart_id IN (
                 SELECT C.id
                 FROM carts C
                 WHERE C.modified_at <= :timeLimit AND customer_user_id IS NULL)',
-            new ResultSetMapping()
+            [
+                'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
+            ],
+            [
+                'timeLimit' => Types::DATETIME_MUTABLE,
+            ]
         );
 
-        $nativeQuery->execute([
-            'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
-        ]);
-
-        $nativeQuery = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'DELETE FROM carts WHERE modified_at <= :timeLimit AND customer_user_id IS NULL',
-            new ResultSetMapping()
+            [
+                'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
+            ],
+            [
+                'timeLimit' => Types::DATETIME_MUTABLE,
+            ]
         );
-
-        $nativeQuery->execute([
-            'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
-        ]);
     }
 
     /**
@@ -78,25 +80,27 @@ class CartRepository
      */
     public function deleteOldCartsForRegisteredCustomerUsers($daysLimit)
     {
-        $nativeQuery = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'DELETE FROM cart_items WHERE cart_id IN (
                 SELECT C.id
                 FROM carts C
                 WHERE C.modified_at <= :timeLimit AND customer_user_id IS NOT NULL)',
-            new ResultSetMapping()
+            [
+                'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
+            ],
+            [
+                'timeLimit' => Types::DATETIME_MUTABLE,
+            ]
         );
 
-        $nativeQuery->execute([
-            'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
-        ]);
-
-        $nativeQuery = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'DELETE FROM carts WHERE modified_at <= :timeLimit AND customer_user_id IS NOT NULL',
-            new ResultSetMapping()
+            [
+                'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
+            ],
+            [
+                'timeLimit' => Types::DATETIME_MUTABLE,
+            ]
         );
-
-        $nativeQuery->execute([
-            'timeLimit' => new DateTime('-' . $daysLimit . ' days'),
-        ]);
     }
 }

--- a/packages/framework/src/Model/Localization/DbIndexesRepository.php
+++ b/packages/framework/src/Model/Localization/DbIndexesRepository.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Model\Localization;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 
 class DbIndexesRepository
 {
@@ -26,10 +26,15 @@ class DbIndexesRepository
      */
     public function updateProductTranslationNameIndexForLocaleAndCollation(string $locale, string $collation)
     {
-        $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'CREATE INDEX IF NOT EXISTS product_translations_name_' . $locale . '_idx
                 ON product_translations (name COLLATE "' . $collation . '") WHERE locale = \':locale\'',
-            new ResultSetMapping()
-        )->execute(['locale' => $locale]);
+            [
+                'locale' => $locale,
+            ],
+            [
+                'locale' => Types::STRING,
+            ]
+        );
     }
 }

--- a/packages/framework/src/Model/Product/Pricing/ProductCalculatedPriceRepository.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductCalculatedPriceRepository.php
@@ -2,8 +2,8 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product\Pricing;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query\ResultSetMapping;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 use Shopsys\FrameworkBundle\Model\Product\Product;
@@ -70,14 +70,15 @@ class ProductCalculatedPriceRepository
      */
     public function createProductCalculatedPricesForPricingGroup(PricingGroup $pricingGroup)
     {
-        $query = $this->em->createNativeQuery(
+        $this->em->getConnection()->executeStatement(
             'INSERT INTO product_calculated_prices (product_id, pricing_group_id, price_with_vat)
-            SELECT id, :pricingGroupId, :priceWithVat FROM products',
-            new ResultSetMapping()
+            SELECT id, :pricingGroupId, NULL FROM products',
+            [
+                'pricingGroupId' => $pricingGroup->getId(),
+            ],
+            [
+                'pricingGroupId' => Types::INTEGER,
+            ]
         );
-        $query->execute([
-            'pricingGroupId' => $pricingGroup->getId(),
-            'priceWithVat' => null,
-        ]);
     }
 }

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -258,3 +258,8 @@ There you can find links to upgrade notes for other versions too.
 
 - add support for finding entity by URL slug to FE API ([#2150](https://github.com/shopsys/shopsys/pull/2150))
     - see #project-base-diff to update your project
+
+- use DBAL native queries for DML instead of ORM Native SQL ([#2148](https://github.com/shopsys/shopsys/pull/2148))
+    - you may want to update your own native queries in similar way
+    - don't forget that parameters in the `executeStatement()` call should have a type explicitly defined (see PR for examples)
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Native queries for DELETE, UPDATE or INSERT statements now don't use [ORM Native SQL API](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/native-sql.html). `EntityManager::getConnection()` to access the native database connection and the `executeStatement()` method for these queries is used instead to ensure working application with database replication configured (see [PrimaryReadReplicaConnection class](https://github.com/doctrine/dbal/blob/2.12.x/lib/Doctrine/DBAL/Connections/PrimaryReadReplicaConnection.php#L19))
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2121  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

DB Replication cannot be yet used as `\Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestListener` always create a transaction (start transaction automatically reconnects to the master) – related PR #2122 

Minimum configuration for testing can be in `doctrine.yaml` file (don't forget to update `test/doctrine.yaml`, or the tests will fail)
```
# Master listens on the port 5454, replica on port 5455
doctrine:
    dbal:
        driver: "%database_driver%"
        host: "%database_host%"
        port: 5454
        dbname: "%database_name%"
        user: "%database_user%"
        password: "%database_password%"
        charset: UTF8
        # Explicitly define server version to overcome the need to connect to the database in early
        # initialization phase (during DIC service creation) for auto-detecting version from the server.
        # See \Doctrine\DBAL\Connection::getDatabasePlatformVersion().
        server_version: "%database_server_version%"
        slaves:
            # A collection of named replica connections (e.g. replica1, replica2)
            reader:
                dbname: "%database_name%"
                host: "%database_host%"
                port: 5455
                user: "%database_user%"
                password: "%database_password%"
                charset: UTF8
```

for running postgre with replicas can be used https://github.com/2hamed/docker-pg-replication 
(older version of postgresql is used, don't try to update to 12 as used recovery.conf is no longer available) 