### PR TITLE
[shopsys] Refactor ECS config to new syntax

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -8,20 +8,14 @@ use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
-
-    $services->set(PhpdocToPropertyTypeFixer::class);
-
-    $parameters->set(
-        Option::SKIP,
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(PhpdocToPropertyTypeFixer::class);
+    $ecsConfig->skip(
         [
             PhpdocToPropertyTypeFixer::class => [
                 __DIR__ . '/packages/*',
@@ -51,6 +45,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ]
     );
 
-    $containerConfigurator->import(__DIR__ . '/packages/*/ecs.php');
-    $containerConfigurator->import(__DIR__ . '/project-base/ecs.php');
+    $ecsConfig->import(__DIR__ . '/packages/*/ecs.php');
+    $ecsConfig->import(__DIR__ . '/project-base/ecs.php');
 };

--- a/packages/backend-api/ecs.php
+++ b/packages/backend-api/ecs.php
@@ -6,34 +6,37 @@ use ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.backend_api', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\BackendApiBundle']]]);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
+        ->call('configure', [
+            [
+                'analyzed_namespaces' => [
+                    'Shopsys\BackendApiBundle',
+                ],
             ],
-            FunctionLengthSniff::class => [
-                __DIR__ . '/src/Controller/**/*Validator.php',
-                __DIR__ . '/install/tests/App/Smoke/BackendApiCreateProductTest.php',
-            ],
-        ]
-    );
+        ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+        FunctionLengthSniff::class => [
+            __DIR__ . '/src/Controller/**/*Validator.php',
+            __DIR__ . '/install/tests/App/Smoke/BackendApiCreateProductTest.php',
+        ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -128,35 +128,32 @@ use SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff;
 use SlevomatCodingStandard\Sniffs\Operators\DisallowEqualOperatorsSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
 use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
 use Symplify\CodingStandard\TokenRunner\Analyzer\FixerAnalyzer\IndentDetector;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $services->defaults()->autowire();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->parallel();
+    $ecsConfig->lineEnding('\n');
 
-    $parameters = $containerConfigurator->parameters();
-
-    $parameters->set(Option::PARALLEL, true);
-
-    $containerConfigurator->import(SetList::PSR_12);
-    $containerConfigurator->import(SetList::CLEAN_CODE);
-    $containerConfigurator->import(SetList::ARRAY);
-    $containerConfigurator->import(SetList::COMMENTS);
-    $containerConfigurator->import(SetList::CONTROL_STRUCTURES);
-    $containerConfigurator->import(SetList::DOCBLOCK);
-    $containerConfigurator->import(SetList::NAMESPACES);
-
-    $parameters->set(Option::LINE_ENDING, '\n');
+    $ecsConfig->sets([
+        SetList::PSR_12,
+        SetList::CLEAN_CODE,
+        SetList::ARRAY,
+        SetList::COMMENTS,
+        SetList::CONTROL_STRUCTURES,
+        SetList::DOCBLOCK,
+        SetList::NAMESPACES,
+    ]);
 
     // helper services
+    $services = $ecsConfig->services();
+    $services->defaults()->autowire();
     $services->set(FunctionsAnalyzer::class);
     $services->set(PhpToDocTypeTransformer::class);
     $services->set(FqnNameResolver::class);
@@ -165,189 +162,202 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FileFinder::class);
 
     // Slevomat Checkers
-    $services->set(UnusedPrivateElementsSniff::class);
-    $services->set(InlineDocCommentDeclarationSniff::class);
-    $services->set(NullableTypeForNullDefaultValueSniff::class);
-    $services->set(ReturnTypeHintSpacingSniff::class);
+    $ecsConfig->rule(UnusedPrivateElementsSniff::class);
+    $ecsConfig->rule(InlineDocCommentDeclarationSniff::class);
+    $ecsConfig->rule(NullableTypeForNullDefaultValueSniff::class);
+    $ecsConfig->rule(ReturnTypeHintSpacingSniff::class);
 
     // Shopsys Checkers
-    $services->set(ForbiddenDumpFixer::class);
-    $services->set(MissingButtonTypeFixer::class);
-    $services->set(OrmJoinColumnRequireNullableFixer::class);
-    $services->set(RedundantMarkDownTrailingSpacesFixer::class);
-    $services->set(ObjectIsCreatedByFactorySniff::class);
-    $services->set(ForbiddenDumpSniff::class);
-    $services->set(ForbiddenExitSniff::class);
-    $services->set(ForbiddenSuperGlobalSniff::class);
-    $services->set(ForbiddenDoctrineInheritanceSniff::class);
-    $services->set(ForbiddenDoctrineDefaultValueSniff::class);
+    $ecsConfig->rule(ForbiddenDumpFixer::class);
+    $ecsConfig->rule(MissingButtonTypeFixer::class);
+    $ecsConfig->rule(OrmJoinColumnRequireNullableFixer::class);
+    $ecsConfig->rule(RedundantMarkDownTrailingSpacesFixer::class);
+    $ecsConfig->rule(ObjectIsCreatedByFactorySniff::class);
+    $ecsConfig->rule(ForbiddenDumpSniff::class);
+    $ecsConfig->rule(ForbiddenExitSniff::class);
+    $ecsConfig->rule(ForbiddenSuperGlobalSniff::class);
+    $ecsConfig->rule(ForbiddenDoctrineInheritanceSniff::class);
+    $ecsConfig->rule(ForbiddenDoctrineDefaultValueSniff::class);
     // method arguments and variables should be $camelCase
-    $services->set(ValidVariableNameSniff::class);
+    $ecsConfig->rule(ValidVariableNameSniff::class);
     // add all @param, @return and @var annotations, in FQN
-    $services->set(MissingParamAnnotationsFixer::class);
-    $services->set(MissingReturnAnnotationFixer::class);
-    $services->set(OrderedParamAnnotationsFixer::class);
-    $services->set(FullyQualifiedClassNameInAnnotationSniff::class);
+    $ecsConfig->rule(MissingParamAnnotationsFixer::class);
+    $ecsConfig->rule(MissingReturnAnnotationFixer::class);
+    $ecsConfig->rule(OrderedParamAnnotationsFixer::class);
+    $ecsConfig->rule(FullyQualifiedClassNameInAnnotationSniff::class);
 
     // Custom Shopsys standards
