### PR TITLE
[shopsys] excluded friendsofphp/php-cs-fixer v2.19.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -182,7 +182,8 @@
     "conflict": {
         "symfony/symfony": "*",
         "symfony/dependency-injection": ">=4.4.19",
-        "codeception/codeception": ">=4.1.19"
+        "codeception/codeception": ">=4.1.19",
+        "friendsofphp/php-cs-fixer": "2.19.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "conflict": {
-        "symfony/dependency-injection": ">=4.4.19 <5.0.0 || 5.1.11 || >=5.2.2"
+        "symfony/dependency-injection": ">=4.4.19 <5.0.0 || 5.1.11 || >=5.2.2",
+        "friendsofphp/php-cs-fixer": "2.19.0"
     },
     "require": {
         "php": "^7.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| version is excluded because of high memory usage, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5695
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
