### PR TITLE
[framework] empty strings are stored as null if possible

### DIFF
--- a/packages/framework/src/Component/String/TransformString.php
+++ b/packages/framework/src/Component/String/TransformString.php
@@ -34,6 +34,19 @@ class TransformString
     }
 
     /**
+     * @param string|null $value
+     * @return string|null
+     */
+    public static function getTrimmedStringOrNullOnEmpty(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return static::emptyToNull(trim($value));
+    }
+
+    /**
      * @param string $string
      * @return string
      * @link http://php.vrana.cz/vytvoreni-pratelskeho-url.php

--- a/packages/framework/src/Migrations/Version20210127085903.php
+++ b/packages/framework/src/Migrations/Version20210127085903.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20210127085903 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('UPDATE category_translations SET name = NULL WHERE TRIM(name) = \'\'');
+
+        $this->sql('UPDATE payment_translations SET name = NULL WHERE TRIM(name) = \'\'');
+        $this->sql('UPDATE payment_translations SET description = NULL WHERE TRIM(description) = \'\'');
+        $this->sql('UPDATE payment_translations SET instructions = NULL WHERE TRIM(instructions) = \'\'');
+
+        $this->sql('UPDATE brand_translations SET description = NULL WHERE TRIM(description) = \'\'');
+
+        $this->sql('UPDATE parameter_translations SET name = NULL WHERE TRIM(name) = \'\'');
+
+        $this->sql('UPDATE product_translations SET name = NULL WHERE TRIM(name) = \'\'');
+        $this->sql('UPDATE product_translations SET variant_alias = NULL WHERE TRIM(variant_alias) = \'\'');
+
+        $this->sql('UPDATE transport_translations SET name = NULL WHERE TRIM(name) = \'\'');
+        $this->sql('UPDATE transport_translations SET description = NULL WHERE TRIM(description) = \'\'');
+        $this->sql('UPDATE transport_translations SET instructions = NULL WHERE TRIM(instructions) = \'\'');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Category/CategoryTranslation.php
+++ b/packages/framework/src/Model/Category/CategoryTranslation.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Category;
 use Doctrine\ORM\Mapping as ORM;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 /**
  * @ORM\Table(name="category_translations")
@@ -18,7 +19,7 @@ class CategoryTranslation extends AbstractTranslation
     protected $translatable;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $name;
@@ -32,10 +33,10 @@ class CategoryTranslation extends AbstractTranslation
     }
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = TransformString::getTrimmedStringOrNullOnEmpty($name);
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentTranslation.php
+++ b/packages/framework/src/Model/Payment/PaymentTranslation.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 /**
  * @ORM\Table(name="payment_translations")
@@ -18,25 +19,25 @@ class PaymentTranslation extends AbstractTranslation
     protected $translatable;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="text", nullable=true)
      */
     protected $description;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="text", nullable=true)
      */
     protected $instructions;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -44,7 +45,7 @@ class PaymentTranslation extends AbstractTranslation
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -52,7 +53,7 @@ class PaymentTranslation extends AbstractTranslation
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getInstructions()
     {
@@ -60,26 +61,26 @@ class PaymentTranslation extends AbstractTranslation
     }
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = TransformString::getTrimmedStringOrNullOnEmpty($name);
     }
 
     /**
-     * @param string $description
+     * @param string|null $description
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = TransformString::getTrimmedStringOrNullOnEmpty($description);
     }
 
     /**
-     * @param string $instructions
+     * @param string|null $instructions
      */
     public function setInstructions($instructions)
     {
-        $this->instructions = $instructions;
+        $this->instructions = TransformString::getTrimmedStringOrNullOnEmpty($instructions);
     }
 }

