### PR TITLE
[framework] fix deprecation Implicit conversion from float to int loses precision

### DIFF
--- a/packages/framework/src/Component/Console/ProgressBarFactory.php
+++ b/packages/framework/src/Component/Console/ProgressBarFactory.php
@@ -54,7 +54,7 @@ class ProgressBarFactory
         return sprintf(
             '%dh %02dm %02ds',
             floor($timeInSeconds / 3600),
-            floor(($timeInSeconds / 60) % 60),
+            floor(intdiv($timeInSeconds, 60) % 60),
             floor($timeInSeconds % 60)
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| float is implicitly cast to int before modulo operand and this causes deprecation warning in PHP 8.1
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
