### PR TITLE
[project-base] fixed memory limit for phpunit

### DIFF
--- a/project-base/phpunit.xml
+++ b/project-base/phpunit.xml
@@ -17,7 +17,7 @@
         <env name="KERNEL_CLASS" value="App\Kernel" />
         <env name="APP_ENV" value="test" />
         <env name="APP_DEBUG" value="false" />
-        <ini name="memory_limit" value="768MB" />
+        <ini name="memory_limit" value="768M" />
     </php>
 
     <testsuites>

--- a/upgrade/UPGRADE-v9.1.3-dev.md
+++ b/upgrade/UPGRADE-v9.1.3-dev.md
@@ -4,3 +4,6 @@ This guide contains instructions to upgrade from version v9.1.2 to v9.1.3-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- fix memory_limit set for PHPUnit ([#2398](https://github.com/shopsys/shopsys/pull/2398))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| memory limit has unit M instead od MB
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
