### PR TITLE
[monorepo] minor fixes in release process

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesOnPackagistReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckPackagesOnPackagistReleaseWorker.php
@@ -50,7 +50,7 @@ final class CheckPackagesOnPackagistReleaseWorker extends AbstractShopsysRelease
         $packagesWithVersions = $this->packageProvider->getPackagesWithVersionsByOrganization('shopsys');
 
         $packageWithoutVersion = [];
-        $versionsAsString = $version->getVersionString();
+        $versionsAsString = $version->getOriginalString();
         foreach ($packagesWithVersions as $package => $packageVersions) {
             if (in_array($versionsAsString, $packageVersions, true)) {
                 continue;

--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagReleaseWorker.php
@@ -24,7 +24,7 @@ final class CreateAndPushGitTagReleaseWorker extends AbstractShopsysReleaseWorke
      */
     public function work(Version $version): void
     {
-        $versionString = $version->getVersionString();
+        $versionString = $version->getOriginalString();
         $this->processRunner->run('git tag ' . $versionString);
         $this->symfonyStyle->note(
             sprintf('You need to push tag manually using "git push origin %s" command.', $versionString)

--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
@@ -26,6 +26,7 @@ final class CreateAndPushGitTagsExceptProjectBaseReleaseWorker extends AbstractS
         'shopsys/phpstorm-inspect',
         'shopsys/changelog-linker',
         'shopsys/monorepo-builder',
+        'shopsys/backend-api',
         // forks
         'shopsys/postgres-search-bundle',
         'shopsys/doctrine-orm',

--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php
@@ -68,7 +68,7 @@ final class CreateAndPushGitTagsExceptProjectBaseReleaseWorker extends AbstractS
         $packages = $this->packageProvider->getPackagesByOrganization('shopsys', self::EXCLUDED_PACKAGES);
         $packageNames = str_replace('shopsys/', '', $packages);
 
-        $versionString = $version->getVersionString();
+        $versionString = $version->getOriginalString();
 
         $tempDirectory = trim($this->processRunner->run('mktemp -d -t shopsys-release-XXXX'));
         $packageNamesWithProblems = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Tags are now created with the `v` prefix as they were in the past. Backend API is now not tagged and this tag is not pushed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
