### PR TITLE
[framework] admin: fixed displaying remove button for urls

### DIFF
--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -241,6 +241,13 @@ class ProductDataFactory implements ProductDataFactoryInterface
             $productData->seoTitles[$domainId] = $product->getSeoTitle($domainId);
             $productData->seoMetaDescriptions[$domainId] = $product->getSeoMetaDescription($domainId);
             $productData->vatsIndexedByDomainId[$domainId] = $product->getVatForDomain($domainId);
+
+            $mainFriendlyUrl = $this->friendlyUrlFacade->findMainFriendlyUrl(
+                $domainId,
+                'front_product_detail',
+                $product->getId()
+            );
+            $productData->urls->mainFriendlyUrlsByDomainId[$domainId] = $mainFriendlyUrl;
         }
         $productData->name = $names;
         $productData->variantAlias = $variantAliases;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was error that main url radio button was not checked by default. This caused connected JS to stop function and that was reason why there was remove button next to the main URL instead of info icon with text, that main URL cannot be removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2034  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
