### PR TITLE
Service alias misconfiguration detector

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Shopsys Framework" default="list">
 
+    <property name="check-alias-configuration" value="true"/>
     <property name="check-and-fix-annotations" value="true"/>
     <property name="npm.framework" value="@shopsys/framework"/>
     <property name="path.root" value="${project.basedir}/project-base"/>

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="shopsys_framework" default="list">
 
+    <property name="check-alias-configuration" value="false"/>
     <property name="check-and-fix-annotations" value="false"/>
     <property name="path.app" value="${path.root}/app"/>
     <property name="path.bin" value="${path.vendor}/bin"/>
@@ -60,7 +61,25 @@
         </else>
     </if>
 
-    <target name="annotations-check" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'annotations-fix' phing target">
+    <target name="annotations-alias-check" description="Detects possible missing service aliases of extended Shopsys Framework classes.">
+        <if>
+            <istrue value="${check-alias-configuration}"/>
+            <then>
+                <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+                    <arg value="${path.bin-console}"/>
+                    <arg value="shopsys:extended-classes:aliases"/>
+                </exec>
+            </then>
+            <else>
+                <echo>
+                    Alias configuration check is turned off by configuration, see "check-alias-configuration" build property.
+                    You are still able to run "shopsys:extended-classes:aliases" Symfony command directly.
+                </echo>
+            </else>
+        </if>
+    </target>
+
+    <target name="annotations-check" depends="annotations-alias-check" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'annotations-fix' phing target">
         <if>
             <istrue value="${check-and-fix-annotations}"/>
             <then>
@@ -79,7 +98,7 @@
         </if>
     </target>
 
-    <target name="annotations-fix" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
+    <target name="annotations-fix" depends="annotations-alias-check" description="Fixes and adds annotations in project classes to improve static analysis and DX with extended classes">
         <if>
             <istrue value="${check-and-fix-annotations}"/>
             <then>

