### PR TITLE
[framework] ImageGenerator now saves right encoded image instead of original one

### DIFF
--- a/packages/framework/src/Component/Image/Processing/ImageGenerator.php
+++ b/packages/framework/src/Component/Image/Processing/ImageGenerator.php
@@ -66,7 +66,7 @@ class ImageGenerator
 
         $interventionImage->encode();
 
-        $this->filesystem->put($targetImageFilepath, $interventionImage);
+        $this->filesystem->put($targetImageFilepath, $interventionImage->getEncoded());
 
         return $targetImageFilepath;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Image in ImageGenerator was encoded, but then was still saved original image. This has been now fixed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
