### PR TITLE
[framework] remove Redis deprecations

### DIFF
--- a/packages/framework/src/Component/Redis/RedisFacade.php
+++ b/packages/framework/src/Component/Redis/RedisFacade.php
@@ -62,7 +62,7 @@ class RedisFacade
         while ($keys !== false) {
             $keys = $redisClient->scan($iterator, $pattern, $suggestedScanBatchSize);
             if (is_array($keys) && count($keys) > 0) {
-                $redisClient->eval("return redis.call('unlink', unpack(ARGV))", $keys);
+                $redisClient->eval("return redis.call('unlink', unpack(ARGV))", $keys, 0);
             }
         }
     }

--- a/packages/framework/src/Component/Redis/RedisVersionsFacade.php
+++ b/packages/framework/src/Component/Redis/RedisVersionsFacade.php
@@ -39,7 +39,7 @@ class RedisVersionsFacade
         $iterator = null;
 
         do {
-            $keys = $this->globalClient->scan($iterator, $versionPattern);
+            $keys = $this->globalClient->scan($iterator, $versionPattern, 0);
 
             if ($keys === false) {
                 continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Redis::scan(): Passing null to parameter #3 ($i_count) of type int is deprecated</br>Redis::eval(): Passing null to parameter #3 ($num_keys) of type int is deprecated
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
