### PR TITLE
Bump flex to ^1.17, 1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
         "symfony/debug-bundle": "^4.4.0",
         "symfony/dotenv": "^4.4.0",
         "symfony/event-dispatcher": "^4.4.0",
-        "symfony/flex": "^1.4",
+        "symfony/flex": "^1.17",
         "symfony/form": "^4.4.0",
         "symfony/monolog-bridge": "^4.4.0",
         "symfony/monolog-bundle": "^3.5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes
|Fixes issues| -
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