--- a/packages/framework/src/Command/DetectMissingServiceAliasesCommand.php
+++ b/packages/framework/src/Command/DetectMissingServiceAliasesCommand.php
@@ -265,7 +265,7 @@ class DetectMissingServiceAliasesCommand extends Command
         foreach ($missingDirectAliases + $unambiguousPossibleMissingAliases as $aliasId => $serviceId) {
             $serviceConfigLines[] = sprintf('    %s:', $aliasId);
             $serviceConfigLines[] = sprintf('        alias: %s', $serviceId);
-            if (in_array($aliasId, $this->containerInfoRegistry->getPublicServiceIds(), true)) {
+            if ($this->containerInfoRegistry->isServiceAccessible($aliasId)) {
                 $serviceConfigLines[] = '        public: true';
             }
             $serviceConfigLines[] = '';

--- a/packages/framework/src/Command/DetectMissingServiceAliasesCommand.php
+++ b/packages/framework/src/Command/DetectMissingServiceAliasesCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class DetectMissingServiceAliasesCommand extends Command
@@ -274,6 +275,18 @@ class DetectMissingServiceAliasesCommand extends Command
             $symfonyStyleIo->title('Recommended addition to your "services.yml" config:');
             $symfonyStyleIo->writeln('<fg=yellow>services:</fg=yellow>');
             $symfonyStyleIo->writeln($serviceConfigLines);
+        }
+
+        if ($unambiguousPossibleMissingAliases !== []) {
+            $symfonyStyleIo->note(
+                'Your IDE might warn you that the key is duplicated in Yaml. This means that the service is already explicitly defined, but not as alias of the project service.'
+            );
+            $symfonyStyleIo->note(sprintf(
+                "For validators (%s) it's recommended to change the class in the original service definition (%s*) and define an alias named after your own class (%s*)",
+                ValidatorInterface::class,
+                static::FQCN_PREFIX_EXTENDED_SERVICES,
+                static::FQCN_PREFIX_APPLICATION
+            ));
         }
 
         $settingYamlLines = [];

--- a/packages/framework/src/Command/DetectMissingServiceAliasesCommand.php
+++ b/packages/framework/src/Command/DetectMissingServiceAliasesCommand.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Shopsys\FrameworkBundle\Component\ServiceAliasContainerInfoRegistry;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Yaml\Yaml;
+
+class DetectMissingServiceAliasesCommand extends Command
+{
+    protected const FQCN_PREFIX_APPLICATION = 'App\\';
+    protected const FQCN_PREFIX_EXTENDED_SERVICES = 'Shopsys\\';
+    protected const SETTING_YAML_FILENAME = 'detect-missing-service-aliases.yaml';
+    protected const SETTING_IGNORED_ALIASES = 'ignoredAliases';
+
+    /**
+     * @var string
+     */
+    protected static $defaultName = 'shopsys:extended-classes:aliases';
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ServiceAliasContainerInfoRegistry
+     */
+    private ServiceAliasContainerInfoRegistry $containerInfoRegistry;
+
+    /**
+     * @var string
+     */
+    private string $settingYamlFilePath;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\ServiceAliasContainerInfoRegistry $containerInfoRegistry
+     * @param string $shopsysRootDir
+     */
+    public function __construct(ServiceAliasContainerInfoRegistry $containerInfoRegistry, string $shopsysRootDir)
+    {
+        parent::__construct();
+
+        $this->containerInfoRegistry = $containerInfoRegistry;
+        $this->settingYamlFilePath = realpath($shopsysRootDir) . '/config/' . static::SETTING_YAML_FILENAME;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription(
+                'Detect possible missing service aliases of extended Shopsys Framework classes.'
+            );
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $symfonyStyleIo = new SymfonyStyle($input, $output);
+
+        $symfonyStyleIo->text('Detecting misconfigurations in Shopsys Framework service aliases...');
+
+        $appServices = $this->getAppServicesWithParentsAndInterfaces();
+
+        $missingDirectAliases = $this->getMissingDirectAliases($appServices);
+        if ($missingDirectAliases !== []) {
+            $this->printMissingDirectAliasesWarning($symfonyStyleIo, $missingDirectAliases);
+        }
+
+        $possibleMissingAliases = $this->getPossibleMissingAliasedServices($appServices);
+        $unambiguousMissingAliases = $this->filterUnambiguousPossibleMissingAliasedServices($possibleMissingAliases);
+        if ($unambiguousMissingAliases !== []) {
+            $this->printUnambiguousPossibleMissingAliasesWarning($symfonyStyleIo, $unambiguousMissingAliases);
+        }
+        if ($possibleMissingAliases !== []) {
+            $this->printAmbiguousPossibleMissingAliasesWarning($symfonyStyleIo, $possibleMissingAliases);
+        }
+
+        if ($missingDirectAliases + $unambiguousMissingAliases + $possibleMissingAliases !== []) {
+            $symfonyStyleIo->error(sprintf(
+                'There were detected some possible misconfigurations of Shopsys Framework service aliases!'
+                . ' Please, either update your service definitions or ignore them in "%s".',
+                $this->settingYamlFilePath
+            ));
+
+            $this->printRecommendation(
+                $symfonyStyleIo,
+                $missingDirectAliases,
+                $unambiguousMissingAliases,
+                $possibleMissingAliases
+            );
+
+            return CommandResultCodes::RESULT_FAIL;
+        }
+
+        $symfonyStyleIo->success('There are no detectable misconfigurations of Shopsys Framework service aliases!');
+
+        return CommandResultCodes::RESULT_OK;
+    }
+
+    /**
+     * @return array<string,array<string,string|string[]>>
+     */
+    private function getAppServicesWithParentsAndInterfaces(): array
+    {
+        $appServicesWithParentsAndInterfaces = [];
+        foreach ($this->containerInfoRegistry->getServiceIdsToClassNames() as $serviceId => $className) {
+            if (str_starts_with($serviceId, static::FQCN_PREFIX_APPLICATION)) {
+                $reflectionClass = ReflectionClass::createFromName($className);
+                $appServicesWithParentsAndInterfaces[$serviceId] = [
+                    'id' => $serviceId,
+                    'parents' => $reflectionClass->getParentClassNames(),
+                    'interfaces' => $reflectionClass->getInterfaceNames(),
+                ];
+            }
+        }
+        return $appServicesWithParentsAndInterfaces;
+    }
+
+    /**
+     * @param array<string,array<string,string|string[]>> $appServices
+     * @return array<string,string>
+     */
+    private function getMissingDirectAliases(array $appServices): array
+    {
+        $missingDirectAliases = [];
+        $aliasIdsToAliases = $this->containerInfoRegistry->getAliasIdsToAliases();
+        $aliasIdsToAliases = array_diff($aliasIdsToAliases, $this->getIgnoredAliases());
+        foreach ($aliasIdsToAliases as $aliasId => $alias) {
+            $finalAlias = $alias;
+            while (array_key_exists($finalAlias, $aliasIdsToAliases)) {
+                $finalAlias = $aliasIdsToAliases[$finalAlias];
+            }
+            if (array_key_exists($finalAlias, $appServices) && $aliasIdsToAliases[$aliasId] !== $finalAlias) {
+                $missingDirectAliases[$aliasId] = $finalAlias;
+            }
+        }
+        ksort($missingDirectAliases);
+
+        return $missingDirectAliases;
+    }
+
+    /**
+     * @param array<string,array<string,string|string[]>> $appServices
+     * @return array<string,string[]>
+     */
+    private function getPossibleMissingAliasedServices(array $appServices): array
+    {
+        $possibleMissingAliasedServices = [];
+        $serviceClassNames = array_keys($this->containerInfoRegistry->getServiceIdsToClassNames());
+        foreach ($appServices as $appService) {
+            $possibleServiceIds = array_merge($appService['parents'], $appService['interfaces']);
+            $possibleServiceIds = array_diff($possibleServiceIds, $this->getIgnoredAliases());
+            foreach ($possibleServiceIds as $possibleServiceId) {
+                $serviceExists = in_array($possibleServiceId, $serviceClassNames, true);
+                if ($serviceExists && str_starts_with($possibleServiceId, static::FQCN_PREFIX_EXTENDED_SERVICES)) {
+                    $possibleMissingAliasedServices[$possibleServiceId][] = $appService['id'];
+                }
+            }
+        }
+        ksort($possibleMissingAliasedServices);
+
+        return $possibleMissingAliasedServices;
+    }
+
+    /**
+     * @param array<string,string[]> $possibleMissingAliasedServices
+     * @return array<string,string>
+     */
+    private function filterUnambiguousPossibleMissingAliasedServices(array &$possibleMissingAliasedServices): array
+    {
+        $unambiguousPossibleMissingAliasedServices = [];
+        foreach ($possibleMissingAliasedServices as $possibleMissingAliasId => $serviceIds) {
+            if (count($serviceIds) === 1) {
+                $unambiguousPossibleMissingAliasedServices[$possibleMissingAliasId] = $serviceIds[0];
+                unset($possibleMissingAliasedServices[$possibleMissingAliasId]);
+            }
+        }
+
+        return $unambiguousPossibleMissingAliasedServices;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getIgnoredAliases(): array
+    {
+        if (file_exists($this->settingYamlFilePath)) {
+            return Yaml::parseFile($this->settingYamlFilePath)[static::SETTING_IGNORED_ALIASES];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyleIo
+     * @param array<string,string> $missingDirectAliases
+     */
+    private function printMissingDirectAliasesWarning(SymfonyStyle $symfonyStyleIo, array $missingDirectAliases): void
+    {
+        $symfonyStyleIo->warning(sprintf(
+            'There are some indirect aliases to project services that should be declared directly for command "%s" to work correctly.',
+            ExtendedClassesAnnotationsCommand::getDefaultName()
+        ));
+        $missingDirectAliasList = [];
+        foreach ($missingDirectAliases as $aliasId => $serviceId) {
+            $missingDirectAliasList[] = sprintf("%s\n    → %s", $aliasId, $serviceId);
+        }
+        $symfonyStyleIo->listing($missingDirectAliasList);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyleIo
+     * @param array<string,string> $unambiguousMissingAliases
+     */
+    private function printUnambiguousPossibleMissingAliasesWarning(SymfonyStyle $symfonyStyleIo, array $unambiguousMissingAliases): void
+    {
+        $symfonyStyleIo->warning(sprintf(
+            'There are some descendants of classes from "%s" in "%s" that are declared as independent services in DIC.'
+            . ' Is it intentional, or did you forget to update services.yml?',
+            static::FQCN_PREFIX_EXTENDED_SERVICES,
+            static::FQCN_PREFIX_APPLICATION
+        ));
+        $missingServiceAliasList = [];
+        foreach ($unambiguousMissingAliases as $aliasId => $serviceId) {
+            $missingServiceAliasList[] = sprintf("%s\n    → %s", $aliasId, $serviceId);
+        }
+        $symfonyStyleIo->listing($missingServiceAliasList);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyleIo
+     * @param array<string,string[]> $possibleMissingAliases
+     */
+    private function printAmbiguousPossibleMissingAliasesWarning(SymfonyStyle $symfonyStyleIo, array $possibleMissingAliases): void
+    {
+        $symfonyStyleIo->warning(sprintf(
+            'There are some multiple descendants of classes from "%s" in "%s" that are declared as independent services in DIC.'
+            . ' This probably means that the parent is a base class that should\'ve been declared as abstract class.'
+            . ' If so, you can ignore them in "%s".',
+            static::FQCN_PREFIX_EXTENDED_SERVICES,
+            static::FQCN_PREFIX_APPLICATION,
+            $this->settingYamlFilePath
+        ));
+        $missingServicesAliasList = [];
+        foreach ($possibleMissingAliases as $aliasId => $serviceIds) {
+            $missingServicesAliasList[] = sprintf("%s\n    → %s", $aliasId, implode("\n    → ", $serviceIds));
+        }
+        $symfonyStyleIo->listing($missingServicesAliasList);
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyleIo
+     * @param array<string,string> $missingDirectAliases
+     * @param array<string,string> $unambiguousPossibleMissingAliases
+     * @param array<string,string[]> $possibleMissingAliases
+     */
+    private function printRecommendation(SymfonyStyle $symfonyStyleIo, array $missingDirectAliases, array $unambiguousPossibleMissingAliases, array $possibleMissingAliases): void
+    {
+        $serviceConfigLines = [];
+        foreach ($missingDirectAliases + $unambiguousPossibleMissingAliases as $aliasId => $serviceId) {
+            $serviceConfigLines[] = sprintf('    %s:', $aliasId);
+            $serviceConfigLines[] = sprintf('        alias: %s', $serviceId);
+            if (in_array($aliasId, $this->containerInfoRegistry->getPublicServiceIds(), true)) {
+                $serviceConfigLines[] = '        public: true';
+            }
+            $serviceConfigLines[] = '';
+        }
+        if ($serviceConfigLines !== []) {
+            $symfonyStyleIo->title('Recommended addition to your "services.yml" config:');
+            $symfonyStyleIo->writeln('<fg=yellow>services:</fg=yellow>');
+            $symfonyStyleIo->writeln($serviceConfigLines);
+        }
+
+        $settingYamlLines = [];
+        foreach (array_keys($possibleMissingAliases) as $aliasId) {
+            $settingYamlLines[] = sprintf('    - %s', $aliasId);
+        }
+        if ($settingYamlLines !== []) {
+            $symfonyStyleIo->title(sprintf('Recommended addition to "%s":', $this->settingYamlFilePath));
+            $symfonyStyleIo->writeln(sprintf('<fg=yellow>%s:</fg=yellow>', static::SETTING_IGNORED_ALIASES));
+            $symfonyStyleIo->writeln($settingYamlLines);
+        }
+
+        $symfonyStyleIo->newLine(2);
+    }
+}

--- a/packages/framework/src/Component/ServiceAliasContainerInfoRegistry.php
+++ b/packages/framework/src/Component/ServiceAliasContainerInfoRegistry.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component;
+
+use RuntimeException;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\SaveServiceAliasContainerInfoCompilerPass;
+
+class ServiceAliasContainerInfoRegistry
+{
+    /**
+     * @var array<string,string>|null
+     */
+    protected ?array $serviceIdsToClassNames = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $publicServiceIds = null;
+
+    /**
+     * @var array<string,string>|null
+     */
+    protected ?array $aliasIdsToAliases = null;
+
+    /**
+     * @param array<string,string> $serviceIdToClassNames
+     */
+    public function setServiceIdsToClassNames(array $serviceIdToClassNames): void
+    {
+        $this->checkDataWasNotSetYet($this->serviceIdsToClassNames);
+
+        $this->serviceIdsToClassNames = $serviceIdToClassNames;
+    }
+
+    /**
+     * @param array<string> $publicServiceIds
+     */
+    public function setPublicServiceIds(array $publicServiceIds): void
+    {
+        $this->checkDataWasNotSetYet($this->publicServiceIds);
+
+        $this->publicServiceIds = $publicServiceIds;
+    }
+
+    /**
+     * @param array<string,string> $aliasIdsToAliases
+     */
+    public function setAliasIdsToAliases(array $aliasIdsToAliases): void
+    {
+        $this->checkDataWasNotSetYet($this->aliasIdsToAliases);
+
+        $this->aliasIdsToAliases = $aliasIdsToAliases;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getServiceIdsToClassNames(): array
+    {
+        return $this->checkDataWasSetByCompilerPass($this->serviceIdsToClassNames);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getPublicServiceIds(): array
+    {
+        return $this->checkDataWasSetByCompilerPass($this->publicServiceIds);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getAliasIdsToAliases(): array
+    {
+        return $this->checkDataWasSetByCompilerPass($this->aliasIdsToAliases);
+    }
+
+    /**
+     * @param array|null $internalData
+     */
+    protected function checkDataWasNotSetYet(?array $internalData): void
+    {
+        if ($internalData !== null) {
+            $message = 'Data was already set during kernel compilation. You cannot overwrite previously set values.';
+
+            throw new RuntimeException($message);
+        }
+    }
+
+    /**
+     * @param array|null $internalData
+     * @return array
+     */
+    protected function checkDataWasSetByCompilerPass(?array $internalData): array
+    {
+        if ($internalData === null) {
+            $message = sprintf(
+                'Data was not set during kernel compilation. Is %s added as a compiler pass in your Kernel?',
+                SaveServiceAliasContainerInfoCompilerPass::class
+            );
+
+            throw new RuntimeException($message);
+        }
+
+        return $internalData;
+    }
+}

--- a/packages/framework/src/DependencyInjection/Compiler/SaveServiceAliasContainerInfoCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/SaveServiceAliasContainerInfoCompilerPass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
+
+use Shopsys\FrameworkBundle\Component\ServiceAliasContainerInfoRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SaveServiceAliasContainerInfoCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $containerInfoDump = $container->findDefinition(ServiceAliasContainerInfoRegistry::class);
+
+        $serviceIdsToClassNames = [];
+        $publicServiceIds = [];
+        foreach ($container->getDefinitions() as $serviceId => $service) {
+            $serviceIdsToClassNames[$serviceId] = $service->getClass();
+            if ($service->isPublic()) {
+                $publicServiceIds[] = $serviceId;
+            }
+        }
+        $containerInfoDump->addMethodCall('setServiceIdsToClassNames', [$serviceIdsToClassNames]);
+        $containerInfoDump->addMethodCall('setPublicServiceIds', [$publicServiceIds]);
+
+        $aliasIdsToAliases = [];
+        foreach ($container->getAliases() as $aliasId => $alias) {
+            $aliasIdsToAliases[$aliasId] = (string)$alias;
+        }
+        $containerInfoDump->addMethodCall('setAliasIdsToAliases', [$aliasIdsToAliases]);
+    }
+}

--- a/packages/framework/src/Resources/config/services/commands.yaml
+++ b/packages/framework/src/Resources/config/services/commands.yaml
@@ -3,6 +3,8 @@ services:
         autowire: true
         autoconfigure: true
         public: false
+        bind:
+            string $shopsysRootDir: "%shopsys.root_dir%"
 
     Shopsys\FrameworkBundle\Command\:
         resource: '../../Command'

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExten
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProductFeedConfigsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProjectFrameworkClassExtensionsCompilerPass;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\SaveServiceAliasContainerInfoCompilerPass;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -43,12 +44,12 @@ class ShopsysFrameworkBundle extends Bundle
         $container->registerForAutoconfiguration(AbstractIndex::class)->addTag('elasticsearch.index');
 
         $environment = $container->getParameter('kernel.environment');
-        if ($environment !== EnvironmentType::DEVELOPMENT) {
-            return;
+        if ($environment === EnvironmentType::DEVELOPMENT) {
+            $container->addCompilerPass(new SaveServiceAliasContainerInfoCompilerPass());
+        } else {
+            $container->addCompilerPass(new RegisterProjectFrameworkClassExtensionsCompilerPass());
+            $container->addResource(new DirectoryResource($container->getParameter('kernel.root_dir') . '/Component'));
+            $container->addResource(new DirectoryResource($container->getParameter('kernel.root_dir') . '/Model'));
         }
-
-        $container->addCompilerPass(new RegisterProjectFrameworkClassExtensionsCompilerPass());
-        $container->addResource(new DirectoryResource($container->getParameter('kernel.root_dir') . '/Component'));
-        $container->addResource(new DirectoryResource($container->getParameter('kernel.root_dir') . '/Model'));
     }
 }

--- a/project-base/build.xml
+++ b/project-base/build.xml
@@ -3,6 +3,7 @@
 
     <property file="${project.basedir}/build/build.local.properties"/>
 
+    <property name="check-alias-configuration" value="true"/>
     <property name="check-and-fix-annotations" value="true"/>
     <property name="path.root" value="${project.basedir}"/>
     <property name="path.vendor" value="${path.root}/vendor"/>

--- a/project-base/config/detect-missing-service-aliases.yaml
+++ b/project-base/config/detect-missing-service-aliases.yaml
@@ -1,0 +1,4 @@
+ignoredAliases:
+  - Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController
+  - Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchFilterTranslation
+  - Shopsys\FrontendApiBundle\Model\Mutation\BaseTokenMutation

--- a/project-base/config/detect-missing-service-aliases.yaml
+++ b/project-base/config/detect-missing-service-aliases.yaml
@@ -1,4 +1,4 @@
 ignoredAliases:
-  - Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController
-  - Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchFilterTranslation
-  - Shopsys\FrontendApiBundle\Model\Mutation\BaseTokenMutation
+    - Shopsys\FrameworkBundle\Controller\Admin\AdminBaseController
+    - Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchFilterTranslation
+    - Shopsys\FrontendApiBundle\Model\Mutation\BaseTokenMutation

--- a/project-base/config/services.yaml
+++ b/project-base/config/services.yaml
@@ -35,6 +35,9 @@ services:
     Shopsys\FrameworkBundle\Model\Article\ArticleDataFactoryInterface:
         alias: App\Model\Article\ArticleDataFactory
 
+    Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory:
+        alias: App\Model\Article\ArticleDataFactory
+
     App\Model\Category\CurrentCategoryResolver: ~
 
     League\Flysystem\FilesystemInterface:
@@ -43,16 +46,31 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface:
         alias: App\Model\Administrator\AdministratorDataFactory
 
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory:
+        alias: App\Model\Administrator\AdministratorDataFactory
+
     Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface:
+        alias: App\Model\Category\CategoryDataFactory
+
+    Shopsys\FrameworkBundle\Model\Category\CategoryDataFactory:
         alias: App\Model\Category\CategoryDataFactory
 
     Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactoryInterface:
         alias: App\Model\Customer\User\CustomerUserDataFactory
 
+    Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactory:
+        alias: App\Model\Customer\User\CustomerUserDataFactory
+
     Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface:
         alias: App\Model\Order\OrderDataFactory
 
+    Shopsys\FrameworkBundle\Model\Order\OrderDataFactory:
+        alias: App\Model\Order\OrderDataFactory
+
     Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactoryInterface:
+        alias: App\Model\Order\Item\OrderItemDataFactory
+
+    Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory:
         alias: App\Model\Order\Item\OrderItemDataFactory
 
     App\Model\Order\OrderDataMapper: ~
@@ -63,10 +81,19 @@ services:
     Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface:
         alias: App\Model\Transport\TransportDataFactory
 
+    Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory:
+        alias: App\Model\Transport\TransportDataFactory
+
     Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactoryInterface:
         alias: App\Model\Payment\PaymentDataFactory
 
+    Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory:
+        alias: App\Model\Payment\PaymentDataFactory
+
     Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface:
+        alias: App\Model\Product\ProductDataFactory
+
+    Shopsys\FrameworkBundle\Model\Product\ProductDataFactory:
         alias: App\Model\Product\ProductDataFactory
 
     Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface:
@@ -81,6 +108,9 @@ services:
     Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade: ~
 
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface:
+        alias: App\Model\Product\Brand\BrandDataFactory
+
+    Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactory:
         alias: App\Model\Product\Brand\BrandDataFactory
 
     App\DataFixtures\Performance\CategoryDataFixture:

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -26,3 +26,18 @@ There you can find links to upgrade notes for other versions too.
         +   {{ icon('question') }}
         ```
     - for more information read our article [Icon function](https://docs.shopsys.com/en/9.1/frontend/icon-function/)
+
+## Tools
+- enable automated check of the alias configuration for extended classes in your project ([#2309](https://github.com/shopsys/shopsys/pull/2309))
+    - in your `build.xml` add the following line to include the check of the alias configuration in your `services.yaml`
+    ```diff
+    + <property name="check-alias-configuration" value="true"/>
+      <property name="check-and-fix-annotations" value="true"/>
+      <property name="path.root" value="${project.basedir}"/>
+      ...
+      <import file="${path.framework}/build.xml"/>
+    ```
+    - run `php phing annotations-alias-check` to check the relevant configuration of your extended classes
+    - then run `php phing annotations-fix` to fix the annotations due to improved understanding of the class extension
+    - thanks to the fixes, your IDE (PHPStorm) and static analysis (PHPStan) will understand your code better
+    - afterwards, running `php phing standards` is highly recommended 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| You can easily forget to declare service aliases on your project. This PR adds an automated detector that should help you in such cases. It will even recommend a service config update that should fix the issues in most cases.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md --> (The check is optional, depending on configuration, and it's disabled by default)
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Employed by Shopsys

This approach could be used to generate service configuration files and even configure the aliases during container compilation in the long run. That would completely eliminate the need for defining aliases manually if classes are extended by the docs (Convention over configuration approach).