### PR TITLE
[shopsys] upgrade overblog/graphql to 0.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
         "nyholm/psr7": "^1.5",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
         "overblog/graphiql-bundle": "^0.2",
-        "overblog/graphql-bundle": "^0.13.3",
+        "overblog/graphql-bundle": "^0.14.3",
         "phing/phing": "^2.17.3",
         "phpdocumentor/reflection-docblock": "^5.3.0",
         "presta/sitemap-bundle": "^3.3",

--- a/docs/frontend-api/introduction-to-frontend-api.md
+++ b/docs/frontend-api/introduction-to-frontend-api.md
@@ -162,7 +162,7 @@ Query:
 
 ### Resolvers
 Resolvers are normal Symfony services.
-They only have to implement the `Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface` to be recognized as an available resolver for the GraphQL.
+They only have to implement the `Overblog\GraphQLBundle\Definition\Resolver\QueryInterface` to be recognized as an available resolver for the GraphQL.
 
 There are several ways how to define resolvers in definition YAML files.
 We use `Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface` to keep definitions simple and easy to read.

--- a/docs/frontend-api/introduction-to-frontend-api.md
+++ b/docs/frontend-api/introduction-to-frontend-api.md
@@ -149,7 +149,7 @@ QueryDecorator:
         fields:
             categories:
                 type: '[Category!]!'                    # Array of the categories will be returned.
-                resolve: "@=resolver('categories')"   # Define the resolver responsible for returning the data. See the resolvers section below.
+                resolve: "@=query('categories')"   # Define the resolver responsible for returning the data. See the resolvers section below.
 ```
 
 And specific `Query` type is defined in `config/graphql/types/Query.types.yaml`
@@ -184,7 +184,7 @@ public function resolve(): array
 public static function getAliases(): array
 {
     return [
-        'resolve' => 'categories',  // field with resolver defined as "@=resolver('categories')" (see above) will use `resolve` method in this class
+        'resolve' => 'categories',  // field with resolver defined as "@=query('categories')" (see above) will use `resolve` method in this class
     ];
 }
 ```

--- a/packages/framework/tests/Unit/Component/Translation/Resources/DummyMutation.types.yaml
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/DummyMutation.types.yaml
@@ -18,4 +18,4 @@ Mutation:
                                     maxMessage: "Email cannot be longer than {{ limit }} characters"
                                     min: 0
                                     minMessage: ~
-                resolve: "@=mutation('newsletter_subscribe', [args, validator])"
+                resolve: "@=mutation('newsletter_subscribe', args, validator)"

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.1",
         "lcobucci/jwt": "^4.1.5",
-        "overblog/graphql-bundle": "^0.13.3",
+        "overblog/graphql-bundle": "^0.14.3",
         "overblog/graphiql-bundle": "^0.2",
         "shopsys/form-types-bundle": "11.0.x-dev",
         "shopsys/framework": "11.0.x-dev",

--- a/packages/frontend-api/src/Model/Resolver/Advert/AdvertPositionsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Advert/AdvertPositionsResolver.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Advert;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Model\Advert\AdvertPositionRegistry;
 
-class AdvertPositionsResolver implements ResolverInterface, AliasedInterface
+class AdvertPositionsResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Advert\AdvertPositionRegistry

--- a/packages/frontend-api/src/Model/Resolver/Advert/AdvertsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Advert/AdvertsResolver.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Advert;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrontendApiBundle\Model\Advert\AdvertFacade;
 
-class AdvertsResolver implements ResolverInterface, AliasedInterface
+class AdvertsResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrontendApiBundle\Model\Advert\AdvertFacade

--- a/packages/frontend-api/src/Model/Resolver/Article/ArticleResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticleResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Article;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
@@ -16,7 +16,7 @@ use Shopsys\FrameworkBundle\Model\LegalConditions\LegalConditionsFacade;
 use Shopsys\FrontendApiBundle\Model\Article\ArticleFacade;
 use Shopsys\FrontendApiBundle\Model\FriendlyUrl\FriendlyUrlFacade;
 
-class ArticleResolver implements ResolverInterface, AliasedInterface
+class ArticleResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrontendApiBundle\Model\Article\ArticleFacade

--- a/packages/frontend-api/src/Model/Resolver/Article/ArticlesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/ArticlesResolver.php
@@ -6,13 +6,13 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Article;
 
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrontendApiBundle\Model\Article\ArticleFacade;
 
