### PR TITLE
[framework] revert generate uuid in migrations from #2417

### DIFF
--- a/packages/framework/src/Command/CreateDatabaseCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseCommand.php
@@ -103,6 +103,9 @@ class CreateDatabaseCommand extends Command
         // "superuser" role that normal DB user does not have.
         $this->getConnection()->executeStatement('CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA pg_catalog');
         $symfonyStyleIo->success('Extension unaccent is created');
+
+        $this->getConnection()->executeStatement('CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA pg_catalog');
+        $symfonyStyleIo->success('Extension "uuid-ossp" is created');
     }
 
     /**

--- a/packages/framework/src/Migrations/Version20190521071335.php
+++ b/packages/framework/src/Migrations/Version20190521071335.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20190521071335 extends AbstractMigration
@@ -14,7 +13,7 @@ class Version20190521071335 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE products ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE products SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE products SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE products ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_B3BA5A5AD17F50A6 ON products (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20190930140221.php
+++ b/packages/framework/src/Migrations/Version20190930140221.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20190930140221 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20190930140221 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE categories ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE categories SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE categories SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE categories ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_3AF34668D17F50A6 ON categories (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200310120000.php
+++ b/packages/framework/src/Migrations/Version20200310120000.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200310120000 extends AbstractMigration
@@ -14,7 +13,7 @@ class Version20200310120000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE payments ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE payments SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE payments SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE payments ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_65D29B32D17F50A6 ON payments (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200310130000.php
+++ b/packages/framework/src/Migrations/Version20200310130000.php
@@ -3,7 +3,6 @@
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200310130000 extends AbstractMigration
@@ -14,7 +13,7 @@ class Version20200310130000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE transports ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE transports SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE transports SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE transports ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_C7BE69E5D17F50A6 ON transports (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200319124638.php
+++ b/packages/framework/src/Migrations/Version20200319124638.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200319124638 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20200319124638 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE customer_users ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE customer_users SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE customer_users SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE customer_users ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_DAB6D0D2D17F50A6 ON customer_users (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200330150340.php
+++ b/packages/framework/src/Migrations/Version20200330150340.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200330150340 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20200330150340 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE orders ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE orders SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE orders SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE orders ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_E52FFDEED17F50A6 ON orders (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200416114815.php
+++ b/packages/framework/src/Migrations/Version20200416114815.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200416114815 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20200416114815 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE customer_user_refresh_token_chain ADD device_id UUID DEFAULT NULL');
-        $this->sql('UPDATE customer_user_refresh_token_chain SET device_id = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE customer_user_refresh_token_chain SET device_id = uuid_generate_v4()');
         $this->sql('ALTER TABLE customer_user_refresh_token_chain ALTER device_id SET NOT NULL');
     }
 

--- a/packages/framework/src/Migrations/Version20200819165818.php
+++ b/packages/framework/src/Migrations/Version20200819165818.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200819165818 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20200819165818 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE articles ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE articles SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE articles SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE articles ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_BFDD3168D17F50A6 ON articles (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200923075659.php
+++ b/packages/framework/src/Migrations/Version20200923075659.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200923075659 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20200923075659 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE brands ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE brands SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE brands SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE brands ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_7EA24434D17F50A6 ON brands (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20200930074334.php
+++ b/packages/framework/src/Migrations/Version20200930074334.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20200930074334 extends AbstractMigration
@@ -16,12 +15,12 @@ class Version20200930074334 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE parameter_values ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE parameter_values SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE parameter_values SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE parameter_values ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_DED94617D17F50A6 ON parameter_values (uuid)');
 
         $this->sql('ALTER TABLE parameters ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE parameters SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE parameters SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE parameters ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_69348FED17F50A6 ON parameters (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20201009082139.php
+++ b/packages/framework/src/Migrations/Version20201009082139.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20201009082139 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20201009082139 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE adverts ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE adverts SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE adverts SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE adverts ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_8C88E777D17F50A6 ON adverts (uuid)');
     }

--- a/packages/framework/src/Migrations/Version20201120143414.php
+++ b/packages/framework/src/Migrations/Version20201120143414.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Ramsey\Uuid\Uuid;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 
 class Version20201120143414 extends AbstractMigration
@@ -16,7 +15,7 @@ class Version20201120143414 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('ALTER TABLE flags ADD uuid UUID DEFAULT NULL');
-        $this->sql('UPDATE flags SET uuid = :uuid', ['uuid' => Uuid::uuid4()->toString()]);
+        $this->sql('UPDATE flags SET uuid = uuid_generate_v4()');
         $this->sql('ALTER TABLE flags ALTER uuid SET NOT NULL');
         $this->sql('CREATE UNIQUE INDEX UNIQ_B0541BAD17F50A6 ON flags (uuid)');
     }

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -36,8 +36,6 @@ There you can find links to upgrade notes for other versions too.
     - `Admin/AdvertController` has a new dependency on `EntityManagerInterface` in the constructor
     - `Admin/BrandController` has a new dependency on `EntityManagerInterface` in the constructor
     - `Admin/SliderController` has a new dependency on `EntityManagerInterface` in the constructor
-    - `uuid-ossp` Postgres extension is no longer created in `CreateDatabaseCommand` as DB-side UUID generation is deprecated now
-        - see https://github.com/doctrine/orm/blob/2.11.x/UPGRADE.md#deprecated-database-side-uuid-generation
 - allow installation of `jms/translation-bundle` version `1.6.2` and higher in `composer.json` ([#2420](https://github.com/shopsys/shopsys/pull/2420))
     - see #project-base-diff to update your project
 - **\[BC break\]** upgrade `lcobucci/jwt` ([#2419](https://github.com/shopsys/shopsys/pull/2419))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| current behavior break unique constraint for existing data. uuid-ossp can be removed along with the upgrade of PostgreSQL in the future.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
