### PR TITLE
WIP: suppressed throwing exception when phpdoc is not valid

### DIFF
--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -131,6 +131,13 @@ class ExtendedClassesAnnotationsCommand extends Command
             }
         }
         $filesForAddingPropertyOrMethodAnnotations = $this->addPropertyAndMethodAnnotationsToProjectClasses($isDryRun);
+
+        if (count($this->methodAnnotationsAdder->warningBag) > 0) {
+            foreach ($this->methodAnnotationsAdder->warningBag as $exception) {
+                $symfonyStyle->warning($exception->getMessage());
+            }
+        }
+
         if (count($filesForAddingPropertyOrMethodAnnotations) > 0) {
             if ($isDryRun) {
                 $symfonyStyle->error('@method or @property annotations need to be added to the following files:');

--- a/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
@@ -21,6 +21,11 @@ class MethodAnnotationsFactory
     protected $annotationsReplacer;
 
     /**
+     * @var \InvalidArgumentException[]
+     */
+    public array $warningBag = [];
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap $annotationsReplacementsMap
      * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer $annotationsReplacer
      */
@@ -69,9 +74,16 @@ class MethodAnnotationsFactory
                 continue;
             }
 
+            try {
+                $docBlockReturnTypes = $reflectionMethodFromFrameworkClass->getDocBlockReturnTypes();
+            } catch (InvalidArgumentException $exception) {
+                $this->warningBag[md5($exception->getMessage())] = $exception;
+                continue;
+            }
+
             $methodReturnTypeIsExtended = $this->methodReturningTypeIsExtendedInProject(
                 $frameworkClassPattern,
-                $reflectionMethodFromFrameworkClass->getDocBlockReturnTypes()
+                $docBlockReturnTypes
             );
 
             $methodParameterTypeIsExtended = $this->methodParameterTypeIsExtendedInProject(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Annotation fixer may fail when there is extended method annotated originaly by a modern phpdoc. This PRs is hot fix which catch these kind of exceptions and transform it into warnings. There should be investigated a better solution for this problem.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

Examples of unparsable annotations with threw error message (see the weird format of message):

message: `"\Shopsys\FrameworkBundle\Model\Category\array<int, array{id: string" is not a valid Fqsen.`
line: https://github.com/shopsys/shopsys/blob/ab69a2d961025b6e494d3929bcbdf7c2a079e99a/packages/framework/src/Model/Category/CategoryFacade.php#L259

---

message: `"\Shopsys\FrameworkBundle\Model\Product\Listing\array<string, string>" is not a valid Fqsen.`
line: https://github.com/shopsys/shopsys/blob/ab69a2d961025b6e494d3929bcbdf7c2a079e99a/packages/framework/src/Model/Product/Listing/ProductListOrderingModeForListFacade.php#L58

---

message: `"\Shopsys\FrameworkBundle\Controller\Admin\node_modules/@shopsys/framework/js/admin/components/CategoryTreeSorting.js" is not a valid Fqsen.`
line: https://github.com/shopsys/shopsys/blob/ab69a2d961025b6e494d3929bcbdf7c2a079e99a/packages/framework/src/Controller/Admin/CategoryController.php#L224