### PR TITLE
[shopsys] removed Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Shopsys Framework
 [![Build Status - master](https://github.com/shopsys/shopsys/workflows/Docker%20build/badge.svg?branch=master)](https://github.com/shopsys/shopsys/actions?query=workflow%3A%22Docker+build%22+branch%3A%22master%22)
-[![Build Status](https://travis-ci.org/shopsys/shopsys.svg?branch=master)](https://travis-ci.org/shopsys/shopsys)
 
 Shopsys Framework is a **fully functional ecommerce platform for businesses transitioning into tech-companies with their own software development team**.
 It contains the most common B2C and B2B features for online stores, and its infrastructure is prepared for high scalability.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Travis is no longer used, so the failing badge is removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