-    $services->set(EmptyStatementSniff::class);
-    $services->set(ForLoopShouldBeWhileLoopSniff::class);
-    $services->set(ForLoopWithTestFunctionCallSniff::class);
-    $services->set(JumbledIncrementerSniff::class);
-    $services->set(UnconditionalIfStatementSniff::class);
-    $services->set(TodoSniff::class);
-    $services->set(FixmeSniff::class);
-    $services->set(NoSpaceAfterCastSniff::class);
-    $services->set(CallTimePassByReferenceSniff::class);
-    $services->set(CyclomaticComplexitySniff::class)
-        ->property('absoluteComplexity', 13);
-    $services->set(ConstructorNameSniff::class);
-    $services->set(CamelCapsFunctionNameSniff::class);
-    $services->set(DiscourageGotoSniff::class);
-    $services->set(NoSilencedErrorsSniff::class);
-    $services->set(GetRequestDataSniff::class);
-    $services->set(InlineCommentSniff::class);
-    $services->set(ValidClassNameSniff::class);
-    $services->set(CamelCapsMethodNameSniff::class);
-    $services->set(PhpCsValidVariableNameSniff::class);
-    $services->set(DisallowMultipleAssignmentsSniff::class);
-    $services->set(DisallowSizeFunctionsInLoopsSniff::class);
-    $services->set(EvalSniff::class);
-    $services->set(GlobalKeywordSniff::class);
-    $services->set(InnerFunctionsSniff::class);
-    $services->set(LowercasePHPFunctionsSniff::class);
-    $services->set(NonExecutableCodeSniff::class);
-    $services->set(StaticThisUsageSniff::class);
-    $services->set(DoubleQuoteUsageSniff::class);
-    $services->set(CastSpacingSniff::class);
-    $services->set(LanguageConstructSpacingSniff::class);
-    $services->set(LogicalOperatorSpacingSniff::class);
-    $services->set(ArraySyntaxFixer::class)
-        ->call('configure', [['syntax' => 'short']]);
-    $services->set(CombineConsecutiveUnsetsFixer::class);
-    $services->set(EregToPregFixer::class);
-    $services->set(FunctionDeclarationArgumentSpacingSniff::class)
-        ->property('equalsSpacing', 1);
-    $services->set(IncludeFixer::class);
-    $services->set(YodaStyleFixer::class)
-        ->call('configure', [['equal' => false, 'identical' => false]]);
-    $services->set(LinebreakAfterOpeningTagFixer::class);
-    $services->set(NativeFunctionCasingFixer::class);
-    $services->set(NoAliasFunctionsFixer::class);
-    $services->set(NoBlankLinesAfterPhpdocFixer::class);
-    $services->set(NoEmptyCommentFixer::class);
-    $services->set(NoEmptyPhpdocFixer::class);
-    $services->set(NoEmptyStatementFixer::class);
-    $services->set(NoLeadingNamespaceWhitespaceFixer::class);
-    $services->set(NoMixedEchoPrintFixer::class);
-    $services->set(NoMultilineWhitespaceAroundDoubleArrowFixer::class);
-    $services->set(NoPhp4ConstructorFixer::class);
-    $services->set(NoShortBoolCastFixer::class);
-    $services->set(NoSpacesAroundOffsetFixer::class);
-    $services->set(NoTrailingCommaInListCallFixer::class);
-    $services->set(NoTrailingCommaInSinglelineArrayFixer::class);
-    $services->set(NoUnneededControlParenthesesFixer::class);
-    $services->set(NoUnusedImportsFixer::class);
-    $services->set(NoUselessReturnFixer::class);
-    $services->set(NoWhitespaceInBlankLineFixer::class);
-    $services->set(NonPrintableCharacterFixer::class);
-    $services->set(NormalizeIndexBraceFixer::class);
-    $services->set(ObjectOperatorWithoutWhitespaceFixer::class);
-    $services->set(OrderedImportsFixer::class)
-        ->call('configure', [['sort_algorithm' => 'alpha', 'imports_order' => ['class', 'function', 'const']]]);
-    $services->set(PhpdocAnnotationWithoutDotFixer::class);
-    $services->set(PhpdocIndentFixer::class);
-    $services->set(PhpdocNoUselessInheritdocFixer::class);
-    $services->set(PhpdocNoAliasTagFixer::class);
-    $services->set(PhpdocNoEmptyReturnFixer::class);
-    $services->set(PhpdocNoAccessFixer::class);
-    $services->set(PhpdocNoPackageFixer::class);
-    $services->set(PhpdocOrderFixer::class);
-    $services->set(PhpdocScalarFixer::class);
-    $services->set(PhpdocSingleLineVarSpacingFixer::class);
-    $services->set(PhpdocTrimFixer::class);
-    $services->set(PhpdocVarWithoutNameFixer::class);
-    $services->set(ProtectedToPrivateFixer::class);
-    $services->set(SelfAccessorFixer::class);
-    $services->set(SemicolonAfterInstructionFixer::class);
-    $services->set(SingleBlankLineBeforeNamespaceFixer::class);
-    $services->set(SpaceAfterSemicolonFixer::class);
-    $services->set(SingleQuoteFixer::class);
-    $services->set(SingleLineCommentStyleFixer::class)
-        ->call('configure', [['comment_types' => ['hash']]]);
-    $services->set(StandardizeNotEqualsFixer::class);
-    $services->set(StrictParamFixer::class);
-    $services->set(TrimArraySpacesFixer::class);
+    $ecsConfig->rule(EmptyStatementSniff::class);
+    $ecsConfig->rule(ForLoopShouldBeWhileLoopSniff::class);
+    $ecsConfig->rule(ForLoopWithTestFunctionCallSniff::class);
+    $ecsConfig->rule(JumbledIncrementerSniff::class);
+    $ecsConfig->rule(UnconditionalIfStatementSniff::class);
+    $ecsConfig->rule(TodoSniff::class);
+    $ecsConfig->rule(FixmeSniff::class);
+    $ecsConfig->rule(NoSpaceAfterCastSniff::class);
+    $ecsConfig->rule(CallTimePassByReferenceSniff::class);
+    $ecsConfig->ruleWithConfiguration(CyclomaticComplexitySniff::class, [
+        'absoluteComplexity' => 13,
+    ]);
+    $ecsConfig->rule(ConstructorNameSniff::class);
+    $ecsConfig->rule(CamelCapsFunctionNameSniff::class);
+    $ecsConfig->rule(DiscourageGotoSniff::class);
+    $ecsConfig->rule(NoSilencedErrorsSniff::class);
+    $ecsConfig->rule(GetRequestDataSniff::class);
+    $ecsConfig->rule(InlineCommentSniff::class);
+    $ecsConfig->rule(ValidClassNameSniff::class);
+    $ecsConfig->rule(CamelCapsMethodNameSniff::class);
+    $ecsConfig->rule(PhpCsValidVariableNameSniff::class);
+    $ecsConfig->rule(DisallowMultipleAssignmentsSniff::class);
+    $ecsConfig->rule(DisallowSizeFunctionsInLoopsSniff::class);
+    $ecsConfig->rule(EvalSniff::class);
+    $ecsConfig->rule(GlobalKeywordSniff::class);
+    $ecsConfig->rule(InnerFunctionsSniff::class);
+    $ecsConfig->rule(LowercasePHPFunctionsSniff::class);
+    $ecsConfig->rule(NonExecutableCodeSniff::class);
+    $ecsConfig->rule(StaticThisUsageSniff::class);
+    $ecsConfig->rule(DoubleQuoteUsageSniff::class);
+    $ecsConfig->rule(CastSpacingSniff::class);
+    $ecsConfig->rule(LanguageConstructSpacingSniff::class);
+    $ecsConfig->rule(LogicalOperatorSpacingSniff::class);
+    $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [
+        'syntax' => 'short',
+    ]);
+    $ecsConfig->rule(CombineConsecutiveUnsetsFixer::class);
+    $ecsConfig->rule(EregToPregFixer::class);
+    $ecsConfig->ruleWithConfiguration(FunctionDeclarationArgumentSpacingSniff::class, [
+        'equalsSpacing' => 1,
+    ]);
+    $ecsConfig->rule(IncludeFixer::class);
+    $ecsConfig->ruleWithConfiguration(YodaStyleFixer::class, [
+        'equal' => false,
+        'identical' => false,
+    ]);
+    $ecsConfig->rule(LinebreakAfterOpeningTagFixer::class);
+    $ecsConfig->rule(NativeFunctionCasingFixer::class);
+    $ecsConfig->rule(NoAliasFunctionsFixer::class);
+    $ecsConfig->rule(NoBlankLinesAfterPhpdocFixer::class);
+    $ecsConfig->rule(NoEmptyCommentFixer::class);
+    $ecsConfig->rule(NoEmptyPhpdocFixer::class);
+    $ecsConfig->rule(NoEmptyStatementFixer::class);
+    $ecsConfig->rule(NoLeadingNamespaceWhitespaceFixer::class);
+    $ecsConfig->rule(NoMixedEchoPrintFixer::class);
+    $ecsConfig->rule(NoMultilineWhitespaceAroundDoubleArrowFixer::class);
+    $ecsConfig->rule(NoPhp4ConstructorFixer::class);
+    $ecsConfig->rule(NoShortBoolCastFixer::class);
+    $ecsConfig->rule(NoSpacesAroundOffsetFixer::class);
+    $ecsConfig->rule(NoTrailingCommaInListCallFixer::class);
+    $ecsConfig->rule(NoTrailingCommaInSinglelineArrayFixer::class);
+    $ecsConfig->rule(NoUnneededControlParenthesesFixer::class);
+    $ecsConfig->rule(NoUnusedImportsFixer::class);
+    $ecsConfig->rule(NoUselessReturnFixer::class);
+    $ecsConfig->rule(NoWhitespaceInBlankLineFixer::class);
+    $ecsConfig->rule(NonPrintableCharacterFixer::class);
+    $ecsConfig->rule(NormalizeIndexBraceFixer::class);
+    $ecsConfig->rule(ObjectOperatorWithoutWhitespaceFixer::class);
+    $ecsConfig->ruleWithConfiguration(OrderedImportsFixer::class, [
+        'sort_algorithm' => 'alpha',
+        'imports_order' => [
+            'class',
+            'function',
+            'const',
+        ],
+    ]);
+    $ecsConfig->rule(PhpdocAnnotationWithoutDotFixer::class);
+    $ecsConfig->rule(PhpdocIndentFixer::class);
+    $ecsConfig->rule(PhpdocNoUselessInheritdocFixer::class);
+    $ecsConfig->rule(PhpdocNoAliasTagFixer::class);
+    $ecsConfig->rule(PhpdocNoEmptyReturnFixer::class);
+    $ecsConfig->rule(PhpdocNoAccessFixer::class);
+    $ecsConfig->rule(PhpdocNoPackageFixer::class);
+    $ecsConfig->rule(PhpdocOrderFixer::class);
+    $ecsConfig->rule(PhpdocScalarFixer::class);
+    $ecsConfig->rule(PhpdocSingleLineVarSpacingFixer::class);
+    $ecsConfig->rule(PhpdocTrimFixer::class);
+    $ecsConfig->rule(PhpdocVarWithoutNameFixer::class);
+    $ecsConfig->rule(ProtectedToPrivateFixer::class);
+    $ecsConfig->rule(SelfAccessorFixer::class);
+    $ecsConfig->rule(SemicolonAfterInstructionFixer::class);
+    $ecsConfig->rule(SingleBlankLineBeforeNamespaceFixer::class);
+    $ecsConfig->rule(SpaceAfterSemicolonFixer::class);
+    $ecsConfig->rule(SingleQuoteFixer::class);
+    $ecsConfig->ruleWithConfiguration(SingleLineCommentStyleFixer::class, [
+        'comment_types' => ['hash'],
+    ]);
+    $ecsConfig->rule(StandardizeNotEqualsFixer::class);
+    $ecsConfig->rule(StrictParamFixer::class);
+    $ecsConfig->rule(TrimArraySpacesFixer::class);
     // keep 1 empty line between constants, properties and methods
     // keep 0 empty lines after class open bracket {
     // keep 0 empty lines before class end bracket }
