### PR TITLE
[framework] CsvReader class is now deprecated

### DIFF
--- a/packages/framework/src/Component/Csv/CsvReader.php
+++ b/packages/framework/src/Component/Csv/CsvReader.php
@@ -4,6 +4,9 @@ namespace Shopsys\FrameworkBundle\Component\Csv;
 
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 
+/**
+ * @deprecated Class is obsolete and will be removed in the next major. Use SplFileObject::fgetcsv() instead.
+ */
 class CsvReader
 {
     /**
@@ -13,6 +16,14 @@ class CsvReader
      */
     public function getRowsFromCsv($filename, $delimiter = ';')
     {
+        @trigger_error(
+            sprintf(
+                'The %s() method is deprecated and will be removed in the next major. Use SplFileObject::fgetcsv() instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         if (!file_exists($filename) || !is_readable($filename)) {
             throw new FileNotFoundException();
         }

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -8,3 +8,5 @@ There you can find links to upgrade notes for other versions too.
 ## Application
 - use different css classes for javascript and tests ([#2179](https://github.com/shopsys/shopsys/pull/2179))
     - see #project-base-diff to update your project
+
+- class `Shopsys\FrameworkBundle\Component\Csv\CsvReader` is deprecated, use `SplFileObject::fgetcsv()` instead ([#2218](https://github.com/shopsys/shopsys/pull/2218))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Class CsvReader should not be used and is deprecated in this PR.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2171  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
