### PR TITLE
[shopsys] docs: remove version warning placeholder from theme

### DIFF
--- a/docs/_theme/main.html
+++ b/docs/_theme/main.html
@@ -14,9 +14,3 @@
         {% endfor %}
     </ul>
 {%- endblock %}
-
-{% block content %}
-    ### VERSION-WARNING-BANNER-PLACEHOLDER ###
-
-    {{ page.content }}
-{% endblock %}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs<1.1
 jinja2==3.0.0
 mkdocs-awesome-pages-plugin==2.1.0
-readthedocs-version-warning-mkdocs-plugin


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the plugin was removed from configuration in 979ff2d44 but the theme was not modified, so the placeholder "### VERSION-WARNING-BANNER-PLACEHOLDER ###" was rendered
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
