### PR TITLE
[framework] transform twig exception to proper 404

### DIFF
--- a/packages/framework/src/Component/Error/ExceptionListener.php
+++ b/packages/framework/src/Component/Error/ExceptionListener.php
@@ -3,6 +3,8 @@
 namespace Shopsys\FrameworkBundle\Component\Error;
 
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Error\RuntimeError;
 
 class ExceptionListener
 {
@@ -16,6 +18,13 @@ class ExceptionListener
      */
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
+        $throwable = $event->getThrowable();
+
+        // NotFoundHttpException during Twig rendering is converted to standard 404 page
+        if ($throwable instanceof RuntimeError && $throwable->getPrevious() instanceof NotFoundHttpException) {
+            $event->setThrowable($throwable->getPrevious());
+        }
+
         $this->lastException = $event->getException();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Default behavior of Symfony is, when NotFoundHttpException is thrown during Twig template rendering during subrequest, application will fail on Twig\Error\RuntimeError (500). This PR transform such exceptions to a proper 404.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2182  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
