### PR TITLE
[docs] changed bc promise link to supported version

### DIFF
--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -47,7 +47,7 @@ During an upgrade to the next major version, you have to make the changes yourse
     The same holds true for the [demoshop repository](https://github.com/shopsys/demoshop) which is a complex example of an ecommerce project using a custom design and modifications.
 
 ### PHP Code
-Basic rules for PHP code are covered by [Symfony Backward Compatibility Promise](https://symfony.com/doc/3.4/contributing/code/bc.html).
+Basic rules for PHP code are covered by [Symfony Backward Compatibility Promise](https://symfony.com/doc/4.4/contributing/code/bc.html).
 
 #### Exceptions
 There are some exceptions that extend or override the BC promise of Symfony, which allows us a bit more flexibility without compromising the user's code:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Currently supported version od Symfony is 4.4. Changed link to Symfony's BC promise to supported version
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
