### PR TITLE
[shopsys] removed prestissimo from open source license acknowledgements

### DIFF
--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -159,11 +159,6 @@ License: Artistic License 2.0
 https://www.npmjs.com/policies/npm-license  
 Copyright (c) 2000-2006, The Perl Foundation
 
-### prestissimo (composer plugin)
-License: MIT  
-https://github.com/hirak/prestissimo/blob/master/LICENSE  
-Copyright (c) 2017 Hiraku NAKANO
-
 ### libicu-dev
 License: ICU License  
 https://metadata.ftp-master.debian.org/changelogs/main/i/icu/icu_57.1-6+deb9u2_copyright  


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| hirak/prestissimo is not used since #2089
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
