### PR TITLE
[shopsys] increase minimal supported version of symfony/proxy-manager-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
         "symfony/monolog-bridge": "^4.4.0",
         "symfony/monolog-bundle": "^3.5.0",
         "symfony/property-info": "^4.4.0",
-        "symfony/proxy-manager-bridge": "^4.4.0",
+        "symfony/proxy-manager-bridge": "^4.4.25",
         "symfony/security-bundle": "^4.4.0",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/translation": "^4.4.0",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -87,7 +87,7 @@
         "symfony/event-dispatcher": "^4.4",
         "symfony/monolog-bundle": "^3.5.0",
         "symfony/property-info": "^4.4",
-        "symfony/proxy-manager-bridge": "^4.4",
+        "symfony/proxy-manager-bridge": "^4.4.25",
         "symfony/security": "^4.4",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony-cmf/routing": "^2.0.3",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -84,7 +84,7 @@
         "symfony/monolog-bridge": "^4.4.0",
         "symfony/monolog-bundle": "^3.5.0",
         "symfony/property-info": "^4.4.0",
-        "symfony/proxy-manager-bridge": "^4.4.0",
+        "symfony/proxy-manager-bridge": "^4.4.25",
         "symfony/security-bundle": "^4.4.0",
         "symfony/swiftmailer-bundle": "^3.2.2",
         "symfony/translation": "^4.4.0",

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -63,3 +63,7 @@ There you can find links to upgrade notes for other versions too.
 
 - update your data fixtures to always generate data with same prices ([#2356](https://github.com/shopsys/shopsys/pull/2356))
     - see #project-base-diff to update your project
+
+- increase minimal version of `symfony/proxy-manager-bridge` package ([#2359](https://github.com/shopsys/shopsys/pull/2359))
+    - see #project-base-diff to update your project
+    - don't forget to update dependency with `composer update symfony/proxy-manager-bridge` 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Lower versions of symfony/proxy-manager-bridge may fail on error. This PR increases minimum installed version of symfony/proxy-manager-bridge to prevent those errors.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
