### PR TITLE
[coding-standards] [http-smoke-testing] dropped PHP 7.4 support

### DIFF
--- a/packages/coding-standards/.github/workflows/run-checks-tests.yaml
+++ b/packages/coding-standards/.github/workflows/run-checks-tests.yaml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0', '8.1']
+                php-versions: ['8.0', '8.1']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -14,7 +14,7 @@
         "friendsofphp/php-cs-fixer": ">=3.3.2"
     },
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
+        "php": "^8.0 || ^8.1",
         "ext-tokenizer": "*",
         "friendsofphp/php-cs-fixer": "^3.3.1",
         "nette/utils": "^3.1.3",

--- a/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
+++ b/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
@@ -6,7 +6,7 @@ jobs:
         runs-on: ubuntu-20.04
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0', '8.1']
+                php-versions: ['8.0', '8.1']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
+        "php": "^8.0 || ^8.1",
         "phpunit/phpunit": "^9.5.20",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| PHP 7.4 support ends within a few months. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
