### PR TITLE
[shopsys] moved translations on front to project-base

### DIFF
--- a/packages/framework/src/Model/Breadcrumb/ErrorPageBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Breadcrumb/ErrorPageBreadcrumbGenerator.php
@@ -6,10 +6,23 @@ use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface;
 use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbItem;
 
 /**
- * @return \Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbItem
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
  */
 class ErrorPageBreadcrumbGenerator implements BreadcrumbGeneratorInterface
 {
+    public function __construct()
+    {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+    }
+
     /**
      * @param string $routeName
      * @param array $routeParameters
@@ -18,7 +31,7 @@ class ErrorPageBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     public function getBreadcrumbItems($routeName, array $routeParameters = [])
     {
         $isPageNotFound = $routeParameters['code'] === '404';
-        $breadcrumbName = $isPageNotFound ? t('Page not found') : t('Oops! Error occurred');
+        $breadcrumbName = $isPageNotFound ? $this->getTranslatedBreadcrumbForNotFoundPage() : $this->getTranslatedBreadcrumbForErrorPage();
 
         return [
             new BreadcrumbItem($breadcrumbName),
@@ -34,5 +47,39 @@ class ErrorPageBreadcrumbGenerator implements BreadcrumbGeneratorInterface
             'front_error_page',
             'front_error_page_format',
         ];
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return string
+     */
+    protected function getTranslatedBreadcrumbForNotFoundPage(): string
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return t('Page not found');
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return string
+     */
+    protected function getTranslatedBreadcrumbForErrorPage(): string
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return t('Oops! Error occurred');
     }
 }

--- a/packages/framework/src/Model/Breadcrumb/SimpleBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Breadcrumb/SimpleBreadcrumbGenerator.php
@@ -5,12 +5,28 @@ namespace Shopsys\FrameworkBundle\Model\Breadcrumb;
 use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbGeneratorInterface;
 use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbItem;
 
+/**
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
+ */
 class SimpleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
 {
     /**
      * @var string[]|null
      */
     protected $routeNameMap;
+
+    public function __construct()
+    {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+    }
 
     /**
      * @param string $routeName
@@ -41,20 +57,37 @@ class SimpleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     {
         if ($this->routeNameMap === null) {
             // Caching in order to translate breadcrumb item names only once
-            $this->routeNameMap = [
-                'front_customer_edit' => t('Edit data'),
-                'front_customer_orders' => t('Orders'),
-                'front_registration_reset_password' => t('Forgotten password'),
-                'front_customer_order_detail_registered' => t('Order detail'),
-                'front_customer_order_detail_unregistered' => t('Order detail'),
-                'front_login' => t('Login'),
-                'front_product_search' => t('Search [noun]'),
-                'front_registration_register' => t('Registration'),
-                'front_brand_list' => t('Brand overview'),
-                'front_contact' => t('Contact'),
-            ];
+            $this->routeNameMap = $this->getTranslatedBreadcrumbsByRouteNames();
         }
 
         return $this->routeNameMap;
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return array<string, string>
+     */
+    protected function getTranslatedBreadcrumbsByRouteNames(): array
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return [
+            'front_customer_edit' => t('Edit data'),
+            'front_customer_orders' => t('Orders'),
+            'front_registration_reset_password' => t('Forgotten password'),
+            'front_customer_order_detail_registered' => t('Order detail'),
+            'front_customer_order_detail_unregistered' => t('Order detail'),
+            'front_login' => t('Login'),
+            'front_product_search' => t('Search [noun]'),
+            'front_registration_register' => t('Registration'),
+            'front_brand_list' => t('Brand overview'),
+            'front_contact' => t('Contact'),
+        ];
     }
 }

--- a/packages/framework/src/Model/Cart/Watcher/CartWatcherFacade.php
+++ b/packages/framework/src/Model/Cart/Watcher/CartWatcherFacade.php
@@ -10,6 +10,9 @@ use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Twig\Environment;
 
