### PR TITLE
[monorepo] do not pull elasticsearch and php-fpm image as they can be built locally

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -199,7 +199,7 @@ jobs:
                 run: "sed -i \"s#elasticsearch-image#${DOCKER_USERNAME}/elasticsearch:${DOCKER_ELASTICSEARCH_IMAGE_TAG}#\" ./docker-compose.yml"
             -   name: Build application
                 run: |
-                    docker-compose pull --parallel webserver postgres elasticsearch redis php-fpm selenium-server
+                    docker-compose pull --parallel webserver postgres redis selenium-server
                     docker-compose up -d
                     docker cp ./ shopsys-framework-php-fpm:/var/www/html
                     docker-compose exec -T php-fpm composer install --optimize-autoloader --no-interaction


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fix of failed build https://github.com/shopsys/shopsys/actions/runs/682543146
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
