### PR TITLE
[framework] fixed dumping translations by adding support for translation domain constants

### DIFF
--- a/packages/framework/src/Component/Translation/PhpParserNodeHelper.php
+++ b/packages/framework/src/Component/Translation/PhpParserNodeHelper.php
@@ -4,12 +4,15 @@ namespace Shopsys\FrameworkBundle\Component\Translation;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Scalar\String_;
 use Shopsys\FrameworkBundle\Component\Translation\Exception\StringValueUnextractableException;
 use SplFileInfo;
 
 class PhpParserNodeHelper
 {
+    protected const TRANSLATOR_CLASS_FQN = '\Shopsys\FrameworkBundle\Component\Translation\Translator';
+
     /**
      * @param \PhpParser\Node $node
      * @param \SplFileInfo $fileInfo
@@ -28,10 +31,15 @@ class PhpParserNodeHelper
             );
         }
 
+        if ($node instanceof ClassConstFetch && $node->class->parts[0] === 'Translator') {
+            return constant(static::TRANSLATOR_CLASS_FQN . '::' . $node->name->name);
+        }
+
         throw new StringValueUnextractableException(
             sprintf(
-                'Can only extract the message ID or message domain from a scalar or concatenated string,'
+                'Can only extract the message ID or message domain from a scalar, concatenated string or "%s" class constant,'
                 . ' but got "%s". Please refactor your code to make it extractable (in %s on line %d).',
+                static::TRANSLATOR_CLASS_FQN,
                 get_class($node),
                 $fileInfo,
                 $node->getLine()

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -547,6 +547,9 @@ msgstr "Vytvořeno administrátorem"
 msgid "Created on"
 msgstr "Vytvořeno dne"
 
+msgid "Creation date"
+msgstr "Datum vytvoření"
+
 msgid "Cron overview"
 msgstr "Přehled cronů"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -547,6 +547,9 @@ msgstr ""
 msgid "Created on"
 msgstr ""
 
+msgid "Creation date"
+msgstr ""
+
 msgid "Cron overview"
 msgstr ""
 

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -226,6 +226,9 @@ msgstr "Vyplňte prosím kurz měny"
 msgid "Please enter currency minimum fraction digits"
 msgstr "Prosím zadejte minimální počet desetinných míst měny"
 
+msgid "Please enter date of creation"
+msgstr "Vyplňte prosím datum vytvoření"
+
 msgid "Please enter default VAT"
 msgstr "Prosím zadejte výchozí výši DPH"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -226,6 +226,9 @@ msgstr ""
 msgid "Please enter currency minimum fraction digits"
 msgstr ""
 
+msgid "Please enter date of creation"
+msgstr ""
+
 msgid "Please enter default VAT"
 msgstr ""
 

--- a/project-base/translations/validators.cs.po
+++ b/project-base/translations/validators.cs.po
@@ -61,9 +61,6 @@ msgstr "Vyplňte prosím název firmy"
 msgid "Please enter content"
 msgstr "Vyplňte prosím text"
 
-msgid "Please enter date of creation"
-msgstr "Vyplňte prosím datum vytvoření"
-
 msgid "Please enter email"
 msgstr "Vyplňte prosím e-mail"
 

--- a/project-base/translations/validators.en.po
+++ b/project-base/translations/validators.en.po
@@ -61,9 +61,6 @@ msgstr ""
 msgid "Please enter content"
 msgstr ""
 
-msgid "Please enter date of creation"
-msgstr ""
-
 msgid "Please enter email"
 msgstr ""
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2549 we have started using constants for translation domains, but sadly, that change was poorly tested and we broke translations dumping. This PR fixes that.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
