### PR TITLE
[framework] only visible parameters are exported to Elasticsearch

### DIFF
--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -446,7 +446,7 @@ class ProductExportRepository
     protected function extractParameters(string $locale, Product $product): array
     {
         $parameters = [];
-        $productParameterValues = $this->parameterRepository->getProductParameterValuesByProductSortedByName(
+        $productParameterValues = $this->parameterRepository->getVisibleProductParameterValuesByProductSortedByName(
             $product,
             $locale
         );

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Shopsys\FrameworkBundle\Model\Product\Parameter;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -343,5 +345,18 @@ class ParameterRepository
         }
 
         return $parameterValuesByUuid;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param string $locale
+     * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValue[]
+     */
+    public function getVisibleProductParameterValuesByProductSortedByName(Product $product, string $locale): array
+    {
+        $queryBuilder = $this->getProductParameterValuesByProductSortedByNameQueryBuilder($product, $locale);
+        $queryBuilder->andWhere('p.visible = true');
+
+        return $queryBuilder->getQuery()->execute();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We use Elasticsearch only for displaying data on frontend, so exporting parameters that are hidden on frontend is not necessary.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
