### PR TITLE
[framework] company name is return when is not null

### DIFF
--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -283,7 +283,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, Serializab
     public function getFullName()
     {
         if ($this->getCustomer()->getBillingAddress()->isCompanyCustomer()) {
-            return $this->getCustomer()->getBillingAddress()->getCompanyName();
+            return (string)$this->getCustomer()->getBillingAddress()->getCompanyName();
         }
 
         return $this->lastName . ' ' . $this->firstName;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Company name is return only when is not null. Inspired by @RostislavKreisinger 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
