### PR TITLE
[framework] Do not show loader element in load order preview

### DIFF
--- a/packages/framework/assets/js/admin/components/OrderPreview.js
+++ b/packages/framework/assets/js/admin/components/OrderPreview.js
@@ -46,7 +46,7 @@ export default class OrderPreview {
                     if (!_this.isLoaded && !_this.isLoading) {
                         _this.isLoading = true;
                         Ajax.ajax({
-                            loaderElement: null,
+                            loaderElement: 'none',
                             url: _this.url,
                             success: (data) => _this.onLoadPreview(data)
                         });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After upgrading javascript codes disable loaderElement will not work with value null, so I recommend turning it off with 'none' value. If you don't like this solution, you can change 'none' value for something different or edit functionality for [loader element](https://github.com/shopsys/shopsys/blob/master/packages/framework/assets/js/common/utils/loaderOverlay.js#L2) with option for turn it off
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
