### PR TITLE
[shopsys] replaced sensiolabs/security-checker with enlightn/security-checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "doctrine/migrations": "^1.6.0",
         "doctrine/persistence": "^1.3.7",
         "elasticsearch/elasticsearch": "^7.6.1",
+        "enlightn/security-checker": "^1.3",
         "fp/jsformvalidator-bundle": "^1.6.1",
         "friendsofphp/php-cs-fixer": "^2.14.0",
         "friendsofsymfony/ckeditor-bundle": "^2.1",
@@ -118,7 +119,6 @@
         "psr/log": "^1.0",
         "ramsey/uuid": "^3.8",
         "roave/better-reflection": "^3.5",
-        "sensiolabs/security-checker": "^6.0",
         "shopsys/doctrine-orm": "^2.7.2",
         "shopsys/ordered-form": "^4.0",
         "shopsys/postgres-search-bundle": "^0.2",
@@ -197,11 +197,12 @@
             "App\\Environment::checkEnvironment",
             "@auto-scripts"
         ],
+        "security-check": "security-checker security:check",
         "auto-scripts": {
             "php phing clean": "script",
             "shopsys:domains-urls:configure": "symfony-cmd",
             "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd",
-            "security-checker security:check": "script"
+            "composer security-check": "script"
         }
     },
     "config": {

--- a/docs/cookbook/jenkins-configuration.md
+++ b/docs/cookbook/jenkins-configuration.md
@@ -570,6 +570,24 @@ since our composer folder is mounted on localhost.
 !!! note
     During composer installation there will be installed 3-rd party software as dependencies of Shopsys Framework with licenses that are described in document [Open Source License Acknowledgements and Third-Party Copyrights](https://github.com/shopsys/shopsys/blob/master/open-source-license-acknowledgements-and-third-party-copyrights.md)
 
+#### Security check
+It's important to be aware of known security vulnerabilities.
+To achieve this, we configure one more special job that checks for security issues every midnight, so we will know when some occurs.
+
+Create the new job, name it for example `master-security-check` and set `Build periodically` parameter in `Build triggers` section to `H 0 * * *`.
+
+Job should be configured the same way as [previously created template](#setting-configuration-template) is, only the last command is
+
+```sh
+/usr/bin/docker exec $JOB_NAME-shopsys-framework-php-fpm php phing security:check
+```
+
+instead of
+
+```sh
+/usr/bin/docker exec $JOB_NAME-shopsys-framework-php-fpm php phing -D production.confirm.action=y db-create test-db-create build-demo-ci
+```
+
 ### Done
 Now just start `Jenkins autojobs` tool again.
 
@@ -590,4 +608,4 @@ Some of the issues can be overcome via [Continuous Integration Using Kubernetes]
 We just did pretty big job, we just configured jenkins that can automatically create jobs by git branches,
 we are able to configure this jobs using `template`, that can build instances of your project in docker.
 
-We created special job that can clean all jobs if they are useless.
+We created special job that can clean all jobs if they are useless and one for periodic check for known security vulnerabilities.

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -855,6 +855,12 @@
         </exec>
     </target>
 
+    <target name="security-check" description="Runs security checks for dependencies with known security vulnerabilities">
+        <exec executable="${path.composer.executable}" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="security-check"/>
+        </exec>
+    </target>
+
     <target name="selenium-run" description="Runs the Selenium server for acceptance testing. ChromeDriver is required. Only for native installation (Selenium is always running in Docker setup).">
         <exec executable="${path.chromedriver.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="--port=4444"/>

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -44,6 +44,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/doctrine-migrations-bundle": "^1.3.0",
         "doctrine/persistence": "^1.3.7",
+        "enlightn/security-checker": "^1.3",
         "fp/jsformvalidator-bundle": "^1.6.1",
         "friendsofsymfony/ckeditor-bundle": "^2.1",
         "fzaninotto/faker": "^1.7.1",
@@ -58,19 +59,18 @@
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable-bundle": "^1.0.3",
         "sensio/framework-extra-bundle": "^5.2",
-        "sensiolabs/security-checker": "^6.0",
         "shopsys/doctrine-orm": "^2.7.2",
-        "shopsys/google-cloud-bundle": "9.1.x-dev",
-        "shopsys/postgres-search-bundle": "^0.2",
-        "shopsys/migrations": "9.1.x-dev",
         "shopsys/form-types-bundle": "9.1.x-dev",
         "shopsys/framework": "9.1.x-dev",
         "shopsys/frontend-api": "9.1.x-dev",
+        "shopsys/google-cloud-bundle": "9.1.x-dev",
+        "shopsys/migrations": "9.1.x-dev",
         "shopsys/plugin-interface": "9.1.x-dev",
+        "shopsys/postgres-search-bundle": "^0.2",
+        "shopsys/product-feed-google": "9.1.x-dev",
         "shopsys/product-feed-heureka": "9.1.x-dev",
         "shopsys/product-feed-heureka-delivery": "9.1.x-dev",
         "shopsys/product-feed-zbozi": "9.1.x-dev",
-        "shopsys/product-feed-google": "9.1.x-dev",
         "shopsys/read-model": "9.1.x-dev",
         "snc/redis-bundle": "^3.2.2",
         "stof/doctrine-extensions-bundle": "^1.3.0",
@@ -134,14 +134,15 @@
             "cp -n config/parameters.yaml.dist config/parameters.yaml || echo '[skiped] parameters.yaml exists'",
             "cp -n config/parameters_test.yaml.dist config/parameters_test.yaml || echo '[skiped] parameters_test.yaml exists'",
             "App\\Environment::checkEnvironment",
-            "@auto-scripts"
+            "@auto-scripts",
+            "@security-check"
         ],
         "auto-scripts": {
             "php phing clean": "script",
             "shopsys:domains-urls:configure": "symfony-cmd",
-            "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd",
-            "security-checker security:check": "script"
-        }
+            "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd"
+        },
+        "security-check": "security-checker security:check"
     },
     "config": {
         "preferred-install": "dist",

--- a/project-base/config/packages/security_checker.yaml
+++ b/project-base/config/packages/security_checker.yaml
@@ -1,8 +1,0 @@
-services:
-    _defaults:
-        autowire: true
-        autoconfigure: true
-
-    SensioLabs\Security\SecurityChecker: null
-
-    SensioLabs\Security\Command\SecurityCheckerCommand: null

--- a/project-base/symfony.lock
+++ b/project-base/symfony.lock
@@ -195,6 +195,9 @@
     "elasticsearch/elasticsearch": {
         "version": "v6.7.2"
     },
+    "enlightn/security-checker": {
+        "version": "v1.2"
+    },
     "ezimuel/guzzlestreams": {
         "version": "3.0.1"
     },
@@ -224,6 +227,9 @@
         "files": [
             ".php_cs.dist"
         ]
+    },
+    "friendsofphp/proxy-manager-lts": {
+        "version": "v1.0.3"
     },
     "friendsofsymfony/ckeditor-bundle": {
         "version": "2.0",
@@ -632,18 +638,6 @@
     "sensio/generator-bundle": {
         "version": "v3.1.7"
     },
-    "sensiolabs/security-checker": {
-        "version": "4.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.0",
-            "ref": "160c9b600564faa1224e8f387d49ef13ceb8b793"
-        },
-        "files": [
-            "project-base/config/packages/security_checker.yaml"
-        ]
-    },
     "shopsys/coding-standards": {
         "version": "dev-mg-weird-flex-but-ok"
     },
