### PR TITLE
[shopsys] excluded not commited files from yaml standards checks

### DIFF
--- a/yaml-standards.yaml
+++ b/yaml-standards.yaml
@@ -1,6 +1,8 @@
 -   pathsToCheck:
         - .
     excludedPaths:
+        - ./docker-compose.yml
+        - ./docker-sync.yml
         - ./vendor
         - ./project-base/node_modules
         - ./project-base/config/domains_urls.yaml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Files, not committed in repository, does not make sense to check for standards
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
