### PR TITLE
fixed dynamic robots.txt on storefront

### DIFF
--- a/project-base/storefront/graphql/generated/index.tsx
+++ b/project-base/storefront/graphql/generated/index.tsx
@@ -3615,6 +3615,11 @@ export type RegistrationMutationVariablesApi = Exact<{
 
 export type RegistrationMutationApi = { __typename?: 'Mutation', Register: { __typename?: 'LoginResult', showCartMergeInfo: boolean, tokens: { __typename?: 'Token', accessToken: string, refreshToken: string } } };
 
+export type RobotsTxtQueryVariablesApi = Exact<{ [key: string]: never; }>;
+
+
+export type RobotsTxtQueryApi = { __typename?: 'Query', settings: { __typename?: 'Settings', seo: { __typename?: 'SeoSetting', robotsTxtContent: string | null } } | null };
+
 export type AutocompleteSearchQueryVariablesApi = Exact<{
   search: Scalars['String']['input'];
   maxProductCount: InputMaybe<Scalars['Int']['input']>;
@@ -6034,6 +6039,19 @@ export const RegistrationMutationDocumentApi = gql`
 
 export function useRegistrationMutationApi() {
   return Urql.useMutation<RegistrationMutationApi, RegistrationMutationVariablesApi>(RegistrationMutationDocumentApi);
+};
+export const RobotsTxtQueryDocumentApi = gql`
+    query RobotsTxtQuery {
+  settings {
+    seo {
+      robotsTxtContent
+    }
+  }
+}
+    `;
+
+export function useRobotsTxtQueryApi(options?: Omit<Urql.UseQueryArgs<RobotsTxtQueryVariablesApi>, 'query'>) {
+  return Urql.useQuery<RobotsTxtQueryApi, RobotsTxtQueryVariablesApi>({ query: RobotsTxtQueryDocumentApi, ...options });
 };
 export const AutocompleteSearchQueryDocumentApi = gql`
     query AutocompleteSearchQuery($search: String!, $maxProductCount: Int, $maxCategoryCount: Int) {

--- a/project-base/storefront/graphql/requests/robotsTxt/RobotsTxtQuery.graphql
+++ b/project-base/storefront/graphql/requests/robotsTxt/RobotsTxtQuery.graphql
@@ -1,0 +1,7 @@
+query RobotsTxtQuery {
+    settings {
+        seo {
+            robotsTxtContent
+        }
+    }
+}

--- a/project-base/storefront/middleware.ts
+++ b/project-base/storefront/middleware.ts
@@ -66,7 +66,7 @@ export const middleware: NextMiddleware = async (request) => {
 
 export const config = {
     matcher: [
-        '/((?!api|_next|favicon.ico|fonts|svg|images|locales|icons|grapesjs-template|grapesjs-homepage-article-template|grapesjs-article-template).*)',
+        '/((?!api|_next|favicon.ico|fonts|svg|images|locales|icons|grapesjs-template|grapesjs-homepage-article-template|grapesjs-article-template|robots).*)',
     ],
 };
 


### PR DESCRIPTION
- additionally added dynamic content from API which is now loaded using the settigns query

| Q             | A
| ------------- | ---
|Description, reason for the PR| Somewhere along the way, robots.txt stopped working. This PR fixes the issue by skipping middleware for this route. Additionally it also includes the dynamic content from the API
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-robots-txt.odin.shopsys.cloud
  - https://cz.sh-robots-txt.odin.shopsys.cloud
<!-- Replace -->
