### PR TITLE
added --resume-step option for release command

### DIFF
--- a/utils/releaser/config/services.yaml
+++ b/utils/releaser/config/services.yaml
@@ -33,3 +33,9 @@ services:
         class: Twig_Loader_Filesystem
         arguments:
             - ['upgrade/template']
+
+    Symplify\MonorepoBuilder\Release\Command\ReleaseCommand:
+        class: Shopsys\Releaser\Command\ReleaseCommand
+
+    Symplify\MonorepoBuilder\Release\ReleaseWorkerProvider:
+        class: Shopsys\Releaser\ReleaseWorker\ReleaseWorkerProvider

--- a/utils/releaser/src/Command/ReleaseCommand.php
+++ b/utils/releaser/src/Command/ReleaseCommand.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\Command;
+
+use PharIo\Version\Version;
+use Shopsys\Releaser\ReleaseWorker\ReleaseWorkerProvider;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\MonorepoBuilder\Configuration\Option;
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
+use Symplify\MonorepoBuilder\Release\Guard\ReleaseGuard;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+use Symplify\PackageBuilder\Console\ShellCode;
+
+final class ReleaseCommand extends Command
+{
+    private const RESUME_STEP = 'resume-step';
+
+    /**
+     * @var \Symfony\Component\Console\Style\SymfonyStyle
+     */
+    private $symfonyStyle;
+
+    /**
+     * @var \Symplify\MonorepoBuilder\Release\Guard\ReleaseGuard
+     */
+    private $releaseGuard;
+
+    /**
+     * @var \Shopsys\Releaser\ReleaseWorker\ReleaseWorkerProvider
+     */
+    private $releaseWorkerProvider;
+
+    /**
+     * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyle
+     * @param \Shopsys\Releaser\ReleaseWorker\ReleaseWorkerProvider $releaseWorkerProvider
+     * @param \Symplify\MonorepoBuilder\Release\Guard\ReleaseGuard $releaseGuard
+     */
+    public function __construct(
+        SymfonyStyle $symfonyStyle,
+        ReleaseWorkerProvider $releaseWorkerProvider,
+        ReleaseGuard $releaseGuard
+    ) {
+        parent::__construct();
+
+        $this->symfonyStyle = $symfonyStyle;
+        $this->releaseGuard = $releaseGuard;
+        $this->releaseWorkerProvider = $releaseWorkerProvider;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(CommandNaming::classToName(self::class));
+        $this->setDescription('Perform release process with set Release Workers.');
+
+        $this->addArgument(
+            Option::VERSION,
+            InputArgument::REQUIRED,
+            'Release version, in format "<major>.<minor>.<patch>" or "v<major>.<minor>.<patch>"'
+        );
+
+        $this->addOption(
+            Option::DRY_RUN,
+            null,
+            InputOption::VALUE_NONE,
+            'Do not perform operations, just their preview'
+        );
+
+        $this->addOption(Option::STAGE, null, InputOption::VALUE_REQUIRED, 'Name of stage to perform');
+        $this->addOption(self::RESUME_STEP, null, InputOption::VALUE_REQUIRED, 'Number of step to start from');
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // validation phase
+        $stage = $input->getOption(Option::STAGE);
+        $stage = $stage !== null ? (string)$stage : $stage;
+        $step = $this->resolveStep($input);
+
+        $this->releaseGuard->guardStage($stage);
+
+        /** @var string $versionArgument */
+        $versionArgument = $input->getArgument(Option::VERSION);
+        $version = $this->createValidVersion($versionArgument, $stage);
+
+        $activeReleaseWorkers = $this->releaseWorkerProvider->provideByStage($stage, $step);
+
+        $totalWorkerCount = count($activeReleaseWorkers) + $step;
+        $isDryRun = (bool)$input->getOption(Option::DRY_RUN);
+
+        foreach ($activeReleaseWorkers as $releaseWorker) {
+            $title = sprintf('%d/%d) %s', ++$step, $totalWorkerCount, $releaseWorker->getDescription($version));
+            $this->symfonyStyle->title($title);
+            $this->printReleaseWorkerMetadata($releaseWorker);
+
+            if ($isDryRun === false) {
+                $releaseWorker->work($version);
+            }
+        }
+
+        if ($isDryRun) {
+            $this->symfonyStyle->note('Running in dry mode, nothing is changed');
+        } elseif ($stage === null) {
+            $this->symfonyStyle->success(sprintf('Version "%s" is now released!', $version->getVersionString()));
+        } else {
+            $this->symfonyStyle->success(
+                sprintf('Stage "%s" for version "%s" is now finished!', $stage, $version->getVersionString())
+            );
+        }
+
+        return ShellCode::SUCCESS;
+    }
+
+    /**
+     * @param string $versionArgument
+     * @param string|null $stage
+     * @return \PharIo\Version\Version
+     */
+    private function createValidVersion(string $versionArgument, ?string $stage): Version
+    {
+        // this object performs validation of version
+        $version = new Version($versionArgument);
+
+        $this->releaseGuard->guardVersion($version, $stage);
+
+        return $version;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @return int
+     */
+    private function resolveStep(InputInterface $input): int
+    {
+        $step = $input->getOption(self::RESUME_STEP);
+
+        return $step !== null ? (int)$step - 1 : 0;
+    }
+
+    /**
+     * @param \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface $releaseWorker
+     */
+    private function printReleaseWorkerMetadata(ReleaseWorkerInterface $releaseWorker): void
+    {
+        if ($this->symfonyStyle->isVerbose() === false) {
+            return;
+        }
+
+        // show priority and class on -v/--verbose/--debug
+        $this->symfonyStyle->writeln('priority: ' . $releaseWorker->getPriority());
+        $this->symfonyStyle->writeln('class: ' . get_class($releaseWorker));
+        $this->symfonyStyle->newLine();
+    }
+}

--- a/utils/releaser/src/ReleaseWorker/ReleaseWorkerProvider.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseWorkerProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker;
+
+use Nette\Utils\Strings;
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\StageAwareInterface;
+use Symplify\MonorepoBuilder\Release\Exception\ConflictingPriorityException;
+
+class ReleaseWorkerProvider
+{
+    /**
+     * @var \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface[]
+     */
+    private $releaseWorkersByPriority = [];
+
+    /**
+     * @param \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface[] $releaseWorkers
+     * @param bool $enableDefaultReleaseWorkers
+     */
+    public function __construct(array $releaseWorkers, bool $enableDefaultReleaseWorkers)
+    {
+        $this->setWorkersAndSortByPriority($releaseWorkers, $enableDefaultReleaseWorkers);
+    }
+
+    /**
+     * @param string|null $stage
+     * @param int $step
+     * @return \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface[]
+     */
+    public function provideByStage(?string $stage, int $step): array
+    {
+        if ($stage === null) {
+            return $this->releaseWorkersByPriority;
+        }
+
+        $activeReleaseWorkers = [];
+        foreach ($this->releaseWorkersByPriority as $releaseWorker) {
+            if ($releaseWorker instanceof StageAwareInterface) {
+                if ($stage === $releaseWorker->getStage()) {
+                    $activeReleaseWorkers[] = $releaseWorker;
+                }
+            }
+        }
+
+        if ($step > 0) {
+            $activeReleaseWorkers = array_slice($activeReleaseWorkers, $step);
+        }
+
+        return $activeReleaseWorkers;
+    }
+
+    /**
+     * @param \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface[] $releaseWorkers
+     * @param bool $enableDefaultReleaseWorkers
+     */
+    private function setWorkersAndSortByPriority(array $releaseWorkers, bool $enableDefaultReleaseWorkers): void
+    {
+        foreach ($releaseWorkers as $releaseWorker) {
+            if ($this->shouldSkip($releaseWorker, $enableDefaultReleaseWorkers)) {
+                continue;
+            }
+
+            $priority = $releaseWorker->getPriority();
+            if (isset($this->releaseWorkersByPriority[$priority])) {
+                throw new ConflictingPriorityException($releaseWorker, $this->releaseWorkersByPriority[$priority]);
+            }
+
+            $this->releaseWorkersByPriority[$priority] = $releaseWorker;
+        }
+
+        krsort($this->releaseWorkersByPriority);
+    }
+
+    /**
+     * @param \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface $releaseWorker
+     * @param bool $enableDefaultReleaseWorkers
+     * @return bool
+     */
+    private function shouldSkip(ReleaseWorkerInterface $releaseWorker, bool $enableDefaultReleaseWorkers): bool
+    {
+        if ($enableDefaultReleaseWorkers) {
+            return false;
+        }
+
+        return Strings::startsWith(get_class($releaseWorker), 'Symplify\MonorepoBuilder\Release');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| we want the "--resume-step" option available even for releasing a new 7.3 version so I cherry picked it from https://github.com/shopsys/shopsys/pull/2293
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