--- a/packages/framework/src/Model/Product/Brand/BrandTranslation.php
+++ b/packages/framework/src/Model/Product/Brand/BrandTranslation.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 use Doctrine\ORM\Mapping as ORM;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 /**
  * @ORM\Table(name="brand_translations")
@@ -18,13 +19,13 @@ class BrandTranslation extends AbstractTranslation
     protected $translatable;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="text", nullable=true)
      */
     protected $description;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -32,10 +33,10 @@ class BrandTranslation extends AbstractTranslation
     }
 
     /**
-     * @param string $description
+     * @param string|null $description
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = TransformString::getTrimmedStringOrNullOnEmpty($description);
     }
 }

--- a/packages/framework/src/Model/Product/Parameter/ParameterTranslation.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterTranslation.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 use Doctrine\ORM\Mapping as ORM;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 /**
  * @ORM\Table(name="parameter_translations")
@@ -32,10 +33,10 @@ class ParameterTranslation extends AbstractTranslation
     }
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = TransformString::getTrimmedStringOrNullOnEmpty($name);
     }
 }

--- a/packages/framework/src/Model/Product/ProductTranslation.php
+++ b/packages/framework/src/Model/Product/ProductTranslation.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 /**
  * @ORM\Table(name="product_translations")
@@ -18,7 +19,7 @@ class ProductTranslation extends AbstractTranslation
     protected $translatable;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $name;
@@ -30,13 +31,13 @@ class ProductTranslation extends AbstractTranslation
     protected $nameTsvector;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $variantAlias;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -44,11 +45,11 @@ class ProductTranslation extends AbstractTranslation
     }
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = TransformString::getTrimmedStringOrNullOnEmpty($name);
     }
 
     /**
@@ -64,6 +65,6 @@ class ProductTranslation extends AbstractTranslation
      */
     public function setVariantAlias($variantAlias)
     {
-        $this->variantAlias = $variantAlias;
+        $this->variantAlias = TransformString::getTrimmedStringOrNullOnEmpty($variantAlias);
     }
 }

--- a/packages/framework/src/Model/Transport/TransportTranslation.php
+++ b/packages/framework/src/Model/Transport/TransportTranslation.php
@@ -5,6 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Transport;
 use Doctrine\ORM\Mapping as ORM;
 use Prezent\Doctrine\Translatable\Annotation as Prezent;
 use Prezent\Doctrine\Translatable\Entity\AbstractTranslation;
+use Shopsys\FrameworkBundle\Component\String\TransformString;
 
 /**
  * @ORM\Table(name="transport_translations")
@@ -18,25 +19,25 @@ class TransportTranslation extends AbstractTranslation
     protected $translatable;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="text", nullable=true)
      */
     protected $description;
 
     /**
-     * @var string
+     * @var string|null
      * @ORM\Column(type="text", nullable=true)
      */
     protected $instructions;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -44,7 +45,7 @@ class TransportTranslation extends AbstractTranslation
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDescription()
     {
@@ -52,7 +53,7 @@ class TransportTranslation extends AbstractTranslation
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getInstructions()
     {
@@ -60,26 +61,26 @@ class TransportTranslation extends AbstractTranslation
     }
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
     public function setName($name)
     {
-        $this->name = $name;
+        $this->name = TransformString::getTrimmedStringOrNullOnEmpty($name);
     }
 
     /**
-     * @param string $description
+     * @param string|null $description
      */
     public function setDescription($description)
     {
-        $this->description = $description;
+        $this->description = TransformString::getTrimmedStringOrNullOnEmpty($description);
     }
 
     /**
-     * @param string $instructions
+     * @param string|null $instructions
      */
     public function setInstructions($instructions)
     {
-        $this->instructions = $instructions;
+        $this->instructions = TransformString::getTrimmedStringOrNullOnEmpty($instructions);
     }
 }

--- a/packages/framework/tests/Unit/Component/String/TransformStringTest.php
+++ b/packages/framework/tests/Unit/Component/String/TransformStringTest.php
@@ -193,4 +193,47 @@ class TransformStringTest extends TestCase
     {
         static::assertSame($expected, TransformString::addOrRemoveTrailingSlashFromString($string));
     }
+
+    /**
+     * @dataProvider trimmedStringOrNullProvider
+     * @param string|null $original
+     * @param string|null $expected
+     */
+    public function testGetTrimmedStringOrNullOnEmpty(?string $original, ?string $expected): void
+    {
+        static::assertSame($expected, TransformString::getTrimmedStringOrNullOnEmpty($original));
+    }
+
+    /**
+     * @return array
+     */
+    public function trimmedStringOrNullProvider(): array
+    {
+        return [
+            [
+                'foo ',
+                'foo',
+            ],
+            [
+                'foo  ',
+                'foo',
+            ],
+            [
+                "\t  foo",
+                'foo',
+            ],
+            [
+                "foo\n\t",
+                'foo',
+            ],
+            [
+                '',
+                null,
+            ],
+            [
+                '  ',
+                null,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We use nullable datatype in our database schema but actually we are saving empty string on many places. This PR unifies saving those empty strings (each of them is converted to null) to prevent confusions.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1735  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
