### PR TITLE
[framework] prevent buying product with zero price

### DIFF
--- a/packages/framework/src/Model/Cart/Watcher/CartWatcher.php
+++ b/packages/framework/src/Model/Cart/Watcher/CartWatcher.php
@@ -3,6 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Cart\Watcher;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
@@ -79,6 +80,14 @@ class CartWatcher
                     );
 
                 if (!$productVisibility->isVisible() || $product->getCalculatedSellingDenied()) {
+                    $notListableItems[] = $item;
+                    continue;
+                }
+
+                $productPrice = $this->productPriceCalculationForCustomerUser->calculatePriceForCurrentUser(
+                    $product
+                );
+                if ($productPrice->getPriceWithVat()->equals(Money::zero())) {
                     $notListableItems[] = $item;
                 }
             } catch (ProductNotFoundException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When there is no price for product and pricing group and recalculations was not executed, it was possible to buy product with zero price for a short period of time. This PR adds check which do not allow customers to buy these products. The whole bug is rare edge case, when there are incomplete data or  different bug introduced during implementation.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2205  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
