### PR TITLE
[shopsys] upgraded jms/translation-bundle to v1.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,7 @@
         "jdorn/sql-formatter": "^1.2",
         "jms/metadata": "^1.6",
         "jms/serializer-bundle": "^2.4",
-        "jms/translation-bundle": "1.4.4",
+        "jms/translation-bundle": "^1.6.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "lcobucci/jwt": "^3.4.6",
         "league/flysystem": "^1.1.4",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -63,7 +63,7 @@
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/metadata": "^1.6",
-        "jms/translation-bundle": "1.4.4",
+        "jms/translation-bundle": "^1.6.2",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "league/flysystem": "^1.1.4",
         "litipk/php-bignumbers": "^0.8.6",

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -53,7 +53,7 @@
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",
         "jms/serializer-bundle": "^2.4",
-        "jms/translation-bundle": "1.4.4",
+        "jms/translation-bundle": "^1.6.2",
         "league/flysystem": "^1.1.4",
         "nyholm/psr7": "^1.5",
         "phing/phing": "^2.16.1",

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -38,6 +38,8 @@ There you can find links to upgrade notes for other versions too.
     - `Admin/SliderController` has a new dependency on `EntityManagerInterface` in the constructor
     - `uuid-ossp` Postgres extension is no longer created in `CreateDatabaseCommand` as DB-side UUID generation is deprecated now
         - see https://github.com/doctrine/orm/blob/2.11.x/UPGRADE.md#deprecated-database-side-uuid-generation
+- allow installation of `jms/translation-bundle` version `1.6.2` and higher in `composer.json` ([#2420](https://github.com/shopsys/shopsys/pull/2420))
+    - see #project-base-diff to update your project
 
 ## Application
 - use different css classes for javascript and tests ([#2179](https://github.com/shopsys/shopsys/pull/2179))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| reason for pinning version from #1860 was resolved in jms/translation-bundle v1.6.0. New version is necessary for update to PHP8.1
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