-class ArticlesResolver implements ResolverInterface, AliasedInterface
+class ArticlesResolver implements QueryInterface, AliasedInterface
 {
     protected const DEFAULT_FIRST_LIMIT = 10;
 

--- a/packages/frontend-api/src/Model/Resolver/Brand/BrandResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Brand/BrandResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Brand;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Exception\BrandNotFoundException;
 use Shopsys\FrontendApiBundle\Model\FriendlyUrl\FriendlyUrlFacade;
 
-class BrandResolver implements ResolverInterface, AliasedInterface
+class BrandResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade

--- a/packages/frontend-api/src/Model/Resolver/Brand/BrandsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Brand/BrandsResolver.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Brand;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 
-class BrandsResolver implements ResolverInterface, AliasedInterface
+class BrandsResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoriesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoriesResolver.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Category;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 
-class CategoriesResolver implements ResolverInterface, AliasedInterface
+class CategoriesResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoriesSearchResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoriesSearchResolver.php
@@ -6,12 +6,12 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Category;
 
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrontendApiBundle\Model\Category\CategoryFacade;
 
-class CategoriesSearchResolver implements ResolverInterface, AliasedInterface
+class CategoriesSearchResolver implements QueryInterface, AliasedInterface
 {
     protected const DEFAULT_FIRST_LIMIT = 10;
 

--- a/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/CategoryResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Category;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
 use Shopsys\FrontendApiBundle\Model\FriendlyUrl\FriendlyUrlFacade;
 
-class CategoryResolver implements ResolverInterface, AliasedInterface
+class CategoryResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade

--- a/packages/frontend-api/src/Model/Resolver/Customer/User/CurrentCustomerUserResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Customer/User/CurrentCustomerUserResolver.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Customer\User;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserWarning;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 
-class CurrentCustomerUserResolver implements ResolverInterface, AliasedInterface
+class CurrentCustomerUserResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser

--- a/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/ImagesResolver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Image;
 
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\Config\Exception\ImageSizeNotFoundException;
@@ -22,7 +22,7 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrontendApiBundle\Component\Image\ImageFacade as FrontendApiImageFacade;
 
-class ImagesResolver implements ResolverInterface
+class ImagesResolver implements QueryInterface
 {
     protected const IMAGE_ENTITY_PRODUCT = 'product';
     protected const IMAGE_ENTITY_CATEGORY = 'category';

--- a/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrderResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Order;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
@@ -15,7 +15,7 @@ use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
 use Shopsys\FrontendApiBundle\Model\Order\OrderFacade as FrontendApiOrderFacade;
 
-class OrderResolver implements ResolverInterface, AliasedInterface
+class OrderResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser

--- a/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/OrdersResolver.php
@@ -6,14 +6,14 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Order;
 
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Overblog\GraphQLBundle\Relay\Connection\Paginator;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrontendApiBundle\Model\Order\OrderFacade;
 
-class OrdersResolver implements ResolverInterface, AliasedInterface
+class OrdersResolver implements QueryInterface, AliasedInterface
 {
     protected const DEFAULT_FIRST_LIMIT = 10;
 

--- a/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/PaymentResolver.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Payment;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Payment\Exception\PaymentNotFoundException;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 
-class PaymentResolver implements ResolverInterface, AliasedInterface
+class PaymentResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade

--- a/packages/frontend-api/src/Model/Resolver/Payment/PaymentsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/PaymentsResolver.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Payment;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 
-class PaymentsResolver implements ResolverInterface, AliasedInterface
+class PaymentsResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Price;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation;
@@ -19,7 +19,7 @@ use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation;
 use Shopsys\FrontendApiBundle\Model\Price\PriceFacade;
 
-class PriceResolver implements ResolverInterface, AliasedInterface
+class PriceResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductDetailResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductDetailResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlNotFoundException;
@@ -13,7 +13,7 @@ use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\ProductElasticsearchProvider;
 use Shopsys\FrontendApiBundle\Model\FriendlyUrl\FriendlyUrlFacade;
 
-class ProductDetailResolver implements ResolverInterface, AliasedInterface
+class ProductDetailResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\ProductElasticsearchProvider

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductsResolver.php
@@ -6,7 +6,7 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Relay\Connection\ConnectionBuilder;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
@@ -15,7 +15,7 @@ use Shopsys\FrontendApiBundle\Model\Product\Connection\ProductConnectionFactory;
 use Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterFacade;
 use Shopsys\FrontendApiBundle\Model\Product\ProductFacade;
 
-class ProductsResolver implements ResolverInterface, AliasedInterface
+class ProductsResolver implements QueryInterface, AliasedInterface
 {
     protected const DEFAULT_FIRST_LIMIT = 10;
 

--- a/packages/frontend-api/src/Model/Resolver/Products/PromotedProductsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/PromotedProductsResolver.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Products;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade;
 
-class PromotedProductsResolver implements ResolverInterface, AliasedInterface
+class PromotedProductsResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade

--- a/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/TransportResolver.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Transport;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Overblog\GraphQLBundle\Error\UserError;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Transport\Exception\TransportNotFoundException;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
 
-class TransportResolver implements ResolverInterface, AliasedInterface
+class TransportResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade

--- a/packages/frontend-api/src/Model/Resolver/Transport/TransportsResolver.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/TransportsResolver.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Transport;
 
 use Overblog\GraphQLBundle\Definition\Resolver\AliasedInterface;
-use Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface;
+use Overblog\GraphQLBundle\Definition\Resolver\QueryInterface;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
 
-class TransportsResolver implements ResolverInterface, AliasedInterface
+class TransportsResolver implements QueryInterface, AliasedInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Transport\TransportFacade

--- a/packages/frontend-api/src/Model/ScalarType/StringType.php
+++ b/packages/frontend-api/src/Model/ScalarType/StringType.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\ScalarType;
 
+use GraphQL\Language\AST\Node;
 use GraphQL\Type\Definition\StringType as BaseStringType;
 
 class StringType extends BaseStringType
 {
     /**
+     * webonix/graphql-php has wrong typing between StringType::parseLiteral and Leaf type interface::parseLiteral,
+     * so phpstan-param annotation must be used
+     *
+     * @phpstan-param \GraphQL\Language\AST\IntValueNode|\GraphQL\Language\AST\FloatValueNode|\GraphQL\Language\AST\StringValueNode|\GraphQL\Language\AST\BooleanValueNode|\GraphQL\Language\AST\NullValueNode $valueNode
      * @param \GraphQL\Language\AST\Node $valueNode
      * @param array|null $variables
-     * @return string|null
+     * @return string
      */
-    public function parseLiteral($valueNode, ?array $variables = null)
+    public function parseLiteral(Node $valueNode, ?array $variables = null)
     {
-        $value = parent::parseLiteral($valueNode, $variables);
-        if ($value === null) {
-            return null;
-        }
-        return trim($value);
+        return trim(parent::parseLiteral($valueNode, $variables));
     }
 
     /**

--- a/packages/frontend-api/src/Resources/config/graphql-types/AdvertImageDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/AdvertImageDecorator.types.yaml
@@ -11,7 +11,7 @@ AdvertImageDecorator:
             image:
                 type: "[Image]"
                 description: "Advert image"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByAdvert(value, args["type"], args["size"])'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByAdvert", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"

--- a/packages/frontend-api/src/Resources/config/graphql-types/BrandDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/BrandDecorator.types.yaml
@@ -28,7 +28,7 @@ BrandDecorator:
             images:
                 type: "[Image]!"
                 description: "Brand images"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByBrand(value, args["type"], args["size"])'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByBrand", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"
@@ -42,4 +42,4 @@ BrandDecorator:
                     builder: "PaginatorArgumentsBuilder"
                     config:
                         orderingModeType: 'ProductOrderingModeEnum'
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Products\\ProductsResolver").resolveByBrand(args, value)'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Products\\ProductsResolver::resolveByBrand", args, value)'

--- a/packages/frontend-api/src/Resources/config/graphql-types/CategoryDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/CategoryDecorator.types.yaml
@@ -19,7 +19,7 @@ CategoryDecorator:
             images:
                 type: "[Image]!"
                 description: "Category images"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByCategory(value, args["type"], args["size"])'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByCategory", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"
@@ -33,7 +33,7 @@ CategoryDecorator:
                     builder: "PaginatorArgumentsBuilder"
                     config:
                         orderingModeType: 'ProductOrderingModeEnum'
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Products\\ProductsResolver").resolveByCategory(args, value)'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Products\\ProductsResolver::resolveByCategory", args, value)'
             seoH1:
                 type: "String"
                 description: "Seo first level heading of category"

--- a/packages/frontend-api/src/Resources/config/graphql-types/MutationDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/MutationDecorator.types.yaml
@@ -10,14 +10,14 @@ MutationDecorator:
                     input:
                         type: OrderInput!
                         validation: cascade
-                resolve: "@=mutation('create_order', [args, validator])"
+                resolve: "@=mutation('create_order', args, validator)"
             Login:
                 type: Token!
                 description: "Login user and return access and refresh tokens"
                 args:
                     input:
                         type: LoginInput!
-                resolve: "@=mutation('user_login', [args])"
+                resolve: "@=mutation('user_login', args)"
             Logout:
                 type: Boolean!
                 description: "Logout user"
@@ -28,7 +28,7 @@ MutationDecorator:
                 args:
                     input:
                         type: RefreshTokenInput!
-                resolve: "@=mutation('refresh_tokens', [args])"
+                resolve: "@=mutation('refresh_tokens', args)"
             ChangePassword:
                 type: 'CurrentCustomerUser!'
                 description: "Changes customer user password"
@@ -36,7 +36,7 @@ MutationDecorator:
                     input:
                         type: ChangePasswordInput!
                         validation: cascade
-                resolve: "@=mutation('customer_user_change_password', [args, validator])"
+                resolve: "@=mutation('customer_user_change_password', args, validator)"
             ChangePersonalData:
                 type: 'CurrentCustomerUser!'
                 description: "Changes customer user personal data"
@@ -44,7 +44,7 @@ MutationDecorator:
                     input:
                         type: ChangePersonalDataInput!
                         validation: cascade
-                resolve: "@=mutation('customer_user_change_personal_data', [args, validator])"
+                resolve: "@=mutation('customer_user_change_personal_data', args, validator)"
             Register:
                 type: Token!
                 description: "Register new customer user"
@@ -52,7 +52,7 @@ MutationDecorator:
                     input:
                         type: RegistrationDataInput!
                         validation: cascade
-                resolve: "@=mutation('customer_user_register', [args, validator])"
+                resolve: "@=mutation('customer_user_register', args, validator)"
             NewsletterSubscribe:
                 type: Boolean!
                 description: "Subscribe for e-mail newsletter"
@@ -60,4 +60,4 @@ MutationDecorator:
                     input:
                         type: NewsletterSubscriptionDataInput!
                         validation: cascade
-                resolve: "@=mutation('newsletter_subscribe', [args, validator])"
+                resolve: "@=mutation('newsletter_subscribe', args, validator)"

--- a/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/PaymentDecorator.types.yaml
@@ -22,11 +22,11 @@ PaymentDecorator:
             price:
                 type: "Price!"
                 description: "Payment price"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByPayment(value)'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver::resolveByPayment", value)'
             images:
                 type: "[Image]!"
                 description: "Payment images"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByPayment(value, args["type"], args["size"])'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByPayment", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"

--- a/packages/frontend-api/src/Resources/config/graphql-types/ProductDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ProductDecorator.types.yaml
@@ -34,11 +34,11 @@ ProductDecorator:
             price:
                 type: "ProductPrice"
                 description: "Product price"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByProduct(value)'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver::resolveByProduct", value)'
             images:
                 type: "[Image]!"
                 description: "Product images"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByProduct(value, args["type"], args["size"])'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByProduct", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"

--- a/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/QueryDecorator.types.yaml
@@ -5,12 +5,12 @@ QueryDecorator:
         fields:
             categories:
                 type: '[Category!]!'
-                resolve: "@=resolver('categories')"
+                resolve: "@=query('categories')"
                 description: "Returns complete list of categories"
             categoriesSearch:
                 type: "CategoryConnection"
                 argsBuilder: "Relay::Connection"
-                resolve: "@=resolver('categoriesSearch', [args])"
+                resolve: "@=query('categoriesSearch', args)"
                 args:
                     search:
                         type: "String!"
@@ -21,11 +21,11 @@ QueryDecorator:
                     builder: "PaginatorArgumentsBuilder"
                     config:
                         orderingModeType: 'ProductOrderingModeEnum'
-                resolve: "@=resolver('products', [args])"
+                resolve: "@=query('products', args)"
                 description: "Returns list of ordered products that can be paginated using `first`, `last`, `before` and `after` keywords"
             product:
                 type: 'Product'
-                resolve: "@=resolver('productDetail', [args['uuid'], args['urlSlug']])"
+                resolve: "@=query('productDetail', args['uuid'], args['urlSlug'])"
                 args:
                     uuid:
                         type: "Uuid"
@@ -40,7 +40,7 @@ QueryDecorator:
                 type: 'Variant'
             category:
                 type: 'Category'
-                resolve: "@=resolver('categoryByUuidOrUrlSlug', [args['uuid'], args['urlSlug']])"
+                resolve: "@=query('categoryByUuidOrUrlSlug', args['uuid'], args['urlSlug'])"
                 args:
                     uuid:
                         type: "Uuid"
@@ -49,38 +49,38 @@ QueryDecorator:
                 description: "Returns category filtered using UUID or URL slug"
             payments:
                 type: '[Payment!]!'
-                resolve: "@=resolver('payments')"
+                resolve: "@=query('payments')"
                 description: "Returns complete list of payment methods"
             payment:
                 type: 'Payment'
-                resolve: "@=resolver('payment', [args['uuid']])"
+                resolve: "@=query('payment', args['uuid'])"
                 args:
                     uuid:
                         type: "Uuid!"
                 description: "Returns payment filtered using UUID"
             transports:
                 type: '[Transport!]!'
-                resolve: "@=resolver('transports')"
+                resolve: "@=query('transports')"
                 description: "Returns complete list of transport methods"
             transport:
                 type: 'Transport'
-                resolve: "@=resolver('transport', [args['uuid']])"
+                resolve: "@=query('transport', args['uuid'])"
                 args:
                     uuid:
                         type: "Uuid!"
                 description: "Returns complete list of transport methods"
             currentCustomerUser:
                 type: 'CurrentCustomerUser!'
-                resolve: "@=resolver('currentCustomerUser')"
+                resolve: "@=query('currentCustomerUser')"
                 description: "Returns currently logged in customer user"
             orders:
                 type: "OrderConnection"
                 argsBuilder: "Relay::Connection"
-                resolve: "@=resolver('orders', [args])"
+                resolve: "@=query('orders', args)"
                 description: "Returns list of orders that can be paginated using `first`, `last`, `before` and `after` keywords"
             order:
                 type: 'Order'
-                resolve: "@=resolver('order', [args['uuid'], args['urlHash']])"
+                resolve: "@=query('order', args['uuid'], args['urlHash'])"
                 args:
                     uuid:
                         type: "Uuid"
@@ -90,14 +90,14 @@ QueryDecorator:
             articles:
                 type: "ArticleConnection"
                 argsBuilder: "Relay::Connection"
-                resolve: "@=resolver('articles', [args, args['placement']])"
+                resolve: "@=query('articles', args, args['placement'])"
                 args:
                     placement:
                         type: "String"
                 description: "Returns list of articles that can be paginated using `first`, `last`, `before` and `after` keywords and filtered by `placement`"
             article:
                 type: 'Article'
-                resolve: "@=resolver('article', [args['uuid'], args['urlSlug']])"
+                resolve: "@=query('article', args['uuid'], args['urlSlug'])"
                 args:
                     uuid:
                         type: "Uuid"
@@ -106,23 +106,23 @@ QueryDecorator:
                 description: "Returns article filtered using UUID or URL slug"
             termsAndConditionsArticle:
                 type: 'Article'
-                resolve: "@=resolver('termsAndConditionsArticle')"
+                resolve: "@=query('termsAndConditionsArticle')"
                 description: "Returns Terms and Conditions article"
             privacyPolicyArticle:
                 type: 'Article'
-                resolve: "@=resolver('privacyPolicyArticle')"
+                resolve: "@=query('privacyPolicyArticle')"
                 description: "Returns privacy policy article"
             cookiesArticle:
                 type: 'Article'
-                resolve: "@=resolver('cookiesArticle')"
+                resolve: "@=query('cookiesArticle')"
                 description: "Returns information about cookies article"
             brands:
                 type: '[Brand!]!'
-                resolve: "@=resolver('brands')"
+                resolve: "@=query('brands')"
                 description: "Returns complete list of brands"
             brand:
                 type: 'Brand'
-                resolve: "@=resolver('brand', [args['uuid'], args['urlSlug']])"
+                resolve: "@=query('brand', args['uuid'], args['urlSlug'])"
                 args:
                     uuid:
                         type: "Uuid"
@@ -131,11 +131,11 @@ QueryDecorator:
                 description: "Returns brand filtered using UUID or URL slug"
             promotedProducts:
                 type: '[Product!]!'
-                resolve: "@=resolver('promotedProducts')"
+                resolve: "@=query('promotedProducts')"
                 description: "Returns promoted products"
             adverts:
                 type: '[Advert!]!'
-                resolve: "@=resolver('adverts', [args['positionName']])"
+                resolve: "@=query('adverts', args['positionName'])"
                 args:
                     positionName:
                         type: "String"
@@ -146,5 +146,5 @@ QueryDecorator:
                 type: 'AdvertImage'
             advertPositions:
                 type: '[AdvertPosition!]!'
-                resolve: "@=resolver('advertPositions')"
+                resolve: "@=query('advertPositions')"
                 description: "Returns list of advert positions."

--- a/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yaml
@@ -22,11 +22,11 @@ TransportDecorator:
             price:
                 type: "Price"
                 description: "Transport price"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver").resolveByTransport(value)'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Price\\PriceResolver::resolveByTransport", value)'
             images:
                 type: "[Image]!"
                 description: "Transport images"
-                resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByTransport(value, args["type"], args["size"])'
+                resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByTransport", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -894,3 +894,30 @@ There you can find links to upgrade notes for other versions too.
         + public function __construct(MailerSettingProvider $mailerSettingProvider, Environment $twigEnvironment)
         ```
     - translations - the `Unable to send updating email` msgid is no longer available
+- update `overblog/graphql-bundle` to `^0.14.3` ([#2479](https://github.com/shopsys/shopsys/pull/2479))
+    - switch implementation of deprecated `Overblog\GraphQLBundle\Definition\Resolver\ResolverInterface` to `Overblog\GraphQLBundle\Definition\Resolver\QueryInterface` in your resolvers
+    - change `resolver` expression function to `query` in your types defined in yaml files
+        - Old signature (deprecated): `resolver(string $alias, array $args = []): mixed`
+        - New signature: `query(string $alias, ...$args): mixed`
+        - Example:
+        ```diff
+        - resolve: "@=resolver('categoriesSearch', [args])"
+        + resolve: "@=query('categoriesSearch', args)"
+        ```
+    - change `service` expression function to `query` in your types defined in yaml files
+        - it is no longer supported to use private services in @=service function
+        - for more details check: https://github.com/overblog/GraphQLBundle/blob/master/docs/definitions/expression-language.md#private-services
+        - Example:
+        ```diff
+        - resolve: '@=service("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver").resolveByAdvert(value, args["type"], args["size"])'
+        + resolve: '@=query("Shopsys\\FrontendApiBundle\\Model\\Resolver\\Image\\ImagesResolver::resolveByAdvert", value, args["type"], args["size"])'
+        ```
+    - `mutation` expression function signature was changed
+        - Old signature: `mutation(string $alias, array $args = []): mixed`
+        - New signature: `mutation(string $alias, ...$args): mixed`
+        - Example:
+        ```diff
+        - resolve: "@=mutation('create_order', [args, validator])"
+        + resolve: resolve: "@=mutation('create_order', args, validator)"
+        ```
+  - check other changes in [GraphQLBundle UPGRADE notes](https://github.com/overblog/GraphQLBundle/blob/master/UPGRADE.md#upgrade-from-013-to-014) and implement them in your codebase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| upgrade overblog/graphql to 0.14
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


These deprecations library triggers by itself:
```
The "Overblog\GraphQLBundle\DependencyInjection\Compiler\ResolverTaggedServiceMappingPass" class is deprecated since 0.14 and will be removed in 1.0. Use "Overblog\GraphQLBundle\DependencyInjection\Compiler\QueryTaggedServiceMappingPass" instead.
```
```
The "Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Resolver" service relies on the deprecated "Overblog\GraphQLBundle\ExpressionLanguage\ExpressionFunction\GraphQL\Resolver" class. It should either be deprecated or its implementation upgraded.
```