### PR TITLE
[framework] fixed validation of customer email edit in administration

### DIFF
--- a/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/User/CustomerUserFormType.php
@@ -207,11 +207,15 @@ class CustomerUserFormType extends AbstractType
     }
 
     /**
-     * @param string $email
+     * @param string|null $email
      * @param \Symfony\Component\Validator\Context\ExecutionContextInterface $context
      */
-    public function validateUniqueEmail(string $email, ExecutionContextInterface $context): void
+    public function validateUniqueEmail(?string $email, ExecutionContextInterface $context): void
     {
+        if ($email === null) {
+            return;
+        }
+
         /** @var \Symfony\Component\Form\Form $form */
         $form = $context->getRoot();
         /** @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData $customerUserData */

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -4,3 +4,7 @@ This guide contains instructions to upgrade from version v9.1.1 to v9.1.2-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- potential **BC break** ([#2300](https://github.com/shopsys/shopsys/pull/2300))
+    - method `Shopsys\FrameworkBundle\Form\Admin\Customer\User\CustomerUserFormType::validateUniqueEmail()` has changed its interface
+        - first argument `$email` was changed to accept `null` or `string` instead of `string` only


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When no email was provided the app failed on strict types
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2296  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
