### PR TITLE
[shopsys] replaced deprecated kernel events

### DIFF
--- a/packages/framework/src/Component/Domain/DomainAwareSecurityHeadersSetter.php
+++ b/packages/framework/src/Component/Domain/DomainAwareSecurityHeadersSetter.php
@@ -2,7 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\Domain;
 
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class DomainAwareSecurityHeadersSetter
 {
@@ -20,9 +20,9 @@ class DomainAwareSecurityHeadersSetter
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;

--- a/packages/framework/src/Component/Domain/DomainSubscriber.php
+++ b/packages/framework/src/Component/Domain/DomainSubscriber.php
@@ -4,7 +4,7 @@ namespace Shopsys\FrameworkBundle\Component\Domain;
 
 use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class DomainSubscriber implements EventSubscriberInterface
@@ -23,9 +23,9 @@ class DomainSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         if ($event->isMasterRequest()) {
             try {

--- a/packages/framework/src/Component/HttpFoundation/DenyScriptNameInRequestPathListener.php
+++ b/packages/framework/src/Component/HttpFoundation/DenyScriptNameInRequestPathListener.php
@@ -3,16 +3,16 @@
 namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class DenyScriptNameInRequestPathListener implements EventSubscriberInterface
 {
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $request = $event->getRequest();

--- a/packages/framework/src/Component/HttpFoundation/ResponseListener.php
+++ b/packages/framework/src/Component/HttpFoundation/ResponseListener.php
@@ -2,14 +2,14 @@
 
 namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
 
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class ResponseListener
 {
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         $event->getResponse()->headers->set('X-Frame-Options', 'sameorigin');
         $event->getResponse()->headers->set('X-XSS-Protection', '1; mode=block');

--- a/packages/framework/src/Component/HttpFoundation/SubRequestListener.php
+++ b/packages/framework/src/Component/HttpFoundation/SubRequestListener.php
@@ -5,8 +5,8 @@ namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
 use Shopsys\FrameworkBundle\Component\HttpFoundation\Exception\TooManyRedirectResponsesException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class SubRequestListener
 {
@@ -21,9 +21,9 @@ class SubRequestListener
     protected $masterRequest;
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ControllerEvent $event
      */
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelController(ControllerEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $this->masterRequest = $event->getRequest();
@@ -47,9 +47,9 @@ class SubRequestListener
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if ($event->isMasterRequest()) {
             if ($this->redirectResponse !== null) {

--- a/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
+++ b/packages/framework/src/Component/HttpFoundation/TransactionalMasterRequestListener.php
@@ -3,9 +3,9 @@
 namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class TransactionalMasterRequestListener
 {
@@ -29,9 +29,9 @@ class TransactionalMasterRequestListener
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         if ($event->isMasterRequest() && !$this->inTransaction) {
             $this->em->beginTransaction();
@@ -40,9 +40,9 @@ class TransactionalMasterRequestListener
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if ($event->isMasterRequest() && $this->inTransaction) {
             $this->em->commit();
@@ -51,9 +51,9 @@ class TransactionalMasterRequestListener
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
         if ($event->isMasterRequest() && $this->inTransaction) {
             $this->em->rollback();

--- a/packages/framework/src/Component/HttpFoundation/VaryResponseByXRequestedWithHeaderListener.php
+++ b/packages/framework/src/Component/HttpFoundation/VaryResponseByXRequestedWithHeaderListener.php
@@ -2,7 +2,7 @@
 
 namespace Shopsys\FrameworkBundle\Component\HttpFoundation;
 
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 /**
  * VaryResponseByXRequestedWithHeaderListener sets "Vary: X-Requested-With" header to every response
@@ -17,9 +17,9 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 class VaryResponseByXRequestedWithHeaderListener
 {
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $event->getResponse()->headers->set('Vary', 'X-Requested-With');

--- a/packages/framework/src/Component/Log/SlowLogSubscriber.php
+++ b/packages/framework/src/Component/Log/SlowLogSubscriber.php
@@ -4,8 +4,8 @@ namespace Shopsys\FrameworkBundle\Component\Log;
 
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class SlowLogSubscriber implements EventSubscriberInterface
@@ -32,9 +32,9 @@ class SlowLogSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      */
-    public function initStartTime(GetResponseEvent $event)
+    public function initStartTime(RequestEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $this->startTime = microtime(true);
@@ -42,9 +42,9 @@ class SlowLogSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\PostResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\TerminateEvent $event
      */
-    public function addNotice(PostResponseEvent $event)
+    public function addNotice(TerminateEvent $event): void
     {
         $requestTime = $this->getRequestTime();
         if ($requestTime <= static::REQUEST_TIME_LIMIT_SECONDS) {

--- a/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
+++ b/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\Reader;
 use ReflectionMethod;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -48,9 +48,9 @@ class RouteCsrfProtector implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ControllerEvent $event
      */
-    public function onKernelController(FilterControllerEvent $event)
+    public function onKernelController(ControllerEvent $event): void
     {
         if ($this->isProtected($event)) {
             $request = $event->getRequest();
@@ -94,10 +94,10 @@ class RouteCsrfProtector implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ControllerEvent $event
      * @return bool
      */
-    protected function isProtected(FilterControllerEvent $event)
+    protected function isProtected(ControllerEvent $event): bool
     {
         if (!$event->isMasterRequest()) {
             return false;

--- a/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
@@ -6,7 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Administrator\Security;
 
 use Shopsys\FrameworkBundle\Model\Administrator\Administrator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -50,9 +50,9 @@ class AdministratorRolesChangedSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         $token = $this->tokenStorage->getToken();
 

--- a/packages/framework/src/Model/Cart/CartMigrationFacade.php
+++ b/packages/framework/src/Model/Cart/CartMigrationFacade.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifierFactory;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 
 class CartMigrationFacade
 {
@@ -84,11 +84,11 @@ class CartMigrationFacade
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterControllerEvent $filterControllerEvent
+     * @param \Symfony\Component\HttpKernel\Event\ControllerEvent $event
      */
-    public function onKernelController(FilterControllerEvent $filterControllerEvent)
+    public function onKernelController(ControllerEvent $event): void
     {
-        $session = $filterControllerEvent->getRequest()->getSession();
+        $session = $event->getRequest()->getSession();
 
         $previousCartIdentifier = $session->get(static::SESSION_PREVIOUS_CART_IDENTIFIER);
         if (

--- a/packages/framework/src/Model/Category/CategoryVisibilityRepository.php
+++ b/packages/framework/src/Model/Category/CategoryVisibilityRepository.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class CategoryVisibilityRepository
 {
@@ -131,9 +131,9 @@ class CategoryVisibilityRepository
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;

--- a/packages/framework/src/Model/Localization/LocalizationListener.php
+++ b/packages/framework/src/Model/Localization/LocalizationListener.php
@@ -5,7 +5,7 @@ namespace Shopsys\FrameworkBundle\Model\Localization;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class LocalizationListener implements EventSubscriberInterface
@@ -41,9 +41,9 @@ class LocalizationListener implements EventSubscriberInterface
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $request = $event->getRequest();

--- a/packages/framework/src/Model/Pricing/InputPriceRecalculationScheduler.php
+++ b/packages/framework/src/Model/Pricing/InputPriceRecalculationScheduler.php
@@ -3,7 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Pricing;
 
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class InputPriceRecalculationScheduler
 {
@@ -48,9 +48,9 @@ class InputPriceRecalculationScheduler
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculator.php
@@ -4,7 +4,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Availability;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Model\Product\Product;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class ProductAvailabilityRecalculator
 {
@@ -99,9 +99,9 @@ class ProductAvailabilityRecalculator
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $this->runImmediateRecalculations();

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\Exception\MainVariantPriceCalculationException;
 use Shopsys\FrameworkBundle\Model\Product\Product;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class ProductPriceRecalculator
 {
@@ -153,9 +153,9 @@ class ProductPriceRecalculator
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if ($event->isMasterRequest()) {
             $this->runImmediateRecalculations();

--- a/packages/framework/src/Model/Product/ProductVisibilityFacade.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityFacade.php
@@ -3,7 +3,7 @@
 namespace Shopsys\FrameworkBundle\Model\Product;
 
 use Shopsys\FrameworkBundle\Model\Category\Category;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class ProductVisibilityFacade
 {
@@ -49,9 +49,9 @@ class ProductVisibilityFacade
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
      */
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelResponse(ResponseEvent $event): void
     {
         if (!$event->isMasterRequest()) {
             return;

--- a/packages/framework/tests/Unit/Component/Domain/DomainSubscriberTest.php
+++ b/packages/framework/tests/Unit/Component/Domain/DomainSubscriberTest.php
@@ -8,13 +8,13 @@ use Shopsys\FrameworkBundle\Component\Domain\DomainSubscriber;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class DomainSubscriberTest extends TestCase
 {
     public function testOnKernelRequestWithoutMasterRequest()
     {
-        $eventMock = $this->getMockBuilder(GetResponseEvent::class)
+        $eventMock = $this->getMockBuilder(RequestEvent::class)
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -29,7 +29,7 @@ class DomainSubscriberTest extends TestCase
 
     public function testOnKernelRequestWithMasterRequestAndSetDomain()
     {
-        $eventMock = $this->getMockBuilder(GetResponseEvent::class)
+        $eventMock = $this->getMockBuilder(RequestEvent::class)
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -48,7 +48,7 @@ class DomainSubscriberTest extends TestCase
     public function testOnKernelRequestWithMasterRequest()
     {
         $getRequestResult = new Request();
-        $eventMock = $this->getMockBuilder(GetResponseEvent::class)
+        $eventMock = $this->getMockBuilder(RequestEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/packages/framework/tests/Unit/Component/HttpFoundation/SubRequestListenerTest.php
+++ b/packages/framework/tests/Unit/Component/HttpFoundation/SubRequestListenerTest.php
@@ -7,8 +7,8 @@ use Shopsys\FrameworkBundle\Component\HttpFoundation\Exception\TooManyRedirectRe
 use Shopsys\FrameworkBundle\Component\HttpFoundation\SubRequestListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class SubRequestListenerTest extends TestCase
 {
@@ -30,7 +30,7 @@ class SubRequestListenerTest extends TestCase
 
     public function testOnKernelResponseOneMasterResponse()
     {
-        $eventMock = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -42,21 +42,21 @@ class SubRequestListenerTest extends TestCase
 
     public function testOnKernelResponseManyRedirectResponses()
     {
-        $eventMock1 = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock1 = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock1->expects($this->once())->method('isMasterRequest')->willReturn(false);
         $eventMock1->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock(true));
 
-        $eventMock2 = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock2 = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock2->expects($this->once())->method('isMasterRequest')->willReturn(false);
         $eventMock2->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock());
 
-        $eventMock3 = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock3 = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -73,21 +73,21 @@ class SubRequestListenerTest extends TestCase
 
     public function testOnKernelResponse()
     {
-        $eventMock1 = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock1 = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock1->expects($this->once())->method('isMasterRequest')->willReturn(false);
         $eventMock1->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock(true, true));
 
-        $eventMock2 = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock2 = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getResponse'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock2->expects($this->once())->method('isMasterRequest')->willReturn(false);
         $eventMock2->expects($this->once())->method('getResponse')->willReturn($this->getResponseMock());
 
-        $eventMock3 = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock3 = $this->getMockBuilder(ResponseEvent::class)
             ->setMethods(['__construct', 'isMasterRequest'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -123,14 +123,14 @@ class SubRequestListenerTest extends TestCase
             'key3' => 'value3',
         ]);
 
-        $eventMock1 = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock1 = $this->getMockBuilder(ControllerEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventMock1->expects($this->once())->method('isMasterRequest')->willReturn(true);
         $eventMock1->expects($this->atLeastOnce())->method('getRequest')->willReturn($masterRequestMock);
 
-        $eventMock2 = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock2 = $this->getMockBuilder(ControllerEvent::class)
             ->setMethods(['__construct', 'isMasterRequest', 'getRequest'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/packages/framework/tests/Unit/Component/Router/Security/RouteCsrfProtectorTest.php
+++ b/packages/framework/tests/Unit/Component/Router/Security/RouteCsrfProtectorTest.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
@@ -18,7 +18,7 @@ class RouteCsrfProtectorTest extends TestCase
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
 
-        $eventMock = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock = $this->getMockBuilder(ControllerEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest', 'getController'])
             ->getMock();
@@ -34,7 +34,7 @@ class RouteCsrfProtectorTest extends TestCase
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
 
-        $eventMock = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock = $this->getMockBuilder(ControllerEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
             ->getMock();
@@ -68,7 +68,7 @@ class RouteCsrfProtectorTest extends TestCase
             }))
             ->willReturn(true);
 
-        $eventMock = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock = $this->getMockBuilder(ControllerEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
             ->getMock();
@@ -89,7 +89,7 @@ class RouteCsrfProtectorTest extends TestCase
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
 
-        $eventMock = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock = $this->getMockBuilder(ControllerEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
             ->getMock();
@@ -125,7 +125,7 @@ class RouteCsrfProtectorTest extends TestCase
             }))
             ->willReturn(false);
 
-        $eventMock = $this->getMockBuilder(FilterControllerEvent::class)
+        $eventMock = $this->getMockBuilder(ControllerEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
             ->getMock();

--- a/packages/framework/tests/Unit/Model/Product/ProductVisibilityFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Product/ProductVisibilityFacadeTest.php
@@ -5,7 +5,7 @@ namespace Tests\FrameworkBundle\Unit\Model\Product;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 class ProductVisibilityFacadeTest extends TestCase
 {
@@ -20,7 +20,7 @@ class ProductVisibilityFacadeTest extends TestCase
         $productVisibilityFacade = new ProductVisibilityFacade($productVisibilityRepositoryMock);
         $productVisibilityFacade->refreshProductsVisibilityForMarkedDelayed();
 
-        $eventMock = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock = $this->getMockBuilder(ResponseEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest'])
             ->getMock();
@@ -37,7 +37,7 @@ class ProductVisibilityFacadeTest extends TestCase
 
         $productVisibilityFacade = new ProductVisibilityFacade($productVisibilityRepositoryMock);
 
-        $eventMock = $this->getMockBuilder(FilterResponseEvent::class)
+        $eventMock = $this->getMockBuilder(ResponseEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest'])
             ->getMock();

--- a/project-base/tests/App/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php
+++ b/project-base/tests/App/Functional/Model/Pricing/InputPriceRecalculationSchedulerTest.php
@@ -18,7 +18,7 @@ use Shopsys\FrameworkBundle\Model\Product\Availability\Availability;
 use Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityData;
 use Shopsys\FrameworkBundle\Model\Transport\TransportDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Tests\App\Test\TransactionFunctionalTestCase;
 use Tests\FrameworkBundle\Test\IsMoneyEqual;
 use Zalas\Injector\PHPUnit\Symfony\TestCase\SymfonyTestContainer;
@@ -75,11 +75,11 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
         $inputPriceRecalculatorMock->expects($this->never())->method('recalculateToInputPricesWithoutVat');
         $inputPriceRecalculatorMock->expects($this->never())->method('recalculateToInputPricesWithVat');
 
-        $filterResponseEventMock = $this->getMockBuilder(FilterResponseEvent::class)
+        $responseEventMock = $this->getMockBuilder(ResponseEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest'])
             ->getMock();
-        $filterResponseEventMock->expects($this->any())->method('isMasterRequest')
+        $responseEventMock->expects($this->any())->method('isMasterRequest')
             ->willReturn(true);
 
         $inputPriceRecalculationScheduler = new InputPriceRecalculationScheduler(
@@ -87,7 +87,7 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
             $this->setting
         );
 
-        $inputPriceRecalculationScheduler->onKernelResponse($filterResponseEventMock);
+        $inputPriceRecalculationScheduler->onKernelResponse($responseEventMock);
     }
 
     public function inputPricesTestDataProvider()
@@ -184,11 +184,11 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
 
         $this->em->flush();
 
-        $filterResponseEventMock = $this->getMockBuilder(FilterResponseEvent::class)
+        $responseEventMock = $this->getMockBuilder(ResponseEvent::class)
             ->disableOriginalConstructor()
             ->setMethods(['isMasterRequest'])
             ->getMock();
-        $filterResponseEventMock->expects($this->any())->method('isMasterRequest')
+        $responseEventMock->expects($this->any())->method('isMasterRequest')
             ->willReturn(true);
 
         if ($scheduleSetInputPricesMethod === self::METHOD_WITH_VAT) {
@@ -197,7 +197,7 @@ class InputPriceRecalculationSchedulerTest extends TransactionFunctionalTestCase
             $this->inputPriceRecalculationScheduler->scheduleSetInputPricesWithoutVat();
         }
 
-        $this->inputPriceRecalculationScheduler->onKernelResponse($filterResponseEventMock);
+        $this->inputPriceRecalculationScheduler->onKernelResponse($responseEventMock);
 
         $this->em->refresh($payment);
         $this->em->refresh($transport);

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -696,10 +696,140 @@ There you can find links to upgrade notes for other versions too.
         - onKernelException(GetResponseForExceptionEvent $event)
         + onKernelException(ExceptionEvent $event): void
         ```
+- replace usage of deprecated kernel events ([#2482](https://github.com/shopsys/shopsys/pull/2482))
+    - see #project-base-diff to update your project
+    - see https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.0.md#httpkernel for the full list of replacements for your code
+    - `Shopsys\FrameworkBundle\Component\Domain\DomainAwareSecurityHeadersSetter` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\Domain\DomainSubscriber` class:
+        - method `onKernelRequest` changed its interface:
+        ```diff
+        - onKernelRequest(GetResponseEvent $event)
+        + onKernelRequest(RequestEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\HttpFoundation\DenyScriptNameInRequestPathListener` class:
+        - method `onKernelRequest` changed its interface:
+        ```diff
+        - onKernelRequest(GetResponseEvent $event)
+        + onKernelRequest(RequestEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\HttpFoundation\ResponseListener` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\HttpFoundation\SubRequestListener` class:
+        - method `onKernelController` changed its interface:
+        ```diff
+        - onKernelController(FilterControllerEvent $event)
+        + onKernelController(ControllerEvent $event): void
+        ```
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\HttpFoundation\TransactionalMasterRequestListener` class:
+        - method `onKernelRequest` changed its interface:
+        ```diff
+        - onKernelRequest(GetResponseEvent $event)
+        + onKernelRequest(RequestEvent $event): void
+        ```
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+        - method `onKernelException` changed its interface:
+        ```diff
+        - onKernelException(GetResponseForExceptionEvent $event)
+        + onKernelException(ExceptionEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\HttpFoundation\VaryResponseByXRequestedWithHeaderListener` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\Log\SlowLogSubscriber` class:
+        - method `initStartTime` changed its interface:
+        ```diff
+        - initStartTime(GetResponseEvent $event)
+        + initStartTime(RequestEvent $event): void
+        ```
+        - method `addNotice` changed its interface:
+        ```diff
+        - addNotice(PostResponseEvent $event)
+        + addNotice(TerminateEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector` class:
+        - method `onKernelController` changed its interface:
+        ```diff
+        - onKernelController(FilterControllerEvent $event)
+        + onKernelController(ControllerEvent $event): void
+        ```
+        - method `isProtected` changed its interface:
+        ```diff
+        - isProtected(FilterControllerEvent $event)
+        + isProtected(ControllerEvent $event): bool
+        ```
+    - `Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorRolesChangedSubscriber` class:
+        - method `onKernelRequest` changed its interface:
+        ```diff
+        - onKernelRequest(GetResponseEvent $event)
+        + onKernelRequest(RequestEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Cart\CartMigrationFacade` class:
+        - method `onKernelController` changed its interface:
+        ```diff
+        - onKernelController(FilterControllerEvent $filterControllerEvent)
+        + onKernelController(ControllerEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Localization\LocalizationListener` class:
+        - method `onKernelRequest` changed its interface:
+        ```diff
+        - onKernelRequest(GetResponseEvent $event)
+        + onKernelRequest(RequestEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Pricing\InputPriceRecalculationScheduler` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculator` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
+    - `Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator` class:
+        - method `onKernelResponse` changed its interface:
+        ```diff
+        - onKernelResponse(FilterResponseEvent $event)
+        + onKernelResponse(ResponseEvent $event): void
+        ```
 
 ## Composer dependencies
 
-- replace swiftmailer with symfony/mailer [#2470](https://github.com/shopsys/shopsys/pull/2470)
+- replace swiftmailer with symfony/mailer ([#2470](https://github.com/shopsys/shopsys/pull/2470))
     - see #project-base-diff
     - from now on, the mail transport is configured using `MAILER_DSN` env variable
         - `MAILER_TRANSPORT`, `MAILER_HOST`, `MAILER_USER`, and `MAILER_PASSWORD` env variables had been removed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Some kernel events were deprecated in favor of better named events. See https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.0.md#httpkernel
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
