### PR TITLE
exclude monolog HTTP exception code 410

### DIFF
--- a/project-base/config/packages/monolog.yaml
+++ b/project-base/config/packages/monolog.yaml
@@ -6,8 +6,7 @@ monolog:
             buffer_size: 1000
             action_level: warning
             handler: nested
-            excluded_404s:
-                - ^/
+            excluded_http_codes: [404, 410]
         nested:
             type: stream
             path: "%shopsys.log_stream%"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `ProductNotFoundException` extends `GoneHttpException`. That means you get 410 instead of 404 when the product is hidden and you access the URL of the product. While 404 errors are not logged in monolog, 410 are still logged and error log is then full of 410 errors. I think we should not log 410 the same as we aren't logging 404.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Current:   
https://symfony.com/doc/current/logging/monolog_regex_based_excludes.html  
Proposed:   
https://symfony.com/doc/current/logging/monolog_exclude_http_codes.html

There might be some other things to adjust like file `config/packages/test/monolog.yaml`