### PR TITLE
[shopsys] bumped version of composer dependency composer/composer in 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "bmatzner/jquery-bundle": "^2.2.2",
     "bmatzner/jquery-ui-bundle": "^1.10.3",
     "commerceguys/intl": "0.7.4",
-    "composer/composer": "^1.6.0",
+    "composer/composer": "^1.10.22",
     "craue/formflow-bundle": "^3.0.3",
     "doctrine/annotations": "^1.6.0",
     "doctrine/cache": "^1.7",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -41,7 +41,7 @@
         "bmatzner/jquery-bundle": "^2.2.2",
         "bmatzner/jquery-ui-bundle": "^1.10.3",
         "commerceguys/intl": "0.7.4",
-        "composer/composer": "^1.6.0",
+        "composer/composer": "^1.10.22",
         "craue/formflow-bundle": "^3.0.3",
         "doctrine/common": "^2.8.1",
         "doctrine/annotations": "^1.6",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -41,7 +41,7 @@
         "bmatzner/jquery-bundle": "^2.2.2",
         "bmatzner/jquery-ui-bundle": "^1.10.3",
         "commerceguys/intl": "0.7.4",
-        "composer/composer": "^1.6.0",
+        "composer/composer": "^1.10.22",
         "craue/formflow-bundle": "^3.0.3",
         "doctrine/annotations": "^1.6.0",
         "doctrine/common": "^2.8.1",

--- a/upgrade/UPGRADE-v7.3.7-dev.md
+++ b/upgrade/UPGRADE-v7.3.7-dev.md
@@ -4,3 +4,7 @@ This guide contains instructions to upgrade from version v7.3.6 to v7.3.7-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- update composer dependency `composer/composer` in your project ([#2314](https://github.com/shopsys/shopsys/pull/2314))
+    - versions bellow `1.10.22` has [reported security issue](https://github.com/composer/composer/security/advisories/GHSA-h5h8-pc6h-jvvx)
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| due to reported security issue GHSA-h5h8-pc6h-jvvx
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
