### PR TITLE
[frontend-api] TokenAuthenicator: use HEADER_AUTHORIZATION consistently

### DIFF
--- a/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
+++ b/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
@@ -43,7 +43,7 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
     public function supports(Request $request): bool
     {
         return $request->headers->has(static::HEADER_AUTHORIZATION) && strpos(
-            $request->headers->get('Authorization'),
+            $request->headers->get(static::HEADER_AUTHORIZATION),
             static::BEARER
         ) === 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Now changing just the value of the constant can make an consistent change in the behavior of TokenAuthenticator. For example, we wanted to change the used header to avoid conflict with HTTP authorization on a non-public deployment of our app (thx to @milanStano for the idea). Even better would be to use DIC parameters instead of both constants, but that would introduce a BC break into SSFW.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Employed by Shopsys
