### PR TITLE
[framework] fixed rendering of DisplayOnlyType in inline data grid

### DIFF
--- a/packages/framework/src/Form/DisplayOnlyType.php
+++ b/packages/framework/src/Form/DisplayOnlyType.php
@@ -18,6 +18,7 @@ class DisplayOnlyType extends AbstractType
                 'mapped' => false,
                 'required' => false,
                 'disabled' => true,
+                'compound' => false,
                 'attr' => [
                     'readonly' => 'readonly',
                     'class' => '',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In inline editation is not rendered DisplayOnlyType. This can be fixed by setting attribute `compound` to `false`.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
