### PR TITLE
[shopsys] bumped version of composer dependency composer/composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "arvenil/ninja-mutex": "^0.4.1",
         "barryvdh/elfinder-flysystem-driver": "^0.2",
         "commerceguys/intl": "^1.0.0",
-        "composer/composer": "^1.6.0",
+        "composer/composer": "^1.10.22",
         "craue/formflow-bundle": "^3.0.3",
         "defuse/php-encryption": "^2.2.1",
         "doctrine/annotations": "^1.6.0",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -40,7 +40,7 @@
         "arvenil/ninja-mutex": "^0.4.1",
         "barryvdh/elfinder-flysystem-driver": "^0.2",
         "commerceguys/intl": "^1.0.0",
-        "composer/composer": "^1.6.0",
+        "composer/composer": "^1.10.22",
         "craue/formflow-bundle": "^3.0.3",
         "defuse/php-encryption": "^2.2.1",
         "doctrine/annotations": "^1.6",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -36,7 +36,7 @@
         "ext-xml": "*",
         "arvenil/ninja-mutex": "^0.4.1",
         "commerceguys/intl": "^1.0.0",
-        "composer/composer": "^1.6.0",
+        "composer/composer": "^1.10.22",
         "craue/formflow-bundle": "^3.0.3",
         "doctrine/annotations": "^1.6.0",
         "doctrine/common": "^2.8.1",

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -11,3 +11,7 @@ There you can find links to upgrade notes for other versions too.
 
 - replace class names defined by FQCN string by `*::class` constant ([#2319](https://github.com/shopsys/shopsys/pull/2300))
     - see #project-base-diff to update your project
+
+- update composer dependency `composer/composer` in your project ([#2313](https://github.com/shopsys/shopsys/pull/2313))
+    - versions bellow `1.10.22` has [reported security issue](https://github.com/composer/composer/security/advisories/GHSA-h5h8-pc6h-jvvx)
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| due to reported security issue GHSA-h5h8-pc6h-jvvx
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
