### PR TITLE
[shopsys] added Translator constant for validators

### DIFF
--- a/packages/framework/src/Component/Translation/ConfigConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConfigConstraintMessageExtractor.php
@@ -49,7 +49,7 @@ class ConfigConstraintMessageExtractor implements FileVisitorInterface
                 foreach ($messages as $message) {
                     // message value can be null or ~
                     if (is_string($message)) {
-                        $catalogue->add(new Message($message, ConstraintMessageExtractor::CONSTRAINT_MESSAGE_DOMAIN));
+                        $catalogue->add(new Message($message, Translator::VALIDATOR_TRANSLATION_DOMAIN));
                     }
                 }
             }

--- a/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
@@ -33,8 +33,6 @@ use Twig\Node\Node as TwigNode;
  */
 class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
 {
-    public const CONSTRAINT_MESSAGE_DOMAIN = 'validators';
-
     /**
      * @var \PhpParser\NodeTraverser
      */
@@ -100,7 +98,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
                 if ($this->isMessageOptionItem($optionItemNode)) {
                     $messageId = PhpParserNodeHelper::getConcatenatedStringValue($optionItemNode->value, $this->file);
 
-                    $message = new Message($messageId, self::CONSTRAINT_MESSAGE_DOMAIN);
+                    $message = new Message($messageId, Translator::VALIDATOR_TRANSLATION_DOMAIN);
                     $message->addSource(new FileSource($this->file->getFilename(), $optionItemNode->getLine()));
 
                     $this->catalogue->add($message);

--- a/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
@@ -115,7 +115,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
             if ($this->isMessagePropertyProperty($propertyProperty)) {
                 $messageId = PhpParserNodeHelper::getConcatenatedStringValue($propertyProperty->default, $this->file);
 
-                $message = new Message($messageId, ConstraintMessageExtractor::CONSTRAINT_MESSAGE_DOMAIN);
+                $message = new Message($messageId, Translator::VALIDATOR_TRANSLATION_DOMAIN);
                 $message->addSource(new FileSource($this->file->getFilename(), $propertyProperty->getLine()));
 
                 $this->catalogue->add($message);

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -142,7 +142,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
 
         $messageId = $firstArgumentWithMessage->value->value; // value with translatable message
 
-        $message = new Message($messageId, ConstraintMessageExtractor::CONSTRAINT_MESSAGE_DOMAIN);
+        $message = new Message($messageId, Translator::VALIDATOR_TRANSLATION_DOMAIN);
         $message->addSource(new FileSource($this->file->getFilename(), $firstArgumentWithMessage->getLine()));
 
         $this->catalogue->add($message);

--- a/packages/framework/src/Component/Translation/Translator.php
+++ b/packages/framework/src/Component/Translation/Translator.php
@@ -14,6 +14,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
 {
     public const DEFAULT_TRANSLATION_DOMAIN = 'messages';
     public const DATA_FIXTURES_TRANSLATION_DOMAIN = 'dataFixtures';
+    public const VALIDATOR_TRANSLATION_DOMAIN = 'validators';
     public const SOURCE_LOCALE = 'en';
 
     /**

--- a/project-base/tests/App/Acceptance/acceptance/PageObject/Front/RegistrationPage.php
+++ b/project-base/tests/App/Acceptance/acceptance/PageObject/Front/RegistrationPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\App\Acceptance\acceptance\PageObject\Front;
 
 use Shopsys\FrameworkBundle\Component\Form\TimedFormTypeExtension;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Tests\App\Acceptance\acceptance\PageObject\AbstractPage;
 use Tests\App\Test\Codeception\AcceptanceTester;
 use Tests\App\Test\Codeception\Module\StrictWebDriver;
@@ -83,7 +84,7 @@ class RegistrationPage extends AbstractPage
         // Error message might be in fancy title - hover over field
         $this->tester->moveMouseOverByCss($fieldClass);
 
-        $this->tester->seeTranslationFrontend($text, 'validators');
+        $this->tester->seeTranslationFrontend($text, Translator::VALIDATOR_TRANSLATION_DOMAIN);
     }
 
     /**

--- a/project-base/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Customer\User;
 
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
 
 class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
@@ -88,19 +89,19 @@ mutation {
             0 => t(
                 'First name cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 100],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
             1 => t(
                 'Last name cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 100],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
             2 => t(
                 'Telephone number cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 30],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
         ];

--- a/project-base/tests/FrontendApiBundle/Functional/Customer/User/RegisterTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Customer/User/RegisterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Customer\User;
 
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class RegisterTest extends GraphQlTestCase
@@ -36,7 +37,7 @@ class RegisterTest extends GraphQlTestCase
         $expectedViolationMessage = t(
             'This email is already registered',
             [],
-            'validators',
+            Translator::VALIDATOR_TRANSLATION_DOMAIN,
             $firstDomainLocale
         );
 
@@ -70,25 +71,25 @@ class RegisterTest extends GraphQlTestCase
             0 => t(
                 'First name cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 100],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
             1 => t(
                 'Last name cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 100],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
             2 => t(
                 'Please enter valid email',
                 [],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
             3 => t(
                 'Password must be at least {{ limit }} characters long',
                 ['{{ limit }}' => 6],
-                'validators',
+                Translator::VALIDATOR_TRANSLATION_DOMAIN,
                 $firstDomainLocale
             ),
         ];

--- a/project-base/tests/FrontendApiBundle/Functional/Newsletter/NewsletterTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Newsletter/NewsletterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\Functional\Newsletter;
 
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class NewsletterTest extends GraphQlTestCase
@@ -33,7 +34,7 @@ class NewsletterTest extends GraphQlTestCase
         $emailError = $responseData['input.email'][0];
 
         $firstDomainLocale = $this->getLocaleForFirstDomain();
-        $expectedViolationMessage = t('Please enter valid email', [], 'validators', $firstDomainLocale);
+        $expectedViolationMessage = t('Please enter valid email', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale);
 
         $this->assertArrayHasKey('message', $emailError);
         $this->assertEquals($expectedViolationMessage, $emailError['message']);

--- a/project-base/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/CompanyFieldsAreValidatedTest.php
@@ -8,6 +8,7 @@ use App\DataFixtures\Demo\PaymentDataFixture;
 use App\DataFixtures\Demo\ProductDataFixture;
 use App\DataFixtures\Demo\TransportDataFixture;
 use App\DataFixtures\Demo\VatDataFixture;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 
 class CompanyFieldsAreValidatedTest extends AbstractOrderTestCase
 {
@@ -17,13 +18,13 @@ class CompanyFieldsAreValidatedTest extends AbstractOrderTestCase
         $expectedValidations = [
             'input.companyName' => [
                 0 => [
-                    'message' => t('Please enter company name', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter company name', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.companyNumber' => [
                 0 => [
-                    'message' => t('Please enter identification number', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter identification number', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],

--- a/project-base/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php
+++ b/project-base/tests/FrontendApiBundle/Functional/Order/DeliveryFieldsAreValidatedTest.php
@@ -8,6 +8,7 @@ use App\DataFixtures\Demo\PaymentDataFixture;
 use App\DataFixtures\Demo\ProductDataFixture;
 use App\DataFixtures\Demo\TransportDataFixture;
 use App\DataFixtures\Demo\VatDataFixture;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 
 class DeliveryFieldsAreValidatedTest extends AbstractOrderTestCase
 {
@@ -17,37 +18,37 @@ class DeliveryFieldsAreValidatedTest extends AbstractOrderTestCase
         $expectedValidations = [
             'input.deliveryFirstName' => [
                 0 => [
-                    'message' => t('Please enter first name of contact person', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter first name of contact person', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryLastName' => [
                 0 => [
-                    'message' => t('Please enter last name of contact person', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter last name of contact person', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryStreet' => [
                 0 => [
-                    'message' => t('Please enter street', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter street', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryCity' => [
                 0 => [
-                    'message' => t('Please enter city', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter city', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryPostcode' => [
                 0 => [
-                    'message' => t('Please enter zip code', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please enter zip code', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],
             'input.deliveryCountry' => [
                 0 => [
-                    'message' => t('Please choose country', [], 'validators', $firstDomainLocale),
+                    'message' => t('Please choose country', [], Translator::VALIDATOR_TRANSLATION_DOMAIN, $firstDomainLocale),
                     'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
                 ],
             ],

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -1193,3 +1193,7 @@ There you can find links to upgrade notes for other versions too.
     - also see #project-base-diff for more information about changes needed to be done in your project
 - lock version of npm `jquery-ui` to version `1.12.1` in order to fix category sorting in admin ([#2558](https://github.com/shopsys/shopsys/pull/2558))
     - see #project-base-diff for more information about changes needed to be done in your project
+- use `Shopsys\FrameworkBundle\Component\Translation\Translator::VALIDATOR_TRANSLATION_DOMAIN` for validators translations ()
+    - `Shopsys\FrameworkBundle\Component\Translation\ConstraintMessageExtractor` class:
+        - constant `CONSTRAINT_MESSAGE_DOMAIN` has been removed, use `Shopsys\FrameworkBundle\Component\Translation\Translator::VALIDATOR_TRANSLATION_DOMAIN` instead
+    - also see #project-base-diff for more information about changes needed to be done in your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In previous PRs we have added translation constants for messages and data fixtures but forgot about validators, this PR fixes it.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
