### PR TITLE
[shopsys] bumped version of doctrine/migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/doctrine-migrations-bundle": "^1.3.0",
-        "doctrine/migrations": "^1.6.0",
+        "doctrine/migrations": "^1.8.1",
         "doctrine/persistence": "^1.3.7",
         "elasticsearch/elasticsearch": "^7.6.1",
         "enlightn/security-checker": "^1.3",

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.2",
         "doctrine/dbal": "^2.5",
         "doctrine/doctrine-migrations-bundle": "^1.3",
-        "doctrine/migrations": "^1.6.0",
+        "doctrine/migrations": "^1.8.1",
         "doctrine/orm": "^2.5",
         "jdorn/sql-formatter": "^1.2",
         "symfony/config": "^3.4|^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| versions bellow 1.8.1 was not working because of namespace mess in it (bug is introduced by #706)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
