### PR TITLE
[framework] destroy intervention image after it is saved in filesystem in order to prevent memory leaks

### DIFF
--- a/packages/framework/src/Component/Image/Processing/ImageProcessor.php
+++ b/packages/framework/src/Component/Image/Processing/ImageProcessor.php
@@ -103,6 +103,8 @@ class ImageProcessor
         $this->filesystem->delete($filepath);
         $this->filesystem->write($newFilepath, $data);
 
+        $image->destroy();
+
         return $filename . '.' . $extension;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In one of our projects, we had to migrate about 700 images from old e-shop. We implemented Symfony command, which runs `ImageFacade::manageImages()`. Everything works normally on local PC. When the command runs on production, it fails because of memory leak. We tried to call `gc_collect_cycles` after every image migration, but it didn't work. After debugging and searching, we found a solution by freeing memory held by `Intervention\Image`. Solution is inspired by https://github.com/Intervention/image/issues/426. 
|New feature| No 
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
