### PR TITLE
router.push and router.replace now navigate correctly between dynamic…

### DIFF
--- a/project-base/storefront/components/Blocks/Product/ProductAction.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductAction.tsx
@@ -22,7 +22,16 @@ export const ProductAction: FC<ProductActionProps> = ({ product, gtmProductListN
         return (
             <ProductActionWrapper>
                 <Button
-                    onClick={() => router.push(product.slug)}
+                    onClick={() =>
+                        router.push(
+                            {
+                                pathname: '/products/[productSlug]',
+                            },
+                            {
+                                pathname: product.slug,
+                            },
+                        )
+                    }
                     name="choose-variant"
                     dataTestId={TEST_IDENTIFIER + '-choose-variant'}
                     className="!w-full"

--- a/project-base/storefront/helpers/filterOptions/seoCategories.ts
+++ b/project-base/storefront/helpers/filterOptions/seoCategories.ts
@@ -1,17 +1,12 @@
 import {
     ListedProductConnectionPreviewFragmentApi,
-    CategoryDetailFragmentApi,
     ProductFilterOptionsFragmentApi,
     ProductOrderingModeEnumApi,
 } from 'graphql/generated';
-import { getUrlWithoutGetParameters } from 'helpers/parsing/getUrlWithoutGetParameters';
-import { getStringWithoutLeadingSlash } from 'helpers/parsing/stringWIthoutSlash';
-import router, { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { DefaultProductFiltersMapType } from 'store/zustand/slices/createSeoCategorySlice';
 import { useSessionStore } from 'store/zustand/useSessionStore';
 import { FilterOptionsParameterUrlQueryType, FilterOptionsUrlQueryType } from 'types/productFilter';
-import { getSlugFromUrl } from 'utils/getSlugFromUrl';
 
 export const DEFAULT_SORT = ProductOrderingModeEnumApi.PriorityApi as const;
 
@@ -202,22 +197,4 @@ export const useHandleDefaultFiltersUpdate = (
             ),
         );
     }, [productsPreview?.productFilterOptions, productsPreview?.defaultOrderingMode]);
-};
-
-export const useHandleSeoCategorySlugUpdate = (category: CategoryDetailFragmentApi | undefined | null) => {
-    const setOriginalCategorySlug = useSessionStore((s) => s.setOriginalCategorySlug);
-    const setWasRedirectedToSeoCategory = useSessionStore((s) => s.setWasRedirectedToSeoCategory);
-    const { asPath } = useRouter();
-    const urlSlug = getSlugFromUrl(getUrlWithoutGetParameters(asPath));
-
-    useEffect(() => {
-        const isCurrentAndRedirectSlugDifferent = getStringWithoutLeadingSlash(category?.slug ?? '') !== urlSlug;
-
-        if (category?.originalCategorySlug && isCurrentAndRedirectSlugDifferent) {
-            setWasRedirectedToSeoCategory(true);
-            router.replace(category.slug, undefined, { shallow: true });
-        }
-
-        setOriginalCategorySlug(category?.originalCategorySlug ?? undefined);
-    }, [category?.originalCategorySlug, category?.slug]);
 };

--- a/project-base/storefront/hooks/useQueryParams.ts
+++ b/project-base/storefront/hooks/useQueryParams.ts
@@ -319,12 +319,26 @@ export const useQueryParams = () => {
         // remove queries which are not set or removed
         const filteredQueries = getFilteredQueries(queries);
 
+        const asPathname = router.asPath.split('?')[0];
+        const dynamicPageQueryKey = getDynamicPageQueryKey(router.pathname);
+
+        let filteredQueriesWithDynamicParam = filteredQueries;
+        if (dynamicPageQueryKey) {
+            filteredQueriesWithDynamicParam = {
+                [dynamicPageQueryKey]: pathnameOverride || asPathname,
+                ...filteredQueries,
+            };
+        }
+
         router[isPush ? 'push' : 'replace'](
             {
-                pathname: pathnameOverride || router.asPath.split('?')[0],
+                pathname: router.pathname,
+                query: filteredQueriesWithDynamicParam,
+            },
+            {
+                pathname: pathnameOverride || asPathname,
                 query: filteredQueries,
             },
-            undefined,
             { shallow: true },
         );
     };
