### PR TITLE
[framework] set products for export to elastic after changing quantity after completing, editing, or deleting order

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -56,7 +56,19 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   add test to keep Elasticsearch converter and mapping in sync ([#2880](https://github.com/shopsys/shopsys/pull/2880))
     -   see #project-base-diff to update your project
-
+-   set products for export to elastic after changing quantity after completing, editing, or deleting order ([#2587](https://github.com/shopsys/shopsys/pull/2587))
+    -   method `Shopsys\FrameworkBundle\Model\Order\Item\OrderProductFacade::__construct()` changed its interface:
+        ```diff
+            public function __construct(
+                protected readonly EntityManagerInterface $em,
+                protected readonly ProductHiddenRecalculator $productHiddenRecalculator,
+                protected readonly ProductSellingDeniedRecalculator $productSellingDeniedRecalculator,
+                protected readonly ProductAvailabilityRecalculationScheduler $productAvailabilityRecalculationScheduler,
+                protected readonly ProductVisibilityFacade $productVisibilityFacade,
+                protected readonly ModuleFacade $moduleFacade,
+        +       protected readonly ProductRepository $productRepository,
+            )
+        ```
 ### Storefront
 
 -   add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Model/Order/Item/OrderProductFacade.php
+++ b/packages/framework/src/Model/Order/Item/OrderProductFacade.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Model\Module\ModuleFacade;
 use Shopsys\FrameworkBundle\Model\Module\ModuleList;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculationScheduler;
 use Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator;
+use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 use Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 
@@ -21,6 +22,7 @@ class OrderProductFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculationScheduler $productAvailabilityRecalculationScheduler
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade $productVisibilityFacade
      * @param \Shopsys\FrameworkBundle\Model\Module\ModuleFacade $moduleFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
@@ -29,6 +31,7 @@ class OrderProductFacade
         protected readonly ProductAvailabilityRecalculationScheduler $productAvailabilityRecalculationScheduler,
         protected readonly ProductVisibilityFacade $productVisibilityFacade,
         protected readonly ModuleFacade $moduleFacade,
+        protected readonly ProductRepository $productRepository,
     ) {
     }
 
@@ -89,6 +92,7 @@ class OrderProductFacade
         $this->em->flush();
 
         $this->productVisibilityFacade->refreshProductsVisibilityForMarked();
+        $this->productRepository->markProductsForExport($relevantProducts);
     }
 
     /**

--- a/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Item/OrderProductFacadeTest.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculationScheduler;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator;
+use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 use Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 use Tests\FrameworkBundle\Unit\Model\Product\TestProductProvider;
@@ -39,6 +40,7 @@ final class OrderProductFacadeTest extends TestCase
             $this->createMock(ProductAvailabilityRecalculationScheduler::class),
             $this->createMock(ProductVisibilityFacade::class),
             $moduleFacadeMock,
+            $this->createMock(ProductRepository::class),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When customer creates order or administrator edit/delete order, products are not marked for export to elastic. For example, customer sold out product but elastic doesn't know product is sold out and eshop still shows products as available but he is not, so I recommend mark bought products for export to elastic. Thanks 🤝
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
