### PR TITLE
[docs] fix basic-data-import.md 

### DIFF
--- a/docs/cookbook/basic-data-import.md
+++ b/docs/cookbook/basic-data-import.md
@@ -346,7 +346,7 @@ private function fillProductData(ProductData $productData, array $externalProduc
 {
     $productData->name[self::LOCALE] = $externalProductData['name'];
     $productData->manualInputPricesByPricingGroupId[self::PRICING_GROUP_ID] = Money::create($externalProductData['price_without_vat']);
-    $productData->vat = $this->vatFacade->getVatByPercent($externalProductData['vat_percent']); // will be implemented in next step
+    $productData->vatsIndexedByDomainId[self::DOMAIN_ID] = $this->vatFacade->getVatByPercent($externalProductData['vat_percent']); // will be implemented in next step
     $productData->ean = $externalProductData['ean'];
     $productData->descriptions[self::DOMAIN_ID] = $externalProductData['description'];
     $productData->usingStock = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ProductData::$vat does not exist anymore, it was replaced with $vatsIndexedByDomainId
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
