### PR TITLE
[shopsys] fixed split packages builds

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -18,14 +18,12 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->skip(
         [
             PhpdocToPropertyTypeFixer::class => [
-                __DIR__ . '/packages/*',
                 __DIR__ . '/project-base/app/src/*',
                 __DIR__ . '/project-base/app/app/*',
                 __DIR__ . '/project-base/app/tests/App/Acceptance/*',
                 __DIR__ . '/utils/*',
             ],
             DeclareStrictTypesFixer::class => [
-                __DIR__ . '/packages/*',
                 __DIR__ . '/utils/*',
             ],
             ConstantVisibilityRequiredSniff::class => [

--- a/packages/coding-standards/.github/workflows/run-checks-tests.yaml
+++ b/packages/coding-standards/.github/workflows/run-checks-tests.yaml
@@ -3,10 +3,10 @@ name: "Checks and tests"
 jobs:
     checks-and-tests:
         name: Run checks and tests in PHP ${{ matrix.php-versions }} ${{ matrix.composer-prefered-dependencies }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php-versions: ['8.0', '8.1']
+                php-versions: ['8.1']
                 composer-prefered-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1",
+        "php": "^8.1",
         "ext-tokenizer": "*",
         "friendsofphp/php-cs-fixer": "^3.3.1",
         "nette/utils": "^3.1.3",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpstan/phpstan": "^1.6.8",
-        "slevomat/coding-standard": "^8.11.1",
+        "slevomat/coding-standard": "^8.13.1",
         "squizlabs/php_codesniffer": "^3.6.2",
         "symfony/finder": "^5.4",
-        "symplify/easy-coding-standard": "^10.2.2"
+        "symplify/easy-coding-standard": "^10.3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.20"

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -60,6 +60,7 @@ use PhpCsFixer\Fixer\ControlStructure\NoTrailingCommaInListCallFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveUnsetsFixer;
@@ -402,6 +403,12 @@ return static function (ECSConfig $ecsConfig): void {
         ListSyntaxFixer::class => null,
         PropertyTypeHintSniff::class => [
             '**Data.php',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 };

--- a/packages/coding-standards/examples/ValidClass.php
+++ b/packages/coding-standards/examples/ValidClass.php
@@ -9,10 +9,7 @@ namespace ShopsysNamespace;
  */
 final class ValidClass
 {
-    /**
-     * @var \ShopsysNamespace\Type
-     */
-    private $parameterCamelCase;
+    private Type $parameterCamelCase;
 
     /**
      * @param \ShopsysNamespace\Type $parameterCamelCase

--- a/packages/form-types-bundle/ecs.php
+++ b/packages/form-types-bundle/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -15,6 +17,12 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->skip([
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/framework/.github/workflows/run-checks-tests.yaml
+++ b/packages/framework/.github/workflows/run-checks-tests.yaml
@@ -17,8 +17,6 @@ jobs:
                     tools: composer
             -   name: Install Composer dependencies
                 run: composer install --optimize-autoloader --no-interaction
-            -   name: Ensure Symfony 4 version
-                run: composer update
             -   name: Run parallel-lint
                 run: php vendor/bin/parallel-lint ./src
             -   name: Run Easy Coding Standards

--- a/packages/framework/ecs.php
+++ b/packages/framework/ecs.php
@@ -141,6 +141,7 @@ return static function (ECSConfig $ecsConfig): void {
         PropertyTypeHintSniff::class => [
             __DIR__ . '/tests/Unit/Component/ClassExtension/Source/*/*.php',
             __DIR__ . '/tests/Unit/Component/ClassExtension/Source/*.php',
+            ...explode("\n", trim(shell_exec("grep -rl '\\* @ORM\\\\Entity' " . escapeshellarg(__DIR__ . '/src')) ?? ''))
         ],
         PhpdocToPropertyTypeFixer::class => [
             __DIR__ . '/src/*',

--- a/packages/framework/ecs.php
+++ b/packages/framework/ecs.php
@@ -6,6 +6,8 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff;
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenDumpFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForbiddenDumpSniff;
@@ -139,6 +141,13 @@ return static function (ECSConfig $ecsConfig): void {
         PropertyTypeHintSniff::class => [
             __DIR__ . '/tests/Unit/Component/ClassExtension/Source/*/*.php',
             __DIR__ . '/tests/Unit/Component/ClassExtension/Source/*.php',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+            __DIR__ . '/tests/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/framework/tests/Test/Provider/TestCurrencyProvider.php
+++ b/packages/framework/tests/Test/Provider/TestCurrencyProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\App\Functional\Model\Pricing\Currency;
+namespace Tests\FrameworkBundle\Test\Provider;
 
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;

--- a/packages/framework/tests/Test/Provider/TestOrderProvider.php
+++ b/packages/framework/tests/Test/Provider/TestOrderProvider.php
@@ -14,7 +14,6 @@ use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportData;
-use Tests\App\Functional\Model\Pricing\Currency\TestCurrencyProvider;
 
 class TestOrderProvider
 {

--- a/packages/frontend-api/ecs.php
+++ b/packages/frontend-api/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -35,6 +37,12 @@ return static function (ECSConfig $ecsConfig): void {
         FunctionLengthSniff::class => [
             __DIR__ . '/tests/FrontendApiBundle/Functional/Article/GetArticlesTest.php',
             __DIR__ . '/src/Model/Resolver/Products/ProductResolverMap.php',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/google-cloud-bundle/ecs.php
+++ b/packages/google-cloud-bundle/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -15,6 +17,12 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->skip([
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
+++ b/packages/http-smoke-testing/.github/workflows/run-checks-tests.yaml
@@ -3,11 +3,11 @@ name: "Checks and tests"
 jobs:
     checks-and-tests:
         name: Run checks and tests in PHP ${{ matrix.php-versions }} ${{ matrix.composer-prefered-dependencies }}
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
-                php-versions: ['8.0', '8.1']
-                composer-prefered-dependencies: ['--prefer-lowest', '']
+                php-versions: ['8.1']
+                composer-preferred-dependencies: ['--prefer-lowest', '']
             fail-fast: false
         steps:
             -   name: GIT checkout branch - ${{ github.ref }}
@@ -21,7 +21,7 @@ jobs:
                     extensions: bcmath, gd, intl, pdo_pgsql, redis, pgsql, zip
                     tools: composer
             -   name: Install Composer dependencies
-                run: composer install --optimize-autoloader --no-interaction
+                run: composer update --optimize-autoloader --no-interaction ${{ matrix.composer-preferred-dependencies }}
             -   name: Run parallel-lint
                 run: php vendor/bin/parallel-lint ./src ./tests
             -   name: Run Easy Coding Standards

--- a/packages/http-smoke-testing/composer.json
+++ b/packages/http-smoke-testing/composer.json
@@ -21,7 +21,7 @@
         }
     },
     "require": {
-        "php": "^8.0 || ^8.1",
+        "php": "^8.1",
         "phpunit/phpunit": "^9.5.20",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",

--- a/packages/http-smoke-testing/ecs.php
+++ b/packages/http-smoke-testing/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -15,6 +17,12 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->skip([
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/migrations/ecs.php
+++ b/packages/migrations/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -37,6 +39,12 @@ return static function (ECSConfig $ecsConfig): void {
         FunctionLengthSniff::class => [
             __DIR__ . '/tests/Unit/Component/Doctrine/SchemaDiffFilterTest.php',
             __DIR__ . '/tests/Unit/Component/Doctrine/Migrations/MigrationsLockComparatorTest.php',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/plugin-interface/ecs.php
+++ b/packages/plugin-interface/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
@@ -15,6 +17,12 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->skip([
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/product-feed-google/ecs.php
+++ b/packages/product-feed-google/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -29,8 +31,13 @@ return static function (ECSConfig $ecsConfig): void {
 
     $ecsConfig->skip([
         ObjectIsCreatedByFactorySniff::class => [
-            __DIR__,
-            '/tests/*',
+            __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/product-feed-google/ecs.php
+++ b/packages/product-feed-google/ecs.php
@@ -7,6 +7,7 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
@@ -38,6 +39,9 @@ return static function (ECSConfig $ecsConfig): void {
         ],
         DeclareStrictTypesFixer::class => [
             __DIR__ . '/src/*',
+        ],
+        PropertyTypeHintSniff::class => [
+            __DIR__ . '/src/Model/Product/GoogleProductDomain.php',
         ],
     ]);
 

--- a/packages/product-feed-heureka-delivery/ecs.php
+++ b/packages/product-feed-heureka-delivery/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -32,6 +34,12 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->skip([
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/product-feed-heureka/ecs.php
+++ b/packages/product-feed-heureka/ecs.php
@@ -9,6 +9,7 @@ use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
 use SlevomatCodingStandard\Sniffs\Functions\FunctionLengthSniff;
+use SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 /**
@@ -50,6 +51,10 @@ return static function (ECSConfig $ecsConfig): void {
         ],
         DeclareStrictTypesFixer::class => [
             __DIR__ . '/src/*',
+        ],
+        PropertyTypeHintSniff::class => [
+            __DIR__ . '/src/Model/Product/HeurekaProductDomain.php',
+            __DIR__ . '/src/Model/HeurekaCategory/HeurekaCategory.php',
         ],
     ]);
 

--- a/packages/product-feed-heureka/ecs.php
+++ b/packages/product-feed-heureka/ecs.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidVariableNameSniff;
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -42,6 +44,12 @@ return static function (ECSConfig $ecsConfig): void {
         ],
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/product-feed-zbozi/ecs.php
+++ b/packages/product-feed-zbozi/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -35,6 +37,12 @@ return static function (ECSConfig $ecsConfig): void {
         ],
         ObjectIsCreatedByFactorySniff::class => [
             __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
         ],
     ]);
 

--- a/packages/read-model/ecs.php
+++ b/packages/read-model/ecs.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Shopsys\CodingStandards\CsFixer\ForbiddenPrivateVisibilityFixer;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use Shopsys\CodingStandards\Sniffs\ObjectIsCreatedByFactorySniff;
@@ -28,11 +30,16 @@ return static function (ECSConfig $ecsConfig): void {
         ]);
 
     $ecsConfig->skip([
-        ObjectIsCreatedByFactorySniff::class =>
-            [
-                __DIR__ . '/src/Product/Detail/ProductDetailViewElasticsearchFactory.php',
-                __DIR__ . '/tests/*',
-            ],
+        ObjectIsCreatedByFactorySniff::class => [
+            __DIR__ . '/src/Product/Detail/ProductDetailViewElasticsearchFactory.php',
+            __DIR__ . '/tests/*',
+        ],
+        PhpdocToPropertyTypeFixer::class => [
+            __DIR__ . '/src/*',
+        ],
+        DeclareStrictTypesFixer::class => [
+            __DIR__ . '/src/*',
+        ],
     ]);
 
     $ecsConfig->import(__DIR__ . '/vendor/shopsys/coding-standards/ecs.php', null, true);

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -6,4 +6,6 @@ This guide contains instructions to upgrade from version v12.0.0 to v13.0.0-dev.
 There you can find links to upgrade notes for other versions too.
 
 - split functional and frontend-api tests into separate suites ([#2641](https://github.com/shopsys/shopsys/pull/2641))
-   - see #project-base-diff to update your project
+    - see #project-base-diff to update your project
+- use TestCurrencyProvider from the framework ([#2662](https://github.com/shopsys/shopsys/pull/2662))
+    - remove class `Tests\App\Functional\Model\Pricing\Currency\TestCurrencyProvider` and use `Tests\FrameworkBundle\Test\Provider\TestCurrencyProvider` instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| On split packages we run checks and those checks were failing on 13.0 branch. This PR fixes that.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
