### PR TITLE
[framework] remove usage of deprecated FrameworkBundle:Redirect:redirect

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlMatcher.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlMatcher.php
@@ -46,7 +46,7 @@ class FriendlyUrlMatcher
         $matchedParameters['id'] = $friendlyUrl->getEntityId();
 
         if (!$friendlyUrl->isMain()) {
-            $matchedParameters['_controller'] = 'FrameworkBundle:Redirect:redirect';
+            $matchedParameters['_controller'] = 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction';
             $matchedParameters['route'] = $friendlyUrl->getRouteName();
             $matchedParameters['permanent'] = true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| https://symfony.com/blog/new-in-symfony-4-1-deprecated-the-bundle-notation
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
