### PR TITLE
[framework] annotation cache don't use doctrine file cache

### DIFF
--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -123,6 +123,7 @@ services:
             - '%kernel.cache_dir%/metadata'
 
     shopsys.framework.cache_driver.annotations_cache:
+        deprecated: The "%service_id%" service is deprecated since shopsys/framework 9.1.2 and will be removed in 10.0.0.
         class: Doctrine\Common\Cache\PhpFileCache
         arguments:
             - '%kernel.cache_dir%/annotations'

--- a/project-base/config/packages/framework.yaml
+++ b/project-base/config/packages/framework.yaml
@@ -1,6 +1,7 @@
 framework:
     annotations:
-        cache: shopsys.framework.cache_driver.annotations_cache
+        cache: file
+        file_cache_dir: '%kernel.cache_dir%/annotations'
     secret: "%secret%"
     router:
         strict_requirements: true

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -15,3 +15,6 @@ There you can find links to upgrade notes for other versions too.
 - update composer dependency `composer/composer` in your project ([#2313](https://github.com/shopsys/shopsys/pull/2313))
     - versions bellow `1.10.22` has [reported security issue](https://github.com/composer/composer/security/advisories/GHSA-h5h8-pc6h-jvvx)
     - see #project-base-diff to update your project
+
+- drop usage of Doctrine\Common\Cache\PhpFileCache as framework annotation cache ([#2326](https://github.com/shopsys/shopsys/pull/2326))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| New versions of doctrine/ and symfony/ packages throws fatal (`Argument 2 passed to Doctrine\Common\Annotations\PsrCachedReader::__construct() must implement interface Psr\Cache\CacheItemPoolInterface, instance of Doctrine\Common\Cache\ChainCache`). This PR fixes compatibility with a new  version of packages and it's a step forward to complete removal of doctrine/cache as it's prepared for removal (https://github.com/doctrine/cache/issues/354)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
