### PR TITLE
[coding-standards] remove STRICT setList from configuration

### DIFF
--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -153,7 +153,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SetList::CONTROL_STRUCTURES);
     $containerConfigurator->import(SetList::DOCBLOCK);
     $containerConfigurator->import(SetList::NAMESPACES);
-    $containerConfigurator->import(SetList::STRICT);
 
     $parameters->set(Option::LINE_ENDING, '\n');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| description follows
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No (setlist introduced in the same version) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

The setList cannot be used as DeclareStrictTypesFixer forces strict types declaration in the split packages and the codebase is not ready for this.

- rule contains four fixers:
-- StrictComparisonFixer - we use DisallowEqualOperatorsSniff instead
-- StrictParamFixer - is defined in the ecs file directly
-- DeclareStrictTypesFixer - cannot be used yet
-- IsNullFixer - is not enforced