### PR TITLE
[shopsys] Sitemap updates

### DIFF
--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapCronModule.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapCronModule.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+use Symfony\Bridge\Monolog\Logger;
+
+class ImageSitemapCronModule implements SimpleCronModuleInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapFacade $imageSitemapFacade
+     */
+    public function __construct(
+        private readonly ImageSitemapFacade $imageSitemapFacade
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setLogger(Logger $logger)
+    {
+    }
+
+    public function run()
+    {
+        $this->imageSitemapFacade->generateForAllDomains();
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapDumper.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapDumper.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use Shopsys\FrameworkBundle\Model\Sitemap\SitemapDumper;
+
+class ImageSitemapDumper extends SitemapDumper
+{
+    /**
+     * @param string|null $section
+     */
+    protected function populate(?string $section = null): void
+    {
+        $event = new ImageSitemapPopulateEvent($this, $section);
+
+        $this->dispatcher->dispatch($event);
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapDumperFactory.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapDumperFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use League\Flysystem\FilesystemInterface;
+use League\Flysystem\MountManager;
+use Shopsys\FrameworkBundle\Model\Sitemap\SitemapDumper;
+use Shopsys\FrameworkBundle\Model\Sitemap\SitemapDumperFactory;
+use Shopsys\FrameworkBundle\Model\Sitemap\SitemapFilePrefixer;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ImageSitemapDumperFactory extends SitemapDumperFactory
+{
+    /**
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
+     * @param \Symfony\Component\Filesystem\Filesystem $localFilesystem
+     * @param \League\Flysystem\FilesystemInterface $filesystem
+     * @param \League\Flysystem\MountManager $mountManager
+     * @param \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFilePrefixer $sitemapFilePrefixer
+     * @param \Symfony\Component\Routing\Generator\UrlGeneratorInterface $urlGenerator
+     * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapFilePrefixer $imageSitemapFilePrefixer
+     */
+    public function __construct(
+        EventDispatcherInterface $eventDispatcher,
+        Filesystem $localFilesystem,
+        FilesystemInterface $filesystem,
+        MountManager $mountManager,
+        SitemapFilePrefixer $sitemapFilePrefixer,
+        UrlGeneratorInterface $urlGenerator,
+        protected readonly ImageSitemapFilePrefixer $imageSitemapFilePrefixer,
+    ) {
+        parent::__construct($eventDispatcher, $localFilesystem, $filesystem, $mountManager, $sitemapFilePrefixer, $urlGenerator);
+    }
+
+    /**
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Sitemap\SitemapDumper
+     */
+    public function createForImagesForDomain(int $domainId): SitemapDumper
+    {
+        return new ImageSitemapDumper(
+            $this->eventDispatcher,
+            $this->localFilesystem,
+            $this->filesystem,
+            $this->mountManager,
+            $this->urlGenerator,
+            $this->imageSitemapFilePrefixer->getSitemapFilePrefixForDomain($domainId),
+            static::MAX_ITEMS_IN_FILE
+        );
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapFacade.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapFacade.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Image\Exception\ImageNotFoundException;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade;
+use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
+
+class ImageSitemapFacade
+{
+    /**
+     * @var string
+     */
+    protected string $sitemapsDir;
+
+    /**
+     * @var string
+     */
+    protected string $sitemapsUrlPrefix;
+
+    /**
+     * @param string $sitemapsDir
+     * @param string $sitemapsUrlPrefix
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapDumperFactory $imageSitemapDumperFactory
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade $pricingGroupSettingFacade
+     * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
+     * @param \Doctrine\ORM\EntityManager $entityManager
+     */
+    public function __construct(
+        string $sitemapsDir,
+        string $sitemapsUrlPrefix,
+        protected readonly Domain $domain,
+        protected readonly ImageSitemapDumperFactory $imageSitemapDumperFactory,
+        protected readonly PricingGroupSettingFacade $pricingGroupSettingFacade,
+        protected readonly ImageFacade $imageFacade,
+        protected readonly FriendlyUrlFacade $friendlyUrlFacade,
+        protected readonly ProductRepository $productRepository,
+        protected readonly EntityManagerInterface $entityManager
+    ) {
+        $this->sitemapsDir = $sitemapsDir;
+        $this->sitemapsUrlPrefix = $sitemapsUrlPrefix;
+    }
+
+    public function generateForAllDomains(): void
+    {
+        foreach ($this->domain->getAll() as $domainConfig) {
+            $this->entityManager->clear();  // For load all translations correctly, we must run clear.
+            $section = (string)$domainConfig->getId();
+
+            $domainSitemapDumper = $this->imageSitemapDumperFactory->createForImagesForDomain($domainConfig->getId());
+            $domainSitemapDumper->dump(
+                $this->sitemapsDir,
+                $domainConfig->getUrl() . $this->sitemapsUrlPrefix . '/',
+                $section
+            );
+        }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @return \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapItem[]
+     */
+    public function getImageSitemapItemsForVisibleProducts(DomainConfig $domainConfig): array
+    {
+        $imageSitemapItems = [];
+        $domainId = $domainConfig->getId();
+        $pricingGroup = $this->pricingGroupSettingFacade->getDefaultPricingGroupByDomainId($domainId);
+        /** @var \App\Model\Product\Product[] $products */
+        $products = $this->productRepository->getAllOfferedProducts($domainId, $pricingGroup);
+
+        foreach ($products as $product) {
+            try {
+                $imageUrl = $this->imageFacade->getImageUrl($domainConfig, $product);
+                $imageSitemapItem = new ImageSitemapItem();
+                $imageSitemapItem->loc = $this->friendlyUrlFacade->getAbsoluteUrlByRouteNameAndEntityId($domainConfig->getId(), 'front_product_detail', $product->getId());
+
+                $sitemapImage = new ImageSitemapItemImage();
+                $sitemapImage->loc = $imageUrl;
+                $sitemapImage->title = $product->getName($domainConfig->getLocale());
+                $imageSitemapItem->images[] = $sitemapImage;
+
+                $imageSitemapItems[] = $imageSitemapItem;
+            } catch (ImageNotFoundException $imageNotFoundException) {
+                continue;
+            }
+        }
+        return $imageSitemapItems;
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapFilePrefixer.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapFilePrefixer.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+class ImageSitemapFilePrefixer
+{
+    /**
+     * @param int $domainId
+     * @return string
+     */
+    public function getSitemapFilePrefixForDomain($domainId): string
+    {
+        return 'domain_' . $domainId . '_sitemap_image';
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapItem.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapItem.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+class ImageSitemapItem
+{
+    /**
+     * @var string
+     */
+    public string $loc;
+
+    /**
+     * @var \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapItemImage[]
+     */
+    public array $images;
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapItemImage.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapItemImage.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+class ImageSitemapItemImage
+{
+    /**
+     * @var string
+     */
+    public string $loc;
+
+    /**
+     * @var string|null
+     */
+    public ?string $caption = null;
+
+    /**
+     * @var string|null
+     */
+    public ?string $geoLocation = null;
+
+    /**
+     * @var string
+     */
+    public string $title;
+
+    /**
+     * @var string|null
+     */
+    public ?string $license = null;
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapListener.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapListener.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use Presta\SitemapBundle\Service\UrlContainerInterface;
+use Presta\SitemapBundle\Sitemap\Url\GoogleImage;
+use Presta\SitemapBundle\Sitemap\Url\GoogleImageUrlDecorator;
+use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ImageSitemapListener implements EventSubscriberInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapFacade $sitemapFacade
+     */
+    public function __construct(
+        protected readonly Domain $domain,
+        protected readonly ImageSitemapFacade $sitemapFacade
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ImageSitemapPopulateEvent::class => 'populateImageSitemap',
+        ];
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapPopulateEvent $event
+     */
+    public function populateImageSitemap(ImageSitemapPopulateEvent $event)
+    {
+        $section = $event->getSection();
+        $domainId = (int)$section;
+
+        /** @var \Presta\SitemapBundle\Service\AbstractGenerator $generator */
+        $generator = $event->getUrlContainer();
+        $generator->setDefaults([
+            'priority' => null,
+            'changefreq' => null,
+            'lastmod' => null,
+        ]);
+        $domainConfig = $this->domain->getDomainConfigById($domainId);
+
+        $productSitemapItems = $this->sitemapFacade->getImageSitemapItemsForVisibleProducts($domainConfig);
+        $this->addUrlsBySitemapItems($productSitemapItems, $generator, 'products');
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapItem[] $imageSitemapItems
+     * @param \Presta\SitemapBundle\Service\UrlContainerInterface $generator
+     * @param string $section
+     */
+    protected function addUrlsBySitemapItems(array $imageSitemapItems, UrlContainerInterface $generator, string $section): void
+    {
+        foreach ($imageSitemapItems as $imageSitemapItem) {
+            $urlConcrete = new UrlConcrete($imageSitemapItem->loc);
+            $decoratedUrl = new GoogleImageUrlDecorator($urlConcrete);
+            foreach ($imageSitemapItem->images as $imageSitemapItemImage) {
+                $googleImage = new GoogleImage(
+                    $imageSitemapItemImage->loc,
+                    $imageSitemapItemImage->caption,
+                    $imageSitemapItemImage->geoLocation,
+                    $imageSitemapItemImage->title,
+                    $imageSitemapItemImage->license
+                );
+                $decoratedUrl->addImage($googleImage);
+            }
+
+            $generator->addUrl($decoratedUrl, $section);
+        }
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapPopulateEvent.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapPopulateEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use Presta\SitemapBundle\Event\SitemapPopulateEvent;
+
+class ImageSitemapPopulateEvent extends SitemapPopulateEvent
+{
+}

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -13,10 +13,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SitemapListener implements EventSubscriberInterface
 {
-    protected const PRIORITY_HOMEPAGE = 1;
-    protected const PRIORITY_CATEGORIES = 0.8;
-    protected const PRIORITY_PRODUCTS = 0.7;
-    protected const PRIORITY_ARTICLES = 0.5;
     protected const PRIORITY_NONE = null;
 
     /**

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -17,21 +17,7 @@ class SitemapListener implements EventSubscriberInterface
     protected const PRIORITY_CATEGORIES = 0.8;
     protected const PRIORITY_PRODUCTS = 0.7;
     protected const PRIORITY_ARTICLES = 0.5;
-
-    /**
-     * @var \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFacade
-     */
-    protected $sitemapFacade;
-
-    /**
-     * @var \Shopsys\FrameworkBundle\Component\Domain\Domain
-     */
-    protected $domain;
-
-    /**
-     * @var \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory
-     */
-    protected $domainRouterFactory;
+    protected const PRIORITY_NONE = null;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Sitemap\SitemapFacade $sitemapFacade
@@ -39,13 +25,10 @@ class SitemapListener implements EventSubscriberInterface
      * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory
      */
     public function __construct(
-        SitemapFacade $sitemapFacade,
-        Domain $domain,
-        DomainRouterFactory $domainRouterFactory
+        protected readonly SitemapFacade $sitemapFacade,
+        protected readonly Domain $domain,
+        protected readonly DomainRouterFactory $domainRouterFactory
     ) {
-        $this->sitemapFacade = $sitemapFacade;
-        $this->domain = $domain;
-        $this->domainRouterFactory = $domainRouterFactory;
     }
 
     /**
@@ -68,9 +51,14 @@ class SitemapListener implements EventSubscriberInterface
 
         /** @var \Presta\SitemapBundle\Service\AbstractGenerator $generator */
         $generator = $event->getUrlContainer();
+        $generator->setDefaults([
+            'priority' => static::PRIORITY_NONE,
+            'changefreq' => null,
+            'lastmod' => null,
+        ]);
         $domainConfig = $this->domain->getDomainConfigById($domainId);
 
-        $this->addHomepageUrl($generator, $domainConfig, $section, static::PRIORITY_HOMEPAGE);
+        $this->addHomepageUrl($generator, $domainConfig, $section, static::PRIORITY_NONE);
 
         $productSitemapItems = $this->sitemapFacade->getSitemapItemsForListableProducts($domainConfig);
         $this->addUrlsBySitemapItems(
@@ -78,7 +66,7 @@ class SitemapListener implements EventSubscriberInterface
             $generator,
             $domainConfig,
             $section,
-            static::PRIORITY_PRODUCTS
+            static::PRIORITY_NONE
         );
 
         $categorySitemapItems = $this->sitemapFacade->getSitemapItemsForVisibleCategories($domainConfig);
@@ -87,7 +75,7 @@ class SitemapListener implements EventSubscriberInterface
             $generator,
             $domainConfig,
             $section,
-            static::PRIORITY_CATEGORIES
+            static::PRIORITY_NONE
         );
 
         $articleSitemapItems = $this->sitemapFacade->getSitemapItemsForArticlesOnDomain($domainConfig);
@@ -96,7 +84,7 @@ class SitemapListener implements EventSubscriberInterface
             $generator,
             $domainConfig,
             $section,
-            static::PRIORITY_ARTICLES
+            static::PRIORITY_NONE
         );
     }
 

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -995,3 +995,19 @@ services:
 
     profiler.storage:
         alias: Shopsys\FrameworkBundle\Component\HttpKernel\Profiler\FileProfilerStorage
+
+
+    Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapDumperFactory:
+        arguments:
+            - '@event_dispatcher'
+
+    Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapFacade:
+        arguments:
+            - '%shopsys.sitemaps_dir%'
+            - '%shopsys.sitemaps_url_prefix%'
+
+    Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapListener:
+        tags:
+            - { name: 'kernel.event_subscriber', priority: 100 }
+
+    Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapFilePrefixer: ~

--- a/packages/framework/src/Resources/views/Common/robots.txt.twig
+++ b/packages/framework/src/Resources/views/Common/robots.txt.twig
@@ -1,1 +1,2 @@
 Sitemap: {{ sitemapUrl }}
+Image Sitemap: {{ imageSitemapUrl }}

--- a/project-base/config/services/cron.yaml
+++ b/project-base/config/services/cron.yaml
@@ -52,6 +52,10 @@ services:
         tags:
             - { name: shopsys.cron, hours: '4', minutes: '0', readableName: 'Generate Sitemap' }
 
+    Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapCronModule:
+        tags:
+            - { name: shopsys.cron, hours: '4', minutes: '10', readableName: 'Generate image sitemap' }
+
     Shopsys\FrameworkBundle\Component\FileUpload\DeleteOldUploadedFilesCronModule:
         tags:
             - { name: shopsys.cron, hours: '5', minutes: '0', readableName: 'Delete old temporary uploaded files' }

--- a/project-base/src/Controller/Front/RobotsController.php
+++ b/project-base/src/Controller/Front/RobotsController.php
@@ -45,6 +45,7 @@ class RobotsController extends FrontBaseController
         $sitemapFilePrefix = $this->sitemapFilePrefixer->getSitemapFilePrefixForDomain($this->domain->getId());
 
         $sitemapUrl = $this->domain->getUrl() . $this->sitemapsUrlPrefix . '/' . $sitemapFilePrefix . '.xml';
+        $imageSitemapUrl = $this->domain->getUrl() . $this->sitemapsUrlPrefix . '/' . $sitemapFilePrefix . '_image' . '.xml';
 
         $response = new Response();
         $response->headers->set('Content-Type', 'text/plain');
@@ -53,6 +54,7 @@ class RobotsController extends FrontBaseController
             '@ShopsysFramework/Common/robots.txt.twig',
             [
                 'sitemapUrl' => $sitemapUrl,
+                'imageSitemapUrl' => $imageSitemapUrl,
             ],
             $response
         );

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -881,6 +881,8 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 - old phpRedisAdmin has been replaced with new Redis Commander ([#2550](https://github.com/shopsys/shopsys/pull/2550))
     - see #project-base-diff to update your project
+- update sitemaps and add product image sitemap ([#2551](https://github.com/shopsys/shopsys/pull/2551))
+    - see #project-base-diff to update your project
 
 ## Composer dependencies
 

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -883,6 +883,11 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 - update sitemaps and add product image sitemap ([#2551](https://github.com/shopsys/shopsys/pull/2551))
     - see #project-base-diff to update your project
+    - from SitemapLister was removed unused constants for page priorities:
+      - PRIORITY_HOMEPAGE
+      - PRIORITY_CATEGORIES
+      - PRIORITY_PRODUCTS
+      - PRIORITY_ARTICLES
 
 ## Composer dependencies
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want the data in the sitemap to be true and relevant, or rather not be there. All information about `<lastmod>`, `<changefreq>` and `<priority>` is removed from the sitemap (page and images). Added image sitemap
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues|  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
