### PR TITLE
remove "vasek-purchart/console-errors-bundle" dependency

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -65,7 +65,7 @@ jobs:
                     docker run -d --name php-fpm ${{ secrets.DOCKER_USERNAME }}/php-fpm:${DOCKER_PHP_FPM_IMAGE_TAG}
                     docker cp ./ php-fpm:/var/www/html
                     docker exec php-fpm composer install --optimize-autoloader --no-interaction
-                    docker exec php-fpm php phing dirs-create test-dirs-create assets npm build-version-generate backend-api-install composer-dev backend-api-oauth-keys-generate frontend-api-enable
+                    docker exec php-fpm php phing backend-api-install composer-dev dirs-create test-dirs-create assets npm build-version-generate backend-api-oauth-keys-generate frontend-api-enable
             -   name: Push branch specific PHP-FPM image to Docker Hub
                 run: |
                     docker commit -m="Include Composer and NPM files" php-fpm ${{ secrets.DOCKER_USERNAME }}/php-fpm:${DOCKER_PHP_FPM_IMAGE_TAG}-${{ github.sha }}
@@ -203,7 +203,7 @@ jobs:
                     docker-compose up -d
                     docker cp ./ shopsys-framework-php-fpm:/var/www/html
                     docker-compose exec -T php-fpm composer install --optimize-autoloader --no-interaction
-                    docker-compose exec -T php-fpm php phing dirs-create test-dirs-create assets npm build-version-generate backend-api-install composer-dev backend-api-oauth-keys-generate frontend-api-enable db-create test-db-create db-demo elasticsearch-index-recreate elasticsearch-export error-pages-generate test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export tests-acceptance-build
+                    docker-compose exec -T php-fpm php phing backend-api-install composer-dev dirs-create test-dirs-create assets npm build-version-generate backend-api-oauth-keys-generate frontend-api-enable db-create test-db-create db-demo elasticsearch-index-recreate elasticsearch-export error-pages-generate test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export tests-acceptance-build
             -   name: Check standards
                 run: docker-compose exec -T php-fpm php phing standards
             -   name: Run tests

--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,6 @@
         "trikoder/oauth2-bundle": "^1.1",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12",
-        "vasek-purchart/console-errors-bundle": "^3.0.0",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/packages/backend-api/install/composer.json.patch
+++ b/packages/backend-api/install/composer.json.patch
@@ -1,8 +1,8 @@
-@@ -148,6 +148,7 @@
-         "symfony/twig-bundle": "^3.4",
-         "symfony/validator": "^3.4",
+@@ -95,6 +95,7 @@
+         "symfony/webpack-encore-bundle": "^1.7",
+         "symfony/workflow": "^4.4.0",
          "tracy/tracy": "^2.4.13",
 +        "trikoder/oauth2-bundle": "^1.1",
          "twig/extensions": "^1.5.1",
-         "twig/twig": "^2.4.8",
-         "vasek-purchart/console-errors-bundle": "^1.0.1",
+         "twig/twig": "^2.9",
+         "webmozart/assert": "^1.4"

--- a/packages/backend-api/install/config/bundles.php.patch
+++ b/packages/backend-api/install/config/bundles.php.patch
@@ -1,4 +1,4 @@
-@@ -40,4 +40,7 @@
+@@ -39,4 +39,7 @@
      Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true],
      Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
      Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],

