### PR TITLE
[framework] fixed title of modal window for deleting with setting replacement

### DIFF
--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -376,6 +376,9 @@ msgstr "Vyberte produkt"
 msgid "Chosen payment name"
 msgstr "Název zvolené platby"
 
+msgid "Choose replacement"
+msgstr "Vyberte náhradu"
+
 msgid "Chosen shipping name"
 msgstr "Název zvolené dopravy"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -376,6 +376,9 @@ msgstr ""
 msgid "Chosen payment name"
 msgstr ""
 
+msgid "Choose replacement"
+msgstr ""
+
 msgid "Chosen shipping name"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Components/ConfirmDelete/setNewAndDelete.html.twig
+++ b/packages/framework/src/Resources/views/Components/ConfirmDelete/setNewAndDelete.html.twig
@@ -1,6 +1,6 @@
 <div class="window-content__in">
     <div class="window-content__heading">
-        <h1 class="wrap-bar__heading">{{ 'Delete status of order'|trans }}</h1>
+        <h1 class="wrap-bar__heading">{{ 'Choose replacement'|trans }}</h1>
     </div>
     {% if possibleReplacements|length > 0 %}
         {{ message|nl2br }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Title of modal window was changed to be more general as it is used on many places and everywhere is displayed title about removing "order status".
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2295 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
