### PR TITLE
[docs] use `CategoryResolverMap` as an example of `ResolverMap` in FE API introduction

### DIFF
--- a/docs/frontend-api/introduction-to-frontend-api.md
+++ b/docs/frontend-api/introduction-to-frontend-api.md
@@ -203,7 +203,7 @@ ResolverMap can be created as a child of `Overblog\GraphQLBundle\Resolver\Resolv
 Example of `ResolverMap`:
 
 ```php
-class ProductResolverMap extends ResolverMap
+class CategoryResolverMap extends ResolverMap
 {
     /**
      * @return array
@@ -211,12 +211,15 @@ class ProductResolverMap extends ResolverMap
     protected function map(): array
     {
         return [
-            'Product' => [
-                'shortDescription' => function (Product $product) {
-                    return $product->getShortDescription($this->domain->getId());
+            'Category' => [
+                'seoH1' => function (Category $category) {
+                    return $category->getSeoH1($this->domain->getId());
                 },
-                'link' => function (Product $product) {
-                    return $this->getProductLink($product);
+                'seoTitle' => function (Category $category) {
+                    return $category->getSeoTitle($this->domain->getId());
+                },
+                'seoMetaDescription' => function (Category $category) {
+                    return $category->getSeoMetaDescription($this->domain->getId());
                 },
             ],
         ];
@@ -229,7 +232,7 @@ Each resolver map must be tagged with the `overblog_graphql.resolver_map` tag.
 ```yaml
 # config/services.yaml
 services:
-    App\Model\FrontendApi\Resolver\ProductResolverMap:
+    App\Model\FrontendApi\Resolver\CategoryResolverMap:
         tags:
             - { name: overblog_graphql.resolver_map, schema: default }
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `ProductResolverMap::map()` has been changed, since introducing `ProductEntityFieldMapper` and `ProductArrayFieldMapper` in  SSFW 9.1. There is also custom section called `ProductResolverMap`.I think it would be better to use `CategoryResolverMap` as an example of `ResolverMap` for better understanding how resolver mappers work (Anyone can look at current implementation of `CategoryResolverMap`).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
