### PR TITLE
[shopsys] extract setter injection methods into trait

### DIFF
--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -2,7 +2,6 @@
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use BadMethodCallException;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
@@ -10,7 +9,7 @@ use Shopsys\FrameworkBundle\Command\Exception\CronCommandException;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,6 +19,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class CronCommand extends Command
 {
+    use SetterInjectionTrait;
+
     private const OPTION_MODULE = 'module';
     private const OPTION_LIST = 'list';
     private const OPTION_INSTANCE_NAME = 'instance-name';
@@ -68,18 +69,7 @@ class CronCommand extends Command
      */
     public function setParameterBag(ParameterBagInterface $parameterBag): void
     {
-        if ($this->parameterBag !== null && $this->parameterBag !== $parameterBag) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->parameterBag !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->parameterBag = $parameterBag;
+        $this->setDependency($parameterBag, 'parameterBag');
     }
 
     protected function configure()

--- a/packages/framework/src/Component/Elasticsearch/AbstractExportChangedCronModule.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractExportChangedCronModule.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\Console\Output\NullOutput;
@@ -14,6 +13,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 abstract class AbstractExportChangedCronModule implements SimpleCronModuleInterface
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex
      */
@@ -74,18 +75,7 @@ abstract class AbstractExportChangedCronModule implements SimpleCronModuleInterf
      */
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher): void
     {
-        if ($this->eventDispatcher !== null && $this->eventDispatcher !== $eventDispatcher) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->eventDispatcher !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->eventDispatcher = $eventDispatcher;
+        $this->setDependency($eventDispatcher, 'eventDispatcher');
     }
 
     public function run()

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -2,20 +2,21 @@
 
 namespace Shopsys\FrameworkBundle\Component\FileUpload;
 
