### PR TITLE
[coding-standards] removed direct dependency symplify/package-builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -178,7 +178,6 @@
         "symplify/easy-coding-standard": "^7.3.18",
         "symplify/easy-coding-standard-tester": "^7.3.18",
         "symplify/monorepo-builder": "^7.3.18",
-        "symplify/package-builder": "^7.3.18",
         "zalas/phpunit-injector": "^1.4"
     },
     "conflict": {

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -21,7 +21,6 @@
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
         "slevomat/coding-standard": "^6.3.5",
         "squizlabs/php_codesniffer": "^3.5.0",
-        "symplify/package-builder": "^7.3.18",
         "symplify/easy-coding-standard": "^7.3.18",
         "symfony/finder": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| package-builder is not our direct dependency so we do not need to require it in our coding-standards.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
