### PR TITLE
[framework] updated elfinder installer to be compatible with helios-ag/fm-elfinder-bundle v10.1

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -111,10 +111,8 @@
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="elfinder:install"/>
-        </exec>
-        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
-            <arg value="${path.bin-console}"/>
-            <arg value="shopsys:elfinder:post-install"/>
+            <arg value="--docroot"/>
+            <arg value="web"/>
         </exec>
     </target>
 

--- a/packages/framework/src/Command/ElFinderInstallerCommand.php
+++ b/packages/framework/src/Command/ElFinderInstallerCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * copy of \FM\ElfinderBundle\Command\ElFinderInstallerCommand and updated to work properly in monorepo
+ * replaces default `elfinder:install` command
+ */
+final class ElFinderInstallerCommand extends Command
+{
+    private const ELFINDER_CSS_DIR = 'studio-42/elfinder/css';
+
+    private const ELFINDER_JS_DIR = 'studio-42/elfinder/js';
+
+    private const ELFINDER_SOUNDS_DIR = 'studio-42/elfinder/sounds';
+
+    private const ELFINDER_IMG_DIR = 'studio-42/elfinder/img';
+
+    protected static $defaultName = 'elfinder:install';
+
+    protected $fileSystem;
+
+    protected $parameterBag;
+
+    /**
+     * @param \Symfony\Component\Filesystem\Filesystem $filesystem
+     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
+     */
+    public function __construct(Filesystem $filesystem, ParameterBagInterface $parameterBag)
+    {
+        $this->fileSystem = $filesystem;
+        $this->parameterBag = $parameterBag;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Copies elfinder assets to public directory')
+            ->addOption('docroot', null, InputOption::VALUE_OPTIONAL, 'Website document root.', 'public')
+            ->setHelp(
+                <<<'EOF'
+Default docroot:
+  <info>public</info>
+
+You can pass docroot:
+  <info>Where to install elfinder</info>
+  <info>php %command.full_name% --docroot=public_html</info>
+EOF
+            );
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dr = $input->getOption('docroot');
+        $io->title('elFinder Installer');
+        $io->comment(sprintf('Trying to install elfinder to %s directory', $dr));
+
+        $rootDir = $this->parameterBag->get('kernel.project_dir');
+        $vendorDir = $this->parameterBag->get('shopsys.vendor_dir');
+
+        $publicDir = sprintf('%s/%s/bundles/fmelfinder', $rootDir, $dr);
+
+        $io->note(sprintf('Starting to install elfinder to %s folder', $publicDir));
+
+        $this->fileSystem->mirror($vendorDir . '/' . self::ELFINDER_CSS_DIR, $publicDir . '/css');
+        $this->fileSystem->mirror($vendorDir . '/' . self::ELFINDER_IMG_DIR, $publicDir . '/img');
+        $this->fileSystem->mirror($vendorDir . '/' . self::ELFINDER_JS_DIR, $publicDir . '/js');
+        $this->fileSystem->mirror($vendorDir . '/' . self::ELFINDER_SOUNDS_DIR, $publicDir . '/sounds');
+
+        $io->success('elFinder assets successfully installed');
+        return 0;
+    }
+}

--- a/packages/framework/src/Command/ElFinderPostInstallCommand.php
+++ b/packages/framework/src/Command/ElFinderPostInstallCommand.php
@@ -11,6 +11,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @deprecated Command is no longer necessary as proper public dir can be set in elfinder:install with --docroot option
+ */
 class ElFinderPostInstallCommand extends Command
 {
     /**
@@ -47,6 +50,11 @@ class ElFinderPostInstallCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $symfonyStyleIo = new SymfonyStyle($input, $output);
+
+        $symfonyStyleIo->warning([
+            'The shopsys:elfinder:post-install command is deprecated and will be removed in the next major. ',
+            'Set public dir via --docroot option of elfinder:install command.',
+        ]);
 
         $publicDir = $this->parameterBag->get('kernel.project_dir') . '/public/bundles/fmelfinder';
         $webDir = $this->parameterBag->get('kernel.project_dir') . '/web/bundles/fmelfinder';

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -19,3 +19,7 @@ There you can find links to upgrade notes for other versions too.
     - security checks are now executed automatically only after composer update, you should add the check into your CI pipeline
     - you can run `composer security-check` or `php phing security-check` to perform security checks
     - see #project-base-diff to update your project
+
+- update elfinder installer to be compatible with `helios-ag/fm-elfinder-bundle` v10.1 ([#2217](https://github.com/shopsys/shopsys/pull/2217))
+    - if you have updated the `assets` phing target, you should remove `shopsys:elfinder:post-install` call
+      and add `--docroot` option for `elfinder:install` command. See PR for inspiration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| New version of helios-ag/fm-elfinder-bundle has come and this PR makes SSFW compatible with that new version.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
