### PR TITLE
[shopsys] inheritdoc docblock is now unified and fixed automatically

### DIFF
--- a/packages/backend-api/src/DependencyInjection/ShopsysBackendApiExtension.php
+++ b/packages/backend-api/src/DependencyInjection/ShopsysBackendApiExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysBackendApiExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -25,7 +25,7 @@ class ShopsysBackendApiExtension extends Extension implements PrependExtensionIn
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function prepend(ContainerBuilder $container)
     {

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -101,6 +101,7 @@ use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer;
 use Shopsys\CodingStandards\CsFixer\MissingButtonTypeFixer;
 use Shopsys\CodingStandards\CsFixer\OrmJoinColumnRequireNullableFixer;
+use Shopsys\CodingStandards\CsFixer\Phpdoc\InheritDocFormatFixer;
 use Shopsys\CodingStandards\CsFixer\Phpdoc\MissingParamAnnotationsFixer;
 use Shopsys\CodingStandards\CsFixer\Phpdoc\MissingReturnAnnotationFixer;
 use Shopsys\CodingStandards\CsFixer\Phpdoc\OrderedParamAnnotationsFixer;
@@ -175,6 +176,7 @@ return static function (ECSConfig $ecsConfig): void {
     ]);
 
     // Shopsys Checkers
+    $ecsConfig->rule(InheritDocFormatFixer::class);
     $ecsConfig->rule(ForbiddenDumpFixer::class);
     $ecsConfig->rule(MissingButtonTypeFixer::class);
     $ecsConfig->rule(OrmJoinColumnRequireNullableFixer::class);

