### PR TITLE
[project-base] changed robots.txt datafixture to avoid encouraging inappropriate practices

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
@@ -127,7 +127,7 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
             );
             $this->setting->setForDomain(
                 SeoSettingFacade::SEO_ROBOTS_TXT_CONTENT,
-                'Disallow: /admin',
+                'Disallow: *?filter=',
                 $domainId,
             );
             $this->setting->setForDomain(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| /admin should not be mentioned in the robots.txt because it reveals the url of administration to everyone. Then it makes no sense to change the admin url
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-better-robots-datafixture.odin.shopsys.cloud
  - https://cz.mg-better-robots-datafixture.odin.shopsys.cloud
<!-- Replace -->
