### PR TITLE
[shopsys] class names are get from `::class` constant instead of FQCN string

### DIFF
--- a/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
+++ b/packages/framework/tests/Unit/Model/Security/AuthenticatorTest.php
@@ -4,8 +4,12 @@ namespace Tests\FrameworkBundle\Unit\Model\Security;
 
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Model\Security\Authenticator;
+use Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException;
 use stdClass;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class AuthenticatorTest extends TestCase
@@ -15,15 +19,15 @@ class AuthenticatorTest extends TestCase
         $authenticator = $this->getAuthenticator();
 
         /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $requestMock */
-        $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
+        $requestMock = $this->createMock(Request::class);
 
         $requestMock->expects($this->never())->method('getSession');
 
-        $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
+        $requestMock->attributes = $this->createMock(ParameterBag::class);
         $requestMock->attributes->expects($this->once())->method('has')->willReturn(true);
         $requestMock->attributes->expects($this->once())->method('get')->willReturn(new stdClass());
 
-        $this->expectException('Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException');
+        $this->expectException(LoginFailedException::class);
         $authenticator->checkLoginProcess($requestMock);
     }
 
@@ -31,19 +35,19 @@ class AuthenticatorTest extends TestCase
     {
         $authenticator = $this->getAuthenticator();
 
-        $sessionMock = $this->createMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $sessionMock = $this->createMock(SessionInterface::class);
         $sessionMock->expects($this->atLeastOnce())->method('get')->willReturn(new stdClass());
         $sessionMock->expects($this->atLeastOnce())->method('remove');
 
         /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $requestMock */
-        $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
+        $requestMock = $this->createMock(Request::class);
         $requestMock->expects($this->once())->method('getSession')->willReturn($sessionMock);
 
-        $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
+        $requestMock->attributes = $this->createMock(ParameterBag::class);
         $requestMock->attributes->expects($this->once())->method('has')->willReturn(false);
         $requestMock->attributes->expects($this->never())->method('get');
 
-        $this->expectException('Shopsys\FrameworkBundle\Model\Security\Exception\LoginFailedException');
+        $this->expectException(LoginFailedException::class);
         $authenticator->checkLoginProcess($requestMock);
     }
 
@@ -51,15 +55,15 @@ class AuthenticatorTest extends TestCase
     {
         $authenticator = $this->getAuthenticator();
 
-        $sessionMock = $this->createMock('\Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $sessionMock = $this->createMock(SessionInterface::class);
         $sessionMock->expects($this->once())->method('get')->willReturn(null);
         $sessionMock->expects($this->once())->method('remove');
 
         /** @var \Symfony\Component\HttpFoundation\Request|\PHPUnit\Framework\MockObject\MockObject $requestMock */
-        $requestMock = $this->createMock('\Symfony\Component\HttpFoundation\Request');
+        $requestMock = $this->createMock(Request::class);
         $requestMock->expects($this->once())->method('getSession')->willReturn($sessionMock);
 
-        $requestMock->attributes = $this->createMock('\Symfony\Component\HttpFoundation\ParameterBag');
+        $requestMock->attributes = $this->createMock(ParameterBag::class);
         $requestMock->attributes->expects($this->once())->method('has')->willReturn(false);
         $requestMock->attributes->expects($this->never())->method('get');
 

--- a/project-base/tests/App/Functional/Model/Administrator/AdministratorRepositoryTest.php
+++ b/project-base/tests/App/Functional/Model/Administrator/AdministratorRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Tests\App\Functional\Model\Administrator;
 
 use App\DataFixtures\Demo\AdministratorDataFixture;
 use DateTime;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\InvalidTokenException;
 use Tests\App\Test\TransactionFunctionalTestCase;
 use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyTestContainer;
 
@@ -55,9 +56,7 @@ class AdministratorRepositoryTest extends TransactionFunctionalTestCase
         );
         $this->em->flush($administrator);
 
-        $this->expectException(
-            '\Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\InvalidTokenException'
-        );
+        $this->expectException(InvalidTokenException::class);
 
         $this->administratorRepository->getByValidMultidomainLoginToken($invalidMultidomainLoginToken);
     }
@@ -76,9 +75,7 @@ class AdministratorRepositoryTest extends TransactionFunctionalTestCase
         );
         $this->em->flush($administrator);
 
-        $this->expectException(
-            '\Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\InvalidTokenException'
-        );
+        $this->expectException(InvalidTokenException::class);
 
         $this->administratorRepository->getByValidMultidomainLoginToken($validMultidomainLoginToken);
     }

--- a/project-base/tests/App/Functional/Model/Cart/CartFacadeTest.php
+++ b/project-base/tests/App/Functional/Model/Cart/CartFacadeTest.php
@@ -7,8 +7,11 @@ namespace Tests\App\Functional\Model\Cart;
 use App\DataFixtures\Demo\ProductDataFixture;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\CartFacade;
+use Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidCartItemException;
+use Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidQuantityException;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifier;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifierFactory;
+use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Tests\App\Test\TransactionFunctionalTestCase;
 use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyTestContainer;
 
@@ -109,7 +112,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
         $customerUserIdentifier = new CustomerUserIdentifier('secretSessionHash');
         $cartFacade = $this->createCartFacade($customerUserIdentifier);
 
-        $this->expectException('\Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException');
+        $this->expectException(ProductNotFoundException::class);
         $cartFacade->addProductToCart($productId, $quantity);
 
         $cart = $this->getCartByCustomerUserIdentifier($customerUserIdentifier);
@@ -163,7 +166,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
         $cartItems = $cart->getItems();
         $cartItem = array_pop($cartItems);
 
-        $this->expectException('\Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidCartItemException');
+        $this->expectException(InvalidCartItemException::class);
         $cartFacade->deleteCartItem($cartItem->getId() + 1);
     }
 
@@ -308,7 +311,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     {
         $product = $this->createProduct();
 
-        $this->expectException('Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidQuantityException');
+        $this->expectException(InvalidQuantityException::class);
 
         /** @phpstan-ignore-next-line */
         $this->cartFacadeFromContainer->addProductToCart($product->getId(), 1.1);
@@ -318,7 +321,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     {
         $product = $this->createProduct();
 
-        $this->expectException('Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidQuantityException');
+        $this->expectException(InvalidQuantityException::class);
         $this->cartFacadeFromContainer->addProductToCart($product->getId(), 0);
     }
 
@@ -326,7 +329,7 @@ class CartFacadeTest extends TransactionFunctionalTestCase
     {
         $product = $this->createProduct();
 
-        $this->expectException('Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidQuantityException');
+        $this->expectException(InvalidQuantityException::class);
         $this->cartFacadeFromContainer->addProductToCart($product->getId(), -10);
     }
 

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -8,3 +8,6 @@ There you can find links to upgrade notes for other versions too.
 - potential **BC break** ([#2300](https://github.com/shopsys/shopsys/pull/2300))
     - method `Shopsys\FrameworkBundle\Form\Admin\Customer\User\CustomerUserFormType::validateUniqueEmail()` has changed its interface
         - first argument `$email` was changed to accept `null` or `string` instead of `string` only
+
+- replace class names defined by FQCN string by `*::class` constant ([#2319](https://github.com/shopsys/shopsys/pull/2300))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to have these usages unified. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
