### PR TITLE
[shopsys] allowed install new version of symfony/dependency-injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
             "Tests\\ProductFeed\\HeurekaDeliveryBundle\\": "packages/product-feed-heureka-delivery/tests/",
             "Tests\\ReadModelBundle\\": "packages/read-model/tests/",
             "Shopsys\\Releaser\\": "utils/releaser/src/",
-            "Shopsys\\Releaser\\Tests\\": "utils/releaser/tests"
+            "Shopsys\\Releaser\\Tests\\": "utils/releaser/tests",
+            "Symplify\\EasyCodingStandard\\Yaml\\": "packages/coding-standards/src/Yaml/"
         }
     },
     "require": {
@@ -181,7 +182,6 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "symfony/dependency-injection": ">=4.4.19",
         "codeception/codeception": ">=4.1.19",
         "friendsofphp/php-cs-fixer": "2.19.0"
     },

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -11,7 +11,6 @@
         }
     ],
     "conflict": {
-        "symfony/dependency-injection": ">=4.4.19 <5.0.0 || 5.1.11 || >=5.2.2",
         "friendsofphp/php-cs-fixer": "2.19.0"
     },
     "require": {
@@ -31,7 +30,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Shopsys\\CodingStandards\\": "src/"
+            "Shopsys\\CodingStandards\\": "src/",
+            "Symplify\\EasyCodingStandard\\Yaml\\": "src/Yaml/"
         }
     },
     "autoload-dev": {

--- a/packages/coding-standards/easy-coding-standard.yml
+++ b/packages/coding-standards/easy-coding-standard.yml
@@ -176,3 +176,6 @@ parameters:
         PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.DetectedCatch: ~
 
         PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\FunctionCallSignatureSniff.Indent: ~
+
+        SlevomatCodingStandard\Sniffs\ControlStructures\DisallowEmptySniff:
+            - '*/src/Yaml/CheckerServiceParametersShifter.php'

--- a/packages/coding-standards/src/Yaml/CheckerServiceParametersShifter.php
+++ b/packages/coding-standards/src/Yaml/CheckerServiceParametersShifter.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Yaml;
+
+use Nette\Utils\Strings;
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
+use Symplify\PackageBuilder\Strings\StringFormatConverter;
+
+/**
+ * Fix for https://github.com/symplify/symplify/issues/2872
+ *
+ * Before:
+ *
+ * services:
+ *      # fixer
+ *      ArrayFixer:
+ *          syntax: short
+ *      # sniff
+ *      ArraySniff:
+ *          syntax: short
+ *
+ * After:
+ *
+ * services:
+ *      # fixer
+ *      ArrayFixer:
+ *          calls:
+ *              - ['configure', [['syntax' => 'short']]
+ *      # sniff
+ *      ArraySniff:
+ *          parameters:
+ *              $syntax: 'short'
+ */
+final class CheckerServiceParametersShifter
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_KEY = 'services';
+
+    /**
+     * @var \Symplify\EasyCodingStandard\Yaml\CheckerConfigurationGuardian
+     */
+    private $checkerConfigurationGuardian;
+
+    /**
+     * @var \Symplify\PackageBuilder\Strings\StringFormatConverter
+     */
+    private $stringFormatConverter;
+
+    private const SERVICE_KEYWORDS = [
+        'alias',
+        'parent',
+        'class',
+        'shared',
+        'synthetic',
+        'lazy',
+        'public',
+        'abstract',
+        'deprecated',
+        'factory',
+        'file',
+        'arguments',
+        'properties',
+        'configurator',
+        'calls',
+        'tags',
+        'decorates',
+        'decoration_inner_name',
+        'decoration_priority',
+        'decoration_on_invalid',
+        'autowire',
+        'autoconfigure',
+        'bind',
+    ];
+
+    public function __construct()
+    {
+        $this->checkerConfigurationGuardian = new CheckerConfigurationGuardian();
+        $this->stringFormatConverter = new StringFormatConverter();
+    }
+
+    /**
+     * @param mixed[] $configuration
+     * @return mixed[]
+     */
+    public function process(array $configuration): array
+    {
+        if (!isset($configuration[self::SERVICES_KEY]) || !is_array($configuration[self::SERVICES_KEY])) {
+            return $configuration;
+        }
+
+        $configuration[self::SERVICES_KEY] = $this->processServices($configuration[self::SERVICES_KEY]);
+
+        return $configuration;
+    }
+
+    /**
+     * @param mixed[] $services
+     * @return mixed[]
+     */
+    private function processServices(array $services): array
+    {
+        foreach ($services as $serviceName => $serviceDefinition) {
+            if (!$this->isCheckerClass($serviceName) || empty($serviceDefinition)) {
+                continue;
+            }
+
+            if (Strings::endsWith($serviceName, 'Fixer')) {
+                $services = $this->processFixer($services, $serviceName, $serviceDefinition);
+            }
+
+            if (Strings::endsWith($serviceName, 'Sniff')) {
+                $services = $this->processSniff($services, $serviceName, $serviceDefinition);
+            }
+
+            // cleanup parameters
+            $services = $this->cleanupParameters($services, $serviceDefinition, $serviceName);
+        }
+
+        return $services;
+    }
+
+    /**
+     * @param string $checker
+     * @return bool
+     */
+    private function isCheckerClass(string $checker): bool
+    {
+        return Strings::endsWith($checker, 'Fixer') || Strings::endsWith($checker, 'Sniff');
+    }
+
+    /**
+     * @param mixed[] $services
+     * @param string $checker
+     * @param mixed[] $serviceDefinition
+     * @return mixed[]
+     */
+    private function processFixer(array $services, string $checker, array $serviceDefinition): array
+    {
+        $this->checkerConfigurationGuardian->ensureFixerIsConfigurable($checker, $serviceDefinition);
+
+        foreach (array_keys($serviceDefinition) as $key) {
+            if ($this->isReservedKey($key)) {
+                continue;
+            }
+
+            $serviceDefinition = $this->correctHeader($checker, $serviceDefinition);
+            $serviceDefinition = $this->stringFormatConverter->camelCaseToUnderscoreInArrayKeys($serviceDefinition);
+
+            $services[$checker]['calls'] = [['configure', [$serviceDefinition]]];
+        }
+
+        return $services;
+    }
+
+    /**
+     * @param mixed[] $services
+     * @param string $checker
+     * @param mixed[] $serviceDefinition
+     * @return mixed[]
+     */
+    private function processSniff(array $services, string $checker, array $serviceDefinition): array
+    {
+        // move parameters to property setters
+        foreach ($serviceDefinition as $key => $value) {
+            if ($this->isReservedKey($key)) {
+                continue;
+            }
+
+            $key = $this->stringFormatConverter->underscoreAndHyphenToCamelCase($key);
+            $this->checkerConfigurationGuardian->ensurePropertyExists($checker, $key);
+
+            $services[$checker]['properties'][$key] = $this->escapeValue($value);
+        }
+
+        return $services;
+    }
+
+    /**
+     * @param mixed[] $services
+     * @param mixed[] $serviceDefinition
+     * @param string $serviceName
+     * @return mixed[]
+     */
+    private function cleanupParameters(array $services, array $serviceDefinition, string $serviceName): array
+    {
+        foreach (array_keys($serviceDefinition) as $key) {
+            if ($this->isReservedKey($key)) {
+                continue;
+            }
+
+            unset($services[$serviceName][$key]);
+        }
+
+        return $services;
+    }
+
+    /**
+     * @param string|int|bool $key
+     * @return bool
+     */
+    private function isReservedKey($key): bool
+    {
+        if (!is_string($key)) {
+            return false;
+        }
+
+        return in_array($key, self::SERVICE_KEYWORDS, true);
+    }
+
+    /**
+     * @param string $checker
+     * @param mixed[] $serviceDefinition
+     * @return mixed[]
+     */
+    private function correctHeader(string $checker, array $serviceDefinition): array
+    {
+        // fixes comment extra bottom space
+        if ($checker !== HeaderCommentFixer::class) {
+            return $serviceDefinition;
+        }
+
+        if (isset($serviceDefinition['header'])) {
+            $serviceDefinition['header'] = trim($serviceDefinition['header']);
+        }
+
+        return $serviceDefinition;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function escapeValue($value)
+    {
+        if (!is_array($value) && !is_string($value)) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $nestedValue) {
+                $value[$key] = $this->escapeValue($nestedValue);
+            }
+
+            return $value;
+        }
+
+        return Strings::replace($value, '#^@#', '@@');
+    }
+}

