### PR TITLE
[github-actions] added postgres healthcheck for review stage

### DIFF
--- a/docker/conf/docker-compose.github-actions.review.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.yml.dist
@@ -18,6 +18,12 @@ services:
             - default
         labels:
             - traefik.enable=false
+        healthcheck:
+            test: ["CMD", "pg_isready"]
+            start_period: 10s
+            interval: 10s
+            timeout: 10s
+            retries: 15
 
     webserver:
         restart: always


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Occasionally, the build tried to load data into Postgres which was still starting. This PR adds a health check for Postgres, so the build now waits for the fully started Postgres.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
