### PR TITLE
[framework] elFinder: thumbnail is only removed when some thumbnail exists

### DIFF
--- a/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
+++ b/packages/framework/src/Component/Filesystem/Flysystem/VolumeDriver.php
@@ -139,7 +139,11 @@ class VolumeDriver extends Driver
             }
         } elseif (!empty($stat['tmb']) && (string)$stat['tmb'] !== '1') {
             $thumbnailPath = $this->createThumbnailPath(rawurldecode($stat['tmb']));
-            $this->_unlink($thumbnailPath);
+
+            if ($this->fs->has($thumbnailPath)) {
+                $this->_unlink($thumbnailPath);
+            }
+
             clearstatcache();
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was problem that elFinder attempts to remove thumbnails for files that have no thumbnail created. This has been fixed in this PR.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2162  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
