### PR TITLE
[shopsys] fix calculation of transport and payment visibilities

### DIFF
--- a/packages/framework/src/Model/Payment/IndependentPaymentVisibilityCalculation.php
+++ b/packages/framework/src/Model/Payment/IndependentPaymentVisibilityCalculation.php
@@ -32,7 +32,7 @@ class IndependentPaymentVisibilityCalculation
             return false;
         }
 
-        if ($payment->isHidden()) {
+        if ($payment->isHidden() || $payment->isDeleted()) {
             return false;
         }
         return $payment->isEnabled($domainId);

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -307,4 +307,14 @@ class PaymentFacade
     {
         return $this->paymentRepository->getOneByUuid($uuid);
     }
+
+    /**
+     * @param string $uuid
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Payment\Payment
+     */
+    public function getEnabledOnDomainByUuid(string $uuid, int $domainId): Payment
+    {
+        return $this->paymentRepository->getEnabledOnDomainByUuid($uuid, $domainId);
+    }
 }

--- a/packages/framework/src/Model/Transport/IndependentTransportVisibilityCalculation.php
+++ b/packages/framework/src/Model/Transport/IndependentTransportVisibilityCalculation.php
@@ -32,9 +32,10 @@ class IndependentTransportVisibilityCalculation
             return false;
         }
 
-        if ($transport->isHidden()) {
+        if ($transport->isHidden() || $transport->isDeleted()) {
             return false;
         }
+
         return $transport->isEnabled($domainId);
     }
 }

--- a/packages/framework/src/Model/Transport/TransportFacade.php
+++ b/packages/framework/src/Model/Transport/TransportFacade.php
@@ -298,4 +298,14 @@ class TransportFacade
     {
         return $this->transportRepository->getOneByUuid($uuid);
     }
+
+    /**
+     * @param string $uuid
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Transport\Transport
+     */
+    public function getEnabledOnDomainByUuid(string $uuid, int $domainId): Transport
+    {
+        return $this->transportRepository->getEnabledOnDomainByUuid($uuid, $domainId);
+    }
 }

--- a/packages/framework/src/Model/Transport/TransportRepository.php
+++ b/packages/framework/src/Model/Transport/TransportRepository.php
@@ -127,4 +127,29 @@ class TransportRepository
 
         return $transport;
     }
+
+    /**
+     * @param string $uuid
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Transport\Transport
+     */
+    public function getEnabledOnDomainByUuid(string $uuid, int $domainId): Transport
+    {
+        $queryBuilder = $this->getTransportRepository()->createQueryBuilder('t')
+            ->join(TransportDomain::class, 'td', Join::WITH, 't.id = td.transport AND td.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
+            ->where('t.uuid = :uuid')
+            ->setParameter('uuid', $uuid)
+            ->andWhere('t.deleted = false')
+            ->andWhere('td.enabled = true')
+            ->andWhere('t.hidden = false');
+
+        $transport = $queryBuilder->getQuery()->getOneOrNullResult();
+
+        if ($transport === null) {
+            throw new TransportNotFoundException('Transport with UUID ' . $uuid . ' does not exist.');
+        }
+
+        return $transport;
+    }
 }

