### PR TITLE
[framework] clean annotation cache before generating db migrations

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -233,14 +233,14 @@
         </exec>
     </target>
 
-    <target name="db-check-mapping" depends="clean-redis" description="Checks if ORM mapping is valid." hidden="true">
+    <target name="db-check-mapping" depends="clean-cache" description="Checks if ORM mapping is valid." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:migrations:check-mapping"/>
         </exec>
     </target>
 
-    <target name="db-check-schema" depends="clean-redis,db-check-mapping" description="Checks if database schema is satisfying ORM and returns a list of suggestions to fix it." hidden="true">
+    <target name="db-check-schema" depends="clean-cache,db-check-mapping" description="Checks if database schema is satisfying ORM and returns a list of suggestions to fix it." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:migrations:check-schema"/>
@@ -290,7 +290,7 @@
         </exec>
     </target>
 
-    <target name="db-migrations-generate" depends="clean-redis,db-check-mapping" description="Generates migration file when DB schema is not satisfying ORM.">
+    <target name="db-migrations-generate" depends="clean-cache,db-check-mapping" description="Generates migration file when DB schema is not satisfying ORM.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:migrations:generate"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in #2107 annotation cache was moved from Redis to file. This PR adjust phing targets related to db-migrations, so the cache is always properly cleared before generating db migrations
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
