### PR TITLE
[framework] Enhancement of check / fix method annotations

### DIFF
--- a/packages/framework/src/Component/ClassExtension/AnnotationsAdder.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsAdder.php
@@ -40,10 +40,9 @@ class AnnotationsAdder
                 "/**\n" . $propertyAndMethodAnnotationsLines . " */\n" . $classKeywordWithName
             );
         } else {
-            $replacedClassDocBlock = str_replace(
-                ' */',
-                $propertyAndMethodAnnotationsLines . ' */',
-                $projectClassDocComment
+            $replacedClassDocBlock = $this->replaceAnnotationsInExistingDocBlock(
+                $projectClassDocComment,
+                $propertyAndMethodAnnotationsLines
             );
             $this->fileContentReplacer->replaceInFile(
                 $projectClassFileName,
@@ -51,5 +50,17 @@ class AnnotationsAdder
                 $replacedClassDocBlock
             );
         }
+    }
+
+    /**
+     * @param string $docBlock
+     * @param string $annotationLinesBlock
+     * @return string
+     */
+    private function replaceAnnotationsInExistingDocBlock(string $docBlock, string $annotationLinesBlock): string
+    {
+        $annotationLinesToAdd = array_filter(explode("\n", $annotationLinesBlock));
+
+        return str_replace(' */', implode("\n", $annotationLinesToAdd) . "\n */", $docBlock);
     }
 }

--- a/packages/framework/src/Component/ClassExtension/AnnotationsAdder.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsAdder.php
@@ -40,7 +40,7 @@ class AnnotationsAdder
                 "/**\n" . $propertyAndMethodAnnotationsLines . " */\n" . $classKeywordWithName
             );
         } else {
-            $replacedClassDocBlock = $this->replaceAnnotationsInExistingDocBlock(
+            $replacedClassDocBlock = $this->replaceInClassDocBlock(
                 $projectClassDocComment,
                 $propertyAndMethodAnnotationsLines
             );
@@ -53,24 +53,24 @@ class AnnotationsAdder
     }
 
     /**
-     * Appends second annotation block, annotation lines with colliding "name" will get replaced instead
+     * Appends annotations to a doc block, annotation lines with colliding "name" will get replaced instead
      *
      * @see extractPropertyOrMethodAnnotationName() for explanation of how the "name" works
-     * @param string $annotation
-     * @param string $annotationToAdd
+     * @param string $classDocBlock
+     * @param string $propertyAndMethodAnnotationsLines
      * @return string
      */
-    protected function replaceAnnotationsInExistingDocBlock(string $annotation, string $annotationToAdd): string
+    protected function replaceInClassDocBlock(string $classDocBlock, string $propertyAndMethodAnnotationsLines): string
     {
         $annotationLinesByName = [];
 
-        $annotationLines = explode("\n", $annotation);
+        $annotationLines = explode("\n", $classDocBlock);
         $annotationStart = array_shift($annotationLines);
         $annotationEnd = array_pop($annotationLines);
         foreach ($annotationLines as $annotationLine) {
             $annotationLinesByName[$this->extractPropertyOrMethodAnnotationName($annotationLine)] = $annotationLine;
         }
-        $annotationLinesToAdd = array_filter(explode("\n", $annotationToAdd));
+        $annotationLinesToAdd = array_filter(explode("\n", $propertyAndMethodAnnotationsLines));
         foreach ($annotationLinesToAdd as $annotationLine) {
             $annotationLinesByName[$this->extractPropertyOrMethodAnnotationName($annotationLine)] = $annotationLine;
         }

--- a/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
@@ -128,9 +128,10 @@ class MethodAnnotationsFactory
         $methodParameterNamesWithTypes = [];
         foreach ($reflectionMethod->getParameters() as $methodParameter) {
             $methodParameterNamesWithTypes[] = sprintf(
-                '%s $%s',
+                '%s $%s%s',
                 $this->annotationsReplacer->replaceInParameterType($methodParameter),
-                $methodParameter->getName()
+                $methodParameter->getName(),
+                $methodParameter->isDefaultValueAvailable() ? ' = ' . json_encode($methodParameter->getDefaultValue()) : ''
             );
         }
 

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsAdderTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsAdderTest.php
@@ -87,4 +87,62 @@ class AnnotationsAdderTest extends TestCase
             " * @method void setCategory(\\App\\Model\\Category\\Category \$category)\n"
         );
     }
