### PR TITLE
[framework] fixed robots.txt migration

### DIFF
--- a/packages/framework/src/Migrations/Version20230404071649.php
+++ b/packages/framework/src/Migrations/Version20230404071649.php
@@ -24,7 +24,7 @@ class Version20230404071649 extends AbstractMigration
 
             if ($seoRobotsTxtContentSettingCount <= 0) {
                 $this->sql(
-                    'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'seoRobotsTxtContent\', :domainId, NULL, \'string\')',
+                    'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'seoRobotsTxtContent\', :domainId, \'\', \'string\')',
                     ['domainId' => $domainId],
                 );
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| DB migration from #2591 sets null to setting value with type string. That's not allowed and end up with error. This PR fixes that value.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
