### PR TITLE
[project-base] fixed wrong price converting in datafixtures

### DIFF
--- a/project-base/src/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/PaymentDataFixture.php
@@ -149,7 +149,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
     private function setPriceForAllDomainDefaultCurrencies(PaymentData $paymentData, Money $price): void
     {
         foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
-            $price = $this->priceConverter->convertPriceWithoutVatToPriceInDomainDefaultCurrency(
+            $convertedPrice = $this->priceConverter->convertPriceWithoutVatToPriceInDomainDefaultCurrency(
                 $price,
                 $domain->getId()
             );
@@ -157,7 +157,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
             /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat */
             $vat = $this->getReferenceForDomain(VatDataFixture::VAT_ZERO, $domain->getId());
 
-            $paymentData->pricesIndexedByDomainId[$domain->getId()] = $price;
+            $paymentData->pricesIndexedByDomainId[$domain->getId()] = $convertedPrice;
             $paymentData->vatsIndexedByDomainId[$domain->getId()] = $vat;
         }
     }

--- a/project-base/src/DataFixtures/Demo/TransportDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/TransportDataFixture.php
@@ -120,7 +120,7 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
     private function setPriceForAllDomains(TransportData $transportData, Money $price): void
     {
         foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
-            $price = $this->priceConverter->convertPriceWithoutVatToPriceInDomainDefaultCurrency(
+            $convertedPrice = $this->priceConverter->convertPriceWithoutVatToPriceInDomainDefaultCurrency(
                 $price,
                 $domain->getId()
             );
@@ -129,7 +129,7 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
             $vat = $this->getReferenceForDomain(VatDataFixture::VAT_HIGH, $domain->getId());
 
             $transportData->vatsIndexedByDomainId[$domain->getId()] = $vat;
-            $transportData->pricesIndexedByDomainId[$domain->getId()] = $price;
+            $transportData->pricesIndexedByDomainId[$domain->getId()] = $convertedPrice;
         }
     }
 

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -49,3 +49,6 @@ There you can find links to upgrade notes for other versions too.
 - improve performance of category sorting ([#2328](https://github.com/shopsys/shopsys/pull/2328))
     - you may want to check [article about category sorting](https://docs.shopsys.com/en/9.1/model/how-to-sort-categories/) to introduce performance improvements to your project
     - `CategoryTreeSorting.js` now calls different action to sort categories. You should check your custom implementation of category sorting **\[possible BC-Break\]**
+
+- fix converting price for Transport and Payment in data fixtures ([#2354](https://github.com/shopsys/shopsys/pull/2354))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Transport and Payment prices have wrong price after data fixtures load. This PR fixes the problem and prices as well.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
