### PR TITLE
logged-in user wishlist and comparison fix

### DIFF
--- a/project-base/storefront/hooks/auth/useAuth.tsx
+++ b/project-base/storefront/hooks/auth/useAuth.tsx
@@ -34,7 +34,6 @@ export const useAuth = (): { login: typeof login; logout: typeof logout } => {
     const [, logoutMutation] = useLogoutApi();
     const t = useTypedTranslationFunction();
     const updateUserState = usePersistStore((store) => store.updateUserState);
-    const clearWishlistUuid = usePersistStore((s) => s.clearWishlistUuid);
     const updateLoginLoadingState = usePersistStore((store) => store.updateLoginLoadingState);
 
     const router = useRouter();
@@ -69,7 +68,6 @@ export const useAuth = (): { login: typeof login; logout: typeof logout } => {
 
         if (logoutResult.data?.Logout) {
             removeTokensFromCookies();
-            clearWishlistUuid();
             showSuccessMessage(t('Successfully logged out'));
 
             if (canUseDom()) {

--- a/project-base/storefront/store/zustand/slices/createWishlistSlice.ts
+++ b/project-base/storefront/store/zustand/slices/createWishlistSlice.ts
@@ -3,8 +3,7 @@ import { StateCreator } from 'zustand';
 export type WishlistSlice = {
     wishlistUuid: string | null;
 
-    updateWishlistUuid: (value: string) => void;
-    clearWishlistUuid: () => void;
+    updateWishlistUuid: (value: string | null) => void;
 };
 
 export const createWishlistSlice: StateCreator<WishlistSlice> = (set) => ({
@@ -12,8 +11,5 @@ export const createWishlistSlice: StateCreator<WishlistSlice> = (set) => ({
 
     updateWishlistUuid: (wishlistUuid) => {
         set({ wishlistUuid });
-    },
-    clearWishlistUuid: () => {
-        set({ wishlistUuid: null });
     },
 });

--- a/project-base/storefront/urql/cacheExchange.ts
+++ b/project-base/storefront/urql/cacheExchange.ts
@@ -114,10 +114,10 @@ export const cache = cacheExchange({
     updates: {
         Mutation: {
             Login(_result, _args, cache) {
-                invalidateFields(cache, ['cart', 'wishlist']);
+                invalidateFields(cache, ['cart']);
             },
             Logout(_result, _args, cache) {
-                invalidateFields(cache, ['cart', 'wishlist']);
+                invalidateFields(cache, ['cart']);
             },
             DeleteDeliveryAddress(_result, _args, cache) {
                 invalidateFields(cache, ['currentCustomerUser']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Authenticated users were not able to use wishlist and product comparison because of query and query parameters bugs. This PR fixes the problem.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
