### PR TITLE
[framework] admin: dashboard: deleted orders are no longer included in statistics

### DIFF
--- a/packages/framework/src/Model/Statistics/StatisticsRepository.php
+++ b/packages/framework/src/Model/Statistics/StatisticsRepository.php
@@ -71,7 +71,7 @@ class StatisticsRepository
         $query = $this->em->createNativeQuery(
             'SELECT DATE(o.created_at) AS date, COUNT(o.created_at) AS count
             FROM orders o
-            WHERE o.created_at BETWEEN :start_date AND :end_date AND o.status_id != :canceled
+            WHERE o.created_at BETWEEN :start_date AND :end_date AND o.status_id != :canceled AND o.deleted = FALSE
             GROUP BY date
             ORDER BY date ASC',
             $resultSetMapping
@@ -125,7 +125,7 @@ class StatisticsRepository
         $query = $this->em->createNativeQuery(
             'SELECT COUNT(o.created_at) AS count
             FROM orders o
-            WHERE o.created_at BETWEEN :start_date AND :end_date AND o.status_id != :canceled',
+            WHERE o.created_at BETWEEN :start_date AND :end_date AND o.status_id != :canceled AND o.deleted = FALSE',
             $resultSetMapping
         );
 
@@ -149,7 +149,7 @@ class StatisticsRepository
         $query = $this->em->createNativeQuery(
             'SELECT SUM(o.total_price_with_vat * c.exchange_rate) AS total_price
             FROM orders o, currencies c
-            WHERE o.created_at BETWEEN :start_date AND :end_date AND o.status_id != :canceled
+            WHERE o.created_at BETWEEN :start_date AND :end_date AND o.status_id != :canceled AND o.deleted = FALSE
             AND o.currency_id = c.id',
             $resultSetMapping
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is confusing when there are some deleted orders in statistics but not visible on orders overview.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
