### PR TITLE
[frontend-api] fixed creating order with no products

### DIFF
--- a/packages/frontend-api/src/Resources/config/graphql-types/OrderInput/OrderInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/OrderInput/OrderInputDecorator.types.yaml
@@ -219,5 +219,7 @@ OrderInputDecorator:
                 type: "[OrderProductInput!]!"
                 description: "A list of products to order to"
                 validation:
+                    -   NotBlank:
+                            message: "Please enter at least one product"
                     -   All:
                             -   Shopsys\FrontendApiBundle\Component\Constraints\ProductCanBeOrdered: ~

--- a/project-base/tests/FrontendApiBundle/Functional/Order/MinimalOrderTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/MinimalOrderTest.php
@@ -161,4 +161,113 @@ class MinimalOrderTest extends AbstractOrderTestCase
                     }
                 }';
     }
+
+    public function testCreateMinimalOrderWithNoProductsThrowError(): void
+    {
+        $response = $this->getResponseContentForQuery($this->getMutationWithNoProducts());
+        $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
+        $errors = $this->getErrorsExtensionValidationFromResponse($response);
+
+        static::assertArrayHasKey('input.products', $errors);
+        static::assertCount(1, $errors['input.products']);
+        static::assertArrayHasKey(0, $errors['input.products']);
+        static::assertArrayHasKey('message', $errors['input.products'][0]);
+        static::assertSame('Please enter at least one product', $errors['input.products'][0]['message']);
+    }
+
+    /**
+     * @return string
+     */
+    private function getMutationWithNoProducts(): string
+    {
+        $domainId = $this->domain->getId();
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vatHigh */
+        $vatHigh = $this->getReferenceForDomain(VatDataFixture::VAT_HIGH, $domainId);
+        /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vatZero */
+        $vatZero = $this->getReferenceForDomain(VatDataFixture::VAT_ZERO, $domainId);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Payment\Payment $paymentCashOnDelivery */
+        $paymentCashOnDelivery = $this->getReference(PaymentDataFixture::PAYMENT_CASH_ON_DELIVERY);
+        $paymentPrice = $this->getMutationPriceConvertedToDomainDefaultCurrency('50', $vatZero);
+
+        /** @var \Shopsys\FrameworkBundle\Model\Transport\Transport $transportCzechPost */
+        $transportCzechPost = $this->getReference(TransportDataFixture::TRANSPORT_CZECH_POST);
+        $transportPrice = $this->getMutationPriceConvertedToDomainDefaultCurrency('100', $vatHigh);
+
+        return 'mutation {
+                    CreateOrder(
+                        input: {
+                            firstName: "firstName"
+                            lastName: "lastName"
+                            email: "user@example.com"
+                            telephone: "+53 123456789"
+                            onCompanyBehalf: false
+                            street: "123 Fake Street"
+                            city: "Springfield"
+                            postcode: "12345"
+                            country: "CZ"
+                            payment: {
+                                uuid: "' . $paymentCashOnDelivery->getUuid() . '"
+                                price: ' . $paymentPrice . '
+                            }
+                            transport: {
+                                uuid: "' . $transportCzechPost->getUuid() . '"
+                                price: ' . $transportPrice . '
+                            }
+                            differentDeliveryAddress: false
+                            products: []
+                        }
+                    ) {
+                        transport {
+                            name
+                        }
+                        payment {
+                            name
+                        }
+                        status
+                        totalPrice {
+                            priceWithVat
+                            priceWithoutVat
+                            vatAmount
+                        }
+                        items {
+                            name
+                            unitPrice {
+                                priceWithVat
+                                priceWithoutVat
+                                vatAmount
+                            }
+                            totalPrice {
+                                priceWithVat
+                                priceWithoutVat
+                                vatAmount
+                            }
+                            quantity
+                            vatRate
+                            unit
+                        }
+                        firstName
+                        lastName
+                        email
+                        telephone
+                        companyName
+                        companyNumber
+                        companyTaxNumber
+                        street
+                        city
+                        postcode
+                        country
+                        differentDeliveryAddress
+                        deliveryFirstName
+                        deliveryLastName
+                        deliveryCompanyName
+                        deliveryTelephone
+                        deliveryStreet
+                        deliveryCity
+                        deliveryPostcode
+                        deliveryCountry
+                        note
+                    }
+                }';
+    }
 }

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -32,3 +32,6 @@ There you can find links to upgrade notes for other versions too.
 
 - fix smoke test for a new product for first domain on https ([#2214](https://github.com/shopsys/shopsys/pull/2214))
     - see #project-base-diff to update your project
+
+- Frontend API: add test for creating order with no product ([#2221](https://github.com/shopsys/shopsys/pull/2221))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It was possible to send order without products vie Frontend API. This PR adds validation rule for that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2204  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