--- a/project-base/symfony.lock
+++ b/project-base/symfony.lock
@@ -429,6 +429,9 @@
     "object-calisthenics/phpcs-calisthenics-rules": {
         "version": "v3.4.0"
     },
+    "ocramius/proxy-manager": {
+        "version": "2.11.1"
+    },
     "overblog/graphiql-bundle": {
         "version": "0.1",
         "recipe": {
@@ -936,6 +939,9 @@
     "symfony/polyfill-php80": {
         "version": "v1.18.0"
     },
+    "symfony/polyfill-php81": {
+        "version": "v1.23.0"
+    },
     "symfony/polyfill-util": {
         "version": "v1.12.0"
     },
@@ -1154,6 +1160,9 @@
     },
     "vasek-purchart/console-errors-bundle": {
         "version": "1.0.1"
+    },
+    "webimpress/safe-writer": {
+        "version": "2.2.0"
     },
     "webmozart/assert": {
         "version": "1.5.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -855,6 +855,9 @@
     "symfony/polyfill-php80": {
         "version": "v1.17.1"
     },
+    "symfony/polyfill-php81": {
+        "version": "v1.23.0"
+    },
     "symfony/process": {
         "version": "v3.4.32"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2210 was locked version of symfony/dependency-injection due to bug in symplify/symplify#2872. This PR allows back installing new versions of the symfony/dependency-injection and fixes introduced bug in symplify/symplify. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

upgrade notes not added because the `project-base/symfony.lock` file is updated automatically and it's not necessary to do anything.