### PR TITLE
[docs] changed bc promise link to supported version

### DIFF
--- a/docs/contributing/backward-compatibility-promise.md
+++ b/docs/contributing/backward-compatibility-promise.md
@@ -23,7 +23,7 @@ Once created, a git tag marking a release will never be removed or edited.
     Pre-release version format is `MAJOR.MINOR.PATCH-<alpha|beta|rc><n>`, eg. `7.0.0-beta5`.
 
 ## The BC Promise in Detail
-Shopsys Framework is built on the shoulders of giants so we've based our BC promise on the [**Symfony Backward Compatibility Promise**](https://symfony.com/doc/3.4/contributing/code/bc.html).
+Shopsys Framework is built on the shoulders of giants so we've based our BC promise on the [**Symfony Backward Compatibility Promise**](https://symfony.com/doc/5.4/contributing/code/bc.html).
 Exceptions from adhering to Symfony's promise and clarifications for non-PHP source codes can be found below.
 
 ### Project-base Repository


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Currently supported version of Symfony is 5.4. Changed link to Symfony's BC promise to a supported version
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
