### PR TITLE
[framework] upgrade guzzlehttp/guzzle to ^7.5 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "friendsofsymfony/ckeditor-bundle": "^2.1",
         "gedmo/doctrine-extensions": "^3.5",
         "google/cloud-storage": "^1.10",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.5",
         "helios-ag/fm-elfinder-bundle": "^10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -57,7 +57,7 @@
         "fakerphp/faker": "^1.19.0",
         "friendsofsymfony/ckeditor-bundle": "^2.1",
         "gedmo/doctrine-extensions": "^3.5",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.5",
         "helios-ag/fm-elfinder-bundle": "^10.0.4",
         "heureka/overeno-zakazniky": "^2.0.6",
         "intervention/image": "^2.3.14",

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -947,3 +947,5 @@ There you can find links to upgrade notes for other versions too.
     - since Symfony 5.0 are all Events from `Symfony\Component\HttpKernel\Event` namespace final and cannot be mocked
 - use logger methods as they're specified in PSR-3 ([#2483](https://github.com/shopsys/shopsys/pull/2483))
     - replace any usages of `Logger::add<Emergency|Alert|Critical|Notice|Debug|Error|Warning|Info>` with corresponding call of `emergency|alert|critical|notice|debug|error|warning|info` method
+- `guzzlehttp/guzzle` has been upgraded to `^7.5` version [#2514](https://github.com/shopsys/shopsys/pull/2514)
+    - support for the older versions has been dropped as they do not support PHP 8.1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The older versions of the library do not support PHP8.1
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
