### PR TITLE
[shopsys] removed unused twig/extensions package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,6 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/workflow": "^4.4.0",
         "tracy/tracy": "^2.4.13",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12",
         "webmozart/assert": "^1.4"
     },

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -95,7 +95,6 @@
         "symfony-cmf/routing-bundle": "^2.0.3",
         "symfony/polyfill-php80": "^1.24.0",
         "tracy/tracy": "^2.4.13",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12",
         "webmozart/assert": "^1.4"
     },

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -41,7 +41,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12"
     },
     "extra": {

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -35,7 +35,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12"
     },
     "extra": {

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -44,7 +44,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12"
     },
     "extra": {

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -41,7 +41,6 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.12"
     },
     "extra": {

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -94,7 +94,6 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/workflow": "^4.4.0",
         "tracy/tracy": "^2.4.13",
-        "twig/extensions": "^1.5.1",
         "twig/twig": "^2.9",
         "webmozart/assert": "^1.4"
     },

--- a/project-base/symfony.lock
+++ b/project-base/symfony.lock
@@ -1015,18 +1015,6 @@
     "tracy/tracy": {
         "version": "v2.6.5"
     },
-    "twig/extensions": {
-        "version": "1.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "a86723ee8d8b2f9437c8ce60a5546a1c267da5ed"
-        },
-        "files": [
-            "config/packages/twig_extensions.yaml"
-        ]
-    },
     "twig/twig": {
         "version": "v2.12.1"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -1027,18 +1027,6 @@
     "tracy/tracy": {
         "version": "v2.6.5"
     },
-    "twig/extensions": {
-        "version": "1.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "a86723ee8d8b2f9437c8ce60a5546a1c267da5ed"
-        },
-        "files": [
-            "project-base/config/packages/twig_extensions.yaml"
-        ]
-    },
     "twig/twig": {
         "version": "v2.12.1"
     },

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -843,6 +843,10 @@ There you can find links to upgrade notes for other versions too.
         - collect(Request $request, Response $response, ?Exception $exception = null): void
         + collect(Request $request, Response $response, ?Throwable $exception = null): void
         ```
+- remove not used `twig/extensions` package ([#2486](https://github.com/shopsys/shopsys/pull/2486))
+    - see #project-base-diff to update your project
+    - see the list of filters and update your code if you use any – https://github.com/twigphp/Twig-extensions
+        - `trans` filter is already used from symfony/twig-bridge package
 
 ## Composer dependencies
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| twig/extensions package is abandoned and not used anywhere in our code, so it was removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
