### PR TITLE
improve UI of Brands Overview

### DIFF
--- a/project-base/app/config/graphql/types/ModelType/Product/Brand/Brand.types.yaml
+++ b/project-base/app/config/graphql/types/ModelType/Product/Brand/Brand.types.yaml
@@ -25,7 +25,7 @@ Brand:
             mainImage:
                 type: "Image"
                 description: "Brand image by params"
-                resolve: '@=query("mainImageByEntityIdPromiseQuery", value, args["type"], args["size"])'
+                resolve: '@=query("mainImageByEntityPromiseQuery", value, args["type"], args["size"])'
                 args:
                     type:
                         type: "String"

--- a/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigation.tsx
+++ b/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigation.tsx
@@ -1,4 +1,4 @@
-import { ListItem } from './ListItem';
+import { SimpleNavigationListItem } from './SimpleNavigationListItem';
 import { getSearchResultLinkType } from 'helpers/mappers/simpleNavigation';
 import { ListedItemPropType } from 'types/simpleNavigation';
 import { twMergeCustom } from 'helpers/twMerge';
@@ -6,21 +6,24 @@ import { twMergeCustom } from 'helpers/twMerge';
 type SimpleNavigationProps = {
     listedItems: ListedItemPropType[];
     imageType?: string;
+    isWithoutSlider?: true;
 };
 
 const TEST_IDENTIFIER = 'blocks-simplenavigation';
 
-export const SimpleNavigation: FC<SimpleNavigationProps> = ({ listedItems, imageType, className }) => {
+export const SimpleNavigation: FC<SimpleNavigationProps> = ({ listedItems, imageType, isWithoutSlider, className }) => {
     return (
         <ul
             className={twMergeCustom(
-                'grid snap-x snap-mandatory auto-cols-[40%] gap-3 overflow-x-auto overscroll-x-contain max-lg:grid-flow-col lg:grid-cols-[repeat(auto-fill,minmax(210px,1fr))]',
+                !isWithoutSlider &&
+                    'snap-x snap-mandatory auto-cols-[40%] grid-flow-col overflow-x-auto overscroll-x-contain lg:grid-flow-row',
+                'grid gap-3 sm:grid-cols-2 lg:grid-cols-[repeat(auto-fill,minmax(210px,1fr))]',
                 className,
             )}
             data-testid={TEST_IDENTIFIER}
         >
             {listedItems.map((listedItem, index) => (
-                <ListItem
+                <SimpleNavigationListItem
                     key={index}
                     linkType={getSearchResultLinkType(listedItem)}
                     listedItem={listedItem}
@@ -28,7 +31,7 @@ export const SimpleNavigation: FC<SimpleNavigationProps> = ({ listedItems, image
                     dataTestId={TEST_IDENTIFIER + '-' + index}
                 >
                     {listedItem.name}
-                </ListItem>
+                </SimpleNavigationListItem>
             ))}
         </ul>
     );

--- a/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigationListItem.tsx
+++ b/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigationListItem.tsx
@@ -3,13 +3,18 @@ import { Image } from 'components/Basic/Image/Image';
 import { FriendlyPagesTypesKeys } from 'types/friendlyUrl';
 import { ListedItemPropType } from 'types/simpleNavigation';
 
-type ListItemProps = {
+type SimpleNavigationListItemProps = {
     listedItem: ListedItemPropType;
     imageType?: string;
     linkType: FriendlyPagesTypesKeys | 'static';
 };
 
-export const ListItem: FC<ListItemProps> = ({ listedItem, imageType, linkType, dataTestId }) => {
+export const SimpleNavigationListItem: FC<SimpleNavigationListItemProps> = ({
+    listedItem,
+    imageType,
+    linkType,
+    dataTestId,
+}) => {
     const itemImage = 'mainImage' in listedItem ? listedItem.mainImage : null;
 
     return (

--- a/project-base/storefront/components/Pages/Brands/BrandsContent.tsx
+++ b/project-base/storefront/components/Pages/Brands/BrandsContent.tsx
@@ -11,7 +11,7 @@ export const BrandsContent: FC = () => {
 
     return (
         <Webline>
-            <SimpleNavigation listedItems={brandsData.brands} />
+            <SimpleNavigation listedItems={brandsData.brands} isWithoutSlider />
         </Webline>
     );
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| on the page /brands-overview is on smaller viewports visible only slider. This fix is for change UI to display it as list of brands instead slider.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1661-fix-ui--brands-overview.odin.shopsys.cloud
  - https://cz.tv-fw-1661-fix-ui--brands-overview.odin.shopsys.cloud
<!-- Replace -->
