### PR TITLE
[framework] cron overview now can display duration of crons over one hour

### DIFF
--- a/packages/framework/src/Controller/Admin/DefaultController.php
+++ b/packages/framework/src/Controller/Admin/DefaultController.php
@@ -25,6 +25,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class DefaultController extends AdminBaseController
 {
     protected const PREVIOUS_DAYS_TO_LOAD_STATISTICS_FOR = 7;
+    protected const HOUR_IN_SECONDS = 60 * 60;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Statistics\StatisticsFacade
@@ -293,10 +294,7 @@ class DefaultController extends AdminBaseController
                 'name' => $cronConfig->getReadableName() ?? $cronModule->getServiceId(),
                 'lastStartedAt' => $cronModule->getLastStartedAt(),
                 'lastFinishedAt' => $cronModule->getLastFinishedAt(),
-                'lastDuration' => is_int($cronModule->getLastDuration()) ? date(
-                    'i:s',
-                    $cronModule->getLastDuration()
-                ) : '',
+                'lastDuration' => $this->getFormattedDuration($cronModule->getLastDuration()),
                 'status' => $cronModule->getStatus(),
                 'enabled' => $cronModule->isEnabled(),
                 'readableFrequency' => $cronConfig->getReadableFrequency(),
@@ -372,5 +370,27 @@ class DefaultController extends AdminBaseController
         );
 
         return $this->redirectToRoute('admin_default_dashboard');
+    }
+
+    /**
+     * @param int|null $durationInSeconds
+     * @return string
+     */
+    protected function getFormattedDuration(?int $durationInSeconds): string
+    {
+        if ($durationInSeconds === null) {
+            return '';
+        }
+
+        $formattedHours = '';
+
+        if ($durationInSeconds >= static::HOUR_IN_SECONDS) {
+            $hours = (int)floor($durationInSeconds / static::HOUR_IN_SECONDS);
+            $formattedHours .= $hours . ':';
+
+            $durationInSeconds -= $hours * static::HOUR_IN_SECONDS;
+        }
+
+        return $formattedHours . date('i:s', $durationInSeconds);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Crons until now could display duration of maximum 59 mins and 59 seconds. Duration lasting longer were stripped of hours and it was not clear how long did cron run. This has been fixed now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2310  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