--- a/packages/coding-standards/src/CsFixer/Phpdoc/InheritDocFormatFixer.php
+++ b/packages/coding-standards/src/CsFixer/Phpdoc/InheritDocFormatFixer.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\CsFixer\Phpdoc;
+
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\DocBlock\Line;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class InheritDocFormatFixer implements FixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            '{@inheritdoc} annotations have to be in the specific format',
+            [new CodeSample(
+                <<<'SAMPLE'
+/**
+ * {@inheritdoc}
+ */
+public function transform($value): ?array
+SAMPLE
+            )]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        /** @var \PhpCsFixer\Tokenizer\Token $token */
+        foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $index => $token) {
+            $doc = new DocBlock($token->getContent());
+            foreach ($doc->getLines() as $line) {
+                if ($this->isInheritDocCandidate($line)) {
+                    $this->fixInheritDoc($line);
+
+                    $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Shopsys/inherit_doc_format';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return preg_match('/\.php$/ui', $file->getFilename()) === 1;
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\Line $line
+     * @return bool
+     */
+    private function isInheritDocCandidate(Line $line): bool
+    {
+        return preg_match('~\{?@[Ii]nherit[dD]oc}?~', $line->getContent()) === 1;
+    }
+
+    /**
+     * @param \PhpCsFixer\DocBlock\Line $line
+     */
+    private function fixInheritDoc(Line $line): void
+    {
+        $line->setContent(
+            preg_replace(
+                '~\{?@[Ii]nherit[dD]oc}?~',
+                '{@inheritdoc}',
+                $line->getContent(),
+            ),
+        );
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ChainedFixer.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ChainedFixer.php
@@ -26,7 +26,7 @@ class ChainedFixer implements FixerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isCandidate(Tokens $tokens): bool
     {
@@ -40,7 +40,7 @@ class ChainedFixer implements FixerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function isRisky(): bool
     {
@@ -54,7 +54,7 @@ class ChainedFixer implements FixerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
@@ -64,7 +64,7 @@ class ChainedFixer implements FixerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getName(): string
     {
@@ -72,7 +72,7 @@ class ChainedFixer implements FixerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getPriority(): int
     {
@@ -80,7 +80,7 @@ class ChainedFixer implements FixerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function supports(SplFileInfo $file): bool
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDumpFixer/ForbiddenDumpFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenDumpFixer/ForbiddenDumpFixerTest.php
@@ -18,7 +18,7 @@ final class ForbiddenDumpFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/ForbiddenPrivateVisibilityFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/ForbiddenPrivateVisibilityFixerTest.php
@@ -23,7 +23,7 @@ final class ForbiddenPrivateVisibilityFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/MissingButtonTypeFixer/MissingButtonTypeFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/MissingButtonTypeFixer/MissingButtonTypeFixerTest.php
@@ -18,7 +18,7 @@ final class MissingButtonTypeFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/OrmJoinColumnRequireNullableFixer/OrmJoinColumnRequireNullableFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/OrmJoinColumnRequireNullableFixer/OrmJoinColumnRequireNullableFixerTest.php
@@ -18,7 +18,7 @@ final class OrmJoinColumnRequireNullableFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/FunctionAnnotationFixer/FunctionAnnotationFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/FunctionAnnotationFixer/FunctionAnnotationFixerTest.php
@@ -63,7 +63,7 @@ final class FunctionAnnotationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/InheritDocFormatFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/InheritDocFormatFixerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\InheritDocFormatFixer;
+
+use Shopsys\CodingStandards\CsFixer\Phpdoc\InheritDocFormatFixer;
+use Tests\CodingStandards\Unit\CsFixer\AbstractFixerTestCase;
+
+/**
+ * @covers \Shopsys\CodingStandards\CsFixer\Phpdoc\InheritDocFormatFixer
+ */
+final class InheritDocFormatFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @return \Shopsys\CodingStandards\CsFixer\Phpdoc\InheritDocFormatFixer
+     */
+    protected function createFixerService(): InheritDocFormatFixer
+    {
+        return new InheritDocFormatFixer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTestingFiles(): iterable
+    {
+        yield [__DIR__ . '/fixed/fixed.php', __DIR__ . '/wrong/wrong.php'];
+        //yield [__DIR__ . '/correct/correct.php'];
+        //yield [__DIR__ . '/correct/correct2.php'];
+        //yield [__DIR__ . '/correct/correct3.php'];
+        //yield [__DIR__ . '/correct/correct4.php'];
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/InheritDocFormatFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/InheritDocFormatFixerTest.php
@@ -21,14 +21,10 @@ final class InheritDocFormatFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {
         yield [__DIR__ . '/fixed/fixed.php', __DIR__ . '/wrong/wrong.php'];
-        //yield [__DIR__ . '/correct/correct.php'];
-        //yield [__DIR__ . '/correct/correct2.php'];
-        //yield [__DIR__ . '/correct/correct3.php'];
-        //yield [__DIR__ . '/correct/correct4.php'];
     }
 }

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/base/base.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/base/base.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\InheritDocFormatFixer;
+
+class InheritDocFormatBaseClass
+{
+    /**
+     * @param int $param
+     */
+    public function methodOne(int $param): void
+    {
+    }
+
+    /**
+     * @param int $param
+     */
+    public function methodTwo(int $param): void
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function methodThree(): string
+    {
+        return 'string';
+    }
+
+    /**
+     * @param int $param
+     * @param string $param2
+     * @return string
+     */
+    public function methodFour(int $param, string $param2): string
+    {
+        return 'string';
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/fixed/fixed.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/fixed/fixed.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\InheritDocFormatFixer;
+
+final class InheritDocFormatTestClass extends InheritDocFormatBaseClass
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function methodOne(int $param): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function methodTwo(int $param): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function methodThree(): string
+    {
+        return 'string';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function methodFour(int $param, string $param2): string
+    {
+        return 'string';
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/wrong/wrong.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/InheritDocFormatFixer/wrong/wrong.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\CodingStandards\Unit\CsFixer\Phpdoc\InheritDocFormatFixer;
+
+final class InheritDocFormatTestClass extends InheritDocFormatBaseClass
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function methodOne(int $param): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function methodTwo(int $param): void
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function methodThree(): string
+    {
+        return 'string';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function methodFour(int $param, string $param2): string
+    {
+        return 'string';
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/MissingParamAnnotationsFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/MissingParamAnnotationsFixerTest.php
@@ -39,7 +39,7 @@ final class MissingParamAnnotationsFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/MissingReturnAnnotationFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/MissingReturnAnnotationFixerTest.php
@@ -39,7 +39,7 @@ final class MissingReturnAnnotationFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/OrderedParamAnnotationsFixer/OrderedParamAnnotationsFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/OrderedParamAnnotationsFixer/OrderedParamAnnotationsFixerTest.php
@@ -24,7 +24,7 @@ final class OrderedParamAnnotationsFixerTest extends AbstractFixerTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/CsFixer/RedundantMarkDownTrailingSpacesFixer/RedundantMarkDownTrailingSpacesFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/RedundantMarkDownTrailingSpacesFixer/RedundantMarkDownTrailingSpacesFixerTest.php
@@ -18,7 +18,7 @@ final class RedundantMarkDownTrailingSpacesFixerTest extends AbstractFixerTestCa
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getTestingFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/ConstantVisibilityRequiredSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ConstantVisibilityRequiredSniff/ConstantVisibilityRequiredSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ConstantVisibilityRequiredSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ConstantVisibilityRequiredSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {
@@ -31,7 +31,7 @@ final class ConstantVisibilityRequiredSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getCorrectFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/ForbiddenDoctrineDefaultValueSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineDefaultValueSniff/ForbiddenDoctrineDefaultValueSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 class ForbiddenDoctrineDefaultValueSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ class ForbiddenDoctrineDefaultValueSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {
@@ -30,7 +30,7 @@ class ForbiddenDoctrineDefaultValueSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getCorrectFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/ForbiddenDoctrineInheritanceSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDoctrineInheritanceSniff/ForbiddenDoctrineInheritanceSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ForbiddenDoctrineInheritanceSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ForbiddenDoctrineInheritanceSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {
@@ -27,7 +27,7 @@ final class ForbiddenDoctrineInheritanceSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getCorrectFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDumpSniff/ForbiddenDumpSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenDumpSniff/ForbiddenDumpSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ForbiddenDumpSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ForbiddenDumpSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenExitSniff/ForbiddenExitSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenExitSniff/ForbiddenExitSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ForbiddenExitSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ForbiddenExitSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ForbiddenSuperGlobalSniff/ForbiddenSuperGlobalSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForbiddenSuperGlobalSniff/ForbiddenSuperGlobalSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ForbiddenSuperGlobalSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ForbiddenSuperGlobalSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/ForceLateStaticBindingForProtectedConstantsSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ForceLateStaticBindingForProtectedConstantsSniff/ForceLateStaticBindingForProtectedConstantsSniffTest.php
@@ -35,7 +35,7 @@ final class ForceLateStaticBindingForProtectedConstantsSniffTest extends Abstrac
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ObjectIsCreatedByFactorySniff/ObjectIsCreatedByFactorySniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ObjectIsCreatedByFactorySniff/ObjectIsCreatedByFactorySniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ObjectIsCreatedByFactorySniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ObjectIsCreatedByFactorySniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getCorrectFiles(): iterable
     {
@@ -26,7 +26,7 @@ final class ObjectIsCreatedByFactorySniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {

--- a/packages/coding-standards/tests/Unit/Sniffs/ValidVariableNameSniff/ValidVariableNameSniffTest.php
+++ b/packages/coding-standards/tests/Unit/Sniffs/ValidVariableNameSniff/ValidVariableNameSniffTest.php
@@ -10,7 +10,7 @@ use Tests\CodingStandards\Unit\Sniffs\AbstractSniffTestCase;
 final class ValidVariableNameSniffTest extends AbstractSniffTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getSniffClassName(): string
     {
@@ -18,7 +18,7 @@ final class ValidVariableNameSniffTest extends AbstractSniffTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getWrongFiles(): iterable
     {

--- a/packages/form-types-bundle/src/DependencyInjection/ShopsysFormTypesExtension.php
+++ b/packages/form-types-bundle/src/DependencyInjection/ShopsysFormTypesExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysFormTypesExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/packages/framework/src/Command/ChangeAdminPasswordCommand.php
+++ b/packages/framework/src/Command/ChangeAdminPasswordCommand.php
@@ -46,7 +46,7 @@ class ChangeAdminPasswordCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/ChangeEnvironmentCommand.php
+++ b/packages/framework/src/Command/ChangeEnvironmentCommand.php
@@ -46,7 +46,7 @@ class ChangeEnvironmentCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CheckRedisCommand.php
+++ b/packages/framework/src/Command/CheckRedisCommand.php
@@ -40,7 +40,7 @@ class CheckRedisCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CheckTimezonesCommand.php
+++ b/packages/framework/src/Command/CheckTimezonesCommand.php
@@ -37,7 +37,7 @@ class CheckTimezonesCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/ConfigureDomainsUrlsCommand.php
+++ b/packages/framework/src/Command/ConfigureDomainsUrlsCommand.php
@@ -44,7 +44,7 @@ class ConfigureDomainsUrlsCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
+++ b/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
@@ -98,7 +98,7 @@ class CreateApplicationDirectoriesCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CreateDatabaseCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseCommand.php
@@ -45,7 +45,7 @@ class CreateDatabaseCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CreateDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseSchemaCommand.php
@@ -36,7 +36,7 @@ class CreateDatabaseSchemaCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CreateDomainsDataCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDataCommand.php
@@ -65,7 +65,7 @@ class CreateDomainsDataCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CreateDomainsDbFunctionsCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDbFunctionsCommand.php
@@ -44,7 +44,7 @@ class CreateDomainsDbFunctionsCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -75,7 +75,7 @@ class CronCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/DatabaseDumpCommand.php
+++ b/packages/framework/src/Command/DatabaseDumpCommand.php
@@ -35,7 +35,7 @@ class DatabaseDumpCommand extends Command
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function configure(): void
     {
@@ -46,7 +46,7 @@ class DatabaseDumpCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/DropDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/DropDatabaseSchemaCommand.php
@@ -36,7 +36,7 @@ class DropDatabaseSchemaCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/ElFinderInstallerCommand.php
+++ b/packages/framework/src/Command/ElFinderInstallerCommand.php
@@ -62,7 +62,7 @@ EOF
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchChangedDataExportCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchChangedDataExportCommand.php
@@ -15,7 +15,7 @@ class ElasticsearchChangedDataExportCommand extends ElasticsearchDataExportComma
     protected static $defaultName = 'shopsys:elasticsearch:changed-data-export';
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function executeCommand(IndexDefinition $indexDefinition, OutputInterface $output): void
     {
@@ -27,7 +27,7 @@ class ElasticsearchChangedDataExportCommand extends ElasticsearchDataExportComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getCommandDescription(): string
     {
@@ -35,7 +35,7 @@ class ElasticsearchChangedDataExportCommand extends ElasticsearchDataExportComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionStartedMessage(): string
     {
@@ -43,7 +43,7 @@ class ElasticsearchChangedDataExportCommand extends ElasticsearchDataExportComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionFinishedMessage(): string
     {

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchDataExportCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchDataExportCommand.php
@@ -41,7 +41,7 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function executeForIndex(OutputInterface $output, AbstractIndex $index): void
     {
@@ -54,7 +54,7 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function executeCommand(IndexDefinition $indexDefinition, OutputInterface $output): void
     {
@@ -66,7 +66,7 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getCommandDescription(): string
     {
@@ -74,7 +74,7 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getArgumentNameDescription(): string
     {
@@ -85,7 +85,7 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionStartedMessage(): string
     {
@@ -93,7 +93,7 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionFinishedMessage(): string
     {

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesDeleteCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesDeleteCommand.php
@@ -15,7 +15,7 @@ class ElasticsearchIndexesDeleteCommand extends AbstractElasticsearchIndexComman
     protected static $defaultName = 'shopsys:elasticsearch:indexes-delete';
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function executeCommand(IndexDefinition $indexDefinition, OutputInterface $output): void
     {
@@ -23,7 +23,7 @@ class ElasticsearchIndexesDeleteCommand extends AbstractElasticsearchIndexComman
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getCommandDescription(): string
     {
@@ -31,7 +31,7 @@ class ElasticsearchIndexesDeleteCommand extends AbstractElasticsearchIndexComman
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getArgumentNameDescription(): string
     {
@@ -42,7 +42,7 @@ class ElasticsearchIndexesDeleteCommand extends AbstractElasticsearchIndexComman
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionStartedMessage(): string
     {
@@ -50,7 +50,7 @@ class ElasticsearchIndexesDeleteCommand extends AbstractElasticsearchIndexComman
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionFinishedMessage(): string
     {

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesMigrateCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesMigrateCommand.php
@@ -15,7 +15,7 @@ class ElasticsearchIndexesMigrateCommand extends AbstractElasticsearchIndexComma
     protected static $defaultName = 'shopsys:elasticsearch:indexes-migrate';
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function executeCommand(IndexDefinition $indexDefinition, OutputInterface $output): void
     {
@@ -23,7 +23,7 @@ class ElasticsearchIndexesMigrateCommand extends AbstractElasticsearchIndexComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getCommandDescription(): string
     {
@@ -31,7 +31,7 @@ class ElasticsearchIndexesMigrateCommand extends AbstractElasticsearchIndexComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getArgumentNameDescription(): string
     {
@@ -42,7 +42,7 @@ class ElasticsearchIndexesMigrateCommand extends AbstractElasticsearchIndexComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionStartedMessage(): string
     {
@@ -50,7 +50,7 @@ class ElasticsearchIndexesMigrateCommand extends AbstractElasticsearchIndexComma
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function getActionFinishedMessage(): string
     {

--- a/packages/framework/src/Command/GenerateErrorPagesCommand.php
+++ b/packages/framework/src/Command/GenerateErrorPagesCommand.php
@@ -36,7 +36,7 @@ class GenerateErrorPagesCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/GenerateFriendlyUrlCommand.php
+++ b/packages/framework/src/Command/GenerateFriendlyUrlCommand.php
@@ -36,7 +36,7 @@ class GenerateFriendlyUrlCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/ImportDefaultDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/ImportDefaultDatabaseSchemaCommand.php
@@ -36,7 +36,7 @@ class ImportDefaultDatabaseSchemaCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/LoadPluginDataFixturesCommand.php
+++ b/packages/framework/src/Command/LoadPluginDataFixturesCommand.php
@@ -36,7 +36,7 @@ class LoadPluginDataFixturesCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/PhingConfigFixerCommand.php
+++ b/packages/framework/src/Command/PhingConfigFixerCommand.php
@@ -45,7 +45,7 @@ class PhingConfigFixerCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/RecalculateCategoryTreeCommand.php
+++ b/packages/framework/src/Command/RecalculateCategoryTreeCommand.php
@@ -38,7 +38,7 @@ class RecalculateCategoryTreeCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/RecalculationsCommand.php
+++ b/packages/framework/src/Command/RecalculationsCommand.php
@@ -82,7 +82,7 @@ class RecalculationsCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/RedisCleanCacheCommand.php
+++ b/packages/framework/src/Command/RedisCleanCacheCommand.php
@@ -38,7 +38,7 @@ class RedisCleanCacheCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/RedisCleanCacheOldCommand.php
+++ b/packages/framework/src/Command/RedisCleanCacheOldCommand.php
@@ -36,7 +36,7 @@ class RedisCleanCacheOldCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/ReplaceDomainsUrlsCommand.php
+++ b/packages/framework/src/Command/ReplaceDomainsUrlsCommand.php
@@ -55,7 +55,7 @@ class ReplaceDomainsUrlsCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/RouterDebugCommandForDomain.php
+++ b/packages/framework/src/Command/RouterDebugCommandForDomain.php
@@ -65,7 +65,7 @@ EOF
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
@@ -73,7 +73,7 @@ EOF
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/RouterMatchCommandForDomain.php
+++ b/packages/framework/src/Command/RouterMatchCommandForDomain.php
@@ -69,7 +69,7 @@ EOF
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/TranslationReplaceSourceCommand.php
+++ b/packages/framework/src/Command/TranslationReplaceSourceCommand.php
@@ -54,7 +54,7 @@ class TranslationReplaceSourceCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Command/YamlLintCommand.php
+++ b/packages/framework/src/Command/YamlLintCommand.php
@@ -80,7 +80,7 @@ EOF
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/framework/src/Component/Cron/DeleteOldCronModuleRunsCronModule.php
+++ b/packages/framework/src/Component/Cron/DeleteOldCronModuleRunsCronModule.php
@@ -18,7 +18,7 @@ class DeleteOldCronModuleRunsCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger): void
     {

--- a/packages/framework/src/Component/Doctrine/MoneyType.php
+++ b/packages/framework/src/Component/Doctrine/MoneyType.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Component\Money\Money;
 class MoneyType extends Type
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getName(): string
     {
@@ -19,7 +19,7 @@ class MoneyType extends Type
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
@@ -27,7 +27,7 @@ class MoneyType extends Type
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
@@ -43,7 +43,7 @@ class MoneyType extends Type
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function convertToPHPValue($value, AbstractPlatform $platform): ?Money
     {

--- a/packages/framework/src/Component/Domain/Multidomain/Twig/FilesystemLoader.php
+++ b/packages/framework/src/Component/Domain/Multidomain/Twig/FilesystemLoader.php
@@ -35,7 +35,7 @@ class FilesystemLoader extends BaseFilesystemLoader
      * When exists a template with filename.{designId}.html.twig, then it is automatically used
      * on domain with this {designId} whenever template named filename.html.twig is on input
      *
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function findTemplate($template, $throw = true): string|false|null
     {

--- a/packages/framework/src/Component/Elasticsearch/AbstractExportSubscriber.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractExportSubscriber.php
@@ -65,7 +65,7 @@ abstract class AbstractExportSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     abstract public static function getSubscribedEvents(): array;
 

--- a/packages/framework/src/Component/Elasticsearch/Debug/ElasticsearchCollector.php
+++ b/packages/framework/src/Component/Elasticsearch/Debug/ElasticsearchCollector.php
@@ -25,7 +25,7 @@ class ElasticsearchCollector extends DataCollector
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
@@ -42,7 +42,7 @@ class ElasticsearchCollector extends DataCollector
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getName(): string
     {

--- a/packages/framework/src/Component/Error/ErrorPageCronModule.php
+++ b/packages/framework/src/Component/Error/ErrorPageCronModule.php
@@ -21,7 +21,7 @@ class ErrorPageCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {

--- a/packages/framework/src/Component/Error/LogoutExceptionSubscriber.php
+++ b/packages/framework/src/Component/Error/LogoutExceptionSubscriber.php
@@ -33,7 +33,7 @@ class LogoutExceptionSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsErrorListener.php
+++ b/packages/framework/src/Component/Error/NotLogFakeHttpExceptionsErrorListener.php
@@ -34,7 +34,7 @@ class NotLogFakeHttpExceptionsErrorListener extends ErrorListener
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     protected function logException(Throwable $exception, string $message, ?string $logLevel = null): void
     {

--- a/packages/framework/src/Component/Form/TimedFormTypeExtension.php
+++ b/packages/framework/src/Component/Form/TimedFormTypeExtension.php
@@ -67,7 +67,7 @@ class TimedFormTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getExtendedTypes(): iterable
     {

--- a/packages/framework/src/Component/Router/NormalizeUrlTrailingSlashSubscriber.php
+++ b/packages/framework/src/Component/Router/NormalizeUrlTrailingSlashSubscriber.php
@@ -28,7 +28,7 @@ class NormalizeUrlTrailingSlashSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Component/Translation/ConfigConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConfigConstraintMessageExtractor.php
@@ -34,7 +34,7 @@ use Twig\Node\Node;
 class ConfigConstraintMessageExtractor implements FileVisitorInterface
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue): void
     {
@@ -77,14 +77,14 @@ class ConfigConstraintMessageExtractor implements FileVisitorInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast): void
     {
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Node $ast): void
     {

--- a/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessageExtractor.php
@@ -56,7 +56,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
     {
@@ -66,7 +66,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function enterNode(Node $node): int|Node|null
     {
@@ -117,7 +117,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function beforeTraverse(array $nodes): ?array
     {
@@ -125,7 +125,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function leaveNode(Node $node): int|Node|null
     {
@@ -133,7 +133,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function afterTraverse(array $nodes): ?array
     {
@@ -141,7 +141,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
     {
@@ -149,7 +149,7 @@ class ConstraintMessageExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {

--- a/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintMessagePropertyExtractor.php
@@ -60,7 +60,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
     {
@@ -70,7 +70,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function enterNode(Node $node): int|Node|null
     {
@@ -86,7 +86,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function leaveNode(Node $node): int|Node|null
     {
@@ -133,7 +133,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function beforeTraverse(array $nodes): ?array
     {
@@ -141,7 +141,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function afterTraverse(array $nodes): ?array
     {
@@ -149,7 +149,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
     {
@@ -157,7 +157,7 @@ class ConstraintMessagePropertyExtractor implements FileVisitorInterface, NodeVi
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {

--- a/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
+++ b/packages/framework/src/Component/Translation/ConstraintViolationExtractor.php
@@ -67,7 +67,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitPhpFile(SplFileInfo $file, MessageCatalogue $catalogue, array $ast)
     {
@@ -77,7 +77,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function enterNode(Node $node): int|Node|null
     {
@@ -149,7 +149,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function beforeTraverse(array $nodes): ?array
     {
@@ -157,7 +157,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function leaveNode(Node $node): int|Node|null
     {
@@ -169,7 +169,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function afterTraverse(array $nodes): ?array
     {
@@ -177,7 +177,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitFile(SplFileInfo $file, MessageCatalogue $catalogue)
     {
@@ -185,7 +185,7 @@ class ConstraintViolationExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {

--- a/packages/framework/src/Component/Translation/JsFileExtractor.php
+++ b/packages/framework/src/Component/Translation/JsFileExtractor.php
@@ -68,7 +68,7 @@ class JsFileExtractor implements FileVisitorInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, Node $ast)
     {

--- a/packages/framework/src/Component/Translation/NormalizingExtractorManager.php
+++ b/packages/framework/src/Component/Translation/NormalizingExtractorManager.php
@@ -30,7 +30,7 @@ class NormalizingExtractorManager extends ExtractorManager
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function extract(): MessageCatalogue
     {

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -81,7 +81,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function enterNode(Node $node): int|Node|null
     {
@@ -238,7 +238,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function beforeTraverse(array $nodes): ?array
     {
@@ -246,7 +246,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function leaveNode(Node $node): int|Node|null
     {
@@ -254,7 +254,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function afterTraverse(array $nodes): ?array
     {
@@ -271,7 +271,7 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function visitTwigFile(SplFileInfo $file, MessageCatalogue $catalogue, TwigNode $ast)
     {

--- a/packages/framework/src/Component/Translation/Translator.php
+++ b/packages/framework/src/Component/Translation/Translator.php
@@ -90,7 +90,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getLocale(): string
     {
@@ -98,7 +98,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function setLocale($locale): void
     {
@@ -107,7 +107,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getCatalogue($locale = null): MessageCatalogueInterface
     {

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysFrameworkExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -65,7 +65,7 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function prepend(ContainerBuilder $container)
     {

--- a/packages/framework/src/Form/CollectionTypeExtension.php
+++ b/packages/framework/src/Form/CollectionTypeExtension.php
@@ -34,7 +34,7 @@ class CollectionTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getExtendedTypes(): iterable
     {

--- a/packages/framework/src/Form/ColorPickerType.php
+++ b/packages/framework/src/Form/ColorPickerType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 class ColorPickerType extends AbstractType
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/Constraints/EmailValidator.php
+++ b/packages/framework/src/Form/Constraints/EmailValidator.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class EmailValidator extends ConstraintValidator
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/packages/framework/src/Form/Constraints/FileAbstractFilesystemValidator.php
+++ b/packages/framework/src/Form/Constraints/FileAbstractFilesystemValidator.php
@@ -45,7 +45,7 @@ class FileAbstractFilesystemValidator extends FileValidator
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/packages/framework/src/Form/Constraints/ImageAbstractFilesystemValidator.php
+++ b/packages/framework/src/Form/Constraints/ImageAbstractFilesystemValidator.php
@@ -45,7 +45,7 @@ class ImageAbstractFilesystemValidator extends ImageValidator
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/packages/framework/src/Form/DatePickerType.php
+++ b/packages/framework/src/Form/DatePickerType.php
@@ -46,7 +46,7 @@ class DatePickerType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/DateTimeType.php
+++ b/packages/framework/src/Form/DateTimeType.php
@@ -40,7 +40,7 @@ class DateTimeType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/DeliveryAddressChoiceType.php
+++ b/packages/framework/src/Form/DeliveryAddressChoiceType.php
@@ -63,7 +63,7 @@ class DeliveryAddressChoiceType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/DeliveryAddressListType.php
+++ b/packages/framework/src/Form/DeliveryAddressListType.php
@@ -36,7 +36,7 @@ class DeliveryAddressListType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/DisplayOnlyCustomerType.php
+++ b/packages/framework/src/Form/DisplayOnlyCustomerType.php
@@ -28,7 +28,7 @@ class DisplayOnlyCustomerType extends AbstractType
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {

--- a/packages/framework/src/Form/DisplayOnlyType.php
+++ b/packages/framework/src/Form/DisplayOnlyType.php
@@ -27,7 +27,7 @@ class DisplayOnlyType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/DisplayOnlyUrlType.php
+++ b/packages/framework/src/Form/DisplayOnlyUrlType.php
@@ -33,7 +33,7 @@ class DisplayOnlyUrlType extends AbstractType
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {

--- a/packages/framework/src/Form/DomainType.php
+++ b/packages/framework/src/Form/DomainType.php
@@ -25,7 +25,7 @@ class DomainType extends AbstractType
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
@@ -44,7 +44,7 @@ class DomainType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/FileUploadType.php
+++ b/packages/framework/src/Form/FileUploadType.php
@@ -166,7 +166,7 @@ class FileUploadType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/HoneyPotType.php
+++ b/packages/framework/src/Form/HoneyPotType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints;
 class HoneyPotType extends AbstractType
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -194,7 +194,7 @@ class ImageUploadType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/InvertChoiceTypeExtension.php
+++ b/packages/framework/src/Form/InvertChoiceTypeExtension.php
@@ -14,7 +14,7 @@ class InvertChoiceTypeExtension extends AbstractTypeExtension
     protected const INVERT_OPTION = 'invert';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getExtendedTypes(): iterable
     {
@@ -22,7 +22,7 @@ class InvertChoiceTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -40,7 +40,7 @@ class InvertChoiceTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {

--- a/packages/framework/src/Form/OrderItemsType.php
+++ b/packages/framework/src/Form/OrderItemsType.php
@@ -40,7 +40,7 @@ class OrderItemsType extends AbstractType
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -73,7 +73,7 @@ class OrderItemsType extends AbstractType
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {

--- a/packages/framework/src/Form/ProductParameterValueType.php
+++ b/packages/framework/src/Form/ProductParameterValueType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 class ProductParameterValueType extends AbstractType
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/ProductType.php
+++ b/packages/framework/src/Form/ProductType.php
@@ -57,7 +57,7 @@ class ProductType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/SingleCheckboxChoiceType.php
+++ b/packages/framework/src/Form/SingleCheckboxChoiceType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class SingleCheckboxChoiceType extends AbstractType
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/SortableValuesType.php
+++ b/packages/framework/src/Form/SortableValuesType.php
@@ -27,7 +27,7 @@ class SortableValuesType extends AbstractType
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParent(): ?string
     {

--- a/packages/framework/src/Form/Transformers/InverseMultipleChoiceTransformer.php
+++ b/packages/framework/src/Form/Transformers/InverseMultipleChoiceTransformer.php
@@ -20,7 +20,7 @@ class InverseMultipleChoiceTransformer implements DataTransformerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function transform($value): ?array
     {
@@ -32,7 +32,7 @@ class InverseMultipleChoiceTransformer implements DataTransformerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function reverseTransform($value): ?array
     {

--- a/packages/framework/src/Form/Transformers/NoopDataTransformer.php
+++ b/packages/framework/src/Form/Transformers/NoopDataTransformer.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 class NoopDataTransformer implements DataTransformerInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function reverseTransform($value): mixed
     {
@@ -15,7 +15,7 @@ class NoopDataTransformer implements DataTransformerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function transform($value): mixed
     {

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -344,14 +344,14 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function eraseCredentials()
     {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getRoles(): array
     {
@@ -365,7 +365,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getSalt(): ?string
     {
@@ -373,7 +373,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function isMultidomainLogin()
     {
@@ -381,7 +381,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function setMultidomainLogin($multidomainLogin)
     {

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactory.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleDataFactory.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Administrator\Role;
 class AdministratorRoleDataFactory implements AdministratorRoleDataFactoryInterface
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function createInstance(): AdministratorRoleData
     {
@@ -15,7 +15,7 @@ class AdministratorRoleDataFactory implements AdministratorRoleDataFactoryInterf
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function create(): AdministratorRoleData
     {
@@ -23,7 +23,7 @@ class AdministratorRoleDataFactory implements AdministratorRoleDataFactoryInterf
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function createFromAdministratorRole(AdministratorRole $administratorRole): AdministratorRoleData
     {

--- a/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
+++ b/packages/framework/src/Model/Administrator/Security/AdministratorRolesChangedSubscriber.php
@@ -40,7 +40,7 @@ class AdministratorRolesChangedSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Model/Article/ArticleBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Article/ArticleBreadcrumbGenerator.php
@@ -21,7 +21,7 @@ class ArticleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getBreadcrumbItems($routeName, array $routeParameters = [])
     {
@@ -33,7 +33,7 @@ class ArticleBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getRouteNames()
     {

--- a/packages/framework/src/Model/Cart/Item/DeleteOldCartsCronModule.php
+++ b/packages/framework/src/Model/Cart/Item/DeleteOldCartsCronModule.php
@@ -22,7 +22,7 @@ class DeleteOldCartsCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {

--- a/packages/framework/src/Model/Category/CategoryBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Category/CategoryBreadcrumbGenerator.php
@@ -31,7 +31,7 @@ class CategoryBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getBreadcrumbItems($routeName, array $routeParameters = [])
     {
@@ -61,7 +61,7 @@ class CategoryBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getRouteNames()
     {

--- a/packages/framework/src/Model/ContactForm/ContactFormSettingsDataFactory.php
+++ b/packages/framework/src/Model/ContactForm/ContactFormSettingsDataFactory.php
@@ -28,7 +28,7 @@ class ContactFormSettingsDataFactory implements ContactFormSettingsDataFactoryIn
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function createFromSettingsByDomainId(int $domainId): ContactFormSettingsData
     {

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -357,14 +357,14 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function eraseCredentials()
     {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getRoles(): array
     {
@@ -372,7 +372,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getSalt(): ?string
     {

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapCronModule.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapCronModule.php
@@ -18,7 +18,7 @@ class ImageSitemapCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapListener.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapListener.php
@@ -24,7 +24,7 @@ class ImageSitemapListener implements EventSubscriberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
+++ b/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
@@ -177,7 +177,7 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
     ];
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function get($currencyCode, $locale = null): Currency
     {
@@ -197,7 +197,7 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @return \CommerceGuys\Intl\Currency\Currency[]
      */

--- a/packages/framework/src/Model/Mail/EventListener/EnvelopeListener.php
+++ b/packages/framework/src/Model/Mail/EventListener/EnvelopeListener.php
@@ -84,7 +84,7 @@ class EnvelopeListener implements EventSubscriberInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Model/PersonalData/PersonalDataBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataBreadcrumbGenerator.php
@@ -8,7 +8,7 @@ use Shopsys\FrameworkBundle\Component\Breadcrumb\BreadcrumbItem;
 class PersonalDataBreadcrumbGenerator implements BreadcrumbGeneratorInterface
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getBreadcrumbItems($routeName, array $routeParameters = [])
     {
@@ -22,7 +22,7 @@ class PersonalDataBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getRouteNames()
     {

--- a/packages/framework/src/Model/Pricing/Vat/VatDeletionCronModule.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatDeletionCronModule.php
@@ -34,7 +34,7 @@ class VatDeletionCronModule implements IteratedCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {
@@ -52,7 +52,7 @@ class VatDeletionCronModule implements IteratedCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function iterate()
     {

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityCronModule.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityCronModule.php
@@ -26,7 +26,7 @@ class ProductAvailabilityCronModule implements IteratedCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {
@@ -42,7 +42,7 @@ class ProductAvailabilityCronModule implements IteratedCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function iterate()
     {

--- a/packages/framework/src/Model/Product/Brand/BrandBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Product/Brand/BrandBreadcrumbGenerator.php
@@ -45,7 +45,7 @@ class BrandBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getRouteNames()
     {

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportSubscriber.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportSubscriber.php
@@ -40,7 +40,7 @@ class ProductExportSubscriber extends AbstractExportSubscriber
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
@@ -33,7 +33,7 @@ class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getTotalCount(int $domainId): int
     {
@@ -41,7 +41,7 @@ class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getChangedCount(int $domainId): int
     {
@@ -49,7 +49,7 @@ class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getChangedIdsForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
     {
@@ -57,7 +57,7 @@ class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getExportDataForIds(int $domainId, array $restrictToIds): array
     {
@@ -69,7 +69,7 @@ class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
     {
@@ -82,7 +82,7 @@ class ProductIndex extends AbstractIndex implements IndexSupportChangesOnlyInter
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public static function getName(): string
     {

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceCronModule.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceCronModule.php
@@ -26,7 +26,7 @@ class ProductPriceCronModule implements IteratedCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {
@@ -42,7 +42,7 @@ class ProductPriceCronModule implements IteratedCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function iterate()
     {

--- a/packages/framework/src/Model/Product/ProductBreadcrumbGenerator.php
+++ b/packages/framework/src/Model/Product/ProductBreadcrumbGenerator.php
@@ -41,7 +41,7 @@ class ProductBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getBreadcrumbItems($routeName, array $routeParameters = [])
     {
@@ -85,7 +85,7 @@ class ProductBreadcrumbGenerator implements BreadcrumbGeneratorInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getRouteNames()
     {

--- a/packages/framework/src/Model/Product/ProductVisibilityImmediateCronModule.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityImmediateCronModule.php
@@ -21,7 +21,7 @@ class ProductVisibilityImmediateCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {

--- a/packages/framework/src/Model/Product/ProductVisibilityMidnightCronModule.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityMidnightCronModule.php
@@ -21,7 +21,7 @@ class ProductVisibilityMidnightCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {

--- a/packages/framework/src/Model/Sitemap/SitemapCronModule.php
+++ b/packages/framework/src/Model/Sitemap/SitemapCronModule.php
@@ -21,7 +21,7 @@ class SitemapCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {

--- a/packages/framework/src/Model/Sitemap/SitemapListener.php
+++ b/packages/framework/src/Model/Sitemap/SitemapListener.php
@@ -28,7 +28,7 @@ class SitemapListener implements EventSubscriberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/framework/src/Twig/JsFormValidatorTwigExtension.php
+++ b/packages/framework/src/Twig/JsFormValidatorTwigExtension.php
@@ -9,7 +9,7 @@ use Fp\JsFormValidatorBundle\Twig\Extension\JsFormValidatorTwigExtension as Base
 class JsFormValidatorTwigExtension extends BaseJsFormValidatorTwigExtension
 {
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getJsValidator($form = null, $onLoad = true, $wrapped = true): string
     {

--- a/packages/framework/tests/Unit/Component/Constraints/FileExtensionMaxLengthValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/FileExtensionMaxLengthValidatorTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 class FileExtensionMaxLengthValidatorTest extends ConstraintValidatorTestCase
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function createValidator()
     {

--- a/packages/framework/tests/Unit/Component/Constraints/UniqueSlugsOnDomainsValidatorTest.php
+++ b/packages/framework/tests/Unit/Component/Constraints/UniqueSlugsOnDomainsValidatorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 class UniqueSlugsOnDomainsValidatorTest extends ConstraintValidatorTestCase
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function createValidator()
     {

--- a/packages/framework/tests/Unit/Component/Elasticsearch/__fixtures/CategoryIndex.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/__fixtures/CategoryIndex.php
@@ -18,7 +18,7 @@ class CategoryIndex extends AbstractIndex
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getTotalCount(int $domainId): int
     {
@@ -26,7 +26,7 @@ class CategoryIndex extends AbstractIndex
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getExportDataForIds(int $domainId, array $restrictToIds): array
     {
@@ -34,7 +34,7 @@ class CategoryIndex extends AbstractIndex
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
     {

--- a/packages/frontend-api/src/Model/Error/ErrorCodeSubscriber.php
+++ b/packages/frontend-api/src/Model/Error/ErrorCodeSubscriber.php
@@ -44,7 +44,7 @@ class ErrorCodeSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getSubscribedEvents(): array
     {

--- a/packages/frontend-api/src/Model/Error/InvalidArgumentUserError.php
+++ b/packages/frontend-api/src/Model/Error/InvalidArgumentUserError.php
@@ -11,7 +11,7 @@ class InvalidArgumentUserError extends UserError implements UserErrorWithCodeInt
     protected const CODE = 'invalid-argument';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Mutation/Customer/User/Exception/InvalidAccountOrPasswordUserError.php
+++ b/packages/frontend-api/src/Model/Mutation/Customer/User/Exception/InvalidAccountOrPasswordUserError.php
@@ -12,7 +12,7 @@ class InvalidAccountOrPasswordUserError extends UserError implements UserErrorWi
     protected const CODE = 'invalid-account-or-password';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Mutation/Customer/User/Exception/TooManyLoginAttemptsUserError.php
+++ b/packages/frontend-api/src/Model/Mutation/Customer/User/Exception/TooManyLoginAttemptsUserError.php
@@ -12,7 +12,7 @@ class TooManyLoginAttemptsUserError extends UserError implements UserErrorWithCo
     protected const CODE = 'too-many-login-attempts';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Mutation/Order/Exception/MailUserError.php
+++ b/packages/frontend-api/src/Model/Mutation/Order/Exception/MailUserError.php
@@ -12,7 +12,7 @@ class MailUserError extends UserError implements UserErrorWithCodeInterface
     protected const CODE = 'mail-failed';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Article/Exception/ArticleNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Article/Exception/ArticleNotFoundUserError.php
@@ -28,7 +28,7 @@ class ArticleNotFoundUserError extends EntityNotFoundUserError implements UserEr
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Brand/Exception/BrandNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Brand/Exception/BrandNotFoundUserError.php
@@ -12,7 +12,7 @@ class BrandNotFoundUserError extends EntityNotFoundUserError implements UserErro
     protected const CODE = 'brand-not-found';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Category/Exception/CategoryNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Category/Exception/CategoryNotFoundUserError.php
@@ -12,7 +12,7 @@ class CategoryNotFoundUserError extends EntityNotFoundUserError implements UserE
     protected const CODE = 'category-not-found';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Image/Exception/ImageSizeInvalidUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/Exception/ImageSizeInvalidUserError.php
@@ -12,7 +12,7 @@ class ImageSizeInvalidUserError extends UserError implements UserErrorWithCodeIn
     protected const CODE = 'image-size-invalid';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Image/Exception/ImageTypeInvalidUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Image/Exception/ImageTypeInvalidUserError.php
@@ -12,7 +12,7 @@ class ImageTypeInvalidUserError extends UserError implements UserErrorWithCodeIn
     protected const CODE = 'image-type-invalid';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Order/Exception/InvalidAccessUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/Exception/InvalidAccessUserError.php
@@ -12,7 +12,7 @@ class InvalidAccessUserError extends UserError implements UserErrorWithCodeInter
     protected const CODE = 'invalid-access';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Order/Exception/OrderNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Order/Exception/OrderNotFoundUserError.php
@@ -12,7 +12,7 @@ class OrderNotFoundUserError extends EntityNotFoundUserError implements UserErro
     protected const CODE = 'order-not-found';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Payment/Exception/PaymentNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Payment/Exception/PaymentNotFoundUserError.php
@@ -12,7 +12,7 @@ class PaymentNotFoundUserError extends EntityNotFoundUserError implements UserEr
     protected const CODE = 'payment-not-found';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Products/Exception/ProductNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/Exception/ProductNotFoundUserError.php
@@ -12,7 +12,7 @@ class ProductNotFoundUserError extends EntityNotFoundUserError implements UserEr
     protected const CODE = 'product-not-found';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Resolver/Transport/Exception/TransportNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Resolver/Transport/Exception/TransportNotFoundUserError.php
@@ -12,7 +12,7 @@ class TransportNotFoundUserError extends EntityNotFoundUserError implements User
     protected const CODE = 'transport-not-found';
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Token/Exception/TokenUserMessageException.php
+++ b/packages/frontend-api/src/Model/Token/Exception/TokenUserMessageException.php
@@ -29,7 +29,7 @@ class TokenUserMessageException extends CustomUserMessageAuthenticationException
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUserErrorCode(): string
     {

--- a/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
+++ b/packages/frontend-api/src/Model/Token/TokenAuthenticator.php
@@ -34,7 +34,7 @@ class TokenAuthenticator extends AbstractAuthenticator
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function authenticate(Request $request): Passport
     {

--- a/packages/google-cloud-bundle/src/DependencyInjection/ShopsysGoogleCloudExtension.php
+++ b/packages/google-cloud-bundle/src/DependencyInjection/ShopsysGoogleCloudExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysGoogleCloudExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/packages/migrations/src/Command/CheckDatabaseSchemaCommand.php
+++ b/packages/migrations/src/Command/CheckDatabaseSchemaCommand.php
@@ -39,7 +39,7 @@ class CheckDatabaseSchemaCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/migrations/src/Command/CheckOrmMappingCommand.php
+++ b/packages/migrations/src/Command/CheckOrmMappingCommand.php
@@ -40,7 +40,7 @@ class CheckOrmMappingCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -70,7 +70,7 @@ class GenerateMigrationCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
+++ b/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
@@ -45,7 +45,7 @@ class GetCountOfMigrationsToExecuteCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/migrations/src/Command/MigrateCommand.php
+++ b/packages/migrations/src/Command/MigrateCommand.php
@@ -61,7 +61,7 @@ class MigrateCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
+++ b/packages/migrations/src/Component/Doctrine/Migrations/AbstractMigration.php
@@ -15,7 +15,7 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
     protected array $sqlQueries = [];
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function addSql(string $sql, array $params = [], array $types = []): void
     {
@@ -38,7 +38,7 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @see \Shopsys\MigrationBundle\Command\MigrateCommand::execute()
      */

--- a/packages/migrations/src/DependencyInjection/ShopsysMigrationExtension.php
+++ b/packages/migrations/src/DependencyInjection/ShopsysMigrationExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysMigrationExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/packages/product-feed-google/src/DependencyInjection/ShopsysProductFeedGoogleExtension.php
+++ b/packages/product-feed-google/src/DependencyInjection/ShopsysProductFeedGoogleExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysProductFeedGoogleExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -20,7 +20,7 @@ class ShopsysProductFeedGoogleExtension extends Extension implements PrependExte
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function prepend(ContainerBuilder $container)
     {

--- a/packages/product-feed-google/src/ShopsysProductFeedGoogleBundle.php
+++ b/packages/product-feed-google/src/ShopsysProductFeedGoogleBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class ShopsysProductFeedGoogleBundle extends Bundle
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {

--- a/packages/product-feed-heureka-delivery/src/DependencyInjection/ShopsysProductFeedHeurekaDeliveryExtension.php
+++ b/packages/product-feed-heureka-delivery/src/DependencyInjection/ShopsysProductFeedHeurekaDeliveryExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysProductFeedHeurekaDeliveryExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/packages/product-feed-heureka/src/DependencyInjection/ShopsysProductFeedHeurekaExtension.php
+++ b/packages/product-feed-heureka/src/DependencyInjection/ShopsysProductFeedHeurekaExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysProductFeedHeurekaExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -21,7 +21,7 @@ class ShopsysProductFeedHeurekaExtension extends Extension implements PrependExt
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function prepend(ContainerBuilder $container)
     {

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryCronModule.php
@@ -35,7 +35,7 @@ class HeurekaCategoryCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setLogger(Logger $logger)
     {
@@ -43,7 +43,7 @@ class HeurekaCategoryCronModule implements SimpleCronModuleInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function run()
     {

--- a/packages/product-feed-heureka/src/ShopsysProductFeedHeurekaBundle.php
+++ b/packages/product-feed-heureka/src/ShopsysProductFeedHeurekaBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class ShopsysProductFeedHeurekaBundle extends Bundle
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {

--- a/packages/product-feed-zbozi/src/DependencyInjection/ShopsysProductFeedZboziExtension.php
+++ b/packages/product-feed-zbozi/src/DependencyInjection/ShopsysProductFeedZboziExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysProductFeedZboziExtension extends Extension implements PrependExtensionInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -20,7 +20,7 @@ class ShopsysProductFeedZboziExtension extends Extension implements PrependExten
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function prepend(ContainerBuilder $container)
     {

--- a/packages/product-feed-zbozi/src/ShopsysProductFeedZboziBundle.php
+++ b/packages/product-feed-zbozi/src/ShopsysProductFeedZboziBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class ShopsysProductFeedZboziBundle extends Bundle
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {

--- a/packages/read-model/src/DependencyInjection/ShopsysReadModelExtension.php
+++ b/packages/read-model/src/DependencyInjection/ShopsysReadModelExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class ShopsysReadModelExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/project-base/src/Command/PerformanceDataCommand.php
+++ b/project-base/src/Command/PerformanceDataCommand.php
@@ -69,7 +69,7 @@ class PerformanceDataCommand extends Command
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {

--- a/project-base/src/DataFixtures/Demo/AdvertDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/AdvertDataFixture.php
@@ -61,7 +61,7 @@ class AdvertDataFixture extends AbstractReferenceFixture implements DependentFix
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/BestsellingProductDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/BestsellingProductDataFixture.php
@@ -59,7 +59,7 @@ class BestsellingProductDataFixture extends AbstractReferenceFixture implements 
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/CustomerUserDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/CustomerUserDataFixture.php
@@ -459,7 +459,7 @@ class CustomerUserDataFixture extends AbstractReferenceFixture implements Depend
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/ImageDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ImageDataFixture.php
@@ -327,7 +327,7 @@ class ImageDataFixture extends AbstractReferenceFixture implements DependentFixt
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/OrderDataFixture.php
@@ -756,7 +756,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/PaymentDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/PaymentDataFixture.php
@@ -131,7 +131,7 @@ class PaymentDataFixture extends AbstractReferenceFixture implements DependentFi
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/ProductAccessoriesDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ProductAccessoriesDataFixture.php
@@ -55,7 +55,7 @@ class ProductAccessoriesDataFixture extends AbstractReferenceFixture implements 
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/ProductDataFixture.php
@@ -9473,7 +9473,7 @@ class ProductDataFixture extends AbstractReferenceFixture implements DependentFi
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies(): array
     {

--- a/project-base/src/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/SettingValueDataFixture.php
@@ -148,7 +148,7 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/TopCategoryDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/TopCategoryDataFixture.php
@@ -49,7 +49,7 @@ class TopCategoryDataFixture extends AbstractReferenceFixture implements Depende
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/TopProductDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/TopProductDataFixture.php
@@ -73,7 +73,7 @@ class TopProductDataFixture extends AbstractReferenceFixture implements Dependen
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/DataFixtures/Demo/TransportDataFixture.php
+++ b/project-base/src/DataFixtures/Demo/TransportDataFixture.php
@@ -140,7 +140,7 @@ class TransportDataFixture extends AbstractReferenceFixture implements Dependent
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getDependencies()
     {

--- a/project-base/src/Form/Admin/AdministratorFormTypeExtension.php
+++ b/project-base/src/Form/Admin/AdministratorFormTypeExtension.php
@@ -18,7 +18,7 @@ class AdministratorFormTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public static function getExtendedTypes(): iterable
     {

--- a/project-base/tests/App/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
+++ b/project-base/tests/App/Test/Codeception/Helper/CloseNewlyOpenedWindowsHelper.php
@@ -13,7 +13,7 @@ use Tests\App\Test\Codeception\Module\StrictWebDriver;
 class CloseNewlyOpenedWindowsHelper extends Module
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function _after(TestInterface $test)
     {

--- a/project-base/tests/App/Test/Codeception/Helper/DatabaseHelper.php
+++ b/project-base/tests/App/Test/Codeception/Helper/DatabaseHelper.php
@@ -11,7 +11,7 @@ use Tests\App\Test\Codeception\Module\Db;
 class DatabaseHelper extends Module
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function _initialize()
     {

--- a/project-base/tests/App/Test/Codeception/Helper/DomainHelper.php
+++ b/project-base/tests/App/Test/Codeception/Helper/DomainHelper.php
@@ -12,7 +12,7 @@ use Tests\App\Test\Codeception\Module\StrictWebDriver;
 class DomainHelper extends Module
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function _before(TestInterface $test)
     {

--- a/project-base/tests/App/Test/Codeception/Helper/SymfonyHelper.php
+++ b/project-base/tests/App/Test/Codeception/Helper/SymfonyHelper.php
@@ -19,7 +19,7 @@ class SymfonyHelper extends Module
     private Kernel $kernel;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function _initialize()
     {
@@ -30,7 +30,7 @@ class SymfonyHelper extends Module
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function _before(TestInterface $test)
     {

--- a/project-base/tests/App/Test/Codeception/Module/Db.php
+++ b/project-base/tests/App/Test/Codeception/Module/Db.php
@@ -28,7 +28,7 @@ class Db extends BaseDb
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function _loadDump($databaseKey = null, $databaseConfig = null)
     {

--- a/project-base/tests/App/Test/Codeception/Module/StrictWebDriver.php
+++ b/project-base/tests/App/Test/Codeception/Module/StrictWebDriver.php
@@ -33,7 +33,7 @@ class StrictWebDriver extends WebDriver
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function match($page, $selector, $throwMalformed = true): array
     {
@@ -46,7 +46,7 @@ class StrictWebDriver extends WebDriver
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function findFields($selector): array
     {

--- a/project-base/tests/App/Test/HttpFoundation/RequestStack.php
+++ b/project-base/tests/App/Test/HttpFoundation/RequestStack.php
@@ -27,7 +27,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function push(Request $request)
     {
@@ -35,7 +35,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function pop()
     {
@@ -43,7 +43,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getCurrentRequest()
     {
@@ -51,7 +51,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getMainRequest(): ?Request
     {
@@ -59,7 +59,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getMasterRequest()
     {
@@ -67,7 +67,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getParentRequest()
     {
@@ -75,7 +75,7 @@ class RequestStack extends BaseRequestStack
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
     public function getSession(): SessionInterface
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| unified the form of inheritdoc annotation to `{@inheritdoc}` (same way as Symfony has)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes