### PR TITLE
[shopsys] fixed join slack link across codebase

### DIFF
--- a/docs/_theme/versions.html
+++ b/docs/_theme/versions.html
@@ -1,7 +1,7 @@
 <div class="rst-versions" role="note" style="cursor: pointer">
     <span class="rst-current-version">
       <a href="https://github.com/shopsys/shopsys/" class="rst-current-version-icon fa fa-github" target="_blank" title="Github"></a>
-      <a href="https://shopsysframework.slack.com/" class="rst-current-version-icon" target="_blank" title="Slack">
+      <a href="https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ" class="rst-current-version-icon" target="_blank" title="Slack">
           <img src="{{ base_url }}/_theme/img/slack.png" class="rst-current-version-icon-image" ></a>
       <a href="https://twitter.com/shopsyscz?lang=cs" class="rst-current-version-icon fa fa-twitter" target="_blank" title="Twitter"></a>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ On these pages, you can find everything you need to know when you want to build 
 If you want to know more about what Shopsys Framework is, you can take a look at our [README.md](https://github.com/shopsys/shopsys/blob/master/README.md).
 
 ## Need help?
-If you are not able to find the desired information here, you can always ask us directly on our [public slack](http://slack.shopsys-framework.com/) or [report an issue](https://github.com/shopsys/shopsys/issues/new) on Github.
+If you are not able to find the desired information here, you can always ask us directly on our [public slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ) or [report an issue](https://github.com/shopsys/shopsys/issues/new) on Github.
 If you are struggling with Docker, [Docker Troubleshooting](./docker/docker-troubleshooting.md) might help you.
 
 ## What is new and how to upgrade

--- a/packages/backend-api/README.md
+++ b/packages/backend-api/README.md
@@ -26,7 +26,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/coding-standards/README.md
+++ b/packages/coding-standards/README.md
@@ -93,7 +93,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/form-types-bundle/README.md
+++ b/packages/form-types-bundle/README.md
@@ -82,7 +82,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -32,7 +32,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/frontend-api/README.md
+++ b/packages/frontend-api/README.md
@@ -48,7 +48,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/google-cloud-bundle/README.md
+++ b/packages/google-cloud-bundle/README.md
@@ -53,7 +53,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/http-smoke-testing/README.md
+++ b/packages/http-smoke-testing/README.md
@@ -182,7 +182,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/migrations/README.md
+++ b/packages/migrations/README.md
@@ -40,7 +40,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/monorepo-tools/README.md
+++ b/packages/monorepo-tools/README.md
@@ -177,6 +177,7 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).

--- a/packages/plugin-interface/README.md
+++ b/packages/plugin-interface/README.md
@@ -220,7 +220,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/product-feed-google/README.md
+++ b/packages/product-feed-google/README.md
@@ -56,7 +56,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/product-feed-heureka-delivery/README.md
+++ b/packages/product-feed-heureka-delivery/README.md
@@ -64,7 +64,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/product-feed-heureka/README.md
+++ b/packages/product-feed-heureka/README.md
@@ -56,7 +56,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/product-feed-zbozi/README.md
+++ b/packages/product-feed-zbozi/README.md
@@ -56,7 +56,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/packages/read-model/README.md
+++ b/packages/read-model/README.md
@@ -46,7 +46,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/project-base/README.md
+++ b/project-base/README.md
@@ -34,7 +34,8 @@ please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 Please, check our [Contribution Guide](https://github.com/shopsys/shopsys/blob/master/CONTRIBUTING.md) before contributing.
 
 ## Support
-What to do when you are in troubles or need some help? Best way is to contact us on our Slack [http://slack.shopsys-framework.com/](http://slack.shopsys-framework.com/)
+What to do when you are in troubles or need some help?
+The best way is to join our [Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).
 
 If you want to [report issues](https://github.com/shopsys/shopsys/issues/new), please use the main [Shopsys repository](https://github.com/shopsys/shopsys).
 

--- a/upgrade/money-class.md
+++ b/upgrade/money-class.md
@@ -464,4 +464,4 @@ Refactor your code if you have used them (you can take a look at [the original c
 
 We know that the change is huge and upgrading might be difficult.
 We want to keep improving Shopsys Framework for you, we hope that this article helped you to safely upgrade your project.
-If you find anything we missed or if you'll need to explain anything more, please [create an issue](https://github.com/shopsys/shopsys/issues/new) or contact us on [our Slack](http://slack.shopsys-framework.com/).
+If you find anything we missed or if you'll need to explain anything more, please [create an issue](https://github.com/shopsys/shopsys/issues/new) or join us on [our Slack](https://join.slack.com/t/shopsysframework/shared_invite/zt-11wx9au4g-e5pXei73UJydHRQ7nVApAQ).


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixed link to join our slack across the codebase. The proper link was in general README.md file, but other occurrences were fixed here.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
