### PR TITLE
[shopsys] set minimal version of symfony/symfony to 3.4.48

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
     "symfony/monolog-bundle": "^3.1.2",
     "symfony/proxy-manager-bridge": "^3.4",
     "symfony/swiftmailer-bundle": "^3.2.2",
-    "symfony/symfony": "^3.4.8",
+    "symfony/symfony": "^3.4.48",
     "tracy/tracy": "^2.4.13",
     "twig/extensions": "^1.5.1",
     "twig/twig": "^2.4.8",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -88,7 +88,7 @@
         "symfony/monolog-bundle": "^3.1.2",
         "symfony/proxy-manager-bridge": "^3.4",
         "symfony/swiftmailer-bundle": "^3.2.2",
-        "symfony/symfony": "^3.4.8",
+        "symfony/symfony": "^3.4.48",
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
         "twig/extensions": "^1.5.1",

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -32,7 +32,7 @@
         "shopsys/framework": "7.3.x-dev",
         "shopsys/migrations": "7.3.x-dev",
         "shopsys/plugin-interface": "7.3.x-dev",
-        "symfony/symfony": "^3.4.8"
+        "symfony/symfony": "^3.4.48"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -35,7 +35,7 @@
         "shopsys/framework": "7.3.x-dev",
         "shopsys/migrations": "7.3.x-dev",
         "shopsys/plugin-interface": "7.3.x-dev",
-        "symfony/symfony": "^3.4.8"
+        "symfony/symfony": "^3.4.48"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -32,7 +32,7 @@
         "shopsys/framework": "7.3.x-dev",
         "shopsys/migrations": "7.3.x-dev",
         "shopsys/plugin-interface": "7.3.x-dev",
-        "symfony/symfony": "^3.4.8"
+        "symfony/symfony": "^3.4.48"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -82,7 +82,7 @@
         "symfony/assetic-bundle": "^2.8.2",
         "symfony/monolog-bundle": "^3.1.2",
         "symfony/swiftmailer-bundle": "^3.2.2",
-        "symfony/symfony": "^3.4.8",
+        "symfony/symfony": "^3.4.48",
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
         "tracy/tracy": "^2.4.13",

--- a/upgrade/UPGRADE-v7.3.7-dev.md
+++ b/upgrade/UPGRADE-v7.3.7-dev.md
@@ -8,3 +8,8 @@ There you can find links to upgrade notes for other versions too.
 - update composer dependency `composer/composer` in your project ([#2314](https://github.com/shopsys/shopsys/pull/2314))
     - versions bellow `1.10.22` has [reported security issue](https://github.com/composer/composer/security/advisories/GHSA-h5h8-pc6h-jvvx)
     - see #project-base-diff to update your project
+
+- update your depedency on `symfony/symfony` ([#2315](https://github.com/shopsys/shopsys/pull/2315))
+    - define the lowest version to `3.4.48` in your `composer.json`
+        - see #project-base-diff
+    - run `composer update symfony/symfony`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| due to security issue in previous versions https://github.com/symfony/symfony/security/advisories/GHSA-5pv8-ppvj-4h68 (CVE-2021-21424)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
