### PR TITLE
[shopsys] locked version of codeception/codeception to not install version 4.1.…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -182,7 +182,8 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "symfony/dependency-injection": ">=4.4.19"
+        "symfony/dependency-injection": ">=4.4.19",
+        "codeception/codeception": ">=4.1.19"
     },
     "scripts": {
         "post-install-cmd": [

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -121,7 +121,8 @@
         "zalas/phpunit-injector": "^1.4"
     },
     "conflict": {
-        "symfony/symfony": "*"
+        "symfony/symfony": "*",
+        "codeception/codeception": ">=4.1.19"
     },
     "scripts": {
         "post-install-cmd": [

--- a/upgrade/UPGRADE-v9.1.1-dev.md
+++ b/upgrade/UPGRADE-v9.1.1-dev.md
@@ -79,3 +79,7 @@ There you can find links to upgrade notes for other versions too.
     - if you are developing on Windows machine, we recommend you to update your installation to our new one using WSL 2. 
       Read [Installation Using Docker on Windows 10](https://github.com/shopsys/shopsys/blob/9.1/docs/installation/installation-using-docker-windows-10.md) article for more information.
     - see #project-base-diff to update your project
+
+- update your composer.json ([#2285](https://github.com/shopsys/shopsys/pull/2285))
+    - add conflict for `codeception/codeception` versions 4.1.19 and higher
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| New release of codeception/codeception (4.1.19) brings strict types to generated file which is in not compatible with our interface - to fix it, there was created PR #2284
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
