### PR TITLE
[product-feed-heureka] ignored errors reported by new squizlabs/php_codesniffer version 3.6.0 in 7.3

### DIFF
--- a/packages/product-feed-heureka/easy-coding-standard.yml
+++ b/packages/product-feed-heureka/easy-coding-standard.yml
@@ -23,5 +23,8 @@ parameters:
         PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff.NotCamelCaps:
             - '*/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php'
 
+        PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff.MemberNotCamelCaps:
+            - '*/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php'
+
         Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff:
             - '*/tests/*'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Errors reported were all like this: Member variable "CATEGORY_ID" is not in valid camel caps format. Those variables are loaded from XML so we have no power over them.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