+/**
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
+ */
 class CartWatcherFacade
 {
     /**
@@ -51,6 +54,16 @@ class CartWatcherFacade
         CurrentCustomerUser $currentCustomerUser,
         Environment $twigEnvironment
     ) {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->flashBag = $flashBag;
         $this->em = $em;
         $this->cartWatcher = $cartWatcher;
@@ -75,7 +88,7 @@ class CartWatcherFacade
         $modifiedItems = $this->cartWatcher->getModifiedPriceItemsAndUpdatePrices($cart);
 
         $messageTemplate = $this->twigEnvironment->createTemplate(
-            t('The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order.')
+            $this->getMessageForChangedProduct()
         );
 
         foreach ($modifiedItems as $cartItem) {
@@ -97,7 +110,7 @@ class CartWatcherFacade
         $toFlush = [];
 
         $messageTemplate = $this->twigEnvironment->createTemplate(
-            t('Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order.')
+            $this->getMessageForNoLongerAvailableExistingProduct()
         );
 
         foreach ($notVisibleItems as $cartItem) {
@@ -107,7 +120,7 @@ class CartWatcherFacade
             } catch (ProductNotFoundException $e) {
                 $this->flashBag->add(
                     FlashMessage::KEY_ERROR,
-                    t('Product you had in cart is no longer in available. Please check your order.')
+                    $this->getMessageForNoLongerAvailableProduct()
                 );
             }
 
@@ -119,5 +132,56 @@ class CartWatcherFacade
         if (count($toFlush) > 0) {
             $this->em->flush($toFlush);
         }
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return string
+     */
+    protected function getMessageForNoLongerAvailableExistingProduct(): string
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return t('Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order.');
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return string
+     */
+    protected function getMessageForNoLongerAvailableProduct(): string
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return t('Product you had in cart is no longer in available. Please check your order.');
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return string
+     */
+    protected function getMessageForChangedProduct(): string
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return t('The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order.');
     }
 }

--- a/packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
+++ b/packages/framework/src/Model/LegalConditions/LegalConditionsFacade.php
@@ -7,6 +7,9 @@ use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Model\Article\Article;
 use Shopsys\FrameworkBundle\Model\Article\ArticleFacade;
 
