### PR TITLE
[framework] fixed bc-breaks of cron module runs

### DIFF
--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Command\Exception\CronCommandException;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -188,11 +189,22 @@ class CronCommand extends Command
     }
 
     /**
+     * @phpstan-ignore-next-line
      * @param int $runEveryMin
      * @return \DateTimeImmutable
      */
-    private function getCurrentRoundedTime(int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT)
+    private function getCurrentRoundedTime(/* int $runEveryMin */)
     {
+        $runEveryMin = DeprecationHelper::triggerNewArgumentInMethod(
+            __METHOD__,
+            '$runEveryMin',
+            'int',
+            func_get_args(),
+            0,
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            true
+        );
+
         $time = new DateTime('now', $this->getCronTimeZone());
         $time->modify('-' . $time->format('s') . ' sec');
         $time->modify('-' . ($time->format('i') % $runEveryMin) . ' min');

--- a/packages/framework/src/Component/Cron/Config/CronConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronConfig.php
@@ -6,6 +6,7 @@ use DateTimeInterface;
 use Shopsys\FrameworkBundle\Component\Cron\Config\Exception\CronModuleConfigNotFoundException;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
 use Shopsys\FrameworkBundle\Component\Cron\Exception\InvalidCronModuleException;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
 
@@ -37,7 +38,9 @@ class CronConfig
      * @param string $timeMinutes
      * @param string $instanceName
      * @param string|null $readableName
+     * @phpstan-ignore-next-line
      * @param int $runEveryMin
+     * @phpstan-ignore-next-line
      * @param int $timeoutIteratedCronSec
      */
     public function registerCronModuleInstance(
@@ -47,12 +50,35 @@ class CronConfig
         string $timeMinutes,
         string $instanceName,
         ?string $readableName = null,
-        int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
-        int $timeoutIteratedCronSec = CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT
+        /*
+        int $runEveryMin,
+        int $timeoutIteratedCronSec,
+        */
     ): void {
         if (!$service instanceof SimpleCronModuleInterface && !$service instanceof IteratedCronModuleInterface) {
             throw new InvalidCronModuleException($serviceId);
         }
+
+        $runEveryMin = DeprecationHelper::triggerNewArgumentInMethod(
+            __METHOD__,
+            '$runEveryMin',
+            'int',
+            func_get_args(),
+            6,
+            CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+            true
+        );
+
+        $timeoutIteratedCronSec = DeprecationHelper::triggerNewArgumentInMethod(
+            __METHOD__,
+            '$timeoutIteratedCronSec',
+            'int',
+            func_get_args(),
+            7,
+            CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            true
+        );
+
         $this->cronTimeResolver->validateTimeString($timeHours, 23, 1);
         $this->cronTimeResolver->validateTimeString($timeMinutes, 55, 5);
 

--- a/packages/framework/src/Component/Cron/CronModuleExecutor.php
+++ b/packages/framework/src/Component/Cron/CronModuleExecutor.php
@@ -6,6 +6,7 @@ use DateInterval;
 use DateTimeImmutable;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Deprecations\DeprecationHelper;
 use Shopsys\FrameworkBundle\DependencyInjection\SetterInjectionTrait;
 use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
 use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
@@ -75,7 +76,7 @@ class CronModuleExecutor
                 $cronModuleService->wakeUp();
             }
             $inProgress = true;
-            while ($this->canRun($cronConfig) && $inProgress === true) {
+            while ($inProgress === true && $this->canRun($cronConfig)) {
                 $inProgress = $cronModuleService->iterate();
             }
             if ($inProgress === true) {
@@ -90,11 +91,23 @@ class CronModuleExecutor
 
     /**
      * @phpstan-impure
-     * @param \Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig|null $cronConfig
+     * @phpstan-ignore-next-line
+     * @param \Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig $cronConfig
      * @return bool
      */
-    public function canRun(?CronModuleConfig $cronConfig = null): bool
+    public function canRun(/* CronModuleConfig $cronConfig */): bool
     {
+        $triggerNewArgumentInMethod = DeprecationHelper::triggerNewArgumentInMethod(
+            __METHOD__,
+            '$cronConfig',
+            'CronModuleConfig',
+            func_get_args(),
+            0,
+            null,
+            true
+        );
+        $cronConfig = $triggerNewArgumentInMethod;
+
         if ($cronConfig !== null) {
             $canRunUntil = $this->startedAt->add(
                 DateInterval::createFromDateString($cronConfig->getTimeoutIteratedCronSec() . ' seconds')

--- a/packages/framework/src/Component/Deprecations/DeprecationHelper.php
+++ b/packages/framework/src/Component/Deprecations/DeprecationHelper.php
@@ -92,4 +92,32 @@ final class DeprecationHelper
             $methodName
         );
     }
+
+    /**
+     * @param string $methodName
+     * @param string $argumentName
+     * @param string $argumentType
+     * @param array $functionArguments
+     * @param int $positionOfArgument
+     * @param mixed $defaultValue
+     * @param bool $required
+     * @return mixed
+     */
+    public static function triggerNewArgumentInMethod(string $methodName, string $argumentName, string $argumentType, array $functionArguments, int $positionOfArgument, mixed $defaultValue, bool $required): mixed
+    {
+        if (count($functionArguments) < $positionOfArgument + 1) {
+            if ($required) {
+                self::trigger(
+                    'Method "%s()" will have a new "%s()" argument of type "%s()" in next major version, not defining it is deprecated.',
+                    $methodName,
+                    $argumentName,
+                    $argumentType,
+                );
+            }
+
+            return $defaultValue;
+        }
+
+        return $functionArguments[$positionOfArgument];
+    }
 }

--- a/upgrade/UPGRADE-v11.0.1-dev.md
+++ b/upgrade/UPGRADE-v11.0.1-dev.md
@@ -82,7 +82,7 @@ There you can find links to upgrade notes for other versions too.
         - method `getCurrentRoundedTime` changed its interface:
         ```diff
             function getCurrentRoundedTime(
-        +       int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT
+        +       int $runEveryMin,
             )
         ```
     - `Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor` class:
@@ -96,7 +96,7 @@ There you can find links to upgrade notes for other versions too.
         - method `canRun` changed its interface:
         ```diff
             function canRun(
-        +       CronModuleConfig|null $cronConfig = null
+        +       CronModuleConfig $cronConfig,
             ): bool
         ```
     - `Shopsys\FrameworkBundle\Command\CronCommand` class:
@@ -109,8 +109,8 @@ There you can find links to upgrade notes for other versions too.
                 string $timeMinutes,
                 string $instanceName,
                 ?string $readableName = null,
-        +       int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
-        +       int $timeoutIteratedCronSec = CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT
+        +       int $runEveryMin,
+        +       int $timeoutIteratedCronSec,
             ): void {
         ```
     - `Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig` class:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| During the implementation of cron module runs we have introduced several BC-breaks, we are solving them here.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
