### PR TITLE
[framework] added Croatia Kuna as legacy currency

### DIFF
--- a/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
+++ b/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
@@ -238,6 +238,12 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
                 'locale' => 'en',
                 'numeric_code' => '974',
             ]),
+            'HRK' => new Currency([
+                'currency_code' => 'HRK',
+                'name' => 'Croatian Kuna',
+                'locale' => 'en',
+                'numeric_code' => '191',
+            ]),
             'MRO' => new Currency([
                 'currency_code' => 'MRO',
                 'name' => 'Mauritanian Ouguiya',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Croatia Kuna is since 1.1.2023 considered a legacy currency
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
