### PR TITLE
[frontend-api] decorators inherits from base type instead of decorator

### DIFF
--- a/packages/frontend-api/src/Resources/config/graphql-types/AdvertCodeDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/AdvertCodeDecorator.types.yaml
@@ -2,7 +2,7 @@ AdvertCodeDecorator:
     type: object
     decorator: true
     inherits:
-        - 'AdvertDecorator'
+        - 'Advert'
     config:
         fields:
             code:

--- a/packages/frontend-api/src/Resources/config/graphql-types/AdvertImageDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/AdvertImageDecorator.types.yaml
@@ -2,7 +2,7 @@ AdvertImageDecorator:
     type: object
     decorator: true
     inherits:
-        - 'AdvertDecorator'
+        - 'Advert'
     config:
         fields:
             link:

--- a/packages/frontend-api/src/Resources/config/graphql-types/ProductPriceDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ProductPriceDecorator.types.yaml
@@ -1,7 +1,7 @@
 ProductPriceDecorator:
     type: object
     inherits:
-        - 'PriceDecorator'
+        - 'Price'
     config:
         description: "Represents the price of the product"
         fields:

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -35,3 +35,7 @@ There you can find links to upgrade notes for other versions too.
 
 - Frontend API: add test for creating order with no product ([#2221](https://github.com/shopsys/shopsys/pull/2221))
     - see #project-base-diff to update your project
+
+- Frontend API: correctly inherited base type in `AdvertCodeDecorator`, `AdvertImageDecorator`, `ProductPriceDecorator` types ([#2222](https://github.com/shopsys/shopsys/pull/2222))
+  - if you extended `Advert` type, you can remove duplicate definitions in `AdvertCode` and `AdvertImage` types
+  - if you extended `Price` type, you can remove duplicate definitions in `ProductPrice` type


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR makes overriding of FEAPI types easier.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2208  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