-    $services->set(ClassAttributesSeparationFixer::class)
-        ->call('configure', [
-            [
-                'elements' => [
-                    'property' => ClassAttributesSeparationFixer::SPACING_ONE,
-                    'method' => ClassAttributesSeparationFixer::SPACING_ONE,
-                ],
-            ],
-        ]);
-    $services->set(DisallowEqualOperatorsSniff::class);
-    $services->set(ValidClassNameSniff::class);
-    $services->set(NoUselessElseFixer::class);
-    $services->set(AssignmentInConditionSniff::class);
-    $services->set(DisallowEmptySniff::class);
-    $services->set(EarlyExitSniff::class)
-        ->property('ignoreStandaloneIfInScope', true)
-        ->property('ignoreOneLineTrailingIf', true)
-        ->property('ignoreTrailingIfWithOneInstruction', true);
-    $services->set(ParentCallSpacingSniff::class)
-        ->property('linesCountBeforeParentCall', 1)
-        ->property('linesCountAfterParentCall', 1);
-    $services->set(ReferenceUsedNamesOnlySniff::class)
-        ->property('allowPartialUses', true);
-    $services->set(DocCommentSpacingSniff::class)
-        ->property('linesCountBetweenDifferentAnnotationsTypes', 0);
-    $services->set(UselessIfConditionWithReturnSniff::class);
+    $ecsConfig->ruleWithConfiguration(ClassAttributesSeparationFixer::class, [
+        'elements' => [
+            'property' => ClassAttributesSeparationFixer::SPACING_ONE,
+            'method' => ClassAttributesSeparationFixer::SPACING_ONE,
+        ],
+    ]);
+    $ecsConfig->rule(DisallowEqualOperatorsSniff::class);
+    $ecsConfig->rule(ValidClassNameSniff::class);
+    $ecsConfig->rule(NoUselessElseFixer::class);
+    $ecsConfig->rule(AssignmentInConditionSniff::class);
+    $ecsConfig->rule(DisallowEmptySniff::class);
+    $ecsConfig->ruleWithConfiguration(EarlyExitSniff::class, [
+        'ignoreStandaloneIfInScope' => true,
+        'ignoreOneLineTrailingIf' => true,
+        'ignoreTrailingIfWithOneInstruction' => true,
+    ]);
+    $ecsConfig->ruleWithConfiguration(ParentCallSpacingSniff::class, [
+        'linesCountBeforeParentCall' => 1,
+        'linesCountAfterParentCall' => 1,
+    ]);
+    $ecsConfig->ruleWithConfiguration(ReferenceUsedNamesOnlySniff::class, [
+        'allowPartialUses' => true,
+    ]);
+    $ecsConfig->ruleWithConfiguration(DocCommentSpacingSniff::class, [
+        'linesCountBetweenDifferentAnnotationsTypes' => 0,
+    ]);
+    $ecsConfig->rule(UselessIfConditionWithReturnSniff::class);
 
     // Code Metrics
