### PR TITLE
[framework] Remove usage of deprecated methods from roave/better-reflection

### DIFF
--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -144,7 +144,7 @@ class ExtendedClassesAnnotationsCommand extends Command
                 $symfonyStyle->listing($filesForAddingPropertyOrMethodAnnotations);
             } else {
                 $symfonyStyle->note(
-                    ['@method or @property annotations were added to the following files:'] + $filesForAddingPropertyOrMethodAnnotations
+                    array_merge(['@method or @property annotations were added to the following files:'], $filesForAddingPropertyOrMethodAnnotations)
                 );
             }
         }

--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -30,37 +30,37 @@ class ExtendedClassesAnnotationsCommand extends Command
     /**
      * @var string
      */
-    protected $projectRootDirectory;
+    protected string $projectRootDirectory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry
      */
-    protected $classExtensionRegistry;
+    protected ClassExtensionRegistry $classExtensionRegistry;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer
      */
-    protected $annotationsReplacer;
+    protected AnnotationsReplacer $annotationsReplacer;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap
      */
-    protected $annotationsReplacementsMap;
+    protected AnnotationsReplacementsMap $annotationsReplacementsMap;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\ClassExtension\PropertyAnnotationsFactory
      */
-    protected $propertyAnnotationsFactory;
+    protected PropertyAnnotationsFactory $propertyAnnotationsFactory;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory
      */
-    protected $methodAnnotationsAdder;
+    protected MethodAnnotationsFactory $methodAnnotationsAdder;
 
     /**
      * @var \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsAdder
      */
-    protected $annotationsAdder;
+    protected AnnotationsAdder $annotationsAdder;
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -131,6 +131,13 @@ class ExtendedClassesAnnotationsCommand extends Command
             }
         }
         $filesForAddingPropertyOrMethodAnnotations = $this->addPropertyAndMethodAnnotationsToProjectClasses($isDryRun);
