### PR TITLE
[framework] CronModuleRepository: fix "Warning: array_pop(): Argument #1 ($array) must be passed by reference, value given"

### DIFF
--- a/packages/framework/src/Component/Cron/CronModuleRepository.php
+++ b/packages/framework/src/Component/Cron/CronModuleRepository.php
@@ -59,7 +59,7 @@ class CronModuleRepository
             'SELECT cm.serviceId FROM ' . CronModule::class . ' cm WHERE cm.scheduled = TRUE'
         );
 
-        return array_map('array_pop', $query->getScalarResult());
+        return $query->getSingleColumnResult();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| running `cron` fails on the warning message
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
