### PR TITLE
[framework] fixed product parameters saving

### DIFF
--- a/packages/framework/assets/js/common/validation/ShopsysConstraintUniqueProductParameters.js
+++ b/packages/framework/assets/js/common/validation/ShopsysConstraintUniqueProductParameters.js
@@ -9,7 +9,7 @@
          */
         this.validate = function (value) {
             const uniqueCollectionValidator = new ShopsysFrameworkBundleFormConstraintsUniqueCollection();
-            uniqueCollectionValidator.message = this.message;
+            uniqueCollectionValidator.message = this.message.replace('{{ parameterName }}', '');
             uniqueCollectionValidator.fields = ['parameter', 'locale'];
             uniqueCollectionValidator.allowEmpty = false;
 

--- a/packages/framework/assets/js/common/validation/customizeFpValidator.js
+++ b/packages/framework/assets/js/common/validation/customizeFpValidator.js
@@ -128,7 +128,9 @@ FpJsFormValidator.getElementValue = function (element) {
 
 FpJsFormValidator._getInputValue = FpJsFormValidator.getInputValue;
 FpJsFormValidator.getInputValue = function (element) {
-    if (element.type === constant('\\FOS\\CKEditorBundle\\Form\\Type\\CKEditorType::class')) {
+    if (element.type === constant('\\FOS\\CKEditorBundle\\Form\\Type\\CKEditorType::class')
+        && CKEDITOR.instances[element.id]
+    ) {
         return CKEDITOR.instances[element.id].getData();
     }
     if (element.type === constant('\\Shopsys\\FrameworkBundle\\Form\\FileUploadType::class') || element.type === constant('\\Shopsys\\FrameworkBundle\\Form\\ImageUploadType::class')) {

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -883,10 +883,9 @@ class ProductFormType extends AbstractType
                 'entry_type' => ProductParameterValueFormType::class,
                 'constraints' => [
                     new UniqueProductParameters([
-                        'message' => 'Each parameter can be used only once',
+                        'message' => 'Parameter {{ parameterName }} is used more than once',
                     ]),
                 ],
-                'invalid_message' => 'Each parameter can be used only once',
                 'error_bubbling' => false,
                 'render_form_row' => false,
             ])

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -889,7 +889,7 @@ class ProductFormType extends AbstractType
                 'error_bubbling' => false,
                 'render_form_row' => false,
             ])
-                ->addViewTransformer($this->productParameterValueToProductParameterValuesLocalizedTransformer));
+               ->addModelTransformer($this->productParameterValueToProductParameterValuesLocalizedTransformer));
 
         return $builderParametersGroup;
     }

--- a/packages/framework/src/Form/Constraints/UniqueProductParametersValidator.php
+++ b/packages/framework/src/Form/Constraints/UniqueProductParametersValidator.php
@@ -18,8 +18,28 @@ class UniqueProductParametersValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, UniqueCollection::class);
         }
 
-        // Dummy validator, because validator is implemented in JS and
-        // \Shopsys\FrameworkBundle\Form\Transformers\ProductParameterValueToProductParameterValuesLocalizedTransformer
-        // throw exception on duplicate parameters
+        $uniqueValues = [];
+        $violations = [];
+
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData $value */
+        foreach ($values as $value) {
+            $parameterId = $value->parameter->getId();
+            $uniqueKey = $parameterId . '-' . $value->parameterValueData->locale;
+
+            if (array_key_exists($uniqueKey, $uniqueValues)) {
+                $violations[$parameterId] = $value->parameter->getName();
+            }
+
+            $uniqueValues[$uniqueKey] = $parameterId;
+        }
+
+        foreach ($violations as $violation) {
+            $this->context->addViolation(
+                $constraint->message,
+                [
+                    '{{ parameterName }}' => $violation,
+                ]
+            );
+        }
     }
 }

--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -58,10 +58,6 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
                 $normValue[$parameterId]->valueTextsByLocale = [];
             }
 
-            if (array_key_exists($locale, $normValue[$parameterId]->valueTextsByLocale)) {
-                throw new TransformationFailedException('Duplicate parameter');
-            }
-
             $normValue[$parameterId]->valueTextsByLocale[$locale] = $productParameterValueData->parameterValueData->text;
         }
 

