### PR TITLE
[framework] admin: customer user form: customer user with not existing email can be saved

### DIFF
--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -218,7 +218,9 @@ class CustomerUserFormType extends AbstractType
         $customerUserData = $form->getData()->customerUserData;
 
         $domainId = $customerUserData->domainId;
-        if ($this->customerUserFacade->findCustomerUserByEmailAndDomain($email, $domainId) !== $this->customerUser) {
+        $existingCustomerWithEmail = $this->customerUserFacade->findCustomerUserByEmailAndDomain($email, $domainId);
+
+        if ($existingCustomerWithEmail !== null && $existingCustomerWithEmail !== $this->customerUser) {
             $context->addViolation('The email is already registered on given domain.');
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Now administrator can't edit customer email because condition is not good. This should help.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
