### PR TITLE
errors on SF can now have different verbosity

### DIFF
--- a/project-base/storefront/helpers/errors/applicationErrors.ts
+++ b/project-base/storefront/helpers/errors/applicationErrors.ts
@@ -1,31 +1,55 @@
-export const ApplicationErrors = {
-    default: 'default',
-    'cart-not-found': 'cart-not-found',
-    'max-allowed-limit': 'max-allowed-limit',
-    'packetery-address-id-invalid': 'packetery-address-id-invalid',
-    'invalid-credentials': 'invalid-credentials',
-    'invalid-refresh-token': 'invalid-refresh-token',
-    'order-emails-not-sent': 'order-emails-not-sent',
-    'order-empty-cart': 'order-empty-cart',
-    'personal-data-request-type-invalid': 'personal-data-request-type-invalid',
-    'blog-category-not-found': 'blog-category-not-found',
-    'image-type-invalid': 'image-type-invalid',
-    'image-size-invalid': 'image-size-invalid',
-    'order-not-found': 'order-not-found',
-    'personal-data-hash-invalid': 'personal-data-hash-invalid',
-    'product-price-missing': 'product-price-missing',
-    'no-result-found-for-slug': 'no-result-found-for-slug',
-    'store-not-found': 'store-not-found',
-    'invalid-token': 'invalid-token',
-    'product-not-found': 'product-not-found',
-    'handling-with-logged-customer-comparison': 'handling-with-logged-customer-comparison',
-    'comparison-not-found': 'comparison-not-found',
-    'compared-item-not-found': 'compared-item-not-found',
-    'compared-item-already-exists': 'compared-item-already-exists',
-    'wishlist-not-found': 'wishlist-not-found',
-    'wishlist-item-already-exists': 'wishlist-item-already-exists',
-    'wishlist-item-not-found': 'wishlist-item-not-found',
-    'seo-page-not-found': 'seo-page-not-found',
+export type ApplicationErrorVerbosityLevel = 'flash-message' | 'no-flash-message' | 'no-log';
+
+const ApplicationErrors = {
+    default: 'flash-message',
+    'cart-not-found': 'flash-message',
+    'max-allowed-limit': 'flash-message',
+    'packetery-address-id-invalid': 'flash-message',
+    'invalid-credentials': 'flash-message',
+    'invalid-refresh-token': 'flash-message',
+    'order-emails-not-sent': 'flash-message',
+    'order-empty-cart': 'flash-message',
+    'personal-data-request-type-invalid': 'flash-message',
+    'blog-category-not-found': 'flash-message',
+    'image-type-invalid': 'flash-message',
+    'image-size-invalid': 'flash-message',
+    'order-not-found': 'flash-message',
+    'personal-data-hash-invalid': 'flash-message',
+    'product-price-missing': 'flash-message',
+    'no-result-found-for-slug': 'no-flash-message',
+    'store-not-found': 'flash-message',
+    'invalid-token': 'no-flash-message',
+    'product-not-found': 'flash-message',
+    'handling-with-logged-customer-comparison': 'flash-message',
+    'comparison-not-found': 'flash-message',
+    'compared-item-not-found': 'flash-message',
+    'compared-item-already-exists': 'flash-message',
+    'seo-page-not-found': 'no-log',
+    'wishlist-not-found': 'flash-message',
+    'wishlist-item-already-exists': 'flash-message',
+    'wishlist-item-not-found': 'flash-message',
 } as const;
 
+type KeysMatching<T, V extends ApplicationErrorVerbosityLevel> = {
+    [K in keyof T]: T[K] extends V ? K : never;
+}[keyof T];
+
+export type FlashMessageKeys = KeysMatching<typeof ApplicationErrors, 'flash-message'>;
+
+export type NoFlashMessageKeys = KeysMatching<typeof ApplicationErrors, 'no-flash-message'>;
+
+export type NoLogKeys = KeysMatching<typeof ApplicationErrors, 'no-log'>;
+
 export type ApplicationErrorsType = keyof typeof ApplicationErrors;
+
+export const isFlashMessageError = (errorCode: string): errorCode is FlashMessageKeys =>
+    Object.keys(ApplicationErrors).includes(errorCode) &&
+    ApplicationErrors[errorCode as keyof typeof ApplicationErrors] === 'flash-message';
+
+export const isNoFlashMessageError = (errorCode: string): errorCode is NoFlashMessageKeys =>
+    Object.keys(ApplicationErrors).includes(errorCode) &&
+    ApplicationErrors[errorCode as keyof typeof ApplicationErrors] === 'no-flash-message';
+
+export const isNoLogError = (errorCode: string): errorCode is NoLogKeys =>
+    Object.keys(ApplicationErrors).includes(errorCode) &&
+    ApplicationErrors[errorCode as keyof typeof ApplicationErrors] === 'no-log';

--- a/project-base/storefront/helpers/errors/errorMessageMapper.ts
+++ b/project-base/storefront/helpers/errors/errorMessageMapper.ts
@@ -1,55 +1,39 @@
-import { ApplicationErrors, ApplicationErrorsType } from './applicationErrors';
+import { FlashMessageKeys } from './applicationErrors';
 import { Translate } from 'next-translate';
-import { ApplicationIgnoredErrors } from './ignoredErrors';
 
-type ApplicationErrorsWithoutIgnoredErrorsType = Exclude<
-    ApplicationErrorsType,
-    (typeof ApplicationIgnoredErrors)[number]
->;
-
-const getErrorMessageTranslationString = (
-    errorCode: ApplicationErrorsWithoutIgnoredErrorsType,
-    t: Translate,
-): string | undefined => {
-    const ERROR_MESSAGES: Record<ApplicationErrorsWithoutIgnoredErrorsType, string | undefined> = {
-        [ApplicationErrors.default]: t('Unknown error.'),
-        [ApplicationErrors['cart-not-found']]: t('Cart not found.'),
-        [ApplicationErrors['max-allowed-limit']]: t('Max allowed limit reached.'),
-        [ApplicationErrors['packetery-address-id-invalid']]: t('Invalid Packetery address id.'),
-        [ApplicationErrors['invalid-credentials']]: t('Invalid credentials.'),
-        [ApplicationErrors['invalid-refresh-token']]: t('Invalid refresh token.'),
-        [ApplicationErrors['order-emails-not-sent']]: t('Automatic order emails was not sent.'),
-        [ApplicationErrors['order-empty-cart']]: t('Cart is empty.'),
-        [ApplicationErrors['personal-data-request-type-invalid']]: t('Invalid request type.'),
-        [ApplicationErrors['blog-category-not-found']]: t('Category not found.'),
-        [ApplicationErrors['image-type-invalid']]: t('Invalid image type.'),
-        [ApplicationErrors['image-size-invalid']]: t('Invalid image size.'),
-        [ApplicationErrors['order-not-found']]: t('Order not found.'),
-        [ApplicationErrors['personal-data-hash-invalid']]: t('Invalid hash.'),
-        [ApplicationErrors['product-price-missing']]: t('Product price is missing.'),
-        [ApplicationErrors['store-not-found']]: t('Store not found.'),
-        [ApplicationErrors['product-not-found']]: t('Product not found.'),
-        [ApplicationErrors['handling-with-logged-customer-comparison']]: t('Product not found.'),
-        [ApplicationErrors['comparison-not-found']]: t('Comparison not found.'),
-        [ApplicationErrors['compared-item-not-found']]: t('Compared product not found.'),
-        [ApplicationErrors['compared-item-already-exists']]: t('Compared product is already compared.'),
-        [ApplicationErrors['wishlist-not-found']]: t('Wishlist not found.'),
-        [ApplicationErrors['wishlist-item-already-exists']]: t('Product in wishlist already exists.'),
-        [ApplicationErrors['wishlist-item-not-found']]: t('Product in wishlist not found.'),
+const getErrorMessageTranslationString = (errorCode: FlashMessageKeys, t: Translate): string | undefined => {
+    const ERROR_MESSAGES: Record<FlashMessageKeys, string> = {
+        default: t('Unknown error.'),
+        'cart-not-found': t('Cart not found.'),
+        'max-allowed-limit': t('Max allowed limit reached.'),
+        'packetery-address-id-invalid': t('Invalid Packetery address id.'),
+        'invalid-credentials': t('Invalid credentials.'),
+        'invalid-refresh-token': t('Invalid refresh token.'),
+        'order-emails-not-sent': t('Automatic order emails was not sent.'),
+        'order-empty-cart': t('Cart is empty.'),
+        'personal-data-request-type-invalid': t('Invalid request type.'),
+        'blog-category-not-found': t('Category not found.'),
+        'image-type-invalid': t('Invalid image type.'),
+        'image-size-invalid': t('Invalid image size.'),
+        'order-not-found': t('Order not found.'),
+        'personal-data-hash-invalid': t('Invalid hash.'),
+        'product-price-missing': t('Product price is missing.'),
+        'store-not-found': t('Store not found.'),
+        'product-not-found': t('Product not found.'),
+        'handling-with-logged-customer-comparison': t('Product not found.'),
+        'comparison-not-found': t('Comparison not found.'),
+        'compared-item-not-found': t('Compared product not found.'),
+        'compared-item-already-exists': t('Compared product is already compared.'),
+        'wishlist-not-found': t('Wishlist not found.'),
+        'wishlist-item-already-exists': t('Product in wishlist already exists.'),
+        'wishlist-item-not-found': t('Product in wishlist not found.'),
     };
 
     return ERROR_MESSAGES[errorCode];
 };
 
-export const hasErrorMessage = (errorCode: string, t: Translate): boolean => {
-    return getErrorMessageTranslationString(errorCode as ApplicationErrorsWithoutIgnoredErrorsType, t) !== undefined;
-};
-
-export const getErrorMessage = (errorCode: string, t: Translate): string => {
-    const translationString = getErrorMessageTranslationString(
-        errorCode as ApplicationErrorsWithoutIgnoredErrorsType,
-        t,
-    );
+export const getErrorMessage = (errorCode: FlashMessageKeys, t: Translate): string => {
+    const translationString = getErrorMessageTranslationString(errorCode, t);
 
     return translationString !== undefined ? t(translationString) : t('Unknown error.');
 };

--- a/project-base/storefront/helpers/errors/ignoredErrors.ts
+++ b/project-base/storefront/helpers/errors/ignoredErrors.ts
@@ -1,8 +1,0 @@
-import { ApplicationErrors } from './applicationErrors';
-
-// errors we don't want to display to users
-export const ApplicationIgnoredErrors = [
-    ApplicationErrors['no-result-found-for-slug'],
-    ApplicationErrors['seo-page-not-found'],
-    ApplicationErrors['invalid-token'],
-] as const;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to be able to differentiate between different error message verbosity in order to specify which errors should be showed to users, which logged in sentry, and which should be completely ignored. With this setting it's now possible.
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
