### PR TITLE
[project-base] transform Twig\Error\RuntimeError to previous exception when caused by NotFoundHttpException

### DIFF
--- a/project-base/src/Controller/Front/ErrorController.php
+++ b/project-base/src/Controller/Front/ErrorController.php
@@ -15,9 +15,11 @@ use Shopsys\FrameworkBundle\Component\Error\ExceptionListener;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Tracy\BlueScreen;
 use Tracy\Debugger;
+use Twig\Error\RuntimeError;
 
 class ErrorController extends FrontBaseController
 {
@@ -88,6 +90,11 @@ class ErrorController extends FrontBaseController
         FlattenException $exception,
         ?DebugLoggerInterface $logger = null
     ) {
+        $lastException = $this->exceptionListener->getLastException();
+        if ($lastException instanceof RuntimeError && $lastException->getPrevious() instanceof NotFoundHttpException) {
+            $exception = FlattenException::createFromThrowable($lastException->getPrevious());
+        }
+
         if ($this->isUnableToResolveDomainInNotDebug($exception)) {
             return $this->createUnableToResolveDomainResponse($request);
         }

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -39,3 +39,6 @@ There you can find links to upgrade notes for other versions too.
 - Frontend API: correctly inherited base type in `AdvertCodeDecorator`, `AdvertImageDecorator`, `ProductPriceDecorator` types ([#2222](https://github.com/shopsys/shopsys/pull/2222))
   - if you extended `Advert` type, you can remove duplicate definitions in `AdvertCode` and `AdvertImage` types
   - if you extended `Price` type, you can remove duplicate definitions in `ProductPrice` type
+
+- transform Twig\Error\RuntimeError to previous exception when it is caused by NotFoundHttpException ([#2224](https://github.com/shopsys/shopsys/pull/2224))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There may be some part in twig (functions or subrequests) which may throws exception. Whet it happens the twig render will fail on `Twig\Error\RuntimeError`. This causes troubles e.g. in rendering menu or breadcrumb where the subrequest could throw `NotFoundHttpException` (see linked issue). That results in error 500 instead of 404. This PR adds check for RuntimeError and checks the previous thrown exception. When it is NotFoundHttpException then it is transformed to previous.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2182  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
