### PR TITLE
unset variants are exported to elastic

### DIFF
--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -40,6 +40,11 @@ class Product extends AbstractTranslatableEntity
     public const VARIANT_TYPE_VARIANT = 'variant';
 
     /**
+     * @var int[]
+     */
+    protected array $unsetVariantIds = [];
+
+    /**
      * @var int
      * @ORM\Column(type="integer")
      * @ORM\Id
@@ -1071,6 +1076,7 @@ class Product extends AbstractTranslatableEntity
         foreach ($this->getVariants() as $originalVariant) {
             if (!in_array($originalVariant, $currentVariants, true)) {
                 $originalVariant->unsetMainVariant();
+                $this->unsetVariantIds[] = $originalVariant->getId();
             }
         }
     }
@@ -1081,5 +1087,13 @@ class Product extends AbstractTranslatableEntity
     public function getUuid(): string
     {
         return $this->uuid;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getUnsetVariantIds(): array
+    {
+        return $this->unsetVariantIds;
     }
 }

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -187,8 +187,7 @@ class ProductFacade
         $this->productVisibilityFacade->refreshProductsVisibilityForMarkedDelayed();
         $this->productPriceRecalculationScheduler->scheduleProductForImmediateRecalculation($product);
 
-        $productToExport = $product->isVariant() ? $product->getMainVariant() : $product;
-        $this->productExportScheduler->scheduleRowIdForImmediateExport($productToExport->getId());
+        $this->scheduleProductForExport($product);
 
         return $product;
     }
@@ -473,5 +472,18 @@ class ProductFacade
         }
 
         return $changedProductNames;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     */
+    protected function scheduleProductForExport(Product $product): void
+    {
+        $productToExport = $product->isVariant() ? $product->getMainVariant() : $product;
+        $this->productExportScheduler->scheduleRowIdForImmediateExport($productToExport->getId());
+
+        foreach ($product->getUnsetVariantIds() as $unsetVariantId) {
+            $this->productExportScheduler->scheduleRowIdForImmediateExport($unsetVariantId);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When you visit variant detail, after it has been removed from main variant, you are wrongly redirected to main variant. When admin remove a variant from its main variant, it is not exported to Elastic. Product data in Elastic still holds information from time it was a product variant. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-unset-variant-elastic.odin.shopsys.cloud
  - https://cz.mt-unset-variant-elastic.odin.shopsys.cloud
<!-- Replace -->
