### PR TITLE
[framework] RegisterProjectFrameworkClassExtensionCompilerPass now ensures that both class and interface alias are registered in Symfony services

### DIFF
--- a/packages/framework/ecs.php
+++ b/packages/framework/ecs.php
@@ -120,6 +120,7 @@ return static function (ECSConfig $ecsConfig): void {
         ],
         EmptyStatementSniff::class . '.DetectedCatch' => [
             __DIR__ . '/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php',
+            __DIR__ . '/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php',
         ],
         ParentCallSpacingSniff::class . '.IncorrectLinesCountBeforeControlStructure' => [
             __DIR__ . '/src/Component/Filesystem/Flysystem/VolumeDriver.php',

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -48,7 +48,9 @@ class ClassExtensionRegistry
      */
     public function addExtendedService(string $parentClassName, string $childClassName): void
     {
-        $this->serviceExtensionMap[$parentClassName] = $childClassName;
+        if (!array_key_exists($parentClassName, $this->serviceExtensionMap)) {
+            $this->serviceExtensionMap[$parentClassName] = $childClassName;
+        }
     }
 
     /**

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\DependencyInjection\Compiler;
 
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionObject;
+use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPassInterface
 {
@@ -18,12 +24,113 @@ class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPas
         $classExtensionRegistryDefinition = $container->findDefinition(ClassExtensionRegistry::class);
 
         foreach ($container->getServiceIds() as $serviceId) {
-            if ($this->isFrameworkClassWithAlias($container, $serviceId)) {
+            try {
                 $aliasId = (string)$container->getAlias($serviceId);
+            } catch (InvalidArgumentException) {
+                $aliasId = null;
+            }
 
-                if ($this->isProjectClass($aliasId)) {
-                    $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$serviceId, $aliasId]);
-                }
+            try {
+                $serviceClass = $container->findDefinition($serviceId)->getClass();
+            } catch (ServiceNotFoundException) {
+                continue;
+            }
+
+            if (!$this->isProjectClass($aliasId) && $this->isProjectClass($serviceClass)) {
+                $aliasId = $serviceClass;
+            }
+
+            $serviceId = $this->getCorrectServiceIdIfServiceIsNotExtendedByAlias($container, $serviceId, $aliasId);
+
+            if (!(
+                $this->isShopsysClassWithAlias($container, $serviceId, $aliasId) ||
+                $this->isShopsysClassWithAliasRegisteredAsService($container, $serviceId, $aliasId)
+            )) {
+                continue;
+            }
+
+            $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$serviceId, $aliasId]);
+            $frameworkClassBetterReflection = ReflectionObject::createFromName($serviceId);
+
+            $this->addAllVariantsOfServiceToClassExtension($frameworkClassBetterReflection, $classExtensionRegistryDefinition, $aliasId);
+        }
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param string $serviceId
+     * @param string|null $aliasId
+     * @return bool
+     */
+    private function isShopsysClassWithAlias(ContainerBuilder $container, string $serviceId, ?string $aliasId): bool
+    {
+        return $this->isShopsysClass($serviceId) && ($container->hasAlias($serviceId) && $this->isProjectClass($aliasId));
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param string $serviceId
+     * @param string|null $aliasId
+     * @return bool
+     */
+    private function isShopsysClassWithAliasRegisteredAsService(ContainerBuilder $container, string $serviceId, ?string $aliasId): bool
+    {
+        if ($aliasId === null || !$this->isShopsysClass($serviceId) || !($this->isProjectClass($aliasId) || $this->isShopsysClass($aliasId))) {
+            return false;
+        }
+
+        try {
+            $container->findDefinition($aliasId);
+
+            return true;
+        } catch (ServiceNotFoundException) {
+            return false;
+        }
+    }
+
+    /**
+     * @param string $serviceId
+     * @return bool
+     */
+    private function isShopsysClass(string $serviceId): bool
+    {
+        return str_starts_with($serviceId, 'Shopsys\\') !== false;
+    }
+
+    /**
+     * @param string|null $serviceId
+     * @return bool
+     */
+    private function isProjectClass(?string $serviceId): bool
+    {
+        if ($serviceId === null) {
+            return false;
+        }
+
+        return str_starts_with($serviceId, 'App') !== false;
+    }
+
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkClassBetterReflection
+     * @param \Symfony\Component\DependencyInjection\Definition $classExtensionRegistryDefinition
+     * @param string $aliasId
+     */
+    private function addAllVariantsOfServiceToClassExtension(
+        ReflectionClass $frameworkClassBetterReflection,
+        Definition $classExtensionRegistryDefinition,
+        string $aliasId
+    ): void {
+        if ($frameworkClassBetterReflection->isInterface()) {
+            $className = preg_replace('/Interface$/', '', $frameworkClassBetterReflection->getName());
+
+            if ($className !== $aliasId && class_exists($className)) {
+                $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$className, $aliasId]);
+            }
+        } else {
+            $interfaceName = $frameworkClassBetterReflection->getName() . 'Interface';
+
+            if ($interfaceName !== $aliasId && interface_exists($interfaceName) && in_array($interfaceName, $frameworkClassBetterReflection->getInterfaceNames(), true)) {
+                $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$interfaceName, $aliasId]);
             }
         }
     }
