### PR TITLE
[shopsys] replaced creating class ProductFilterData by factory

### DIFF
--- a/packages/framework/src/Model/Product/Filter/ProductFilterDataFactory.php
+++ b/packages/framework/src/Model/Product/Filter/ProductFilterDataFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Filter;
+
+class ProductFilterDataFactory
+{
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData
+     */
+    public function create(): ProductFilterData
+    {
+        return new ProductFilterData();
+    }
+}

--- a/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
+++ b/packages/framework/src/Model/Product/ProductOnCurrentDomainFacade.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Query;
 use Shopsys\FrameworkBundle\Component\Doctrine\SortableNullsWalker;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryRepository;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
@@ -17,10 +18,13 @@ use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountRepository;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 
 class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterface
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductRepository
      */
@@ -57,6 +61,11 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
     protected $brandRepository;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null
+     */
+    protected ?ProductFilterDataFactory $productFilterDataFactory;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
@@ -64,6 +73,7 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountRepository $productFilterCountRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository $productAccessoryRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandRepository $brandRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null $productFilterDataFactory
      */
     public function __construct(
         ProductRepository $productRepository,
@@ -72,7 +82,8 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
         CategoryRepository $categoryRepository,
         ProductFilterCountRepository $productFilterCountRepository,
         ProductAccessoryRepository $productAccessoryRepository,
-        BrandRepository $brandRepository
+        BrandRepository $brandRepository,
+        ?ProductFilterDataFactory $productFilterDataFactory = null
     ) {
         $this->productRepository = $productRepository;
         $this->domain = $domain;
@@ -81,6 +92,17 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
         $this->productFilterCountRepository = $productFilterCountRepository;
         $this->productAccessoryRepository = $productAccessoryRepository;
         $this->brandRepository = $brandRepository;
+        $this->productFilterDataFactory = $productFilterDataFactory;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory $productFilterDataFactory
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setParameterBag(ProductFilterDataFactory $productFilterDataFactory): void
+    {
+        $this->setDependency($productFilterDataFactory, 'productFilterDataFactory');
     }
 
     /**
@@ -211,7 +233,7 @@ class ProductOnCurrentDomainFacade implements ProductOnCurrentDomainFacadeInterf
      */
     public function getSearchAutocompleteProducts(?string $searchText, int $limit): PaginationResult
     {
-        $emptyProductFilterData = new ProductFilterData();
+        $emptyProductFilterData = $this->productFilterDataFactory->create();
 
         $page = 1;
 

--- a/packages/frontend-api/src/Model/Product/Filter/ProductFilterDataMapper.php
+++ b/packages/frontend-api/src/Model/Product/Filter/ProductFilterDataMapper.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Product\Filter;
 
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterData;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade;
 
 class ProductFilterDataMapper
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade
      */
@@ -38,18 +42,36 @@ class ProductFilterDataMapper
     protected array $parameterValuesByUuid = [];
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null
+     */
+    protected ?ProductFilterDataFactory $productFilterDataFactory;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade $parameterFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null $productFilterDataFactory
      */
     public function __construct(
         FlagFacade $flagFacade,
         BrandFacade $brandFacade,
-        ParameterFacade $parameterFacade
+        ParameterFacade $parameterFacade,
+        ?ProductFilterDataFactory $productFilterDataFactory = null
     ) {
         $this->flagFacade = $flagFacade;
         $this->brandFacade = $brandFacade;
         $this->parameterFacade = $parameterFacade;
+        $this->productFilterDataFactory = $productFilterDataFactory;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory $productFilterDataFactory
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setParameterBag(ProductFilterDataFactory $productFilterDataFactory): void
+    {
+        $this->setDependency($productFilterDataFactory, 'productFilterDataFactory');
     }
 
     /**
@@ -58,7 +80,7 @@ class ProductFilterDataMapper
      */
     public function mapFrontendApiFilterToProductFilterData(array $frontendApiFilter): ProductFilterData
     {
-        $productFilterData = new ProductFilterData();
+        $productFilterData = $this->productFilterDataFactory->create();
         $productFilterData->minimalPrice = $frontendApiFilter['minimalPrice'] ?? null;
         $productFilterData->maximalPrice = $frontendApiFilter['maximalPrice'] ?? null;
         $productFilterData->parameters = $this->getParametersAndValuesByUuids($frontendApiFilter['parameters'] ?? []);

--- a/packages/frontend-api/src/Model/Product/Filter/ProductFilterFacade.php
+++ b/packages/frontend-api/src/Model/Product/Filter/ProductFilterFacade.php
@@ -6,14 +6,18 @@ namespace Shopsys\FrontendApiBundle\Model\Product\Filter;
 
 use Overblog\GraphQLBundle\Definition\Argument;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfig;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory;
 
 class ProductFilterFacade
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
      */
@@ -40,21 +44,39 @@ class ProductFilterFacade
     protected array $productFilterConfigCache = [];
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null
+     */
+    protected ?ProductFilterDataFactory $productFilterDataFactory;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterDataMapper $productFilterDataMapper
      * @param \Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterNormalizer $productFilterNormalizer
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory $productFilterConfigFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null $productFilterDataFactory
      */
     public function __construct(
         Domain $domain,
         ProductFilterDataMapper $productFilterDataMapper,
         ProductFilterNormalizer $productFilterNormalizer,
-        ProductFilterConfigFactory $productFilterConfigFactory
+        ProductFilterConfigFactory $productFilterConfigFactory,
+        ?ProductFilterDataFactory $productFilterDataFactory = null
     ) {
         $this->productFilterDataMapper = $productFilterDataMapper;
         $this->productFilterNormalizer = $productFilterNormalizer;
         $this->productFilterConfigFactory = $productFilterConfigFactory;
         $this->domain = $domain;
+        $this->productFilterDataFactory = $productFilterDataFactory;
+    }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory $productFilterDataFactory
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setParameterBag(ProductFilterDataFactory $productFilterDataFactory): void
+    {
+        $this->setDependency($productFilterDataFactory, 'productFilterDataFactory');
     }
 
     /**
@@ -135,7 +157,7 @@ class ProductFilterFacade
     public function getValidatedProductFilterDataForAll(Argument $argument): ProductFilterData
     {
         if ($argument['filter'] === null) {
-            return new ProductFilterData();
+            return $this->productFilterDataFactory->create();
         }
 
         $productFilterConfig = $this->getProductFilterConfigForAll();
@@ -151,7 +173,7 @@ class ProductFilterFacade
     public function getValidatedProductFilterDataForCategory(Argument $argument, Category $category): ProductFilterData
     {
         if ($argument['filter'] === null) {
-            return new ProductFilterData();
+            return $this->productFilterDataFactory->create();
         }
 
         $productFilterConfig = $this->getProductFilterConfigForCategory($category);
@@ -167,7 +189,7 @@ class ProductFilterFacade
     public function getValidatedProductFilterDataForBrand(Argument $argument, Brand $brand): ProductFilterData
     {
         if ($argument['filter'] === null) {
-            return new ProductFilterData();
+            return $this->productFilterDataFactory->create();
         }
 
         $productFilterConfig = $this->getProductFilterConfigForBrand($brand);

--- a/packages/frontend-api/src/Model/Product/ProductFacade.php
+++ b/packages/frontend-api/src/Model/Product/ProductFacade.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Product;
 
 use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory;
 use Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository;
 
 class ProductFacade
 {
+    use SetterInjectionTrait;
+
     /**
      * @var \Shopsys\FrontendApiBundle\Model\Product\ProductRepository
      */
@@ -31,19 +35,38 @@ class ProductFacade
     protected $productElasticsearchRepository;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null
+     */
+    protected ?ProductFilterDataFactory $productFilterDataFactory;
+
+    /**
      * @param \Shopsys\FrontendApiBundle\Model\Product\ProductRepository $productRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory $filterQueryFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory|null $productFilterDataFactory
      */
     public function __construct(
         ProductRepository $productRepository,
         FilterQueryFactory $filterQueryFactory,
-        ProductElasticsearchRepository $productElasticsearchRepository
+        ProductElasticsearchRepository $productElasticsearchRepository,
+        ?ProductFilterDataFactory $productFilterDataFactory = null
     ) {
         $this->productRepository = $productRepository;
         $this->filterQueryFactory = $filterQueryFactory;
         $this->productElasticsearchRepository = $productElasticsearchRepository;
+        $this->productFilterDataFactory = $productFilterDataFactory;
     }
+
+    /**
+     * @required
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory $productFilterDataFactory
+     * @internal This function will be replaced by constructor injection in next major
+     */
+    public function setParameterBag(ProductFilterDataFactory $productFilterDataFactory): void
+    {
+        $this->setDependency($productFilterDataFactory, 'productFilterDataFactory');
+    }
+
 
     /**
      * @param string $uuid
@@ -96,7 +119,7 @@ class ProductFacade
     {
         DeprecationHelper::triggerMethod(__METHOD__, 'getFilteredProductsOnCurrentDomain');
 
-        $emptyProductFilterData = new ProductFilterData();
+        $emptyProductFilterData = $this->productFilterDataFactory->create();
         $filterQuery = $this->filterQueryFactory->createWithProductFilterData(
             $emptyProductFilterData,
             $orderingModeId,
@@ -151,7 +174,7 @@ class ProductFacade
     {
         DeprecationHelper::triggerMethod(__METHOD__, 'getFilteredProductsByCategory');
 
-        $emptyProductFilterData = new ProductFilterData();
+        $emptyProductFilterData = $this->productFilterDataFactory->create();
         $filterQuery = $this->filterQueryFactory->createListableProductsByCategoryId(
             $emptyProductFilterData,
             $orderingModeId,
@@ -246,7 +269,7 @@ class ProductFacade
     {
         DeprecationHelper::triggerMethod(__METHOD__, 'getFilteredProductsByBrand');
 
-        $emptyProductFilterData = new ProductFilterData();
+        $emptyProductFilterData = $this->productFilterDataFactory->create();
         $filterQuery = $this->filterQueryFactory->createListableProductsByBrandId(
             $emptyProductFilterData,
             $orderingModeId,

--- a/project-base/src/Controller/Front/ProductController.php
+++ b/project-base/src/Controller/Front/ProductController.php
@@ -7,6 +7,7 @@ namespace App\Controller\Front;
 use App\Form\Front\Product\ProductFilterFormType;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\String\TransformString;
+use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Module\ModuleFacade;
@@ -14,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Module\ModuleList;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForBrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForListFacade;
 use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingModeForSearchFacade;
@@ -97,6 +99,11 @@ class ProductController extends FrontBaseController
     protected $productDetailViewFacade;
 
     /**
+     * @var \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory
+     */
+    protected ProductFilterDataFactory $productFilterDataFactory;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Twig\RequestExtension $requestExtension
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
@@ -110,6 +117,7 @@ class ProductController extends FrontBaseController
      * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade
      * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductVariantsViewFacadeInterface $listedProductVariantsViewFacade
      * @param \Shopsys\ReadModelBundle\Product\Detail\ProductDetailViewFacadeInterface $productDetailViewFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory $productFilterDataFactory
      */
     public function __construct(
         RequestExtension $requestExtension,
@@ -124,7 +132,8 @@ class ProductController extends FrontBaseController
         BrandFacade $brandFacade,
         ListedProductViewFacadeInterface $listedProductViewFacade,
         ListedProductVariantsViewFacadeInterface $listedProductVariantsViewFacade,
-        ProductDetailViewFacadeInterface $productDetailViewFacade
+        ProductDetailViewFacadeInterface $productDetailViewFacade,
+        ProductFilterDataFactory $productFilterDataFactory
     ) {
         $this->requestExtension = $requestExtension;
         $this->categoryFacade = $categoryFacade;
@@ -139,6 +148,7 @@ class ProductController extends FrontBaseController
         $this->listedProductViewFacade = $listedProductViewFacade;
         $this->listedProductVariantsViewFacade = $listedProductVariantsViewFacade;
         $this->productDetailViewFacade = $productDetailViewFacade;
+        $this->productFilterDataFactory = $productFilterDataFactory;
     }
 
     /**
@@ -176,7 +186,7 @@ class ProductController extends FrontBaseController
             $request
         );
 
-        $productFilterData = new ProductFilterData();
+        $productFilterData = $this->productFilterDataFactory->create();
 
         $productFilterConfig = $this->createProductFilterConfigForCategory($category);
         $filterForm = $this->createForm(ProductFilterFormType::class, $productFilterData, [
@@ -275,7 +285,7 @@ class ProductController extends FrontBaseController
             $request
         );
 
-        $productFilterData = new ProductFilterData();
+        $productFilterData = $this->productFilterDataFactory->create();
 
         $productFilterConfig = $this->createProductFilterConfigForSearch($searchText);
         $filterForm = $this->createForm(ProductFilterFormType::class, $productFilterData, [

--- a/upgrade/UPGRADE-v9.1.3-dev.md
+++ b/upgrade/UPGRADE-v9.1.3-dev.md
@@ -4,3 +4,12 @@ This guide contains instructions to upgrade from version v9.1.2 to v9.1.3-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- use factory for creating class `ProductFilterData` ([#2380](https://github.com/shopsys/shopsys/pull/2380))
+    - the class dependency on `ProductFilterDataFactory` was added in following classes:
+        - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade`
+        - `Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade`
+        - `Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterDataMapper`
+        - `Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterFacade`
+        - `Shopsys\FrontendApiBundle\Model\Product\ProductFacade`
+    - see #project-base-diff


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Instance of class `ProductFilterData` is not create by factory. When creating instances just in place makes it hard to extend. This PR introduces a factory to improve extensibility.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
