### PR TITLE
[framework] shutdown kernel after generating error page

### DIFF
--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -157,6 +157,7 @@ class ErrorPagesFacade
 
         $errorPageResponse = $errorPageKernel->handle($errorPageFakeRequest);
         $errorPageKernel->terminate($errorPageFakeRequest, $errorPageResponse);
+        $errorPageKernel->shutdown();
 
         if ($expectedStatusCode !== $errorPageResponse->getStatusCode()) {
             throw new BadErrorPageStatusCodeException(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There are three error pages generated during the deployment of the application for each domain, every error page generation opens a new DB connection that is not properly closed. That means you can easily exceed the allowed DB connections during the deployment. Calling `shutdown` should solve the issue. The original author of the solution is https://github.com/MlynekMartinCZ :wink: We have not tested the solution properly and we are not sure whether the solution is 100 % legit, so we ask you, the maintainers of SSFW, to verify this solution, thank you!
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
