### PR TITLE
[framework] CustomerUserPasswordFacade has dependency passed with setter injection

### DIFF
--- a/packages/framework/src/Model/Customer/User/CustomerUserPasswordFacade.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserPasswordFacade.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Customer\User;
 
+use BadMethodCallException;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\String\HashGenerator;
 use Shopsys\FrameworkBundle\Model\Customer\Exception\InvalidResetPasswordHashUserException;
@@ -59,13 +60,43 @@ class CustomerUserPasswordFacade
         EncoderFactoryInterface $encoderFactory,
         ResetPasswordMailFacade $resetPasswordMailFacade,
         HashGenerator $hashGenerator,
-        CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade
+        ?CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade = null
     ) {
         $this->em = $em;
         $this->customerUserRepository = $customerUserRepository;
         $this->encoderFactory = $encoderFactory;
         $this->resetPasswordMailFacade = $resetPasswordMailFacade;
         $this->hashGenerator = $hashGenerator;
+        $this->customerUserRefreshTokenChainFacade = $customerUserRefreshTokenChainFacade;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setCustomerUserRefreshTokenChainFacade(
+        CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade
+    ): void {
+        if (
+            $this->customerUserRefreshTokenChainFacade !== null
+            && $this->customerUserRefreshTokenChainFacade !== $customerUserRefreshTokenChainFacade
+        ) {
+            throw new BadMethodCallException(
+                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
+            );
+        }
+        if ($this->customerUserRefreshTokenChainFacade !== null) {
+            return;
+        }
+
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. Use the constructor injection instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
         $this->customerUserRefreshTokenChainFacade = $customerUserRefreshTokenChainFacade;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #1891 there was introduced a BC break because of the required dependency. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
