### PR TITLE
[framework] changing parameter name now affects product detail

### DIFF
--- a/packages/framework/src/Model/Product/Elasticsearch/MarkProductForExportSubscriber.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/MarkProductForExportSubscriber.php
@@ -100,6 +100,7 @@ class MarkProductForExportSubscriber implements EventSubscriberInterface
     {
         return [
             ParameterEvent::DELETE => 'markAffectedByParameter',
+            ParameterEvent::UPDATE => 'markAffectedByParameter',
             BrandEvent::DELETE => 'markAffectedByBrand',
             AvailabilityEvent::UPDATE => 'markAffectedByAvailability',
             AvailabilityEvent::DELETE => 'markAffectedByAvailability',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Parameter names are exported to elastic, so when a parameter is updated, changes have to be propagated to Elasticsearch.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2160 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
