### PR TITLE
doctrine/orm 2.16.0 and higher are now marked as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -196,7 +196,7 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "doctrine/orm": "2.12.0",
+        "doctrine/orm": "2.12.0 || >=2.16.0",
         "friendsofphp/php-cs-fixer": "2.19.0",
         "guzzlehttp/psr7": "<=1.8.3, >=2.0.0, <=2.1.0"
     },

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -118,7 +118,7 @@
         }
     },
     "conflict": {
-        "doctrine/orm": "2.12.0"
+        "doctrine/orm": "2.12.0 || >=2.16.0"
     },
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Order item creation depends on the order of autoincrement ids. The way in which order the inserts are executed changed in 2.16.0. See https://github.com/doctrine/orm/pull/10547 and https://github.com/doctrine/orm/issues/10864
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
