### PR TITLE
[shopsys] increased the minimal version of `league/flysystem`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "lcobucci/jwt": "^3.3",
-        "league/flysystem": "^1.0",
+        "league/flysystem": "^1.1.4",
         "litipk/php-bignumbers": "^0.8.6",
         "nikic/php-parser": "^4.0",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -65,7 +65,7 @@
         "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
-        "league/flysystem": "^1.0",
+        "league/flysystem": "^1.1.4",
         "litipk/php-bignumbers": "^0.8.6",
         "nikic/php-parser": "^4.0",
         "presta/sitemap-bundle": "^1.5.3",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -54,7 +54,7 @@
         "jms/serializer-bundle": "^2.4",
         "jms/translation-bundle": "1.4.4",
         "joschi127/doctrine-entity-override-bundle": "^0.7.2",
-        "league/flysystem": "^1.0",
+        "league/flysystem": "^1.1.4",
         "phing/phing": "^2.16.1",
         "presta/sitemap-bundle": "^1.5.3",
         "prezent/doctrine-translatable-bundle": "^1.0.3",

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -80,3 +80,7 @@ There you can find links to upgrade notes for other versions too.
 - increase minimal version of `doctrine/dbal` package ([#2360](https://github.com/shopsys/shopsys/pull/2360))
     - see #project-base-diff to update your project
     - don't forget to update dependency with `composer update doctrine/dbal` 
+
+- increase minimal version of `league/flysystem` package ([#2365](https://github.com/shopsys/shopsys/pull/2365))
+    - see #project-base-diff to update your project
+    - don't forget to update dependency with `composer update league/flysystem`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| due to security issue https://github.com/thephpleague/flysystem/security/advisories/GHSA-9f46-5r25-5wfm
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
