### PR TITLE
[framework] fixed editing country error

### DIFF
--- a/packages/framework/src/Form/Admin/Country/CountryFormType.php
+++ b/packages/framework/src/Form/Admin/Country/CountryFormType.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Country\Country;
 use Shopsys\FrameworkBundle\Model\Country\CountryData;
 use Shopsys\FrameworkBundle\Model\Country\CountryFacade;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -82,7 +83,7 @@ class CountryFormType extends AbstractType
                 'label' => t('Display on'),
             ])
             ->add('priority', MultidomainType::class, [
-                'entry_type' => TextType::class,
+                'entry_type' => IntegerType::class,
                 'entry_options' => [
                     'attr' => [
                         'icon' => true,

--- a/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/theme.html.twig
@@ -155,6 +155,10 @@
     </div>
 {% endblock checkbox_row %}
 
+{% block integer_row -%}
+    {{- block('text_row') -}}
+{% endblock integer_row %}
+
 {% block text_row -%}
     {% if localized is defined %}
         <div class="form-line__side form-line__side--multilanguage">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Multidomain text type is passed to the data class as an array of strings. Priority should be an array of integers, so it breaks the type in the next methods.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-country-edit.odin.shopsys.cloud
  - https://cz.mg-fix-country-edit.odin.shopsys.cloud
<!-- Replace -->