--- a/packages/frontend-api/src/Component/Constraints/PaymentCanBeUsedValidator.php
+++ b/packages/frontend-api/src/Component/Constraints/PaymentCanBeUsedValidator.php
@@ -70,7 +70,7 @@ class PaymentCanBeUsedValidator extends ConstraintValidator
 
         try {
             $paymentEntity = $this->paymentFacade->getByUuid($uuid);
-            if (!$paymentEntity->isEnabled($this->domain->getId())) {
+            if ($paymentEntity->isDeleted() || !$paymentEntity->isEnabled($this->domain->getId())) {
                 throw new PaymentNotFoundException('Payment is disabled on domain');
             }
         } catch (PaymentNotFoundException $exception) {

--- a/packages/frontend-api/src/Component/Constraints/TransportCanBeUsedValidator.php
+++ b/packages/frontend-api/src/Component/Constraints/TransportCanBeUsedValidator.php
@@ -73,7 +73,7 @@ class TransportCanBeUsedValidator extends ConstraintValidator
 
         try {
             $transportEntity = $this->transportFacade->getByUuid($uuid);
-            if (!$transportEntity->isEnabled($this->domain->getId())) {
+            if ($transportEntity->isDeleted() || !$transportEntity->isEnabled($this->domain->getId())) {
                 throw new TransportNotFoundException('Transport is disabled on domain');
             }
         } catch (TransportNotFoundException $exception) {

--- a/packages/frontend-api/src/Model/Order/OrderDataFactory.php
+++ b/packages/frontend-api/src/Model/Order/OrderDataFactory.php
@@ -137,7 +137,10 @@ class OrderDataFactory
             $this->domain->getId()
         );
 
-        $cloneOrderData->transport = $this->transportFacade->getByUuid($input['transport']['uuid']);
+        $cloneOrderData->transport = $this->transportFacade->getEnabledOnDomainByUuid(
+            $input['transport']['uuid'],
+            $this->domain->getId()
+        );
 
         $cloneOrderData->currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId());
 

--- a/packages/frontend-api/src/Model/Order/OrderDataFactory.php
+++ b/packages/frontend-api/src/Model/Order/OrderDataFactory.php
@@ -132,7 +132,11 @@ class OrderDataFactory
     {
         $cloneOrderData = clone $orderData;
 
-        $cloneOrderData->payment = $this->paymentFacade->getByUuid($input['payment']['uuid']);
+        $cloneOrderData->payment = $this->paymentFacade->getEnabledOnDomainByUuid(
+            $input['payment']['uuid'],
+            $this->domain->getId()
+        );
+
         $cloneOrderData->transport = $this->transportFacade->getByUuid($input['transport']['uuid']);
 
         $cloneOrderData->currency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId($this->domain->getId());

--- a/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
@@ -41,7 +41,7 @@ class PaymentResolver implements ResolverInterface, AliasedInterface
     public function resolver(string $uuid): Payment
     {
         try {
-            return $this->paymentFacade->getByUuid($uuid);
+            return $this->paymentFacade->getEnabledOnDomainByUuid($uuid, $this->domain->getId());
         } catch (PaymentNotFoundException $paymentNotFoundException) {
             throw new UserError($paymentNotFoundException->getMessage());
         }

--- a/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
@@ -41,7 +41,7 @@ class TransportResolver implements ResolverInterface, AliasedInterface
     public function resolver(string $uuid): Transport
     {
         try {
-            return $this->transportFacade->getByUuid($uuid);
+            return $this->transportFacade->getEnabledOnDomainByUuid($uuid, $this->domain->getId());
         } catch (TransportNotFoundException $transportNotFoundException) {
             throw new UserError($transportNotFoundException->getMessage());
         }

--- a/project-base/tests/App/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
+++ b/project-base/tests/App/Functional/Model/Transport/IndependentTransportVisibilityCalculationTest.php
@@ -118,12 +118,33 @@ class IndependentTransportVisibilityCalculationTest extends TransactionFunctiona
         );
     }
 
+    public function testIsNotIndependentlyVisibleWhenDeleted(): void
+    {
+        $enabledOnDomains = [
+            Domain::FIRST_DOMAIN_ID => true,
+            Domain::SECOND_DOMAIN_ID => true,
+        ];
+
+        $transport = $this->getDefaultTransport($enabledOnDomains, false, true);
+
+        $this->em->persist($transport);
+        $this->em->flush();
+
+        $this->assertFalse(
+            $this->independentTransportVisibilityCalculation->isIndependentlyVisible(
+                $transport,
+                Domain::FIRST_DOMAIN_ID
+            )
+        );
+    }
+
     /**
      * @param array $enabledForDomains
      * @param bool $hidden
+     * @param bool $deleted
      * @return \App\Model\Transport\Transport
      */
-    public function getDefaultTransport($enabledForDomains, $hidden)
+    public function getDefaultTransport($enabledForDomains, $hidden, bool $deleted = false)
     {
         $transportData = $this->transportDataFactory->create();
         $names = [];
@@ -135,7 +156,13 @@ class IndependentTransportVisibilityCalculationTest extends TransactionFunctiona
         $transportData->hidden = $hidden;
         $transportData->enabled = $this->getFilteredEnabledForDomains($enabledForDomains);
 
-        return new Transport($transportData);
+        $transport = new Transport($transportData);
+
+        if ($deleted) {
+            $transport->markAsDeleted();
+        }
+
+        return $transport;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Attribute deleted of transport and payment was not used in consideration during calculation of their visibilities. Also transport and payment frontend API resolvers were not taking visibility in consideration.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2302 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
