### PR TITLE
[framework] remove product variant urls from sitemap

### DIFF
--- a/packages/framework/src/Model/Sitemap/SitemapFacade.php
+++ b/packages/framework/src/Model/Sitemap/SitemapFacade.php
@@ -80,11 +80,11 @@ class SitemapFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \Shopsys\FrameworkBundle\Model\Sitemap\SitemapItem[]
      */
-    public function getSitemapItemsForVisibleProducts(DomainConfig $domainConfig)
+    public function getSitemapItemsForListableProducts(DomainConfig $domainConfig)
     {
         $pricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($domainConfig->getId());
 
-        return $this->sitemapRepository->getSitemapItemsForVisibleProducts($domainConfig, $pricingGroup);
+        return $this->sitemapRepository->getSitemapItemsForListableProducts($domainConfig, $pricingGroup);
     }
 
     /**

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -72,7 +72,7 @@ class SitemapListener implements EventSubscriberInterface
 
         $this->addHomepageUrl($generator, $domainConfig, $section, static::PRIORITY_HOMEPAGE);
 
-        $productSitemapItems = $this->sitemapFacade->getSitemapItemsForVisibleProducts($domainConfig);
+        $productSitemapItems = $this->sitemapFacade->getSitemapItemsForListableProducts($domainConfig);
         $this->addUrlsBySitemapItems(
             $productSitemapItems,
             $generator,

--- a/packages/framework/src/Model/Sitemap/SitemapRepository.php
+++ b/packages/framework/src/Model/Sitemap/SitemapRepository.php
@@ -49,9 +49,9 @@ class SitemapRepository
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @return \Shopsys\FrameworkBundle\Model\Sitemap\SitemapItem[]
      */
-    public function getSitemapItemsForVisibleProducts(DomainConfig $domainConfig, PricingGroup $pricingGroup)
+    public function getSitemapItemsForListableProducts(DomainConfig $domainConfig, PricingGroup $pricingGroup)
     {
-        $queryBuilder = $this->productRepository->getAllVisibleQueryBuilder($domainConfig->getId(), $pricingGroup);
+        $queryBuilder = $this->productRepository->getAllListableQueryBuilder($domainConfig->getId(), $pricingGroup);
         $queryBuilder
             ->select('fu.slug')
             ->join(

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -870,6 +870,9 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 - fill missing customer demo data for smooth testing of application ([#2529](https://github.com/shopsys/shopsys/pull/2529))
     - see #project-base-diff to update your project
+- remove product variant urls from sitemap ([#2530](https://github.com/shopsys/shopsys/pull/2530))
+    - replace usages of `SitemapFacade::getSitemapItemsForVisibleProducts()` with `SitemapFacade::getSitemapItemsForListableProducts()` in your project as old method no longer exists
+    - replace usages of `SitemapRepository::getSitemapItemsForVisibleProducts()` with `SitemapRepository::getSitemapItemsForListableProducts()` in your project as old method no longer exists
 
 ## Composer dependencies
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| the sitemap now contains only the url addresses of the common product and the main product variants. Links to product variants do not have their own landing page, so they are not in the sitemap.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