--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -33,48 +33,48 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
     }
 
     /**
-     * @param mixed $normData
+     * @param mixed $value
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData[]|null
      */
-    public function transform($normData)
+    public function transform($value)
     {
-        if ($normData === null) {
+        if ($value === null) {
             return null;
         }
 
-        if (!is_array($normData)) {
+        if (!is_array($value)) {
             throw new TransformationFailedException('Invalid value');
         }
 
-        $normValue = [];
+        $normData = [];
         /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData $productParameterValueData */
-        foreach ($normData as $productParameterValueData) {
+        foreach ($value as $productParameterValueData) {
             $parameterId = $productParameterValueData->parameter->getId();
             $locale = $productParameterValueData->parameterValueData->locale;
 
-            if (!array_key_exists($parameterId, $normValue)) {
-                $normValue[$parameterId] = new ProductParameterValuesLocalizedData();
-                $normValue[$parameterId]->parameter = $productParameterValueData->parameter;
-                $normValue[$parameterId]->valueTextsByLocale = [];
+            if (!array_key_exists($parameterId, $normData)) {
+                $normData[$parameterId] = new ProductParameterValuesLocalizedData();
+                $normData[$parameterId]->parameter = $productParameterValueData->parameter;
+                $normData[$parameterId]->valueTextsByLocale = [];
             }
 
-            $normValue[$parameterId]->valueTextsByLocale[$locale] = $productParameterValueData->parameterValueData->text;
+            $normData[$parameterId]->valueTextsByLocale[$locale] = $productParameterValueData->parameterValueData->text;
         }
 
-        return array_values($normValue);
+        return array_values($normData);
     }
 
     /**
-     * @param mixed $viewData
+     * @param mixed $value
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[]
      */
-    public function reverseTransform($viewData)
+    public function reverseTransform($value)
     {
-        if (is_array($viewData)) {
-            $normData = [];
+        if (is_array($value)) {
+            $modelData = [];
 
             /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData $productParameterValuesLocalizedData */
-            foreach ($viewData as $productParameterValuesLocalizedData) {
+            foreach ($value as $productParameterValuesLocalizedData) {
                 foreach ($productParameterValuesLocalizedData->valueTextsByLocale as $locale => $valueText) {
                     if ($valueText !== null) {
                         $productParameterValueData = $this->productParameterValueDataFactory->create();
@@ -84,12 +84,12 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
                         $parameterValueData->locale = $locale;
                         $productParameterValueData->parameterValueData = $parameterValueData;
 
-                        $normData[] = $productParameterValueData;
+                        $modelData[] = $productParameterValueData;
                     }
                 }
             }
 
-            return $normData;
+            return $modelData;
         }
 
         throw new TransformationFailedException('Invalid value');

--- a/packages/framework/src/Resources/views/Admin/Form/productParameterValue.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/productParameterValue.html.twig
@@ -35,11 +35,13 @@
             </div>
             <div class="js-parameters" data-prototype="{{ self.parameterRow(form.vars.prototype)|escape }}" data-index="{{ form|length }}">
 
-            {% for key, parameter in form %}
-                {{ self.parameterRow(parameter, key) }}
-            {% else %}
-                {% do form.setRendered %}
-            {% endfor %}
+                {{ form_errors(form) }}
+
+                {% for key, parameter in form %}
+                    {{ self.parameterRow(parameter, key) }}
+                {% else %}
+                    {% do form.setRendered %}
+                {% endfor %}
 
                 <div class="js-parameters-empty-item table-params__row">
                     <div class="table-params__cell">{{ 'Add some parameters'|trans }}</div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Parameters in the collection were not saved, when parameter was added, deleted, and added again without page reload. This was fixed. Also, server-side validation is now more user-friendly – outputs which parameters are duplicated.  
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1562  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Example of improved validation:
<img width="399" alt="Snímek obrazovky 2021-02-28 v 23 45 15" src="https://user-images.githubusercontent.com/1177414/109436263-0caa6300-7a1f-11eb-8628-398191400856.png">
