### PR TITLE
[framework] Use magic methods instead of Serializable interface

### DIFF
--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -5,7 +5,6 @@ namespace Shopsys\FrameworkBundle\Model\Administrator;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Serializable;
 use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Model\Administrator\Exception\MandatoryAdministratorRoleIsMissingException;
 use Shopsys\FrameworkBundle\Model\Security\Roles;
@@ -22,7 +21,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  *   }
  * )
  */
-class Administrator implements UserInterface, Serializable, UniqueLoginInterface, TimelimitLoginInterface
+class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLoginInterface
 {
     /**
      * @ORM\Column(type="integer")
@@ -305,37 +304,34 @@ class Administrator implements UserInterface, Serializable, UniqueLoginInterface
     }
 
     /**
-     * @inheritDoc
+     * @return array{id: int, username: string, password: string, realName: string, loginToken: string, timestamp: int, rolesChangedAt: ?\DateTime}
      */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize([
-            $this->id,
-            $this->username,
-            $this->password,
-            $this->realName,
-            $this->loginToken,
-            time(),
-            $this->rolesChangedAt,
-        ]);
+        return [
+            'id' => $this->id,
+            'username' => $this->username,
+            'password' => $this->password,
+            'realName' => $this->realName,
+            'loginToken' => $this->loginToken,
+            'timestamp' => time(),
+            'rolesChangedAt' => $this->rolesChangedAt,
+        ];
     }
 
     /**
-     * @inheritDoc
+     * @param array{id: int, username: string, password: string, realName: string, loginToken: string, timestamp: int, rolesChangedAt: ?\DateTime} $data
      */
-    public function unserialize($serialized)
+    public function __unserialize(array $data): void
     {
-        [
-            $this->id,
-            $this->username,
-            $this->password,
-            $this->realName,
-            $this->loginToken,
-            $timestamp,
-            $this->rolesChangedAt
-        ] = unserialize($serialized);
+        $this->id = $data['id'];
+        $this->username = $data['username'];
+        $this->password = $data['password'];
+        $this->realName = $data['realName'];
+        $this->loginToken = $data['loginToken'];
+        $this->rolesChangedAt = $data['rolesChangedAt'];
         $this->lastActivity = new DateTime();
-        $this->lastActivity->setTimestamp($timestamp);
+        $this->lastActivity->setTimestamp($data['timestamp']);
     }
 
     /**

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -6,7 +6,6 @@ use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
-use Serializable;
 use Shopsys\FrameworkBundle\Model\Customer\Customer;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress;
 use Shopsys\FrameworkBundle\Model\Security\Roles;
@@ -25,7 +24,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * )
  * @ORM\Entity
  */
-class CustomerUser implements UserInterface, TimelimitLoginInterface, Serializable
+class CustomerUser implements UserInterface, TimelimitLoginInterface
 {
     /**
      * @ORM\Column(type="integer")
@@ -322,33 +321,30 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, Serializab
     }
 
     /**
-     * @inheritDoc
+     * @return array{id: int , email: string, password: string, timestamp: int, domainId: int}
      */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize([
-            $this->id,
-            $this->email,
-            $this->password,
-            time(), // lastActivity
-            $this->domainId,
-        ]);
+        return [
+            'id' => $this->id,
+            'email' => $this->email,
+            'password' => $this->password,
+            'timestamp' => time(), // lastActivity
+            'domainId' => $this->domainId,
+        ];
     }
 
     /**
-     * @inheritDoc
+     * @param array{id: int , email: string, password: string, timestamp: int, domainId: int} $data
      */
-    public function unserialize($serialized)
+    public function __unserialize(array $data): void
     {
-        [
-            $this->id,
-            $this->email,
-            $this->password,
-            $timestamp,
-            $this->domainId
-        ] = unserialize($serialized);
+        $this->id = $data['id'];
+        $this->email = $data['email'];
+        $this->password = $data['password'];
+        $this->domainId = $data['domainId'];
         $this->lastActivity = new DateTime();
-        $this->lastActivity->setTimestamp($timestamp);
+        $this->lastActivity->setTimestamp($data['timestamp']);
     }
 
     /**

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -162,7 +162,7 @@ There you can find links to upgrade notes for other versions too.
     - if you need the backend-api in the current state, you can fork it and handle the compatibility with the new versions of the other packages
 - allow running npm scripts even when they are not executable ([#2403](https://github.com/shopsys/shopsys/pull/2403))
     - see #project-base-diff to update your project
-- **\[BC break\]** class `\Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer` was changed
+- **\[BC break\]** class `\Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer` was changed ([#2426](https://github.com/shopsys/shopsys/pull/2426))
     - constructor changed interface
         ```diff
             /**
@@ -175,7 +175,7 @@ There you can find links to upgrade notes for other versions too.
             ) {
     ```
 
-- **\[BC break\]** class `\Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory` was changed
+- **\[BC break\]** class `\Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory` was changed ([#2426](https://github.com/shopsys/shopsys/pull/2426))
     - constructor changed interface
         ```diff
             /**
@@ -193,3 +193,9 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
     - update your dependencies with `composer update` after you set `platform.php` in `composer.json` to the required version
     - if you use custom Dockerfile, don't forget to rebuild your image with the new version of PHP
+- class `\Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser` no longer implements `Serializable` interface
+    - public methods `serialize()` and `unserialize()` were removed ([#2431](https://github.com/shopsys/shopsys/pull/2431))
+    - `__serialize()` and `__serialize()` are used instead
+- class `\Shopsys\FrameworkBundle\Model\Administrator\Administrator` no longer implements `Serializable` interface ([#2431](https://github.com/shopsys/shopsys/pull/2431))
+    - public methods `serialize()` and `unserialize()` were removed
+    - `__serialize()` and `__unserialize()` are used instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Resolves deprecated usage of `Serializable` interface in `\Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser` and `\Shopsys\FrameworkBundle\Model\Administrator\Administrator`<br/> For more info see notes and Example 2 here: https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No (But PHP >=7.4.0 is required) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
