### PR TITLE
error popup is now shown after the first invalid form submission

### DIFF
--- a/project-base/storefront/hooks/forms/useErrorPopupVisibility.ts
+++ b/project-base/storefront/hooks/forms/useErrorPopupVisibility.ts
@@ -9,12 +9,12 @@ export const useErrorPopupVisibility = <T extends FieldValues>(
 
     useEffect(() => {
         if (
-            formProviderMethods.formState.isSubmitting &&
+            formProviderMethods.formState.isSubmitted &&
             (Object.keys(formProviderMethods.formState.errors).length > 0 || overrideVisibility)
         ) {
             setErrorPopupVisibility(true);
         }
-    }, [formProviderMethods.formState.isSubmitting, formProviderMethods.formState.errors, overrideVisibility]);
+    }, [formProviderMethods.formState.isSubmitted, formProviderMethods.formState.errors, overrideVisibility]);
 
     return [isErrorPopupVisible, setErrorPopupVisibility];
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Error popup was not shown right after the first invalid form submission, but required 2 submissions. This PR fixes the issue.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues|
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
