### PR TITLE
Fix persist on null object in create delivery address

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -268,6 +268,12 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   see #project-base-diff to update your project
 
+#### fix persist on null object in create delivery address ([#2350](https://github.com/shopsys/shopsys/pull/2350))
+
+-   `Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFacade` class has changed:
+    -   `create` method was renamed to `createIfAddressFilled` and return type was changed to `?DeliveryAddress`
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Model/Customer/DeliveryAddressFacade.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddressFacade.php
@@ -34,11 +34,15 @@ class DeliveryAddressFacade
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData $deliveryAddressData
-     * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress
+     * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress|null
      */
-    public function create(DeliveryAddressData $deliveryAddressData): DeliveryAddress
+    public function createIfAddressFilled(DeliveryAddressData $deliveryAddressData): ?DeliveryAddress
     {
         $deliveryAddress = $this->deliveryAddressFactory->create($deliveryAddressData);
+
+        if ($deliveryAddress === null) {
+            return null;
+        }
 
         $this->em->persist($deliveryAddress);
         $this->em->flush();

--- a/packages/framework/src/Model/Customer/User/CustomerUserFacade.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserFacade.php
@@ -103,10 +103,13 @@ class CustomerUserFacade
             && $customerUserUpdateData->deliveryAddressData->addressFilled
         ) {
             $customerUserUpdateData->deliveryAddressData->customer = $customer;
-            $deliveryAddress = $this->deliveryAddressFacade->create($customerUserUpdateData->deliveryAddressData);
+            $deliveryAddress = $this->deliveryAddressFacade->createIfAddressFilled($customerUserUpdateData->deliveryAddressData);
 
             $customerData = $this->customerDataFactory->createFromCustomer($customer);
-            $customerData->deliveryAddresses[] = $deliveryAddress;
+
+            if ($deliveryAddress !== null) {
+                $customerData->deliveryAddresses[] = $deliveryAddress;
+            }
             $this->customerFacade->edit($customer->getId(), $customerData);
 
             $customerUserUpdateData->customerUserData->defaultDeliveryAddress = $deliveryAddress;
@@ -158,7 +161,7 @@ class CustomerUserFacade
             && $customerUserUpdateData->deliveryAddressData->addressFilled
         ) {
             $customerUserUpdateData->deliveryAddressData->customer = $customerUser->getCustomer();
-            $deliveryAddress = $this->deliveryAddressFacade->create($customerUserUpdateData->deliveryAddressData);
+            $deliveryAddress = $this->deliveryAddressFacade->createIfAddressFilled($customerUserUpdateData->deliveryAddressData);
             $customerUserUpdateData->customerUserData->defaultDeliveryAddress = $deliveryAddress;
         }
 

--- a/project-base/app/src/Model/Customer/DeliveryAddressFacade.php
+++ b/project-base/app/src/Model/Customer/DeliveryAddressFacade.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFacade as BaseDelivery
 /**
  * @property \App\Model\Customer\DeliveryAddressRepository $deliveryAddressRepository
  * @method edit(int $deliveryAddressId, \App\Model\Customer\DeliveryAddressData $deliveryAddressData)
- * @method \App\Model\Customer\DeliveryAddress create(\App\Model\Customer\DeliveryAddressData $deliveryAddressData)
+ * @method \App\Model\Customer\DeliveryAddress|null createIfAddressFilled(\App\Model\Customer\DeliveryAddressData $deliveryAddressData)
  * @method \App\Model\Customer\DeliveryAddress delete(int $deliveryAddressId)
  * @method \App\Model\Customer\DeliveryAddress getById(int $deliveryAddressId)
  * @method __construct(\Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFactory $deliveryAddressFactory, \App\Model\Customer\DeliveryAddressRepository $deliveryAddressRepository, \Doctrine\ORM\EntityManagerInterface $em)

--- a/project-base/app/tests/FrontendApiBundle/Functional/Customer/SetDefaultDeliveryAddressTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Customer/SetDefaultDeliveryAddressTest.php
@@ -63,6 +63,6 @@ class SetDefaultDeliveryAddressTest extends GraphQlWithLoginTestCase
         $deliveryAddressData->country = $country;
         $deliveryAddressData->customer = $customerUser->getCustomer();
 
-        return $this->deliveryAddressFacade->create($deliveryAddressData);
+        return $this->deliveryAddressFacade->createIfAddressFilled($deliveryAddressData);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Error on create delivery address, if $data->addressFilled is set to false
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Fix error 500 on create deliveryAddress when $data->addressFilled set to false, because persists null object.
