### PR TITLE
[shopsys] checking if order status update email should be sent is done directly in OrderMailFacade instead in multiple places

### DIFF
--- a/packages/framework/src/Model/Order/Mail/OrderMailFacade.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMailFacade.php
@@ -54,6 +54,11 @@ class OrderMailFacade
     public function sendEmail(Order $order)
     {
         $mailTemplate = $this->getMailTemplateByStatusAndDomainId($order->getStatus(), $order->getDomainId());
+
+        if (!$mailTemplate->isSendMail()) {
+            return;
+        }
+
         $messageData = $this->orderMail->createMessage($mailTemplate, $order);
         $messageData->attachments = $this->uploadedFileFacade->getUploadedFilesByEntity($mailTemplate);
         $this->mailer->send($messageData);

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -356,11 +356,8 @@ class OrderFacade
 
         $this->em->flush();
         if ($orderEditResult->isStatusChanged()) {
-            $mailTemplate = $this->orderMailFacade
-                ->getMailTemplateByStatusAndDomainId($order->getStatus(), $order->getDomainId());
-            if ($mailTemplate->isSendMail()) {
-                $this->orderMailFacade->sendEmail($order);
-            }
+            $this->orderMailFacade->sendEmail($order);
+
             if ($originalOrderStatus->getType() === OrderStatus::TYPE_CANCELED) {
                 $this->orderProductFacade->subtractOrderProductsFromStock($order->getProductItems());
             }

--- a/packages/frontend-api/src/Model/Mutation/Order/CreateOrderMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Order/CreateOrderMutation.php
@@ -60,13 +60,7 @@ class CreateOrderMutation extends AbstractMutation
      */
     protected function sendEmail(Order $order)
     {
-        $mailTemplate = $this->orderMailFacade->getMailTemplateByStatusAndDomainId(
-            $order->getStatus(),
-            $order->getDomainId()
-        );
-        if ($mailTemplate->isSendMail()) {
-            $this->orderMailFacade->sendEmail($order);
-        }
+        $this->orderMailFacade->sendEmail($order);
     }
 
     /**

--- a/project-base/src/Controller/Front/OrderController.php
+++ b/project-base/src/Controller/Front/OrderController.php
@@ -6,7 +6,6 @@ namespace App\Controller\Front;
 
 use App\Form\Front\Order\DomainAwareOrderFlowFactory;
 use App\Model\Order\FrontOrderData;
-use App\Model\Order\Order;
 use App\Model\Order\OrderData;
 use App\Model\Order\OrderDataMapper;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
@@ -227,7 +226,7 @@ class OrderController extends FrontBaseController
 
                 $orderFlow->reset();
 
-                $this->sendMail($order);
+                $this->orderMailFacade->sendEmail($order);
 
                 $requestStack->getSession()->set(self::SESSION_CREATED_ORDER, $order->getId());
 
@@ -414,19 +413,5 @@ class OrderController extends FrontBaseController
                 $this->domain->getId()
             ),
         ]);
-    }
-
-    /**
-     * @param \App\Model\Order\Order $order
-     */
-    private function sendMail(Order $order): void
-    {
-        $mailTemplate = $this->orderMailFacade->getMailTemplateByStatusAndDomainId(
-            $order->getStatus(),
-            $order->getDomainId()
-        );
-        if ($mailTemplate->isSendMail()) {
-            $this->orderMailFacade->sendEmail($order);
-        }
     }
 }

--- a/upgrade/UPGRADE-v11.0.1-dev.md
+++ b/upgrade/UPGRADE-v11.0.1-dev.md
@@ -141,3 +141,5 @@ There you can find links to upgrade notes for other versions too.
             </exec>
         </target>
     ```
+- remove no longer necessary encapsulation of sending OrderMail by checking if it is enabled as it is now done directly in OrderMailFacade ([#2588](https://github.com/shopsys/shopsys/pull/2588))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Checking if email can be sent was done on multiple places and developers could forget to do such check. Using of sendMail method should be now more straightforward.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
