### PR TITLE
[framework] new doctrine/orm version conflicted due to bc break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,8 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "friendsofphp/php-cs-fixer": "2.19.0"
+        "friendsofphp/php-cs-fixer": "2.19.0",
+        "doctrine/orm": "2.12.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -115,6 +115,9 @@
             "require": "^4.4.0"
         }
     },
+    "conflict": {
+        "doctrine/orm": "2.12.0"
+    },
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In doctrine/orm:2.12.0 is a conflicting change with prezent/doctrine-translatable package. This PR temporarily conflicts new version until https://github.com/Prezent/doctrine-translatable/pull/41 is resolved.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
