### PR TITLE
[framework] admin: fix label alignment in multidomain fields

### DIFF
--- a/packages/framework/assets/styles/admin/components/form/line.less
+++ b/packages/framework/assets/styles/admin/components/form/line.less
@@ -1,5 +1,5 @@
-@form-line-input-size: 230px;
-@form-line-label-size: 230px;
+@form-line-input-size: 250px;
+@form-line-label-size: 250px;
 @form-line-gap-size: 10px;
 @form-line-padding-horizontal: 22px;
 @form-line-padding-vertical: 15px;

--- a/packages/framework/assets/styles/admin/components/form/line.less
+++ b/packages/framework/assets/styles/admin/components/form/line.less
@@ -32,6 +32,11 @@
         padding-bottom: 0;
     }
 
+    &--no-horizontal-gap {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
     & + .form-line,
     &__js + .form-line {
         border-top: 0;

--- a/packages/framework/assets/styles/admin/components/in/ckeditor.less
+++ b/packages/framework/assets/styles/admin/components/in/ckeditor.less
@@ -1,6 +1,4 @@
 .in-ckeditor {
-    padding-top: 45px;
-    
     &--with-gap {
         padding-left: 35px;
     }

--- a/packages/framework/assets/styles/admin/components/in/ckeditor.less
+++ b/packages/framework/assets/styles/admin/components/in/ckeditor.less
@@ -1,4 +1,6 @@
 .in-ckeditor {
+    padding-top: 45px;
+    
     &--with-gap {
         padding-left: 35px;
     }

--- a/packages/framework/assets/styles/admin/components/in/image.less
+++ b/packages/framework/assets/styles/admin/components/in/image.less
@@ -48,6 +48,7 @@
         .in-image--long-bordered & {
             height: auto;
             padding-top: 5px;
+            padding-left: 10px;
         }
 
         .in-product-visibility &,

--- a/packages/framework/assets/styles/admin/core/form/input.less
+++ b/packages/framework/assets/styles/admin/core/form/input.less
@@ -15,6 +15,8 @@
 @input-width-with-domain: 408px;
 @input-bg-color: @color-f;
 
+@input-domain-top-offset: 9px;
+
 .input {
     width: @input-width;
     max-width: 100%;
@@ -190,14 +192,15 @@
     }
 
     &__domain {
+        display: flex;
+        align-items: center;
         position: absolute;
-        top: 22px;
+        top: @input-domain-top-offset;
         left: 10px;
         width: 46px;
-        height: calc(~"@{input-height} - 2*10px");
+        height: calc(~"@{input-height} - 2* @{input-domain-top-offset}");
 
         img {
-            .center-image();
             max-width: @in-image-width;
             max-height: @in-image-height;
         }

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -169,7 +169,7 @@
             </div>
             {{ form_errors(form) }}
         </div>
-    {% elseif multidomain is defined %}
+    {% elseif multidomain is defined and multidomain %}
         <div class="form-line__side form-line__side--multidomain">
             <div class="form-line__item">
                 <div class="input__wrap">
@@ -217,7 +217,7 @@
 {%- endblock text_row %}
 
 {% block money_row %}
-    {% if multidomain is defined %}
+    {% if multidomain is defined and multidomain %}
         <div class="form-line__side form-line__side--multidomain">
             <div class="form-line__item">
                 <div class="input__wrap">
@@ -269,8 +269,8 @@
             {% if js_container is not null %}
                 <div class="{{ js_container.container_class }}" data-type="{{ js_container.data_type }}">
             {% endif %}
-            <div class="form-line{% if multidomain is defined and isMultidomain() %} form-line--no-horizontal-gap{% endif %}">
-            {% if multidomain is defined %}
+            <div class="form-line{% if multidomain is defined and multidomain and isMultidomain() %} form-line--no-horizontal-gap{% endif %}">
+            {% if multidomain is defined and multidomain %}
                 {% if isMultidomain() %}
                     {{ form_label(form, getDomainName(domainId)) }}
                 {% endif %}
@@ -279,7 +279,7 @@
             {% endif %}
             {{- form_errors(form) -}}
             {% if newline is not defined %}
-                {% if multidomain is defined and isMultidomain() %}
+                {% if multidomain is defined and multidomain and isMultidomain() %}
                     <div class="form-line__side form-line__side--multidomain">
                         <div class="input__wrap">
                             {{- form_widget(form, { attr: { class: 'input--domain' }}) -}}
@@ -868,7 +868,7 @@
 {% endmacro %}
 
 {% block yes_no_row %}
-    {% if multidomain is defined %}
+    {% if multidomain is defined and multidomain %}
         <div class="form-line__side">
             {% if isMultidomain() %}
                 {{ domainIcon(domainId, 'long-bordered') }}

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -279,7 +279,7 @@
             {% endif %}
             {{- form_errors(form) -}}
             {% if newline is not defined %}
-                {% if isMultidomain() %}
+                {% if multidomain is defined and isMultidomain() %}
                     <div class="form-line__side form-line__side--multidomain">
                         <div class="input__wrap">
                             {{- form_widget(form, { attr: { class: 'input--domain' }}) -}}
@@ -289,8 +289,10 @@
                         </div>
                     </div>
                 {% else %}
-                    <div class="form-line__item form-line__item--full-width">
-                        {{- form_widget(form) -}}
+                    <div class="form-line__side">
+                        <div class="form-line__item form-line__item--full-width">
+                            {{- form_widget(form) -}}
+                        </div>
                     </div>
                 {% endif %}
             {% else %}

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -289,10 +289,8 @@
                         </div>
                     </div>
                 {% else %}
-                    <div>
-                        <div class="form-line__item form-line__item--full-width">
-                            {{- form_widget(form) -}}
-                        </div>
+                    <div class="form-line__item form-line__item--full-width">
+                        {{- form_widget(form) -}}
                     </div>
                 {% endif %}
             {% else %}

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -50,7 +50,7 @@
 
 {% block form_row %}
     {% if render_form_row %}
-        <div class="form-line{{ attr.disabledField is defined ? ' form-input-disabled form-line--disabled' }}">
+        <div class="form-line{% if multidomain is defined and multidomain %} form-line--no-horizontal-gap{% endif %}{{ attr.disabledField is defined ? ' form-input-disabled form-line--disabled' }}">
         {{ form_errors(form) }}
         {{ form_label(form, label) }}
     {% endif %}
@@ -269,22 +269,32 @@
             {% if js_container is not null %}
                 <div class="{{ js_container.container_class }}" data-type="{{ js_container.data_type }}">
             {% endif %}
-            <div class="form-line">
+            <div class="form-line{% if multidomain is defined and isMultidomain() %} form-line--no-horizontal-gap{% endif %}">
             {% if multidomain is defined %}
                 {% if isMultidomain() %}
                     {{ form_label(form, getDomainName(domainId)) }}
-                    {{ domainIcon(domainId) }}
                 {% endif %}
             {% else %}
                 {{ form_label(form, label) }}
             {% endif %}
             {{- form_errors(form) -}}
             {% if newline is not defined %}
-                <div{% if isMultidomain() %} class="form-line__side"{% endif %}>
-                    <div class="form-line__item form-line__item--full-width">
-                        {{- form_widget(form) -}}
+                {% if isMultidomain() %}
+                    <div class="form-line__side form-line__side--multidomain">
+                        <div class="input__wrap">
+                            {{- form_widget(form, { attr: { class: 'input--domain' }}) -}}
+                            <span class="input__domain">
+                                {{ domainIcon(domainId) }}
+                            </span>
+                        </div>
                     </div>
-                </div>
+                {% else %}
+                    <div>
+                        <div class="form-line__item form-line__item--full-width">
+                            {{- form_widget(form) -}}
+                        </div>
+                    </div>
+                {% endif %}
             {% else %}
                 <div{% if isMultidomain() %} class="form-line__side"{% endif %}>
                     {% set inputAttr = attr|merge({'class': (attr.class|default('') ~ ' input--textarea')|trim}) %}
@@ -859,11 +869,13 @@
 
 {% block yes_no_row %}
     {% if multidomain is defined %}
-        {% if isMultidomain() %}
-            {{ domainIcon(domainId, 'long-bordered') }}
-        {% endif %}
-        {{ form_widget(form, { isSimple: isSimple|default(isMultidomain()) }) }}
-        {{ form_errors(form) }}
+        <div class="form-line__side">
+            {% if isMultidomain() %}
+                {{ domainIcon(domainId, 'long-bordered') }}
+            {% endif %}
+            {{ form_widget(form, { isSimple: isSimple|default(isMultidomain()) }) }}
+            {{ form_errors(form) }}
+        </div>
     {% else %}
         {{ block('form_row') }}
     {% endif %}

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -869,13 +869,11 @@
 
 {% block yes_no_row %}
     {% if multidomain is defined and multidomain %}
-        <div class="form-line__side">
-            {% if isMultidomain() %}
-                {{ domainIcon(domainId, 'long-bordered') }}
-            {% endif %}
-            {{ form_widget(form, { isSimple: isSimple|default(isMultidomain()) }) }}
-            {{ form_errors(form) }}
-        </div>
+        {% if isMultidomain() %}
+            {{ domainIcon(domainId, 'long-bordered') }}
+        {% endif %}
+        {{ form_widget(form, { isSimple: isSimple|default(isMultidomain()) }) }}
+        {{ form_errors(form) }}
     {% else %}
         {{ block('form_row') }}
     {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Labels in the administration were bad align when the multidomain fields were added. This PR fixes this.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1783
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