+/**
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
+ */
 class LegalConditionsFacade
 {
     /**
@@ -34,6 +37,16 @@ class LegalConditionsFacade
         Setting $setting,
         Domain $domain
     ) {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->articleFacade = $articleFacade;
         $this->setting = $setting;
         $this->domain = $domain;
@@ -58,10 +71,19 @@ class LegalConditionsFacade
     }
 
     /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
      * @return string
      */
     public function getTermsAndConditionsDownloadFilename()
     {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return t('Terms-and-conditions.html');
     }
 

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
@@ -4,6 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Listing;
 
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
+ */
 class ProductListOrderingModeForBrandFacade
 {
     protected const COOKIE_NAME = 'productListOrderingModeForBrand';
@@ -18,6 +21,16 @@ class ProductListOrderingModeForBrandFacade
      */
     public function __construct(RequestToOrderingModeIdConverter $requestToOrderingModeIdConverter)
     {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->requestToOrderingModeIdConverter = $requestToOrderingModeIdConverter;
     }
 
@@ -27,14 +40,8 @@ class ProductListOrderingModeForBrandFacade
     public function getProductListOrderingConfig()
     {
         return new ProductListOrderingConfig(
-            [
-                ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
-                ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
-                ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
-                ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
-                ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
-            ],
-            ProductListOrderingConfig::ORDER_BY_PRIORITY,
+            $this->getSupportedOrderingModesNamesById(),
+            $this->getDefaultOrderingModeId(),
             static::COOKIE_NAME
         );
     }
@@ -49,5 +56,36 @@ class ProductListOrderingModeForBrandFacade
             $request,
             $this->getProductListOrderingConfig()
         );
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return array<string, string>
+     */
+    protected function getSupportedOrderingModesNamesById(): array
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return [
+            ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
+            ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrderingModeId(): string
+    {
+        return ProductListOrderingConfig::ORDER_BY_PRIORITY;
     }
 }

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
@@ -4,6 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Listing;
 
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
+ */
 class ProductListOrderingModeForListFacade
 {
     protected const COOKIE_NAME = 'productListOrderingMode';
@@ -18,6 +21,16 @@ class ProductListOrderingModeForListFacade
      */
     public function __construct(RequestToOrderingModeIdConverter $requestToOrderingModeIdConverter)
     {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->requestToOrderingModeIdConverter = $requestToOrderingModeIdConverter;
     }
 
@@ -27,14 +40,8 @@ class ProductListOrderingModeForListFacade
     public function getProductListOrderingConfig()
     {
         return new ProductListOrderingConfig(
-            [
-                ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
-                ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
-                ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
-                ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
-                ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
-            ],
-            ProductListOrderingConfig::ORDER_BY_PRIORITY,
+            $this->getSupportedOrderingModesNamesById(),
+            $this->getDefaultOrderingModeId(),
             static::COOKIE_NAME
         );
     }
@@ -49,5 +56,36 @@ class ProductListOrderingModeForListFacade
             $request,
             $this->getProductListOrderingConfig()
         );
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return array<string, string>
+     */
+    protected function getSupportedOrderingModesNamesById(): array
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return [
+            ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
+            ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrderingModeId(): string
+    {
+        return ProductListOrderingConfig::ORDER_BY_PRIORITY;
     }
 }

--- a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
@@ -4,6 +4,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Listing;
 
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated Class will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.
+ */
 class ProductListOrderingModeForSearchFacade
 {
     protected const COOKIE_NAME = 'productSearchOrderingMode';
@@ -18,6 +21,16 @@ class ProductListOrderingModeForSearchFacade
      */
     public function __construct(RequestToOrderingModeIdConverter $requestToOrderingModeIdConverter)
     {
+        if (static::class === self::class) {
+            trigger_error(
+                sprintf(
+                    'Class "%s" will be changed to abstract class in next major version. Extend this class to your project and implement corresponding methods instead.',
+                    self::class
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $this->requestToOrderingModeIdConverter = $requestToOrderingModeIdConverter;
     }
 
@@ -27,15 +40,8 @@ class ProductListOrderingModeForSearchFacade
     public function getProductListOrderingConfig()
     {
         return new ProductListOrderingConfig(
-            [
-                ProductListOrderingConfig::ORDER_BY_RELEVANCE => t('relevance'),
-                ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
-                ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
-                ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
-                ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
-                ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
-            ],
-            ProductListOrderingConfig::ORDER_BY_RELEVANCE,
+            $this->getSupportedOrderingModesNamesById(),
+            $this->getDefaultOrderingModeId(),
             static::COOKIE_NAME
         );
     }
@@ -50,5 +56,37 @@ class ProductListOrderingModeForSearchFacade
             $request,
             $this->getProductListOrderingConfig()
         );
+    }
+
+    /**
+     * @deprecated Method will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.
+     * @return array<string, string>
+     */
+    protected function getSupportedOrderingModesNamesById(): array
+    {
+        trigger_error(
+            sprintf(
+                'Method "%s" will be changed to abstract in next major version. Extend this class to your project and implement method by yourself instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return [
+            ProductListOrderingConfig::ORDER_BY_RELEVANCE => t('relevance'),
+            ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
+            ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getDefaultOrderingModeId(): string
+    {
+        return ProductListOrderingConfig::ORDER_BY_RELEVANCE;
     }
 }

--- a/project-base/config/services.yaml
+++ b/project-base/config/services.yaml
@@ -43,11 +43,23 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface:
         alias: App\Model\Administrator\AdministratorDataFactory
 
+    Shopsys\FrameworkBundle\Model\Breadcrumb\ErrorPageBreadcrumbGenerator:
+        alias: App\Model\Breadcrumb\ErrorPageBreadcrumbGenerator
+
+    Shopsys\FrameworkBundle\Model\Breadcrumb\SimpleBreadcrumbGenerator:
+        alias: App\Model\Breadcrumb\SimpleBreadcrumbGenerator
+
+    Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade:
+        alias: App\Model\Cart\Watcher\CartWatcherFacade
+
     Shopsys\FrameworkBundle\Model\Category\CategoryDataFactoryInterface:
         alias: App\Model\Category\CategoryDataFactory
 
     Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactoryInterface:
         alias: App\Model\Customer\User\CustomerUserDataFactory
+
+    Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade:
+        alias: App\Model\LegalConditions\LegalConditionsFacade
 
     Shopsys\FrameworkBundle\Model\Order\OrderDataFactoryInterface:
         alias: App\Model\Order\OrderDataFactory
@@ -82,6 +94,15 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactoryInterface:
         alias: App\Model\Product\Brand\BrandDataFactory
+
+    Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade:
+        alias: App\Model\Product\Listing\ProductListOrderingModeForBrandFacade
+
+    Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade:
+        alias: App\Model\Product\Listing\ProductListOrderingModeForListFacade
+
+    Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade:
+        alias: App\Model\Product\Listing\ProductListOrderingModeForSearchFacade
 
     App\DataFixtures\Performance\CategoryDataFixture:
         arguments:

--- a/project-base/src/Controller/Front/ContactFormController.php
+++ b/project-base/src/Controller/Front/ContactFormController.php
@@ -21,7 +21,7 @@ class ContactFormController extends FrontBaseController
     private $contactFormFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade
+     * @var \App\Model\LegalConditions\LegalConditionsFacade
      */
     private $legalConditionsFacade;
 
@@ -37,7 +37,7 @@ class ContactFormController extends FrontBaseController
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\ContactForm\ContactFormFacade $contactFormFacade
-     * @param \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
+     * @param \App\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\ContactForm\ContactFormSettingsFacade $contactFormSettingsFacade
      */

--- a/project-base/src/Controller/Front/NewsletterController.php
+++ b/project-base/src/Controller/Front/NewsletterController.php
@@ -22,7 +22,7 @@ class NewsletterController extends FrontBaseController
     private $newsletterFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade
+     * @var \App\Model\LegalConditions\LegalConditionsFacade
      */
     private $legalConditionsFacade;
 
@@ -38,7 +38,7 @@ class NewsletterController extends FrontBaseController
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade $newsletterFacade
-     * @param \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
+     * @param \App\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Form\FormTimeProvider $formTimeProvider
      */

--- a/project-base/src/Controller/Front/OrderController.php
+++ b/project-base/src/Controller/Front/OrderController.php
@@ -105,7 +105,7 @@ class OrderController extends FrontBaseController
     private $session;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade
+     * @var \App\Model\LegalConditions\LegalConditionsFacade
      */
     private $legalConditionsFacade;
 
@@ -129,7 +129,7 @@ class OrderController extends FrontBaseController
      * @param \Symfony\Component\HttpFoundation\Session\SessionInterface $session
      * @param \Shopsys\FrameworkBundle\Model\Order\Watcher\TransportAndPaymentWatcher $transportAndPaymentWatcher
      * @param \Shopsys\FrameworkBundle\Model\Order\Mail\OrderMailFacade $orderMailFacade
-     * @param \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
+     * @param \App\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
      * @param \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade $newsletterFacade
      */
     public function __construct(

--- a/project-base/src/Controller/Front/ProductController.php
+++ b/project-base/src/Controller/Front/ProductController.php
@@ -57,17 +57,17 @@ class ProductController extends FrontBaseController
     private $requestExtension;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade
+     * @var \App\Model\Product\Listing\ProductListOrderingModeForListFacade
      */
     private $productListOrderingModeForListFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade
+     * @var \App\Model\Product\Listing\ProductListOrderingModeForBrandFacade
      */
     private $productListOrderingModeForBrandFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade
+     * @var \App\Model\Product\Listing\ProductListOrderingModeForSearchFacade
      */
     private $productListOrderingModeForSearchFacade;
 
@@ -102,9 +102,9 @@ class ProductController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory $productFilterConfigFactory
-     * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade $productListOrderingModeForListFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade $productListOrderingModeForBrandFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade $productListOrderingModeForSearchFacade
+     * @param \App\Model\Product\Listing\ProductListOrderingModeForListFacade $productListOrderingModeForListFacade
+     * @param \App\Model\Product\Listing\ProductListOrderingModeForBrandFacade $productListOrderingModeForBrandFacade
+     * @param \App\Model\Product\Listing\ProductListOrderingModeForSearchFacade $productListOrderingModeForSearchFacade
      * @param \Shopsys\FrameworkBundle\Model\Module\ModuleFacade $moduleFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
      * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade

--- a/project-base/src/Controller/Front/RegistrationController.php
+++ b/project-base/src/Controller/Front/RegistrationController.php
@@ -37,7 +37,7 @@ class RegistrationController extends FrontBaseController
     private $authenticator;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade
+     * @var \App\Model\LegalConditions\LegalConditionsFacade
      */
     private $legalConditionsFacade;
 
@@ -46,7 +46,7 @@ class RegistrationController extends FrontBaseController
      * @param \App\Model\Customer\User\CustomerUserDataFactory $customerUserDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade $customerUserFacade
      * @param \Shopsys\FrameworkBundle\Model\Security\Authenticator $authenticator
-     * @param \Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
+     * @param \App\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
      */
     public function __construct(
         Domain $domain,

--- a/project-base/src/Model/Breadcrumb/ErrorPageBreadcrumbGenerator.php
+++ b/project-base/src/Model/Breadcrumb/ErrorPageBreadcrumbGenerator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Breadcrumb;
+
+use Shopsys\FrameworkBundle\Model\Breadcrumb\ErrorPageBreadcrumbGenerator as BaseErrorPageBreadcrumbGenerator;
+
+class ErrorPageBreadcrumbGenerator extends BaseErrorPageBreadcrumbGenerator
+{
+    /**
+     * @return string
+     */
+    protected function getTranslatedBreadcrumbForNotFoundPage(): string
+    {
+        return t('Page not found');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getTranslatedBreadcrumbForErrorPage(): string
+    {
+        return t('Oops! Error occurred');
+    }
+}

--- a/project-base/src/Model/Breadcrumb/SimpleBreadcrumbGenerator.php
+++ b/project-base/src/Model/Breadcrumb/SimpleBreadcrumbGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Breadcrumb;
+
+use Shopsys\FrameworkBundle\Model\Breadcrumb\SimpleBreadcrumbGenerator as BaseSimpleBreadcrumbGenerator;
+
+class SimpleBreadcrumbGenerator extends BaseSimpleBreadcrumbGenerator
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function getTranslatedBreadcrumbsByRouteNames(): array
+    {
+        return [
+            'front_customer_edit' => t('Edit data'),
+            'front_customer_orders' => t('Orders'),
+            'front_registration_reset_password' => t('Forgotten password'),
+            'front_customer_order_detail_registered' => t('Order detail'),
+            'front_customer_order_detail_unregistered' => t('Order detail'),
+            'front_login' => t('Login'),
+            'front_product_search' => t('Search [noun]'),
+            'front_registration_register' => t('Registration'),
+            'front_brand_list' => t('Brand overview'),
+            'front_contact' => t('Contact'),
+        ];
+    }
+}

--- a/project-base/src/Model/Cart/Watcher/CartWatcherFacade.php
+++ b/project-base/src/Model/Cart/Watcher/CartWatcherFacade.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Cart\Watcher;
+
+use Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade as BaseCartWatcherFacade;
+
+class CartWatcherFacade extends BaseCartWatcherFacade
+{
+    /**
+     * @return string
+     */
+    protected function getMessageForNoLongerAvailableExistingProduct(): string
+    {
+        return t('Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order.');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMessageForNoLongerAvailableProduct(): string
+    {
+        return t('Product you had in cart is no longer in available. Please check your order.');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMessageForChangedProduct(): string
+    {
+        return t('The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order.');
+    }
+}

--- a/project-base/src/Model/LegalConditions/LegalConditionsFacade.php
+++ b/project-base/src/Model/LegalConditions/LegalConditionsFacade.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\LegalConditions;
+
+use Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade as BaseLegalConditionsFacade;
+
+/**
+ * @method \App\Model\Article\Article|null findTermsAndConditions(int $domainId)
+ * @method setTermsAndConditions(\App\Model\Article\Article|null $termsAndConditions, int $domainId)
+ * @method \App\Model\Article\Article|null findPrivacyPolicy(int $domainId)
+ * @method setPrivacyPolicy(\App\Model\Article\Article|null $privacyPolicy, int $domainId)
+ * @method bool isArticleUsedAsLegalConditions(\App\Model\Article\Article $article)
+ * @method \App\Model\Article\Article|null findArticle(string $settingKey, int $domainId)
+ * @method setArticle(string $settingKey, \App\Model\Article\Article|null $privacyPolicy, int $domainId)
+ */
+class LegalConditionsFacade extends BaseLegalConditionsFacade
+{
+    /**
+     * @return string
+     */
+    public function getTermsAndConditionsDownloadFilename(): string
+    {
+        return t('Terms-and-conditions.html');
+    }
+}

--- a/project-base/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
+++ b/project-base/src/Model/Product/Listing/ProductListOrderingModeForBrandFacade.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Product\Listing;
+
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade as BaseProductListOrderingModeForBrandFacade;
+
+class ProductListOrderingModeForBrandFacade extends BaseProductListOrderingModeForBrandFacade
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function getSupportedOrderingModesNamesById(): array
+    {
+        return [
+            ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
+            ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
+        ];
+    }
+}

--- a/project-base/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
+++ b/project-base/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Product\Listing;
+
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade as BaseProductListOrderingModeForListFacade;
+
+class ProductListOrderingModeForListFacade extends BaseProductListOrderingModeForListFacade
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function getSupportedOrderingModesNamesById(): array
+    {
+        return [
+            ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
+            ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
+        ];
+    }
+}

--- a/project-base/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
+++ b/project-base/src/Model/Product/Listing/ProductListOrderingModeForSearchFacade.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Product\Listing;
+
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
+use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade as BaseProductListOrderingModeForSearchFacade;
+
+class ProductListOrderingModeForSearchFacade extends BaseProductListOrderingModeForSearchFacade
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function getSupportedOrderingModesNamesById(): array
+    {
+        return [
+            ProductListOrderingConfig::ORDER_BY_RELEVANCE => t('relevance'),
+            ProductListOrderingConfig::ORDER_BY_PRIORITY => t('TOP'),
+            ProductListOrderingConfig::ORDER_BY_NAME_ASC => t('alphabetically A -> Z'),
+            ProductListOrderingConfig::ORDER_BY_NAME_DESC => t('alphabetically Z -> A'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_ASC => t('from the cheapest'),
+            ProductListOrderingConfig::ORDER_BY_PRICE_DESC => t('from most expensive'),
+        ];
+    }
+}

--- a/project-base/translations/messages.cs.po
+++ b/project-base/translations/messages.cs.po
@@ -172,6 +172,9 @@ msgstr "Stáhnout zákaznické údaje"
 msgid "EAN"
 msgstr "EAN"
 
+msgid "Edit data"
+msgstr "Upravit údaje"
+
 msgid "Email"
 msgstr "E-mail"
 
@@ -325,6 +328,9 @@ msgstr ""
 msgid "Online shop"
 msgstr "Internetový obchod"
 
+msgid "Oops! Error occurred"
+msgstr "Jejda! Nastala chyba"
+
 msgid "Oops! Error occurred."
 msgstr "Jejda! Nastala chyba."
 
@@ -346,6 +352,9 @@ msgstr "Objednat"
 msgid "Order completed"
 msgstr "Objednávka dokončena"
 
+msgid "Order detail"
+msgstr "Detail objednávky"
+
 msgid "Order not found"
 msgstr "Objednávka nebyla nalezena"
 
@@ -360,6 +369,9 @@ msgstr "Objednávky"
 
 msgid "Our customers who bought this bought also"
 msgstr "Naši zákaznící k tomuto produktu nejčastěji nakupují"
+
+msgid "Page not found"
+msgstr "Stránka nenalezena"
 
 msgid "Page not found!"
 msgstr "Stránka nenalezena!"
@@ -442,6 +454,9 @@ msgstr "Do košíku bylo vloženo zboží <strong>{{ name }}</strong> ({{ quanti
 msgid "Product <strong>{{ name }}</strong> added to the cart (total amount {{ quantity|formatNumber }} {{ unitName }})"
 msgstr "Do košíku bylo vloženo zboží <strong>{{ name }}</strong> (celkem již {{ quantity|formatNumber }} {{ unitName }})"
 
+msgid "Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order."
+msgstr "Zboží <strong>{{ name }}</strong>, které jste měli v košíku, již není v nabídce. Prosím, překontrolujte si objednávku."
+
 msgid "Product filter"
 msgstr "Filtr produktů"
 
@@ -450,6 +465,9 @@ msgstr "Informace o produktu"
 
 msgid "Product no longer on sale"
 msgstr "Zboží se již neprodává"
+
+msgid "Product you had in cart is no longer in available. Please check your order."
+msgstr "Zboží, které jste měli v košíku, již není v nabídce. Prosím, překontrolujte si objednávku."
 
 msgid "Product {{ name }} removed from cart"
 msgstr "Z košíku bylo odstraněno zboží {{ name }}"
@@ -492,6 +510,9 @@ msgstr "Zaokrouhlení"
 
 msgid "Save changes"
 msgstr "Uložit změny"
+
+msgid "Search [noun]"
+msgstr "Hledání"
 
 msgid "Search [verb]"
 msgstr "Vyhledat"
@@ -547,6 +568,9 @@ msgstr "Přihlášení k zpravodaji"
 msgid "Subscription was failed"
 msgstr "Přihlášení k novinkám selhalo"
 
+msgid "TOP"
+msgstr "TOP"
+
 msgid "Tax number"
 msgstr "DIČ"
 
@@ -559,6 +583,9 @@ msgstr "Telefon"
 msgid "Terms and conditions"
 msgstr "Obchodní podmínky"
 
+msgid "Terms-and-conditions.html"
+msgstr "Obchodní-podmínky.html"
+
 msgid "Thank you, your message has been sent."
 msgstr "Děkujeme, váš vzkaz byl odeslán."
 
@@ -570,6 +597,9 @@ msgstr "V průběhu objednávkového procesu byla změněna cena platby {{ payme
 
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."
 msgstr "V průběhu objednávkového procesu byla změněna cena dopravy {{ transportName }}. Prosím, překontrolujte si objednávku."
+
+msgid "The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order."
+msgstr "Byla změněna cena zboží <strong>{{ name }}</strong>, které máte v košíku. Prosím, překontrolujte si objednávku."
 
 msgid "This account doesn't exist or password is incorrect"
 msgstr "Zadali jste špatné uživatelské jméno nebo heslo"
@@ -679,6 +709,12 @@ msgstr "Vaše údaje byly úspěšně zaktualizovány"
 msgid "Your discount"
 msgstr "Vaše sleva"
 
+msgid "alphabetically A -> Z"
+msgstr "abecedně A -> Z"
+
+msgid "alphabetically Z -> A"
+msgstr "abecedně Z -> A"
+
 msgid "excluding VAT"
 msgstr "bez DPH"
 
@@ -688,11 +724,20 @@ msgstr "z"
 msgid "from %price%"
 msgstr "od %price%"
 
+msgid "from most expensive"
+msgstr "od nejdražšího"
+
+msgid "from the cheapest"
+msgstr "od nejlevnějšího"
+
 msgid "products"
 msgstr "zboží"
 
 msgid "records"
 msgstr "záznamů"
+
+msgid "relevance"
+msgstr "relevance"
 
 msgid "to"
 msgstr "do"

--- a/project-base/translations/messages.en.po
+++ b/project-base/translations/messages.en.po
@@ -172,6 +172,9 @@ msgstr ""
 msgid "EAN"
 msgstr ""
 
+msgid "Edit data"
+msgstr ""
+
 msgid "Email"
 msgstr ""
 
@@ -325,6 +328,9 @@ msgstr ""
 msgid "Online shop"
 msgstr ""
 
+msgid "Oops! Error occurred"
+msgstr ""
+
 msgid "Oops! Error occurred."
 msgstr ""
 
@@ -346,6 +352,9 @@ msgstr "Order"
 msgid "Order completed"
 msgstr ""
 
+msgid "Order detail"
+msgstr ""
+
 msgid "Order not found"
 msgstr ""
 
@@ -359,6 +368,9 @@ msgid "Orders"
 msgstr ""
 
 msgid "Our customers who bought this bought also"
+msgstr ""
+
+msgid "Page not found"
 msgstr ""
 
 msgid "Page not found!"
@@ -442,6 +454,9 @@ msgstr ""
 msgid "Product <strong>{{ name }}</strong> added to the cart (total amount {{ quantity|formatNumber }} {{ unitName }})"
 msgstr ""
 
+msgid "Product <strong>{{ name }}</strong> you had in cart is no longer available. Please check your order."
+msgstr ""
+
 msgid "Product filter"
 msgstr ""
 
@@ -449,6 +464,9 @@ msgid "Product information"
 msgstr ""
 
 msgid "Product no longer on sale"
+msgstr ""
+
+msgid "Product you had in cart is no longer in available. Please check your order."
 msgstr ""
 
 msgid "Product {{ name }} removed from cart"
@@ -491,6 +509,9 @@ msgid "Rounding"
 msgstr ""
 
 msgid "Save changes"
+msgstr ""
+
+msgid "Search [noun]"
 msgstr ""
 
 msgid "Search [verb]"
@@ -547,6 +568,9 @@ msgstr ""
 msgid "Subscription was failed"
 msgstr ""
 
+msgid "TOP"
+msgstr ""
+
 msgid "Tax number"
 msgstr ""
 
@@ -559,6 +583,9 @@ msgstr ""
 msgid "Terms and conditions"
 msgstr ""
 
+msgid "Terms-and-conditions.html"
+msgstr ""
+
 msgid "Thank you, your message has been sent."
 msgstr ""
 
@@ -569,6 +596,9 @@ msgid "The price of payment {{ paymentName }} changed during ordering process. C
 msgstr ""
 
 msgid "The price of shipping {{ transportName }} changed during ordering process. Check your order, please."
+msgstr ""
+
+msgid "The price of the product <strong>{{ name }}</strong> you have in cart has changed. Please, check your order."
 msgstr ""
 
 msgid "This account doesn't exist or password is incorrect"
@@ -679,6 +709,12 @@ msgstr ""
 msgid "Your discount"
 msgstr ""
 
+msgid "alphabetically A -> Z"
+msgstr ""
+
+msgid "alphabetically Z -> A"
+msgstr ""
+
 msgid "excluding VAT"
 msgstr ""
 
@@ -688,10 +724,19 @@ msgstr ""
 msgid "from %price%"
 msgstr ""
 
+msgid "from most expensive"
+msgstr ""
+
+msgid "from the cheapest"
+msgstr ""
+
 msgid "products"
 msgstr ""
 
 msgid "records"
+msgstr ""
+
+msgid "relevance"
 msgstr ""
 
 msgid "to"

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -30,3 +30,18 @@ There you can find links to upgrade notes for other versions too.
 
 - update `ProductFilterPage` so it is resistant to case changes ([#2330](https://github.com/shopsys/shopsys/pull/2330))
     - see #project-base-diff to update your project
+
+- extend and implement methods which are marked to be abstract ([#2337](https://github.com/shopsys/shopsys/pull/2337))
+    - following methods will become abstract:
+        - `Shopsys\FrameworkBundle\Model\Breadcrumb\ErrorPageBreadcrumbGenerator::getTranslatedBreadcrumbForNotFoundPage()`
+        - `Shopsys\FrameworkBundle\Model\Breadcrumb\ErrorPageBreadcrumbGenerator::getTranslatedBreadcrumbForErrorPage()`
+        - `Shopsys\FrameworkBundle\Model\Breadcrumb\SimpleBreadcrumbGenerator::getTranslatedBreadcrumbsByRouteNames()`
+        - `Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade::getMessageForNoLongerAvailableExistingProduct()`
+        - `Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade::getMessageForNoLongerAvailableProduct()`
+        - `Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade::getMessageForChangedProduct()`
+        - `Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade::getTermsAndConditionsDownloadFilename()`
+        - `Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade::getSupportedOrderingModesNamesById()`
+        - `Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade::getSupportedOrderingModesNamesById()`
+        - `Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade::getSupportedOrderingModesNamesById()`
+    - run `php phing translations-dump` to extract translations and translate it
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Some translations from front could not be exported to project-base translations because they were used in classes of framework. This PR expose methods to project-base to be exported.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| fixes #1383  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
