### PR TITLE
[framework] Symfony profiler shows query or mutation name for API requests

### DIFF
--- a/packages/framework/src/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/packages/framework/src/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -74,10 +74,11 @@ class FileProfilerStorage extends BaseFileProfilerStorage
                     $content = json_decode($collector->getContent(), true);
                     if (is_array($content) && array_key_exists('query', $content) && strpos($content['query'], '{')) {
                         $queryString = $content['query'];
-                        $re = '/(?<type>query|mutation){(\s*(?<name>[a-zA-Z0-9]+))/m';
+                        $re = '/(?<type>query|mutation)[^{]*{\s*(?<name>[a-zA-Z0-9]+)/m';
                         $matches = [];
-                        preg_match($re, $queryString, $matches);
-                        $profile->setUrl($profile->getUrl() . ' - ' . $matches['type'] . '{' . $matches['name'] . '}');
+                        if (preg_match($re, $queryString, $matches) !== false) {
+                            $profile->setUrl($profile->getUrl() . ' - ' . $matches['type'] . ' ' . $matches['name']);
+                        }
                     }
                 } catch (InvalidArgumentException) {
                     return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Named queries/mutations should be parsed too. A parsing error should not fall on an silent error. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
