### PR TITLE
[framework] fixed javascript validation for radiobuttons

### DIFF
--- a/packages/framework/assets/js/common/validation/customizeBundle.js
+++ b/packages/framework/assets/js/common/validation/customizeBundle.js
@@ -177,7 +177,7 @@ export default class CustomizeBundle {
     }
 
     static isExpandedChoiceFormType (element, value) {
-        return element.type === constant('\\Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType::class') && !$.isArray(value);
+        return element.type === constant('\\Symfony\\Component\\Form\\Extension\\Core\\Type\\ChoiceType::class') && $.isArray(value);
     }
 
     static isExpandedChoiceEmpty (value) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `isExpandedChoiceEmpty` function accepts only arrays as an argument. In `isExpandedChoiceFormType` was a bad condition, so the scalar value could be passed into this function, resulting in javascript error. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2054 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Can be tested on `admin/advert/new/` path