### PR TITLE
[project-base] restored feeds

### DIFF
--- a/project-base/app/config/bundles.php
+++ b/project-base/app/config/bundles.php
@@ -18,6 +18,7 @@ return [
     Shopsys\MigrationBundle\ShopsysMigrationBundle::class => ['all' => true],
     Shopsys\ProductFeed\HeurekaBundle\ShopsysProductFeedHeurekaBundle::class => ['all' => true],
     Shopsys\ProductFeed\GoogleBundle\ShopsysProductFeedGoogleBundle::class => ['all' => true],
+    Shopsys\ProductFeed\HeurekaDeliveryBundle\ShopsysProductFeedHeurekaDeliveryBundle::class => ['all' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
     Snc\RedisBundle\SncRedisBundle::class => ['all' => true],
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],

--- a/project-base/app/config/bundles.php
+++ b/project-base/app/config/bundles.php
@@ -18,6 +18,7 @@ return [
     Shopsys\MigrationBundle\ShopsysMigrationBundle::class => ['all' => true],
     Shopsys\ProductFeed\HeurekaBundle\ShopsysProductFeedHeurekaBundle::class => ['all' => true],
     Shopsys\ProductFeed\GoogleBundle\ShopsysProductFeedGoogleBundle::class => ['all' => true],
+    Shopsys\ProductFeed\ZboziBundle\ShopsysProductFeedZboziBundle::class => ['all' => true],
     Shopsys\ProductFeed\HeurekaDeliveryBundle\ShopsysProductFeedHeurekaDeliveryBundle::class => ['all' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
     Snc\RedisBundle\SncRedisBundle::class => ['all' => true],

--- a/project-base/app/config/cron.yaml
+++ b/project-base/app/config/cron.yaml
@@ -63,6 +63,10 @@ services:
         tags:
             - { name: shopsys.cron, hours: '*/6', minutes: '0', instanceName: export, readableName: 'Generate daily feeds' }
 
+    Shopsys\FrameworkBundle\Model\Feed\HourlyFeedCronModule:
+        tags:
+            - { name: shopsys.cron, hours: '*', minutes: '10', instanceName: export, readableName: 'Generate hourly feeds' }
+
     Shopsys\FrameworkBundle\Model\Sitemap\SitemapCronModule:
         tags:
             - { name: shopsys.cron, hours: '4', minutes: '0', instanceName: export, readableName: 'Generate Sitemap' }
@@ -107,10 +111,6 @@ services:
         tags:
             - { name: shopsys.cron, hours: '*', minutes: '*', instanceName: products, readableName: "Export changed products to Elasticsearch" }
 
-    # @todo mg remove?
-    Shopsys\FrameworkBundle\Model\Feed\HourlyFeedCronModule:
-        tags:
-            - { name: shopsys.cron, hours: '*', minutes: '10', instanceName: default, readableName: 'Generate hourly feeds' }
     # Akeneo import products
 
     App\Model\Category\Transfer\Akeneo\AkeneoImportCategoryCronModule:

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -736,6 +736,9 @@ services:
     Shopsys\ProductFeed\HeurekaBundle\Model\FeedItem\HeurekaFeedItemFactory:
         alias: App\ProductFeed\Heureka\Model\FeedItem\HeurekaFeedItemFactory
 
+    Shopsys\ProductFeed\HeurekaDeliveryBundle\Model\FeedItem\HeurekaDeliveryDataRepository:
+        alias: App\ProductFeed\HeurekaDelivery\Model\FeedItem\HeurekaDeliveryDataRepository
+
     Shopsys\ProductFeed\GoogleBundle\Model\FeedItem\GoogleFeedItemFactory:
         alias: App\ProductFeed\Google\Model\FeedItem\GoogleFeedItemFactory
 

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -745,6 +745,9 @@ services:
     Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductRepository:
         alias: App\ProductFeed\Google\Model\Product\GoogleProductRepository
 
+    Shopsys\ProductFeed\ZboziBundle\Model\FeedItem\ZboziFeedItemFactory:
+        alias: App\ProductFeed\Zbozi\Model\FeedItem\ZboziFeedItemFactory
+
     Shopsys\FrameworkBundle\Model\Transport\TransportFacade:
         alias: App\Model\Transport\TransportFacade
 

--- a/project-base/app/src/ProductFeed/HeurekaDelivery/Model/FeedItem/HeurekaDeliveryDataRepository.php
+++ b/project-base/app/src/ProductFeed/HeurekaDelivery/Model/FeedItem/HeurekaDeliveryDataRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProductFeed\HeurekaDelivery\Model\FeedItem;
+
+use App\Model\Stock\ProductStock;
+use Doctrine\ORM\Query\Expr\Join;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\ProductFeed\HeurekaDeliveryBundle\Model\FeedItem\HeurekaDeliveryDataRepository as BaseHeurekaDeliveryDataRepository;
+
+/**
+ * @method __construct(\App\Model\Product\ProductRepository $productRepository)
+ */
+class HeurekaDeliveryDataRepository extends BaseHeurekaDeliveryDataRepository
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
+     * @param int|null $lastSeekId
+     * @param int $maxResults
+     * @return array[]
+     */
+    public function getDataRows(
+        DomainConfig $domainConfig,
+        PricingGroup $pricingGroup,
+        ?int $lastSeekId,
+        int $maxResults,
+    ): array {
+        $queryBuilder = $this->productRepository->getAllSellableQueryBuilder($domainConfig->getId(), $pricingGroup);
+        $queryBuilder->leftJoin(ProductStock::class, 'ps', Join::WITH, 'ps.product = p');
+        $queryBuilder->having('SUM(ps.productQuantity) > 0');
+
+
+        $queryBuilder->select('p.id, SUM(ps.productQuantity) as stockQuantity')
+            ->groupBy('p.id')
+            ->orderBy('p.id', 'asc')
+            ->setMaxResults($maxResults);
+
+        if ($lastSeekId !== null) {
+            $queryBuilder->andWhere('p.id > :lastProductId')->setParameter('lastProductId', $lastSeekId);
+        }
+
+        return $queryBuilder->getQuery()->getScalarResult();
+    }
+}

--- a/project-base/app/src/ProductFeed/Zbozi/Model/FeedItem/ZboziFeedItemFactory.php
+++ b/project-base/app/src/ProductFeed/Zbozi/Model/FeedItem/ZboziFeedItemFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ProductFeed\Zbozi\Model\FeedItem;
+
+use App\Model\Product\Availability\ProductAvailabilityFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Model\Product\Collection\ProductParametersBatchLoader;
+use Shopsys\FrameworkBundle\Model\Product\Collection\ProductUrlsBatchLoader;
+use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+use Shopsys\ProductFeed\ZboziBundle\Model\FeedItem\ZboziFeedItem;
+use Shopsys\ProductFeed\ZboziBundle\Model\FeedItem\ZboziFeedItemFactory as BaseZboziFeedItemFactory;
+use Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomain;
+
+/**
+ * @method string|null getBrandName(\App\Model\Product\Product $product)
+ * @method \Shopsys\FrameworkBundle\Model\Pricing\Price getPrice(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
+ * @method string[] getPathToMainCategory(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
+ */
+class ZboziFeedItemFactory extends BaseZboziFeedItemFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser $productPriceCalculationForCustomerUser
+     * @param \Shopsys\FrameworkBundle\Model\Product\Collection\ProductUrlsBatchLoader $productUrlsBatchLoader
+     * @param \Shopsys\FrameworkBundle\Model\Product\Collection\ProductParametersBatchLoader $productParametersBatchLoader
+     * @param \App\Model\Category\CategoryFacade $categoryFacade
+     * @param \App\Model\Product\Availability\ProductAvailabilityFacade $productAvailabilityFacade
+     */
+    public function __construct(
+        ProductPriceCalculationForCustomerUser $productPriceCalculationForCustomerUser,
+        ProductUrlsBatchLoader $productUrlsBatchLoader,
+        ProductParametersBatchLoader $productParametersBatchLoader,
+        CategoryFacade $categoryFacade,
+        private readonly ProductAvailabilityFacade $productAvailabilityFacade,
+    ) {
+        parent::__construct($productPriceCalculationForCustomerUser, $productUrlsBatchLoader, $productParametersBatchLoader, $categoryFacade);
+    }
+
+    /**
+     * @param \App\Model\Product\Product $product
+     * @param \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomain|null $zboziProductDomain
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @return \Shopsys\ProductFeed\ZboziBundle\Model\FeedItem\ZboziFeedItem
+     */
+    public function create(
+        Product $product,
+        ?ZboziProductDomain $zboziProductDomain,
+        DomainConfig $domainConfig,
+    ): ZboziFeedItem {
+        $mainVariantId = $product->isVariant() ? $product->getMainVariant()->getId() : null;
+        $cpc = $zboziProductDomain !== null ? $zboziProductDomain->getCpc() : null;
+        $cpcSearch = $zboziProductDomain !== null ? $zboziProductDomain->getCpcSearch() : null;
+
+        return new ZboziFeedItem(
+            $product->getId(),
+            $product->getFullname($domainConfig->getLocale()),
+            $this->productUrlsBatchLoader->getProductUrl($product, $domainConfig),
+            $this->getPrice($product, $domainConfig),
+            $this->getPathToMainCategory($product, $domainConfig),
+            $this->productParametersBatchLoader->getProductParametersByName($product, $domainConfig),
+            $mainVariantId,
+            $product->getDescription($domainConfig->getId()),
+            $this->productUrlsBatchLoader->getProductImageUrl($product, $domainConfig),
+            $this->getBrandName($product),
+            $product->getEan(),
+            $product->getPartno(),
+            $this->productAvailabilityFacade->getProductAvailabilityDaysByDomainId($product, $domainConfig->getId()),
+            $cpc,
+            $cpcSearch,
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| zboziCz and heurekaDelivery feeds were disabled in #2622. This PR restores them
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-availability-feed.odin.shopsys.cloud
  - https://cz.mg-availability-feed.odin.shopsys.cloud
<!-- Replace -->