+
+    /**
+     * @return string[][]
+     */
+    public function extractPropertyOrMethodAnnotationNameDataProvider(): array
+    {
+        return [
+            ['property-test', '@property $test'],
+            ['property-test', '@property int $test'],
+            ['property-test', '@property int[] $test'],
+            ['property-test', '@property int[]|null $test'],
+            ['property-test', '@property array<int,array<string,string[]>> $test'],
+            ['property-test', '@property int[]|null $test This is a testing property'],
+            ['property-testDifferentName', '@property $testDifferentName'],
+            ['property-test', ' * @property $test  '],
+            ['method-test', '@method test()'],
+            ['method-test', '@method void test($parameter)'],
+            ['method-test', '@method test(array $parameter)'],
+            ['method-test', '@method test(array $parameter = [], int $number = 0)'],
+            ['method-test', '@method int test()'],
+            ['method-test', '@method int[] test()'],
+            ['method-test', '@method int[]|null test()'],
+            ['method-test', '@method array<int,array<string,string[]>> test()'],
+            ['method-test', '@method int[]|null test() This is a testing method'],
+            ['method-testDifferentName', '@method testDifferentName()'],
+            ['method-test', ' * @method test()  '],
+            ['@property invalidIdentifier', '@property invalidIdentifier'],
+            ['@method invalidIdentifier', '@method invalidIdentifier'],
+            ['@author Aaron Aardvark', '@author Aaron Aardvark'],
+            ['Any non-property and non-method string', 'Any non-property and non-method string'],
+        ];
+    }
+
+    /**
+     * @dataProvider extractPropertyOrMethodAnnotationNameDataProvider
+     * @param string $expectedPropertyName
+     * @param string $propertyLine
+     */
+    public function testExtractPropertyOrMethodAnnotationName(string $expectedPropertyName, string $propertyLine): void
+    {
+        $fileContentsReplacerMock = $this->createMock(FileContentsReplacer::class);
+        $annotationsAdder = (new class($fileContentsReplacerMock) extends AnnotationsAdder {
+            /**
+             * Method overridden to make it public and thus testable
+             *
+             * @param string $annotationLine
+             * @return string
+             */
+            public function extractPropertyOrMethodAnnotationName(string $annotationLine): string
+            {
+                return parent::extractPropertyOrMethodAnnotationName($annotationLine);
+            }
+        });
+
+        $annotationName = $annotationsAdder->extractPropertyOrMethodAnnotationName($propertyLine);
+
+        $this->assertSame($expectedPropertyName, $annotationName);
+    }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsAdderTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsAdderTest.php
@@ -9,6 +9,7 @@ use Roave\BetterReflection\Reflection\ReflectionObject;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsAdder;
 use Shopsys\FrameworkBundle\Component\ClassExtension\FileContentsReplacer;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest\DummyClassWithAnAnnotation;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest\DummyClassWithMethodAnnotation;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest\DummyClassWithNoAnnotation;
 
 class AnnotationsAdderTest extends TestCase
@@ -68,5 +69,22 @@ class AnnotationsAdderTest extends TestCase
 
         $annotationsAdder = new AnnotationsAdder($fileContentsReplacerMock);
         $annotationsAdder->addAnnotationToClass($betterReflectionClass, '');
+    }
+
+    public function testAddMethodAnnotationToClassReplacesPrevious(): void
+    {
+        $betterReflectionClass = ReflectionObject::createFromName(DummyClassWithMethodAnnotation::class);
+        $fileContentsReplacerMock = $this->createMock(FileContentsReplacer::class);
+        $fileContentsReplacerMock->expects($this->once())->method('replaceInFile')->with(
+            $betterReflectionClass->getFileName(),
+            "/**\n * @method void setCategory(\\Shopsys\\FrameworkBundle\\Model\\Category\\Category \$category)\n */",
+            "/**\n * @method void setCategory(\\App\\Model\\Category\\Category \$category)\n */"
+        );
+
+        $annotationsAdder = new AnnotationsAdder($fileContentsReplacerMock);
+        $annotationsAdder->addAnnotationToClass(
+            $betterReflectionClass,
+            " * @method void setCategory(\\App\\Model\\Category\\Category \$category)\n"
+        );
     }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
@@ -49,7 +49,7 @@ class MethodAnnotationsFactoryTest extends TestCase
     /**
      * @return array
      */