-    $services->set(ClassTraitAndInterfaceLengthSniff::class)
-        ->property('maxLength', 550);
-    $services->set(FunctionLengthSniff::class)
-        ->property('maxLength', 60);
-    $services->set(PropertyPerClassLimitSniff::class)
-        ->property('maxCount', 30);
+    $ecsConfig->ruleWithConfiguration(ClassTraitAndInterfaceLengthSniff::class, [
+        'maxLength' => 550,
+    ]);
+    $ecsConfig->ruleWithConfiguration(FunctionLengthSniff::class, [
+        'maxLength' => 60,
+    ]);
+    $ecsConfig->ruleWithConfiguration(PropertyPerClassLimitSniff::class, [
+        'maxCount' => 30,
+    ]);
 
-    $parameters->set(
-        Option::SKIP,
-        [
-            __DIR__ . '/tests/Unit/**/wrong/*',
-            __DIR__ . '/tests/Unit/**/Wrong/*',
-            __DIR__ . '/tests/Unit/**/correct/*',
-            __DIR__ . '/tests/Unit/**/Correct/*',
-            __DIR__ . '/tests/Unit/**/fixed/*',
-            // private properties should not start with "_"
-            PhpCsValidVariableNameSniff::class . '.PrivateNoUnderscore' => null,
-            // it is not necessary to have blank line after control structure
-            ControlStructureSpacingSniff::class . '.NoLineAfterClose' => null,
-            // allow empty "catch (Exception $exception) { }"
-            EmptyStatementSniff::class . '.DetectedCatch' => null,
-            FunctionCallSignatureSniff::class . '.Indent' => null,
-            ArrayOpenerAndCloserNewlineFixer::class => null,
-            ArrayListItemNewlineFixer::class => null,
-            DisallowCommentAfterCodeSniff::class . '.DisallowedCommentAfterCode' => null,
-            // rule is applied via `clean-code` set, but we do not want to use it for now
-            // some variables exist just because of the right annotation
-            ReturnAssignmentFixer::class => null,
-            // rule is applied via `control-structures` set, but we do not want to use it for now
-            OrderedClassElementsFixer::class => null,
-            // rule is applied via `docblock` set, but we do not want to use it for now
-            // remove variable name from @var and @type annotations
-            PhpdocVarWithoutNameFixer::class => null,
-            // rule is applied via `docblock` set, but we do not want to use it for now
-            // remove inheritdoc
-            NoSuperfluousPhpdocTagsFixer::class => null,
-            // rule breaks jms/translation-bundle as it fails on this usage: `[, $b] = $var`
-            // won't do any changes after upgrade
-            ListSyntaxFixer::class => null,
-        ]
-    );
+    $ecsConfig->skip([
+        __DIR__ . '/tests/Unit/**/wrong/*',
+        __DIR__ . '/tests/Unit/**/Wrong/*',
+        __DIR__ . '/tests/Unit/**/correct/*',
+        __DIR__ . '/tests/Unit/**/Correct/*',
+        __DIR__ . '/tests/Unit/**/fixed/*',
+        // private properties should not start with "_"
+        PhpCsValidVariableNameSniff::class . '.PrivateNoUnderscore' => null,
+        // it is not necessary to have blank line after control structure
+        ControlStructureSpacingSniff::class . '.NoLineAfterClose' => null,
+        // allow empty "catch (Exception $exception) { }"
+        EmptyStatementSniff::class . '.DetectedCatch' => null,
+        FunctionCallSignatureSniff::class . '.Indent' => null,
+        ArrayOpenerAndCloserNewlineFixer::class => null,
+        ArrayListItemNewlineFixer::class => null,
+        DisallowCommentAfterCodeSniff::class . '.DisallowedCommentAfterCode' => null,
+        // rule is applied via `clean-code` set, but we do not want to use it for now
+        // some variables exist just because of the right annotation
+        ReturnAssignmentFixer::class => null,
+        // rule is applied via `control-structures` set, but we do not want to use it for now
+        OrderedClassElementsFixer::class => null,
+        // rule is applied via `docblock` set, but we do not want to use it for now
+        // remove variable name from @var and @type annotations
+        PhpdocVarWithoutNameFixer::class => null,
+        // rule is applied via `docblock` set, but we do not want to use it for now
+        // remove inheritdoc
+        NoSuperfluousPhpdocTagsFixer::class => null,
+        // rule breaks jms/translation-bundle as it fails on this usage: `[, $b] = $var`
+        // won't do any changes after upgrade
+        ListSyntaxFixer::class => null,
+    ]);
 };

