### PR TITLE
[shopsys] update session and cart lifetime

### DIFF
--- a/packages/framework/src/Model/Cart/CartFacade.php
+++ b/packages/framework/src/Model/Cart/CartFacade.php
@@ -18,8 +18,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 
 class CartFacade
 {
-    protected const DAYS_LIMIT_FOR_UNREGISTERED = 60;
-    protected const DAYS_LIMIT_FOR_REGISTERED = 120;
+    protected const DAYS_LIMIT = 130;
 
     /**
      * @var \Doctrine\ORM\EntityManagerInterface
@@ -252,6 +251,9 @@ class CartFacade
 
                 return null;
             }
+
+            $cart->setModifiedNow();
+            $this->em->flush();
         }
 
         return $cart;
@@ -290,6 +292,9 @@ class CartFacade
 
             $this->em->persist($cart);
             $this->em->flush();
+        } else {
+            $cart->setModifiedNow();
+            $this->em->flush();
         }
 
         return $cart;
@@ -311,7 +316,7 @@ class CartFacade
 
     public function deleteOldCarts()
     {
-        $this->cartRepository->deleteOldCartsForUnregisteredCustomerUsers(static::DAYS_LIMIT_FOR_UNREGISTERED);
-        $this->cartRepository->deleteOldCartsForRegisteredCustomerUsers(static::DAYS_LIMIT_FOR_REGISTERED);
+        $this->cartRepository->deleteOldCartsForUnregisteredCustomerUsers(static::DAYS_LIMIT);
+        $this->cartRepository->deleteOldCartsForRegisteredCustomerUsers(static::DAYS_LIMIT);
     }
 }

--- a/project-base/config/packages/framework.yaml
+++ b/project-base/config/packages/framework.yaml
@@ -17,6 +17,7 @@ framework:
         # Disable the default PHP session garbage collection.
         # Session garbage collection is responsibility of hosting.
         gc_probability: 0
+        cookie_lifetime: 31536000 # 365 days * 24 hours * 3600 seconds
     fragments: ~
     http_method_override: true
     profiler:

--- a/project-base/tests/App/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
+++ b/project-base/tests/App/Functional/Model/Cart/CartFacadeDeleteOldCartsTest.php
@@ -93,7 +93,7 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
         $cartFacade = $this->getCartFacadeForUnregisteredCustomer();
         $cart = $this->createCartWithProduct($customerUserIdentifier, $cartFacade);
 
-        $cart->setModifiedAt(new DateTime('- 61 days'));
+        $cart->setModifiedAt(new DateTime('- 131 days'));
 
         $this->em->flush();
 
@@ -108,7 +108,7 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
         $cartFacade = $this->getCartFacadeForUnregisteredCustomer();
         $cart = $this->createCartWithProduct($customerUserIdentifier, $cartFacade);
 
-        $cart->setModifiedAt(new DateTime('- 59 days'));
+        $cart->setModifiedAt(new DateTime('- 129 days'));
 
         $this->em->flush();
 
@@ -123,7 +123,7 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
         $cartFacade = $this->getCartFacadeForRegisteredCustomer();
         $cart = $this->createCartWithProduct($customerUserIdentifier, $cartFacade);
 
-        $cart->setModifiedAt(new DateTime('- 121 days'));
+        $cart->setModifiedAt(new DateTime('- 131 days'));
 
         $this->em->flush();
 
@@ -138,7 +138,7 @@ class CartFacadeDeleteOldCartsTest extends TransactionFunctionalTestCase
         $cartFacade = $this->getCartFacadeForRegisteredCustomer();
         $cart = $this->createCartWithProduct($customerUserIdentifier, $cartFacade);
 
-        $cart->setModifiedAt(new DateTime('- 119 days'));
+        $cart->setModifiedAt(new DateTime('- 129 days'));
 
         $this->em->flush();
 

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -873,6 +873,8 @@ There you can find links to upgrade notes for other versions too.
 - remove product variant urls from sitemap ([#2530](https://github.com/shopsys/shopsys/pull/2530))
     - replace usages of `SitemapFacade::getSitemapItemsForVisibleProducts()` with `SitemapFacade::getSitemapItemsForListableProducts()` in your project as old method no longer exists
     - replace usages of `SitemapRepository::getSitemapItemsForVisibleProducts()` with `SitemapRepository::getSitemapItemsForListableProducts()` in your project as old method no longer exists
+- session is valid for a year and the cart is now only deleted after 130 days from the user's last activity ([#2537](https://github.com/shopsys/shopsys/pull/2537))
+    - see #project-base-diff to update your project
 
 ## Composer dependencies
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|  session is valid for a year instead of relation only and the cart is now deleted after 130 days from the user's last activity
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
