### PR TITLE
[shopsys] update twig/twig to v2.15.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/workflow": "^5.4",
         "tracy/tracy": "^2.4.13",
-        "twig/twig": "^2.12",
+        "twig/twig": "^2.15.4",
         "webmozart/assert": "^1.4",
         "webonyx/graphql-php": "^14.5"
     },

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -95,7 +95,7 @@
         "symfony-cmf/routing-bundle": "^2.0.3",
         "symfony/polyfill-php80": "^1.24.0",
         "tracy/tracy": "^2.4.13",
-        "twig/twig": "^2.12",
+        "twig/twig": "^2.15.4",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/packages/product-feed-google/composer.json
+++ b/packages/product-feed-google/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/twig": "^2.12"
+        "twig/twig": "^2.15.4"
     },
     "extra": {
         "branch-alias": {

--- a/packages/product-feed-heureka-delivery/composer.json
+++ b/packages/product-feed-heureka-delivery/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/twig": "^2.12"
+        "twig/twig": "^v2.15.4"
     },
     "extra": {
         "branch-alias": {

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/twig": "^2.12"
+        "twig/twig": "^2.15.4"
     },
     "extra": {
         "branch-alias": {

--- a/packages/product-feed-zbozi/composer.json
+++ b/packages/product-feed-zbozi/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.20",
         "shopsys/coding-standards": "11.0.x-dev",
-        "twig/twig": "^2.12"
+        "twig/twig": "^2.15.4"
     },
     "extra": {
         "branch-alias": {

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -94,7 +94,7 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/workflow": "^5.4",
         "tracy/tracy": "^2.4.13",
-        "twig/twig": "^2.9",
+        "twig/twig": "^2.15.4",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -866,6 +866,8 @@ There you can find links to upgrade notes for other versions too.
     - static `tc()` function was removed from global namespace, use `t()` with `count` parameter instead
 - update to latest version heureka/overeno-zakazniky package ([#2526](https://github.com/shopsys/shopsys/pull/2526))
     - see #project-base-diff to update your project
+- update twig/twig to v2.15.4 in order to fix CVE-2022-39261 ([#2527](https://github.com/shopsys/shopsys/pull/2527))
+    - see #project-base-diff to update your project
 
 ## Composer dependencies
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| update twig/twig to v2.15.4 - fix CVE-2022-39261 - https://symfony.com/blog/twig-security-release-possibility-to-load-a-template-outside-a-configured-directory-when-using-the-filesystem-loader
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
