### PR TITLE
[project-base] data fixtures always create same prices independently on input price setting

### DIFF
--- a/project-base/src/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/PaymentDataFixture.php
@@ -150,15 +150,17 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
     {
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currencyCzk */
         $currencyCzk = $this->getReference(CurrencyDataFixture::CURRENCY_CZK);
-        foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
-            $convertedPrice = $this->priceConverter->convertPriceWithoutVatToDomainDefaultCurrencyPrice(
-                $price,
-                $currencyCzk,
-                $domain->getId()
-            );
 
+        foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
             /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat */
             $vat = $this->getReferenceForDomain(VatDataFixture::VAT_ZERO, $domain->getId());
+
+            $convertedPrice = $this->priceConverter->convertPriceToInputPriceWithoutVatInDomainDefaultCurrency(
+                $price,
+                $currencyCzk,
+                $vat->getPercent(),
+                $domain->getId()
+            );
 
             $paymentData->pricesIndexedByDomainId[$domain->getId()] = $convertedPrice;
             $paymentData->vatsIndexedByDomainId[$domain->getId()] = $vat;

--- a/project-base/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ProductDataFixture.php
@@ -9309,10 +9309,15 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
     {
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currencyCzk */
         $currencyCzk = $this->getReference(CurrencyDataFixture::CURRENCY_CZK);
+
         foreach ($this->pricingGroupFacade->getAll() as $pricingGroup) {
-            $money = $this->priceConverter->convertPriceWithoutVatToDomainDefaultCurrencyPrice(
+            /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat */
+            $vat = $this->getReferenceForDomain(VatDataFixture::VAT_HIGH, $pricingGroup->getDomainId());
+
+            $money = $this->priceConverter->convertPriceToInputPriceWithoutVatInDomainDefaultCurrency(
                 Money::create($price),
                 $currencyCzk,
+                $vat->getPercent(),
                 $pricingGroup->getDomainId()
             );
 

--- a/project-base/src/DataFixtures/Demo/TransportDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/TransportDataFixture.php
@@ -121,15 +121,17 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
     {
         /** @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currencyCzk */
         $currencyCzk = $this->getReference(CurrencyDataFixture::CURRENCY_CZK);
-        foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
-            $convertedPrice = $this->priceConverter->convertPriceWithoutVatToDomainDefaultCurrencyPrice(
-                $price,
-                $currencyCzk,
-                $domain->getId()
-            );
 
+        foreach ($this->domain->getAllIncludingDomainConfigsWithoutDataCreated() as $domain) {
             /** @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat $vat */
             $vat = $this->getReferenceForDomain(VatDataFixture::VAT_HIGH, $domain->getId());
+
+            $convertedPrice = $this->priceConverter->convertPriceToInputPriceWithoutVatInDomainDefaultCurrency(
+                $price,
+                $currencyCzk,
+                $vat->getPercent(),
+                $domain->getId()
+            );
 
             $transportData->vatsIndexedByDomainId[$domain->getId()] = $vat;
             $transportData->pricesIndexedByDomainId[$domain->getId()] = $convertedPrice;

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -60,3 +60,6 @@ There you can find links to upgrade notes for other versions too.
     - `PriceConverter::convertPriceWithoutVatToPriceInDomainDefaultCurrency` is deprecated, use `convertPriceWithoutVatToPriceInDomainDefaultCurrency` instead (the new method requires `$priceCurrency` argument)
     - `PriceConverter::convertPriceWithVatToPriceInDomainDefaultCurrency` is deprecated, use `convertPriceWithVatToPriceInDomainDefaultCurrency` instead (the new method requires `$priceCurrency` argument)
     - see #project-base-diff to update your project
+
+- update your data fixtures to always generate data with same prices ([#2356](https://github.com/shopsys/shopsys/pull/2356))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Prices were different for different input price setting. This could cause automatic tests to fail. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
