### PR TITLE
[shopsys] hotfix: locked helios-ag/fm-elfinder-bundle to version 10.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "gedmo/doctrine-extensions": "^2.4.34",
         "google/cloud-storage": "^1.10",
         "guzzlehttp/guzzle": "^6.3",
-        "helios-ag/fm-elfinder-bundle": "^10.0.4",
+        "helios-ag/fm-elfinder-bundle": "~10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jdorn/sql-formatter": "^1.2",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -58,7 +58,7 @@
         "fzaninotto/faker": "^1.7.1",
         "gedmo/doctrine-extensions": "^2.4.34",
         "guzzlehttp/guzzle": "^6.3",
-        "helios-ag/fm-elfinder-bundle": "^10.0.4",
+        "helios-ag/fm-elfinder-bundle": "~10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/metadata": "^1.6",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -47,7 +47,7 @@
         "fp/jsformvalidator-bundle": "^1.6.1",
         "friendsofsymfony/ckeditor-bundle": "^2.1",
         "fzaninotto/faker": "^1.7.1",
-        "helios-ag/fm-elfinder-bundle": "^10.0.4",
+        "helios-ag/fm-elfinder-bundle": "~10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/serializer-bundle": "^2.4",


### PR DESCRIPTION
see change https://github.com/helios-ag/FMElfinderBundle/pull/436

| Q             | A
| ------------- | ---
|Description, reason for the PR| locked helios-ag/fm-elfinder-bundle to version 10.0.* as applicaiton is not compatible wit 10.1.*
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
