### PR TITLE
migrations: fixed namespace selection when only one is available

### DIFF
--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -145,7 +145,7 @@ class GenerateMigrationCommand extends Command
             return new MigrationsLocation($migrationDirectoriesIndexedByNamespace[$chosenNamespace], $chosenNamespace);
         }
 
-        $firstNamespace = array_key_first($migrationDirectoriesIndexedByNamespace);
+        $firstNamespace = reset($availableNamespaces);
 
         return new MigrationsLocation($migrationDirectoriesIndexedByNamespace[$firstNamespace], $firstNamespace);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When only one namespace is available (eg. when in the context of the project), the first namespace should be selected from available namespaces, not from every registered namespaces
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
