### PR TITLE
[framework] Add commonly used methods to Price class

### DIFF
--- a/packages/framework/src/Model/Pricing/Price.php
+++ b/packages/framework/src/Model/Pricing/Price.php
@@ -89,13 +89,40 @@ class Price
     }
 
     /**
+     * @param int|string $multiplier
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
+     */
+    public function multiply($multiplier): self
+    {
+        return new self(
+            $this->priceWithoutVat->multiply($multiplier),
+            $this->priceWithVat->multiply($multiplier)
+        );
+    }
+
+    /**
      * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
      */
     public function inverse(): self
     {
-        return new self(
-            $this->priceWithoutVat->multiply(-1),
-            $this->priceWithVat->multiply(-1)
-        );
+        return $this->multiply(-1);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $price
+     * @return bool
+     */
+    public function equals(self $price): bool
+    {
+        return $this->priceWithoutVat->equals($price->priceWithoutVat)
+            && $this->priceWithVat->equals($price->priceWithVat);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isZero(): bool
+    {
+        return $this->priceWithoutVat->isZero() && $this->priceWithVat->isZero();
     }
 }


### PR DESCRIPTION
- `multiply`, `isZero` and `equals` are safe to use in `Price` and are commonly needed
- comparing `Price` objects is unsafe as there are two independent comparable parts in each object (same goes to `isPositive`/`isNegative`)
- dividing `Price` objects is unsafe as there might be unforeseen rounding issues
- rounding `Price` objects would need providing two `$scale` arguments and it's not needed often in my experience

| Q             | A
| ------------- | ---
|Description, reason for the PR| Commonly needed functions in Price class are missing and we are forced to manipulate with Prices in a rather awkward ways...
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Employed by Shopsys
