### PR TITLE
[framework] fixed sitemap priority type

### DIFF
--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -105,7 +105,7 @@ class SitemapListener implements EventSubscriberInterface
      * @param \Presta\SitemapBundle\Service\AbstractGenerator $generator
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @param string $section
-     * @param int $elementPriority
+     * @param float|string|int|null $elementPriority
      */
     protected function addUrlsBySitemapItems(
         array $sitemapItems,
@@ -125,7 +125,7 @@ class SitemapListener implements EventSubscriberInterface
      * @param \Presta\SitemapBundle\Service\AbstractGenerator $generator
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @param string $section
-     * @param int $elementPriority
+     * @param float|string|int|null  $elementPriority
      */
     protected function addHomepageUrl(
         AbstractGenerator $generator,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Priority can be more than just `int`. In fact, almost every priority set is a `float`
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
