### PR TITLE
[coding-standards] hotfix: exclude version of symfony/dependency-injection which breaks ECS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,8 @@
         "zalas/phpunit-injector": "^1.4"
     },
     "conflict": {
-        "symfony/symfony": "*"
+        "symfony/symfony": "*",
+        "symfony/dependency-injection": ">=4.4.19 <5.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -10,6 +10,9 @@
             "homepage": "https://www.shopsys.com/"
         }
     ],
+    "conflict": {
+        "symfony/dependency-injection": ">=4.4.19 <5.0"
+    },
     "require": {
         "php": "^7.2",
         "ext-tokenizer": "*",


### PR DESCRIPTION
See
- https://github.com/symplify/symplify/issues/2872
- https://github.com/symfony/dependency-injection/commit/d749132342b401fb36621bfdee91363dffb87189

| Q             | A
| ------------- | ---
|Description, reason for the PR| New release of symfony/dependency-injection breaks symplify/easy-coding-standard which in versions <9 and they will never be fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
