### PR TITLE
remove closed filter groups from DOM

### DIFF
--- a/project-base/storefront/components/Blocks/Product/Filter/FilterElements.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterElements.tsx
@@ -12,9 +12,7 @@ export const FilterGroupTitle: FC<{ onClick: () => void }> = ({ children, onClic
     </div>
 );
 
-export const FilterGroupContent: FC<{ isOpen: boolean }> = ({ children, isOpen }) => (
-    <div className={twJoin('mb-6 flex-col flex-wrap', isOpen ? 'flex' : 'hidden')}>{children}</div>
-);
+export const FilterGroupContent: FC = ({ children }) => <div className="mb-6 flex flex-col flex-wrap">{children}</div>;
 
 export const FilterGroupContentItem: FC<{ isDisabled: boolean }> = ({ children, isDisabled, dataTestId }) => (
     <div className={twJoin('mb-3', isDisabled && 'pointer-events-none opacity-30')} data-testid={dataTestId}>

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupGeneric.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupGeneric.tsx
@@ -62,40 +62,42 @@ export const FilterGroupGeneric: FC<FilterGroupGenericProps> = ({
                 {title}
                 <FilterGroupIcon isOpen={isGroupOpen} />
             </FilterGroupTitle>
-            <FilterGroupContent isOpen={isGroupOpen}>
-                {defaultOptions && (
-                    <>
-                        {defaultOptions.map((option, index) => {
-                            const isFlagAndSelectedByDefault =
-                                filterField === 'flags' && defaultSelectedFlags.has(option.uuid);
-                            const isChecked = !!selectedItems?.includes(option.uuid) || isFlagAndSelectedByDefault;
+            {isGroupOpen && (
+                <FilterGroupContent>
+                    {defaultOptions && (
+                        <>
+                            {defaultOptions.map((option, index) => {
+                                const isFlagAndSelectedByDefault =
+                                    filterField === 'flags' && defaultSelectedFlags.has(option.uuid);
+                                const isChecked = !!selectedItems?.includes(option.uuid) || isFlagAndSelectedByDefault;
 
-                            return (
-                                <FilterGroupContentItem
-                                    key={option.uuid}
-                                    isDisabled={option.count === 0 && !isChecked}
-                                    dataTestId={getDataTestId(filterField) + '-' + index}
-                                >
-                                    <Checkbox
-                                        id={`${filterField}.${index}.checked`}
-                                        name={`${filterField}.${index}.checked`}
-                                        label={option.name}
-                                        onChange={() => handleCheck(option.uuid)}
-                                        value={isChecked}
-                                        count={option.count}
-                                    />
-                                </FilterGroupContentItem>
-                            );
-                        })}
+                                return (
+                                    <FilterGroupContentItem
+                                        key={option.uuid}
+                                        isDisabled={option.count === 0 && !isChecked}
+                                        dataTestId={getDataTestId(filterField) + '-' + index}
+                                    >
+                                        <Checkbox
+                                            id={`${filterField}.${index}.checked`}
+                                            name={`${filterField}.${index}.checked`}
+                                            label={option.name}
+                                            onChange={() => handleCheck(option.uuid)}
+                                            value={isChecked}
+                                            count={option.count}
+                                        />
+                                    </FilterGroupContentItem>
+                                );
+                            })}
 
-                        {isShowLessMoreShown && (
-                            <ShowAllButton onClick={() => setAreAllItemsShown((prev) => !prev)}>
-                                {isWithAllItemsShown ? t('show less') : t('show more')}
-                            </ShowAllButton>
-                        )}
-                    </>
-                )}
-            </FilterGroupContent>
+                            {isShowLessMoreShown && (
+                                <ShowAllButton onClick={() => setAreAllItemsShown((prev) => !prev)}>
+                                    {isWithAllItemsShown ? t('show less') : t('show more')}
+                                </ShowAllButton>
+                            )}
+                        </>
+                    )}
+                </FilterGroupContent>
+            )}
         </FilterGroupWrapper>
     );
 };

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupInStock.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupInStock.tsx
@@ -24,16 +24,18 @@ export const FilterGroupInStock: FC<FilterGroupInStockProps> = ({ title, inStock
                 {title}
                 <FilterGroupIcon isOpen={isGroupOpen} />
             </FilterGroupTitle>
-            <FilterGroupContent isOpen={isGroupOpen}>
-                <Checkbox
-                    name="onlyInStock"
-                    id="onlyInStock"
-                    onChange={() => updateFilterInStock(!filter?.onlyInStock)}
-                    label={t('In stock')}
-                    count={inStockCount}
-                    value={!!filter?.onlyInStock}
-                />
-            </FilterGroupContent>
+            {isGroupOpen && (
+                <FilterGroupContent>
+                    <Checkbox
+                        name="onlyInStock"
+                        id="onlyInStock"
+                        onChange={() => updateFilterInStock(!filter?.onlyInStock)}
+                        label={t('In stock')}
+                        count={inStockCount}
+                        value={!!filter?.onlyInStock}
+                    />
+                </FilterGroupContent>
+            )}
         </FilterGroupWrapper>
     );
 };

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupParameters.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupParameters.tsx
@@ -62,98 +62,100 @@ export const FilterGroupParameters: FC<FilterGroupParametersProps> = ({
                 {title}
                 <FilterGroupIcon isOpen={!isGroupCollapsed} />
             </FilterGroupTitle>
-            <FilterGroupContent isOpen={!isGroupCollapsed}>
-                {isCheckboxType && (
-                    <>
-                        {defaultOptions.map((parameterValueOption, index) => {
-                            const isChecked = getIsSelectedParameterValue(
-                                defaultSelectedParameters,
-                                selectedParameter?.values,
-                                parameter.uuid,
-                                parameterValueOption.uuid,
-                            );
-                            const id = `parameters.${parameterIndex}.values.${index}.checked`;
+            {isGroupCollapsed && (
+                <FilterGroupContent>
+                    {isCheckboxType && (
+                        <>
+                            {defaultOptions.map((parameterValueOption, index) => {
+                                const isChecked = getIsSelectedParameterValue(
+                                    defaultSelectedParameters,
+                                    selectedParameter?.values,
+                                    parameter.uuid,
+                                    parameterValueOption.uuid,
+                                );
+                                const id = `parameters.${parameterIndex}.values.${index}.checked`;
 
-                            return (
-                                <FilterGroupContentItem
-                                    key={parameterValueOption.uuid}
-                                    isDisabled={parameterValueOption.count === 0 && !isChecked}
-                                    dataTestId={getDataTestId(parameterIndex) + '-' + index}
-                                >
-                                    <Checkbox
+                                return (
+                                    <FilterGroupContentItem
+                                        key={parameterValueOption.uuid}
+                                        isDisabled={parameterValueOption.count === 0 && !isChecked}
+                                        dataTestId={getDataTestId(parameterIndex) + '-' + index}
+                                    >
+                                        <Checkbox
+                                            id={id}
+                                            name={id}
+                                            label={parameterValueOption.text}
+                                            onChange={() =>
+                                                updateFilterParameters(parameter.uuid, parameterValueOption.uuid)
+                                            }
+                                            value={isChecked}
+                                            count={parameterValueOption.count}
+                                        />
+                                    </FilterGroupContentItem>
+                                );
+                            })}
+                            {!!hiddenOptions.length && (
+                                <ShowAllButton onClick={() => setIsWithAllItemsShown((prev) => !prev)}>
+                                    {isWithAllItemsShown ? t('show less') : t('show more')}
+                                </ShowAllButton>
+                            )}
+                        </>
+                    )}
+
+                    {parameter.__typename === 'ParameterColorFilterOption' && (
+                        <div className="flex flex-wrap">
+                            {parameter.values.map((parameterValue, index) => {
+                                const isChecked = getIsSelectedParameterValue(
+                                    defaultSelectedParameters,
+                                    selectedParameter?.values,
+                                    parameter.uuid,
+                                    parameterValue.uuid,
+                                );
+                                const id = `parameters.${parameterIndex}.values.${index}.checked`;
+
+                                return (
+                                    <CheckboxColor
+                                        key={parameterValue.uuid}
+                                        bgColor={parameterValue.rgbHex ?? undefined}
+                                        dataTestId={getDataTestId(index)}
                                         id={id}
                                         name={id}
-                                        label={parameterValueOption.text}
-                                        onChange={() =>
-                                            updateFilterParameters(parameter.uuid, parameterValueOption.uuid)
-                                        }
+                                        disabled={parameterValue.count === 0 && !isChecked}
+                                        onChange={() => updateFilterParameters(parameter.uuid, parameterValue.uuid)}
                                         value={isChecked}
-                                        count={parameterValueOption.count}
+                                        label={parameterValue.text}
                                     />
-                                </FilterGroupContentItem>
-                            );
-                        })}
-                        {!!hiddenOptions.length && (
-                            <ShowAllButton onClick={() => setIsWithAllItemsShown((prev) => !prev)}>
-                                {isWithAllItemsShown ? t('show less') : t('show more')}
-                            </ShowAllButton>
-                        )}
-                    </>
-                )}
-
-                {parameter.__typename === 'ParameterColorFilterOption' && (
-                    <div className="flex flex-wrap">
-                        {parameter.values.map((parameterValue, index) => {
-                            const isChecked = getIsSelectedParameterValue(
-                                defaultSelectedParameters,
-                                selectedParameter?.values,
-                                parameter.uuid,
-                                parameterValue.uuid,
-                            );
-                            const id = `parameters.${parameterIndex}.values.${index}.checked`;
-
-                            return (
-                                <CheckboxColor
-                                    key={parameterValue.uuid}
-                                    bgColor={parameterValue.rgbHex ?? undefined}
-                                    dataTestId={getDataTestId(index)}
-                                    id={id}
-                                    name={id}
-                                    disabled={parameterValue.count === 0 && !isChecked}
-                                    onChange={() => updateFilterParameters(parameter.uuid, parameterValue.uuid)}
-                                    value={isChecked}
-                                    label={parameterValue.text}
-                                />
-                            );
-                        })}
-                    </div>
-                )}
-                {parameter.__typename === 'ParameterSliderFilterOption' && (
-                    <RangeSlider
-                        min={parameter.minimalValue}
-                        max={parameter.maximalValue}
-                        minValue={selectedParameter?.minimalValue ?? parameter.minimalValue}
-                        maxValue={selectedParameter?.maximalValue ?? parameter.maximalValue}
-                        setMinValueCallback={(value) =>
-                            updateFilterParameters(
-                                parameter.uuid,
-                                undefined,
-                                parameter.minimalValue === value ? undefined : value,
-                                selectedParameter?.maximalValue,
-                            )
-                        }
-                        setMaxValueCallback={(value) =>
-                            updateFilterParameters(
-                                parameter.uuid,
-                                undefined,
-                                selectedParameter?.minimalValue,
-                                parameter.maximalValue === value ? undefined : value,
-                            )
-                        }
-                        isDisabled={!parameter.isSelectable}
-                    />
-                )}
-            </FilterGroupContent>
+                                );
+                            })}
+                        </div>
+                    )}
+                    {parameter.__typename === 'ParameterSliderFilterOption' && (
+                        <RangeSlider
+                            min={parameter.minimalValue}
+                            max={parameter.maximalValue}
+                            minValue={selectedParameter?.minimalValue ?? parameter.minimalValue}
+                            maxValue={selectedParameter?.maximalValue ?? parameter.maximalValue}
+                            setMinValueCallback={(value) =>
+                                updateFilterParameters(
+                                    parameter.uuid,
+                                    undefined,
+                                    parameter.minimalValue === value ? undefined : value,
+                                    selectedParameter?.maximalValue,
+                                )
+                            }
+                            setMaxValueCallback={(value) =>
+                                updateFilterParameters(
+                                    parameter.uuid,
+                                    undefined,
+                                    selectedParameter?.minimalValue,
+                                    parameter.maximalValue === value ? undefined : value,
+                                )
+                            }
+                            isDisabled={!parameter.isSelectable}
+                        />
+                    )}
+                </FilterGroupContent>
+            )}
         </FilterGroupWrapper>
     );
 };

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupParameters.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupParameters.tsx
@@ -62,7 +62,7 @@ export const FilterGroupParameters: FC<FilterGroupParametersProps> = ({
                 {title}
                 <FilterGroupIcon isOpen={!isGroupCollapsed} />
             </FilterGroupTitle>
-            {isGroupCollapsed && (
+            {!isGroupCollapsed && (
                 <FilterGroupContent>
                     {isCheckboxType && (
                         <>

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupPrice.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupPrice.tsx
@@ -40,16 +40,18 @@ export const FilterGroupPrice: FC<FilterGroupPriceProps> = ({ title, initialMinP
                 {title}
                 <FilterGroupIcon isOpen={isGroupOpen} />
             </FilterGroupTitle>
-            <FilterGroupContent isOpen={isGroupOpen}>
-                <RangeSlider
-                    min={minPriceOption}
-                    max={maxPriceOption}
-                    minValue={minimalPrice || minPriceOption}
-                    maxValue={maximalPrice || maxPriceOption}
-                    setMinValueCallback={setMinimalPrice}
-                    setMaxValueCallback={setMaximalPrice}
-                />
-            </FilterGroupContent>
+            {isGroupOpen && (
+                <FilterGroupContent>
+                    <RangeSlider
+                        min={minPriceOption}
+                        max={maxPriceOption}
+                        minValue={minimalPrice || minPriceOption}
+                        maxValue={maximalPrice || maxPriceOption}
+                        setMinValueCallback={setMinimalPrice}
+                        setMaxValueCallback={setMaximalPrice}
+                    />
+                </FilterGroupContent>
+            )}
         </FilterGroupWrapper>
     );
 };


### PR DESCRIPTION
- on projects usually they have closed filters, because of that it is not necessary to include them in the DOM
- this helps with smaller DOM

| Q             | A
| ------------- | ---
|Description, reason for the PR| On projects usually they have closed filters, because of that it is not necessary to include them in the DOM. This helps with smaller DOM.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1676-remove-closed-filter-groups-from-dom.odin.shopsys.cloud
  - https://cz.tv-fw-1676-remove-closed-filter-groups-from-dom.odin.shopsys.cloud
<!-- Replace -->
