### PR TITLE
[framework] fix implementations of FileVisitorInterface::visitTwigFile

### DIFF
--- a/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
@@ -17,7 +17,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitor\NameResolver;
 use SplFileInfo;
 use Symfony\Component\Validator\Constraint;
-use Twig_Node;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Extracts custom messages from constraint constructors for translation.
@@ -153,7 +153,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @inheritdoc
      */
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
         return null;
     }

--- a/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
@@ -15,7 +15,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitor\NameResolver;
 use SplFileInfo;
 use Symfony\Component\Validator\Constraint;
-use Twig_Node;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Extracts messages from public properties (with names ending "message") of custom constraints for translation.
@@ -159,7 +159,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     /**
      * @inheritdoc
      */
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
         return null;
     }

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -17,7 +17,7 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitor\NameResolver;
 use SplFileInfo;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Twig_Node;
+use Twig\Node\Node as TwigNode;
 
 /**
  * Extracts custom message from constraint callback function.
@@ -187,7 +187,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     /**
      * @inheritdoc
      */
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
         return null;
     }

--- a/packages/framework/src/Component/Translation/JsFileExtractor.php
+++ b/packages/framework/src/Component/Translation/JsFileExtractor.php
@@ -7,7 +7,7 @@ use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use SplFileInfo;
-use Twig_Node;
+use Twig\Node\Node;
 
 class JsFileExtractor implements FileVisitorInterface
 {
@@ -70,11 +70,9 @@ class JsFileExtractor implements FileVisitorInterface
     }
 
     /**
-     * @param \SplFileInfo $file
-     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
-     * @param \Twig_Node $node
+     * @inheritdoc
      */
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $node)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Node $ast)
     {
     }
 }

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -17,7 +17,7 @@ use PhpParser\NodeVisitor;
 use Shopsys\FrameworkBundle\Component\Translation\Exception\ExtractionException;
 use Shopsys\FrameworkBundle\Component\Translation\Exception\MessageIdArgumentNotPresent;
 use SplFileInfo;
-use Twig_Node;
+use Twig\Node\Node as TwigNode;
 
 class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
 {
@@ -273,11 +273,9 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @param \SplFileInfo $file
-     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
-     * @param \Twig_Node $ast
+     * @inheritdoc
      */
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {
         return null;
     }

--- a/packages/framework/src/Component/Translation/TwigFileExtractor.php
+++ b/packages/framework/src/Component/Translation/TwigFileExtractor.php
@@ -7,7 +7,7 @@ use JMS\TranslationBundle\Translation\Extractor\File\TwigFileExtractor as Origin
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
 use ReflectionObject;
 use SplFileInfo;
-use Twig_Node;
+use Twig\Node\Node;
 
 class TwigFileExtractor implements FileVisitorInterface
 {
@@ -60,7 +60,7 @@ class TwigFileExtractor implements FileVisitorInterface
     /**
      * {@inheritdoc}
      */
-    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Twig_Node $ast)
+    public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Node $ast)
     {
         $this->originalTwigFileExtractor->visitTwigFile($file, $catalogue, $ast);
     }

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -4,3 +4,14 @@ This guide contains instructions to upgrade from version 10.0.0 to 11.0.0-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/master/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+## Application
+
+- fix implementations of FileVisitorInterface::visitTwigFile ([#2465](https://github.com/shopsys/shopsys/pull/2465))
+    - in the following classes, an interface of `visitTwigFile` was fixed to comply with `FileVisitorInterface`
+        - `ConstraintMessageExtractor`
+        - `ConstraintMessagePropertyExtractor`
+        - `ConstraintViolationExtractor`
+        - `JsFileExtractor`
+        - `PhpFileExtractor`
+        - `TwigFileExtractor`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the errors were reported by the new version of PHPStan, see eg. https://github.com/shopsys/shopsys/runs/6587756007?check_suite_focus=true
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
