### PR TITLE
[framework] script name (index.php) in URL now always returns 404

### DIFF
--- a/packages/framework/src/Component/Domain/Domain.php
+++ b/packages/framework/src/Component/Domain/Domain.php
@@ -172,8 +172,7 @@ class Domain implements DomainIdsProviderInterface
      */
     public function switchDomainByRequest(Request $request)
     {
-        // Request::getBasePath() never contains script file name (/index.php)
-        $url = $request->getSchemeAndHttpHost() . $request->getBasePath();
+        $url = $request->getSchemeAndHttpHost();
 
         foreach ($this->domainConfigs as $domainConfig) {
             if ($domainConfig->getUrl() === $url) {

--- a/packages/framework/src/Component/HttpFoundation/DenyScriptNameInRequestPathListener.php
+++ b/packages/framework/src/Component/HttpFoundation/DenyScriptNameInRequestPathListener.php
@@ -33,7 +33,9 @@ class DenyScriptNameInRequestPathListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::REQUEST => 'onKernelRequest',
+            // Check for access URL with script file has to be done after setting Domain in DomainSubscriber
+            // as other subscribers depends on the domain properly set, but before any other services.
+            KernelEvents::REQUEST => [['onKernelRequest', 90]],
         ];
     }
 }

--- a/packages/framework/src/Component/Router/NormalizeUrlTrailingSlashSubscriber.php
+++ b/packages/framework/src/Component/Router/NormalizeUrlTrailingSlashSubscriber.php
@@ -46,7 +46,10 @@ class NormalizeUrlTrailingSlashSubscriber implements EventSubscriberInterface
             $pathInfo = $event->getRequest()->getPathInfo();
             $pathInfo = TransformString::addOrRemoveTrailingSlashFromString($pathInfo);
 
-            $this->redirectToExistingPath($pathInfo, $event);
+            // prevents invalid redirection if request URL is http://host/index.php as $pathInfo is empty in that case
+            if ($pathInfo !== '') {
+                $this->redirectToExistingPath($pathInfo, $event);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| URL with `index.php` can throw an unhandled exception or redirect to an invalid location. This PR always returns 404, when index.php is present in the URL (examples follows)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2071  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

<details><summary>tested URLs (click to show)</summary>

- http://127.0.0.1:8000/index.php
- http://127.0.0.1:8000/index.php/
- http://127.0.0.1:8000/whatever/index.php
- http://127.0.0.1:8000/whatever/index.php/
- http://127.0.0.1:8000/index.php/whatever
- http://127.0.0.1:8000/index.php/whatever/
- http://127.0.0.1:8000/whatever/index.php/whatever
- http://127.0.0.1:8000/whatever/index.php/whatever/
- http://127.0.0.1:8000/whatever/index.php/whatever/index.php
- http://127.0.0.1:8000/whatever/index.php/whatever/index.php/
- http://127.0.0.1:8000/whatever/index.php/whatever/index.php/whatever
- http://127.0.0.1:8000/whatever/index.php/whatever/index.php/whatever/

</details>

