### PR TITLE
[shopsys] bump minimal version of doctrine/dbal package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "doctrine/collections": "^1.5",
         "doctrine/common": "^2.8.1",
         "doctrine/data-fixtures": "^1.3",
-        "doctrine/dbal": "^2.7",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/doctrine-migrations-bundle": "^1.3.0",

--- a/packages/backend-api/composer.json
+++ b/packages/backend-api/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4.1",
         "ext-json": "*",
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.7",
+        "doctrine/dbal": "^2.11",
         "friendsofsymfony/rest-bundle": "^2.5",
         "jms/serializer-bundle": "^2.4",
         "ramsey/uuid": "^3.8",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -48,7 +48,7 @@
         "doctrine/collections": "^1.5",
         "doctrine/common": "^2.8.1",
         "doctrine/data-fixtures": "^1.3",
-        "doctrine/dbal": "^2.7",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/persistence": "^1.3.7",

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^7.2",
-        "doctrine/dbal": "^2.5",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "doctrine/migrations": "^1.8.1",
         "doctrine/orm": "^2.5",

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4.1",
         "ext-json": "*",
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.7",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/persistence": "^1.3.7",
         "shopsys/doctrine-orm": "^2.7.2",

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -27,7 +27,7 @@
         "ext-pdo": "*",
         "ext-simplexml": "*",
         "doctrine/collections": "^1.5",
-        "doctrine/dbal": "^2.7",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/persistence": "^1.3.7",
         "shopsys/doctrine-orm": "^2.7.2",

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.4.1",
         "ext-json": "*",
         "ext-pdo": "*",
-        "doctrine/dbal": "^2.7",
+        "doctrine/dbal": "^2.11",
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/persistence": "^1.3.7",
         "shopsys/doctrine-orm": "^2.7.2",

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -76,3 +76,7 @@ There you can find links to upgrade notes for other versions too.
       +  background-image: url("/web/public/styleguide/images/icon_large_up.svg")
       ```
     - see #project-base-diff to update your project
+
+- increase minimal version of `doctrine/dbal` package ([#2360](https://github.com/shopsys/shopsys/pull/2360))
+    - see #project-base-diff to update your project
+    - don't forget to update dependency with `composer update doctrine/dbal` 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| we are using `executeStatement()` from (#2148) method which was added in 2.11 (see https://github.com/doctrine/dbal/commit/524a23b045d899a620f27f369acee7accf76cb2b)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
