### PR TITLE
[framework] added info about default ordering in elasticsearch

### DIFF
--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -58,6 +58,10 @@ class FilterQuery
     }
 
     /**
+     * Default Elasticsearch ordering is by relevance, represented by _score field
+     * In case you need to alter the ordering by relevance behavior, you can add condition
+     * if ($orderingModeId === ProductListOrderingConfig::ORDER_BY_RELEVANCE)
+     *
      * @param string $orderingModeId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Default ordering in FilterQuery is now a little bit more clear.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2165 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
