### PR TITLE
[github-actions] wait for containers ready state before checks

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -280,12 +280,9 @@ jobs:
                 with:
                     name: docker-compose
             -   name: Build application
-                run: docker compose up -d storefront php-fpm
+                run: docker compose up -d --wait storefront php-fpm
             -   name: Move schema.graphql to Storefront container
                 run: docker compose cp ./project-base/app/schema.graphql storefront:/home/node/app/schema.graphql
-            -   name: Install dev dependencies
-                run: |
-                    docker compose exec storefront pnpm install --dev --frozen-lockfile
             -   name: Check no NEXT_PUBLIC_ variables are used
                 run: |
                     docker compose exec --user root storefront apk add grep

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -407,7 +407,7 @@ jobs:
             -   name: Build application
                 run: |
                     mv docker-compose.cypress.yml docker-compose.yml
-                    docker compose up -d
+                    docker compose up -d --wait
                     docker compose exec php-fpm php phing -D production.confirm.action=y db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate test-db-create test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export
                     docker compose exec php-fpm php phing -D production.confirm.action=y -D change.environment=acc environment-change
             -   name: Run Cypress tests
@@ -529,7 +529,7 @@ jobs:
             -   name: Build application
                 run: |
                     mv docker-compose.cypress.yml docker-compose.yml
-                    docker compose up -d
+                    docker compose up -d --wait
                     docker compose exec php-fpm php phing -D production.confirm.action=y db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate test-db-create test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export
                     docker compose exec php-fpm php phing -D production.confirm.action=y -D change.environment=acc environment-change
             -   name: Run Cypress tests

--- a/docker/conf/docker-compose.github-actions.cypress.yml.dist
+++ b/docker/conf/docker-compose.github-actions.cypress.yml.dist
@@ -15,6 +15,12 @@ services:
             - postgres
             - -c
             - config_file=/var/lib/postgresql/data/postgresql.conf
+        healthcheck:
+            test: ["CMD", "pg_isready"]
+            start_period: 10s
+            interval: 10s
+            timeout: 10s
+            retries: 15
 
     webserver:
         image: nginx:1.13-alpine

--- a/docker/conf/docker-compose.github-actions.yml.dist
+++ b/docker/conf/docker-compose.github-actions.yml.dist
@@ -36,6 +36,12 @@ services:
             - dev
         ports:
             - "3000:3000"
+        healthcheck:
+            test: wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+            start_period: 30s
+            interval: 30s
+            timeout: 10s
+            retries: 5
         volumes:
             - ./project-base/storefront:/home/node/app
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| dev dependencies in storefront-standards job are automatically installed on container run (thanks to `dev` command), so installing them manually is unnecessary. This PR improves the test stability by removing the concurrent installation causing occasional errors while installing dependencies.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