-use BadMethodCallException;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\FileUpload\Exception\MoveToEntityFailedException;
 use Shopsys\FrameworkBundle\Component\FileUpload\Exception\UploadFailedException;
 use Shopsys\FrameworkBundle\Component\String\TransformString;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FileUpload
 {
+    use SetterInjectionTrait;
+
     protected const TEMPORARY_DIRECTORY = 'fileUploads';
     protected const DELETE_OLD_FILES_SECONDS = 86400;
 
@@ -88,18 +89,7 @@ class FileUpload
      */
     public function setEventDispatcher(ParameterBagInterface $parameterBag): void
     {
-        if ($this->parameterBag !== null && $this->parameterBag !== $parameterBag) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->parameterBag !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->parameterBag = $parameterBag;
+        $this->setDependency($parameterBag, 'parameterBag');
     }
 
     /**

--- a/packages/framework/src/Component/Image/Config/ImageConfig.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfig.php
@@ -2,14 +2,15 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image\Config;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageEntityConfigNotFoundException;
 use Shopsys\FrameworkBundle\Component\Image\Image;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 
 class ImageConfig
 {
+    use SetterInjectionTrait;
+
     public const ORIGINAL_SIZE_NAME = 'original';
     public const DEFAULT_SIZE_NAME = 'default';
 
@@ -58,19 +59,7 @@ class ImageConfig
      */
     public function setEntityNameResolver(EntityNameResolver $entityNameResolver): void
     {
-        if ($this->entityNameResolver !== null && $this->entityNameResolver !== $entityNameResolver) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->entityNameResolver !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->entityNameResolver = $entityNameResolver;
+        $this->setDependency($entityNameResolver, 'entityNameResolver');
         $this->setUpImageEntityConfigsByClass($this->imageEntityConfigsByClass);
     }
 

--- a/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
+++ b/packages/framework/src/Component/Image/Config/ImageConfigLoader.php
@@ -2,8 +2,6 @@
 
 namespace Shopsys\FrameworkBundle\Component\Image\Config;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateEntityNameException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\DuplicateMediaException;
@@ -13,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Image\Config\Exception\EntityParseExceptio
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageConfigException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\WidthAndHeightMissingException;
 use Shopsys\FrameworkBundle\Component\Utils\Utils;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -20,6 +19,8 @@ use Symfony\Component\Yaml\Parser;
 
 class ImageConfigLoader
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Symfony\Component\Filesystem\Filesystem
      */
@@ -57,19 +58,7 @@ class ImageConfigLoader
      */
     public function setEntityNameResolver(EntityNameResolver $entityNameResolver): void
     {
-        if ($this->entityNameResolver !== null && $this->entityNameResolver !== $entityNameResolver) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->entityNameResolver !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->entityNameResolver = $entityNameResolver;
+        $this->setDependency($entityNameResolver, 'entityNameResolver');
     }
 
     /**

--- a/packages/framework/src/Component/Router/DomainRouterFactory.php
+++ b/packages/framework/src/Component/Router/DomainRouterFactory.php
@@ -2,7 +2,6 @@
 
 namespace Shopsys\FrameworkBundle\Component\Router;
 
-use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -10,6 +9,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Exception\InvalidDomainIdException;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Router\Exception\RouterNotResolvedException;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRouterFactory;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -18,6 +18,8 @@ use Symfony\Component\Routing\RequestContext;
 
 class DomainRouterFactory
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory
      */
@@ -101,18 +103,7 @@ class DomainRouterFactory
      */
     public function setContainer(ContainerInterface $container): void
     {
-        if ($this->container !== null && $this->container !== $container) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->container !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->container = $container;
+        $this->setDependency($container, 'container');
     }
 
     /**

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -4,18 +4,20 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
-use BadMethodCallException;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\ReachMaxUrlUniqueResolveAttemptException;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Contracts\Cache\CacheInterface;
 
 class FriendlyUrlFacade
 {
+    use SetterInjectionTrait;
+
     protected const MAX_URL_UNIQUE_RESOLVE_ATTEMPT = 100;
 
     /**
@@ -300,21 +302,7 @@ class FriendlyUrlFacade
      */
     public function setFriendlyUrlCacheKeyProvider(FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider): void
     {
-        if (
-            $this->friendlyUrlCacheKeyProvider !== null
-            && $this->friendlyUrlCacheKeyProvider !== $friendlyUrlCacheKeyProvider
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->friendlyUrlCacheKeyProvider !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
+        $this->setDependency($friendlyUrlCacheKeyProvider, 'friendlyUrlCacheKeyProvider');
     }
 
     /**

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGenerator.php
@@ -2,11 +2,11 @@
 
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
-use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\MethodGenerateIsNotSupportedException;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGenerator as BaseUrlGenerator;
@@ -18,6 +18,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 
 class FriendlyUrlGenerator extends BaseUrlGenerator
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository
      */
@@ -215,20 +217,6 @@ class FriendlyUrlGenerator extends BaseUrlGenerator
      */
     public function setFriendlyUrlCacheKeyProvider(FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider): void
     {
-        if (
-            $this->friendlyUrlCacheKeyProvider !== null
-            && $this->friendlyUrlCacheKeyProvider !== $friendlyUrlCacheKeyProvider
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->friendlyUrlCacheKeyProvider !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
+        $this->setDependency($friendlyUrlCacheKeyProvider, 'friendlyUrlCacheKeyProvider');
     }
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRouterFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlRouterFactory.php
@@ -2,15 +2,16 @@
 
 namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Contracts\Cache\CacheInterface;
 
 class FriendlyUrlRouterFactory
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Symfony\Component\Config\Loader\LoaderInterface
      */
@@ -86,20 +87,6 @@ class FriendlyUrlRouterFactory
      */
     public function setFriendlyUrlCacheKeyProvider(FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider): void
     {
-        if (
-            $this->friendlyUrlCacheKeyProvider !== null
-            && $this->friendlyUrlCacheKeyProvider !== $friendlyUrlCacheKeyProvider
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->friendlyUrlCacheKeyProvider !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->friendlyUrlCacheKeyProvider = $friendlyUrlCacheKeyProvider;
+        $this->setDependency($friendlyUrlCacheKeyProvider, 'friendlyUrlCacheKeyProvider');
     }
 }

--- a/packages/framework/src/Component/Router/LocalizedRouterFactory.php
+++ b/packages/framework/src/Component/Router/LocalizedRouterFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Router;
 
-use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\FrameworkBundle\Component\Router\Exception\LocalizedRoutingConfigFileNotFoundException;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -15,6 +15,8 @@ use Symfony\Component\Routing\RequestContext;
 
 class LocalizedRouterFactory
 {
+    use SetterInjectionTrait;
+
     /**
      * @deprecated This loader is deprecated and will be removed in the next major. Use Symfony\Bundle\FrameworkBundle\Routing\Router instead of Symfony\Component\Routing\Router without this dependency.
      * @var \Symfony\Component\Config\Loader\LoaderInterface
@@ -67,18 +69,7 @@ class LocalizedRouterFactory
      */
     public function setContainer(ContainerInterface $container): void
     {
-        if ($this->container !== null && $this->container !== $container) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->container !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->container = $container;
+        $this->setDependency($container, 'container');
     }
 
     /**

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
@@ -13,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Grid\MoneyConvertingDataSourceDecorator;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Form\Admin\Customer\User\CustomerUserUpdateFormType;
 use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData;
 use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormType;
@@ -32,6 +31,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CustomerController extends AdminBaseController
 {
+    use SetterInjectionTrait;
+
     protected const LOGIN_AS_TOKEN_ID_PREFIX = 'loginAs';
 
     /**
@@ -143,20 +144,7 @@ class CustomerController extends AdminBaseController
      */
     public function setDomain(Domain $domain): void
     {
-        if ($this->domain !== null && $this->domain !== $domain) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-
-        if ($this->domain !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->domain = $domain;
+        $this->setDependency($domain, 'domain');
     }
 
     /**

--- a/packages/framework/src/DependencyInjection/SetterInjectionTrait.php
+++ b/packages/framework/src/DependencyInjection/SetterInjectionTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\DependencyInjection;
+
+use BadMethodCallException;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+
+trait SetterInjectionTrait
+{
+    /**
+     * @param object $argument
+     * @param string $propertyName
+     */
+    public function setDependency(object $argument, string $propertyName): void
+    {
+        $caller = debug_backtrace()[1];
+        $methodName = $caller['function'];
+
+        if (isset($caller['class'])) {
+            $methodName = $caller['class'] . '::' . $methodName;
+        }
+
+        if ($this->{$propertyName} !== null && $argument !== $this->{$propertyName}) {
+            throw new BadMethodCallException(
+                sprintf('Method "%s()" has been already called and cannot be called multiple times.', $methodName)
+            );
+        }
+        if ($this->{$propertyName} !== null) {
+            return;
+        }
+
+        DeprecationHelper::triggerSetterInjection($methodName);
+
+        $this->{$propertyName} = $argument;
+    }
+}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter;
 
-use BadMethodCallException;
 use Doctrine\ORM\QueryBuilder;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
@@ -18,6 +17,8 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class ProductCategoryFilter implements AdvancedSearchFilterInterface
 {
+    use SetterInjectionTrait;
+
     public const NAME = 'productCategory';
 
     /**
@@ -58,18 +59,7 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
      */
     public function setLocalization(Localization $localization): void
     {
-        if ($this->localization !== null && $this->localization !== $localization) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->localization !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->localization = $localization;
+        $this->setDependency($localization, 'localization');
     }
 
     /**

--- a/packages/framework/src/Model/Customer/User/CustomerUserPasswordFacade.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserPasswordFacade.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Customer\User;
 
-use BadMethodCallException;
 use Doctrine\ORM\EntityManagerInterface;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\String\HashGenerator;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Customer\Exception\InvalidResetPasswordHashUserException;
 use Shopsys\FrameworkBundle\Model\Customer\Mail\ResetPasswordMailFacade;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 class CustomerUserPasswordFacade
 {
+    use SetterInjectionTrait;
+
     public const RESET_PASSWORD_HASH_LENGTH = 50;
     public const MINIMUM_PASSWORD_LENGTH = 6;
 
@@ -79,21 +80,7 @@ class CustomerUserPasswordFacade
     public function setCustomerUserRefreshTokenChainFacade(
         CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade
     ): void {
-        if (
-            $this->customerUserRefreshTokenChainFacade !== null
-            && $this->customerUserRefreshTokenChainFacade !== $customerUserRefreshTokenChainFacade
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->customerUserRefreshTokenChainFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->customerUserRefreshTokenChainFacade = $customerUserRefreshTokenChainFacade;
+        $this->setDependency($customerUserRefreshTokenChainFacade, 'customerUserRefreshTokenChainFacade');
     }
 
     /**

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch;
 
-use BadMethodCallException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandCachedFacade;
@@ -25,6 +24,8 @@ use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository;
 
 class ProductExportRepository
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
      */
@@ -118,22 +119,7 @@ class ProductExportRepository
      */
     public function setCategoryFacade(CategoryFacade $categoryFacade): void
     {
-        if (
-            $this->categoryFacade !== null
-            && $this->categoryFacade !== $categoryFacade
-        ) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->categoryFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->categoryFacade = $categoryFacade;
+        $this->setDependency($categoryFacade, 'categoryFacade');
     }
 
     /**
@@ -143,22 +129,7 @@ class ProductExportRepository
      */
     public function setProductAccessoryFacade(ProductAccessoryFacade $productAccessoryFacade): void
     {
-        if (
-            $this->productAccessoryFacade !== null
-            && $this->productAccessoryFacade !== $productAccessoryFacade
-        ) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->productAccessoryFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productAccessoryFacade = $productAccessoryFacade;
+        $this->setDependency($productAccessoryFacade, 'productAccessoryFacade');
     }
 
     /**
@@ -168,22 +139,7 @@ class ProductExportRepository
      */
     public function setBrandCachedFacade(BrandCachedFacade $brandCachedFacade): void
     {
-        if (
-            $this->brandCachedFacade !== null
-            && $this->brandCachedFacade !== $brandCachedFacade
-        ) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->brandCachedFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->brandCachedFacade = $brandCachedFacade;
+        $this->setDependency($brandCachedFacade, 'brandCachedFacade');
     }
 
     /**
@@ -379,8 +335,8 @@ class ProductExportRepository
             ->select('p')
             ->from(Product::class, 'p')
             ->join(ProductVisibility::class, 'prv', Join::WITH, 'prv.product = p.id')
-                ->andWhere('prv.domainId = :domainId')
-                ->andWhere('prv.visible = TRUE')
+            ->andWhere('prv.domainId = :domainId')
+            ->andWhere('prv.visible = TRUE')
             ->groupBy('p.id')
             ->orderBy('p.id');
 

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -2,12 +2,11 @@
 
 namespace Shopsys\FrameworkBundle\Model\Product;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository;
@@ -20,6 +19,8 @@ use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
 
 class ProductDataFactory implements ProductDataFactoryInterface
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade
      */
@@ -137,18 +138,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
      */
     public function setAvailabilityFacade(AvailabilityFacade $availabilityFacade)
     {
-        if ($this->availabilityFacade !== null && $this->availabilityFacade !== $availabilityFacade) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->availabilityFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->availabilityFacade = $availabilityFacade;
+        $this->setDependency($availabilityFacade, 'availabilityFacade');
     }
 
     /**

--- a/packages/framework/src/Twig/UploadedFileExtension.php
+++ b/packages/framework/src/Twig/UploadedFileExtension.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Twig;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\Exception\ImageNotFoundException;
 use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile;
 use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade;
 use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileLocator;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Twig\FileThumbnail\FileThumbnailExtension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class UploadedFileExtension extends AbstractExtension
 {
+    use SetterInjectionTrait;
+
     protected const FILE_NOT_FOUND_ICON_TYPE = 'not-found';
 
     /**
@@ -64,18 +65,7 @@ class UploadedFileExtension extends AbstractExtension
      */
     public function setUploadedFileLocator(UploadedFileLocator $uploadedFileLocator)
     {
-        if ($this->uploadedFileLocator !== null && $this->uploadedFileLocator !== $uploadedFileLocator) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->uploadedFileLocator !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->uploadedFileLocator = $uploadedFileLocator;
+        $this->setDependency($uploadedFileLocator, 'uploadedFileLocator');
     }
 
     /**

--- a/packages/frontend-api/src/Component/Constraints/ProductCanBeOrderedValidator.php
+++ b/packages/frontend-api/src/Component/Constraints/ProductCanBeOrderedValidator.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Component\Constraints;
 
-use BadMethodCallException;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade;
@@ -18,6 +17,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class ProductCanBeOrderedValidator extends ConstraintValidator
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
      * @deprecated This property will be removed in next major version as it is no longer in use
@@ -72,22 +73,7 @@ class ProductCanBeOrderedValidator extends ConstraintValidator
      */
     public function setFrontendApiProductFacade(FrontendApiProductFacade $frontendApiProductFacade): void
     {
-        if (
-            $this->frontendApiProductFacade !== null
-            && $this->frontendApiProductFacade !== $frontendApiProductFacade
-        ) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->frontendApiProductFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->frontendApiProductFacade = $frontendApiProductFacade;
+        $this->setDependency($frontendApiProductFacade, 'frontendApiProductFacade');
     }
 
     /**

--- a/packages/frontend-api/src/Controller/FrontendApiController.php
+++ b/packages/frontend-api/src/Controller/FrontendApiController.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Controller;
 
-use BadMethodCallException;
 use Overblog\GraphQLBundle\Controller\GraphController;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrontendApiBundle\Component\Domain\EnabledOnDomainChecker;
 use Shopsys\FrontendApiBundle\Model\GraphqlConfigurator;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -15,6 +14,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FrontendApiController
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrontendApiBundle\Component\Domain\EnabledOnDomainChecker
      */
@@ -92,18 +93,6 @@ class FrontendApiController
      */
     public function setGraphqlConfigurator(GraphqlConfigurator $graphqlConfigurator): void
     {
-        if ($this->graphqlConfigurator !== null && $this->graphqlConfigurator !== $graphqlConfigurator) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->graphqlConfigurator !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->graphqlConfigurator = $graphqlConfigurator;
+        $this->setDependency($graphqlConfigurator, 'graphqlConfigurator');
     }
 }

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Category;
 
-use BadMethodCallException;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
@@ -18,6 +18,8 @@ use Shopsys\FrontendApiBundle\Model\FriendlyUrl\FriendlyUrlFacade;
 
 class CategoryResolver implements ResolverInterface, AliasedInterface
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
@@ -55,19 +57,7 @@ class CategoryResolver implements ResolverInterface, AliasedInterface
      */
     public function setDomain(Domain $domain): void
     {
-        if ($this->domain !== null && $this->domain !== $domain) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->domain !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->domain = $domain;
+        $this->setDependency($domain, 'domain');
     }
 
     /**
@@ -77,19 +67,7 @@ class CategoryResolver implements ResolverInterface, AliasedInterface
      */
     public function setFriendlyUrlFacade(FriendlyUrlFacade $friendlyUrlFacade): void
     {
-        if ($this->friendlyUrlFacade !== null && $this->friendlyUrlFacade !== $friendlyUrlFacade) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->friendlyUrlFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->friendlyUrlFacade = $friendlyUrlFacade;
+        $this->setDependency($friendlyUrlFacade, 'friendlyUrlFacade');
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Image;
 
-use BadMethodCallException;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Error\UserError;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageSizeNotFoundException;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageTypeNotFoundException;
@@ -16,6 +14,7 @@ use Shopsys\FrameworkBundle\Component\Image\Config\ImageEntityConfig;
 use Shopsys\FrameworkBundle\Component\Image\Config\ImageSizeConfig;
 use Shopsys\FrameworkBundle\Component\Image\Image;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Advert\Advert;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
@@ -26,6 +25,8 @@ use Shopsys\FrontendApiBundle\Component\Image\ImageFacade as FrontendApiImageFac
 
 class ImagesResolver implements ResolverInterface
 {
+    use SetterInjectionTrait;
+
     protected const IMAGE_ENTITY_PRODUCT = 'product';
     protected const IMAGE_ENTITY_CATEGORY = 'category';
     protected const IMAGE_ENTITY_PAYMENT = 'payment';
@@ -78,19 +79,7 @@ class ImagesResolver implements ResolverInterface
      */
     public function setFrontendApiImageFacade(FrontendApiImageFacade $frontendApiImageFacade): void
     {
-        if ($this->frontendApiImageFacade !== null && $this->frontendApiImageFacade !== $frontendApiImageFacade) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->frontendApiImageFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->frontendApiImageFacade = $frontendApiImageFacade;
+        $this->setDependency($frontendApiImageFacade, 'frontendApiImageFacade');
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Price;
 
-use BadMethodCallException;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
@@ -23,6 +22,8 @@ use Shopsys\FrontendApiBundle\Model\Price\PriceFacade;
 
 class PriceResolver implements ResolverInterface, AliasedInterface
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade
      */
@@ -92,18 +93,7 @@ class PriceResolver implements ResolverInterface, AliasedInterface
      */
     public function setPriceFacade(PriceFacade $priceFacade): void
     {
-        if ($this->priceFacade !== null && $this->priceFacade !== $priceFacade) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->priceFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->priceFacade = $priceFacade;
+        $this->setDependency($priceFacade, 'priceFacade');
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductResolverMap.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductResolverMap.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
 use ArrayObject;
-use BadMethodCallException;
 use GraphQL\Type\Definition\ResolveInfo;
 use Overblog\GraphQLBundle\Definition\ArgumentInterface;
 use Overblog\GraphQLBundle\Resolver\FieldResolver;
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Collection\ProductCollectionFacade;
 use Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade;
@@ -22,6 +22,8 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\DataMapper\ProductEntityFi
 
 class ProductResolverMap extends ResolverMap
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      * @deprecated Used only in deprecated method, will be removed in the next major release
@@ -87,21 +89,7 @@ class ProductResolverMap extends ResolverMap
      */
     public function setProductArrayFieldMapper(ProductArrayFieldMapper $productArrayFieldMapper): void
     {
-        if (
-            $this->productArrayFieldMapper !== null
-            && $this->productArrayFieldMapper !== $productArrayFieldMapper
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->productArrayFieldMapper !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productArrayFieldMapper = $productArrayFieldMapper;
+        $this->setDependency($productArrayFieldMapper, 'productArrayFieldMapper');
     }
 
     /**
@@ -111,21 +99,7 @@ class ProductResolverMap extends ResolverMap
      */
     public function setProductEntityFieldMapper(ProductEntityFieldMapper $productEntityFieldMapper): void
     {
-        if (
-            $this->productEntityFieldMapper !== null
-            && $this->productEntityFieldMapper !== $productEntityFieldMapper
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->productEntityFieldMapper !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productEntityFieldMapper = $productEntityFieldMapper;
+        $this->setDependency($productEntityFieldMapper, 'productEntityFieldMapper');
     }
 
     /**

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
-use BadMethodCallException;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
 use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
-use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
@@ -20,6 +19,8 @@ use Shopsys\FrontendApiBundle\Model\Product\ProductFacade;
 
 class ProductsResolver implements ResolverInterface, AliasedInterface
 {
+    use SetterInjectionTrait;
+
     protected const DEFAULT_FIRST_LIMIT = 10;
     /**
      * @deprecated This will be removed in next major release
@@ -78,19 +79,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function setProductFacade(ProductFacade $productFacade): void
     {
-        if ($this->productFacade !== null && $this->productFacade !== $productFacade) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-        if ($this->productFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productFacade = $productFacade;
+        $this->setDependency($productFacade, 'productFacade');
     }
 
     /**
@@ -100,20 +89,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function setProductFilterFacade(ProductFilterFacade $productFilterFacade): void
     {
-        if ($this->productFilterFacade !== null && $this->productFilterFacade !== $productFilterFacade) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-
-        if ($this->productFilterFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productFilterFacade = $productFilterFacade;
+        $this->setDependency($productFilterFacade, 'productFilterFacade');
     }
 
     /**
@@ -123,23 +99,7 @@ class ProductsResolver implements ResolverInterface, AliasedInterface
      */
     public function setProductConnectionFactory(ProductConnectionFactory $productConnectionFactory): void
     {
-        if (
-            $this->productConnectionFactory !== null
-            && $this->productConnectionFactory !== $productConnectionFactory
-        ) {
-            throw new BadMethodCallException(sprintf(
-                'Method "%s" has been already called and cannot be called multiple times.',
-                __METHOD__
-            ));
-        }
-
-        if ($this->productConnectionFactory !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productConnectionFactory = $productConnectionFactory;
+        $this->setDependency($productConnectionFactory, 'productConnectionFactory');
     }
 
     /**

--- a/packages/read-model/src/Product/Listed/ListedProductViewElasticFacade.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewElasticFacade.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\ReadModelBundle\Product\Listed;
 
-use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\NoProductPriceForPricingGroupException;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryFacade;
@@ -23,6 +23,8 @@ use Shopsys\ReadModelBundle\Product\Action\ProductActionViewFactory;
 
 class ListedProductViewElasticFacade implements ListedProductViewFacadeInterface
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductFacade
      */
@@ -321,21 +323,7 @@ class ListedProductViewElasticFacade implements ListedProductViewFacadeInterface
      */
     public function setProductActionViewFactory(ProductActionViewFactory $productActionViewFactory): void
     {
-        if (
-            $this->productActionViewFactory !== null
-            && $this->productActionViewFactory !== $productActionViewFactory
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->productActionViewFactory !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productActionViewFactory = $productActionViewFactory;
+        $this->setDependency($productActionViewFactory, 'productActionViewFactory');
     }
 
     /**
@@ -345,20 +333,6 @@ class ListedProductViewElasticFacade implements ListedProductViewFacadeInterface
      */
     public function setProductElasticsearchProvider(ProductElasticsearchProvider $productElasticsearchProvider): void
     {
-        if (
-            $this->productElasticsearchProvider !== null
-            && $this->productElasticsearchProvider !== $productElasticsearchProvider
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->productElasticsearchProvider !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productElasticsearchProvider = $productElasticsearchProvider;
+        $this->setDependency($productElasticsearchProvider, 'productElasticsearchProvider');
     }
 }

--- a/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
+++ b/packages/read-model/src/Product/Listed/ListedProductViewFactory.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\ReadModelBundle\Product\Listed;
 
-use BadMethodCallException;
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Pricing\Exception\NoProductPriceForPricingGroupException;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
@@ -22,6 +22,8 @@ use Shopsys\ReadModelBundle\Product\Action\ProductActionViewFactory;
 
 class ListedProductViewFactory
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
@@ -267,18 +269,7 @@ class ListedProductViewFactory
      */
     public function setImageViewFacade(ImageViewFacadeInterface $imageViewFacade): void
     {
-        if ($this->imageViewFacade !== null && $this->imageViewFacade !== $imageViewFacade) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->imageViewFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->imageViewFacade = $imageViewFacade;
+        $this->setDependency($imageViewFacade, 'imageViewFacade');
     }
 
     /**
@@ -288,18 +279,7 @@ class ListedProductViewFactory
      */
     public function setProductActionViewFacade(ProductActionViewFacadeInterface $productActionViewFacade): void
     {
-        if ($this->productActionViewFacade !== null && $this->productActionViewFacade !== $productActionViewFacade) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->productActionViewFacade !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productActionViewFacade = $productActionViewFacade;
+        $this->setDependency($productActionViewFacade, 'productActionViewFacade');
     }
 
     /**
@@ -309,21 +289,7 @@ class ListedProductViewFactory
      */
     public function setProductActionViewFactory(ProductActionViewFactory $productActionViewFactory): void
     {
-        if (
-            $this->productActionViewFactory !== null
-            && $this->productActionViewFactory !== $productActionViewFactory
-        ) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->productActionViewFactory !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->productActionViewFactory = $productActionViewFactory;
+        $this->setDependency($productActionViewFactory, 'productActionViewFactory');
     }
 
     /**
@@ -333,18 +299,7 @@ class ListedProductViewFactory
      */
     public function setCurrentCustomerUser(CurrentCustomerUser $currentCustomerUser): void
     {
-        if ($this->currentCustomerUser !== null && $this->currentCustomerUser !== $currentCustomerUser) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->currentCustomerUser !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->currentCustomerUser = $currentCustomerUser;
+        $this->setDependency($currentCustomerUser, 'currentCustomerUser');
     }
 
     /**
@@ -354,17 +309,6 @@ class ListedProductViewFactory
      */
     public function setPriceFactory(PriceFactory $priceFactory): void
     {
-        if ($this->priceFactory !== null && $this->priceFactory !== $priceFactory) {
-            throw new BadMethodCallException(
-                sprintf('Method "%s" has been already called and cannot be called multiple times.', __METHOD__)
-            );
-        }
-        if ($this->priceFactory !== null) {
-            return;
-        }
-
-        DeprecationHelper::triggerSetterInjection(__METHOD__);
-
-        $this->priceFactory = $priceFactory;
+        $this->setDependency($priceFactory, 'priceFactory');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Setter injection methods are one of the ways to maintain backward compatibility, but they're tedious to write. This PR introduces the trait to set dependency with rules we had. Every setter injection method now uses the method from this trait. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
