### PR TITLE
[frontend-api] attempt to create jwt configuration without keys now create unsecured signer instead of error

### DIFF
--- a/packages/frontend-api/src/Model/Token/JwtConfigurationFactory.php
+++ b/packages/frontend-api/src/Model/Token/JwtConfigurationFactory.php
@@ -12,6 +12,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class JwtConfigurationFactory
 {
+    private const FRONTEND_API_KEYS_FILEPATH_PARAMETER = 'shopsys.frontend_api.keys_filepath';
+
     /**
      * @var \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface
      */
@@ -39,6 +41,10 @@ class JwtConfigurationFactory
      */
     public function create(): Configuration
     {
+        if (!$this->parameterBag->has(self::FRONTEND_API_KEYS_FILEPATH_PARAMETER)) {
+            return Configuration::forUnsecuredSigner();
+        }
+
         return Configuration::forAsymmetricSigner(
             $this->getSigner(),
             $this->getPrivateKey(),
@@ -51,7 +57,7 @@ class JwtConfigurationFactory
      */
     public function getPrivateKey(): Key
     {
-        $apiKeyFilepath = $this->parameterBag->get('shopsys.frontend_api.keys_filepath');
+        $apiKeyFilepath = $this->parameterBag->get(self::FRONTEND_API_KEYS_FILEPATH_PARAMETER);
 
         return Key\InMemory::file($apiKeyFilepath . '/private.key');
     }
@@ -61,7 +67,7 @@ class JwtConfigurationFactory
      */
     public function getPublicKey(): Key
     {
-        $apiKeyFilepath = $this->parameterBag->get('shopsys.frontend_api.keys_filepath');
+        $apiKeyFilepath = $this->parameterBag->get(self::FRONTEND_API_KEYS_FILEPATH_PARAMETER);
 
         return Key\InMemory::file($apiKeyFilepath . '/public.key');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2419 was introduced new JWT configuration factory. If Frontend API is disabled and this class is injected (typically in some tests), the application crashes. This PR fixes it by creating an unsecured signer in that case. **CREATING AN UNSECURED SIGNER IS NOT A GOOD IDEA FOR PRODUCTION ENVIRONMENT**
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
