### PR TITLE
[shopsys] excluded friendsofphp/php-cs-fixer v2.19.0 in 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,7 +160,8 @@
   "conflict": {
     "symfony/dependency-injection": "3.4.15|3.4.16",
     "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
-    "twig/twig": "2.6.1"
+    "twig/twig": "2.6.1",
+    "friendsofphp/php-cs-fixer": "2.19.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -26,7 +26,8 @@
         "symplify/easy-coding-standard-tester": "^5.2.17"
     },
     "conflict": {
-        "symplify/better-phpdoc-parser": "5.4.14|5.4.15"
+        "symplify/better-phpdoc-parser": "5.4.14|5.4.15",
+        "friendsofphp/php-cs-fixer": "2.19.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| version is excluded because of high memory usage, see FriendsOfPHP/PHP-CS-Fixer#5695d
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
