### PR TITLE
[framework] removed validation of DisplayOnlyType

### DIFF
--- a/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
+++ b/packages/framework/src/Form/Admin/Administrator/AdministratorFormType.php
@@ -37,9 +37,6 @@ class AdministratorFormType extends AbstractType
         if ($options['scenario'] === self::SCENARIO_EDIT) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
-                    'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter article name']),
-                    ],
                     'data' => $options['administrator']->getId(),
                     'label' => t('ID'),
                 ]);

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -128,9 +128,6 @@ class CategoryFormType extends AbstractType
         if ($options['scenario'] === self::SCENARIO_EDIT) {
             $builderSettingsGroup
                 ->add('id', DisplayOnlyType::class, [
-                    'constraints' => [
-                        new Constraints\NotBlank(['message' => 'Please enter article name']),
-                    ],
                     'data' => $options['category']->getId(),
                     'label' => t('ID'),
                 ]);

--- a/packages/framework/src/Form/DisplayOnlyType.php
+++ b/packages/framework/src/Form/DisplayOnlyType.php
@@ -17,6 +17,7 @@ class DisplayOnlyType extends AbstractType
             ->setDefaults([
                 'mapped' => false,
                 'required' => false,
+                'disabled' => true,
                 'attr' => [
                     'readonly' => 'readonly',
                     'class' => '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| DisplayOnlyType is only for displaying the value. Any validation is not necessary and editing this field should not affect anything.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1867 , fixes #1943 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
