### PR TITLE
[framework] fix delete file action without filename

### DIFF
--- a/packages/framework/src/Controller/Admin/FileUploadController.php
+++ b/packages/framework/src/Controller/Admin/FileUploadController.php
@@ -82,6 +82,11 @@ class FileUploadController extends AdminBaseController
     public function deleteTemporaryFileAction(Request $request)
     {
         $filename = $request->get('filename');
+
+        if ($filename === null) {
+            return new JsonResponse(false);
+        }
+
         $actionResult = $this->fileUpload->tryDeleteTemporaryFile($filename);
 
         return new JsonResponse($actionResult);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| if filename is not provided, null is in the end passed as 3rd argument to preg_replace() function, and this is deprecated since PHP8.1
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
