### PR TITLE
[shopsys] fix incorrect deprecated annotation in ProductOnCurrentDomainElasticFacade

### DIFF
--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -311,7 +311,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param int $categoryId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsByCategoryId() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory::createListableProductsByCategoryId() instead.
      */
     protected function createListableProductsInCategoryFilterQuery(
         ProductFilterData $productFilterData,
@@ -336,7 +336,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param int $brandId
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsByBrandId() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory::createListableProductsByBrandId() instead.
      */
     protected function createListableProductsForBrandFilterQuery(
         ProductFilterData $productFilterData,
@@ -361,7 +361,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $limit
      * @param string|null $searchText
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createListableProductsBySearchText() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory::createListableProductsBySearchText() instead.
      */
     protected function createListableProductsForSearchTextFilterQuery(
         ProductFilterData $productFilterData,
@@ -387,7 +387,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
      * @param int $page
      * @param int $limit
      * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::createWithProductFilterData() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory::createWithProductFilterData() instead.
      */
     protected function createFilterQueryWithProductFilterData(
         ProductFilterData $productFilterData,
@@ -405,7 +405,7 @@ class ProductOnCurrentDomainElasticFacade implements ProductOnCurrentDomainFacad
 
     /**
      * @return string
-     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterQueryFactory::getIndexName() instead.
+     * @deprecated This method will be removed in next major version. Use \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory::getIndexName() instead.
      */
     protected function getIndexName(): string
     {

--- a/upgrade/UPGRADE-v9.0.3.md
+++ b/upgrade/UPGRADE-v9.0.3.md
@@ -10,11 +10,11 @@ There you can find links to upgrade notes for other versions too.
 
 - ProductOnCurrentDomainElasticFacade has been refactored ([#2036](https://github.com/shopsys/shopsys/pull/2036))
     - these methods are now deprecated:
-        - `ProductOnCurrentDomainElasticFacade::createListableProductsInCategoryFilterQuery()` use `ProductFilterQueryFactory::createListableProductsByCategoryId()` instead
-        - `ProductOnCurrentDomainElasticFacade::createListableProductsForBrandFilterQuery()` use `ProductFilterQueryFactory::createListableProductsByBrandId()` instead
-        - `ProductOnCurrentDomainElasticFacade::createListableProductsForSearchTextFilterQuery()` use `ProductFilterQueryFactory::createListableProductsBySearchText()` instead
-        - `ProductOnCurrentDomainElasticFacade::createFilterQueryWithProductFilterData()` use `ProductFilterQueryFactory::createWithProductFilterData()` instead
-        - `ProductOnCurrentDomainElasticFacade::getIndexName()` use `ProductFilterQueryFactory::getIndexName()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsInCategoryFilterQuery()` use `FilterQueryFactory::createListableProductsByCategoryId()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsForBrandFilterQuery()` use `FilterQueryFactory::createListableProductsByBrandId()` instead
+        - `ProductOnCurrentDomainElasticFacade::createListableProductsForSearchTextFilterQuery()` use `FilterQueryFactory::createListableProductsBySearchText()` instead
+        - `ProductOnCurrentDomainElasticFacade::createFilterQueryWithProductFilterData()` use `FilterQueryFactory::createWithProductFilterData()` instead
+        - `ProductOnCurrentDomainElasticFacade::getIndexName()` use `FilterQueryFactory::getIndexName()` instead
 
 - remove FE API only dependencies from framework ([#2041](https://github.com/shopsys/shopsys/pull/2041))
     - these methods have been marked as deprecated and will be removed in next major version:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `ProductFilterQueryFactory` mentioned in upgrade notes and in annotations does not exists
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
