### PR TITLE
[shopsys] logger usage is now compliant with PSR-3

### DIFF
--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -74,7 +74,7 @@ class CronFacade
      */
     protected function runModules(array $cronModuleConfigs, string $instanceName): void
     {
-        $this->logger->addInfo(sprintf('====== Start of cron instance %s ======', $instanceName));
+        $this->logger->info(sprintf('====== Start of cron instance %s ======', $instanceName));
 
         foreach ($cronModuleConfigs as $cronModuleConfig) {
             $this->runSingleModule($cronModuleConfig);
@@ -83,7 +83,7 @@ class CronFacade
             }
         }
 
-        $this->logger->addInfo(sprintf('======= End of cron instance %s =======', $instanceName));
+        $this->logger->info(sprintf('======= End of cron instance %s =======', $instanceName));
     }
 
     /**
@@ -105,7 +105,7 @@ class CronFacade
             return;
         }
 
-        $this->logger->addInfo('Start of ' . $cronModuleConfig->getServiceId());
+        $this->logger->info('Start of ' . $cronModuleConfig->getServiceId());
         $cronModuleService = $cronModuleConfig->getService();
         $cronModuleService->setLogger($this->logger);
         $this->cronModuleFacade->markCronAsStarted($cronModuleConfig);
@@ -117,7 +117,7 @@ class CronFacade
             );
         } catch (Throwable $throwable) {
             $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
-            $this->logger->addError('End of ' . $cronModuleConfig->getServiceId() . ' because of error', [
+            $this->logger->error('End of ' . $cronModuleConfig->getServiceId() . ' because of error', [
                 'throwable' => $throwable,
             ]);
             throw $throwable;
@@ -127,10 +127,10 @@ class CronFacade
 
         if ($status === CronModuleExecutor::RUN_STATUS_OK) {
             $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
-            $this->logger->addInfo('End of ' . $cronModuleConfig->getServiceId());
+            $this->logger->info('End of ' . $cronModuleConfig->getServiceId());
         } elseif ($status === CronModuleExecutor::RUN_STATUS_SUSPENDED) {
             $this->cronModuleFacade->suspendModule($cronModuleConfig);
-            $this->logger->addInfo('Suspend ' . $cronModuleConfig->getServiceId());
+            $this->logger->info('Suspend ' . $cronModuleConfig->getServiceId());
         } elseif ($status === CronModuleExecutor::RUN_STATUS_TIMEOUT) {
             $this->logger->info('Cron reached timeout.');
         }

--- a/packages/framework/src/Component/Domain/DomainIconResizer.php
+++ b/packages/framework/src/Component/Domain/DomainIconResizer.php
@@ -69,7 +69,7 @@ class DomainIconResizer
                 $message,
                 $ex
             );
-            $this->logger->addError($message, ['exception' => $moveToFolderFailedException]);
+            $this->logger->error($message, ['exception' => $moveToFolderFailedException]);
             throw $moveToFolderFailedException;
         }
     }

--- a/packages/framework/src/Component/Log/SlowLogSubscriber.php
+++ b/packages/framework/src/Component/Log/SlowLogSubscriber.php
@@ -55,7 +55,7 @@ class SlowLogSubscriber implements EventSubscriberInterface
         $controllerNameAndAction = $event->getRequest()->get('_controller');
 
         $message = $requestTime . ' ' . $controllerNameAndAction . ' ' . $requestUri;
-        $this->logger->addNotice($message);
+        $this->logger->notice($message);
     }
 
     /**

--- a/packages/framework/src/Model/Feed/DailyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/DailyFeedCronModule.php
@@ -65,7 +65,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
     public function iterate(): bool
     {
         if ($this->getFeedExportCreationDataQueue()->isEmpty()) {
-            $this->logger->addDebug('Queue is empty, no feeds to process.');
+            $this->logger->debug('Queue is empty, no feeds to process.');
 
             return false;
         }
@@ -80,7 +80,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
             $feedInfo = $this->currentFeedExport->getFeedInfo();
             $domainConfig = $this->currentFeedExport->getDomainConfig();
 
-            $this->logger->addDebug(sprintf(
+            $this->logger->debug(sprintf(
                 'Feed "%s" generated on domain "%s" into "%s".',
                 $feedInfo->getName(),
                 $domainConfig->getName(),
@@ -118,7 +118,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
         $this->setting->set(Setting::FEED_DOMAIN_ID_TO_CONTINUE, $currentDomain->getId());
         $this->setting->set(Setting::FEED_ITEM_ID_TO_CONTINUE, $lastSeekId);
 
-        $this->logger->addDebug(sprintf(
+        $this->logger->debug(sprintf(
             'Going to sleep... Will continue with feed "%s" on "%s", processing from ID %d.',
             $currentFeedName,
             $currentDomain->getName(),
@@ -147,7 +147,7 @@ class DailyFeedCronModule implements IteratedCronModuleInterface
         $this->currentFeedExport = $this->createCurrentFeedExport($lastSeekId);
         $this->currentFeedExport->wakeUp();
 
-        $this->logger->addDebug(sprintf(
+        $this->logger->debug(sprintf(
             'Waking up... Continuing with feed "%s" on "%s", processing from ID %d.',
             $this->getFeedExportCreationDataQueue()->getCurrentFeedName(),
             $this->getFeedExportCreationDataQueue()->getCurrentDomain()->getName(),

--- a/packages/framework/src/Model/Feed/HourlyFeedCronModule.php
+++ b/packages/framework/src/Model/Feed/HourlyFeedCronModule.php
@@ -49,7 +49,7 @@ class HourlyFeedCronModule implements SimpleCronModuleInterface
                 $this->feedFacade->generateFeed($feedInfo->getName(), $domainConfig);
                 $endTime = microtime(true);
 
-                $this->logger->addDebug(sprintf(
+                $this->logger->debug(sprintf(
                     'Feed "%s" generated on domain "%s" into "%s" in %.3f s',
                     $feedInfo->getName(),
                     $domainConfig->getName(),

--- a/packages/framework/src/Model/Pricing/Vat/VatDeletionCronModule.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatDeletionCronModule.php
@@ -44,7 +44,7 @@ class VatDeletionCronModule implements IteratedCronModuleInterface
     public function sleep()
     {
         $deletedVatsCount = $this->vatFacade->deleteAllReplacedVats();
-        $this->logger->addInfo('Deleted ' . $deletedVatsCount . ' vats');
+        $this->logger->info('Deleted ' . $deletedVatsCount . ' vats');
     }
 
     public function wakeUp()
@@ -63,7 +63,7 @@ class VatDeletionCronModule implements IteratedCronModuleInterface
         } else {
             $deletedVatsCount = $this->vatFacade->deleteAllReplacedVats();
             $this->logger->debug('All vats are replaced');
-            $this->logger->addInfo('Deleted ' . $deletedVatsCount . ' vats');
+            $this->logger->info('Deleted ' . $deletedVatsCount . ' vats');
         }
 
         return $batchResult;

--- a/packages/plugin-interface/README.md
+++ b/packages/plugin-interface/README.md
@@ -198,7 +198,7 @@ class AcmeDataDownloadCronModule implements SimpleCronModuleInterface
         $data = $this->downloadData();
         $this->saveData($data);
 
-        $this->logger->addInfo(sprintf('Downloaded %d new records.', count($data)));
+        $this->logger->info(sprintf('Downloaded %d new records.', count($data)));
     }
 
     // ...

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
@@ -51,7 +51,7 @@ class HeurekaCategoryCronModule implements SimpleCronModuleInterface
             $heurekaCategoriesData = $this->heurekaCategoryDownloader->getHeurekaCategories();
             $this->heurekaCategoryFacade->saveHeurekaCategories($heurekaCategoriesData);
         } catch (HeurekaCategoryDownloadFailedException $e) {
-            $this->logger->addError($e->getMessage());
+            $this->logger->error($e->getMessage());
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Usage of logger functions should be compatible with PSR-3 interface. This allows seamless logger switching and helps with future Symfony 5 update.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
