### PR TITLE
[shopsys] do not mock Events in tests

### DIFF
--- a/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
+++ b/packages/framework/src/Component/Router/Security/RouteCsrfProtector.php
@@ -20,12 +20,12 @@ class RouteCsrfProtector implements EventSubscriberInterface
     /**
      * @var \Doctrine\Common\Annotations\Reader
      */
-    protected $annotationReader;
+    protected Reader $annotationReader;
 
     /**
      * @var \Symfony\Component\Security\Csrf\CsrfTokenManagerInterface
      */
-    protected $tokenManager;
+    protected CsrfTokenManagerInterface $tokenManager;
 
     /**
      * @param \Doctrine\Common\Annotations\Reader $annotationReader
@@ -40,7 +40,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
     /**
      * @return string[]
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',
@@ -67,7 +67,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
      * @param string $routeName
      * @return string
      */
-    public function getCsrfTokenId($routeName)
+    public function getCsrfTokenId(string $routeName): string
     {
         return static::CSRF_TOKEN_ID_PREFIX . $routeName;
     }
@@ -76,7 +76,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
      * @param string $routeName
      * @return string
      */
-    public function getCsrfTokenByRoute($routeName)
+    public function getCsrfTokenByRoute(string $routeName): string
     {
         return $this->tokenManager->getToken($this->getCsrfTokenId($routeName))->getValue();
     }
@@ -86,7 +86,7 @@ class RouteCsrfProtector implements EventSubscriberInterface
      * @param string $csrfToken
      * @return bool
      */
