### PR TITLE
[framework] Symfony profiler contains extended URLs for graphQL API requests

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -91,7 +91,7 @@
         "symfony/monolog-bundle": "^3.5.0",
         "symfony/property-info": "^5.4",
         "symfony/proxy-manager-bridge": "^5.4",
-        "symfony/security": "^5.4",
+        "symfony/security-bundle": "^5.4",
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
         "symfony/polyfill-php80": "^1.24.0",

--- a/packages/framework/src/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/packages/framework/src/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\HttpKernel\Profiler;
+
+use GuzzleHttp\Exception\InvalidArgumentException;
+use RuntimeException;
+use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
+use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage as BaseFileProfilerStorage;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use function dirname;
+use function function_exists;
+use function GuzzleHttp\json_decode;
+use const LOCK_EX;
+
+class FileProfilerStorage extends BaseFileProfilerStorage
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \RuntimeException
+     */
+    public function write(Profile $profile): bool
+    {
+        $file = $this->getFilename($profile->getToken());
+
+        $profileIndexed = is_file($file);
+        if (!$profileIndexed) {
+            // Create directory
+            $dir = dirname($file);
+            if (!is_dir($dir) && @mkdir($dir, 0777, true) === false && !is_dir($dir)) {
+                throw new RuntimeException(sprintf('Unable to create the storage directory (%s).', $dir));
+            }
+        }
+
+        $data = $this->getDataByProfile($profile);
+
+        if (file_put_contents($file, $data, LOCK_EX) === false) {
+            return false;
+        }
+
+        if (!$profileIndexed) {
+            $file = fopen($this->getIndexFilename(), 'a');
+            // Add to index
+            if ($file === false) {
+                return false;
+            }
+
+            fputcsv($file, [
+                $profile->getToken(),
+                $profile->getIp(),
+                $profile->getMethod(),
+                $profile->getUrl(),
+                $profile->getTime(),
+                $profile->getParentToken(),
+                $profile->getStatusCode(),
+            ]);
+            fclose($file);
+        }
+
+        return true;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Profiler\Profile $profile
+     */
+    protected function updateProfileUrlForGqlRequests(Profile $profile): void
+    {
+        if (str_ends_with($profile->getUrl(), '/graphql/') && $profile->hasCollector('request')) {
+            $collector = $profile->getCollector('request');
+            if ($collector instanceof RequestDataCollector) {
+                try {
+                    $content = json_decode($collector->getContent(), true);
+                    if (is_array($content) && array_key_exists('query', $content) && strpos($content['query'], '{')) {
+                        $queryString = $content['query'];
+                        $re = '/(?<type>query|mutation){(\s*(?<name>[a-zA-Z0-9]+))/m';
+                        $matches = [];
+                        preg_match($re, $queryString, $matches);
+                        $profile->setUrl($profile->getUrl() . ' - ' . $matches['type'] . '{' . $matches['name'] . '}');
+                    }
+                } catch (InvalidArgumentException) {
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Profiler\Profile $profile
+     * @return string
+     */
+    protected function getDataByProfile(Profile $profile): string
+    {
+        $profileToken = $profile->getToken();
+        // when there are errors in sub-requests, the parent and/or children tokens
+        // may equal the profile token, resulting in infinite loops
+        $parentToken = $profile->getParentToken() !== $profileToken ? $profile->getParentToken() : null;
+        $childrenToken = array_filter(array_map(function (Profile $p) use ($profileToken) {
+            return $profileToken !== $p->getToken() ? $p->getToken() : null;
+        }, $profile->getChildren()));
+
+        $this->updateProfileUrlForGqlRequests($profile);
+
+        // Store profile
+        $data = [
+            'token' => $profileToken,
+            'parent' => $parentToken,
+            'children' => $childrenToken,
+            'data' => $profile->getCollectors(),
+            'ip' => $profile->getIp(),
+            'method' => $profile->getMethod(),
+            'url' => $profile->getUrl(),
+            'time' => $profile->getTime(),
+            'status_code' => $profile->getStatusCode(),
+        ];
+
+        $data = serialize($data);
+        if (function_exists('gzencode')) {
+            $data = gzencode($data, 3);
+        }
+
+        return $data;
+    }
+}

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -988,3 +988,10 @@ services:
             $debug: '%kernel.debug%'
             $environment: '%kernel.environment%'
             $overwriteDomainUrl: '%env(default::OVERWRITE_DOMAIN_URL)%'
+
+    Shopsys\FrameworkBundle\Component\HttpKernel\Profiler\FileProfilerStorage:
+        arguments:
+            $dsn: 'file:%kernel.project_dir%/var/cache/profiler'
+
+    profiler.storage:
+        alias: Shopsys\FrameworkBundle\Component\HttpKernel\Profiler\FileProfilerStorage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| URLs in symfony profiler contain information about a query or mutation. ( http://127.0.0.1:8000/graphql/ - query{categories} )
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
