### PR TITLE
[framework] columns in grid can now be reordered

### DIFF
--- a/docs/administration/grid.md
+++ b/docs/administration/grid.md
@@ -74,6 +74,33 @@ However, not all grids have their own factories, sometimes they are created in p
 In such a case, you need to fork the corresponding method and rewrite it to suit your needs.
 We are planning some refactorings to enable you easier and unified way of grid customizations.
 
+### Reordering columns
+If you need to reorder columns in the existing grid, you may use the `reorderColumns()` method.
+
+```php
+namespace App\Grid\Payment;
+
+use Shopsys\FrameworkBundle\Model\Payment\Grid\PaymentGridFactory as BasePaymentGridFactory;
+
+class PaymentGridFactory extends BasePaymentGridFactory
+{
+    public function create()
+    {
+        $grid = parent::create();
+ 
+        $grid->reorderColumns([
+            'enabled',
+            'name',
+        ]);
+ 
+        return $grid;
+    }
+}
+```
+
+Grid columns will be rendered in the order they are defined in the `reorderColumns()` method.
+If any column is missing in the `reorderColumns` method call, it will be rendered after mentioned columns in the original order. 
+
 ## Further reading - cookbooks
 If you want to implement a new grid, you can follow the cookbooks:
 

--- a/packages/framework/src/Component/Grid/Grid.php
+++ b/packages/framework/src/Component/Grid/Grid.php
@@ -777,4 +777,18 @@ class Grid
     {
         return $this->multipleDragAndDrop;
     }
+
+    /**
+     * @param string[] $orderedColumnIds
+     */
+    public function reorderColumns(array $orderedColumnIds): void
+    {
+        $orderedColumns = [];
+
+        foreach ($orderedColumnIds as $columnId) {
+            $orderedColumns[$columnId] = $this->columnsById[$columnId];
+        }
+
+        $this->columnsById = [...$orderedColumns, ...$this->columnsById];
+    }
 }

--- a/packages/framework/tests/Unit/Component/Grid/GridTest.php
+++ b/packages/framework/tests/Unit/Component/Grid/GridTest.php
@@ -308,4 +308,39 @@ class GridTest extends TestCase
         $grid->enableDragAndDrop($entityClass);
         $this->assertTrue($grid->isDragAndDrop());
     }
+
+    public function testReorderColumns(): void
+    {
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $twigMock = $this->createMock(Environment::class);
+        $routerMock = $this->createMock(Router::class);
+        $routeCsrfProtectorMock = $this->createMock(RouteCsrfProtector::class);
+        $dataSourceMock = $this->createMock(DataSourceInterface::class);
+
+        $grid = new Grid(
+            'gridId',
+            $dataSourceMock,
+            $requestStack,
+            $routerMock,
+            $routeCsrfProtectorMock,
+            $twigMock
+        );
+
+        $column1 = $grid->addColumn('columnId1', 'sourceColumnName1', 'title1');
+        $column2 = $grid->addColumn('columnId2', 'sourceColumnName2', 'title2');
+        $column3 = $grid->addColumn('columnId3', 'sourceColumnName3', 'title3');
+
+        $grid->reorderColumns(['columnId2', 'columnId1']);
+
+        $expectedColumns = [
+            'columnId2' => $column2,
+            'columnId1' => $column1,
+            'columnId3' => $column3,
+        ];
+
+        $this->assertSame($expectedColumns, $grid->getColumnsById());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If project extend any existing grid (for example Product List grid in administration), it may be useful to be able to reorder columns (when it's needed to have fields in specific order)
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
