### PR TITLE
[project-base] smoke test for new product now work with HTTPS domain

### DIFF
--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -29,3 +29,6 @@ There you can find links to upgrade notes for other versions too.
 
 - add test to check if entities are refreshed after order is completed and after recalculation ([#2202](https://github.com/shopsys/shopsys/pull/2202))
     - see #project-base-diff to update your project
+
+- fix smoke test for a new product for first domain on https ([#2214](https://github.com/shopsys/shopsys/pull/2214))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR fixes failing smoke test for a new product in case the first domain is set as HTTPS.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2139 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
