### PR TITLE
[project-base] removed product images entity caching

### DIFF
--- a/project-base/app/src/Model/Product/Transfer/Akeneo/TransferredProductProcessor.php
+++ b/project-base/app/src/Model/Product/Transfer/Akeneo/TransferredProductProcessor.php
@@ -15,7 +15,6 @@ use App\Model\Transfer\TransferLoggerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Generator;
 use League\Flysystem\FilesystemOperator;
-use Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig;
 
 class TransferredProductProcessor
 {
@@ -43,7 +42,6 @@ class TransferredProductProcessor
      * @param \App\Model\Product\Transfer\Akeneo\AssetTransferAkeneoFacade $assetTransferAkeneoFacade
      * @param \App\Component\FileUpload\FileUpload $fileUpload
      * @param \App\Model\Product\Parameter\ParameterFacade $parameterFacade
-     * @param \Shopsys\FrameworkBundle\Component\Image\Config\ImageConfig $imageConfig
      * @param \League\Flysystem\FilesystemOperator $filesystem
      */
     public function __construct(
@@ -56,7 +54,6 @@ class TransferredProductProcessor
         private readonly AssetTransferAkeneoFacade $assetTransferAkeneoFacade,
         private readonly FileUpload $fileUpload,
         private readonly ParameterFacade $parameterFacade,
-        private readonly ImageConfig $imageConfig,
         private readonly FilesystemOperator $filesystem,
     ) {
     }
@@ -72,11 +69,6 @@ class TransferredProductProcessor
 
         $product = $this->findProductByIdentifier((string)$akeneoProductData['identifier']);
 
-        if ($product !== null) {
-            $entityName = $this->imageConfig->getEntityName($product);
-            $entityId = $product->getId();
-            $this->imageFacade->invalidateCacheByEntityNameAndEntityIdAndType($entityName, $entityId, null);
-        }
         $productData = $this->productTransferAkeneoMapper->mapAkeneoProductDataToProductData($akeneoProductData, $product, $logger);
 
         if ($product === null) {

--- a/project-base/app/src/Model/ProductFeed/Mergado/FeedItem/MergadoFeedItem.php
+++ b/project-base/app/src/Model/ProductFeed/Mergado/FeedItem/MergadoFeedItem.php
@@ -31,7 +31,7 @@ class MergadoFeedItem implements FeedItemInterface
      * @param array $shortDescriptionUsp
      * @param int $deliveryDays
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice $price
-     * @param array $galleryImageUrls
+     * @param string[] $galleryImageUrls
      * @param array $parameters
      * @param string $currencyCode
      * @param string|null $description
@@ -161,7 +161,7 @@ class MergadoFeedItem implements FeedItemInterface
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getGalleryImageUrls(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Image URLs are already cached as strings in Redis, it's not necessary to have multiple caching layer. More info follows
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

- image URLs are still cached as strings
- entity caching was used only in image sitemap and Mergado feeds
- entity caching in Redis causing more problems than benefits
-- high Redis memory usage
-- problems with partial collections in cached entities

Potential performance loss while generating feeds should be compensated with a different mechanism, than entity caching.