### PR TITLE
[releaser] switched from old changelog to Github Releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+changelog:
+    exclude:
+        labels:
+            - "Will not fix"
+    categories:
+        - title: ":sparkles: Enhancements and features"
+          labels:
+              - "Enhancement"
+        - title: ":bug: Bug Fixes"
+          labels:
+              - "Bug"
+        - title: ":hammer: Developer experience and refactoring"
+          labels:
+              - "DX & Refactoring"
+        - title: ":book: Documentation"
+          labels:
+              - "Documentation"
+        - title: ":art: Design & appearance"
+          labels:
+              - "Design & Appearance"
+        - title: ":rocket: Performance"
+          labels:
+              - "Performance"
+        - title: ":cloud: Infrastructure"
+          labels:
+              - "Infrastructure"
+        - title: ":warning: Security"
+          labels:
+              - "Security"
+        - title: "Other Changes"
+          labels:
+              - "*"

--- a/utils/releaser/config/release.php
+++ b/utils/releaser/config/release.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Shopsys\Releaser\ReleaseWorker\CheckCorrectReleaseVersionReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\Release\CheckChangelogForTodaysDateReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\Release\CheckoutToReleaseCandidateBranchReleaseWorker;
+use Shopsys\Releaser\ReleaseWorker\Release\CheckReleaseDraftAndReleaseItReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\Release\CheckUncommittedChangesReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\Release\CreateAndCommitLockFilesReleaseWorker;
 use Shopsys\Releaser\ReleaseWorker\Release\CreateAndPushGitTagReleaseWorker;
@@ -28,4 +29,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(CreateAndPushGitTagsExceptProjectBaseReleaseWorker::class);
     $services->set(CreateAndCommitLockFilesReleaseWorker::class);
     $services->set(CreateAndPushGitTagReleaseWorker::class);
+    $services->set(CheckReleaseDraftAndReleaseItReleaseWorker::class);
 };

--- a/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesGithubActionsBuildsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractCheckPackagesGithubActionsBuildsReleaseWorker.php
@@ -57,7 +57,7 @@ abstract class AbstractCheckPackagesGithubActionsBuildsReleaseWorker extends Abs
         );
         $statusForPackages = $this->githubActionsStatusReporter->getStatusForPackagesByOrganizationAndBranch(
             'shopsys',
-            $this->getBranchName(),
+            $initialBranchName,
             $githubToken
         );
 

--- a/utils/releaser/src/ReleaseWorker/Release/CheckReleaseDraftAndReleaseItReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/Release/CheckReleaseDraftAndReleaseItReleaseWorker.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\Releaser\ReleaseWorker\Release;
+
+use PharIo\Version\Version;
+use Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker;
+use Shopsys\Releaser\Stage;
+
+final class CheckReleaseDraftAndReleaseItReleaseWorker extends AbstractShopsysReleaseWorker
+{
+    /**
+     * @param \PharIo\Version\Version $version
+     * @param string $initialBranchName
+     * @return string
+     */
+    public function getDescription(Version $version, string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME): string
+    {
+        return '[Manually] Update release draft to make release of it.';
+    }
+
+    /**
+     * @param \PharIo\Version\Version $version
+     * @param string $initialBranchName
+     */
+    public function work(Version $version, string $initialBranchName = AbstractShopsysReleaseWorker::MAIN_BRANCH_NAME): void
+    {
+        $this->symfonyStyle->note('Go to https://github.com/shopsys/shopsys/releases and find draft you have created earlier.');
+        $this->symfonyStyle->note('Edit draft, check if today date is set in title, set it as latest release if you are releasing highest version yet and click Publish release.');
+
+        $this->confirm('Confirm that you have updated draft and turned it into release.');
+    }
+
+    /**
+     * @return string
+     */
+    public function getStage(): string
+    {
+        return Stage::RELEASE;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Old changelog generator was problematic and we found, that Github solves this for us.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
