### PR TITLE
[framework] bump minimal version of litipk/php-bignumbers package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "knplabs/knp-menu-bundle": "^2.2.1",
         "lcobucci/jwt": "^3.3",
         "league/flysystem": "^1.0",
-        "litipk/php-bignumbers": "^0.8",
+        "litipk/php-bignumbers": "^0.8.6",
         "nikic/php-parser": "^4.0",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
         "overblog/graphiql-bundle": "^0.2",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -66,7 +66,7 @@
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "league/flysystem": "^1.0",
-        "litipk/php-bignumbers": "^0.8",
+        "litipk/php-bignumbers": "^0.8.6",
         "nikic/php-parser": "^4.0",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable": "^1.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| we are using `::isGreaterThan(), ::isGreaterOrEqualTo(), ::isLessThan(), ::isLessOrEqualTo()` methods which was added in 0.8.6 (see https://github.com/Litipk/php-bignumbers/commit/68b2705b26d6f73697b37c74bb192e29e4f9e5cc)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