@@ -345,4 +359,15 @@ export const useQueryParams = () => {
         updateFilterParameters,
         resetAllFilters,
     };
+};
+
+const getDynamicPageQueryKey = (pathname: string) => {
+    const start = pathname.indexOf('[');
+    const end = pathname.indexOf(']');
+
+    if (start !== -1 && end !== -1) {
+        return pathname.substring(start + 1, end);
+    }
+
+    return undefined;
 };

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -202,7 +202,13 @@ export const handleSeoCategorySlugUpdate = (
 
     if (originalCategorySlug && isCurrentAndRedirectSlugDifferent && categorySlug) {
         setWasRedirectedToSeoCategory(true);
-        router.replace(categorySlug, undefined, { shallow: true });
+        router.replace(
+            { pathname: '/categories/[categorySlug]', query: { categorySlug: '/televize-audio-nejlevnejsi' } },
+            { pathname: categorySlug },
+            {
+                shallow: true,
+            },
+        );
     }
 
     setOriginalCategorySlug(originalCategorySlug ?? undefined);

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.resetAllFilters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.resetAllFilters.test.ts
@@ -21,6 +21,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -46,6 +47,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -68,6 +70,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().resetAllFilters tests', () => {
     test('resetting all filters should clear filter and page from query', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -97,12 +100,18 @@ describe('useQueryParams().resetAllFilters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceDescApi,
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceDescApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -122,6 +131,7 @@ describe('useQueryParams().resetAllFilters tests', () => {
         });
 
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -139,12 +149,18 @@ describe('useQueryParams().resetAllFilters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
@@ -5,10 +5,12 @@ import { useRouter } from 'next/router';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -31,6 +33,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().updateFilterBrands tests', () => {
     test('brand should be added to query if not present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {},
@@ -40,6 +43,15 @@ describe('useQueryParams().updateFilterBrands tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: ['test-brand'],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -47,7 +59,6 @@ describe('useQueryParams().updateFilterBrands tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -56,6 +67,7 @@ describe('useQueryParams().updateFilterBrands tests', () => {
 
     test('brand should be removed from query if already present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ brands: ['test-brand'] }) },
@@ -65,10 +77,13 @@ describe('useQueryParams().updateFilterBrands tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {},
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
@@ -5,10 +5,12 @@ import { useRouter } from 'next/router';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -31,6 +33,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().updateFilterFlags tests', () => {
     test('flag should be added to query if not present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {},
@@ -40,6 +43,15 @@ describe('useQueryParams().updateFilterFlags tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        flags: ['test-flag'],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -47,7 +59,6 @@ describe('useQueryParams().updateFilterFlags tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -56,6 +67,7 @@ describe('useQueryParams().updateFilterFlags tests', () => {
 
     test('flag should be removed from query if already present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ flags: ['test-flag'] }) },
@@ -65,10 +77,13 @@ describe('useQueryParams().updateFilterFlags tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {},
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
@@ -17,6 +17,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -38,6 +39,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -63,10 +65,18 @@ describe('useQueryParams().updateFilterInStock tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ onlyInStock: true }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ onlyInStock: true }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ onlyInStock: true }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -75,6 +85,7 @@ describe('useQueryParams().updateFilterInStock tests', () => {
 
     test('onlyInStock should be set to false if updating with `false`', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ onlyInStock: true }) },
@@ -84,10 +95,13 @@ describe('useQueryParams().updateFilterInStock tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {},
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -113,6 +127,27 @@ describe('useQueryParams().updateFilterInStock tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        onlyInStock: true,
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -132,7 +167,6 @@ describe('useQueryParams().updateFilterInStock tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -144,6 +178,15 @@ describe('useQueryParams().updateFilterInStock tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        onlyInStock: true,
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -151,7 +194,6 @@ describe('useQueryParams().updateFilterInStock tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
@@ -17,6 +17,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -38,6 +39,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -60,6 +62,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().updateFilterParameters tests', () => {
     test('checkbox parameter value should be added to query if parameter is already present but value is not', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -82,6 +85,24 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -98,7 +119,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -107,6 +127,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
     test('checkbox parameter should be added to query if not present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -125,6 +146,24 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3'],
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -141,7 +180,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -150,6 +188,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
     test('checkbox parameter value should be removed from query if parameter and value are both present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -172,6 +211,24 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3'],
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -188,7 +245,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -197,6 +253,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
     test('checkbox parameter should be removed from query if parameter and value are both present and removed value is the only one', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -219,6 +276,20 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -231,7 +302,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -240,6 +310,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
     test('slider parameter should be added to query if not present', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -259,6 +330,26 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                minimalValue: 100,
+                                maximalValue: 1000,
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                minimalValue: 200,
+                                maximalValue: 2000,
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -277,7 +368,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -286,6 +376,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
     test('slider parameter should be updated if its values change', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -310,6 +401,26 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                minimalValue: 100,
+                                maximalValue: 1000,
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                minimalValue: 300,
+                                maximalValue: 3000,
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -328,7 +439,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -337,6 +447,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
     test('slider parameter should be removed from query if already present and values are set to undefined', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: {
@@ -361,6 +472,21 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                minimalValue: 100,
+                                maximalValue: 1000,
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -374,7 +500,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -397,6 +522,26 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -415,7 +560,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -441,6 +585,20 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-5'],
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -453,7 +611,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -479,6 +636,31 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3'],
+                            },
+                            {
+                                parameter: 'default-parameter-3',
+                                minimalValue: 100,
+                                maximalValue: 1000,
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -502,7 +684,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -525,6 +706,21 @@ describe('useQueryParams().updateFilterParameters tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-3',
+                                minimalValue: 100,
+                                maximalValue: 1000,
+                            },
+                        ],
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -538,7 +734,6 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
@@ -17,6 +17,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -39,6 +40,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -61,6 +63,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().updateFilterPriceMaximum tests', () => {
     test('maximalPrice should not be updated if it is the same as current maximal price', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }) },
@@ -70,10 +73,18 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -82,6 +93,7 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
     test('maximalPrice should be updated if it differs from the current maximal price', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }) },
@@ -91,10 +103,18 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1100 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1100 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1100 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -103,6 +123,7 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
     test('maximalPrice should be reset if it is set to undefined', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }) },
@@ -112,10 +133,13 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {},
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -138,6 +162,15 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        maximalPrice: 1000,
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -145,7 +178,6 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -171,6 +203,27 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        maximalPrice: 1000,
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -190,7 +243,6 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
@@ -17,6 +17,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -38,6 +39,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -60,6 +62,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().updateFilterPriceMinimum tests', () => {
     test('minimalPrice should not be updated if it is the same as current minimal price', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1000 }) },
@@ -69,10 +72,18 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1000 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1000 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1000 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -81,6 +92,7 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
     test('minimalPrice should be updated if it differs from the current minimal price', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1000 }) },
@@ -90,10 +102,18 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1100 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1100 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1100 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -102,6 +122,7 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
     test('minimalPrice should be reset if it is set to undefined', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 1000 }) },
@@ -111,10 +132,13 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {},
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -137,6 +161,15 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        minimalPrice: 100,
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -144,7 +177,6 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -170,6 +202,27 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        minimalPrice: 100,
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -189,7 +242,6 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
@@ -17,6 +17,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -38,6 +39,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -60,6 +62,7 @@ vi.mock('store/zustand/useSessionStore', () => ({
 describe('useQueryParams().updateFilterPrices tests', () => {
     test('only minimalPrice should be updated if it differs from the current minimal price', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1000 }) },
@@ -69,10 +72,18 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 150, maximalPrice: 1000 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 150, maximalPrice: 1000 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 150, maximalPrice: 1000 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -81,6 +92,7 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
     test('only maximalPrice should be updated if it differs from the current maximal price', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1000 }) },
@@ -90,10 +102,18 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1100 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1100 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1100 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -102,6 +122,7 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
     test('both minimalPrice and maximalPrice should be updated if they differs from the current values', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1000 }) },
@@ -111,10 +132,18 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 150, maximalPrice: 1100 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 150, maximalPrice: 1100 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 150, maximalPrice: 1100 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -123,6 +152,7 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
     test('minimalPrice should be reset if it is set to undefined', () => {
         (useRouter as Mock).mockImplementation(() => ({
+            pathname: CATEGORY_PATHNAME,
             asPath: CATEGORY_URL,
             push: mockPush,
             query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ minimalPrice: 100, maximalPrice: 1000 }) },
@@ -132,10 +162,18 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }) },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }),
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({ maximalPrice: 1000 }),
+                },
+            },
             {
                 shallow: true,
             },
@@ -158,6 +196,16 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        minimalPrice: 100,
+                        maximalPrice: 1000,
+                    }),
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -166,7 +214,6 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                     }),
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -192,6 +239,28 @@ describe('useQueryParams().updateFilterPrices tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        minimalPrice: 100,
+                        maximalPrice: 1000,
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -212,7 +281,6 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updatePagination.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updatePagination.test.ts
@@ -4,10 +4,12 @@ import { useQueryParams } from 'hooks/useQueryParams';
 import { describe, expect, test, vi } from 'vitest';
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -33,10 +35,13 @@ describe('useQueryParams().updatePagination tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {},
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -48,12 +53,15 @@ describe('useQueryParams().updatePagination tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: { categorySlug: CATEGORY_URL, [PAGE_QUERY_PARAMETER_NAME]: '2' },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [PAGE_QUERY_PARAMETER_NAME]: '2',
                 },
             },
-            undefined,
             {
                 shallow: true,
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
@@ -16,6 +16,7 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 }));
 
 const CATEGORY_URL = '/category-url';
+const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
 const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
@@ -41,6 +42,7 @@ vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
     useRouter: vi.fn(() => ({
+        pathname: CATEGORY_PATHNAME,
         asPath: CATEGORY_URL,
         push: mockPush,
         query: {},
@@ -64,7 +66,14 @@ describe('useQueryParams().updateSort tests', () => {
     test('sort should not be updated if updating with the default sort', () => {
         useQueryParams().updateSort(ProductOrderingModeEnumApi.PriorityApi);
 
-        expect(mockPush).toBeCalledWith({ pathname: CATEGORY_URL, query: {} }, undefined, { shallow: true });
+        expect(mockPush).toBeCalledWith(
+            { pathname: CATEGORY_PATHNAME, query: { categorySlug: CATEGORY_URL } },
+            {
+                pathname: CATEGORY_URL,
+                query: {},
+            },
+            { shallow: true },
+        );
     });
 
     test('sort should be updated if updating with new sort', () => {
@@ -72,10 +81,18 @@ describe('useQueryParams().updateSort tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
-                pathname: CATEGORY_URL,
-                query: { [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi },
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
             },
-            undefined,
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
             { shallow: true },
         );
     });
@@ -96,6 +113,26 @@ describe('useQueryParams().updateSort tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        flags: ['default-flag-1', 'default-flag-2'],
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceDescApi,
+                },
+            },
+            {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
@@ -114,7 +151,6 @@ describe('useQueryParams().updateSort tests', () => {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceDescApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },
@@ -140,12 +176,18 @@ describe('useQueryParams().updateSort tests', () => {
 
         expect(mockPush).toBeCalledWith(
             {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceDescApi,
+                },
+            },
+            {
                 pathname: CATEGORY_URL,
                 query: {
                     [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceDescApi,
                 },
             },
-            undefined,
             {
                 shallow: true,
             },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In some places our approach to pushing and replacing the URL with next router was invalid. It caused unnecessary reloads and SSR calls. This PR fixes that issue.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