--- a/packages/framework/src/Component/Console/ConsoleExitCodeSubscriber.php
+++ b/packages/framework/src/Component/Console/ConsoleExitCodeSubscriber.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Console;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Taken from https://github.com/VasekPurchart/Console-Errors-Bundle/blob/master/src/Console/ConsoleExitCodeListener.php
+ * because so far, the bundle does not support PHP 8, @see https://github.com/VasekPurchart/Console-Errors-Bundle/issues/11
+ */
+class ConsoleExitCodeSubscriber implements EventSubscriberInterface
+{
+    protected const LOG_LEVEL = LogLevel::ERROR;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected LoggerInterface $logger;
+
+    /**
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Event\ConsoleTerminateEvent $event
+     */
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
+    {
+        $statusCode = $event->getExitCode();
+        $command = $event->getCommand();
+
+        if ($statusCode === 0) {
+            return;
+        }
+
+        if ($statusCode > 255) {
+            $statusCode = 255;
+            $event->setExitCode($statusCode);
+        }
+
+        $this->logger->log(static::LOG_LEVEL, sprintf(
+            'Command `%s` exited with status code %d',
+            $command->getName(),
+            $statusCode
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::TERMINATE => 'onConsoleTerminate',
+        ];
+    }
+}

--- a/packages/framework/tests/Unit/Component/Console/ConsoleExitCodeSubscriberTest.php
+++ b/packages/framework/tests/Unit/Component/Console/ConsoleExitCodeSubscriberTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Console;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Shopsys\FrameworkBundle\Component\Console\ConsoleExitCodeSubscriber;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Taken from https://github.com/VasekPurchart/Console-Errors-Bundle/blob/master/tests/Console/ConsoleExitCodeListenerTest.php
+ * because so far, the bundle does not support PHP 8, @see https://github.com/VasekPurchart/Console-Errors-Bundle/issues/11
+ */
+class ConsoleExitCodeSubscriberTest extends TestCase
+{
+    public function testLogError(): void
+    {
+        $commandName = 'hello:world';
+        $exitCode = 123;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::ERROR, $this->logicalAnd(
+                $this->stringContains($commandName),
+                $this->stringContains((string)$exitCode)
+            ));
+
+        $command = new Command($commandName);
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);
+
+        $consoleExitCodeSubscriber = new ConsoleExitCodeSubscriber($logger);
+        $consoleExitCodeSubscriber->onConsoleTerminate($event);
+    }
+
+    public function testLogErrorExitCodeMax255(): void
+    {
+        $commandName = 'hello:world';
+        $exitCode = 999;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::ERROR, $this->logicalAnd(
+                $this->stringContains($commandName),
+                $this->stringContains('255')
+            ));
+
+        $command = new Command($commandName);
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);
+
+        $consoleExitCodeSubscriber = new ConsoleExitCodeSubscriber($logger);
+        $consoleExitCodeSubscriber->onConsoleTerminate($event);
+    }
+
+    public function testZeroExitCodeDoesNotLog(): void
+    {
+        $commandName = 'hello:world';
+        $exitCode = 0;
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->never())
+            ->method('log');
+
+        $command = new Command($commandName);
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);
+
+        $consoleExitCodeSubscriber = new ConsoleExitCodeSubscriber($logger);
+        $consoleExitCodeSubscriber->onConsoleTerminate($event);
+    }
+}

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -96,7 +96,6 @@
         "tracy/tracy": "^2.4.13",
         "twig/extensions": "^1.5.1",
         "twig/twig": "^2.9",
-        "vasek-purchart/console-errors-bundle": "^3.0.0",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/project-base/config/bundles.php
+++ b/project-base/config/bundles.php
@@ -32,7 +32,6 @@ return [
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle::class => ['all' => true],
-    VasekPurchart\ConsoleErrorsBundle\ConsoleErrorsBundle::class => ['all' => true],
     FOS\CKEditorBundle\FOSCKEditorBundle::class => ['all' => true],
     Fp\JsFormValidatorBundle\FpJsFormValidatorBundle::class => ['all' => true],
     Shopsys\FrameworkBundle\ShopsysFrameworkBundle::class => ['all' => true],

--- a/project-base/symfony.lock
+++ b/project-base/symfony.lock
@@ -1164,9 +1164,6 @@
     "twig/twig": {
         "version": "v2.12.1"
     },
-    "vasek-purchart/console-errors-bundle": {
-        "version": "1.0.1"
-    },
     "webimpress/safe-writer": {
         "version": "2.2.0"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -1083,9 +1083,6 @@
     "twig/twig": {
         "version": "v2.12.1"
     },
-    "vasek-purchart/console-errors-bundle": {
-        "version": "1.0.1"
-    },
     "webimpress/safe-writer": {
         "version": "2.1.0"
     },

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -5,6 +5,10 @@ This guide contains instructions to upgrade from version v9.1.0 to v9.2.0-dev.
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
 
+## Composer dependencies
+- remove `vasek-purchart/console-errors-bundle` dependency ([#2408](https://github.com/shopsys/shopsys/pull/2408))
+    - see #project-base-diff to update your project
+
 ## Application
 - use different css classes for javascript and tests ([#2179](https://github.com/shopsys/shopsys/pull/2179))
     - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the bundle does not support PHP 8
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
