### PR TITLE
[framework] non-project classes are not automatically added registered as an extended service for the interface

### DIFF
--- a/packages/framework/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterProjectFrameworkClassExtensionsCompilerPass.php
@@ -49,9 +49,13 @@ class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPas
                 continue;
             }
 
-            $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$serviceId, $aliasId]);
             $frameworkClassBetterReflection = ReflectionObject::createFromName($serviceId);
 
+            if ($frameworkClassBetterReflection->isInterface() && !$this->isProjectClass($aliasId)) {
+                continue;
+            }
+
+            $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$serviceId, $aliasId]);
             $this->addAllVariantsOfServiceToClassExtension($frameworkClassBetterReflection, $classExtensionRegistryDefinition, $aliasId);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It's not desirable to be forced to change the code copied from the framework when no custom extended class exists. Example follows.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


If you extend the following class from framework 
```
class CartMigrationFacade
{
   // ....

    /**
     * @param \Doctrine\ORM\EntityManagerInterface $em
     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifierFactory $customerUserIdentifierFactory
     * @param \Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface $cartItemFactory
     * @param \Shopsys\FrameworkBundle\Model\Cart\CartFacade $cartFacade
     */
    public function __construct(
        EntityManagerInterface $em,
        CustomerUserIdentifierFactory $customerUserIdentifierFactory,
        CartItemFactoryInterface $cartItemFactory,
        CartFacade $cartFacade
    ) {
        $this->em = $em;
        $this->customerUserIdentifierFactory = $customerUserIdentifierFactory;
        $this->cartItemFactory = $cartItemFactory;
        $this->cartFacade = $cartFacade;
    }
```

in your project, then, until the change in this PR, the annotation fixer forced the @method annotation for constructor where param type for `$cartItemFactory` was changed from `\Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface` to `\Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory.

This change is hard to understand because framework's implementation should be covered completely by the interface. 