### PR TITLE
[monorepo] added release candidate step for generating Apiary.io blueprint

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/GenerateApiaryBlueprintReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/GenerateApiaryBlueprintReleaseWorker.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\ReleaseCandidate;
+
+use PharIo\Version\Version;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class GenerateApiaryBlueprintReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyle
+     */
+    public function __construct(SymfonyStyle $symfonyStyle)
+    {
+        $this->symfonyStyle = $symfonyStyle;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return 'Generate Apiary.io blueprint "php phing frontend-api-generate-apiary-blueprint" and commit it';
+    }
+
+    /**
+     * Higher first
+     *
+     * @return int
+     */
+    public function getPriority(): int
+    {
+        return 870;
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     */
+    public function work(Version $version): void
+    {
+        $this->processRunner->run('php phing frontend-api-generate-apiary-blueprint');
+
+        if ($this->hasGeneratedBlueprint()) {
+            $this->commit('generated Apiary.io blueprint');
+
+            $this->confirm(
+                'Confirm that you checked generated blueprint and the changes are committed'
+            );
+        } else {
+            $this->symfonyStyle->success('There are no changes in blueprint');
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function hasGeneratedBlueprint(): bool
+    {
+        return !$this->isGitWorkingTreeEmpty();
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::RELEASE_CANDIDATE;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In past we have forgot to generate Apiary.io blueprint. This PR ensures it will not be forgotten again.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
