### PR TITLE
[framework] fixed editing order email for newly created order status

### DIFF
--- a/packages/framework/src/Form/Transformers/EmptyWysiwygTransformer.php
+++ b/packages/framework/src/Form/Transformers/EmptyWysiwygTransformer.php
@@ -23,6 +23,10 @@ class EmptyWysiwygTransformer implements DataTransformerInterface
      */
     public function transform($value): mixed
     {
+        if ($value === null) {
+            return null;
+        }
+
         $trimmedValue = strip_tags(preg_replace('/\s|\&nbsp\;/', '', $value));
 
         if ($trimmedValue === '') {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Editing order mail template for newly created order status was failing on error. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

To reproduce:
- create new order status http://127.0.0.1:8000/admin/order-status/list/
- edit mail template for newly created order item http://127.0.0.1:8000/admin/mail/template/
- see error







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-mail-template-edit.odin.shopsys.cloud
  - https://cz.mg-fix-mail-template-edit.odin.shopsys.cloud
<!-- Replace -->
