### PR TITLE
forms are now validated after manual value setting

### DIFF
--- a/project-base/storefront/components/Blocks/UserConsent/UserConsentForm.tsx
+++ b/project-base/storefront/components/Blocks/UserConsent/UserConsentForm.tsx
@@ -37,7 +37,7 @@ export const UserConsentForm: FC<UserConsentFormProps> = ({ onSetCallback }) => 
 
     const acceptAllCookieChoices = useCallback(() => {
         for (const key in formMeta.fields) {
-            formProviderMethods.setValue(key as keyof UserConsentFormType, true);
+            formProviderMethods.setValue(key as keyof UserConsentFormType, true, { shouldValidate: true });
         }
 
         saveCookieChoices();
@@ -45,7 +45,7 @@ export const UserConsentForm: FC<UserConsentFormProps> = ({ onSetCallback }) => 
 
     const rejectAllCookieChoices = useCallback(() => {
         for (const key in formMeta.fields) {
-            formProviderMethods.setValue(key as keyof UserConsentFormType, false);
+            formProviderMethods.setValue(key as keyof UserConsentFormType, false, { shouldValidate: true });
         }
 
         saveCookieChoices();

--- a/project-base/storefront/components/Pages/Customer/EditProfileContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfileContent.tsx
@@ -128,9 +128,9 @@ export const EditProfileContent: FC<EditProfileContentProps> = ({ currentCustome
         if (isResultOk) {
             if (messages.success !== undefined) {
                 showSuccessMessage(messages.success);
-                formProviderMethods.setValue('passwordOld', '');
-                formProviderMethods.setValue('passwordFirst', '');
-                formProviderMethods.setValue('passwordSecond', '');
+                formProviderMethods.setValue('passwordOld', '', { shouldValidate: true });
+                formProviderMethods.setValue('passwordFirst', '', { shouldValidate: true });
+                formProviderMethods.setValue('passwordSecond', '', { shouldValidate: true });
             }
             if (callbacks?.success !== undefined) {
                 callbacks.success();

--- a/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationAddress.tsx
@@ -31,9 +31,9 @@ export const ContactInformationAddress: FC = () => {
 
     useEffect(() => {
         if (countriesAsSelectOptions.length > 0 && countryValue.value === '') {
-            setValue(formMeta.fields.country.name, countriesAsSelectOptions[0]);
+            setValue(formMeta.fields.country.name, countriesAsSelectOptions[0], { shouldValidate: true });
         }
-    }, [countriesAsSelectOptions, countryValue, formMeta.fields.country.name, setValue]);
+    }, [countriesAsSelectOptions, countryValue, formMeta.fields.country.name]);
 
     if (countriesAsSelectOptions.length === 0) {
         return null;

--- a/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationDeliveryAddress.tsx
@@ -49,14 +49,14 @@ export const ContactInformationDeliveryAddress: FC = () => {
             if (selectedCountryOption) {
                 const formValues = getValues();
 
-                setValue(formMeta.fields.deliveryFirstName.name, formValues.firstName);
-                setValue(formMeta.fields.deliveryLastName.name, formValues.lastName);
-                setValue(formMeta.fields.deliveryCompanyName.name, formValues.companyName);
-                setValue(formMeta.fields.deliveryTelephone.name, formValues.telephone);
-                setValue(formMeta.fields.deliveryStreet.name, pickupPlace.street);
-                setValue(formMeta.fields.deliveryCity.name, pickupPlace.city);
-                setValue(formMeta.fields.deliveryPostcode.name, pickupPlace.postcode);
-                setValue(formMeta.fields.deliveryCountry.name, selectedCountryOption);
+                setValue(formMeta.fields.deliveryFirstName.name, formValues.firstName, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryLastName.name, formValues.lastName, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryCompanyName.name, formValues.companyName, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryTelephone.name, formValues.telephone, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryStreet.name, pickupPlace.street, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryCity.name, pickupPlace.city, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryPostcode.name, pickupPlace.postcode, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryCountry.name, selectedCountryOption, { shouldValidate: true });
 
                 updateContactInformation({ ...pickupPlace, country: selectedCountryOption });
             }
@@ -71,27 +71,29 @@ export const ContactInformationDeliveryAddress: FC = () => {
             )!;
 
             if (countriesAsSelectOptions.length) {
-                setValue(formMeta.fields.deliveryFirstName.name, deliveryAddress.firstName);
-                setValue(formMeta.fields.deliveryLastName.name, deliveryAddress.lastName);
-                setValue(formMeta.fields.deliveryCompanyName.name, deliveryAddress.companyName);
-                setValue(formMeta.fields.deliveryTelephone.name, deliveryAddress.telephone);
-                setValue(formMeta.fields.deliveryCountry.name, selectedCountryOption);
+                setValue(formMeta.fields.deliveryFirstName.name, deliveryAddress.firstName, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryLastName.name, deliveryAddress.lastName, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryCompanyName.name, deliveryAddress.companyName, {
+                    shouldValidate: true,
+                });
+                setValue(formMeta.fields.deliveryTelephone.name, deliveryAddress.telephone, { shouldValidate: true });
+                setValue(formMeta.fields.deliveryCountry.name, selectedCountryOption, { shouldValidate: true });
 
                 if (!pickupPlace) {
-                    setValue(formMeta.fields.deliveryStreet.name, deliveryAddress.street);
-                    setValue(formMeta.fields.deliveryCity.name, deliveryAddress.city);
-                    setValue(formMeta.fields.deliveryPostcode.name, deliveryAddress.postcode);
+                    setValue(formMeta.fields.deliveryStreet.name, deliveryAddress.street, { shouldValidate: true });
+                    setValue(formMeta.fields.deliveryCity.name, deliveryAddress.city, { shouldValidate: true });
+                    setValue(formMeta.fields.deliveryPostcode.name, deliveryAddress.postcode, { shouldValidate: true });
                 }
             }
         } else if (deliveryAddressUuid === '') {
-            setValue(formMeta.fields.deliveryFirstName.name, '');
-            setValue(formMeta.fields.deliveryLastName.name, '');
-            setValue(formMeta.fields.deliveryCompanyName.name, '');
-            setValue(formMeta.fields.deliveryTelephone.name, '');
-            setValue(formMeta.fields.deliveryStreet.name, '');
-            setValue(formMeta.fields.deliveryCity.name, '');
-            setValue(formMeta.fields.deliveryPostcode.name, '');
-            setValue(formMeta.fields.deliveryCountry.name, countriesAsSelectOptions[0]);
+            setValue(formMeta.fields.deliveryFirstName.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryLastName.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryCompanyName.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryTelephone.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryStreet.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryCity.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryPostcode.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryCountry.name, countriesAsSelectOptions[0], { shouldValidate: true });
         }
     }, [deliveryAddressUuid, countriesAsSelectOptions]);
 

--- a/project-base/storefront/components/Pages/Registration/RegistrationAddress.tsx
+++ b/project-base/storefront/components/Pages/Registration/RegistrationAddress.tsx
@@ -25,7 +25,7 @@ export const RegistrationAddress: FC = () => {
 
     useEffect(() => {
         if (countriesAsSelectOptions.length > 0) {
-            setValue(formMeta.fields.country.name, countriesAsSelectOptions[0]);
+            setValue(formMeta.fields.country.name, countriesAsSelectOptions[0], { shouldValidate: true });
         }
     }, [countriesAsSelectOptions, formMeta.fields.country.name, setValue]);
 

--- a/project-base/storefront/pages/order/contact-information.tsx
+++ b/project-base/storefront/pages/order/contact-information.tsx
@@ -73,9 +73,13 @@ const ContactInformationPage: FC<ServerSidePropsType> = () => {
     useEffect(() => {
         if (customer === undefined) {
             if (user?.companyCustomer) {
-                formProviderMethods.setValue(formMeta.fields.customer.name, CustomerTypeEnum.CompanyCustomer);
+                formProviderMethods.setValue(formMeta.fields.customer.name, CustomerTypeEnum.CompanyCustomer, {
+                    shouldValidate: true,
+                });
             } else {
-                formProviderMethods.setValue(formMeta.fields.customer.name, CustomerTypeEnum.CommonCustomer);
+                formProviderMethods.setValue(formMeta.fields.customer.name, CustomerTypeEnum.CommonCustomer, {
+                    shouldValidate: true,
+                });
             }
         }
     }, []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Before, when values were set manually, forms were not validated, which caused incorrect behavior in some cases, such as when parts of the form were mirroring an invalid form even though the form was valid. This PR adds manual validation after setting a value which resolves the problem.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-forms-manual-validation-fix.odin.shopsys.cloud
  - https://cz.sh-forms-manual-validation-fix.odin.shopsys.cloud
<!-- Replace -->
