### PR TITLE
[framework] allow multiple elasticsearch hosts

### DIFF
--- a/docs/installation/application-configuration.md
+++ b/docs/installation/application-configuration.md
@@ -32,7 +32,7 @@ You may want to set some settings in a different way (such as production, test, 
 | `DATABASE_NAME`                        | `'shopsys'`                          | ...                                                                                  |
 | `DATABASE_USER`                        | `'root'`                             | ...                                                                                  |
 | `DATABASE_PASSWORD`                    | `'root'`                             | ...                                                                                  |
-| `ELASTICSEARCH_HOST`                   | `'elasticsearch:9200'`               | host of your Elasticsearch                                                           |
+| `ELASTICSEARCH_HOST`                   | `'elasticsearch:9200'`               | host of your Elasticsearch, you can use multiple hosts like `'["elasticsearch:9200", "elasticsearch2:9200"]'` |
 | `REDIS_HOST`                           | `'redis'`                            | host of your Redis storage (credentials are not supported right now)                 |
 | `REDIS_PREFIX`                         | `''`                                 | separates more projects that use the same redis service                              |
 | `MAILER_TRANSPORT`                     | `'smtp'`                             | access data of your mail server                                                      |

--- a/packages/framework/src/Component/Elasticsearch/ElasticsearchClientFactory.php
+++ b/packages/framework/src/Component/Elasticsearch/ElasticsearchClientFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
+
+use Elasticsearch\ClientBuilder;
+use JsonException;
+
+class ElasticsearchClientFactory
+{
+    /**
+     * @param string $hosts
+     * @return \Elasticsearch\ClientBuilder
+     */
+    public static function create(string $hosts): ClientBuilder
+    {
+        $clientBuilder = new ClientBuilder();
+
+        $clientBuilder->setHosts(self::parseHosts($hosts));
+
+        return $clientBuilder;
+    }
+
+    /**
+     * @param string $hosts
+     * @return string[]
+     */
+    protected static function parseHosts(string $hosts): array
+    {
+        try {
+            return json_decode($hosts, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            return [$hosts];
+        }
+    }
+}

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -935,11 +935,9 @@ services:
 
     Elasticsearch\ClientBuilder:
         class: Elasticsearch\ClientBuilder
-        factory: [Elasticsearch\ClientBuilder, create]
+        factory: [Shopsys\FrameworkBundle\Component\Elasticsearch\ElasticsearchClientFactory, create]
+        arguments: ['%env(default:elasticsearch_host:ELASTICSEARCH_HOST)%']
         calls:
-            -   method: setHosts
-                arguments:
-                    - ['%elasticsearch_host%']
             -   method: setTracer
                 arguments:
                     - '@shopsys.component.elasticsearch.tracer'

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -49,3 +49,7 @@ There you can find links to upgrade notes for other versions too.
 
 - initialize CKEditor after the click into appropriate field ([#2177](https://github.com/shopsys/shopsys/pull/2177))
     - see #project-base-diff to update your project
+
+- allow multiple elasticsearch hosts ([#2240](https://github.com/shopsys/shopsys/pull/2240))
+    - now it's possible to set multiple elasticsearch hosts like `'["elasticsearch:9200", "elasticsearch2:9200"]'`
+    - `Elasticsearch\ClientBuilder` is now created with a different factory, you may want to check your overridden service definition (see PR for details)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR allows setting up multiple Elasticsearch hosts to be able to connect to a cluster of nodes.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
