### PR TITLE
hotfix: prevent coding-standards of failing with symfony/dependency-injection in v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -182,7 +182,7 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "symfony/dependency-injection": ">=4.4.19 <5.0"
+        "symfony/dependency-injection": ">=4.4.19"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "conflict": {
-        "symfony/dependency-injection": ">=4.4.19 <5.0"
+        "symfony/dependency-injection": ">=4.4.19"
     },
     "require": {
         "php": "^7.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2210 we defined conflict on symfony/dependency-injection unfortunatelly there is also conflict in version 5 which is used in our package shopsys/coding-standards
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
