### PR TITLE
[framework] fixed NotIdenticalToEmailLocalPart validator with null values

### DIFF
--- a/packages/framework/src/Form/Constraints/NotIdenticalToEmailLocalPartValidator.php
+++ b/packages/framework/src/Form/Constraints/NotIdenticalToEmailLocalPartValidator.php
@@ -25,12 +25,14 @@ class NotIdenticalToEmailLocalPartValidator extends ConstraintValidator
         $password = $propertyAccessor->getValue($values, $constraint->password);
         $email = $propertyAccessor->getValue($values, $constraint->email);
 
-        if (strpos($email, $password . '@') === 0) {
+        if ($password === null || $email === null) {
+            return;
+        }
+
+        if (str_starts_with($email, $password . '@')) {
             $this->context->buildViolation($constraint->message)
                 ->atPath($constraint->errorPath)
                 ->addViolation();
-
-            return;
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| this PR fixes error 500 while creating a user from administration if no values are filled.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
