### PR TITLE
[framework] fixed bestsellers edit in admin

### DIFF
--- a/packages/framework/src/Controller/Admin/BestsellingProductController.php
+++ b/packages/framework/src/Controller/Admin/BestsellingProductController.php
@@ -55,11 +55,13 @@ class BestsellingProductController extends AdminBaseController
     /**
      * @Route("/product/bestselling-product/detail/")
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
     public function detailAction(Request $request)
     {
-        $category = $this->categoryFacade->getById($request->get('categoryId'));
-        $domainId = $request->get('domainId');
+        $categoryId = (int)$request->query->get('categoryId');
+        $category = $this->categoryFacade->getById($categoryId);
+        $domainId = (int)$request->get('domainId');
 
         $products = $this->manualBestsellingProductFacade->getProductsIndexedByPosition(
             $category,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| manually add bestseller to category throws an error. This PR fixes that
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
