### PR TITLE
[framework] restrict symfony to version 4

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -109,5 +109,10 @@
     },
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"
+    },
+    "extra": {
+        "symfony": {
+            "require": "^4.4.0"
+        }
     }
 }

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -38,9 +38,6 @@ parameters:
         -
             message: '#^Unsafe usage of new static\(\).#'
             path: %currentWorkingDirectory%/src/*
-        -
-            message: '#^Parameter \#2 \$default of method Symfony\\Component\\HttpFoundation\\InputBag::get\(\) expects string\|null, array given\.$#'
-            path: %currentWorkingDirectory%/src/Component/Grid/Grid.php
     excludes_analyse:
         # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:annotations" command
         - %currentWorkingDirectory%/tests/Unit/Component/ClassExtension/Source/*


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| shopsys/framework is meant to be used exclusively with shopsys/project-base, so the Symfony dependencies were restricted to version 4 to prevent installing a newer major version after package split. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
