### PR TITLE
[coding-standards] allowed installing coding-standards with symfony 5 and higher

### DIFF
--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "conflict": {
-        "symfony/dependency-injection": ">=4.4.19"
+        "symfony/dependency-injection": ">=4.4.19 <5.0.0 || 5.1.11 || >=5.2.2"
     },
     "require": {
         "php": "^7.2",
@@ -23,7 +23,7 @@
         "squizlabs/php_codesniffer": "^3.5.0",
         "symplify/package-builder": "^7.3.18",
         "symplify/easy-coding-standard": "^7.3.18",
-        "symfony/finder": "^4.4|5.0"
+        "symfony/finder": "^4.4|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2183 was added posibility to install `coding-standard` with symfony 5.0. Unforutenatelly there is missing support for higher versions.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
