### PR TITLE
ecs: removed rule for maximum line length in conditions and function calls

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -14,13 +14,8 @@ services:
     SlevomatCodingStandard\Sniffs\Classes\ParentCallSpacingSniff:
         linesCountBeforeParentCall: 1
         linesCountAfterParentCall: 1
-    SlevomatCodingStandard\Sniffs\ControlStructures\RequireMultiLineConditionSniff:
-        minLineLength: 120
-        alwaysSplitAllConditionParts: true
     SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
         allowPartialUses: true
-    SlevomatCodingStandard\Sniffs\Functions\RequireMultiLineCallSniff:
-        minLineLength: 120
     SlevomatCodingStandard\Sniffs\Commenting\DeprecatedAnnotationDeclarationSniff: ~
     SlevomatCodingStandard\Sniffs\Commenting\DocCommentSpacingSniff:
         linesCountBetweenDifferentAnnotationsTypes: 0

--- a/project-base/easy-coding-standard.yml
+++ b/project-base/easy-coding-standard.yml
@@ -23,15 +23,8 @@ services:
         linesCountBeforeParentCall: 1
         linesCountAfterParentCall: 1
     # @deprecated This will be moved from project-base to coding-standards package in next major version
-    SlevomatCodingStandard\Sniffs\ControlStructures\RequireMultiLineConditionSniff:
-        minLineLength: 120
-        alwaysSplitAllConditionParts: true
-    # @deprecated This will be moved from project-base to coding-standards package in next major version
     SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
         allowPartialUses: true
-    # @deprecated This will be moved from project-base to coding-standards package in next major version
-    SlevomatCodingStandard\Sniffs\Functions\RequireMultiLineCallSniff:
-        minLineLength: 120
     # @deprecated This will be moved from project-base to coding-standards package in next major version
     SlevomatCodingStandard\Sniffs\Commenting\DeprecatedAnnotationDeclarationSniff: ~
     # @deprecated This will be moved from project-base to coding-standards package in next major version

--- a/upgrade/UPGRADE-v9.1.0-dev.md
+++ b/upgrade/UPGRADE-v9.1.0-dev.md
@@ -124,7 +124,7 @@ There you can find links to upgrade notes for other versions too.
             use `Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFactory::getIdsForProducts()` instead
     - see [project-base-diff](https://github.com/shopsys/project-base/commit/a15ca000c86133fa1c63d2c9638b8a2a69d18da2) to update your project
 
-- added more coding standards ([#2035](https://github.com/shopsys/shopsys/pull/2035), [#2052](https://github.com/shopsys/shopsys/pull/2052))
+- added more coding standards ([#2035](https://github.com/shopsys/shopsys/pull/2035), [#2052](https://github.com/shopsys/shopsys/pull/2052), [#2173](https://github.com/shopsys/shopsys/pull/2173))
     - the most of the rules have their own fixer, run `php phing ecs-fix` to resolve them
         - you need to run `ecs-fix` multiple times unless it is OK, because of the amount of changes
     - disallowed usage of `empty()` is one which must be fixed manually


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2035 was introduced rule for maximum line length in conditions and function calls. This rule is controversial between programmers so it is removed for now. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
