### PR TITLE
fixed cache behavior during manual updates after cart mutations

### DIFF
--- a/project-base/storefront/connectors/cart/Cart.ts
+++ b/project-base/storefront/connectors/cart/Cart.ts
@@ -44,7 +44,6 @@ export const useCurrentCart = (fromCache = true): CurrentCartType => {
         isLoading: stale,
         isFetching: fetching,
         modifications: cartData?.cart?.modifications ?? null,
-        refetchCart,
     };
 };
 

--- a/project-base/storefront/hooks/cart/useReloadCart.ts
+++ b/project-base/storefront/hooks/cart/useReloadCart.ts
@@ -4,23 +4,31 @@ import { getUrlWithoutGetParameters } from 'helpers/parsing/getUrlWithoutGetPara
 import { useTypedTranslationFunction } from 'hooks/typescript/useTypedTranslationFunction';
 import { useCurrentUserData } from 'hooks/user/useCurrentUserData';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { usePersistStore } from 'store/zustand/usePersistStore';
+import { useClient } from 'urql';
+import { CartQueryDocumentApi } from 'graphql/generated';
 
 export const useReloadCart = (): void => {
-    const { modifications, refetchCart } = useCurrentCart(false);
+    const { modifications } = useCurrentCart(false);
     const [changePaymentInCart] = useChangePaymentInCart();
     const t = useTypedTranslationFunction();
     const router = useRouter();
-    const slug = useMemo(() => getUrlWithoutGetParameters(router.asPath), [router.asPath]);
+    const slug = getUrlWithoutGetParameters(router.asPath);
     const { isUserLoggedIn } = useCurrentUserData();
+    const updateLastVisitedSlug = usePersistStore((store) => store.updateLastVisitedSlug);
+    const lastVisitedSlug = usePersistStore((store) => store.lastVisitedSlug);
     const cartUuid = usePersistStore((store) => store.cartUuid);
+    const client = useClient();
 
     useEffect(() => {
-        if (cartUuid || isUserLoggedIn) {
-            refetchCart();
+        const hasSlugChanged = lastVisitedSlug !== slug;
+        updateLastVisitedSlug(slug);
+
+        if ((cartUuid || isUserLoggedIn) && hasSlugChanged) {
+            client.query(CartQueryDocumentApi, { cartUuid }, { requestPolicy: 'network-only' }).toPromise();
         }
-    }, [slug, refetchCart, isUserLoggedIn, cartUuid]);
+    }, [slug]);
 
     useEffect(() => {
         if (modifications) {

--- a/project-base/storefront/store/zustand/slices/createGeneralSlice.ts
+++ b/project-base/storefront/store/zustand/slices/createGeneralSlice.ts
@@ -4,14 +4,20 @@ type LoginLoadingStatus = 'loading' | 'loading-with-cart-modifications';
 
 export type LoginLoadingSlice = {
     loginLoading: LoginLoadingStatus | null;
+    lastVisitedSlug: string | null;
 
     updateLoginLoadingState: (value: LoginLoadingStatus | null) => void;
+    updateLastVisitedSlug: (value: string) => void;
 };
 
 export const createLoginLoadingSlice: StateCreator<LoginLoadingSlice> = (set) => ({
     loginLoading: null,
+    lastVisitedSlug: null,
 
     updateLoginLoadingState: (value) => {
         set({ loginLoading: value });
+    },
+    updateLastVisitedSlug: (value) => {
+        set({ lastVisitedSlug: value });
     },
 });

--- a/project-base/storefront/types/cart.ts
+++ b/project-base/storefront/types/cart.ts
@@ -6,7 +6,6 @@ import {
     SimplePaymentFragmentApi,
     TransportWithAvailablePaymentsAndStoresFragmentApi,
 } from 'graphql/generated';
-import { OperationContext } from 'urql';
 
 export type CurrentCartType = {
     cart: Maybe<CartFragmentApi>;
@@ -19,5 +18,4 @@ export type CurrentCartType = {
     isLoading: boolean;
     isFetching: boolean;
     modifications: Maybe<CartModificationsFragmentApi>;
-    refetchCart: (opts?: Partial<OperationContext>) => void;
 };

--- a/project-base/storefront/urql/cacheExchange.ts
+++ b/project-base/storefront/urql/cacheExchange.ts
@@ -1,15 +1,21 @@
 import { Cache, cacheExchange, Data } from '@urql/exchange-graphcache';
 import { IntrospectionQuery } from 'graphql';
 import {
+    AddToCartMutationVariablesApi,
     AddToCartResultApi,
+    ApplyPromoCodeToCartMutationVariablesApi,
     CartApi,
     CartQueryApi,
     CartQueryDocumentApi,
     CartQueryVariablesApi,
     ChangePaymentInCartInputApi,
     ChangePaymentInCartMutationApi,
+    ChangePaymentInCartMutationVariablesApi,
     ChangeTransportInCartInputApi,
     ChangeTransportInCartMutationApi,
+    ChangeTransportInCartMutationVariablesApi,
+    RemoveFromCartMutationVariablesApi,
+    RemovePromoCodeFromCartMutationVariablesApi,
     TransportsQueryApi,
     TransportsQueryDocumentApi,
     TransportsQueryVariablesApi,
@@ -106,43 +112,43 @@ export const cache = cacheExchange({
             CreateOrder(_result, _args, cache) {
                 invalidateFields(cache, ['currentCustomerUser']);
             },
-            AddToCart(result, _args, cache) {
+            AddToCart(result, args: AddToCartMutationVariablesApi, cache) {
                 const newCart =
                     typeof result.AddToCart !== 'undefined' ? (result.AddToCart as AddToCartResultApi) : undefined;
-                manuallyUpdateCartFragment(cache, newCart?.cart);
+                manuallyUpdateCartFragment(cache, newCart?.cart, args.input.cartUuid);
             },
-            ChangeTransportInCart(result, _args, cache) {
+            ChangeTransportInCart(result, args: ChangeTransportInCartMutationVariablesApi, cache) {
                 const newCart =
                     typeof result.ChangeTransportInCart !== 'undefined'
                         ? (result.ChangeTransportInCart as CartApi)
                         : undefined;
-                manuallyUpdateCartFragment(cache, newCart);
+                manuallyUpdateCartFragment(cache, newCart, args.input.cartUuid);
             },
-            ChangePaymentInCart(result, _args, cache) {
+            ChangePaymentInCart(result, args: ChangePaymentInCartMutationVariablesApi, cache) {
                 const newCart =
                     typeof result.ChangePaymentInCart !== 'undefined'
                         ? (result.ChangePaymentInCart as CartApi)
                         : undefined;
-                manuallyUpdateCartFragment(cache, newCart);
+                manuallyUpdateCartFragment(cache, newCart, args.input.cartUuid);
             },
-            RemoveFromCart(result, _args, cache) {
+            RemoveFromCart(result, args: RemoveFromCartMutationVariablesApi, cache) {
                 const newCart =
                     typeof result.RemoveFromCart !== 'undefined' ? (result.RemoveFromCart as CartApi) : undefined;
-                manuallyUpdateCartFragment(cache, newCart);
+                manuallyUpdateCartFragment(cache, newCart, args.input.cartUuid);
             },
-            ApplyPromoCodeToCart(result, _args, cache) {
+            ApplyPromoCodeToCart(result, args: ApplyPromoCodeToCartMutationVariablesApi, cache) {
                 const newCart =
                     typeof result.ApplyPromoCodeToCart !== 'undefined'
                         ? (result.ApplyPromoCodeToCart as CartApi)
                         : undefined;
-                manuallyUpdateCartFragment(cache, newCart);
+                manuallyUpdateCartFragment(cache, newCart, args.input.cartUuid);
             },
-            RemovePromoCodeFromCart(result, _args, cache) {
+            RemovePromoCodeFromCart(result, args: RemovePromoCodeFromCartMutationVariablesApi, cache) {
                 const newCart =
                     typeof result.RemovePromoCodeFromCart !== 'undefined'
                         ? (result.RemovePromoCodeFromCart as CartApi)
                         : undefined;
-                manuallyUpdateCartFragment(cache, newCart);
+                manuallyUpdateCartFragment(cache, newCart, args.input.cartUuid);
             },
             addProductToComparison(result, _args, cache) {
                 invalidateFields(cache, ['comparison']);
@@ -203,24 +209,14 @@ const invalidateFields = (cache: Cache, fields: string[]): void => {
     }
 };
 
-const manuallyUpdateCartFragment = (cache: Cache, newCart: CartApi | undefined) => {
-    if (newCart !== undefined) {
-        cache.updateQuery<CartQueryApi, CartQueryVariablesApi>(
-            { query: CartQueryDocumentApi, variables: { cartUuid: newCart.uuid } },
-            (data) => {
-                if (typeof newCart !== 'undefined') {
-                    // eslint-disable-next-line no-param-reassign
-                    data = {
-                        __typename: 'Query',
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore
-                        cart: newCart,
-                    };
-                }
-
-                return data;
-            },
-        );
+const manuallyUpdateCartFragment = (cache: Cache, newCart: CartApi | undefined, cartUuid: string | null) => {
+    if (newCart && cartUuid) {
+        cache.updateQuery({ query: CartQueryDocumentApi, variables: { cartUuid } }, (data) => {
+            if (data !== null) {
+                data.cart = newCart;
+            }
+            return data;
+        });
     }
 };
 

--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -1,9 +1,13 @@
 import { showErrorMessage } from 'components/Helpers/toasts';
+import { CartQueryDocumentApi } from 'graphql/generated';
 import { removeTokensFromCookies } from 'helpers/auth/tokens';
+import { ApplicationErrors } from 'helpers/errors/applicationErrors';
 import { getUserFriendlyErrors } from 'helpers/errors/friendlyErrorMessageParser';
 import { logException } from 'helpers/errors/logException';
 import { GetServerSidePropsContext, NextPageContext } from 'next';
 import { Translate } from 'next-translate';
+import { ParsedErrors } from 'types/error';
+import { GtmMessageOriginType } from 'types/gtm/enums';
 import { Exchange } from 'urql';
 import { pipe, tap } from 'wonka';
 
@@ -27,10 +31,37 @@ export const getErrorExchange =
                     const parsedErrors = t ? getUserFriendlyErrors(error, t) : undefined;
                     logException(error);
 
-                    if (parsedErrors?.applicationError) {
+                    if (!parsedErrors) {
+                        return;
+                    }
+
+                    const isCartError = operation.query === CartQueryDocumentApi;
+                    if (isCartError) {
+                        handleCartError(parsedErrors);
+
+                        return;
+                    }
+
+                    if (parsedErrors.applicationError) {
                         showErrorMessage(parsedErrors.applicationError.message);
                     }
                 }),
             );
         };
     };
+
+const handleCartError = ({ userError, applicationError }: ParsedErrors) => {
+    switch (applicationError?.type) {
+        case ApplicationErrors['cart-not-found']:
+            break;
+        case ApplicationErrors.default:
+            showErrorMessage(applicationError.message, GtmMessageOriginType.cart);
+            break;
+    }
+
+    if (userError?.validation !== undefined) {
+        for (const invalidFieldName in userError.validation) {
+            showErrorMessage(userError.validation[invalidFieldName].message, GtmMessageOriginType.cart);
+        }
+    }
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The Urql GraphCache did not behave correctly when it was manually updated in some specific scenarios. Namely  when he cart UUID in cache was null. New approach uses the cart UUID from mutation arguments, which should be more robust.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)|No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)? |Yes
