### PR TITLE
[shopsys] dropped support for unsupported PHP in packages

### DIFF
--- a/packages/coding-standards/.github/workflows/run-checks-tests.yaml
+++ b/packages/coding-standards/.github/workflows/run-checks-tests.yaml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4']
+                php-versions: ['7.4', '8.0', '8.1']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/coding-standards/.travis.yml
+++ b/packages/coding-standards/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
+    - 8.0
+    - 8.1
 
 env:
     - DEPENDENCY_VERSION='--prefer-lowest'

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -14,18 +14,19 @@
         "friendsofphp/php-cs-fixer": "2.19.0"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4 || ^8.0 || ^8.1",
         "ext-tokenizer": "*",
-        "friendsofphp/php-cs-fixer": "^2.14.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3.1",
+        "friendsofphp/php-cs-fixer": "^2.17.0",
+        "nette/utils": "^3.1.3",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "slevomat/coding-standard": "^6.3.5",
         "squizlabs/php_codesniffer": "^3.5.0",
         "symplify/easy-coding-standard": "^8.3.48",
         "symfony/finder": "^4.4|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.5.23"
     },
     "autoload": {
         "psr-4": {

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/ConstantVisibilityRequiredSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/ConstantVisibilityRequiredSniffTest.php
@@ -24,7 +24,7 @@ final class ConstantVisibilityRequiredSniffTest extends AbstractSniffTestCase
     {
         yield [__DIR__ . '/wrong/SingleValue.php'];
         yield [__DIR__ . '/wrong/MissingAnnotation.php'];
-        yield [__DIR__ . '/wrong/Mixed.php'];
+        yield [__DIR__ . '/wrong/Various.php'];
         yield [__DIR__ . '/wrong/MixedAtTheEnd.php'];
         yield [__DIR__ . '/wrong/MixedInTheMiddle.php'];
         yield [__DIR__ . '/wrong/SingleValueAfterMethodWithoutNamespace.php'];
@@ -36,7 +36,7 @@ final class ConstantVisibilityRequiredSniffTest extends AbstractSniffTestCase
     public function getCorrectFiles(): iterable
     {
         yield [__DIR__ . '/correct/Annotation.php'];
-        yield [__DIR__ . '/correct/Mixed.php'];
+        yield [__DIR__ . '/correct/Various.php'];
         yield [__DIR__ . '/correct/MixedVisibilities.php'];
         yield [__DIR__ . '/correct/MultipleValues.php'];
         yield [__DIR__ . '/correct/noClass.php'];

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/Various.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/correct/Various.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Correct;
 
-class Mixed
+class Various
 {
     /** @access private */
     const A = 'value';

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/Various.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/wrong/Various.php
@@ -2,7 +2,7 @@
 
 namespace Tests\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff\Wrong;
 
-class Mixed
+class Various
 {
     const A = 'value';
     public const B = 'value';

--- a/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
+++ b/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4']
+                php-versions: ['7.4', '8.0', '8.1']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/http-smoke-testing/.travis.yml
+++ b/packages/http-smoke-testing/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
+    - 8.0
+    - 8.1
 
 env:
     - DEPENDENCIES=""

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -21,13 +21,13 @@
         }
     },
     "require": {
-        "php": "^7.2",
-        "phpunit/phpunit": "^8.0",
+        "php": "^7.4 || ^8.0 || ^8.1",
+        "phpunit/phpunit": "^8.5.23",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/routing": "^3.4|^4.0|^5.0",
-        "doctrine/annotations": "^1.6"
+        "doctrine/annotations": "^1.10.4"
     },
     "require-dev": {
         "shopsys/coding-standards": "9.2.x-dev",

--- a/packages/migrations/.github/workflows/run-checks-tests.yaml
+++ b/packages/migrations/.github/workflows/run-checks-tests.yaml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                php-versions: ['7.2', '7.3', '7.4']
+                php-versions: ['7.4']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/migrations/.travis.yml
+++ b/packages/migrations/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 7.2
-    - 7.3
     - 7.4
 
 cache:

--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.4",
         "doctrine/dbal": "^2.11",
         "doctrine/doctrine-migrations-bundle": "^1.3",
         "doctrine/migrations": "^1.8.1",

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -82,3 +82,6 @@ There you can find links to upgrade notes for other versions too.
         - if you use default Shopsys Framework configuration, you can just use `ecs.php` (see #project-base-diff)
         - for your custom configuration, you can leverage https://github.com/symplify/config-transformer
     - see #project-base-diff to update your project 
+- **\[BC break\]** dropped support for unsupported PHP in packages ([#2416](https://github.com/shopsys/shopsys/pull/2416))
+    - packages `shopsys/migrations`, `shopsys/coding-standards`, and `shopsys/http-smoke-testing` no longer support PHP 7.2 and 7.3
+    - support for PHP 8.0 and 8.1 added to `shopsys/coding-standards` and `shopsys/http-smoke-testing`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| PHP 7.2 and 7.3 are no longer supported, so the support of those versions was dropped in packages `shopsys/migrations`, `shopsys/coding-standards`, and `shopsys/http-smoke-testing`. Support for PHP 8.0 and 8.1 added for `shopsys/coding-standards` and `shopsys/http-smoke-testing`.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

see succesfull builds:
- https://github.com/shopsys/coding-standards/actions/runs/1993697489
- https://github.com/shopsys/http-smoke-testing/actions/runs/1993753197