### PR TITLE
[shopsys] update docs: installation and "latest" warning message

### DIFF
--- a/docs/installation/installation-using-docker-linux.md
+++ b/docs/installation/installation-using-docker-linux.md
@@ -19,13 +19,14 @@ Take a look at the article about [Monorepo](../introduction/monorepo.md) for mor
 ## Steps
 ### 1. Create new project from Shopsys Framework sources
 ```sh
-composer create-project shopsys/project-base --no-install --keep-vcs
+composer create-project shopsys/project-base --no-install --keep-vcs --ignore-platform-reqs
 cd project-base
 ```
 
 !!! note "Notes"
     - The `--no-install` option disables installation of the vendors - this will be done later in the Docker container
     - The `--keep-vcs` option initializes GIT repository in your project folder that is needed for diff commands of the application build and keeps the GIT history of `shopsys/project-base`
+    - The `--ignore-platform-reqs` option ensures your local PHP setup is not verified (it is not needed, everything is installed in Docker later)
 
 ### 2. Installation
 Now, you have two options:

--- a/docs/installation/installation-using-docker-macos.md
+++ b/docs/installation/installation-using-docker-macos.md
@@ -25,13 +25,14 @@ This solution uses [*docker-sync*](http://docker-sync.io/) (for relatively fast 
 ## Steps
 ### 1. Create new project from Shopsys Framework sources
 ```sh
-composer create-project shopsys/project-base --no-install --keep-vcs
+composer create-project shopsys/project-base --no-install --keep-vcs --ignore-platform-reqs
 cd project-base
 ```
 
 !!! note "Notes"
     - The `--no-install` option disables installation of the vendors - this will be done later in the Docker container
     - The `--keep-vcs` option initializes GIT repository in your project folder that is needed for diff commands of the application build and keeps the GIT history of `shopsys/project-base`
+    - The `--ignore-platform-reqs` option ensures your local PHP setup is not verified (it is not needed, everything is installed in Docker later)
 
 ### 2. Installation
 Now, you have two options:

--- a/docs/installation/installation-using-docker-windows-10.md
+++ b/docs/installation/installation-using-docker-windows-10.md
@@ -64,7 +64,7 @@ cd ~/
 Install project with composer
 
 ```sh
-composer create-project shopsys/project-base --no-install --keep-vcs
+composer create-project shopsys/project-base --no-install --keep-vcs --ignore-platform-reqs
 cd project-base
 ```
 
@@ -74,6 +74,7 @@ cd project-base
 !!! note "Notes"
     - The `--no-install` option disables installation of the vendors - this will be done later in the Docker container
     - The `--keep-vcs` option initializes GIT repository in your project folder that is needed for diff commands of the application build and keeps the GIT history of `shopsys/project-base`
+    - The `--ignore-platform-reqs` option ensures your local PHP setup is not verified (it is not needed, everything is installed in Docker later)
 
 ### 2. Installation
 Now, you have two options:

--- a/docs/introduction/basics-about-package-architecture.md
+++ b/docs/introduction/basics-about-package-architecture.md
@@ -46,7 +46,7 @@ Other candidates for extraction into modules are for example payment methods gat
 ### Create new project from Shopsys Framework sources
 Install [`shopsys/project-base`](https://github.com/shopsys/project-base) using composer to get your own private copy.
 ```sh
-composer create-project shopsys/project-base --no-install --keep-vcs
+composer create-project shopsys/project-base --no-install --keep-vcs --ignore-platform-reqs
 ```
 For more detailed instructions, follow [Installation Using Docker](../installation/installation-guide.md#installation-using-docker).
 #### Why not clone or fork?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,9 +20,5 @@ markdown_extensions:
 
 plugins:
     - search
-    -   readthedocs-version-warning:
-            project_id: "490215"
-            show_on_versions:
-                - latest
     -   awesome-pages:
             filename: navigation.yml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the installation of project-base using `composer create-project` might fail unnecessarily when local PHP setup is not met with the app requirements. Also, the warning message should not be displayed as the current stable version is the latest one
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| No
