### PR TITLE
FE API Advert.catgories field returns visible categories only

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1267,6 +1267,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     +   protected function createCurrentFeedExport(?int $lastSeekId = null): ?FeedExport
     ```
 
+-   fix display advert on invisible category ([#2701](https://github.com/shopsys/shopsys/pull/2701))
+    -   see #project-base-diff to update your project
+
 ### Storefront
 
 -   add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Model/Advert/Advert.php
+++ b/packages/framework/src/Model/Advert/Advert.php
@@ -232,4 +232,18 @@ class Advert
     {
         return $this->datetimeVisibleTo;
     }
+
+    /**
+     * @return int[]
+     */
+    public function getCategoryIds(): array
+    {
+        $categoryIds = [];
+
+        foreach ($this->getCategories() as $category) {
+            $categoryIds[] = $category->getId();
+        }
+
+        return $categoryIds;
+    }
 }

--- a/project-base/app/src/FrontendApi/Model/Category/CategoriesBatchLoader.php
+++ b/project-base/app/src/FrontendApi/Model/Category/CategoriesBatchLoader.php
@@ -28,6 +28,6 @@ class CategoriesBatchLoader
      */
     public function loadByIds(array $categoriesIds): Promise
     {
-        return $this->promiseAdapter->all($this->categoryFacade->getCategoriesByIds($categoriesIds, $this->domain->getCurrentDomainConfig()));
+        return $this->promiseAdapter->all($this->categoryFacade->getVisibleCategoriesByIds($categoriesIds, $this->domain->getCurrentDomainConfig()));
     }
 }

--- a/project-base/app/src/FrontendApi/Model/Category/CategoryFacade.php
+++ b/project-base/app/src/FrontendApi/Model/Category/CategoryFacade.php
@@ -41,8 +41,8 @@ class CategoryFacade extends BaseCategoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \App\Model\Category\Category[][]
      */
-    public function getCategoriesByIds(array $categoriesIds, DomainConfig $domainConfig): array
+    public function getVisibleCategoriesByIds(array $categoriesIds, DomainConfig $domainConfig): array
     {
-        return $this->categoryRepository->getCategoriesByIds($categoriesIds, $domainConfig);
+        return $this->categoryRepository->getVisibleCategoriesByIds($categoriesIds, $domainConfig);
     }
 }

--- a/project-base/app/src/FrontendApi/Model/Category/CategoryRepository.php
+++ b/project-base/app/src/FrontendApi/Model/Category/CategoryRepository.php
@@ -108,7 +108,7 @@ class CategoryRepository extends BaseCategoryRepository
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \App\Model\Category\Category[][]
      */
-    public function getCategoriesByIds(array $categoriesIds, DomainConfig $domainConfig): array
+    public function getVisibleCategoriesByIds(array $categoriesIds, DomainConfig $domainConfig): array
     {
         $queryBuilder = $this->categoryRepository->getAllVisibleByDomainIdQueryBuilder($domainConfig->getId())
             ->addSelect('cd')

--- a/project-base/app/src/FrontendApi/Resolver/Advert/AdvertResolverMap.php
+++ b/project-base/app/src/FrontendApi/Resolver/Advert/AdvertResolverMap.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\FrontendApi\Resolver\Advert;
+
+use App\Model\Advert\Advert;
+use GraphQL\Executor\Promise\Promise;
+use Overblog\DataLoader\DataLoaderInterface;
+use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrontendApiBundle\Model\Resolver\Advert\AdvertResolverMap as BaseAdvertResolverMap;
+
+class AdvertResolverMap extends BaseAdvertResolverMap
+{
+    protected const RESOLVER_CATEGORIES_FIELD = 'categories';
+
+    /**
+     * @param \App\Component\Image\ImageFacade $imageFacade
+     * @param \Overblog\DataLoader\DataLoaderInterface $categoriesBatchLoader
+     */
+    public function __construct(
+        ImageFacade $imageFacade,
+        private readonly DataLoaderInterface $categoriesBatchLoader,
+    ) {
+        parent::__construct($imageFacade);
+    }
+
+    /**
+     * @return array
+     */
+    protected function map(): array
+    {
+        $commonAdvertResolverFields = [
+            self::RESOLVER_CATEGORIES_FIELD => $this->mapVisibleCategories(...),
+        ];
+
+        $resultMap = parent::map();
+        $resultMap[BaseAdvertResolverMap::RESOLVER_ADVERT_CODE] = $commonAdvertResolverFields;
+        $resultMap[BaseAdvertResolverMap::RESOLVER_ADVERT_IMAGE] = $commonAdvertResolverFields;
+
+        return $resultMap;
+    }
+
+    /**
+     * @param \App\Model\Advert\Advert $advert
+     * @return \GraphQL\Executor\Promise\Promise
+     */
+    private function mapVisibleCategories(Advert $advert): Promise
+    {
+        return $this->categoriesBatchLoader->load($advert->getCategoryIds());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR prevents FE API from accessing non visible categories trough FE API type Advert. Otherwise it might lead to some issues, like accessing category friendly URL that does not exist. Steps to reproduce <ul><li>create new category in admin</li><li>fill category name for 1. domain</li><li>save the category</li><li>assign category to existing advert called "Demo category advert" on second domain</li><li>save the advert</li><li>go to 2. domain homepage</li><li>you sould see an unkonwn error</li><li>if you do not see the error, remove storefront cache and return to homepage on 2.domain</li></ul>
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-advert-categories.odin.shopsys.cloud
  - https://cz.mt-advert-categories.odin.shopsys.cloud
<!-- Replace -->
