### PR TITLE
[shopsys] fix builds of split packages

### DIFF
--- a/packages/framework/.github/workflows/run-checks-tests.yaml
+++ b/packages/framework/.github/workflows/run-checks-tests.yaml
@@ -17,6 +17,8 @@ jobs:
                     tools: composer
             -   name: Install Composer dependencies
                 run: composer install --optimize-autoloader --no-interaction
+            -   name: Ensure Symfony 4 version
+                run: composer update
             -   name: Run parallel-lint
                 run: php vendor/bin/parallel-lint ./src
             -   name: Run Easy Coding Standards

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -41,7 +41,7 @@ parameters:
         -
             # our fork of doctrine-orm (https://github.com/shopsys/doctrine-orm) needs to be updated to resolve the reported issues
             message: '#^Method Shopsys\\FrameworkBundle\\Component\\EntityExtension\\EntityManagerDecorator::.*\(\) should return T of object\|null but returns object\|null.#'
-            path: %currentWorkingDirectory%/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
+            path: %currentWorkingDirectory%/src/Component/EntityExtension/EntityManagerDecorator.php
     excludes_analyse:
         # Exclude "Source" folder dedicated for testing functionality connected to "shopsys:extended-classes:annotations" command
         - %currentWorkingDirectory%/tests/Unit/Component/ClassExtension/Source/*

--- a/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
+++ b/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
@@ -21,6 +21,7 @@ jobs:
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies
+                run: composer install --optimize-autoloader --no-interaction
             -   name: Run parallel-lint
                 run: php vendor/bin/parallel-lint ./src ./tests
             -   name: Run Easy Coding Standards

--- a/project-base/.github/workflows/docker-build.yaml
+++ b/project-base/.github/workflows/docker-build.yaml
@@ -9,8 +9,14 @@ jobs:
                 uses: actions/checkout@v2
                 with:
                     ref: ${{ github.ref }}
+            -   name: Configure application
+                run: echo 1 | ./scripts/configure.sh
+            -   name: Install composer dependencies
+                run: docker-compose exec -T php-fpm composer install
+            -   name: Ensure Symfony 4 version
+                run: docker-compose exec -T php-fpm composer update
             -   name: Build application
-                run: echo 1 | ./scripts/install.sh
+                run: docker-compose exec -T php-fpm php phing db-create test-db-create build-demo-dev-quick error-pages-generate
             -   name: Check standards
                 run: docker-compose exec -T php-fpm php phing standards
             -   name: Run tests

--- a/project-base/phpstan.neon
+++ b/project-base/phpstan.neon
@@ -25,7 +25,7 @@ parameters:
         -
             # Ignore annotations in generated code
             message: '#^PHPDoc tag @param for parameter \$function with type callable is not subtype of native type Closure.$#'
-            path: %currentWorkingDirectory%/project-base/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php
+            path: %currentWorkingDirectory%/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php
         -
             # phpstan-symfony extension cannot work right with symfony test container at the moment https://github.com/phpstan/phpstan-symfony/issues/27
             message: '#^Service "[^"]+" is private.$#'

--- a/project-base/scripts/configure.sh
+++ b/project-base/scripts/configure.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+numberRegex="^[0-9]+([.][0-9]+)?$"
+operatingSystem=""
+allowedValues=(1 2)
+projectPathPrefix=""
+echo This is installation script that will install demo Shopsys Framework application on docker with all required containers and with demo database created.
+
+docker ps -q &> /dev/null
+if [[ "$?" != 0 ]]; then
+    1>&2 echo -e "\e[31mERROR:\e[0m Unable to connect to docker. Either the docker service is not running, or the current user is not allowed to run docker."
+    exit 1
+fi
+
+set -e
+
+echo "Start with specifying your operating system: \
+
+    1) Linux or Windows with WSL 2
+    2) Mac
+    "
+
+while [[ 1 -eq 1 ]]
+do
+    read -p "Enter OS number: " operatingSystem
+    if [[ ${operatingSystem} =~ $numberRegex ]] ; then
+        if [[ " ${allowedValues[@]} " =~ " ${operatingSystem} " ]]; then
+            break;
+        fi
+        echo "Not existing value, please enter one of existing values"
+    else
+        echo "Please enter a number"
+    fi
+done
+
+if [[ -d "project-base" ]]; then
+    projectPathPrefix="project-base/"
+    echo "You are in monorepo, prefixing paths app paths with ${projectPathPrefix}"
+fi
+
+echo "Creating config files.."
+cp -f "${projectPathPrefix}config/parameters.yaml.dist" "${projectPathPrefix}config/parameters.yaml"
+cp -f "${projectPathPrefix}config/parameters_test.yaml.dist" "${projectPathPrefix}config/parameters_test.yaml"
+cp -f "${projectPathPrefix}config/domains_urls.yaml.dist" "${projectPathPrefix}config/domains_urls.yaml"
+
+echo "Creating docker configuration.."
+case "$operatingSystem" in
+    "1")
+        cp -f docker/conf/docker-compose.yml.dist docker-compose.yml
+
+        sed -i -r "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
+        sed -i -r "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
+        ;;
+    "2")
+        cp -f docker/conf/docker-compose-mac.yml.dist docker-compose.yml
+        cp -f docker/conf/docker-sync.yml.dist docker-sync.yml
+
+        sed -i '' -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
+        sed -i '' -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
+
+        if [[ $1 != --skip-aliasing ]]; then
+            echo "You will be asked to enter sudo password in case to allow second domain alias in your system config.."
+            sudo ifconfig lo0 alias 127.0.0.2 up
+        fi
+
+        mkdir -p ${projectPathPrefix}var/postgres-data ${projectPathPrefix}var/elasticsearch-data vendor
+        docker-sync start
+        ;;
+esac
+
+echo "Starting docker-compose.."
+
+docker-compose up -d --build

--- a/project-base/scripts/install.sh
+++ b/project-base/scripts/install.sh
@@ -1,75 +1,8 @@
 #!/bin/bash
-numberRegex="^[0-9]+([.][0-9]+)?$"
-operatingSystem=""
-allowedValues=(1 2)
-projectPathPrefix=""
-echo This is installation script that will install demo Shopsys Framework application on docker with all required containers and with demo database created.
 
-docker ps -q &> /dev/null
-if [[ "$?" != 0 ]]; then
-    1>&2 echo -e "\e[31mERROR:\e[0m Unable to connect to docker. Either the docker service is not running, or the current user is not allowed to run docker."
-    exit 1
-fi
-
-set -e
-
-echo "Start with specifying your operating system: \
-
-    1) Linux or Windows with WSL 2
-    2) Mac
-    "
-
-while [[ 1 -eq 1 ]]
-do
-    read -p "Enter OS number: " operatingSystem
-    if [[ ${operatingSystem} =~ $numberRegex ]] ; then
-        if [[ " ${allowedValues[@]} " =~ " ${operatingSystem} " ]]; then
-            break;
-        fi
-        echo "Not existing value, please enter one of existing values"
-    else
-        echo "Please enter a number"
-    fi
-done
-
-if [[ -d "project-base" ]]; then
-    projectPathPrefix="project-base/"
-    echo "You are in monorepo, prefixing paths app paths with ${projectPathPrefix}"
-fi
-
-echo "Creating config files.."
-cp -f "${projectPathPrefix}config/parameters.yaml.dist" "${projectPathPrefix}config/parameters.yaml"
-cp -f "${projectPathPrefix}config/parameters_test.yaml.dist" "${projectPathPrefix}config/parameters_test.yaml"
-cp -f "${projectPathPrefix}config/domains_urls.yaml.dist" "${projectPathPrefix}config/domains_urls.yaml"
-
-echo "Creating docker configuration.."
-case "$operatingSystem" in
-    "1")
-        cp -f docker/conf/docker-compose.yml.dist docker-compose.yml
-
-        sed -i -r "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
-        sed -i -r "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
-        ;;
-    "2")
-        cp -f docker/conf/docker-compose-mac.yml.dist docker-compose.yml
-        cp -f docker/conf/docker-sync.yml.dist docker-sync.yml
-
-        sed -i '' -E "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
-        sed -i '' -E "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
-
-        if [[ $1 != --skip-aliasing ]]; then
-            echo "You will be asked to enter sudo password in case to allow second domain alias in your system config.."
-            sudo ifconfig lo0 alias 127.0.0.2 up
-        fi
-
-        mkdir -p ${projectPathPrefix}var/postgres-data ${projectPathPrefix}var/elasticsearch-data vendor
-        docker-sync start
-        ;;
-esac
-
-echo "Starting docker-compose.."
-
-docker-compose up -d --build
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/configure.sh"
 
 echo "Installing application inside a php-fpm container"
 

--- a/upgrade/UPGRADE-v9.1.3-dev.md
+++ b/upgrade/UPGRADE-v9.1.3-dev.md
@@ -17,3 +17,5 @@ There you can find links to upgrade notes for other versions too.
 - fix your standards
   - extract parts of `CustomerUserDataFixture::getCustomerUserUpdateData()` into private methods to lower the cyclomatic complexity of the method
   - see #project-base-diff
+- extract part of `install.sh` script into a new separate file (`configure.sh`) ([#2404](https://github.com/shopsys/shopsys/pull/2404))
+  - see #project-base-diff

--- a/upgrade/UPGRADE-v9.1.3-dev.md
+++ b/upgrade/UPGRADE-v9.1.3-dev.md
@@ -11,6 +11,8 @@ There you can find links to upgrade notes for other versions too.
   - **\[BC break\]** upgrade `codeception/codeception` to `^4.1.22` so you get rid of [the security problem](https://github.com/advisories/GHSA-4574-qv3w-fcmg)
     - you might need to update your `Tests\App\Test\Codeception\AcceptanceTester` to respect changes (added strict typehints) in `Tests\FrameworkBundle\Test\Codeception\ActorInterface`
     - in `StrictWebDriver::seeInElement`, use `assertStringContainsString` instead of `assertContains`
+    - beware, the entry in `phpstan.neon` was fixed in the follow-up pull request ([#2404](https://github.com/shopsys/shopsys/pull/2404))
+      - see #project-base-diff
   - allow plugins in your `composer.json`
     - this is required when using composer in version `2.2.0` and above. If you are running your project in docker, you might need to re-build your docker image to get the upgraded composer.
   - upgrade `composer/composer` to `^1.10.23` so you get rid of [the security problem](https://github.com/composer/composer/security/advisories/GHSA-frqg-7g38-6gcf) 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| builds of split packages `shopsys/framework`, `shopsys/project-base`, and `shopsys/http-smoke-testing` are failing because of a few issues
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
