### PR TITLE
[framework] Remove var dumps from API response

### DIFF
--- a/docs/cookbook/dump-variables.md
+++ b/docs/cookbook/dump-variables.md
@@ -1,0 +1,14 @@
+# Dump variables
+Shopsys Framework uses Symfony with its VarDumper. 
+In addition to the standard function `dump()`, we implement the function `d()`, which you can pass any number of attributes where each one is dumped.
+
+Dumped variables are primarily available in the profiler. 
+
+Since we do not want to dump variables into the JSON response when developing the frontend API, the dumps are directed to the Symfony dump server. (https://symfony.com/doc/current/components/var_dumper.html#the-dump-server)
+
+You can find the debug settings in the file `config/packages/dev/debug.yaml`:
+
+Start the server with the `server:dump` command and whenever you call the `d()`, the dumped data will not be displayed in the output but sent to that server, which outputs it to its own console or to an HTML file.
+```
+php bin/console server:dump
+```

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -18,3 +18,4 @@
 * [Create Advanced Grid](./create-advanced-grid.md)
 * [Extending Product List](./extending-product-list.md)
 * [Adding a New Email Template](./adding-a-new-email-template.md)
+* [Dump variables in framework](./dump-variables.md)

--- a/project-base/config/packages/dev/debug.yaml
+++ b/project-base/config/packages/dev/debug.yaml
@@ -1,3 +1,4 @@
 debug:
     max_items: 500
     max_string_length: 5000
+    dump_destination: tcp://0.0.0.0:9912 # dumps are available in profiler or for reading dumps start server php bin/console server:dump


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| var dumps are not sent with the response, instead they are redirected to the symfony dump server. https://symfony.com/doc/current/components/var_dumper.html#var-dumper-dump-server
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
