### PR TITLE
[framework] free text in order is now correctly translated to orders language

### DIFF
--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -175,7 +175,7 @@ class PriceExtension extends AbstractExtension
     public function priceTextWithCurrencyByCurrencyIdAndLocaleFilter(Money $price, int $currencyId, string $locale): string
     {
         if ($price->isZero()) {
-            return t('Free');
+            return t('Free', [], 'messages', $locale);
         }
         $currency = $this->currencyFacade->getById($currencyId);
         return $this->formatCurrency($price, $currency, $locale);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Wrong text in order
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2345  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