@@ -31,19 +138,22 @@ class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPas
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      * @param string $serviceId
-     * @return bool
+     * @param string|null $aliasId
+     * @return string
      */
-    private function isFrameworkClassWithAlias(ContainerBuilder $container, string $serviceId): bool
+    private function getCorrectServiceIdIfServiceIsNotExtendedByAlias(ContainerBuilder $container, string $serviceId, ?string $aliasId): string
     {
-        return strpos($serviceId, 'Shopsys\FrameworkBundle') !== false && $container->hasAlias($serviceId);
-    }
+        if ($this->isProjectClass($aliasId)) {
+            try {
+                $baseClassName = (string)ReflectionObject::createFromName($serviceId)->getLocatedSource()->getName();
 
-    /**
-     * @param string $serviceId
-     * @return bool
-     */
-    private function isProjectClass(string $serviceId): bool
-    {
-        return strpos($serviceId, 'App') !== false;
+                if ($this->isShopsysClass($baseClassName)) {
+                    $serviceId = $baseClassName;
+                }
+            } catch (IdentifierNotFound) {
+            }
+        }
+
+        return $serviceId;
     }
 }

--- a/project-base/src/Controller/Front/CartController.php
+++ b/project-base/src/Controller/Front/CartController.php
@@ -59,7 +59,7 @@ class CartController extends FrontBaseController
     private $errorExtractor;
 
     /**
-     * @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface
+     * @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade
      */
     private $listedProductViewFacade;
 
@@ -79,7 +79,7 @@ class CartController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade $freeTransportAndPaymentFacade
      * @param \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory
      * @param \Shopsys\FrameworkBundle\Component\FlashMessage\ErrorExtractor $errorExtractor
-     * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade
+     * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade $listedProductViewFacade
      * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      * @param \Shopsys\FrameworkBundle\Model\Module\ModuleFacade $moduleFacade
      */

--- a/project-base/src/Controller/Front/CustomerController.php
+++ b/project-base/src/Controller/Front/CustomerController.php
@@ -47,7 +47,7 @@ class CustomerController extends FrontBaseController
     private $loginAsUserFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory
      */
     private $customerUserUpdateDataFactory;
 
