### PR TITLE
[shopsys] Use getValues() instead of toArray() on Doctrine Collections

### DIFF
--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -259,7 +259,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
      */
     public function getAdministratorRoles(): array
     {
-        return $this->roles->toArray();
+        return $this->roles->getValues();
     }
 
     /**
@@ -348,7 +348,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     {
         $roles = [];
         /** @var \Shopsys\FrameworkBundle\Model\Administrator\Role\AdministratorRole $role */
-        foreach ($this->roles->toArray() as $role) {
+        foreach ($this->roles->getValues() as $role) {
             $roles[] = $role->getRole();
         }
 
@@ -414,7 +414,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
 
     protected function checkRolesContainAdminRole(): void
     {
-        foreach ($this->roles->toArray() as $role) {
+        foreach ($this->roles->getValues() as $role) {
             if (in_array($role->getRole(), Roles::getMandatoryAdministratorRoles(), true)) {
                 return;
             }

--- a/packages/framework/src/Model/Cart/Cart.php
+++ b/packages/framework/src/Model/Cart/Cart.php
@@ -102,7 +102,7 @@ class Cart
      */
     public function getItems()
     {
-        return array_values($this->items->toArray());
+        return $this->items->getValues();
     }
 
     /**

--- a/packages/framework/src/Model/Category/Category.php
+++ b/packages/framework/src/Model/Category/Category.php
@@ -181,7 +181,7 @@ class Category extends AbstractTranslatableEntity
      */
     public function getChildren()
     {
-        return $this->children->toArray();
+        return $this->children->getValues();
     }
 
     /**

--- a/packages/framework/src/Model/Customer/Customer.php
+++ b/packages/framework/src/Model/Customer/Customer.php
@@ -111,7 +111,7 @@ class Customer
      */
     public function getDeliveryAddresses(): array
     {
-        return $this->deliveryAddresses->toArray();
+        return $this->deliveryAddresses->getValues();
     }
 
     /**

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -624,7 +624,7 @@ class Order
      */
     public function getItems()
     {
-        return $this->items->toArray();
+        return $this->items->getValues();
     }
 
     /**

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -165,7 +165,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
      */
     public function getTransports()
     {
-        return $this->transports->toArray();
+        return $this->transports->getValues();
     }
 
     /**
@@ -245,7 +245,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
      */
     public function getPrices()
     {
-        return $this->prices->toArray();
+        return $this->prices->getValues();
     }
 
     /**

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -615,7 +615,7 @@ class Product extends AbstractTranslatableEntity
         foreach ($productCategoryDomains as $productCategoryDomain) {
             if ($this->isProductCategoryDomainInArray(
                 $productCategoryDomain,
-                $this->productCategoryDomains->toArray()
+                $this->productCategoryDomains->getValues()
             ) === false) {
                 $this->productCategoryDomains->add($productCategoryDomain);
             }
@@ -668,7 +668,7 @@ class Product extends AbstractTranslatableEntity
      */
     public function getFlags()
     {
-        return $this->flags->toArray();
+        return $this->flags->getValues();
     }
 
     /**
@@ -809,7 +809,7 @@ class Product extends AbstractTranslatableEntity
 
         $this->variants->add($variant);
         $variant->setMainVariant($this);
-        $variant->copyProductCategoryDomains($this->productCategoryDomains->toArray());
+        $variant->copyProductCategoryDomains($this->productCategoryDomains->getValues());
     }
 
     /**
@@ -842,7 +842,7 @@ class Product extends AbstractTranslatableEntity
      */
     public function getVariants()
     {
-        return $this->variants->toArray();
+        return $this->variants->getValues();
     }
 
     public function unsetMainVariant()

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -180,7 +180,7 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
      */
     public function getPrices()
     {
-        return $this->prices->toArray();
+        return $this->prices->getValues();
     }
 
     /**
@@ -337,7 +337,7 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
      */
     public function getPayments()
     {
-        return $this->payments->toArray();
+        return $this->payments->getValues();
     }
 
     /**

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategory.php
@@ -128,6 +128,6 @@ class HeurekaCategory
      */
     public function getCategories()
     {
-        return $this->categories->toArray();
+        return $this->categories->getValues();
     }
 }

--- a/upgrade/UPGRADE-v9.2.0-dev.md
+++ b/upgrade/UPGRADE-v9.2.0-dev.md
@@ -199,3 +199,10 @@ There you can find links to upgrade notes for other versions too.
 - upgrade easy coding standards to v10 ([#2435](https://github.com/shopsys/shopsys/pull/2435))
     - see #project-base-diff to update your project
     - code style was adjusted, don't forget to check standards and update your code accordingly
+- Doctrine Collections - use `getValues()` instead of `toArray()` ([#2439](https://github.com/shopsys/shopsys/pull/2439))
+    - For details see issue ([#2409](https://github.com/shopsys/shopsys/issues/2409))
+    ```diff
+        $collection = new ArrayCollection([0, 1]);
+    -   $collection->toArray();
+    +   $collection->getValues();
+    ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Using `toArray()` on Doctrine Collections might be problematic as described in #2409  
|New feature| No
|[BC breaks]| No
|Fixes issues| closes #2409 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
