### PR TITLE
don't show 500 error page when you have 405 http code

### DIFF
--- a/packages/framework/src/Component/Error/ErrorPagesFacade.php
+++ b/packages/framework/src/Component/Error/ErrorPagesFacade.php
@@ -103,6 +103,7 @@ class ErrorPagesFacade
         switch ($statusCode) {
             case Response::HTTP_NOT_FOUND:
             case Response::HTTP_FORBIDDEN:
+            case Response::HTTP_METHOD_NOT_ALLOWED:
                 return static::PAGE_STATUS_CODE_404;
             case Response::HTTP_GONE:
                 return static::PAGE_STATUS_CODE_410;

--- a/project-base/config/packages/acc/monolog.yaml
+++ b/project-base/config/packages/acc/monolog.yaml
@@ -5,4 +5,4 @@ monolog:
             buffer_size: 1000
             action_level: warning
             handler: nested
-            excluded_http_codes: [{ 404: ['^/'] }]
+            excluded_http_codes: [{ 404: ['^/'] }, { 405: ['^/'] }]

--- a/project-base/config/packages/prod/monolog.yaml
+++ b/project-base/config/packages/prod/monolog.yaml
@@ -5,4 +5,4 @@ monolog:
             buffer_size: 1000
             action_level: warning
             handler: nested
-            excluded_http_codes: [{ 404: ['^/'] }]
+            excluded_http_codes: [{ 404: ['^/'] }, { 405: ['^/'] }]

--- a/project-base/config/packages/test/monolog.yaml
+++ b/project-base/config/packages/test/monolog.yaml
@@ -6,7 +6,7 @@ monolog:
             buffer_size: 1000
             action_level: warning
             handler: nested
-            excluded_http_codes: [ { 404: [ '^/' ] } ]
+            excluded_http_codes: [{ 404: ['^/'] }, { 405: ['^/'] }]
         nested:
             type: stream
             path: "%shopsys.log_stream%"

--- a/upgrade/UPGRADE-v11.0.1-dev.md
+++ b/upgrade/UPGRADE-v11.0.1-dev.md
@@ -216,3 +216,5 @@ There you can find links to upgrade notes for other versions too.
             ) {
         ```
     - see #project-base-diff to update your project
+- exclude 405 errors from logging ([#2666](https://github.com/shopsys/shopsys/pull/2666))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When you go URL that has allowed only POST requests you will  get 500 error page and it will be logged as error (see bottom). I recommend showing better 404 page and don't log this useless information. Thanks 🤝
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

full error message:
```
request.ERROR: Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException: "No route found for "GET http://127.0.0.1:8000/search/autocomplete/": Method Not Allowed (Allow: POST)" at /var/www/html/vendor/symfony/http-kernel/EventListener/RouterListener.php line 139 Error ID: VRk8rNsI0Q {"exception":"[object] (Symfony\\Component\\HttpKernel\\Exception\\MethodNotAllowedHttpException(code: 0): No route found for \"GET http://127.0.0.1:8000/search/autocomplete/\": Method Not Allowed (Allow: POST) at /var/www/html/vendor/symfony/http-kernel/EventListener/RouterListener.php:139)\n[previous exception] [object] (Symfony\\Component\\Routing\\Exception\\MethodNotAllowedException(code: 0):  at /var/www/html/vendor/symfony/routing/Matcher/Dumper/CompiledUrlMatcherTrait.php:46)"} []
```