### PR TITLE
[framework] ElFinder abort exception is now muted

### DIFF
--- a/packages/framework/src/Controller/ElFinder/ElfinderController.php
+++ b/packages/framework/src/Controller/ElFinder/ElfinderController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Controller\ElFinder;
+
+use elFinderAbortException;
+use FM\ElfinderBundle\Controller\ElFinderController as BaseElFinderController;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class ElfinderController extends BaseElFinderController
+{
+    /**
+     * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param string $instance
+     * @param string $homeFolder
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
+     */
+    public function load(SessionInterface $session, EventDispatcherInterface $eventDispatcher, Request $request, string $instance, string $homeFolder): JsonResponse
+    {
+        try {
+            return parent::load($session, $eventDispatcher, $request, $instance, $homeFolder);
+        } catch (elFinderAbortException $ex) {
+            return $this->json([]);
+        }
+    }
+}

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -51,6 +51,11 @@ services:
         calls:
             - [seed, ['%faker.seed%']]
 
+    FM\ElfinderBundle\Controller\ElFinderController:
+        class: Shopsys\FrameworkBundle\Controller\ElFinder\ElfinderController
+        calls:
+            - { method: setContainer, arguments: [ '@service_container' ] }
+
     fragment.handler:
         class: Shopsys\FrameworkBundle\Component\HttpFoundation\FragmentHandler
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ElFinder lock mechanism is bound to the local filesystem. When the application is running on several replicas, it's possible one replica creates a lock, but different tries to read it. This PR catch thrown exception and returns empty response instead.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


This PR is related to #2172