### PR TITLE
[framework] translate constraint messages in yaml files in config directory

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -1271,6 +1271,7 @@
             <arg value="${path.bin-console}"/>
             <arg value="translation:extract"/>
             <arg value="--dir=${path.src}"/>
+            <arg value="--dir=${path.config}"/>
             <arg value="--dir=${path.templates}"/>
             <arg value="--dir=${path.var}/translations/projectBase"/>
             <arg value="--exclude-dir=frontend/plugins"/>

--- a/packages/framework/src/Component/Translation/ConfigConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConfigConstraintMessageExtractor.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Translation;
+
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Yaml\Yaml;
+use Twig\Node\Node;
+
+/**
+ * Extracts constraint messages from GraphQl config yaml files.
+ *
+ * Example:
+ *  Mutation:
+ *      type: object
+ *      config:
+ *          fields:
+ *              NewsletterSubscribe:
+ *                  type: Boolean!
+ *                  description: "Subscribe for e-mail newsletter"
+ *                  args:
+ *                      input:
+ *                          type: "String!"
+ *                          validation:
+ *                              -   NotBlank:
+ *                                      message: "Please enter email"
+ */
+class ConfigConstraintMessageExtractor implements FileVisitorInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue): void
+    {
+        if ($file->getExtension() === 'yaml' || $file->getExtension() === 'yml') {
+            $yamlContent = Yaml::parseFile($file->getRealPath(), Yaml::PARSE_CUSTOM_TAGS);
+            if ($yamlContent !== null) {
+                $validationArrays = $this->getAllValuesOfArrayKeysByPattern($yamlContent, '/^validation$/');
+                $validationArraysWithoutCascade = array_filter($validationArrays, static function ($value) {
+                    return $value !== 'cascade';
+                });
+                $messages = $this->getAllValuesOfArrayKeysByPattern($validationArraysWithoutCascade, '/.*message.*/i');
+                foreach ($messages as $message) {
+                    // message value can be null or ~
+                    if (is_string($message)) {
+                        $catalogue->add(new Message($message, ConstraintMessageExtractor::CONSTRAINT_MESSAGE_DOMAIN));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array $yamlContent
+     * @param string $pattern
+     * @return array
+     */
+    protected function getAllValuesOfArrayKeysByPattern(array $yamlContent, string $pattern): array
+    {
+        $iterator = new RecursiveArrayIterator($yamlContent);
+        $recursive = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
+        $elements = [];
+        foreach ($recursive as $key => $value) {
+            preg_match($pattern, (string)$key, $matches);
+            if (count($matches) > 0) {
+                $elements[] = $value;
+            }
+        }
+
+        return $elements;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Node $ast): void
+    {
+    }
+}

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -310,6 +310,10 @@ services:
         tags:
             - { name: jms_translation.file_visitor }
 
+    Shopsys\FrameworkBundle\Component\Translation\ConfigConstraintMessageExtractor:
+        tags:
+            - { name: jms_translation.file_visitor }
+
     Shopsys\FrameworkBundle\Component\Translation\PoDumper:
         tags:
             - { name: jms_translation.dumper, format: po }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -85,9 +85,6 @@ msgstr "Přidat stát"
 msgid "Add item"
 msgstr "Přidat položku"
 
-msgid "Add only to order confirmation page"
-msgstr "Vložit jen na stránku s potvrzením objednávky"
-
 msgid "Add product"
 msgstr "Přidat zboží"
 
@@ -165,9 +162,6 @@ msgstr "Všechny e-maily budou doručeny pouze na uvedenou adresu."
 
 msgid "All emails will be sent only to entered addresses."
 msgstr "Všechny e-maily budou doručeny pouze na uvedené adresy."
-
-msgid "All pages"
-msgstr "Všechny stránky"
 
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
 msgstr "Pokud je zaškrtnuto, všechny ceny je třeba nastavovat ručně, jinak se jednotková cena bez DPH a celkové ceny pro tuto položku přepočítají automaticky."
@@ -571,9 +565,6 @@ msgstr "Cron se serviceId `%serviceId%` byl naplánován"
 msgid "Cropping"
 msgstr "Ořezávání"
 
-msgid "Currencies"
-msgstr "Měny"
-
 msgid "Currencies and rounding"
 msgstr "Měny a zaokrouhlování"
 
@@ -678,9 +669,6 @@ msgstr "Smazat"
 
 msgid "Delete and set"
 msgstr "Smazat a nastavit"
-
-msgid "Delete status of order"
-msgstr "Smazat stav objednávky"
 
 msgid "Delivery address"
 msgstr "Dodací adresa"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -85,9 +85,6 @@ msgstr ""
 msgid "Add item"
 msgstr ""
 
-msgid "Add only to order confirmation page"
-msgstr ""
-
 msgid "Add product"
 msgstr ""
 
@@ -164,9 +161,6 @@ msgid "All emails will be sent only to entered address."
 msgstr ""
 
 msgid "All emails will be sent only to entered addresses."
-msgstr ""
-
-msgid "All pages"
 msgstr ""
 
 msgid "All prices have to be handled manually if checked, otherwise the unit price without VAT and the total prices for that item will be recalculated automatically."
@@ -571,9 +565,6 @@ msgstr ""
 msgid "Cropping"
 msgstr ""
 
-msgid "Currencies"
-msgstr ""
-
 msgid "Currencies and rounding"
 msgstr ""
 
@@ -677,9 +668,6 @@ msgid "Delete"
 msgstr ""
 
 msgid "Delete and set"
-msgstr ""
-
-msgid "Delete status of order"
 msgstr ""
 
 msgid "Delivery address"

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -40,9 +40,6 @@ msgstr "Kód státu {{ country_code }} neexistuje. Povolené kódy státu jsou {
 msgid "EAN cannot be longer than {{ limit }} characters"
 msgstr "EAN nesmí být delší než {{ limit }} znaků"
 
-msgid "Each parameter can be used only once"
-msgstr "Každý parametr může být nastaven pouze jednou"
-
 msgid "Email cannot be longer than {{ limit }} characters"
 msgstr "E-mail nesmí být delší než {{ limit }} znaků"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -40,9 +40,6 @@ msgstr ""
 msgid "EAN cannot be longer than {{ limit }} characters"
 msgstr ""
 
-msgid "Each parameter can be used only once"
-msgstr ""
-
 msgid "Email cannot be longer than {{ limit }} characters"
 msgstr ""
 

--- a/packages/framework/tests/Unit/Component/Translation/ConfigConstraintMessageExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/ConfigConstraintMessageExtractorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Translation;
+
+use JMS\TranslationBundle\Model\Message;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Translation\ConfigConstraintMessageExtractor;
+use SplFileInfo;
+
+class ConfigConstraintMessageExtractorTest extends TestCase
+{
+    public function testMessagesAreExtractedFromConfigYamlFile(): void
+    {
+        $file = new SplFileInfo(__DIR__ . '/Resources/DummyMutation.types.yaml');
+
+        $actualCatalogue = $this->extract($file);
+
+        $expectedCatalogue = new MessageCatalogue();
+
+        $message1 = new Message('Please enter email', 'validators');
+        $message2 = new Message('Please enter valid email', 'validators');
+        $message3 = new Message('Email cannot be longer than {{ limit }} characters', 'validators');
+        $expectedCatalogue->add($message1);
+        $expectedCatalogue->add($message2);
+        $expectedCatalogue->add($message3);
+
+        $this->assertEquals($expectedCatalogue, $actualCatalogue);
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     * @return \JMS\TranslationBundle\Model\MessageCatalogue
+     */
+    private function extract(SplFileInfo $file): MessageCatalogue
+    {
+        $extractor = new ConfigConstraintMessageExtractor();
+
+        $catalogue = new MessageCatalogue();
+        $extractor->visitFile($file, $catalogue);
+
+        return $catalogue;
+    }
+}

--- a/packages/framework/tests/Unit/Component/Translation/Resources/DummyMutation.types.yaml
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/DummyMutation.types.yaml
@@ -1,0 +1,21 @@
+Mutation:
+    type: object
+    config:
+        fields:
+            NewsletterSubscribe:
+                type: Boolean!
+                description: "Subscribe for e-mail newsletter"
+                args:
+                    input:
+                        type: "String!"
+                        validation:
+                            -   NotBlank:
+                                    message: "Please enter email"
+                            -   Email:
+                                    message: "Please enter valid email"
+                            -   Length:
+                                    max: 255
+                                    maxMessage: "Email cannot be longer than {{ limit }} characters"
+                                    min: 0
+                                    minMessage: ~
+                resolve: "@=mutation('newsletter_subscribe', [args, validator])"

--- a/packages/frontend-api/src/Resources/translations/validators.cs.po
+++ b/packages/frontend-api/src/Resources/translations/validators.cs.po
@@ -4,11 +4,98 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: cs\n"
 
+msgid "City name cannot be longer than {{ limit }} characters"
+msgstr "Název města nesmí být delší než {{ limit }} znaků"
+
+msgid "Company name cannot be longer than {{ limit }} characters"
+msgstr "Název firmy nesmí být delší než {{ limit }} znaků"
+
+msgid "Email cannot be longer than {{ limit }} characters"
+msgstr "E-mail nesmí být delší než {{ limit }} znaků"
+
+msgid "First name cannot be longer than {{ limit }} characters"
+msgstr "Jméno nesmí být delší než {{ limit }} znaků"
+
+msgid "First name of contact person cannot be longer than {{ limit }} characters"
+msgstr "Jméno kontaktní osoby nesmí být delší než {{ limit }} znaků"
+
+msgid "Identification number cannot be longer than {{ limit }} characters"
+msgstr "IČ nesmí být delší než {{ limit }} znaků"
+
+msgid "Last name cannot be longer than {{ limit }} characters"
+msgstr "Příjmení nesmí být delší než {{ limit }} znaků"
+
+msgid "Last name of contact person cannot be longer than {{ limit }} characters"
+msgstr "Příjmení kontaktní osoby nesmí být delší než {{ limit }} znaků"
+
+msgid "New password must be at least {{ limit }} characters long"
+msgstr "Nové heslo musí mít minimálně {{ limit }} znaků"
+
+msgid "Old password must be at least {{ limit }} characters long"
+msgstr "Staré heslo musí mít minimálně {{ limit }} znaků"
+
+msgid "Password must be at least {{ limit }} characters long"
+msgstr "Heslo musí mít minimálně {{ limit }} znaků"
+
 msgid "Payment {{ uuid }} doesn't exist"
 msgstr "Platba {{ uuid }} neexistuje"
 
 msgid "Please choose a valid combination of transport and payment"
 msgstr "Prosím vyberte povolenou kombinaci dopravy a platby"
+
+msgid "Please choose country"
+msgstr "Prosím vyberte stát"
+
+msgid "Please enter at least one product"
+msgstr "Zadejte prosím alespoň jeden produkt"
+
+msgid "Please enter city"
+msgstr "Vyplňte prosím město"
+
+msgid "Please enter company name"
+msgstr "Vyplňte prosím název firmy"
+
+msgid "Please enter email"
+msgstr "Vyplňte prosím e-mail"
+
+msgid "Please enter first name"
+msgstr "Vyplňte prosím jméno"
+
+msgid "Please enter first name of contact person"
+msgstr "Vyplňte prosím jméno kontaktní osoby"
+
+msgid "Please enter identification number"
+msgstr "Vyplňte prosím IČ"
+
+msgid "Please enter last name"
+msgstr "Vyplňte prosím příjmení"
+
+msgid "Please enter last name of contact person"
+msgstr "Vyplňte prosím příjmení kontaktní osoby"
+
+msgid "Please enter new password"
+msgstr "Zadejte prosím nové heslo"
+
+msgid "Please enter old password"
+msgstr "Zadejte staré heslo"
+
+msgid "Please enter password"
+msgstr "Vyplňte prosím heslo"
+
+msgid "Please enter street"
+msgstr "Vyplňte prosím ulici"
+
+msgid "Please enter telephone number"
+msgstr "Vyplňte prosím telefon"
+
+msgid "Please enter valid email"
+msgstr "Vyplňte prosím platný e-mail"
+
+msgid "Please enter your email address"
+msgstr "Prosím zadejte svůj e-mail"
+
+msgid "Please enter zip code"
+msgstr "Vyplňte prosím PSČ"
 
 msgid "Price for payment {{ uuid }} has changed"
 msgstr "Cena platby {{ uuid }} se změnila"
@@ -25,6 +112,21 @@ msgstr "Zboží {{ uuid }} nemá prodejní cenu"
 msgid "Product {{ uuid }} no longer available or doesn't exist"
 msgstr "Zboží {{ uuid }} již není v nabídce nebo neexistuje"
 
+msgid "Street name cannot be longer than {{ limit }} characters"
+msgstr "Název ulice nesmí být delší než {{ limit }} znaků"
+
+msgid "Tax number cannot be longer than {{ limit }} characters"
+msgstr "DIČ nesmí být delší než {{ limit }} znaků"
+
+msgid "Telephone number cannot be longer than {{ limit }} characters"
+msgstr "Telefon nesmí být delší než {{ limit }} znaků"
+
+msgid "This email is already registered"
+msgstr "Tento e-mail je již registrován"
+
 msgid "Transport {{ uuid }} doesn't exist"
 msgstr "Doprava {{ uuid }} neexistuje"
+
+msgid "Zip code cannot be longer than {{ limit }} characters"
+msgstr "PSČ nesmí být delší než {{ limit }} znaků"
 

--- a/packages/frontend-api/src/Resources/translations/validators.en.po
+++ b/packages/frontend-api/src/Resources/translations/validators.en.po
@@ -4,10 +4,97 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 
+msgid "City name cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Company name cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Email cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "First name cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "First name of contact person cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Identification number cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Last name cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Last name of contact person cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "New password must be at least {{ limit }} characters long"
+msgstr ""
+
+msgid "Old password must be at least {{ limit }} characters long"
+msgstr ""
+
+msgid "Password must be at least {{ limit }} characters long"
+msgstr ""
+
 msgid "Payment {{ uuid }} doesn't exist"
 msgstr ""
 
 msgid "Please choose a valid combination of transport and payment"
+msgstr ""
+
+msgid "Please choose country"
+msgstr ""
+
+msgid "Please enter at least one product"
+msgstr ""
+
+msgid "Please enter city"
+msgstr ""
+
+msgid "Please enter company name"
+msgstr ""
+
+msgid "Please enter email"
+msgstr ""
+
+msgid "Please enter first name"
+msgstr ""
+
+msgid "Please enter first name of contact person"
+msgstr ""
+
+msgid "Please enter identification number"
+msgstr ""
+
+msgid "Please enter last name"
+msgstr ""
+
+msgid "Please enter last name of contact person"
+msgstr ""
+
+msgid "Please enter new password"
+msgstr ""
+
+msgid "Please enter old password"
+msgstr ""
+
+msgid "Please enter password"
+msgstr ""
+
+msgid "Please enter street"
+msgstr ""
+
+msgid "Please enter telephone number"
+msgstr ""
+
+msgid "Please enter valid email"
+msgstr ""
+
+msgid "Please enter your email address"
+msgstr ""
+
+msgid "Please enter zip code"
 msgstr ""
 
 msgid "Price for payment {{ uuid }} has changed"
@@ -25,6 +112,21 @@ msgstr ""
 msgid "Product {{ uuid }} no longer available or doesn't exist"
 msgstr ""
 
+msgid "Street name cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Tax number cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "Telephone number cannot be longer than {{ limit }} characters"
+msgstr ""
+
+msgid "This email is already registered"
+msgstr ""
+
 msgid "Transport {{ uuid }} doesn't exist"
+msgstr ""
+
+msgid "Zip code cannot be longer than {{ limit }} characters"
 msgstr ""
 

--- a/upgrade/UPGRADE-v10.0.0-dev.md
+++ b/upgrade/UPGRADE-v10.0.0-dev.md
@@ -294,3 +294,10 @@ All the changes are considered as backwards incompatible.
         - public function __construct(?int $transportId = null, int $domainId, ?Exception $previous = null)
         + public function __construct(int $domainId, ?int $transportId = null, ?Exception $previous = null)
         ```
+- unused translations have been removed ([#2442](https://github.com/shopsys/shopsys/pull/2442))
+    - the following `msgid` entries are no longer available, if you use any of them in your project, you need to dump and fill in the translations at your side:
+        - "Add only to order confirmation page"
+        - "All pages"
+        - "Currencies"
+        - "Delete status of order"
+        - "Each parameter can be used only once"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Functionality to translate custom constraint messages for GraphQL. It's possible Frontend and Backend validation are not exactly same, so you wanna FE developers to be informatied about what this is issue and they can show error message customer. P.S.: czech language is not my native speak language so please check czech translate. Thanks
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
