### PR TITLE
[shopsys] entites are refreshed after product visibility recalculations

### DIFF
--- a/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
+++ b/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
@@ -96,6 +96,24 @@ class EntityManagerDecorator extends BaseEntityManagerDecorator
 
     /**
      * @param string $className
+     */
+    public function refreshLoadedEntitiesByClassName(string $className): void
+    {
+        $className = $this->entityNameResolver->resolve($className);
+
+        $identityMap = $this->getUnitOfWork()->getIdentityMap();
+
+        if (!array_key_exists($className, $identityMap)) {
+            return;
+        }
+
+        foreach ($identityMap[$className] as $entity) {
+            $this->refresh($entity);
+        }
+    }
+
+    /**
+     * @param string $className
      * @return \Doctrine\Common\Persistence\ObjectRepository
      */
     public function getRepository($className)

--- a/packages/framework/src/Model/Product/ProductVisibilityRepository.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityRepository.php
@@ -15,7 +15,7 @@ use Shopsys\FrameworkBundle\Model\Product\Exception\ProductVisibilityNotFoundExc
 class ProductVisibilityRepository
 {
     /**
-     * @var \Doctrine\ORM\EntityManagerInterface
+     * @var \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator
      */
     protected $em;
 
@@ -30,7 +30,7 @@ class ProductVisibilityRepository
     protected $pricingGroupRepository;
 
     /**
-     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator $em
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupRepository $pricingGroupRepository
      */
@@ -54,6 +54,10 @@ class ProductVisibilityRepository
         $this->hideMainVariantsWithoutVisibleVariants($onlyMarkedProducts);
         $this->refreshGlobalProductVisibility($onlyMarkedProducts);
         $this->markAllProductsVisibilityAsRecalculated();
+
+        // refresh entities after native query calls
+        $this->em->refreshLoadedEntitiesByClassName(Product::class);
+        $this->em->refreshLoadedEntitiesByClassName(ProductVisibility::class);
     }
 
     /**

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -26,3 +26,6 @@ There you can find links to upgrade notes for other versions too.
 
 - all fields defined in GraphQL type `Product` are correctly inherited in `RegularProduct`, `Variant`, `MainVariant` types ([#2195](https://github.com/shopsys/shopsys/pull/2195))
     - if you extended `Product` type, you could remove duplicate definitions in `RegularProduct`, `Variant`, `MainVariant` types
+
+- add test to check if entities are refreshed after order is completed and after recalculation ([#2202](https://github.com/shopsys/shopsys/pull/2202))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| entities are, by default, not refreshed in identity map after update with native query. This PR add a manual refresh of loaded entities, so it's safe to work with those entites after recalculations (=native queries).
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2108 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

