### PR TITLE
[migrations] add psr/log dependency

### DIFF
--- a/packages/migrations/composer.json
+++ b/packages/migrations/composer.json
@@ -27,6 +27,7 @@
         "doctrine/migrations": "^3.4.1",
         "doctrine/orm": "^2.5",
         "jdorn/sql-formatter": "^1.2",
+        "psr/log": "^1.0",
         "symfony/config": "^3.4|^4.0",
         "symfony/console": "^3.4|^4.0",
         "symfony/dependency-injection": "^3.4|^4.0",

--- a/packages/migrations/tests/Unit/Component/Doctrine/Migrations/AbstractMigrationLockTestCase.php
+++ b/packages/migrations/tests/Unit/Component/Doctrine/Migrations/AbstractMigrationLockTestCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\MigrationBundle\Unit\Component\Doctrine\Migrations;
 
-use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\MigrationsLock;
 
 abstract class AbstractMigrationLockTestCase extends AbstractMigrationTestCase
@@ -33,7 +33,7 @@ abstract class AbstractMigrationLockTestCase extends AbstractMigrationTestCase
      */
     protected function createNewMigrationsLock(): MigrationsLock
     {
-        $loggerMock = $this->createMock(Logger::class);
+        $loggerMock = $this->createMock(LoggerInterface::class);
 
         return new MigrationsLock(static::MIGRATION_LOCK, $loggerMock);
     }


### PR DESCRIPTION
- fixed AbstractMigrationLockTestCase so it creates mock from LoggerInterface instead of Monolog\Logger

| Q             | A
| ------------- | ---
|Description, reason for the PR| the package itself should require all the dependencies it uses, otherwise, it might end non-funcioning, see https://github.com/shopsys/migrations/runs/5770698635?check_suite_focus=true
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