--- a/packages/form-types-bundle/ecs.php
+++ b/packages/form-types-bundle/ecs.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-        ]
-    );
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/framework/ecs.php
+++ b/packages/framework/ecs.php
@@ -18,117 +18,20 @@ use Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff;
 use SlevomatCodingStandard\Sniffs\Classes\ParentCallSpacingSniff;
 use SlevomatCodingStandard\Sniffs\ControlStructures\DisallowEmptySniff;
 use SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDefaultCommentFixer;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            FunctionLengthSniff::class => [
-                __DIR__ . '/src/Controller/Admin/DefaultController.php',
-                __DIR__ . '/src/Form/Admin/*/*FormType.php',
-                __DIR__ . '/src/Migrations/Version*.php',
-                __DIR__ . '/src/Model/AdminNavigation/SideMenuBuilder.php',
-                __DIR__ . '/src/Model/Order/Preview/OrderPreviewCalculation.php',
-                __DIR__ . '/src/Model/Product/ProductVisibilityRepository.php',
-                __DIR__ . '/src/Model/Product/Search/FilterQuery.php',
-                __DIR__ . '/src/Controller/Admin/AdministratorController.php',
-                __DIR__ . '/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php',
-                __DIR__ . '/tests/Unit/Component/Domain/DomainDataCreatorTest.php',
-                __DIR__ . '/tests/Unit/Component/Image/ImageLocatorTest.php',
-                __DIR__ . '/tests/Unit/Component/Image/Config/ImageConfigLoaderTest.php',
-                __DIR__ . '/tests/Unit/Component/Image/Config/ImageConfigTest.php',
-                __DIR__ . '/tests/Unit/Model/Category/CategoryNestedSetCalculatorTest.php',
-                __DIR__ . '/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php',
-                __DIR__ . '/src/Form/Constraints/FileAbstractFilesystemValidator.php',
-            ],
-            PropertyPerClassLimitSniff::class => [
-                __DIR__ . '/src/Model/Order/Order.php',
-                __DIR__ . '/src/Model/Order/OrderData.php',
-                __DIR__ . '/src/Model/Product/Product.php',
-                __DIR__ . '/src/Model/Product/ProductData.php',
-            ],
-            ClassTraitAndInterfaceLengthSniff::class => [
-                __DIR__ . '/src/Form/Admin/Product/ProductFormType.php',
-                __DIR__ . '/src/Command/TranslationReplaceSourceCommand.php',
-                __DIR__ . '/src/Component/Grid/Grid.php',
-                __DIR__ . '/src/Model/Order/Order.php',
-                __DIR__ . '/src/Model/Order/OrderFacade.php',
-                __DIR__ . '/src/Model/Product/Product.php',
-                __DIR__ . '/src/Model/Product/ProductRepository.php',
-                __DIR__ . '/src/Model/Product/Elasticsearch/ProductExportRepository.php',
-                __DIR__ . '/tests/Test/Codeception/ActorInterface.php',
-                __DIR__ . '/tests/Unit/Component/Money/MoneyTest.php',
-                __DIR__ . '/src/Model/Product/Search/FilterQuery.php',
-                __DIR__ . '/src/Model/Category/CategoryFacade.php',
-                __DIR__ . '/src/Model/Category/CategoryRepository.php',
-                __DIR__ . '/src/Model/Product/ProductFacade.php',
-            ],
-            EmptyStatementSniff::class . '.DetectedWhile' => [
-                __DIR__ . '/src/Model/Product/Availability/ProductAvailabilityRecalculator.php',
-                __DIR__ . '/src/Model/Product/Pricing/ProductPriceRecalculator.php',
-            ],
-            CamelCapsFunctionNameSniff::class => [
-                __DIR__ . '/src/Component/Doctrine/MoneyType.php',
-                __DIR__ . '/tests/Test/Codeception/ActorInterface.php',
-                __DIR__ . '/src/Component/EntityExtension/QueryBuilder.php',
-            ],
-            ForbiddenDumpFixer::class => [
-                __DIR__ . '/src/Resources/views/Debug/Elasticsearch/template.html.twig',
-            ],
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-                __DIR__ . '/src/Component/Domain/DomainFactoryOverwritingDomainUrl.php',
-                __DIR__ . '/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php',
-                __DIR__ . '/src/Model/Order/Preview/OrderPreviewCalculation.php',
-                __DIR__ . '/src/Component/EntityExtension/EntityExtensionSubscriber.php',
-            ],
-            ForbiddenDumpSniff::class => [
-                __DIR__ . '/src/Component/DateTimeHelper/Exception/CannotParseDateTimeException.php',
-                __DIR__ . '/src/Component/Doctrine/Cache/PermanentPhpFileCache.php',
-                __DIR__ . '/src/Twig/VarDumperExtension.php',
-                __DIR__ . '/src/Resources/views/Migration/migration.php.twig',
-            ],
-            ValidVariableNameSniff::class => [
-                __DIR__ . '/tests/Test/Codeception/ActorInterface.php',
-            ],
-            MethodDeclarationSniff::class . '.Underscore' => [
-                __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',
-            ],
-            CyclomaticComplexitySniff::class . '.MaxExceeded' => [
-                __DIR__ . '/src/Form/Constraints/FileAbstractFilesystemValidator.php',
-                __DIR__ . '/src/Model/Product/Search/ProductElasticsearchConverter.php',
-            ],
-            EmptyStatementSniff::class . '.DetectedCatch' => [
-                __DIR__ . '/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php',
-            ],
-            ParentCallSpacingSniff::class . '.IncorrectLinesCountBeforeControlStructure' => [
-                __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',
-            ],
-            DisallowEmptySniff::class . '.DisallowedEmpty' => [
-                __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',
-                __DIR__ . '/src/Model/AdminNavigation/RoutingExtension.php',
-            ],
-            UnusedVariableSniff::class => [
-                __DIR__ . '/src/Component/Form/ResizeFormListener.php',
-            ],
-            RemoveUselessDefaultCommentFixer::class => [
-                __DIR__ . '/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithAnAnnotation.php',
-            ],
-        ]
-    );
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in these namespaces
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.framework', ForbiddenPrivateVisibilityFixer::class)
         ->call('configure', [
             [
@@ -144,5 +47,99 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
         ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        FunctionLengthSniff::class => [
+            __DIR__ . '/src/Controller/Admin/DefaultController.php',
+            __DIR__ . '/src/Form/Admin/*/*FormType.php',
+            __DIR__ . '/src/Migrations/Version*.php',
+            __DIR__ . '/src/Model/AdminNavigation/SideMenuBuilder.php',
+            __DIR__ . '/src/Model/Order/Preview/OrderPreviewCalculation.php',
+            __DIR__ . '/src/Model/Product/ProductVisibilityRepository.php',
+            __DIR__ . '/src/Model/Product/Search/FilterQuery.php',
+            __DIR__ . '/src/Controller/Admin/AdministratorController.php',
+            __DIR__ . '/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php',
+            __DIR__ . '/tests/Unit/Component/Domain/DomainDataCreatorTest.php',
+            __DIR__ . '/tests/Unit/Component/Image/ImageLocatorTest.php',
+            __DIR__ . '/tests/Unit/Component/Image/Config/ImageConfigLoaderTest.php',
+            __DIR__ . '/tests/Unit/Component/Image/Config/ImageConfigTest.php',
+            __DIR__ . '/tests/Unit/Model/Category/CategoryNestedSetCalculatorTest.php',
+            __DIR__ . '/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php',
+            __DIR__ . '/src/Form/Constraints/FileAbstractFilesystemValidator.php',
+        ],
+        PropertyPerClassLimitSniff::class => [
+            __DIR__ . '/src/Model/Order/Order.php',
+            __DIR__ . '/src/Model/Order/OrderData.php',
+            __DIR__ . '/src/Model/Product/Product.php',
+            __DIR__ . '/src/Model/Product/ProductData.php',
+        ],
+        ClassTraitAndInterfaceLengthSniff::class => [
+            __DIR__ . '/src/Form/Admin/Product/ProductFormType.php',
+            __DIR__ . '/src/Command/TranslationReplaceSourceCommand.php',
+            __DIR__ . '/src/Component/Grid/Grid.php',
+            __DIR__ . '/src/Model/Order/Order.php',
+            __DIR__ . '/src/Model/Order/OrderFacade.php',
+            __DIR__ . '/src/Model/Product/Product.php',
+            __DIR__ . '/src/Model/Product/ProductRepository.php',
+            __DIR__ . '/src/Model/Product/Elasticsearch/ProductExportRepository.php',
+            __DIR__ . '/tests/Test/Codeception/ActorInterface.php',
+            __DIR__ . '/tests/Unit/Component/Money/MoneyTest.php',
+            __DIR__ . '/src/Model/Product/Search/FilterQuery.php',
+            __DIR__ . '/src/Model/Category/CategoryFacade.php',
+            __DIR__ . '/src/Model/Category/CategoryRepository.php',
+            __DIR__ . '/src/Model/Product/ProductFacade.php',
+        ],
+        EmptyStatementSniff::class . '.DetectedWhile' => [
+            __DIR__ . '/src/Model/Product/Availability/ProductAvailabilityRecalculator.php',
+            __DIR__ . '/src/Model/Product/Pricing/ProductPriceRecalculator.php',
+        ],
+        CamelCapsFunctionNameSniff::class => [
+            __DIR__ . '/src/Component/Doctrine/MoneyType.php',
+            __DIR__ . '/tests/Test/Codeception/ActorInterface.php',
+            __DIR__ . '/src/Component/EntityExtension/QueryBuilder.php',
+        ],
+        ForbiddenDumpFixer::class => [
+            __DIR__ . '/src/Resources/views/Debug/Elasticsearch/template.html.twig',
+        ],
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+            __DIR__ . '/src/Component/Domain/DomainFactoryOverwritingDomainUrl.php',
+            __DIR__ . '/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php',
+            __DIR__ . '/src/Model/Order/Preview/OrderPreviewCalculation.php',
+            __DIR__ . '/src/Component/EntityExtension/EntityExtensionSubscriber.php',
+        ],
+        ForbiddenDumpSniff::class => [
+            __DIR__ . '/src/Component/DateTimeHelper/Exception/CannotParseDateTimeException.php',
+            __DIR__ . '/src/Component/Doctrine/Cache/PermanentPhpFileCache.php',
+            __DIR__ . '/src/Twig/VarDumperExtension.php',
+            __DIR__ . '/src/Resources/views/Migration/migration.php.twig',
+        ],
+        ValidVariableNameSniff::class => [
+            __DIR__ . '/tests/Test/Codeception/ActorInterface.php',
+        ],
+        MethodDeclarationSniff::class . '.Underscore' => [
+            __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',
+        ],
+        CyclomaticComplexitySniff::class . '.MaxExceeded' => [
+            __DIR__ . '/src/Form/Constraints/FileAbstractFilesystemValidator.php',
+            __DIR__ . '/src/Model/Product/Search/ProductElasticsearchConverter.php',
+        ],
+        EmptyStatementSniff::class . '.DetectedCatch' => [
+            __DIR__ . '/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php',
+        ],
+        ParentCallSpacingSniff::class . '.IncorrectLinesCountBeforeControlStructure' => [
+            __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',
+        ],
+        DisallowEmptySniff::class . '.DisallowedEmpty' => [
+            __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',
+            __DIR__ . '/src/Model/AdminNavigation/RoutingExtension.php',
+        ],
+        UnusedVariableSniff::class => [
+            __DIR__ . '/src/Component/Form/ResizeFormListener.php',
+        ],
+        RemoveUselessDefaultCommentFixer::class => [
+            __DIR__ . '/tests/Unit/Component/ClassExtension/Source/AnnotationsAdderTest/DummyClassWithAnAnnotation.php',
+        ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/frontend-api/ecs.php
+++ b/packages/frontend-api/ecs.php
@@ -6,34 +6,37 @@ use ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.frontend_api', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\FrontendApiBundle']]]);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
+        ->call('configure', [
+            [
+                'analyzed_namespaces' => [
+                    'Shopsys\FrontendApiBundle',
+                ],
             ],
-            FunctionLengthSniff::class => [
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php',
-                __DIR__ . '/src/Model/Resolver/Products/ProductResolverMap.php',
-            ],
-        ]
-    );
+        ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+        FunctionLengthSniff::class => [
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php',
+            __DIR__ . '/src/Model/Resolver/Products/ProductResolverMap.php',
+        ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/google-cloud-bundle/ecs.php
+++ b/packages/google-cloud-bundle/ecs.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
 
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-        ]
-    );
-
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/http-smoke-testing/ecs.php
+++ b/packages/http-smoke-testing/ecs.php
@@ -4,26 +4,19 @@ declare(strict_types=1);
 
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
 
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-        ]
-    );
-
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/migrations/ecs.php
+++ b/packages/migrations/ecs.php
@@ -6,35 +6,20 @@ use ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
-use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $containerConfigurator->import(SetList::PSR_12);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            __DIR__ . '/src/Resources/views/Migration/migration.php.twig',
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-            FunctionLengthSniff::class => [
-                __DIR__ . '/tests/Unit/Component/Doctrine/SchemaDiffFilterTest.php',
-                __DIR__ . '/tests/Unit/Component/Doctrine/Migrations/MigrationsLockComparatorTest.php',
-            ],
-        ]
-    );
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in these namespaces
-    $services->set('forbidden_private_visibility_fixer.framework', ForbiddenPrivateVisibilityFixer::class)
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
+    $services->set('forbidden_private_visibility_fixer.migrations', ForbiddenPrivateVisibilityFixer::class)
         ->call('configure', [
             [
                 'analyzed_namespaces' => [
@@ -44,7 +29,16 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ],
         ]);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
+    $ecsConfig->skip([
+        __DIR__ . '/src/Resources/views/Migration/migration.php.twig',
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+        FunctionLengthSniff::class => [
+            __DIR__ . '/tests/Unit/Component/Doctrine/SchemaDiffFilterTest.php',
+            __DIR__ . '/tests/Unit/Component/Doctrine/Migrations/MigrationsLockComparatorTest.php',
+        ],
+    ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/plugin-interface/ecs.php
+++ b/packages/plugin-interface/ecs.php
@@ -4,24 +4,19 @@ declare(strict_types=1);
 
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
 
-    $parameters->set(Option::SKIP, [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-        ]
-    );
-
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/product-feed-google/ecs.php
+++ b/packages/product-feed-google/ecs.php
@@ -5,30 +5,34 @@ declare(strict_types=1);
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.product_feed_google', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\ProductFeed\GoogleBundle\Model']]]);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__, '/tests/*',
+        ->call('configure', [
+            [
+                'analyzed_namespaces' => [
+                    'Shopsys\ProductFeed\GoogleBundle\Model',
+                ],
             ],
-        ]
-    );
+        ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__,
+            '/tests/*',
+        ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/product-feed-heureka-delivery/ecs.php
+++ b/packages/product-feed-heureka-delivery/ecs.php
@@ -5,30 +5,35 @@ declare(strict_types=1);
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
-    $services->set('forbidden_private_visibility_fixer.product_feed_heureka_delivery', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\ProductFeed\HeurekaDeliveryBundle\Model']]]);
-
-    $parameters->set(
-        Option::SKIP,
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
+    $services->set(
+        'forbidden_private_visibility_fixer.product_feed_heureka_delivery',
+        ForbiddenPrivateVisibilityFixer::class
+    )->call('configure', [
         [
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
+            'analyzed_namespaces' => [
+                'Shopsys\ProductFeed\HeurekaDeliveryBundle\Model',
             ],
-        ]
-    );
+        ],
+    ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/product-feed-heureka/ecs.php
+++ b/packages/product-feed-heureka/ecs.php
@@ -7,40 +7,43 @@ use PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSn
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.product_feed_heureka', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\ProductFeed\HeurekaBundle\Model']]]);
+        ->call('configure', [
+            [
+                'analyzed_namespaces' => [
+                    'Shopsys\ProductFeed\HeurekaBundle\Model',
+                ],
+            ],
+        ]);
 
