### PR TITLE
[framework] cron overview is now available for admin in the default state

### DIFF
--- a/packages/framework/src/Controller/Admin/DefaultController.php
+++ b/packages/framework/src/Controller/Admin/DefaultController.php
@@ -384,6 +384,10 @@ class DefaultController extends AdminBaseController
      */
     public function cronDetailAction(string $serviceId): Response
     {
+        if ($this->getParameter('shopsys.display_cron_overview_for_superadmin_only') === true) {
+            $this->denyAccessUnlessGranted(Roles::ROLE_SUPER_ADMIN);
+        }
+
         $cronModule = $this->cronModuleFacade->getCronModuleByServiceId($serviceId);
         $cronModuleRuns = $this->cronModuleFacade->getAllRunsByCronModule($cronModule);
         $cronConfig = $this->cronConfig->getCronModuleConfigByServiceId($serviceId);

--- a/packages/framework/src/Resources/config/parameters_common.yaml
+++ b/packages/framework/src/Resources/config/parameters_common.yaml
@@ -19,7 +19,7 @@ parameters:
 
     shopsys.image.enable_lazy_load: false
 
-    shopsys.display_cron_overview_for_superadmin_only: true
+    shopsys.display_cron_overview_for_superadmin_only: false
 
     env(IGNORE_DEFAULT_ADMIN_PASSWORD_CHECK): '0'
     env(REDIS_PREFIX): ''

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2164,6 +2164,9 @@ msgstr "Byla upravena stránka slideru <strong><a href=\"{{ url }}\">{{ name }}<
 msgid "Slider pages"
 msgstr "Stránky slideru"
 
+msgid "Some data may not be localized or serve the technical administrators of the e-shop."
+msgstr "Některé údaje nemusí být lokalizovány nebo slouží technickým správcům e-shopu."
+
 msgid "Sorting priority"
 msgstr "Priorita řazení"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2164,6 +2164,9 @@ msgstr ""
 msgid "Slider pages"
 msgstr ""
 
+msgid "Some data may not be localized or serve the technical administrators of the e-shop."
+msgstr ""
+
 msgid "Sorting priority"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Content/Default/index.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Default/index.html.twig
@@ -76,6 +76,8 @@
             <div class="wrap-bar"></div>
             <h2>{{ 'Cron overview'|trans }} {% if cronGridViews|length > 1 %}({{ instanceName }}){% endif %}</h2>
             {{ cronGridView.render() }}
+            <div class="wrap-bar"></div>
+            <div>{{ 'Some data may not be localized or serve the technical administrators of the e-shop.'|trans }}</div>
         {% endfor %}
     {% endif %}
 {% endblock %}

--- a/project-base/config/packages/security.yaml
+++ b/project-base/config/packages/security.yaml
@@ -85,6 +85,7 @@ security:
         # same pattern must be in routing_front.yaml
         - { path: ^/login-as-remembered-user/$, roles: PUBLIC_ACCESS }
         - { path: ^/admin/superadmin/, roles: ROLE_SUPER_ADMIN }
+        - { path: ^/admin/cron/detail/*, roles: ROLE_ADMIN }
         - { path: ^/admin/cron/*, roles: ROLE_SUPER_ADMIN }
         - { path: ^/admin/currency/, roles: ROLE_SUPER_ADMIN }
         - { path: ^/admin/translation/list/$, roles: ROLE_SUPER_ADMIN }

--- a/project-base/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -14,6 +14,7 @@ use App\DataFixtures\Demo\VatDataFixture;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
+use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule;
 use Shopsys\HttpSmokeTesting\Auth\BasicHttpAuth;
 use Shopsys\HttpSmokeTesting\Auth\NoAuth;
 use Shopsys\HttpSmokeTesting\RequestDataSet;
@@ -296,7 +297,7 @@ class RouteConfigCustomization
                     ->setExpectedStatusCode(200);
             })->customizeByRouteName('admin_default_crondetail', function (RouteConfig $config) {
                 $config->changeDefaultRequestDataSet('Use correct ID of cron module.')
-                    ->setExpectedStatusCode(302);
+                    ->setParameter('serviceId', VatDeletionCronModule::class);
             });
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Cron overview is one of the useful features and should be available even for the admin
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
