### PR TITLE
[framework] product visibility is now recalculated, when their category is removed

### DIFF
--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -198,6 +198,9 @@ class CategoryFacade
     public function deleteById($categoryId)
     {
         $category = $this->categoryRepository->getById($categoryId);
+
+        $this->categoryVisibilityRecalculationScheduler->scheduleRecalculation($category);
+
         foreach ($category->getChildren() as $child) {
             $child->setParent($category->getParent());
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When category was removed, no recalculations of products has been scheduled. This PR adds such functionality.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1763 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