@@ -864,9 +858,6 @@
             "src/Controller/.gitignore",
             "src/Kernel.php"
         ]
-    },
-    "symfony/http-client": {
-        "version": "v4.3.6"
     },
     "symfony/http-client-contracts": {
         "version": "v1.1.7"

--- a/symfony.lock
+++ b/symfony.lock
@@ -180,6 +180,9 @@
     "elasticsearch/elasticsearch": {
         "version": "v6.7.2"
     },
+    "enlightn/security-checker": {
+        "version": "v1.2"
+    },
     "ezimuel/guzzlestreams": {
         "version": "3.0.1"
     },
@@ -602,18 +605,6 @@
     "sensio/framework-extra-bundle": {
         "version": "v3.0.29"
     },
-    "sensiolabs/security-checker": {
-        "version": "4.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.0",
-            "ref": "160c9b600564faa1224e8f387d49ef13ceb8b793"
-        },
-        "files": [
-            "project-base/config/packages/security_checker.yaml"
-        ]
-    },
     "shopsys/doctrine-orm": {
         "version": "v2.6.3"
     },
@@ -786,9 +777,6 @@
             "project-base/src/Controller/.gitignore",
             "project-base/src/Kernel.php"
         ]
-    },
-    "symfony/http-client": {
-        "version": "v4.3.6"
     },
     "symfony/http-client-contracts": {
         "version": "v1.1.7"

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -13,3 +13,9 @@ There you can find links to upgrade notes for other versions too.
 
 - update annotations for EntityExtensionTest.php ([#2197](https://github.com/shopsys/shopsys/pull/2197))
     - see #project-base-diff to update your project
+
+- replace `sensiolabs/security-checker` with `enlightn/security-checker` ([#2211](https://github.com/shopsys/shopsys/pull/2211))
+    - you can run `composer remove sensiolabs/security-checker; composer require enlightn/security-checker ^1.3` to avoid manual editing of composer files
+    - security checks are now executed automatically only after composer update, you should add the check into your CI pipeline
+    - you can run `composer security-check` or `php phing security-check` to perform security checks
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| API on security.symfony.com nearing the end of service, so this PR introduces the replacement
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
