### PR TITLE
Fix broken interface

### DIFF
--- a/packages/framework/src/Form/Transformers/CategoriesIdsToCategoriesTransformer.php
+++ b/packages/framework/src/Form/Transformers/CategoriesIdsToCategoriesTransformer.php
@@ -26,7 +26,7 @@ class CategoriesIdsToCategoriesTransformer implements DataTransformerInterface
      * @param \Shopsys\FrameworkBundle\Model\Category\Category[]|null $categories
      * @return int[]
      */
-    public function transform($categories): array
+    public function transform($categories)
     {
         $categoriesIds = [];
 
@@ -41,9 +41,9 @@ class CategoriesIdsToCategoriesTransformer implements DataTransformerInterface
 
     /**
      * @param int[] $categoriesIds
-     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
+     * @return \Shopsys\FrameworkBundle\Model\Category\Category[]|null
      */
-    public function reverseTransform($categoriesIds): array
+    public function reverseTransform($categoriesIds)
     {
         $categories = [];
 

--- a/packages/framework/src/Form/Transformers/CategoriesTypeTransformer.php
+++ b/packages/framework/src/Form/Transformers/CategoriesTypeTransformer.php
@@ -24,7 +24,7 @@ class CategoriesTypeTransformer implements DataTransformerInterface
      * @param \Shopsys\FrameworkBundle\Model\Category\Category[]|null $categories
      * @return bool[]
      */
-    public function transform($categories): array
+    public function transform($categories)
     {
         $categories = $categories ?? [];
         $allCategories = $this->categoryFacade->getAllCategoriesOfCollapsedTree($categories);
@@ -42,7 +42,7 @@ class CategoriesTypeTransformer implements DataTransformerInterface
      * @param bool[]|null $isCheckedIndexedByCategoryId
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
-    public function reverseTransform($isCheckedIndexedByCategoryId): array
+    public function reverseTransform($isCheckedIndexedByCategoryId)
     {
         $categories = [];
         foreach ($isCheckedIndexedByCategoryId ?? [] as $categoryId => $isChecked) {

--- a/packages/framework/src/Form/Transformers/EmptyWysiwygTransformer.php
+++ b/packages/framework/src/Form/Transformers/EmptyWysiwygTransformer.php
@@ -10,7 +10,7 @@ class EmptyWysiwygTransformer implements DataTransformerInterface
      * @param mixed $value
      * @return mixed
      */
-    public function reverseTransform($value): mixed
+    public function reverseTransform($value)
     {
         return $value;
     }
@@ -19,7 +19,7 @@ class EmptyWysiwygTransformer implements DataTransformerInterface
      * @param mixed $value
      * @return mixed
      */
-    public function transform($value): mixed
+    public function transform($value)
     {
         $trimmedValue = strip_tags(preg_replace('/\s|\&nbsp\;/', '', $value));
         if ($trimmedValue === '') {

--- a/packages/framework/src/Form/Transformers/ImagesIdsToImagesTransformer.php
+++ b/packages/framework/src/Form/Transformers/ImagesIdsToImagesTransformer.php
@@ -26,7 +26,7 @@ class ImagesIdsToImagesTransformer implements DataTransformerInterface
      * @param \Shopsys\FrameworkBundle\Component\Image\Image[]|null $images
      * @return int[]
      */
-    public function transform($images): array
+    public function transform($images)
     {
         $imagesIds = [];
 
@@ -41,9 +41,9 @@ class ImagesIdsToImagesTransformer implements DataTransformerInterface
 
     /**
      * @param int[] $imagesIds
-     * @return \Shopsys\FrameworkBundle\Component\Image\Image[]
+     * @return \Shopsys\FrameworkBundle\Component\Image\Image[]|null
      */
-    public function reverseTransform($imagesIds): array
+    public function reverseTransform($imagesIds)
     {
         $images = [];
 

--- a/packages/framework/src/Form/Transformers/IndexedBooleansToArrayOfIndexesTransformer.php
+++ b/packages/framework/src/Form/Transformers/IndexedBooleansToArrayOfIndexesTransformer.php
@@ -9,7 +9,7 @@ class IndexedBooleansToArrayOfIndexesTransformer implements DataTransformerInter
     /**
      * {@inheritdoc}
      */
-    public function transform($value): ?array
+    public function transform($value)
     {
         if (!is_array($value)) {
             return null;
@@ -21,7 +21,7 @@ class IndexedBooleansToArrayOfIndexesTransformer implements DataTransformerInter
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($value): ?array
+    public function reverseTransform($value)
     {
         if (!is_array($value)) {
             return null;

--- a/packages/framework/src/Form/Transformers/InverseMultipleChoiceTransformer.php
+++ b/packages/framework/src/Form/Transformers/InverseMultipleChoiceTransformer.php
@@ -22,7 +22,7 @@ class InverseMultipleChoiceTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function transform($value): ?array
+    public function transform($value)
     {
         if (!is_array($value)) {
             return null;
@@ -34,7 +34,7 @@ class InverseMultipleChoiceTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function reverseTransform($value): ?array
+    public function reverseTransform($value)
     {
         if (!is_array($value)) {
             return null;

--- a/packages/framework/src/Form/Transformers/InverseTransformer.php
+++ b/packages/framework/src/Form/Transformers/InverseTransformer.php
@@ -10,7 +10,7 @@ class InverseTransformer implements DataTransformerInterface
      * @param bool $value
      * @return bool
      */
-    public function transform($value): bool
+    public function transform($value)
     {
         return !$value;
     }
@@ -19,7 +19,7 @@ class InverseTransformer implements DataTransformerInterface
      * @param bool $value
      * @return bool
      */
-    public function reverseTransform($value): bool
+    public function reverseTransform($value)
     {
         return !$value;
     }

--- a/packages/framework/src/Form/Transformers/NoopDataTransformer.php
+++ b/packages/framework/src/Form/Transformers/NoopDataTransformer.php
@@ -9,7 +9,7 @@ class NoopDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function reverseTransform($value): mixed
+    public function reverseTransform($value)
     {
         return $value;
     }
@@ -17,7 +17,7 @@ class NoopDataTransformer implements DataTransformerInterface
     /**
      * {@inheritDoc}
      */
-    public function transform($value): mixed
+    public function transform($value)
     {
         return $value;
     }

--- a/packages/framework/src/Form/Transformers/ProductIdToProductTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductIdToProductTransformer.php
@@ -27,7 +27,7 @@ class ProductIdToProductTransformer implements DataTransformerInterface
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
      * @return int|null
      */
-    public function transform($product): ?int
+    public function transform($product)
     {
         if ($product instanceof Product) {
             return $product->getId();
@@ -39,7 +39,7 @@ class ProductIdToProductTransformer implements DataTransformerInterface
      * @param int $productId
      * @return \Shopsys\FrameworkBundle\Model\Product\Product|null
      */
-    public function reverseTransform($productId): ?Product
+    public function reverseTransform($productId)
     {
         if ((int)$productId === 0) {
             return null;

--- a/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductParameterValueToProductParameterValuesLocalizedTransformer.php
@@ -36,7 +36,7 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
      * @param mixed $value
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData[]|null
      */
-    public function transform($value): ?array
+    public function transform($value)
     {
         if ($value === null) {
             return null;
@@ -68,7 +68,7 @@ class ProductParameterValueToProductParameterValuesLocalizedTransformer implemen
      * @param mixed $value
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[]
      */
-    public function reverseTransform($value): array
+    public function reverseTransform($value)
     {
         if (is_array($value)) {
             $modelData = [];

--- a/packages/framework/src/Form/Transformers/ProductsIdsToProductsTransformer.php
+++ b/packages/framework/src/Form/Transformers/ProductsIdsToProductsTransformer.php
@@ -26,7 +26,7 @@ class ProductsIdsToProductsTransformer implements DataTransformerInterface
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[]|null $products
      * @return int[]
      */
-    public function transform($products): array
+    public function transform($products)
     {
         $productsIds = [];
 
@@ -41,9 +41,9 @@ class ProductsIdsToProductsTransformer implements DataTransformerInterface
 
     /**
      * @param int[] $productsIds
-     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]|null
      */
-    public function reverseTransform($productsIds): array
+    public function reverseTransform($productsIds)
     {
         $products = [];
 

--- a/packages/framework/src/Form/Transformers/RemoveDuplicatesFromArrayTransformer.php
+++ b/packages/framework/src/Form/Transformers/RemoveDuplicatesFromArrayTransformer.php
@@ -10,7 +10,7 @@ class RemoveDuplicatesFromArrayTransformer implements DataTransformerInterface
      * @param mixed $values
      * @return mixed
      */
-    public function transform($values): mixed
+    public function transform($values)
     {
         return $values;
     }
@@ -19,7 +19,7 @@ class RemoveDuplicatesFromArrayTransformer implements DataTransformerInterface
      * @param array|null $array
      * @return array|null
      */
-    public function reverseTransform($array): ?array
+    public function reverseTransform($array)
     {
         if (is_array($array)) {
             $result = [];

--- a/packages/framework/src/Form/Transformers/RemoveWhitespacesTransformer.php
+++ b/packages/framework/src/Form/Transformers/RemoveWhitespacesTransformer.php
@@ -10,7 +10,7 @@ class RemoveWhitespacesTransformer implements DataTransformerInterface
      * @param string|null $value
      * @return string|null
      */
-    public function transform($value): ?string
+    public function transform($value)
     {
         return $value;
     }
@@ -19,7 +19,7 @@ class RemoveWhitespacesTransformer implements DataTransformerInterface
      * @param string|null $value
      * @return string|null
      */
-    public function reverseTransform($value): ?string
+    public function reverseTransform($value)
     {
         return $value === null ? null : preg_replace('/\s/', '', $value);
     }

--- a/upgrade/UPGRADE-v11.0.1-dev.md
+++ b/upgrade/UPGRADE-v11.0.1-dev.md
@@ -4,3 +4,6 @@ This guide contains instructions to upgrade from version v11.0.0 to v11.0.1-dev.
 
 **Before you start, don't forget to take a look at [general instructions](https://github.com/shopsys/shopsys/blob/7.3/UPGRADE.md) about upgrading.**
 There you can find links to upgrade notes for other versions too.
+
+- Fix broken interface ([#2580](https://github.com/shopsys/shopsys/pull/2580))
+    - update your Transformers by DataTransformerInterface.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This reverts commit 5ef06b304e147be64adf51322d82966d8efa977d. All Transformer classes implement theDataTransformerInterface and a previous modification broke this interface.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
