### PR TITLE
[frontend-api] Payment price is required

### DIFF
--- a/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yaml
@@ -20,7 +20,7 @@ PaymentDecorator:
                 type: "Int!"
                 description: "Payment position"
             price:
-                type: "Price"
+                type: "Price!"
                 description: "Payment price"
                 resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByPayment(value)'
             images:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Payment price must be required because `Shopsys\FrontendApiBundle\Model\Resolver\Price::resolveByPayment` always returns object of `\Shopsys\FrameworkBundle\Model\Pricing\Price`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes