### PR TITLE
[project-base] ProductFilterPage now uses mb_stripos instead of stripos

### DIFF
--- a/project-base/tests/App/Acceptance/acceptance/PageObject/Front/ProductFilterPage.php
+++ b/project-base/tests/App/Acceptance/acceptance/PageObject/Front/ProductFilterPage.php
@@ -92,7 +92,7 @@ class ProductFilterPage extends AbstractPage
             try {
                 $itemLabel = $item->findElement(WebDriverBy::cssSelector('.js-product-filter-parameter-label'));
 
-                if (stripos($itemLabel->getText(), $translatedParameterLabel) !== false) {
+                if (mb_stripos($itemLabel->getText(), $translatedParameterLabel) !== false) {
                     return $item;
                 }
             } catch (NoSuchElementException $ex) {
@@ -123,7 +123,7 @@ class ProductFilterPage extends AbstractPage
         foreach ($parameterValueDivs as $parameterValueDiv) {
             try {
                 $labelElement = $parameterValueDiv->findElement(WebDriverBy::cssSelector('label'));
-                if (stripos($labelElement->getText(), $translatedParameterValueText) !== false) {
+                if (mb_stripos($labelElement->getText(), $translatedParameterValueText) !== false) {
                     return $labelElement;
                 }
             } catch (NoSuchElementException $ex) {

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -27,3 +27,6 @@ There you can find links to upgrade notes for other versions too.
 
 - remove unused multipleProductsInOrder.graphql file ([#2306](https://github.com/shopsys/shopsys/pull/2306))
     - see #project-base-diff to update your project
+
+- update `ProductFilterPage` so it is resistant to case changes ([#2330](https://github.com/shopsys/shopsys/pull/2330))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
- this makes the class functions resistant to case changes of the product filter labels

| Q             | A
| ------------- | ---
|Description, reason for the PR| change from "Úhlopříčka" to "ÚHLOPŘÍČKA" during product filter styling broke `ProductFilterCest::testAllProductFilters` test
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
