### PR TITLE
[frontend-api] product decorators inherit all fields from product type

### DIFF
--- a/packages/frontend-api/src/Resources/config/graphql-types/MainVariantDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/MainVariantDecorator.types.yaml
@@ -2,7 +2,7 @@ MainVariantDecorator:
     type: object
     decorator: true
     inherits:
-        - 'ProductDecorator'
+        - 'Product'
     config:
         fields:
             variants:

--- a/packages/frontend-api/src/Resources/config/graphql-types/RegularProductDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/RegularProductDecorator.types.yaml
@@ -2,7 +2,7 @@ RegularProductDecorator:
     type: object
     decorator: true
     inherits:
-        - 'ProductDecorator'
+        - 'Product'
     config:
         interfaces:
             - 'Product'

--- a/packages/frontend-api/src/Resources/config/graphql-types/VariantDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/VariantDecorator.types.yaml
@@ -2,7 +2,7 @@ VariantDecorator:
     type: object
     decorator: true
     inherits:
-        - 'ProductDecorator'
+        - 'Product'
     config:
         fields:
             mainVariant:

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -23,3 +23,6 @@ There you can find links to upgrade notes for other versions too.
 - update elfinder installer to be compatible with `helios-ag/fm-elfinder-bundle` v10.1 ([#2217](https://github.com/shopsys/shopsys/pull/2217))
     - if you have updated the `assets` phing target, you should remove `shopsys:elfinder:post-install` call
       and add `--docroot` option for `elfinder:install` command. See PR for inspiration
+
+- all fields defined in GraphQL type `Product` are correctly inherited in `RegularProduct`, `Variant`, `MainVariant` types ([#2195](https://github.com/shopsys/shopsys/pull/2195))
+    - if you extended `Product` type, you could remove duplicate definitions in `RegularProduct`, `Variant`, `MainVariant` types


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| product decorators are correctly configured to inherit all fields from product type.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No (But I'm not sure) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
