### PR TITLE
[framework] debug collectors are now future compatible with Symfony 5

### DIFF
--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Collector;
 
-use Exception;
 use PharIo\Version\Version;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface;
@@ -12,6 +11,7 @@ use Shopsys\FrameworkBundle\ShopsysFrameworkBundle;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Throwable;
 
 class ShopsysFrameworkDataCollector extends DataCollector
 {
@@ -40,7 +40,7 @@ class ShopsysFrameworkDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->data = [
             'version' => ShopsysFrameworkBundle::VERSION,

--- a/packages/framework/src/Component/Elasticsearch/Debug/ElasticsearchCollector.php
+++ b/packages/framework/src/Component/Elasticsearch/Debug/ElasticsearchCollector.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Debug;
 
-use Exception;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Throwable;
 
 class ElasticsearchCollector extends DataCollector
 {
@@ -27,7 +27,7 @@ class ElasticsearchCollector extends DataCollector
     /**
      * @inheritdoc
      */
-    public function collect(Request $request, Response $response, ?Exception $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->data = [
             'requests' => $this->elasticsearchRequestCollection->getCollectedData(),

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -830,6 +830,19 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
     - replace parameter `kernel.root_dir` with `%kernel.project_dir%/src` in your codebase
     - parameter `shopsys.framework.javascript_sources_dir` was removed because it's not used anywhere
+- debug data collectors are now future compatible with Symfony 5 ([#2484](https://github.com/shopsys/shopsys/pull/2484))
+    - `Shopsys\FrameworkBundle\Component\Collector\ShopsysFrameworkDataCollector` class:
+        - method `collect` changed its interface:
+        ```diff
+        - collect(Request $request, Response $response, ?Exception $exception = null): void
+        + collect(Request $request, Response $response, ?Throwable $exception = null): void
+        ```
+    - `Shopsys\FrameworkBundle\Component\Elasticsearch\Debug\ElasticsearchCollector` class:
+        - method `collect` changed its interface:
+        ```diff
+        - collect(Request $request, Response $response, ?Exception $exception = null): void
+        + collect(Request $request, Response $response, ?Throwable $exception = null): void
+        ```
 
 ## Composer dependencies
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In Symfony 5, the `collect` method of the debug data collectors change its interface.  This PR make code future compatible with this change, so its easier to update to Symfony 5 in the future
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