-    protected function isCsrfTokenValid($routeName, $csrfToken)
+    protected function isCsrfTokenValid(string $routeName, string $csrfToken): bool
     {
         $token = new CsrfToken($this->getCsrfTokenId($routeName), $csrfToken);
 

--- a/packages/framework/tests/Unit/Component/Router/Security/ControllerNotProtected.php
+++ b/packages/framework/tests/Unit/Component/Router/Security/ControllerNotProtected.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\FrameworkBundle\Unit\Component\Router\Security;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class ControllerNotProtected
+{
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function __invoke(): Response
+    {
+        return new Response();
+    }
+}

--- a/packages/framework/tests/Unit/Component/Router/Security/ControllerProtected.php
+++ b/packages/framework/tests/Unit/Component/Router/Security/ControllerProtected.php
@@ -3,17 +3,16 @@
 namespace Tests\FrameworkBundle\Unit\Component\Router\Security;
 
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
+use Symfony\Component\HttpFoundation\Response;
 
-class DummyController
+final class ControllerProtected
 {
-    public function withoutProtectionAction()
-    {
-    }
-
     /**
      * @CsrfProtection
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function withProtectionAction()
+    public function __invoke(): Response
     {
+        return new Response();
     }
 }

--- a/packages/framework/tests/Unit/Component/Router/Security/RouteCsrfProtectorTest.php
+++ b/packages/framework/tests/Unit/Component/Router/Security/RouteCsrfProtectorTest.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
@@ -18,15 +19,18 @@ class RouteCsrfProtectorTest extends TestCase
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
 
-        $eventMock = $this->getMockBuilder(ControllerEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest', 'getController'])
-            ->getMock();
-        $eventMock->expects($this->atLeastOnce())->method('isMasterRequest')->willReturn(false);
-        $eventMock->expects($this->never())->method('getController');
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new ControllerProtected(),
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+        );
 
         $routeCsrfProtector = new RouteCsrfProtector($annotationReader, $tokenManagerMock);
-        $routeCsrfProtector->onKernelController($eventMock);
+        $routeCsrfProtector->onKernelController($event);
+
+        // test is expecting exception is not thrown and assert true suppress warning about no assertions
+        $this->assertTrue(true);
     }
 
     public function testRequestWithoutProtection(): void
@@ -34,19 +38,18 @@ class RouteCsrfProtectorTest extends TestCase
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
 
-        $eventMock = $this->getMockBuilder(ControllerEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
-            ->getMock();
-        $eventMock->expects($this->atLeastOnce())->method('isMasterRequest')->willReturn(true);
-        $eventMock
-            ->expects($this->atLeastOnce())
-            ->method('getController')
-            ->willReturn([DummyController::class, 'withoutProtectionAction']);
-        $eventMock->expects($this->never())->method('getRequest');
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new ControllerNotProtected(),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+        );
 
         $routeCsrfProtector = new RouteCsrfProtector($annotationReader, $tokenManagerMock);
-        $routeCsrfProtector->onKernelController($eventMock);
+        $routeCsrfProtector->onKernelController($event);
+
+        // test is expecting exception is not thrown and assert true suppress warning about no assertions
+        $this->assertTrue(true);
     }
 
     public function testRequestWithProtection(): void
@@ -61,7 +64,7 @@ class RouteCsrfProtectorTest extends TestCase
         );
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->getMockBuilder(CsrfTokenManager::class)
-            ->setMethods(['isTokenValid'])
+            ->onlyMethods(['isTokenValid'])
             ->disableOriginalConstructor()
             ->getMock();
         $tokenManagerMock
@@ -72,19 +75,15 @@ class RouteCsrfProtectorTest extends TestCase
             }))
             ->willReturn(true);
 
-        $eventMock = $this->getMockBuilder(ControllerEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
-            ->getMock();
-        $eventMock->expects($this->atLeastOnce())->method('isMasterRequest')->willReturn(true);
-        $eventMock
-            ->expects($this->atLeastOnce())
-            ->method('getController')
-            ->willReturn([DummyController::class, 'withProtectionAction']);
-        $eventMock->expects($this->atLeastOnce())->method('getRequest')->willReturn($request);
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new ControllerProtected(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+        );
 
         $routeCsrfProtector = new RouteCsrfProtector($annotationReader, $tokenManagerMock);
-        $routeCsrfProtector->onKernelController($eventMock);
+        $routeCsrfProtector->onKernelController($event);
     }
 
     public function testRequestWithProtectionWithoutCsrfToken(): void
@@ -93,21 +92,17 @@ class RouteCsrfProtectorTest extends TestCase
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
 
-        $eventMock = $this->getMockBuilder(ControllerEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
-            ->getMock();
-        $eventMock->expects($this->atLeastOnce())->method('isMasterRequest')->willReturn(true);
-        $eventMock
-            ->expects($this->atLeastOnce())
-            ->method('getController')
-            ->willReturn([DummyController::class, 'withProtectionAction']);
-        $eventMock->expects($this->atLeastOnce())->method('getRequest')->willReturn($request);
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new ControllerProtected(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+        );
 
         $routeCsrfProtector = new RouteCsrfProtector($annotationReader, $tokenManagerMock);
 
         $this->expectException(BadRequestHttpException::class);
-        $routeCsrfProtector->onKernelController($eventMock);
+        $routeCsrfProtector->onKernelController($event);
     }
 
     public function testRequestWithProtectionWithInvalidCsrfToken(): void
@@ -122,7 +117,7 @@ class RouteCsrfProtectorTest extends TestCase
         );
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->getMockBuilder(CsrfTokenManager::class)
-            ->setMethods(['isTokenValid'])
+            ->onlyMethods(['isTokenValid'])
             ->disableOriginalConstructor()
             ->getMock();
         $tokenManagerMock
@@ -133,20 +128,16 @@ class RouteCsrfProtectorTest extends TestCase
             }))
             ->willReturn(false);
 
-        $eventMock = $this->getMockBuilder(ControllerEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest', 'getController', 'getRequest'])
-            ->getMock();
-        $eventMock->expects($this->atLeastOnce())->method('isMasterRequest')->willReturn(true);
-        $eventMock
-            ->expects($this->atLeastOnce())
-            ->method('getController')
-            ->willReturn([DummyController::class, 'withProtectionAction']);
-        $eventMock->expects($this->atLeastOnce())->method('getRequest')->willReturn($request);
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new ControllerProtected(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+        );
 
         $routeCsrfProtector = new RouteCsrfProtector($annotationReader, $tokenManagerMock);
 
         $this->expectException(BadRequestHttpException::class);
-        $routeCsrfProtector->onKernelController($eventMock);
+        $routeCsrfProtector->onKernelController($event);
     }
 }

--- a/packages/framework/tests/Unit/Component/Router/Security/RouteCsrfProtectorTest.php
+++ b/packages/framework/tests/Unit/Component/Router/Security/RouteCsrfProtectorTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManager;
 
 class RouteCsrfProtectorTest extends TestCase
 {
-    public function testSubRequest()
+    public function testSubRequest(): void
     {
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
@@ -29,7 +29,7 @@ class RouteCsrfProtectorTest extends TestCase
         $routeCsrfProtector->onKernelController($eventMock);
     }
 
-    public function testRequestWithoutProtection()
+    public function testRequestWithoutProtection(): void
     {
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->createMock(CsrfTokenManager::class);
@@ -49,12 +49,16 @@ class RouteCsrfProtectorTest extends TestCase
         $routeCsrfProtector->onKernelController($eventMock);
     }
 
-    public function testRequestWithProtection()
+    public function testRequestWithProtection(): void
     {
         $validCsrfToken = 'validCsrfToken';
-        $request = new Request([
-            RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER => $validCsrfToken,
-        ]);
+        $request = new Request(
+            [
+                RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER => $validCsrfToken,
+            ],
+            [],
+            ['_route' => 'someRouteName']
+        );
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->getMockBuilder(CsrfTokenManager::class)
             ->setMethods(['isTokenValid'])
@@ -83,7 +87,7 @@ class RouteCsrfProtectorTest extends TestCase
         $routeCsrfProtector->onKernelController($eventMock);
     }
 
-    public function testRequestWithProtectionWithoutCsrfToken()
+    public function testRequestWithProtectionWithoutCsrfToken(): void
     {
         $request = new Request();
         $annotationReader = new AnnotationReader();
@@ -106,12 +110,16 @@ class RouteCsrfProtectorTest extends TestCase
         $routeCsrfProtector->onKernelController($eventMock);
     }
 
-    public function testRequestWithProtectionWithInvalidCsrfToken()
+    public function testRequestWithProtectionWithInvalidCsrfToken(): void
     {
         $invalidCsrfToken = 'invalidCsrfToken';
-        $request = new Request([
-            RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER => $invalidCsrfToken,
-        ]);
+        $request = new Request(
+            [
+                RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER => $invalidCsrfToken,
+            ],
+            [],
+            ['_route' => 'someRouteName']
+        );
         $annotationReader = new AnnotationReader();
         $tokenManagerMock = $this->getMockBuilder(CsrfTokenManager::class)
             ->setMethods(['isTokenValid'])

--- a/packages/framework/tests/Unit/Model/Product/ProductVisibilityFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Product/ProductVisibilityFacadeTest.php
@@ -5,11 +5,14 @@ namespace Tests\FrameworkBundle\Unit\Model\Product;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class ProductVisibilityFacadeTest extends TestCase
 {
-    public function testOnKernelResponseRecalc()
+    public function testOnKernelResponseRecalc(): void
     {
         $productVisibilityRepositoryMock = $this->createMock(ProductVisibilityRepository::class);
         $productVisibilityRepositoryMock
@@ -20,34 +23,34 @@ class ProductVisibilityFacadeTest extends TestCase
         $productVisibilityFacade = new ProductVisibilityFacade($productVisibilityRepositoryMock);
         $productVisibilityFacade->refreshProductsVisibilityForMarkedDelayed();
 
-        $eventMock = $this->getMockBuilder(ResponseEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest'])
-            ->getMock();
-        $eventMock->expects($this->any())->method('isMasterRequest')
-            ->willReturn(true);
+        $responseEvent = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
 
-        $productVisibilityFacade->onKernelResponse($eventMock);
+        $productVisibilityFacade->onKernelResponse($responseEvent);
     }
 
-    public function testOnKernelResponseNoRecalc()
+    public function testOnKernelResponseNoRecalc(): void
     {
         $productVisibilityRepositoryMock = $this->createMock(ProductVisibilityRepository::class);
         $productVisibilityRepositoryMock->expects($this->never())->method('refreshProductsVisibility');
 
         $productVisibilityFacade = new ProductVisibilityFacade($productVisibilityRepositoryMock);
 
-        $eventMock = $this->getMockBuilder(ResponseEvent::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isMasterRequest'])
-            ->getMock();
-        $eventMock->expects($this->any())->method('isMasterRequest')
-            ->willReturn(true);
+        $responseEvent = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
 
-        $productVisibilityFacade->onKernelResponse($eventMock);
+        $productVisibilityFacade->onKernelResponse($responseEvent);
     }
 
-    public function testRefreshProductsVisibility()
+    public function testRefreshProductsVisibility(): void
     {
         $productVisibilityRepositoryMock = $this->createMock(ProductVisibilityRepository::class);
         $productVisibilityRepositoryMock->expects($this->once())->method('refreshProductsVisibility');
@@ -56,7 +59,7 @@ class ProductVisibilityFacadeTest extends TestCase
         $productVisibilityFacade->refreshProductsVisibility();
     }
 
-    public function testRefreshProductsVisibilityForMarked()
+    public function testRefreshProductsVisibilityForMarked(): void
     {
         $productVisibilityRepositoryMock = $this->createMock(ProductVisibilityRepository::class);
         $productVisibilityRepositoryMock

--- a/packages/framework/tests/Unit/Model/Security/LoginListenerTest.php
+++ b/packages/framework/tests/Unit/Model/Security/LoginListenerTest.php
@@ -17,10 +17,10 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
 class LoginListenerTest extends TestCase
 {
-    public function testOnSecurityInteractiveLoginUnique()
+    public function testOnSecurityInteractiveLoginUnique(): void
     {
         $emMock = $this->getMockBuilder(EntityManager::class)
-            ->setMethods(['__construct', 'persist', 'flush'])
+            ->onlyMethods(['__construct', 'persist', 'flush'])
             ->disableOriginalConstructor()
             ->getMock();
         $emMock->expects($this->once())->method('flush');
@@ -31,30 +31,24 @@ class LoginListenerTest extends TestCase
         $tokenMock = $this->createMock(TokenInterface::class);
         $tokenMock->expects($this->once())->method('getUser')->willReturn($userMock);
 
-        $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
-            ->setMethods(['__construct', 'getAuthenticationToken'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
-
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
-            ->setMethods(['__construct'])
+            ->onlyMethods(['__construct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
 
         $loginListener = new LoginListener($emMock, $orderFlowFacadeMock, $administratorActivityFacadeMock);
-        $loginListener->onSecurityInteractiveLogin($eventMock);
+        $loginListener->onSecurityInteractiveLogin(new InteractiveLoginEvent(new Request(), $tokenMock));
     }
 
-    public function testOnSecurityInteractiveLoginTimelimit()
+    public function testOnSecurityInteractiveLoginTimeLimit(): void
     {
         $emMock = $this->getMockBuilder(EntityManager::class)
-            ->setMethods(['__construct', 'persist', 'flush'])
+            ->onlyMethods(['__construct', 'persist', 'flush'])
             ->disableOriginalConstructor()
             ->getMock();
-        $emMock->expects($this->any())->method('flush');
+        $emMock->expects($this->atLeastOnce())->method('flush');
 
         $userMock = $this->createMock(TimelimitLoginInterface::class);
         $userMock->expects($this->once())->method('setLastActivity');
@@ -62,47 +56,35 @@ class LoginListenerTest extends TestCase
         $tokenMock = $this->createMock(TokenInterface::class);
         $tokenMock->expects($this->once())->method('getUser')->willReturn($userMock);
 
-        $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
-            ->setMethods(['__construct', 'getAuthenticationToken'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
-
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
-            ->setMethods(['__construct'])
+            ->onlyMethods(['__construct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
 
         $loginListener = new LoginListener($emMock, $orderFlowFacadeMock, $administratorActivityFacadeMock);
-        $loginListener->onSecurityInteractiveLogin($eventMock);
+        $loginListener->onSecurityInteractiveLogin(new InteractiveLoginEvent(new Request(), $tokenMock));
     }
 
-    public function testOnSecurityInteractiveLoginResetOrderForm()
+    public function testOnSecurityInteractiveLoginResetOrderForm(): void
     {
         $emMock = $this->getMockBuilder(EntityManager::class)
-            ->setMethods(['__construct', 'persist', 'flush'])
+            ->onlyMethods(['__construct', 'persist', 'flush'])
             ->disableOriginalConstructor()
             ->getMock();
-        $emMock->expects($this->any())->method('flush');
+        $emMock->expects($this->atLeastOnce())->method('flush');
 
         $userMock = $this->getMockBuilder(CustomerUser::class)
-            ->setMethods(['__construct'])
+            ->onlyMethods(['__construct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $tokenMock = $this->createMock(TokenInterface::class);
         $tokenMock->expects($this->once())->method('getUser')->willReturn($userMock);
 
-        $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
-            ->setMethods(['__construct', 'getAuthenticationToken'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
-
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
-            ->setMethods(['__construct', 'resetOrderForm'])
+            ->onlyMethods(['__construct', 'resetOrderForm'])
             ->disableOriginalConstructor()
             ->getMock();
         $orderFlowFacadeMock->expects($this->once())->method('resetOrderForm');
@@ -110,13 +92,13 @@ class LoginListenerTest extends TestCase
         $administratorActivityFacadeMock = $this->createMock(AdministratorActivityFacade::class);
 
         $loginListener = new LoginListener($emMock, $orderFlowFacadeMock, $administratorActivityFacadeMock);
-        $loginListener->onSecurityInteractiveLogin($eventMock);
+        $loginListener->onSecurityInteractiveLogin(new InteractiveLoginEvent(new Request(), $tokenMock));
     }
 
-    public function testOnSecurityInteractiveLoginAdministrator()
+    public function testOnSecurityInteractiveLoginAdministrator(): void
     {
         $emMock = $this->getMockBuilder(EntityManager::class)
-            ->setMethods(['__construct', 'persist', 'flush'])
+            ->onlyMethods(['__construct', 'persist', 'flush'])
             ->disableOriginalConstructor()
             ->getMock();
         $emMock->expects($this->once())->method('flush');
@@ -127,25 +109,18 @@ class LoginListenerTest extends TestCase
         $tokenMock = $this->createMock(TokenInterface::class);
         $tokenMock->expects($this->once())->method('getUser')->willReturn($administratorMock);
 
-        $eventMock = $this->getMockBuilder(InteractiveLoginEvent::class)
-            ->setMethods(['__construct', 'getAuthenticationToken', 'getRequest'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $eventMock->expects($this->once())->method('getAuthenticationToken')->willReturn($tokenMock);
-        $eventMock->expects($this->once())->method('getRequest')->willReturn(new Request());
-
         $orderFlowFacadeMock = $this->getMockBuilder(OrderFlowFacade::class)
-            ->setMethods(['__construct'])
+            ->onlyMethods(['__construct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $administratorActivityFacadeMock = $this->getMockBuilder(AdministratorActivityFacade::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $administratorActivityFacadeMock->expects($this->once())->method('create');
 
         $loginListener = new LoginListener($emMock, $orderFlowFacadeMock, $administratorActivityFacadeMock);
-        $loginListener->onSecurityInteractiveLogin($eventMock);
+        $loginListener->onSecurityInteractiveLogin(new InteractiveLoginEvent(new Request(), $tokenMock));
     }
 }

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -941,4 +941,7 @@ There you can find links to upgrade notes for other versions too.
         - resolve: "@=mutation('create_order', [args, validator])"
         + resolve: resolve: "@=mutation('create_order', args, validator)"
         ```
-  - check other changes in [GraphQLBundle UPGRADE notes](https://github.com/overblog/GraphQLBundle/blob/master/UPGRADE.md#upgrade-from-013-to-014) and implement them in your codebase
+    - check other changes in [GraphQLBundle UPGRADE notes](https://github.com/overblog/GraphQLBundle/blob/master/UPGRADE.md#upgrade-from-013-to-014) and implement them in your codebase
+- remove mocked Events from your tests ([#2490](https://github.com/shopsys/shopsys/pull/2490))
+    - see #project-base-diff
+    - since Symfony 5.0 are all Events from `Symfony\Component\HttpKernel\Event` namespace final and cannot be mocked


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Event classes are final in Symfony 5
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| Allow upgrade to Symfony 5
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
