### PR TITLE
[frontend-api] removed deprecated use of time as integer in IAT and EXP claims

### DIFF
--- a/packages/frontend-api/src/Model/Token/TokenFacade.php
+++ b/packages/frontend-api/src/Model/Token/TokenFacade.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Token;
 
 use BadMethodCallException;
+use DateInterval;
 use DateTime;
+use DateTimeImmutable;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;
@@ -97,13 +99,14 @@ class TokenFacade
      */
     protected function getTokenBuilderWithExpiration(int $expiration): Builder
     {
-        $currentTime = time();
+        $currentTime = new DateTimeImmutable();
+        $expirationTime = $currentTime->add(new DateInterval('PT' . $expiration . 'S'));
 
         return (new Builder())
             ->issuedBy($this->domain->getUrl())
             ->permittedFor($this->domain->getUrl())
             ->issuedAt($currentTime)
-            ->expiresAt($currentTime + $expiration);
+            ->expiresAt($expirationTime);
     }
 
     /**

--- a/packages/frontend-api/src/Model/Token/TokenFacade.php
+++ b/packages/frontend-api/src/Model/Token/TokenFacade.php
@@ -159,7 +159,7 @@ class TokenFacade
         $validationData->setAudience($this->domain->getUrl());
         $validationData->setIssuer($this->domain->getUrl());
 
-        if ($token->isExpired()) {
+        if ($token->isExpired(new DateTimeImmutable())) {
             throw new ExpiredTokenUserMessageException('Token is expired. Please renew.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Using integer as a time value in lcobucci/jwt is deprecated* since version 3.4. This PR change `issued at` and `expires at` claims to use DateTimeImmutable object instead
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| No

\* throws `Using integers for registered date claims is deprecated, please use DateTimeImmutable objects instead`

see 
- https://github.com/lcobucci/jwt/blob/3.4.0/src/Builder.php#L140
- https://github.com/lcobucci/jwt/blob/3.4.0/src/Builder.php#L150