-    $parameters->set(
-        Option::SKIP,
-        [
-            FunctionLengthSniff::class => [
-                __DIR__ . '/src/DataFixtures/HeurekaProductDataFixture.php',
-                __DIR__ . '/tests/Unit/HeurekaFeedTest.php',
-            ],
-            ValidVariableNameSniff::class . '.MemberNotCamelCaps' => [
-                __DIR__ . '/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php',
-            ],
-            ValidVariableNameSniff::class . '.NotCamelCaps' => [
-                __DIR__ . '/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php',
-            ],
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-        ]
-    );
+    $ecsConfig->skip([
+        FunctionLengthSniff::class => [
+            __DIR__ . '/src/DataFixtures/HeurekaProductDataFixture.php',
+            __DIR__ . '/tests/Unit/HeurekaFeedTest.php',
+        ],
+        ValidVariableNameSniff::class . '.MemberNotCamelCaps' => [
+            __DIR__ . '/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php',
+        ],
+        ValidVariableNameSniff::class . '.NotCamelCaps' => [
+            __DIR__ . '/src/Model/HeurekaCategory/HeurekaCategoryDownloader.php',
+        ],
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/product-feed-zbozi/ecs.php
+++ b/packages/product-feed-zbozi/ecs.php
@@ -6,34 +6,37 @@ use ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.product_feed_zbozi', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\ProductFeed\ZboziBundle\Model']]]);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            FunctionLengthSniff::class => [
-                __DIR__ . '/src/DataFixtures/ZboziPluginDataFixture.php',
-                __DIR__ . '/tests/Unit/ZboziFeedTest.php',
+        ->call('configure', [
+            [
+                'analyzed_namespaces' => [
+                    'Shopsys\ProductFeed\ZboziBundle\Model',
+                ],
             ],
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-        ]
-    );
+        ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        FunctionLengthSniff::class => [
+            __DIR__ . '/src/DataFixtures/ZboziPluginDataFixture.php',
+            __DIR__ . '/tests/Unit/ZboziFeedTest.php',
+        ],
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/packages/read-model/ecs.php
+++ b/packages/read-model/ecs.php
@@ -5,32 +5,35 @@ declare(strict_types=1);
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(ForceLateStaticBindingForProtectedConstantsSniff::class);
 
-    $services->set(ForceLateStaticBindingForProtectedConstantsSniff::class);
-
-    // this package is meant to be extensible using class inheritance, so we want to avoid private visibilities in the model namespace
+    /*
+     * this package is meant to be extensible using class inheritance,
+     * so we want to avoid private visibilities in the model namespace
+     */
+    $services = $ecsConfig->services();
     $services->set('forbidden_private_visibility_fixer.read_model', ForbiddenPrivateVisibilityFixer::class)
-        ->call('configure', [['analyzed_namespaces' => ['Shopsys\ReadModelBundle']]]);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            ObjectIsCreatedByFactorySniff::class =>
-                [
-                    __DIR__ . '/src/Product/Detail/ProductDetailViewElasticsearchFactory.php',
-                    __DIR__ . '/tests/*',
+        ->call('configure', [
+            [
+                'analyzed_namespaces' => [
+                    'Shopsys\ReadModelBundle',
                 ],
-        ]
-    );
+            ],
+        ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->skip([
+        ObjectIsCreatedByFactorySniff::class =>
+            [
+                __DIR__ . '/src/Product/Detail/ProductDetailViewElasticsearchFactory.php',
+                __DIR__ . '/tests/*',
+            ],
+    ]);
+
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/project-base/ecs.php
+++ b/project-base/ecs.php
@@ -11,101 +11,95 @@ use Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineInheritanceSniff;
 use Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
 use Shopsys\CodingStandards\Sniffs\ValidVariableNameSniff;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
- * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $containerConfigurator
+ * @param Symplify\EasyCodingStandard\Config\ECSConfig $ecsConfig
  */
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-    $parameters = $containerConfigurator->parameters();
+return static function (ECSConfig $ecsConfig): void {
+    $ecsConfig->rule(DeclareStrictTypesFixer::class);
+    $ecsConfig->rule(PhpdocToPropertyTypeFixer::class);
 
-    $services->set(DeclareStrictTypesFixer::class);
-    $services->set(PhpdocToPropertyTypeFixer::class);
-
-    $parameters->set(
-        Option::SKIP,
-        [
-            __DIR__ . '/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php',
-            __DIR__ . '/var/cache/*',
-            PhpdocToPropertyTypeFixer::class => [
-                __DIR__ . '/src/*',
-                __DIR__ . '/app/*',
-                __DIR__ . '/tests/App/Acceptance/*',
-            ],
-            FunctionLengthSniff::class => [
-                __DIR__ . '/src/DataFixtures/*/*DataFixture.php',
-                __DIR__ . '/src/DataFixtures/Demo/ProductDataFixtureLoader.php',
-                __DIR__ . '/src/Controller/Front/OrderController.php',
-                __DIR__ . '/src/Form/Front/Customer/BillingAddressFormType.php',
-                __DIR__ . '/src/Form/Front/Customer/DeliveryAddressFormType.php',
-                __DIR__ . '/src/Form/Front/Order/PersonalInfoFormType.php',
-                __DIR__ . '/tests/App/Functional/EntityExtension/EntityExtensionTest.php',
-                __DIR__ . '/tests/App/Functional/Model/Order/OrderFacadeTest.php',
-                __DIR__ . '/tests/App/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php',
-                __DIR__ . '/tests/App/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php',
-                __DIR__ . '/tests/App/Smoke/BackendApiCreateProductTest.php',
-                __DIR__ . '/tests/App/Smoke/Http/RouteConfigCustomization.php',
-                __DIR__ . '/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php',
-                __DIR__ . '/tests/App/Functional/Model/Cart/CartMigrationFacadeTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Advert/GetAdvertsTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/DynamicFieldsInOrderTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/FullOrderTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/MinimalOrderTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Order/MultipleProductsInOrderTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductsTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Product/PromotedProductsTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Brand/BrandTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Brand/BrandsTest.php',
-                __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductsFilteringOptionsTest.php',
-            ],
-            ClassTraitAndInterfaceLengthSniff::class => [
-                __DIR__ . '/tests/App/Functional/Model/Product/ProductVisibilityRepositoryTest.php',
-                __DIR__ . '/src/DataFixtures/Demo/OrderDataFixture.php',
-                __DIR__ . '/src/DataFixtures/Demo/ProductDataFixture.php',
-                __DIR__ . '/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php',
-                __DIR__ . '/tests/App/Test/Codeception/Module/StrictWebDriver.php']
-            ,
-            CyclomaticComplexitySniff::class => [
-                __DIR__ . '/src/DataFixtures/Demo/ProductDataFixture.php',
-                __DIR__ . '/src/DataFixtures/Demo/CategoryDataFixture',
-            ],
-            ValidVariableNameSniff::class => [
-                __DIR__ . '/tests/App/Functional/EntityExtension/EntityExtensionTest.php',
-                __DIR__ . '/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php',
-            ],
-            ObjectIsCreatedByFactorySniff::class => [
-                __DIR__ . '/tests/*',
-            ],
-            ForbiddenDumpSniff::class => [
-                __DIR__ . '/tests/App/Functional/Model/Cart/CartFacadeTest.php',
-            ],
-            ForbiddenDoctrineInheritanceSniff::class => [
-                __DIR__ . '/src/*',
-                __DIR__ . '/tests/App/*',
-            ],
-            'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff.Underscore' => [
-                __DIR__ . '/tests/App/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php',
-                __DIR__ . '/tests/App/Test/Codeception/Helper/DatabaseHelper.php',
-                __DIR__ . '/tests/App/Test/Codeception/Helper/DomainHelper.php',
-                __DIR__ . '/tests/App/Test/Codeception/Helper/LocalizationHelper.php',
-                __DIR__ . '/tests/App/Test/Codeception/Helper/NumberFormatHelper.php',
-                __DIR__ . '/tests/App/Test/Codeception/Helper/SymfonyHelper.php',
-                __DIR__ . '/tests/App/Test/Codeception/Module/Db.php',
-            ],
+    $ecsConfig->skip([
+        __DIR__ . '/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php',
+        __DIR__ . '/var/cache/*',
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+            __DIR__ . '/app/*',
+            __DIR__ . '/tests/App/Acceptance/*',
+        ],
+        FunctionLengthSniff::class => [
+            __DIR__ . '/src/DataFixtures/*/*DataFixture.php',
+            __DIR__ . '/src/DataFixtures/Demo/ProductDataFixtureLoader.php',
+            __DIR__ . '/src/Controller/Front/OrderController.php',
+            __DIR__ . '/src/Form/Front/Customer/BillingAddressFormType.php',
+            __DIR__ . '/src/Form/Front/Customer/DeliveryAddressFormType.php',
+            __DIR__ . '/src/Form/Front/Order/PersonalInfoFormType.php',
+            __DIR__ . '/tests/App/Functional/EntityExtension/EntityExtensionTest.php',
+            __DIR__ . '/tests/App/Functional/Model/Order/OrderFacadeTest.php',
+            __DIR__ . '/tests/App/Functional/Model/Order/Preview/OrderPreviewCalculationTest.php',
+            __DIR__ . '/tests/App/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php',
+            __DIR__ . '/tests/App/Smoke/BackendApiCreateProductTest.php',
+            __DIR__ . '/tests/App/Smoke/Http/RouteConfigCustomization.php',
+            __DIR__ . '/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php',
+            __DIR__ . '/tests/App/Functional/Model/Cart/CartMigrationFacadeTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Advert/GetAdvertsTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Image/ProductImagesTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Payment/PaymentsTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Transport/TransportsTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/DynamicFieldsInOrderTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/FullOrderTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/GetOrdersAsAuthenticatedCustomerUserTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/MinimalOrderTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Order/MultipleProductsInOrderTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductVariantTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductsTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Product/PromotedProductsTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Brand/BrandTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Brand/BrandsTest.php',
+            __DIR__ . '/tests/FrontendApiBundle/Functional/Product/ProductsFilteringOptionsTest.php',
+        ],
+        ClassTraitAndInterfaceLengthSniff::class => [
+            __DIR__ . '/tests/App/Functional/Model/Product/ProductVisibilityRepositoryTest.php',
+            __DIR__ . '/src/DataFixtures/Demo/OrderDataFixture.php',
+            __DIR__ . '/src/DataFixtures/Demo/ProductDataFixture.php',
+            __DIR__ . '/tests/App/Functional/Model/Product/ProductOnCurrentDomainFacadeCountDataTest.php',
+            __DIR__ . '/tests/App/Test/Codeception/Module/StrictWebDriver.php',
         ]
-    );
+        ,
+        CyclomaticComplexitySniff::class => [
+            __DIR__ . '/src/DataFixtures/Demo/ProductDataFixture.php',
+            __DIR__ . '/src/DataFixtures/Demo/CategoryDataFixture',
+        ],
+        ValidVariableNameSniff::class => [
+            __DIR__ . '/tests/App/Functional/EntityExtension/EntityExtensionTest.php',
+            __DIR__ . '/tests/App/Test/Codeception/_generated/AcceptanceTesterActions.php',
+        ],
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/tests/*',
+        ],
+        ForbiddenDumpSniff::class => [
+            __DIR__ . '/tests/App/Functional/Model/Cart/CartFacadeTest.php',
+        ],
+        ForbiddenDoctrineInheritanceSniff::class => [
+            __DIR__ . '/src/*',
+            __DIR__ . '/tests/App/*',
+        ],
+        'PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff.Underscore' => [
+            __DIR__ . '/tests/App/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php',
+            __DIR__ . '/tests/App/Test/Codeception/Helper/DatabaseHelper.php',
+            __DIR__ . '/tests/App/Test/Codeception/Helper/DomainHelper.php',
+            __DIR__ . '/tests/App/Test/Codeception/Helper/LocalizationHelper.php',
+            __DIR__ . '/tests/App/Test/Codeception/Helper/NumberFormatHelper.php',
+            __DIR__ . '/tests/App/Test/Codeception/Helper/SymfonyHelper.php',
+            __DIR__ . '/tests/App/Test/Codeception/Module/Db.php',
+        ],
+    ]);
 
-    $containerConfigurator->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
+    $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);
 };

--- a/upgrade/UPGRADE-v10.0.0-dev.md
+++ b/upgrade/UPGRADE-v10.0.0-dev.md
@@ -133,6 +133,7 @@ All the changes are considered as backwards incompatible.
     - removed dependency on `symplify/easy-coding-standard-tester`, you should change your custom coding standards tests
         - you can find inspiration in https://github.com/shopsys/shopsys/pull/2415/files
     - switch configuration of easy-coding-standard from yaml file to php file
+        <!--- TODO change link to latest version of ecs.php file  --->
         - if you use default Shopsys Framework configuration, you can just use default [`ecs.php`](https://github.com/shopsys/project-base/blob/master/ecs.php)
         - for your custom configuration, you can leverage https://github.com/symplify/config-transformer
     - see [project-base-diff-1](https://github.com/shopsys/project-base/commit/ddf72564195a625a288a4b8ee48559eded3bac58) and [project-base-diff-2](https://github.com/shopsys/project-base/commit/e45f75397880b124ab5fe32498126dfc536fb7d2) to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Removes deprecation notices about new config syntax<br />New config was released a week ago.<br />See: https://tomasvotruba.com/blog/new-in-ecs-simpler-config/
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
