### PR TITLE
[framework] improved readibility of MethodAnnotationsFactory::getMethodAnnotationLine() method

### DIFF
--- a/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
@@ -64,24 +64,29 @@ class MethodAnnotationsFactory
     ): string {
         foreach ($this->annotationsReplacementsMap->getPatterns() as $frameworkClassPattern) {
             $methodName = $reflectionMethodFromFrameworkClass->getName();
+
             if ($this->isMethodImplementedInClass($methodName, $projectClassBetterReflection)) {
                 continue;
             }
 
-            if ($this->methodReturningTypeIsExtendedInProject(
+            $methodReturnTypeIsExtended = $this->methodReturningTypeIsExtendedInProject(
                 $frameworkClassPattern,
                 $reflectionMethodFromFrameworkClass->getDocBlockReturnTypes()
-            )
-                || $this->methodParameterTypeIsExtendedInProject(
-                    $frameworkClassPattern,
-                    $reflectionMethodFromFrameworkClass->getParameters()
-                )) {
+            );
+
+            $methodParameterTypeIsExtended = $this->methodParameterTypeIsExtendedInProject(
+                $frameworkClassPattern,
+                $reflectionMethodFromFrameworkClass->getParameters()
+            );
+
+            if ($methodReturnTypeIsExtended || $methodParameterTypeIsExtended) {
                 $optionalStaticKeyword = $reflectionMethodFromFrameworkClass->isStatic() ? 'static ' : '';
-                $returnType = $this->annotationsReplacer->replaceInMethodReturnType(
+
+                $replaceReturnType = $this->annotationsReplacer->replaceInMethodReturnType(
                     $reflectionMethodFromFrameworkClass
-                ) !== '' ? $this->annotationsReplacer->replaceInMethodReturnType(
-                    $reflectionMethodFromFrameworkClass
-                ) . ' ' : '';
+                );
+
+                $returnType = $replaceReturnType !== '' ? $replaceReturnType . ' ' : '';
                 $parameterNamesWithTypes = $this->getMethodParameterNamesWithTypes(
                     $reflectionMethodFromFrameworkClass
                 );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| MethodAnnotationsFactory::getMethodAnnotationLine() method was almost impossible to read, so it has been refactored to be more developer friendly.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
