### PR TITLE
[project-base] fix quantity validation in cart form

### DIFF
--- a/project-base/src/Form/Front/Cart/AddProductFormType.php
+++ b/project-base/src/Form/Front/Cart/AddProductFormType.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Form\Front\Cart;
 
+use Shopsys\FrameworkBundle\Form\Constraints\ConstraintValue;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
@@ -27,11 +28,14 @@ class AddProductFormType extends AbstractType
                     new Constraints\Regex(['pattern' => '/^\d+$/']),
                 ],
             ])
-            ->add('quantity', TextType::class, [
+            ->add('quantity', NumberType::class, [
                 'data' => 1,
                 'constraints' => [
                     new Constraints\GreaterThan(0),
-                    new Constraints\Regex(['pattern' => '/^\d+$/']),
+                    new Constraints\LessThanOrEqual([
+                        'value' => ConstraintValue::INTEGER_MAX_VALUE,
+                        'message' => 'Please enter valid quantity',
+                    ]),
                 ],
             ])
             ->add('add', SubmitType::class);

--- a/project-base/src/Form/Front/Cart/CartFormType.php
+++ b/project-base/src/Form/Front/Cart/CartFormType.php
@@ -7,8 +7,8 @@ namespace App\Form\Front\Cart;
 use Shopsys\FrameworkBundle\Form\Constraints\ConstraintValue;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
@@ -25,7 +25,7 @@ class CartFormType extends AbstractType
             ->add('quantities', CollectionType::class, [
                 'allow_add' => true,
                 'allow_delete' => true,
-                'entry_type' => TextType::class,
+                'entry_type' => NumberType::class,
                 'constraints' => [
                     new Constraints\All([
                         'constraints' => [

--- a/upgrade/UPGRADE-v9.1.2-dev.md
+++ b/upgrade/UPGRADE-v9.1.2-dev.md
@@ -84,3 +84,6 @@ There you can find links to upgrade notes for other versions too.
 - increase minimal version of `league/flysystem` package ([#2365](https://github.com/shopsys/shopsys/pull/2365))
     - see #project-base-diff to update your project
     - don't forget to update dependency with `composer update league/flysystem`
+
+- update form setting for quantity in cart ([#2367](https://github.com/shopsys/shopsys/pull/2367))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is possible to fill value like `2a` for quantity. The app crashes because of it when trying to complete these ordrers. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
