### PR TITLE
[frontend-api] UserEntityNotFoundError has been renamed to EntityNotFoundUserError

### DIFF
--- a/packages/frontend-api/src/Model/Error/EntityNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Error/EntityNotFoundUserError.php
@@ -6,7 +6,7 @@ namespace Shopsys\FrontendApiBundle\Model\Error;
 
 use Overblog\GraphQLBundle\Error\UserError;
 
-abstract class UserEntityNotFoundError extends UserError
+abstract class EntityNotFoundUserError extends UserError
 {
     /**
      * @param string $message

--- a/packages/frontend-api/src/Model/Resolver/Article/Exception/ArticleNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/Exception/ArticleNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Article\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class ArticleNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class ArticleNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'article-not-found';
 

--- a/packages/frontend-api/src/Model/Resolver/Brand/Exception/BrandNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Brand/Exception/BrandNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Brand\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class BrandNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class BrandNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'brand-not-found';
 

--- a/packages/frontend-api/src/Model/Resolver/Category/Exception/CategoryNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/Exception/CategoryNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Category\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class CategoryNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class CategoryNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'category-not-found';
 

--- a/packages/frontend-api/src/Model/Resolver/Order/Exception/OrderNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/Exception/OrderNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Order\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class OrderNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class OrderNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'order-not-found';
 

--- a/packages/frontend-api/src/Model/Resolver/Payment/Exception/PaymentNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/Exception/PaymentNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Payment\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class PaymentNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class PaymentNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'payment-not-found';
 

--- a/packages/frontend-api/src/Model/Resolver/Products/Exception/ProductNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/Exception/ProductNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Products\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class ProductNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class ProductNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'product-not-found';
 

--- a/packages/frontend-api/src/Model/Resolver/Transport/Exception/TransportNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/Exception/TransportNotFoundUserError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Resolver\Transport\Exception;
 
-use Shopsys\FrontendApiBundle\Model\Error\UserEntityNotFoundError;
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
-class TransportNotFoundUserError extends UserEntityNotFoundError implements UserErrorWithCodeInterface
+class TransportNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
 {
     protected const CODE = 'transport-not-found';
 

--- a/upgrade/UPGRADE-v11.0.0-dev.md
+++ b/upgrade/UPGRADE-v11.0.0-dev.md
@@ -1622,3 +1622,5 @@ There you can find links to upgrade notes for other versions too.
         + uploadImages(object $entity, array $currentFilenamesIndexedByImageIdAndLocale, ?array $temporaryFilenamesIndexedByImageId, ?string $type)
         ```
     - also see #project-base-diff for more information about changes needed to be done in your project
+- update abstract class of UserErrors in frontend API ([#])
+    - `UserEntityNotFoundError` has been renamed to `EntityNotFoundUserError` update all your usages accordingly


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| UserEntityNotFoundError was badly named so we fixed it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
