### PR TITLE
[shopsys] locked version of jquery-ui to 1.12.1 in order to fix category ordering in admin

### DIFF
--- a/packages/framework/assets/package.json
+++ b/packages/framework/assets/package.json
@@ -16,7 +16,7 @@
     "counterup2": "^1.0.4",
     "jquery": "^3.4.1",
     "jquery-hoverintent": "^1.10.1",
-    "jquery-ui": "^1.12.1",
+    "jquery-ui": "1.12.1",
     "jquery-ui-touch-punch": "^0.2.3",
     "magnific-popup": "^1.1.0",
     "select2": "^4.0.12",

--- a/project-base/package.json
+++ b/project-base/package.json
@@ -61,7 +61,7 @@
         "codemirror": "^5.49.2",
         "counterup2": "^1.0.4",
         "jquery-hoverintent": "^1.10.1",
-        "jquery-ui": "^1.12.1",
+        "jquery-ui": "1.12.1",
         "jquery-ui-touch-punch": "^0.2.3",
         "jquery.cookie": "^1.4.1",
         "magnific-popup": "^1.1.0",

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -1188,3 +1188,5 @@ There you can find links to upgrade notes for other versions too.
       + __construct(RequestStack $requestStack, CurrentCustomerUser $currentCustomerUser, RouterInterface $router, Domain $domain)
       ```
     - also see #project-base-diff for more information about changes needed to be done in your project
+- lock version of npm `jquery-ui` to version `1.12.1` in order to fix category sorting in admin ([#2558](https://github.com/shopsys/shopsys/pull/2558))
+    - see #project-base-diff for more information about changes needed to be done in your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Newer version breaks nestedSortable https://github.com/ilikenwf/nestedSortable/issues/138. This can be fixed by changing nestedSortable to https://github.com/ilikenwf/nestedSortable after they release newer version than 2.0.0
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