@@ -62,7 +62,7 @@ class CustomerController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemPriceCalculation $orderItemPriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Security\LoginAsUserFacade $loginAsUserFacade
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface $customerUserUpdateDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFacade $deliveryAddressFacade
      */
     public function __construct(

--- a/project-base/src/Controller/Front/HomepageController.php
+++ b/project-base/src/Controller/Front/HomepageController.php
@@ -27,7 +27,7 @@ class HomepageController extends FrontBaseController
     private $domain;
 
     /**
-     * @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface
+     * @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade
      */
     private $listedProductViewFacade;
 
@@ -35,7 +35,7 @@ class HomepageController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemFacade $sliderItemFacade
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade
+     * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade $listedProductViewFacade
      */
     public function __construct(
         SliderItemFacade $sliderItemFacade,

--- a/project-base/src/Controller/Front/PersonalDataController.php
+++ b/project-base/src/Controller/Front/PersonalDataController.php
@@ -56,7 +56,7 @@ class PersonalDataController extends FrontBaseController
     private $personalDataAccessMailFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactory
      */
     private $personalDataAccessRequestDataFactory;
 
@@ -73,7 +73,7 @@ class PersonalDataController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade $newsletterFacade
      * @param \Shopsys\FrameworkBundle\Model\PersonalData\Mail\PersonalDataAccessMailFacade $personalDataAccessMailFacade
      * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestFacade $personalDataAccessRequestFacade
-     * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactoryInterface $personalDataAccessRequestDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\PersonalData\PersonalDataAccessRequestDataFactory $personalDataAccessRequestDataFactory
      * @param \Shopsys\FrameworkBundle\Component\HttpFoundation\XmlResponse $xmlResponse
      */
     public function __construct(

--- a/project-base/src/Controller/Front/ProductController.php
+++ b/project-base/src/Controller/Front/ProductController.php
@@ -47,7 +47,7 @@ class ProductController extends FrontBaseController
     private $domain;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade
      */
     private $productOnCurrentDomainFacade;
 
@@ -82,7 +82,7 @@ class ProductController extends FrontBaseController
     private $brandFacade;
 
     /**
-     * @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface
+     * @var \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade
      */
     private $listedProductViewFacade;
 
@@ -100,14 +100,14 @@ class ProductController extends FrontBaseController
      * @param \Shopsys\FrameworkBundle\Twig\RequestExtension $requestExtension
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade $productOnCurrentDomainFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterConfigFactory $productFilterConfigFactory
      * @param \App\Model\Product\Listing\ProductListOrderingModeForListFacade $productListOrderingModeForListFacade
      * @param \App\Model\Product\Listing\ProductListOrderingModeForBrandFacade $productListOrderingModeForBrandFacade
      * @param \App\Model\Product\Listing\ProductListOrderingModeForSearchFacade $productListOrderingModeForSearchFacade
      * @param \Shopsys\FrameworkBundle\Model\Module\ModuleFacade $moduleFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade $brandFacade
-     * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewFacadeInterface $listedProductViewFacade
+     * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductViewElasticFacade $listedProductViewFacade
      * @param \Shopsys\ReadModelBundle\Product\Listed\ListedProductVariantsViewFacadeInterface $listedProductVariantsViewFacade
      * @param \Shopsys\ReadModelBundle\Product\Detail\ProductDetailViewFacadeInterface $productDetailViewFacade
      */

--- a/project-base/src/Controller/Front/SearchController.php
+++ b/project-base/src/Controller/Front/SearchController.php
@@ -20,13 +20,13 @@ class SearchController extends FrontBaseController
     private $categoryFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface
+     * @var \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade
      */
     private $productOnCurrentDomainFacade;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacadeInterface $productOnCurrentDomainFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainElasticFacade $productOnCurrentDomainFacade
      */
     public function __construct(
         CategoryFacade $categoryFacade,

--- a/project-base/src/DataFixtures/Demo/AdvertDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/AdvertDataFixture.php
@@ -21,13 +21,13 @@ class AdvertDataFixture extends AbstractReferenceFixture implements DependentFix
     private $advertFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactory
      */
     private $advertDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertFacade $advertFacade
-     * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactoryInterface $advertDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertDataFactory $advertDataFactory
      */
     public function __construct(AdvertFacade $advertFacade, AdvertDataFactoryInterface $advertDataFactory)
     {

--- a/project-base/src/DataFixtures/Demo/AvailabilityDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/AvailabilityDataFixture.php
@@ -26,7 +26,7 @@ class AvailabilityDataFixture extends AbstractReferenceFixture
     private $availabilityFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactory
      */
     private $availabilityDataFactory;
 
@@ -42,7 +42,7 @@ class AvailabilityDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactoryInterface $availabilityDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityDataFactory $availabilityDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */

--- a/project-base/src/DataFixtures/Demo/CountryDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/CountryDataFixture.php
@@ -23,7 +23,7 @@ class CountryDataFixture extends AbstractReferenceFixture
     private $countryFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Country\CountryDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Country\CountryDataFactory
      */
     private $countryDataFactory;
 
@@ -34,7 +34,7 @@ class CountryDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade
-     * @param \Shopsys\FrameworkBundle\Model\Country\CountryDataFactoryInterface $countryDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Country\CountryDataFactory $countryDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(CountryFacade $countryFacade, CountryDataFactoryInterface $countryDataFactory, Domain $domain)

--- a/project-base/src/DataFixtures/Demo/CurrencyDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/CurrencyDataFixture.php
@@ -22,13 +22,13 @@ class CurrencyDataFixture extends AbstractReferenceFixture
     private $currencyFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactory
      */
     private $currencyDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactoryInterface $currencyDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyDataFactory $currencyDataFactory
      */
     public function __construct(
         CurrencyFacade $currencyFacade,

--- a/project-base/src/DataFixtures/Demo/CustomerUserDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/CustomerUserDataFixture.php
@@ -70,7 +70,7 @@ class CustomerUserDataFixture extends AbstractReferenceFixture implements Depend
     private $domain;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory
      */
     private $customerUserUpdateDataFactory;
 
@@ -85,7 +85,7 @@ class CustomerUserDataFixture extends AbstractReferenceFixture implements Depend
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator $em
      * @param \Shopsys\FrameworkBundle\Component\String\HashGenerator $hashGenerator
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface $customerUserUpdateDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory
      * @param \App\Model\Customer\User\CustomerUserDataFactory $customerUserDataFactory
      */
     public function __construct(

--- a/project-base/src/DataFixtures/Demo/FlagDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/FlagDataFixture.php
@@ -24,7 +24,7 @@ class FlagDataFixture extends AbstractReferenceFixture
     private $flagFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagDataFactory
      */
     private $flagDataFactory;
 
@@ -35,7 +35,7 @@ class FlagDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade $flagFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagDataFactoryInterface $flagDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Flag\FlagDataFactory $flagDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(

--- a/project-base/src/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -16,12 +16,12 @@ use Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactoryInterface;
 class MailTemplateDataFixture extends AbstractReferenceFixture
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactory
      */
     private $mailTemplateFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Mail\MailTemplateDataFactory
      */
     private $mailTemplateDataFactory;
 
@@ -31,8 +31,8 @@ class MailTemplateDataFixture extends AbstractReferenceFixture
     private $domain;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactoryInterface $mailTemplateFactory
-     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateDataFactoryInterface $mailTemplateDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactory $mailTemplateFactory
+     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(

--- a/project-base/src/DataFixtures/Demo/OrderStatusDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/OrderStatusDataFixture.php
@@ -30,14 +30,14 @@ class OrderStatusDataFixture extends AbstractReferenceFixture
     private $domain;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactory
      */
     private $orderStatusDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade $orderStatusFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactoryInterface $orderStatusDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusDataFactory $orderStatusDataFactory
      */
     public function __construct(
         OrderStatusFacade $orderStatusFacade,

--- a/project-base/src/DataFixtures/Demo/PricingGroupDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/PricingGroupDataFixture.php
@@ -25,7 +25,7 @@ class PricingGroupDataFixture extends AbstractReferenceFixture
     private $pricingGroupFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactory
      */
     private $pricingGroupDataFactory;
 
@@ -41,7 +41,7 @@ class PricingGroupDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactoryInterface $pricingGroupDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupDataFactory $pricingGroupDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade $pricingGroupSettingFacade
      */

--- a/project-base/src/DataFixtures/Demo/PromoCodeDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/PromoCodeDataFixture.php
@@ -17,13 +17,13 @@ class PromoCodeDataFixture extends AbstractReferenceFixture
     private $promoCodeFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory
      */
     private $promoCodeDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade $promoCodeFacade
-     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactoryInterface $promoCodeDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeDataFactory $promoCodeDataFactory
      */
     public function __construct(
         PromoCodeFacade $promoCodeFacade,

--- a/project-base/src/DataFixtures/Demo/ScriptDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ScriptDataFixture.php
@@ -18,13 +18,13 @@ class ScriptDataFixture extends AbstractReferenceFixture
     private $scriptFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Script\ScriptDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Script\ScriptDataFactory
      */
     private $scriptDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Script\ScriptFacade $scriptFacade
-     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptDataFactoryInterface $scriptDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Script\ScriptDataFactory $scriptDataFactory
      */
     public function __construct(
         ScriptFacade $scriptFacade,

--- a/project-base/src/DataFixtures/Demo/SliderItemDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/SliderItemDataFixture.php
@@ -18,13 +18,13 @@ class SliderItemDataFixture extends AbstractReferenceFixture
     private $sliderItemFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactory
      */
     private $sliderItemDataFactory;
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemFacade $sliderItemFacade
-     * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactoryInterface $sliderItemDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactory $sliderItemDataFactory
      */
     public function __construct(
         SliderItemFacade $sliderItemFacade,

--- a/project-base/src/DataFixtures/Demo/UnitDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/UnitDataFixture.php
@@ -24,7 +24,7 @@ class UnitDataFixture extends AbstractReferenceFixture
     private $unitFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactory
      */
     private $unitDataFactory;
 
@@ -40,7 +40,7 @@ class UnitDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
-     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactoryInterface $unitDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactory $unitDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */

--- a/project-base/src/DataFixtures/Demo/VatDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/VatDataFixture.php
@@ -26,7 +26,7 @@ class VatDataFixture extends AbstractReferenceFixture
     private $vatFacade;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactory
      */
     private $vatDataFactory;
 
@@ -42,7 +42,7 @@ class VatDataFixture extends AbstractReferenceFixture
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactoryInterface $vatDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDataFactory $vatDataFactory
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */

--- a/project-base/src/DataFixtures/Performance/CustomerUserDataFixture.php
+++ b/project-base/src/DataFixtures/Performance/CustomerUserDataFixture.php
@@ -67,12 +67,12 @@ class CustomerUserDataFixture
     private $progressBarFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory
      */
     private $customerUserUpdateDataFactory;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactory
      */
     private $deliveryAddressDataFactory;
 
@@ -86,8 +86,8 @@ class CustomerUserDataFixture
      * @param \Faker\Generator $faker
      * @param \Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade $persistentReferenceFacade
      * @param \Shopsys\FrameworkBundle\Component\Console\ProgressBarFactory $progressBarFactory
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface $customerUserUpdateDataFactory
-     * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactoryInterface $deliveryAddressDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactory $deliveryAddressDataFactory
      */
     public function __construct(
         $userCountPerDomain,

--- a/project-base/src/Form/Front/Customer/User/CustomerUserUpdateFormType.php
+++ b/project-base/src/Form/Front/Customer/User/CustomerUserUpdateFormType.php
@@ -15,12 +15,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class CustomerUserUpdateFormType extends AbstractType
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface
+     * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory
      */
     private $customerUserUpdateDataFactory;
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactoryInterface $customerUserUpdateDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory
      */
     public function __construct(CustomerUserUpdateDataFactoryInterface $customerUserUpdateDataFactory)
     {

--- a/project-base/src/Model/Administrator/AdministratorDataFactory.php
+++ b/project-base/src/Model/Administrator/AdministratorDataFactory.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory as Base
 /**
  * @method \App\Model\Administrator\AdministratorData create()
  * @method \App\Model\Administrator\AdministratorData createFromAdministrator(\App\Model\Administrator\Administrator $administrator)
+ * @method fillFromAdministrator(\App\Model\Administrator\AdministratorData $administratorData, \App\Model\Administrator\Administrator $administrator)
  */
 class AdministratorDataFactory extends BaseAdministratorDataFactory
 {

--- a/project-base/src/Model/Article/ArticleDataFactory.php
+++ b/project-base/src/Model/Article/ArticleDataFactory.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory as BaseArticleDataF
 /**
  * @method \App\Model\Article\ArticleData create()
  * @method \App\Model\Article\ArticleData createFromArticle(\App\Model\Article\Article $article)
+ * @method fillNew(\App\Model\Article\ArticleData $articleData)
  */
 class ArticleDataFactory extends BaseArticleDataFactory
 {

--- a/project-base/src/Model/Category/CategoryDataFactory.php
+++ b/project-base/src/Model/Category/CategoryDataFactory.php
@@ -10,6 +10,8 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactory as BaseCategoryDa
 /**
  * @method \App\Model\Category\CategoryData createFromCategory(\App\Model\Category\Category $category)
  * @method \App\Model\Category\CategoryData create()
+ * @method fillNew(\App\Model\Category\CategoryData $categoryData)
+ * @method fillFromCategory(\App\Model\Category\CategoryData $categoryData, \App\Model\Category\Category $category)
  */
 class CategoryDataFactory extends BaseCategoryDataFactory
 {

--- a/project-base/src/Model/Customer/User/CustomerUserDataFactory.php
+++ b/project-base/src/Model/Customer/User/CustomerUserDataFactory.php
@@ -12,6 +12,8 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactory as BaseU
  * @method \App\Model\Customer\User\CustomerUserData createForCustomer(\Shopsys\FrameworkBundle\Model\Customer\Customer $customer)
  * @method \App\Model\Customer\User\CustomerUserData createForDomainId(int $domainId)
  * @method \App\Model\Customer\User\CustomerUserData createFromCustomerUser(\App\Model\Customer\User\CustomerUser $customerUser)
+ * @method fillForDomainId(\App\Model\Customer\User\CustomerUserData $customerUserData, int $domainId)
+ * @method fillFromUser(\App\Model\Customer\User\CustomerUserData $customerUserData, \App\Model\Customer\User\CustomerUser $customerUser)
  */
 class CustomerUserDataFactory extends BaseUserDataFactory
 {

--- a/project-base/src/Model/Order/Item/OrderItemDataFactory.php
+++ b/project-base/src/Model/Order/Item/OrderItemDataFactory.php
@@ -10,6 +10,9 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory as BaseOrderIt
 /**
  * @method \App\Model\Order\Item\OrderItemData create()
  * @method \App\Model\Order\Item\OrderItemData createFromOrderItem(\App\Model\Order\Item\OrderItem $orderItem)
+ * @method fillFromOrderItem(\App\Model\Order\Item\OrderItemData $orderItemData, \App\Model\Order\Item\OrderItem $orderItem)
+ * @method addFieldsByOrderItemType(\App\Model\Order\Item\OrderItemData $orderItemData, \App\Model\Order\Item\OrderItem $orderItem)
+ * @method bool isUsingPriceCalculation(\App\Model\Order\Item\OrderItemData $orderItemData, \App\Model\Order\Item\OrderItem $orderItem)
  */
 class OrderItemDataFactory extends BaseOrderItemDataFactory
 {

--- a/project-base/src/Model/Order/OrderDataFactory.php
+++ b/project-base/src/Model/Order/OrderDataFactory.php
@@ -10,6 +10,9 @@ use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory as BaseOrderDataFactory
 /**
  * @method \App\Model\Order\OrderData create()
  * @method \App\Model\Order\OrderData createFromOrder(\App\Model\Order\Order $order)
+ * @property \App\Model\Order\Item\OrderItemDataFactory $orderItemDataFactory
+ * @method __construct(\App\Model\Order\Item\OrderItemDataFactory $orderItemDataFactory)
+ * @method fillFromOrder(\App\Model\Order\OrderData $orderData, \App\Model\Order\Order $order)
  */
 class OrderDataFactory extends BaseOrderDataFactory
 {

--- a/project-base/src/Model/Payment/PaymentDataFactory.php
+++ b/project-base/src/Model/Payment/PaymentDataFactory.php
@@ -14,6 +14,8 @@ use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 /**
  * @method \App\Model\Payment\PaymentData create()
  * @method \App\Model\Payment\PaymentData createFromPayment(\App\Model\Payment\Payment $payment)
+ * @method fillNew(\App\Model\Payment\PaymentData $paymentData)
+ * @method fillFromPayment(\App\Model\Payment\PaymentData $paymentData, \App\Model\Payment\Payment $payment)
  */
 class PaymentDataFactory extends BasePaymentDataFactory
 {

--- a/project-base/src/Model/Product/Brand/BrandDataFactory.php
+++ b/project-base/src/Model/Product/Brand/BrandDataFactory.php
@@ -14,6 +14,8 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade;
 /**
  * @method \App\Model\Product\Brand\BrandData create()
  * @method \App\Model\Product\Brand\BrandData createFromBrand(\App\Model\Product\Brand\Brand $brand)
+ * @method fillNew(\App\Model\Product\Brand\BrandData $brandData)
+ * @method fillFromBrand(\App\Model\Product\Brand\BrandData $brandData, \App\Model\Product\Brand\Brand $brand)
  */
 class BrandDataFactory extends BaseBrandDataFactory
 {

--- a/project-base/src/Model/Product/ProductDataFactory.php
+++ b/project-base/src/Model/Product/ProductDataFactory.php
@@ -10,6 +10,11 @@ use Shopsys\FrameworkBundle\Model\Product\ProductDataFactory as BaseProductDataF
 /**
  * @method \App\Model\Product\ProductData create()
  * @method \App\Model\Product\ProductData createFromProduct(\App\Model\Product\Product $product)
+ * @method fillNew(\App\Model\Product\ProductData $productData)
+ * @method fillFromProduct(\App\Model\Product\ProductData $productData, \App\Model\Product\Product $product)
+ * @method \App\Model\Product\Product[] getAccessoriesData(\App\Model\Product\Product $product)
+ * @method \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[] getParametersData(\App\Model\Product\Product $product)
+ * @method __construct(\Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade, \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductInputPriceFacade $productInputPriceFacade, \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository $parameterRepository, \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade, \Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryRepository $productAccessoryRepository, \Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade $pluginDataFormExtensionFacade, \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueDataFactory $productParameterValueDataFactory, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade $pricingGroupFacade, \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade $availabilityFacade, \Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadDataFactory $imageUploadDataFactory)
  */
 class ProductDataFactory extends BaseProductDataFactory
 {

--- a/project-base/src/Model/Transport/TransportDataFactory.php
+++ b/project-base/src/Model/Transport/TransportDataFactory.php
@@ -10,6 +10,8 @@ use Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory as BaseTranspor
 /**
  * @method \App\Model\Transport\TransportData create()
  * @method \App\Model\Transport\TransportData createFromTransport(\App\Model\Transport\Transport $transport)
+ * @method fillNew(\App\Model\Transport\TransportData $transportData)
+ * @method fillFromTransport(\App\Model\Transport\TransportData $transportData, \App\Model\Transport\Transport $transport)
  */
 class TransportDataFactory extends BaseTransportDataFactory
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| All variants of service needs to be registered in class extension for annotation fixer to work correctly.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2400 closes #2539  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
