### PR TITLE
[releaser] lock files are now created in a separate folder

### DIFF
--- a/utils/releaser/src/ReleaseWorker/Release/CreateAndCommitLockFilesReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CreateAndCommitLockFilesReleaseWorker.php
@@ -16,7 +16,7 @@ final class CreateAndCommitLockFilesReleaseWorker extends AbstractShopsysRelease
      */
     public function getDescription(Version $version): string
     {
-        return 'Create and commit composer.lock, package-lock.json, and migrations-lock.yml and [Manually] push it';
+        return 'Create and commit composer.lock, symfony.lock, package-lock.json, and migrations-lock.yml and [Manually] push it';
     }
 
     /**
@@ -24,32 +24,42 @@ final class CreateAndCommitLockFilesReleaseWorker extends AbstractShopsysRelease
      */
     public function work(Version $version): void
     {
-        $this->symfonyStyle->note(
-            'Removing vendor/, node_modules/, composer.lock, migrations-lock.yml, and package-lock.json'
+        $currentDir = trim($this->processRunner->run('pwd'));
+
+        $packageName = 'project-base';
+        $tempDirectory = trim($this->processRunner->run('mktemp -d -t shopsys-release-XXXX'));
+
+        $this->symfonyStyle->note(sprintf('Cloning shopsys/%s. This can take a while.', $packageName));
+        $this->processRunner->run(
+            sprintf('cd %s && git clone --branch=%s https://github.com/shopsys/%s.git', $tempDirectory, $this->initialBranchName, $packageName)
         );
-        $this->processRunner->run('rm -rf project-base/vendor');
-        $this->processRunner->run('rm -rf project-base/node_modules');
-        $this->processRunner->run('rm -f project-base/composer.lock');
-        $this->processRunner->run('rm -f project-base/package-lock.json');
-        $this->processRunner->run('rm -f project-base/migrations-lock.yml');
-        $this->processRunner->run('cd project-base && composer install && npm install');
+
+        $this->symfonyStyle->note('Installing dependencies');
+        $this->processRunner->run(sprintf('cd %s/project-base && composer update && npm install', $tempDirectory));
+        $this->processRunner->run(sprintf('cd %s/project-base && php phing db-rebuild', $tempDirectory));
+
+        $this->symfonyStyle->note('Committing changes in composer.lock, symfony.lock, package-lock.json, and migrations-lock.yml');
+        $this->processRunner->run(sprintf('cp %s/project-base/composer.lock %s/project-base/composer.lock', $tempDirectory, $currentDir));
+        $this->processRunner->run(sprintf('cp %s/project-base/symfony.lock %s/project-base/symfony.lock', $tempDirectory, $currentDir));
+        $this->processRunner->run(sprintf('cp %s/project-base/package-lock.json %s/project-base/package-lock.json', $tempDirectory, $currentDir));
+        $this->processRunner->run(sprintf('cp %s/project-base/migrations-lock.yml %s/project-base/migrations-lock.yml', $tempDirectory, $currentDir));
 
         $this->processRunner->run('git add -f project-base/composer.lock');
+        $this->processRunner->run('git add project-base/symfony.lock');
         $this->processRunner->run('git add -f project-base/package-lock.json');
-
-        $this->processRunner->run('rm -rf project-base/vendor');
-        $this->processRunner->run('composer install');
-
-        $this->processRunner->run('php phing db-rebuild');
         $this->processRunner->run('git add -f project-base/migrations-lock.yml');
 
         $message = sprintf('locked versions of dependencies for %s release', $version->getVersionString());
         $this->commit($message);
 
-        $this->symfonyStyle->note('push last commit with composer, package, and migration locks');
+        $this->symfonyStyle->note([
+            'Push last commit with generated lock files',
+            'You have to allow push to the protected branch here https://github.com/shopsys/shopsys/settings/branches first',
+        ]);
+
         $this->symfonyStyle->confirm(
             sprintf(
-                'confirm that composer.lock, package-lock.json, and migrations-lock.yml are pushed to "%s" branch',
+                'confirm that composer.lock, symfony.lock, package-lock.json, and migrations-lock.yml are pushed to "%s" branch',
                 $this->initialBranchName
             )
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| `CreateAndCommitLockFilesReleaseWorker` now install dependencies in a separate folder to avoid namespace conflict while releasing
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
