### PR TITLE
[frontend-api] avoid session starting in FE API

### DIFF
--- a/packages/framework/src/Component/Error/LogoutExceptionSubscriber.php
+++ b/packages/framework/src/Component/Error/LogoutExceptionSubscriber.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Error;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\FlashMessage\FlashBagProvider;
 use Shopsys\FrameworkBundle\Component\FlashMessage\FlashMessage;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
@@ -18,9 +18,9 @@ use Symfony\Component\Security\Core\Exception\LogoutException;
 class LogoutExceptionSubscriber implements EventSubscriberInterface
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface
+     * @var \Shopsys\FrameworkBundle\Component\FlashMessage\FlashBagProvider
      */
-    protected $flashBag;
+    protected FlashBagProvider $flashBagProvider;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser
@@ -38,18 +38,18 @@ class LogoutExceptionSubscriber implements EventSubscriberInterface
     protected $domain;
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface $flashBag
+     * @param \Shopsys\FrameworkBundle\Component\FlashMessage\FlashBagProvider $flashBagProvider
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Symfony\Component\Routing\RouterInterface $router
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
-        FlashBagInterface $flashBag,
+        FlashBagProvider $flashBagProvider,
         CurrentCustomerUser $currentCustomerUser,
         RouterInterface $router,
         Domain $domain
     ) {
-        $this->flashBag = $flashBag;
+        $this->flashBagProvider = $flashBagProvider;
         $this->currentCustomerUser = $currentCustomerUser;
         $this->router = $router;
         $this->domain = $domain;
@@ -78,7 +78,7 @@ class LogoutExceptionSubscriber implements EventSubscriberInterface
                 $domainId = $this->currentCustomerUser->findCurrentCustomerUser()->getDomainId();
                 $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
 
-                $this->flashBag->add(
+                $this->flashBagProvider->getFlashBag()?->add(
                     FlashMessage::KEY_ERROR,
                     t(
                         'There was an error during logout attempt. If you really want to sign out, please try it again.',

--- a/packages/framework/src/Component/FlashMessage/FlashBagProvider.php
+++ b/packages/framework/src/Component/FlashMessage/FlashBagProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\FlashMessage;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+
+class FlashBagProvider
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\RequestStack
+     */
+    protected RequestStack $requestStack;
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface|null
+     */
+    public function getFlashBag(): ?FlashBagInterface
+    {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest === null) {
+            return null;
+        }
+
+        /** @var \Symfony\Component\HttpFoundation\Session\Session $session */
+        $session = $currentRequest->getSession();
+
+        return $session->getFlashBag();
+    }
+}

--- a/packages/framework/src/Model/Cart/CartMigrationFacade.php
+++ b/packages/framework/src/Model/Cart/CartMigrationFacade.php
@@ -88,6 +88,15 @@ class CartMigrationFacade
      */
     public function onKernelController(ControllerEvent $event): void
     {
+        $frontendApiControllerClass = 'Shopsys\FrontendApiBundle\Controller\FrontendApiController';
+        $controller = $event->getController();
+        if (is_array($controller) && isset($controller[0])) {
+            $controller = $controller[0];
+        }
+
+        if ($controller instanceof $frontendApiControllerClass) {
+            return;
+        }
         $session = $event->getRequest()->getSession();
 
         $previousCartIdentifier = $session->get(static::SESSION_PREVIOUS_CART_IDENTIFIER);

--- a/packages/frontend-api/src/Component/SessionChecker/SessionChecker.php
+++ b/packages/frontend-api/src/Component/SessionChecker/SessionChecker.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Component\SessionChecker;
+
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+class SessionChecker
+{
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+     */
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        $request = $event->getRequest();
+        if (!$request->hasSession() || !$request->getSession()->isStarted() || !str_contains($request->getRequestUri(), 'graphql')) {
+            return;
+        }
+        $response = $event->getResponse();
+        $response->setContent('Session must not be started in the FE API. Check your code, please');
+    }
+}

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -39,3 +39,7 @@ services:
 
     Lcobucci\JWT\Configuration:
         factory: ['@Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationFactory', create]
+
+    Shopsys\FrontendApiBundle\Component\SessionChecker\SessionChecker:
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: -999 } # must be run before the session is closed (in Symfony\Component\HttpKernel\EventListener\SessionListener::onKernelResponse)

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -865,6 +865,25 @@ There you can find links to upgrade notes for other versions too.
     - static `tc()` method was removed from `\Shopsys\FrameworkBundle\Component\Translation\Translator`, use `t()` with `count` parameter instead
     - static `tc()` function was removed from global namespace, use `t()` with `count` parameter instead 
 
+- avoid the session starting in the frontend API ([#2497](https://github.com/shopsys/shopsys/pull/2497))
+    - beware, the changes might affect you even if you do not use the FE API in your project
+    - class `Shopsys\FrameworkBundle\Component\Error\LogoutExceptionSubscriber`:
+        - property `$flashBag` was removed, you can use `$this->flashBagProvider->getFlashBag()` to access the implementation of `FlashBagInterface` instead
+        - the constructor changed the interface:
+        ```diff
+            public function __construct(
+        -        FlashBagInterface $flashBag,
+        +        FlashBagProvider $flashBagProvider,
+        ```
+    - class `Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade`:
+        - property `$flashBag` was removed, you can use `$this->flashBagProvider->getFlashBag()` to access the implementation of `FlashBagInterface` instead
+        - the constructor changed the interface:
+        ```diff
+            public function __construct(
+        -        FlashBagInterface $flashBag,
+        +        FlashBagProvider $flashBagProvider,
+        ```
+
 ## Composer dependencies
 
 - replace swiftmailer with symfony/mailer ([#2470](https://github.com/shopsys/shopsys/pull/2470))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| FE API is stateless hence it does not use the session. The problem is the session is started for each GraphQL query anyway. In our code, the session is started even in the FE API for two reasons: 1) autowiring of `FlashBagInterface` Symfony service anywhere in the application -> the session is started during the build of the container (see https://github.com/symfony/symfony/pull/36063); 2) `CartMigrationFacade` is defined as an event listener that listens on the `kernel.controller` event, therefore it is triggered even in the API requests. The facade was originally used in the Twig frontend only so it uses the session, but in the API requests, it does not work (and does not make any sense there). Besides the fact the session is useless in the API, it can be also dangerous as Redis can get overwhelmed by the huge number of pointless session entries. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes