### PR TITLE
[releaser] improve information in after-release stage

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AbstractCheckShopsysInstallReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractCheckShopsysInstallReleaseWorker.php
@@ -14,7 +14,7 @@ abstract class AbstractCheckShopsysInstallReleaseWorker extends AbstractShopsysR
      */
     public function getDescription(Version $version): string
     {
-        return '[Manually] Install Shopsys Framework (project-base) using installation guides (using Docker on Linux and Mac and natively)';
+        return '[Manually] Install Shopsys Framework (project-base) using installation guides on all supported operating systems.';
     }
 
     /**

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckShopsysInstallReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckShopsysInstallReleaseWorker.php
@@ -4,11 +4,21 @@ declare(strict_types=1);
 
 namespace Shopsys\Releaser\ReleaseWorker\AfterRelease;
 
+use PharIo\Version\Version;
 use Shopsys\Releaser\ReleaseWorker\AbstractCheckShopsysInstallReleaseWorker;
 use Shopsys\Releaser\Stage;
 
 final class CheckShopsysInstallReleaseWorker extends AbstractCheckShopsysInstallReleaseWorker
 {
+    /**
+     * @param \PharIo\Version\Version $version
+     * @return string
+     */
+    public function getDescription(Version $version): string
+    {
+        return '[Manually] Install Shopsys Framework (project-base) using installation guides on all supported operating systems. You need to wait with the installation until the monorepo is split.';
+    }
+
     /**
      * @return string
      */

--- a/utils/releaser/src/ReleaseWorker/AfterRelease/SetMutualDependenciesToDevelopmentVersionReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/SetMutualDependenciesToDevelopmentVersionReleaseWorker.php
@@ -73,6 +73,15 @@ final class SetMutualDependenciesToDevelopmentVersionReleaseWorker extends Abstr
         $this->confirm(
             sprintf('Confirm you have pushed the new commit into the "%s" branch', $this->initialBranchName)
         );
+        if ($this->initialBranchName === 'master') {
+            return;
+        }
+
+        $this->symfonyStyle->note(
+            sprintf('You are not on master branch so you have to split "%s" branch using tool-monorepo-force-split-branch manually on Heimdall now.
+            You will need the split monorepo later for verifying local intallation.', $this->initialBranchName)
+        );
+        $this->confirm('Confirm the monorepo split is running.');
     }
 
     /**


### PR DESCRIPTION
- added information about necessity of manually splitting monorepo when not on master branch

| Q             | A
| ------------- | ---
|Description, reason for the PR| there is a confusing moment when releasing a version that is not on master - you have tag in project-base but the tag is not in any branch until the monorepo branch is split 
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

**Note:** it would be nice to merge 10.0 branch into master after this PR is merged