### PR TITLE
[framework] fixed seoRobotsTxtContent null value in settings

### DIFF
--- a/packages/framework/src/Migrations/Version20230404071649.php
+++ b/packages/framework/src/Migrations/Version20230404071649.php
@@ -24,7 +24,7 @@ class Version20230404071649 extends AbstractMigration
 
             if ($seoRobotsTxtContentSettingCount <= 0) {
                 $this->sql(
-                    'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'seoRobotsTxtContent\', :domainId, \'\', \'string\')',
+                    'INSERT INTO setting_values (name, domain_id, value, type) VALUES (\'seoRobotsTxtContent\', :domainId, NULL, \'string\')',
                     ['domainId' => $domainId],
                 );
             }

--- a/packages/framework/src/Migrations/Version20230817135234.php
+++ b/packages/framework/src/Migrations/Version20230817135234.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20230817135234 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('UPDATE setting_values SET value = \'\' WHERE name = \'seoRobotsTxtContent\' AND value IS NULL');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Field in settings is of a type string, but the value set in #2591 in DB migration was null, causing problems. Fix for upcoming version 13.0. This commit reverts #2692 as DB migrations should not be edited back. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-robot-migration-13.odin.shopsys.cloud
  - https://cz.mg-fix-robot-migration-13.odin.shopsys.cloud
<!-- Replace -->
