### PR TITLE
[docs] linked post-installation steps for linux installation

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -12,6 +12,7 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 * [Docker](https://docs.docker.com/engine/installation/)
     * At least version **17.05 or higher** so it supports [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/).
+    * It's necessary to perform [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user), to be able to run docker commands as non-root user.
 * [Docker Compose](https://docs.docker.com/compose/install/)
     * At least version **1.17.0 or higher** because we use compose file version `3.4`
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In Linux installation guide is now linked a required post-installation step to be able to run docker as non-root user.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2297  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
