### PR TITLE
[shopsys] fix storefront file permissions for user with uid different from 1000

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -284,7 +284,6 @@ jobs:
                 run: docker compose cp ./project-base/app/schema.graphql storefront:/home/node/app/schema.graphql
             -   name: Install dev dependencies
                 run: |
-                    docker compose exec --user root storefront chown -R node:node /home/node/app
                     docker compose exec storefront pnpm install --dev --frozen-lockfile
             -   name: Check no NEXT_PUBLIC_ variables are used
                 run: |
@@ -295,7 +294,6 @@ jobs:
                     docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
                     docker compose cp php-fpm:/var/www/html/project-base/app/schema.graphql /tmp/schema.graphql
                     docker compose cp /tmp/schema.graphql storefront:/home/node/app/schema.graphql
-                    docker compose exec -u root storefront chown -R node:node /home/node/app
                     docker compose exec storefront sh check-code-gen.sh
             -   name: Check standards
                 run: docker compose exec storefront pnpm run check
@@ -334,7 +332,6 @@ jobs:
                 run: |
                     docker compose pull --parallel postgres webserver elasticsearch redis php-fpm storefront
                     docker compose up -d postgres webserver elasticsearch redis php-fpm storefront
-                    docker compose exec -T --user root storefront chown -R node:node /home/node/app
                     docker compose exec -T php-fpm php phing -D production.confirm.action=y -D change.environment=dev environment-change test-dirs-create db-create test-db-create db-demo elasticsearch-index-recreate elasticsearch-export error-pages-generate
             -   name: Run tests
                 run: docker compose exec -T php-fpm php phing -D production.confirm.action=y tests
@@ -516,7 +513,6 @@ jobs:
                     docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
                     docker compose cp php-fpm:/var/www/html/project-base/app/schema.graphql /tmp/schema.graphql
                     docker compose cp /tmp/schema.graphql storefront:/home/node/app/schema.graphql
-                    docker compose exec -u root storefront chown -R node:node /home/node/app
                     docker compose exec storefront sh check-code-gen.sh
             -   name: Check Storefront standards
                 run: docker compose exec storefront pnpm run check

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -37,7 +37,6 @@ services:
             target: development
             args:
                 node_uid: 1000
-                node_gid: 1000
         container_name: shopsys-framework-storefront
         command: # Optional
             - dev # change to `- build` if you want to test application build

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -42,7 +42,6 @@ services:
             target: development
             args:
                 node_uid: 1000
-                node_gid: 1000
         container_name: shopsys-framework-storefront
         command: # Optional
             - dev # change to `- build` if you want to test application build

--- a/project-base/scripts/configure.sh
+++ b/project-base/scripts/configure.sh
@@ -48,7 +48,6 @@ case "$operatingSystem" in
         sed -i -r "s#www_data_uid: [0-9]+#www_data_uid: $(id -u)#" ./docker-compose.yml
         sed -i -r "s#www_data_gid: [0-9]+#www_data_gid: $(id -g)#" ./docker-compose.yml
         sed -i -r "s#node_uid: [0-9]+#node_uid: $(id -u)#" ./docker-compose.yml
-        sed -i -r "s#node_gid: [0-9]+#node_gid: $(id -g)#" ./docker-compose.yml
 
         echo "Starting docker-compose"
         docker-compose up -d --build --force-recreate

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -3,7 +3,15 @@ FROM node:18.15.0-alpine as development
 RUN corepack enable
 RUN corepack prepare --activate pnpm@8.6.7
 
-ARG APP_DIR=/home/node/app
+ARG HOME_DIR=/home/node
+ARG APP_DIR=$HOME_DIR/app
+
+# Ensure that files are mounted with the correct permissions
+ARG node_uid
+RUN apk add --no-cache shadow
+
+RUN if [[ -n "$node_uid" && "$node_uid" -ne 1000 ]]; then usermod -u $node_uid node && chown -R node $HOME_DIR; fi;
+
 USER node
 WORKDIR $APP_DIR
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Linux user with different UID than 1000 was not able to run storefront container in dev environment due to wrong ownership of files from the volume. This PR adds auto fixing of the permissions and removes no longer necessary chown in github actions builds.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