+
+        if (count($this->methodAnnotationsAdder->getWarnings()) > 0) {
+            foreach ($this->methodAnnotationsAdder->getWarnings() as $exception) {
+                $symfonyStyle->warning($exception->getMessage());
+            }
+        }
+
         if (count($filesForAddingPropertyOrMethodAnnotations) > 0) {
             if ($isDryRun) {
                 $symfonyStyle->error('@method or @property annotations need to be added to the following files:');

--- a/packages/framework/src/Component/ClassExtension/DocBlockParser.php
+++ b/packages/framework/src/Component/ClassExtension/DocBlockParser.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+use phpDocumentor\Reflection\DocBlock\Tags\TagWithType;
+use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\Type;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+use Shopsys\FrameworkBundle\Component\ClassExtension\Exception\DocBlockParserAmbiguousTagException;
+
+class DocBlockParser
+{
+    /**
+     * @var \phpDocumentor\Reflection\DocBlockFactory
+     */
+    protected DocBlockFactory $docBlockFactory;
+
+    public function __construct()
+    {
+        $this->docBlockFactory = DocBlockFactory::createInstance();
+    }
+
+    /**
+     * @param string $docBlock
+     * @return \phpDocumentor\Reflection\Type[]
+     */
+    public function getReturnTypes(string $docBlock): array
+    {
+        if ($docBlock === '') {
+            return [];
+        }
+
+        /** @var \phpDocumentor\Reflection\DocBlock\Tags\TagWithType[] $tags */
+        $tags = $this->docBlockFactory->create($docBlock)->getTagsByName('return');
+
+        return array_map(static fn (TagWithType $tag) => $tag->getType(), $tags);
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionParameter $reflectionParameter
+     * @return \phpDocumentor\Reflection\Type|null
+     */
+    public function getParameterType(ReflectionParameter $reflectionParameter): ?Type
+    {
+        $docBlock = $reflectionParameter->getDeclaringFunction()->getDocComment();
+
+        if ($docBlock === '') {
+            return null;
+        }
+
+        /** @var \phpDocumentor\Reflection\DocBlock\Tags\Param[] $functionParamTags */
+        $functionParamTags = $this->docBlockFactory
+            ->create($docBlock)
+            ->getTagsByName('param');
+
+        /** @var \phpDocumentor\Reflection\Type|null $paramType */
+        $paramType = null;
+
+        foreach ($functionParamTags as $tag) {
+            if ($tag->getVariableName() === $reflectionParameter->getName()) {
+                $paramType = $tag->getType();
+            }
+        }
+
+        return $paramType;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @return \phpDocumentor\Reflection\Type|null
+     */
+    public function getPropertyType(ReflectionProperty $reflectionProperty): ?Type
+    {
+        $docBlock = $reflectionProperty->getDocComment();
+
+        if ($docBlock === '') {
+            return null;
+        }
+
+        /** @var \phpDocumentor\Reflection\DocBlock\Tags\Var_[] $propertyVarTags */
+        $propertyVarTags = $this->docBlockFactory
+            ->create($docBlock)
+            ->getTagsByName('var');
+
+        if (count($propertyVarTags) > 1) {
+            $filePath = sprintf(
+                '%s::$%s',
+                $reflectionProperty->getImplementingClass()->getName(),
+                $reflectionProperty->getName()
+            );
+
+            throw new DocBlockParserAmbiguousTagException('@var', $filePath);
+        }
+
+        if (!isset($propertyVarTags[0])) {
+            return null;
+        }
+
+        return $propertyVarTags[0]->getType();
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/Exception/DocBlockParserAmbiguousTagException.php
+++ b/packages/framework/src/Component/ClassExtension/Exception/DocBlockParserAmbiguousTagException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension\Exception;
+
+class DocBlockParserAmbiguousTagException extends DocBlockParserException
+{
+    /**
+     * @param string $tagName
+     * @param string $propertyPath
+     */
+    public function __construct(string $tagName, string $propertyPath)
+    {
+        parent::__construct(
+            "Doc block should have only 1 ${tagName} tag.\nProperty: ${propertyPath}\n",
+        );
+    }
+}

--- a/packages/framework/src/Component/ClassExtension/Exception/DocBlockParserException.php
+++ b/packages/framework/src/Component/ClassExtension/Exception/DocBlockParserException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension\Exception;
+
+use Exception;
+
+class DocBlockParserException extends Exception
+{
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
@@ -11,6 +11,7 @@ use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
+use Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\DummyClassForAnnotationsReplacerTest;
 
 class AnnotationsReplacerTest extends TestCase
@@ -28,7 +29,7 @@ class AnnotationsReplacerTest extends TestCase
             'Shopsys\FrameworkBundle\Model\Article\ArticleData' => 'App\Model\Article\ArticleData',
         ]);
 
-        $this->annotationsReplacer = new AnnotationsReplacer($replacementMap);
+        $this->annotationsReplacer = new AnnotationsReplacer($replacementMap, new DocBlockParser());
     }
 
     /**

--- a/packages/framework/tests/Unit/Component/ClassExtension/DocBlockParserTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/DocBlockParserTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\ClassExtension;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Null_;
+use phpDocumentor\Reflection\Types\Object_;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\ReflectionObject;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+use Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser;
+use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\DummyClassForAnnotationsReplacerTest;
+
+class DocBlockParserTest extends TestCase
+{
+    /**
+     * @var \Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser
+     */
+    private DocBlockParser $docBlockParser;
+
+    protected function setUp(): void
+    {
+        $this->docBlockParser = new DocBlockParser();
+    }
+
+    /**
+     * @dataProvider methodPhpDocReturnTypeDataProvider
+     * @param string $phpDoc
+     * @param string[] $returnTypes
+     */
+    public function testGetReturnTypesFromPhpDoc(string $phpDoc, array $returnTypes): void
+    {
+        $this->assertEquals($returnTypes, $this->docBlockParser->getReturnTypes($phpDoc));
+    }
+
+    /**
+     * @dataProvider methodPhpDocParamTypeDataProvider
+     * @param \Roave\BetterReflection\Reflection\ReflectionParameter $reflectionParameter
+     * @param string $paramTypeString
+     */
+    public function testGetMethodParamTypeFromPhpDoc(
+        ReflectionParameter $reflectionParameter,
+        string $paramTypeString
+    ): void {
+        $this->assertEquals($this->docBlockParser->getParameterType($reflectionParameter), $paramTypeString);
+    }
+
+    /**
+     * @dataProvider methodPhpDocPropertyTypeDataProvider
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @param string $paramTypeString
+     */
+    public function testGetPropertyTypeFromPhpDoc(
+        ReflectionProperty $reflectionProperty,
+        string $paramTypeString
+    ): void {
+        $this->assertEquals($this->docBlockParser->getPropertyType($reflectionProperty), $paramTypeString);
+    }
+
+    /**
+     * @return array<string|\phpDocumentor\Reflection\Type[]>[]
+     */
+    public function methodPhpDocReturnTypeDataProvider(): array
+    {
+        $reflectionClass = ReflectionObject::createFromName(DummyClassForAnnotationsReplacerTest::class);
+
+        return [
+            [
+                $reflectionClass->getMethod('returnsFrameworkCategoryFacade')->getDocComment(),
+                [new Object_(new Fqsen('\Shopsys\FrameworkBundle\Model\Category\CategoryFacade'))],
+            ],
+            [
+                $reflectionClass->getMethod('returnsFrameworkCategoryFacadeOrNull')->getDocComment(),
+                [
+                    new Compound([
+                        new Object_(new Fqsen('\Shopsys\FrameworkBundle\Model\Category\CategoryFacade')),
+                        new Null_(),
+                    ]),
+                ],
+            ],
+            [
+                $reflectionClass->getMethod('returnsFrameworkArticleDataArray')->getDocComment(),
+                [new Array_(new Object_(new Fqsen('\Shopsys\FrameworkBundle\Model\Article\ArticleData')))],
+            ],
+            [
+                $reflectionClass->getMethod('returnsInt')->getDocComment(),
+                [new Integer()],
+            ],
+            [
+                $reflectionClass->getMethod('acceptsVariousParameters')->getDocComment(),
+                [],
+            ],
+            [
+                $reflectionClass->getMethod('returnsNotTypedArray')->getDocComment(),
+                [new Array_()],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<(\Roave\BetterReflection\Reflection\ReflectionParameter|string|null)>[]
+     */
+    public function methodPhpDocParamTypeDataProvider(): array
+    {
+        $reflectionClass = ReflectionObject::createFromName(DummyClassForAnnotationsReplacerTest::class);
+        $reflectionMethod = $reflectionClass->getMethod('acceptsVariousParameters');
+
+        return [
+            [
+                $reflectionMethod->getParameter('categoryFacade'),
+                '\Shopsys\FrameworkBundle\Model\Category\CategoryFacade',
+            ],
+            [
+                $reflectionMethod->getParameter('categoryFacadeOrNull'),
+                '\Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null',
+            ],
+            [
+                $reflectionMethod->getParameter('array'),
+                '\Shopsys\FrameworkBundle\Model\Article\ArticleData[]',
+            ],
+            [
+                $reflectionMethod->getParameter('integer'),
+                'int',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<\Roave\BetterReflection\Reflection\ReflectionProperty|string>[]
+     */
+    public function methodPhpDocPropertyTypeDataProvider(): array
+    {
+        $reflectionClass = ReflectionObject::createFromName(DummyClassForAnnotationsReplacerTest::class);
+
+        return [
+            [
+                $reflectionClass->getProperty('categoryFacadeOrNull'),
+                '\Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null',
+            ],
+            [
+                $reflectionClass->getProperty('integer'),
+                'int',
+            ],
+            [
+                $reflectionClass->getProperty('articleDataArray'),
+                '\Shopsys\FrameworkBundle\Model\Article\ArticleData[]',
+            ],
+        ];
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/MethodAnnotationsFactoryTest.php
@@ -9,6 +9,7 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionObject;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
+use Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser;
 use Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass2;
@@ -37,9 +38,11 @@ class MethodAnnotationsFactoryTest extends TestCase
             'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\BaseClass4' => 'Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\MethodAnnotationsFactoryTest\ChildClass4',
         ]);
 
+        $docBlockParser = new DocBlockParser();
         $this->methodAnnotationsFactory = new MethodAnnotationsFactory(
             $replacementMap,
-            new AnnotationsReplacer($replacementMap)
+            new AnnotationsReplacer($replacementMap, $docBlockParser),
+            $docBlockParser,
         );
     }
 

--- a/packages/framework/tests/Unit/Component/ClassExtension/PropertyAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/PropertyAnnotationsFactoryTest.php
@@ -9,6 +9,7 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionObject;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap;
 use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
+use Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser;
 use Shopsys\FrameworkBundle\Component\ClassExtension\PropertyAnnotationsFactory;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass;
 use Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass2;
@@ -38,7 +39,7 @@ class PropertyAnnotationsFactoryTest extends TestCase
 
         $this->propertyAnnotationsFactory = new PropertyAnnotationsFactory(
             $replacementMap,
-            new AnnotationsReplacer($replacementMap)
+            new AnnotationsReplacer($replacementMap, new DocBlockParser())
         );
     }
 

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacerTest.php
@@ -50,6 +50,20 @@ class DummyClassForAnnotationsReplacerTest
     }
 
     /**
+     * @return array<string, int>
+     */
+    public function returnsAssocArray()
+    {
+    }
+
+    /**
+     * @return array
+     */
+    public function returnsNotTypedArray()
+    {
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null $categoryFacadeOrNull
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData[] $array

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -162,3 +162,30 @@ There you can find links to upgrade notes for other versions too.
     - if you need the backend-api in the current state, you can fork it and handle the compatibility with the new versions of the other packages
 - allow running npm scripts even when they are not executable ([#2403](https://github.com/shopsys/shopsys/pull/2403))
     - see #project-base-diff to update your project
+- **\[BC break\]** class `\Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer` was changed
+    - constructor changed interface
+        ```diff
+            /**
+             * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap $annotationsReplacementsMap
+        +    * @param \Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser $docBlockParser
+             */
+            public function __construct(
+                AnnotationsReplacementsMap $annotationsReplacementsMap,
+        +       DocBlockParser $docBlockParser
+            ) {
+    ```
+
+- **\[BC break\]** class `\Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory` was changed
+    - constructor changed interface
+        ```diff
+            /**
+             * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacementsMap $annotationsReplacementsMap
+             * @param \Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer $annotationsReplacer
+        +    * @param \Shopsys\FrameworkBundle\Component\ClassExtension\DocBlockParser $docBlockParser
+             */
+             public function __construct(
+                 AnnotationsReplacementsMap $annotationsReplacementsMap,
+                 AnnotationsReplacer $annotationsReplacer,
+        +        DocBlockParser $docBlockParser
+             ) {
+        ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|Removes all usages of methods that are no longer available in roave/better-reflection v5.x so that we can upgrade to version 5 in the future without problems. After uppgrade of roave/better-reflection phpdocumentor/reflection-docblock must be added as new dependency to composer.json
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
