### PR TITLE
[frontend-api] removed graphql hotfix after underlying issue was resolved

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
         "nyholm/psr7": "^1.5",
         "object-calisthenics/phpcs-calisthenics-rules": "^3.1",
         "overblog/graphiql-bundle": "^0.2",
-        "overblog/graphql-bundle": "^0.13",
+        "overblog/graphql-bundle": "^0.13.3",
         "phing/phing": "^2.17.3",
         "phpdocumentor/reflection-docblock": "^5.3.0",
         "presta/sitemap-bundle": "^3.3",

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.1",
         "lcobucci/jwt": "^4.1.5",
-        "overblog/graphql-bundle": "^0.13",
+        "overblog/graphql-bundle": "^0.13.3",
         "overblog/graphiql-bundle": "^0.2",
         "shopsys/form-types-bundle": "11.0.x-dev",
         "shopsys/framework": "11.0.x-dev",

--- a/packages/frontend-api/src/Resources/config/parameters.yaml
+++ b/packages/frontend-api/src/Resources/config/parameters.yaml
@@ -1,5 +1,2 @@
 parameters:
     shopsys.frontend_api.domains: []
-
-    # hotfix for https://github.com/overblog/GraphQLBundle/issues/588
-    container.build_id: null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| hotfix was present due to https://github.com/overblog/GraphQLBundle/issues/588, underlying issue was resolved in the version 0.13.3, so the hotfix is not necessary anymore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
