### PR TITLE
fix: only specific localized static URLs are now allowed for each domain

### DIFF
--- a/project-base/storefront/middleware.ts
+++ b/project-base/storefront/middleware.ts
@@ -15,9 +15,13 @@ const ERROR_PAGE_ROUTE = '/404';
 export const middleware: NextMiddleware = async (request) => {
     try {
         const host = getHostFromRequest(request);
+        console.log('host', host);
         const domainUrlFromStaticUrls = getDomainUrlFromStaticUrls(host);
+        console.log('domainUrlFromStaticUrls', domainUrlFromStaticUrls);
         const staticUrlsAvailableForDomain = getStaticUrlsAvailableForDomain(domainUrlFromStaticUrls);
+        console.log('staticUrlsAvailableForDomain', JSON.stringify(staticUrlsAvailableForDomain));
         const rewriteTargetUrl = getRewriteTargetPathname(request, staticUrlsAvailableForDomain);
+        console.log('rewriteTargetUrl',rewriteTargetUrl)
 
         if (rewriteTargetUrl) {
             const rewriteUrlObject = new URL(rewriteTargetUrl, request.url);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Because of a bug, some domains allowed for multiple versions of static URLs (e.g. 'cart' and 'kosik'). This PR fixes the problem
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
