### PR TITLE
[framework] fix entity name in FrontendCustomerUserProvider

### DIFF
--- a/packages/framework/src/Model/Customer/User/FrontendCustomerUserProvider.php
+++ b/packages/framework/src/Model/Customer/User/FrontendCustomerUserProvider.php
@@ -46,7 +46,7 @@ class FrontendCustomerUserProvider implements UserProviderInterface
 
         if ($customerUser === null) {
             $message = sprintf(
-                'Unable to find an active Shopsys\FrameworkBundle\Model\Customer\User object identified by email "%s".',
+                'Unable to find an active CustomerUser entity identified by email "%s".',
                 $email
             );
             throw new UsernameNotFoundException($message, 0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `Shopsys\FrameworkBundle\Model\Customer\User` does not exist anymore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes<!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Btw, the same "problem" is in `AdministratorUserProvider` :wink: 