### PR TITLE
[framework] category tree in administration is now hideable

### DIFF
--- a/packages/framework/assets/styles/admin/components/form/tree.less
+++ b/packages/framework/assets/styles/admin/components/form/tree.less
@@ -1,4 +1,4 @@
-@form-tree-icon-size: 17px;
+@form-tree-icon-size: 13px;
 
 .form-tree {
     width: 440px;
@@ -158,13 +158,14 @@
         }
 
         &__icon {
-            margin-right: 5px;
+            margin: 3px 5px 0;
+            vertical-align: center;
             float: left;
             font-size: @form-tree-icon-size;
 
             &--level {
                 margin-top: 3px;
-                margin-left: 14px
+                margin-left: 17px
             }
         }
 

--- a/packages/framework/src/Resources/views/Admin/Content/Category/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Category/list.html.twig
@@ -17,10 +17,13 @@
 
     {% macro categoryTreeItem(categoriesWithPreloadedChildren, isFirstLevel) %}
         {% import _self as self %}
-        <ul class="js-category-tree-items {{ isFirstLevel ? 'form-tree__content' : '' }}">
+        <ul class="js-category-tree-items js-category-tree-form-children-container {{ isFirstLevel ? 'form-tree__content' : '' }}">
             {% for categoryWithPreloadedChildren in categoriesWithPreloadedChildren %}
-                <li class="js-category-tree-item form-tree__item" id="js-category-tree-{{ categoryWithPreloadedChildren.category.id }}">
-                    <div class="js-category-tree-item-line form-tree__item__drag">
+                <li class="js-category-tree-item form-tree__item js-category-tree-form-item"
+                    id="js-category-tree-{{ categoryWithPreloadedChildren.category.id }}"
+                    data-has-children="{{ categoryWithPreloadedChildren.children|length ? 'true' }}">
+                    <div class="js-category-tree-item-line form-tree__item__drag form-tree__item__click">
+                        <span class="js-category-tree-form-item-icon form-tree__item__icon form-tree__item__icon--level sprite sprite-level"></span>
                         <img src="{{ asset('public/admin/images/icons/level.png') }}" class="form-tree__item__icon form-tree__item__icon--level" />
                         <span class="js-category-tree-item-line  js-category-tree-item-handle form-tree__item__name">{{ categoryWithPreloadedChildren.category.name }}</span>
                         <span class="js-category-tree-item-icons form-tree__item__controls">
@@ -49,7 +52,7 @@
     {% if isForAllDomains %}
         <div class="wrap-divider">
             <div class="form-line">
-                <div id="js-category-tree-sorting" class="form-tree form-tree--open form-tree--dragable">
+                <div id="js-category-tree-sorting" class="js-category-tree-form form-tree form-tree--open form-tree--dragable">
                     {{ self.categoryTreeItem(categoriesWithPreloadedChildren, true) }}
                 </div>
             </div>
@@ -73,7 +76,7 @@
         </div>
         <div class="wrap-divider">
             <div class="form-line">
-                <div class="form-tree form-tree--open form-tree--dragable">
+                <div class="js-category-tree-form form-tree form-tree--open form-tree--dragable">
                     {{ self.categoryTreeItem(categoriesWithPreloadedChildren, true) }}
                 </div>
             </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| administrator wanst hideable category tree in admin section
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