-    public function testGetProjectClassNecessaryMethodAnnotationsLinesEmptyResultDataProvider(): array
+    public function getProjectClassNecessaryMethodAnnotationsLinesEmptyResultDataProvider(): array
     {
         return [
             'method redeclared in the child using annotation' => [ReflectionObject::createFromName(
@@ -71,7 +71,7 @@ class MethodAnnotationsFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider testGetProjectClassNecessaryMethodAnnotationsLinesEmptyResultDataProvider
+     * @dataProvider getProjectClassNecessaryMethodAnnotationsLinesEmptyResultDataProvider
      * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkReflectionClass
      * @param \Roave\BetterReflection\Reflection\ReflectionClass $projectReflectionClass
      */

--- a/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
@@ -110,14 +110,13 @@ class MethodAnnotationsFactoryTest extends TestCase
             ReflectionObject::createFromName(BaseClass5::class),
             ReflectionObject::createFromName(ChildClass5::class)
         );
-        d($annotationLines);
 
         $this->assertStringContainsString(
-            '@method setCategory(\App\Model\Category\Category|null $category=null)',
+            '@method setCategory(\App\Model\Category\Category|null $category = null)',
             $annotationLines
         );
         $this->assertStringContainsString(
-            '@method setCategoryWithString(\App\Model\Category\Category $category, string $string="default")',
+            '@method setCategoryWithString(\App\Model\Category\Category $category, string $string = "default")',
             $annotationLines
         );
     }

--- a/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
@@ -14,10 +14,12 @@ use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotations
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass2;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass3;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass4;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass5;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass2;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass3;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass4;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass5;
 
 class MethodAnnotationsFactoryTest extends TestCase
 {
@@ -35,6 +37,7 @@ class MethodAnnotationsFactoryTest extends TestCase
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass2' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass2',
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass3' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass3',
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass4' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass4',
+            'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass5' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass5',
         ]);
 
         $this->methodAnnotationsFactory = new MethodAnnotationsFactory(
@@ -97,6 +100,24 @@ class MethodAnnotationsFactoryTest extends TestCase
         );
         $this->assertStringContainsString(
             '@method setCategory(\App\Model\Category\Category $category)',
+            $annotationLines
+        );
+    }
+
+    public function testGetProjectClassNecessaryMethodWithDefaultValueAnnotationsLines(): void
+    {
+        $annotationLines = $this->methodAnnotationsFactory->getProjectClassNecessaryMethodAnnotationsLines(
+            ReflectionObject::createFromName(BaseClass5::class),
+            ReflectionObject::createFromName(ChildClass5::class)
+        );
+        d($annotationLines);
+
+        $this->assertStringContainsString(
+            '@method setCategory(\App\Model\Category\Category|null $category=null)',
+            $annotationLines
+        );
+        $this->assertStringContainsString(
+            '@method setCategoryWithString(\App\Model\Category\Category $category, string $string="default")',
             $annotationLines
         );
     }

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithMethodAnnotation.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithMethodAnnotation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\AnnotationsAdderTest;
+
+/**
+ * @method void setCategory(\Shopsys\FrameworkBundle\Model\Category\Category $category)
+ */
+class DummyClassWithMethodAnnotation
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass5.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/BaseClass5.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+use Shopsys\FrameworkBundle\Model\Category\Category;
+
+class BaseClass5
+{
+    public const DEFAULT_VALUE = 'default';
+
+    /**
+     * This method accepts parameter with type that is registered in the class extension map and hence the "@method" annotation must be added to the child class
+     *
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $category
+     */
+    public function setCategory(?Category $category = null)
+    {
+    }
+
+    /**
+     * This method accepts parameter with type that is registered in the class extension map and hence the "@method" annotation must be added to the child class
+     *
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param string $string
+     */
+    public function setCategoryWithString(Category $category, string $string = self::DEFAULT_VALUE)
+    {
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass5.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/MethodAnnotationsFactoryTest/ChildClass5.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest;
+
+class ChildClass5 extends BaseClass5
+{
+}

--- a/project-base/src/Model/Category/Category.php
+++ b/project-base/src/Model/Category/Category.php
@@ -17,7 +17,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
  * @property \App\Model\Category\Category[]|\Doctrine\Common\Collections\Collection $children
  * @method \App\Model\Category\Category|null getParent()
  * @method \App\Model\Category\Category[] getChildren()
- * @method setParent(\App\Model\Category\Category|null $parent)
+ * @method setParent(\App\Model\Category\Category|null $parent = null)
  * @method setTranslations(\App\Model\Category\CategoryData $categoryData)
  * @method setDomains(\App\Model\Category\CategoryData $categoryData)
  * @method createDomains(\App\Model\Category\CategoryData $categoryData)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixes phing targets `annotations-fix` and `annotations-check` for cases when parameters have default values and cases when there already was a `@method` annotation but it needs an update
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #2273
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Employed by Shopsys

In essence, after extending `\Framework\ClassA` with `\App\ClassA`, `phing annotaitons-fix` now does:

```diff
  /*
-  * @method existingMethod(\Framework\ClassA $objectA, \App\ClassB $objectB)
+  * @method existingMethod(\App\ClassA $object, \App\ClassB $objectB)
+  * @method newMethodWithDefaultValue(\App\ClassA $object = null)
   */
  class MyClass {
```

instead of 

```diff
  /*
   * @method existingMethod(\Framework\ClassA $object, \App\ClassB $objectB)
+  * @method newMethodWithDefaultValue(\App\ClassA $object)
+  * @method existingMethod(\App\ClassA $object)
   */
  class MyClass {
```

Which is great for static analysis and for longer work on projects where methods with many parameters have duplicated annotations (as you iteratively extend different parameters' classes).