### PR TITLE
[framework] fix homepage slider items not ordered by position

### DIFF
--- a/packages/framework/src/Controller/Admin/SliderController.php
+++ b/packages/framework/src/Controller/Admin/SliderController.php
@@ -78,7 +78,8 @@ class SliderController extends AdminBaseController
             ->from(SliderItem::class, 's')
             ->where('s.domainId = :selectedDomainId')
             ->setParameter('selectedDomainId', $this->adminDomainTabsFacade->getSelectedDomainId())
-            ->orderBy('s.position');
+            ->orderBy('s.position')
+            ->addOrderBy('s.id');
         $dataSource = new QueryBuilderDataSource($queryBuilder, 's.id');
 
         $grid = $this->gridFactory->create('sliderItemList', $dataSource);

--- a/packages/framework/src/Model/Slider/SliderItemRepository.php
+++ b/packages/framework/src/Model/Slider/SliderItemRepository.php
@@ -3,6 +3,8 @@
 namespace Shopsys\FrameworkBundle\Model\Slider;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Shopsys\FrameworkBundle\Component\Doctrine\SortableNullsWalker;
 use Shopsys\FrameworkBundle\Model\Slider\Exception\SliderItemNotFoundException;
 
 class SliderItemRepository
@@ -68,9 +70,18 @@ class SliderItemRepository
      */
     public function getAllVisibleByDomainId($domainId)
     {
-        return $this->getSliderItemRepository()->findBy([
-            'domainId' => $domainId,
-            'hidden' => false,
-        ]);
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->select('si')
+            ->from(SliderItem::class, 'si')
+            ->where('si.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
+            ->andWhere('si.hidden = false')
+            ->orderBy('si.position')
+            ->addOrderBy('si.id');
+
+        return $queryBuilder
+            ->getQuery()
+            ->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, SortableNullsWalker::class)
+            ->execute();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Slider items on homepage can be ordered in administration, that change `position` attribute, but when displaying slider items on homepage, this position information is lost and the items are not ordered by it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| No <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
