### PR TITLE
[frontend-api] removed deprecated use of `Token::getClaim` in FrontendApiUserFactory

### DIFF
--- a/packages/frontend-api/src/Model/User/FrontendApiUserFactory.php
+++ b/packages/frontend-api/src/Model/User/FrontendApiUserFactory.php
@@ -15,11 +15,11 @@ class FrontendApiUserFactory implements FrontendApiUserFactoryInterface
     public function createFromToken(Token $token): FrontendApiUser
     {
         return new FrontendApiUser(
-            $token->getClaim(FrontendApiUser::CLAIM_UUID),
-            $token->getClaim(FrontendApiUser::CLAIM_FULL_NAME),
-            $token->getClaim(FrontendApiUser::CLAIM_EMAIL),
-            $token->getClaim(FrontendApiUser::CLAIM_DEVICE_ID),
-            $token->getClaim(FrontendApiUser::CLAIM_ROLES)
+            $token->claims()->get(FrontendApiUser::CLAIM_UUID),
+            $token->claims()->get(FrontendApiUser::CLAIM_FULL_NAME),
+            $token->claims()->get(FrontendApiUser::CLAIM_EMAIL),
+            $token->claims()->get(FrontendApiUser::CLAIM_DEVICE_ID),
+            $token->claims()->get(FrontendApiUser::CLAIM_ROLES)
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Method `Lcobucci\JWT\Token::getClaim()` has been removed from the interface in v4.0. Inspired by @RostislavKreisinger 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
