### PR TITLE
registration after order now uses data from URL

### DIFF
--- a/project-base/storefront/components/Pages/OrderConfirmation/RegistrationAfterOrder.tsx
+++ b/project-base/storefront/components/Pages/OrderConfirmation/RegistrationAfterOrder.tsx
@@ -14,12 +14,12 @@ import { getUserFriendlyErrors } from 'helpers/errors/friendlyErrorMessageParser
 import { onGtmSendFormEventHandler } from 'gtm/helpers/eventHandlers';
 import { useErrorPopupVisibility } from 'hooks/forms/useErrorPopupVisibility';
 import useTranslation from 'next-translate/useTranslation';
-import { useCurrentUserContactInformation } from 'hooks/user/useCurrentUserContactInformation';
 import Trans from 'next-translate/Trans';
 import dynamic from 'next/dynamic';
 import { FormProvider, SubmitHandler } from 'react-hook-form';
 import { RegistrationAfterOrderFormType } from 'types/form';
 import { GtmFormType, GtmMessageOriginType } from 'gtm/types/enums';
+import { ContactInformation } from 'store/slices/createContactInformationSlice';
 
 const ErrorPopup = dynamic(() => import('components/Forms/Lib/ErrorPopup').then((component) => component.ErrorPopup));
 
@@ -27,10 +27,10 @@ const TEST_IDENTIFIER = 'pages-orderconfirmation-registration-create-account';
 
 type RegistrationAfterOrderProps = {
     lastOrderUuid: string;
+    registrationData: ContactInformation;
 };
 
-export const RegistrationAfterOrder: FC<RegistrationAfterOrderProps> = ({ lastOrderUuid }) => {
-    const contactInformation = useCurrentUserContactInformation();
+export const RegistrationAfterOrder: FC<RegistrationAfterOrderProps> = ({ lastOrderUuid, registrationData }) => {
     const [, register] = useRegistrationMutationApi();
     const { t } = useTranslation();
     const [formProviderMethods] = useRegistrationAfterOrderForm();
@@ -40,9 +40,9 @@ export const RegistrationAfterOrder: FC<RegistrationAfterOrderProps> = ({ lastOr
     const onRegistrationSubmitHandler: SubmitHandler<RegistrationAfterOrderFormType> = async (data) => {
         const registerResult = await register({
             ...data,
-            ...contactInformation,
-            country: contactInformation.country.value,
-            companyCustomer: contactInformation.customer === 'companyCustomer',
+            ...registrationData,
+            country: registrationData.country.value,
+            companyCustomer: registrationData.customer === 'companyCustomer',
             previousCartUuid: null,
             lastOrderUuid,
         });

--- a/project-base/storefront/pages/order/contact-information.tsx
+++ b/project-base/storefront/pages/order/contact-information.tsx
@@ -180,6 +180,10 @@ const ContactInformationPage: FC<ServerSidePropsType> = () => {
             updateUserState({
                 cartUuid: null,
             });
+
+            if (!user) {
+                query.registrationData = JSON.stringify(formValues);
+            }
             resetContactInformation();
 
             router.replace(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Registration after order did not work because the contact information data was deleted right after order creation. In order to not intervene with that logic and also in order to avoid rewriting the GTM logic, the contact information registration data is sent to the order confirmation page using a masked URL query.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-registration-after-order-fix.odin.shopsys.cloud
  - https://cz.sh-registration-after-order-fix.odin.shopsys.cloud
<!-- Replace -->
