### PR TITLE
[monorepo] fixed guzzlehttp/promise functions usage

### DIFF
--- a/utils/releaser/src/Guzzle/ApiCaller.php
+++ b/utils/releaser/src/Guzzle/ApiCaller.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Shopsys\Releaser\Guzzle;
 
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Request;
 use Nette\Utils\Json;
-use function GuzzleHttp\Promise\unwrap;
 
 final class ApiCaller
 {
@@ -54,7 +54,7 @@ final class ApiCaller
 
         // Wait on all of the requests to complete. Throws a ConnectException if any of the requests fail
         /** @var \Psr\Http\Message\ResponseInterface[] $responses */
-        $responses = unwrap($promises);
+        $responses = Utils::unwrap($promises);
 
         $stringResponses = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| guzzlehttp/promise no longer register functions in favor of static call of GuzzleHttp\Promise\Utils::* methods. see https://github.com/guzzle/guzzle/pull/2712
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
