### PR TITLE
[shopsys] Elasticsearch: defined structure for ID

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -625,6 +625,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   docker-compose: add rabbitMQ and php-consumer containers for review stage on gitlab CI [#2953](https://github.com/shopsys/shopsys/pull/2953)
     -   see #project-base-diff to update your project
+-   define elasticsearch type for ID in structure ([#2495](https://github.com/shopsys/shopsys/pull/2495))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php
@@ -14,6 +14,7 @@ class ProductElasticsearchConverter
     {
         $result = $product;
 
+        $result['id'] = $product['id'] ?? 0;
         $result['availability'] = $product['availability'] ?? '';
         $result['catnum'] = $product['catnum'] ?? '';
         $result['description'] = $product['description'] ?? '';

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -152,7 +152,10 @@ class ProductElasticsearchRepository implements ResetInterface
     {
         return array_map(function ($value) {
             $data = $value['_source'];
-            $data['id'] = (int)$value['_id'];
+
+            if (!array_key_exists('id', $data)) {
+                $data['id'] = (int)$value['_id'];
+            }
 
             return $this->productElasticsearchConverter->fillEmptyFields($data);
         }, $result['hits']['hits']);

--- a/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Search/ProductElasticsearchConverterTest.php
@@ -12,6 +12,7 @@ class ProductElasticsearchConverterTest extends TestCase
     public function testFillEmptyFields(): void
     {
         $product = [
+            'id' => 1,
             'name' => '47" LG 47LA790V (FHD)',
             'catnum' => '5965879P',
             'partno' => '47LA790V',
@@ -21,6 +22,7 @@ class ProductElasticsearchConverterTest extends TestCase
         ];
 
         $expected = [
+            'id' => 1,
             'name' => '47" LG 47LA790V (FHD)',
             'catnum' => '5965879P',
             'partno' => '47LA790V',
@@ -59,6 +61,7 @@ class ProductElasticsearchConverterTest extends TestCase
     public function testFillEmptyParameterFields(): void
     {
         $product = [
+            'id' => 1,
             'name' => '47" LG 47LA790V (FHD)',
             'catnum' => '5965879P',
             'partno' => '47LA790V',
@@ -74,6 +77,7 @@ class ProductElasticsearchConverterTest extends TestCase
         ];
 
         $expected = [
+            'id' => 1,
             'name' => '47" LG 47LA790V (FHD)',
             'catnum' => '5965879P',
             'partno' => '47LA790V',

--- a/project-base/app/src/Resources/definition/product/1.json
+++ b/project-base/app/src/Resources/definition/product/1.json
@@ -111,6 +111,9 @@
   },
   "mappings": {
     "properties": {
+      "id": {
+        "type": "integer"
+      },
       "searching_names": {
         "type": "text",
         "analyzer": "stemming",

--- a/project-base/app/src/Resources/definition/product/2.json
+++ b/project-base/app/src/Resources/definition/product/2.json
@@ -111,6 +111,9 @@
   },
   "mappings": {
     "properties": {
+      "id": {
+        "type": "integer"
+      },
       "searching_names": {
         "type": "text",
         "analyzer": "stemming",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If I understand elastic structure right, we use `_id` and `id` where `_id` comes [from array index](https://github.com/shopsys/shopsys/blob/16da913a4dab9cef20132520bfd3c5d384972bf7/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php#L154) and `id` comes [from classic bulk data](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php#L224). If my theory is correct, `id` has no defined structure and he should have it. I understand is little thing but I would like to see all data defined in structure, for sure. If I am wrong, you can close this PR. Thanks 🤝
|New feature| No 
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes
|Fixes issues| ... 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
