### PR TITLE
[frontend-api] authentication failure now return errors as array

### DIFF
--- a/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
+++ b/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
@@ -106,7 +106,7 @@ class TokenAuthenticator extends AbstractAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         $responseData = [
-            'errors' => FormattedError::createFromException($exception),
+            'errors' => [FormattedError::createFromException($exception)],
         ];
 
         return new JsonResponse($responseData, Response::HTTP_UNAUTHORIZED);

--- a/project-base/tests/FrontendApiBundle/Functional/Login/LoginTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Login/LoginTest.php
@@ -61,9 +61,11 @@ class LoginTest extends GraphQlTestCase
     {
         $expectedError = [
             'errors' => [
-                'message' => 'Token is not valid.',
-                'extensions' => [
-                    'category' => 'token',
+                [
+                    'message' => 'Token is not valid.',
+                    'extensions' => [
+                        'category' => 'token',
+                    ],
                 ],
             ],
         ];

--- a/upgrade/UPGRADE-v11.0.1-dev.md
+++ b/upgrade/UPGRADE-v11.0.1-dev.md
@@ -162,3 +162,5 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 - improve config folder structure ([#2607](https://github.com/shopsys/shopsys/pull/2607))
     - see #project-base-diff to update your project
+- FE-API: fix return value for authentication failure ([#2387](https://github.com/shopsys/shopsys/pull/2387))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `errors` should be always an array of objects, so it's the same as in other error responses
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Possible (changes response after authentication failure in FE API) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
