### PR TITLE
[shopsys] FE API returns visible category by uuid

### DIFF
--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -128,6 +128,23 @@ class CategoryFacade
     }
 
     /**
+     * @param int $domainId
+     * @param string $categoryUuid
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category
+     */
+    public function getVisibleOnDomainByUuid(int $domainId, string $categoryUuid): Category
+    {
+        $category = $this->getByUuid($categoryUuid);
+        if (!$category->isVisible($domainId)) {
+            throw new CategoryNotFoundException(
+                sprintf('Category with UUID "%s" is not visible on domain ID "%s"', $categoryUuid, $domainId)
+            );
+        }
+
+        return $category;
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryData $categoryData
      * @return \Shopsys\FrameworkBundle\Model\Category\Category
      */

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
@@ -114,7 +114,7 @@ class CategoryResolver implements ResolverInterface, AliasedInterface
             E_USER_DEPRECATED
         );
         try {
-            return $this->categoryFacade->getByUuid($uuid);
+            return $this->categoryFacade->getVisibleOnDomainByUuid($this->domain->getId(), $uuid);
         } catch (CategoryNotFoundException $categoryNotFoundException) {
             throw new UserError($categoryNotFoundException->getMessage());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| FE API returns category by uuid, which is visible on domain
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
