### PR TITLE
migrate SVG icons to standalone components

### DIFF
--- a/project-base/storefront/components/Basic/Icon/Icon.tsx
+++ b/project-base/storefront/components/Basic/Icon/Icon.tsx
@@ -1,47 +1,22 @@
-import { twMergeCustom } from 'helpers/twMerge';
 import { HTMLAttributes } from 'react';
 import { ExtractNativePropsFromDefault } from 'typeHelpers/ExtractNativePropsFromDefault';
 
 type NativeProps = ExtractNativePropsFromDefault<HTMLAttributes<HTMLElement>, never, 'onClick' | 'title'>;
 
-type IconProps = NativeProps &
-    (
-        | {
-              icon: JSX.Element;
-              alt?: never;
-              width?: never;
-              height?: never;
-          }
-        | {
-              icon: string;
-              alt: string | undefined;
-              width?: number;
-              height?: number;
-          }
-    );
+type IconProps = NativeProps & {
+    icon: string;
+    alt: string | undefined;
+    width?: number;
+    height?: number;
+};
 
-export const Icon: FC<IconProps> = ({ icon, height, width, title, alt, className, ...props }) => (
-    <>
-        {typeof icon === 'string' ? (
-            <img
-                src={`/icons/${icon}.png`}
-                height={height !== undefined ? height : '24'}
-                width={width !== undefined ? width : '24'}
-                title={title}
-                alt={alt}
-                data-testid={'basic-icon-' + icon}
-            />
-        ) : (
-            <i
-                className={twMergeCustom(
-                    'inline-flex w-[14px] text-center font-normal normal-case leading-none [&>svg]:h-full [&>svg]:w-full',
-                    className,
-                )}
-                data-testid={'basic-icon-iconsvg-' + icon}
-                {...props}
-            >
-                {icon}
-            </i>
-        )}
-    </>
-);
+export const Icon: FC<IconProps> = ({ icon, height, width, ...props }) => {
+    return (
+        <img
+            src={`/icons/${icon}.png`}
+            height={height !== undefined ? height : '24'}
+            width={width !== undefined ? width : '24'}
+            {...props}
+        />
+    );
+};

--- a/project-base/storefront/components/Basic/Icon/IconImage.tsx
+++ b/project-base/storefront/components/Basic/Icon/IconImage.tsx
@@ -3,14 +3,14 @@ import { ExtractNativePropsFromDefault } from 'typeHelpers/ExtractNativePropsFro
 
 type NativeProps = ExtractNativePropsFromDefault<HTMLAttributes<HTMLElement>, never, 'onClick' | 'title'>;
 
-type IconProps = NativeProps & {
+type IconImageProps = NativeProps & {
     icon: string;
     alt: string | undefined;
     width?: number;
     height?: number;
 };
 
-export const Icon: FC<IconProps> = ({ icon, height, width, ...props }) => {
+export const IconImage: FC<IconImageProps> = ({ icon, height, width, ...props }) => {
     return (
         <img
             src={`/icons/${icon}.png`}

--- a/project-base/storefront/components/Basic/Icon/IconsSvg.tsx
+++ b/project-base/storefront/components/Basic/Icon/IconsSvg.tsx
@@ -1,5 +1,9 @@
-export const Arrow: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+import { SVGProps } from 'react';
+
+type SvgFC<P = object> = FC<P & SVGProps<SVGSVGElement>>;
+
+export const Arrow: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M509.498 163.448l-53.446-53.445L256 310.054 55.95 110.003 2.503 163.448l226.775 226.775a37.8 37.8-90 0 0 53.445 0z"
             fill="currentColor"
@@ -7,8 +11,8 @@ export const Arrow: FC = () => (
     </svg>
 );
 
-export const ArrowRight: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const ArrowRight: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M501.396 236.195l-183.095-183.1C313.074 47.87 306.108 45 298.68 45c-7.437 0-14.399 2.873-19.625 8.095l-16.624 16.628c-5.222 5.219-8.1 12.189-8.1 19.62 0 7.428 2.878 14.633 8.1 19.852l106.816 107.05H29.89c-15.3 0-27.39 11.978-27.39 27.283v23.507c0 15.305 12.09 28.491 27.39 28.491h340.57L262.435 403.174c-5.222 5.227-8.1 12.007-8.1 19.439 0 7.423 2.878 14.303 8.1 19.525l16.624 16.575c5.227 5.226 12.189 8.075 19.624 8.075 7.428 0 14.394-2.886 19.62-8.112L501.4 275.58c5.24-5.243 8.12-12.242 8.1-19.682.016-7.465-2.86-14.468-8.104-19.703z"
             fill="currentColor"
@@ -16,8 +20,8 @@ export const ArrowRight: FC = () => (
     </svg>
 );
 
-export const Cart: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Cart: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M117.806 2.5c-9.153 0-16.084 4.686-20.256 10.154C80.848 34.54 46.937 80.24 29.052 103.936c-.747.99-5.002 6.232-5.003 15.155L24 438.723c-.008 39.21 31.737 70.777 71.158 70.777h319.09c39.422 0 71.147-31.567 71.159-70.777l.097-319.583c.002-8.003-3.81-13.564-5.052-15.204-18.224-24.073-49.903-67.235-68.448-91.282C405.367 4.048 397.895 2.5 391.698 2.5zm12.68 50.718h248.532l30.469 40.533H99.896zm-55.938 90.643h360.068l.073 293.791c.003 13.95-10.04 21.378-20.257 21.378H94.926c-9.308 0-20.302-6.452-20.306-21.378zm63.392 53.3v25.357c0 64.123 52.517 116.69 116.64 116.69 64.123 0 116.638-52.567 116.638-116.69V197.16h-50.716v25.358c0 36.714-29.208 65.971-65.922 65.971-36.713 0-65.922-29.257-65.922-65.97V197.16z"
             fill="currentColor"
@@ -25,8 +29,8 @@ export const Cart: FC = () => (
     </svg>
 );
 
-export const Cross: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Cross: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M509.5 256c0 140.004-113.496 253.5-253.5 253.5C115.996 509.5 2.5 396.004 2.5 256 2.5 115.996 115.996 2.5 256 2.5c140.004 0 253.5 113.496 253.5 253.5z"
             overflow="visible"
@@ -41,8 +45,8 @@ export const Cross: FC = () => (
     </svg>
 );
 
-export const Search: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Search: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M225.772 2.5C102.663 2.5 2.5 102.663 2.5 225.772c0 123.116 100.163 223.272 223.272 223.272 123.116 0 223.272-100.156 223.272-223.272C449.044 102.663 348.888 2.5 225.772 2.5zm0 405.326c-100.383 0-182.053-81.67-182.053-182.053S125.39 43.719 225.772 43.719s182.053 81.67 182.053 182.053-81.67 182.054-182.053 182.054z"
             fill="currentColor"
@@ -54,8 +58,8 @@ export const Search: FC = () => (
     </svg>
 );
 
-export const Chat: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Chat: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M244.208.496c37.877-.09 75.223 8.779 109.04 25.84 82.575 41.269 134.844 125.767 134.88 218.08.078 32.778-9.529 64.314-22.366 94.358l46.52 139.615a26.947 26.947 0 01-34.1 34.102L338.564 465.97c-30.059 12.844-61.614 22.451-94.41 22.366-92.253-.057-176.694-52.277-217.975-134.775v-.053C9.092 319.66.19 282.278.288 244.362v-12.734a26.947 26.947 0 01.054-1.474C7.163 106.498 106.29 7.372 229.946.55a26.947 26.947 0 011.474-.053h12.735zm.052 53.889a26.947 26.947 0 01-.052 0h-11.473C136.24 59.82 59.613 136.448 54.177 232.944v11.472a26.947 26.947 0 010 .052 186.993 186.993 0 0020.103 84.78 26.947 26.947 0 01.053.105c32.196 64.422 97.855 105.066 169.875 105.094a26.947 26.947 0 01.052 0 186.978 186.978 0 0084.78-20.103 26.947 26.947 0 0120.682-1.473l94.358 31.417-31.418-94.358a26.947 26.947 0 011.474-20.682 186.977 186.977 0 0020.103-84.78 26.947 26.947 0 010-.052c-.028-72.02-40.672-137.679-105.094-169.876a26.947 26.947 0 01-.105-.052 186.982 186.982 0 00-84.78-20.103z"
             overflow="visible"
@@ -64,8 +68,8 @@ export const Chat: FC = () => (
     </svg>
 );
 
-export const Marker: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
+export const Marker: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
         <path
             overflow="visible"
             fill="currentColor"
@@ -74,8 +78,8 @@ export const Marker: FC = () => (
     </svg>
 );
 
-export const User: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const User: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M255.992 315.584c-59.93 0-111.747 14.714-152.185 45.576C63.368 392.022 35.587 438.08 20 495.766l50.822 13.732c13.368-49.474 35.166-83.777 64.924-106.488 29.758-22.711 68.752-34.781 120.246-34.781 51.492 0 90.487 12.074 120.246 34.789 29.76 22.714 51.558 57.021 64.926 106.482l50.822-13.736C476.4 438.092 448.62 392.035 408.182 361.17c-40.437-30.865-92.257-45.586-152.19-45.586zm0-313.084c-72.376 0-131.613 59.237-131.613 131.613 0 72.377 59.237 131.616 131.613 131.616 72.377 0 131.615-59.24 131.615-131.616S328.37 2.5 255.992 2.5zm0 52.646c43.925 0 78.969 35.043 78.969 78.967 0 43.925-35.044 78.969-78.969 78.969s-78.967-35.044-78.967-78.969c0-43.924 35.042-78.967 78.967-78.967z"
             overflow="visible"
@@ -84,8 +88,8 @@ export const User: FC = () => (
     </svg>
 );
 
-export const Close: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Close: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M302.449 255.999L499.864 58.577c12.848-12.842 12.848-33.604 0-46.446-12.841-12.841-33.604-12.841-46.445 0L255.997 209.553 58.581 12.13C45.734-.71 24.977-.71 12.136 12.131c-12.848 12.842-12.848 33.604 0 46.446L209.55 255.998 12.136 453.42c-12.848 12.842-12.848 33.604 0 46.446 6.4 6.406 14.814 9.623 23.222 9.623a32.756 32.756 0 0023.223-9.623l197.416-197.422 197.422 197.422a32.756 32.756 0 0023.223 9.623 32.756 32.756 0 0023.222-9.623c12.848-12.842 12.848-33.604 0-46.446zm0 0"
             fill="currentColor"
@@ -93,8 +97,8 @@ export const Close: FC = () => (
     </svg>
 );
 
-export const Menu: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 12">
+export const Menu: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 12">
         <g fill="none">
             <path stroke="#000" d="M0 6H15.996 0" />
             <path fill="currentColor" d="M16 0v2H0V0zM15.996 10v2H0v-2z" />
@@ -102,8 +106,8 @@ export const Menu: FC = () => (
     </svg>
 );
 
-export const Remove: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Remove: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g>
             <path
                 d="M456.051 2.504L2.503 456.053l53.445 53.445L509.497 55.95z"
@@ -115,8 +119,8 @@ export const Remove: FC = () => (
     </svg>
 );
 
-export const NotImplementedYet: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const NotImplementedYet: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M256 512c-68.38 0-132.667-26.629-181.02-74.98C26.629 388.667 0 324.38 0 256S26.629 123.333 74.98 74.98C123.333 26.629 187.62 0 256 0s132.667 26.629 181.02 74.98C485.371 123.333 512 187.62 512 256s-26.629 132.667-74.98 181.02C388.667 485.371 324.38 512 256 512zm0-472C136.897 40 40 136.897 40 256s96.897 216 216 216 216-96.897 216-216S375.103 40 256 40zm93.737 260.188c-9.319-5.931-21.681-3.184-27.61 6.136-.247.387-25.137 38.737-67.127 38.737s-66.88-38.35-67.127-38.737c-5.93-9.319-18.291-12.066-27.61-6.136s-12.066 18.292-6.136 27.61c1.488 2.338 37.172 57.263 100.873 57.263s99.385-54.924 100.873-57.263c5.93-9.319 3.183-21.68-6.136-27.61zM168 165c13.807 0 25 11.193 25 25s-11.193 25-25 25-25-11.193-25-25 11.193-25 25-25zm150 25c0 13.807 11.193 25 25 25s25-11.193 25-25-11.193-25-25-25-25 11.193-25 25z"
             fill="currentColor"
@@ -124,8 +128,8 @@ export const NotImplementedYet: FC = () => (
     </svg>
 );
 
-export const Triangle: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Triangle: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="m84.125 188.612 252.164-171.93C373.509-8.695 424.253.905 449.63 38.125a81.566 81.566 0 0 1 14.174 45.949v343.86c0 45.048-36.518 81.566-81.566 81.566a81.568 81.568 0 0 1-45.95-14.174L84.126 323.396c-37.22-25.377-46.82-76.122-21.443-113.341a81.57 81.57 0 0 1 21.443-21.443z"
             fill="currentColor"
@@ -133,14 +137,14 @@ export const Triangle: FC = () => (
     </svg>
 );
 
-export const Sort: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 14">
+export const Sort: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 14">
         <path d="M0 0h21v2H0zm0 6h12.833v2H0zm0 6h17.5v2H0z" fill="currentColor" />
     </svg>
 );
 
-export const RemoveBold: FC = () => (
-    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+export const RemoveBold: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M489.846 394.952L350.899 256.005l138.947-138.947c26.204-26.204 26.204-68.69 0-94.894-26.204-26.204-68.69-26.204-94.894 0L255.994 161.11 117.047 22.153c-26.215-26.204-68.702-26.204-94.894 0-26.204 26.214-26.204 68.701 0 94.894L161.11 255.994 22.153 394.94c-26.204 26.214-26.204 68.701 0 94.894 13.118 13.107 30.274 19.65 47.452 19.65 17.167 0 34.346-6.554 47.453-19.65l138.936-138.936 138.958 138.947c13.118 13.096 30.274 19.65 47.452 19.65 17.179 0 34.346-6.554 47.453-19.65 26.193-26.204 26.193-68.68-.011-94.894z"
             fill="currentColor"
@@ -148,8 +152,8 @@ export const RemoveBold: FC = () => (
     </svg>
 );
 
-export const RemoveThin: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const RemoveThin: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M509.5 32.372L479.628 2.5 256 226.128 32.372 2.5 2.5 32.372 226.128 256 2.5 479.628 32.372 509.5 256 285.872 479.628 509.5l29.872-29.872L285.872 256z"
             fill="currentColor"
@@ -157,8 +161,8 @@ export const RemoveThin: FC = () => (
     </svg>
 );
 
-export const Plus: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Plus: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M2.5 287.632h221.868V509.5h63.264V287.632H509.5v-63.264H287.632V2.5h-63.264v221.868H2.5z"
             fill="currentColor"
@@ -166,8 +170,8 @@ export const Plus: FC = () => (
     </svg>
 );
 
-export const Filter: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Filter: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g transform="matrix(23.04546 0 0 23.04545 -9169.492 -192542.19)">
             <g stroke="none">
                 <path d="M401.5 8357.5h1v7h-1zm0 10h1v7h-1zm7-2h1v9h-1zm0-8h1v5h-1z" fill="currentColor" />
@@ -178,8 +182,8 @@ export const Filter: FC = () => (
     </svg>
 );
 
-export const Phone: FC = () => (
-    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+export const Phone: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M73.698 2.5c-41.49-.077-74.72 36.314-70.901 77.635a25.353 25.353 0 0 0 0 .346c7.961 74.689 33.436 146.425 74.317 209.435.02.03.03.069.05.1.012.018.037.03.05.049a472.057 472.057 0 0 0 145.118 144.871c.013.009.037-.008.05 0a480.098 480.098 0 0 0 209.039 74.219 25.353 25.353 0 0 0 .445.05c41.33 3.686 77.661-29.557 77.635-71.05v-68.673a25.353 25.353 0 0 0-6.14-16.438c-6.844-27.567-25.942-51.047-55.156-55.156a25.353 25.353 0 0 0-.198 0c-20.099-2.644-39.869-7.59-58.87-14.656h-.098c-25.934-9.696-55.337-3.446-75.06 15.992a25.353 25.353 0 0 0-.1.1l-13.665 13.615c-40.9-26.304-75.362-60.7-101.746-101.549l13.566-13.566a25.353 25.353 0 0 0 .148-.099c19.508-19.704 25.784-49.157 15.993-75.11a269.681 269.681 0 0 1-14.656-58.72 25.353 25.353 0 0 0-.05-.248c-5.022-35.17-35.672-61.504-71.197-61.147H73.697zm-.1 50.7a25.353 25.353 0 0 0 .1 0h68.821a25.353 25.353 0 0 0 .248 0c10.492-.105 19.064 7.24 20.547 17.626a320.18 320.18 0 0 0 17.379 69.614 25.353 25.353 0 0 0 .05.1c2.826 7.492 1.055 15.741-4.605 21.487l-29.064 29.014a25.353 25.353 0 0 0-4.11 30.5 392.043 392.043 0 0 0 147.15 146.901 25.353 25.353 0 0 0 30.45-4.11l29.063-29.013c5.763-5.651 14.127-7.444 21.686-4.605a25.353 25.353 0 0 0 .05 0 320.538 320.538 0 0 0 69.811 17.379c10.54 1.482 17.902 10.215 17.627 20.745a25.353 25.353 0 0 0 0 .644v68.722c.008 12.449-9.947 21.488-22.33 20.449-66.505-7.27-130.39-29.9-186.56-66.247a25.353 25.353 0 0 0-.199-.149c-52.27-33.146-96.627-77.363-129.87-129.572a25.353 25.353 0 0 0-.098-.198C83.194 206.199 60.452 142.06 53.299 75.332 52.257 63.048 61.24 53.168 73.6 53.2z"
             fill="currentColor"
@@ -187,8 +191,8 @@ export const Phone: FC = () => (
     </svg>
 );
 
-export const Youtube: FC = () => (
-    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+export const Youtube: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M411.826 77.913H111.304C44.522 77.913 0 122.435 0 178.087v155.826c0 55.652 44.522 100.174 111.304 100.174h300.522c55.652 0 100.174-44.522 100.174-100.174V178.087c0-55.652-44.522-100.174-100.174-100.174ZM356.174 256l-144.696 66.783V178.087z"
             fill="currentColor"
@@ -196,8 +200,8 @@ export const Youtube: FC = () => (
     </svg>
 );
 
-export const Instagram: FC = () => (
-    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+export const Instagram: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M365.678 2.307A1731.544 1731.544 0 0 0 95.62 18.19c-31.771 0-47.658 15.886-47.658 31.772-15.886 0-31.772 15.887-31.772 47.658L.307 145.277A1731.544 1731.544 0 0 0 16.19 415.336c0 31.771 15.886 47.656 31.772 47.656 0 15.886 15.887 31.772 47.658 31.772l47.656 15.886a1858.63 1858.63 0 0 0 270.059-15.886c47.657-15.886 63.542-31.77 79.428-79.428l15.886-47.658a1858.63 1858.63 0 0 0 0-222.4L492.764 97.62c0-31.771-15.886-47.658-31.772-47.658 0-15.886-15.885-31.772-47.656-31.772L365.678 2.307zM159.164 49.963A1795.087 1795.087 0 0 1 397.45 65.85l31.772 15.884 15.886 31.772 15.885 47.658a1795.087 1795.087 0 0 1 0 190.629l-15.885 47.656c0 31.772-15.886 47.658-47.658 47.658l-47.656 15.885a1795.087 1795.087 0 0 1-238.287-15.885l-31.772-15.886-15.884-31.772-15.887-47.656A1795.087 1795.087 0 0 1 63.85 113.506l15.884-31.772 31.772-15.884 47.658-15.887z"
             fill="currentColor"
@@ -209,14 +213,14 @@ export const Instagram: FC = () => (
     </svg>
 );
 
-export const MapMarker: FC = () => (
-    <svg viewBox="0 0 30 38" xmlns="http://www.w3.org/2000/svg">
+export const MapMarker: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 30 38" xmlns="http://www.w3.org/2000/svg">
         <path d="M30,15A15,15,0,1,0,10.089,29.161L15,38l4.911-8.839A14.994,14.994,0,0,0,30,15Z" fill="currentColor" />
     </svg>
 );
 
-export const Checkmark: FC = () => (
-    <svg viewBox="0 0 36 36" xmlns="http://www.w3.org/1999/xlink" aria-hidden="true" role="img">
+export const Checkmark: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 36 36" xmlns="http://www.w3.org/1999/xlink" aria-hidden="true" role="img">
         <path fill="#77B255" d="M36 32a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V4a4 4 0 0 1 4-4h28a4 4 0 0 1 4 4v28z"></path>
         <path
             fill="#FFF"
@@ -225,8 +229,8 @@ export const Checkmark: FC = () => (
     </svg>
 );
 
-export const Warning: FC = () => (
-    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+export const Warning: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M11.158 3.475c.37-.633 1.305-.633 1.684 0l9.029 15.109c.37.632-.098 1.416-.848 1.416H2.977c-.75 0-1.218-.784-.848-1.416ZM13 15h-2v2h2v-2Zm-1-6c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1Z"
             fill="currentColor"
@@ -234,8 +238,8 @@ export const Warning: FC = () => (
     </svg>
 );
 
-export const Spinner: FC = () => (
-    <svg viewBox="0 0 32 32" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+export const Spinner: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 32 32" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path opacity=".25" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4" />
         <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z">
             <animateTransform
@@ -250,8 +254,8 @@ export const Spinner: FC = () => (
     </svg>
 );
 
-export const Info: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+export const Info: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M494.29 256c0 131.604-106.686 238.29-238.29 238.29-131.604 0-238.29-106.686-238.29-238.29C17.71 124.397 124.396 17.71 256 17.71c131.604 0 238.29 106.686 238.29 238.29z"
             fill="transparent"
@@ -276,8 +280,8 @@ export const Info: FC = () => (
     </svg>
 );
 
-export const Compare: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 21">
+export const Compare: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 21">
         <path
             d="m10.117 14.488.083-.053-.083.053Zm.083.132 3.552 5.63h-7.16l3.608-5.63Z"
             stroke="currentColor"
@@ -309,8 +313,8 @@ export const Compare: FC = () => (
     </svg>
 );
 
-export const ArrowSecondary: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 17">
+export const ArrowSecondary: SvgFC = (props) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 17">
         <path
             fillRule="evenodd"
             clipRule="evenodd"
@@ -320,8 +324,8 @@ export const ArrowSecondary: FC = () => (
     </svg>
 );
 
-export const Play: FC = () => (
-    <svg viewBox="0 0 9 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+export const Play: SvgFC = (props) => (
+    <svg {...props} viewBox="0 0 9 11" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="m1.4218 1.5 6.5 4.3333-6.5 4.3334V1.5Z"
             stroke="currentColor"
@@ -332,26 +336,12 @@ export const Play: FC = () => (
     </svg>
 );
 
-export const Heart: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 19">
+export const Heart: SvgFC<{ isFull: boolean }> = ({ isFull, ...props }) => (
+    <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 19">
         <path
             clipRule="evenodd"
             d="M20.046 2.591a5.43 5.43 0 0 0-7.681 0l-1.047 1.047-1.046-1.047a5.431 5.431 0 0 0-7.681 7.681l1.046 1.047 6.267 6.267a2 2 0 0 0 2.829 0L19 11.319l1.046-1.047a5.43 5.43 0 0 0 0-7.68Z"
-            stroke="currentColor"
-            fill="transparent"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-        />
-    </svg>
-);
-
-export const HeartFull: FC = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 19">
-        <path
-            clipRule="evenodd"
-            d="M20.046 2.591a5.43 5.43 0 0 0-7.681 0l-1.047 1.047-1.046-1.047a5.431 5.431 0 0 0-7.681 7.681l1.046 1.047 6.267 6.267a2 2 0 0 0 2.829 0L19 11.319l1.046-1.047a5.43 5.43 0 0 0 0-7.68Z"
-            fill="currentColor"
+            fill={isFull ? 'currentColor' : 'transparent'}
             stroke="currentColor"
             strokeWidth="1.5"
             strokeLinecap="round"
@@ -360,8 +350,8 @@ export const HeartFull: FC = () => (
     </svg>
 );
 
-export const EmptyCart: FC = () => (
-    <svg width="572" height="512" viewBox="0 0 572 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+export const EmptyCart: SvgFC = (props) => (
+    <svg {...props} width="572" height="512" viewBox="0 0 572 512" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             fillRule="evenodd"
             clipRule="evenodd"

--- a/project-base/storefront/components/Basic/Icon/IconsSvg.tsx
+++ b/project-base/storefront/components/Basic/Icon/IconsSvg.tsx
@@ -2,7 +2,7 @@ import { SVGProps } from 'react';
 
 type SvgFC<P = object> = FC<P & SVGProps<SVGSVGElement>>;
 
-export const Arrow: SvgFC = (props) => (
+export const ArrowIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M509.498 163.448l-53.446-53.445L256 310.054 55.95 110.003 2.503 163.448l226.775 226.775a37.8 37.8-90 0 0 53.445 0z"
@@ -11,7 +11,7 @@ export const Arrow: SvgFC = (props) => (
     </svg>
 );
 
-export const ArrowRight: SvgFC = (props) => (
+export const ArrowRightIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M501.396 236.195l-183.095-183.1C313.074 47.87 306.108 45 298.68 45c-7.437 0-14.399 2.873-19.625 8.095l-16.624 16.628c-5.222 5.219-8.1 12.189-8.1 19.62 0 7.428 2.878 14.633 8.1 19.852l106.816 107.05H29.89c-15.3 0-27.39 11.978-27.39 27.283v23.507c0 15.305 12.09 28.491 27.39 28.491h340.57L262.435 403.174c-5.222 5.227-8.1 12.007-8.1 19.439 0 7.423 2.878 14.303 8.1 19.525l16.624 16.575c5.227 5.226 12.189 8.075 19.624 8.075 7.428 0 14.394-2.886 19.62-8.112L501.4 275.58c5.24-5.243 8.12-12.242 8.1-19.682.016-7.465-2.86-14.468-8.104-19.703z"
@@ -20,7 +20,7 @@ export const ArrowRight: SvgFC = (props) => (
     </svg>
 );
 
-export const Cart: SvgFC = (props) => (
+export const CartIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M117.806 2.5c-9.153 0-16.084 4.686-20.256 10.154C80.848 34.54 46.937 80.24 29.052 103.936c-.747.99-5.002 6.232-5.003 15.155L24 438.723c-.008 39.21 31.737 70.777 71.158 70.777h319.09c39.422 0 71.147-31.567 71.159-70.777l.097-319.583c.002-8.003-3.81-13.564-5.052-15.204-18.224-24.073-49.903-67.235-68.448-91.282C405.367 4.048 397.895 2.5 391.698 2.5zm12.68 50.718h248.532l30.469 40.533H99.896zm-55.938 90.643h360.068l.073 293.791c.003 13.95-10.04 21.378-20.257 21.378H94.926c-9.308 0-20.302-6.452-20.306-21.378zm63.392 53.3v25.357c0 64.123 52.517 116.69 116.64 116.69 64.123 0 116.638-52.567 116.638-116.69V197.16h-50.716v25.358c0 36.714-29.208 65.971-65.922 65.971-36.713 0-65.922-29.257-65.922-65.97V197.16z"
@@ -29,7 +29,7 @@ export const Cart: SvgFC = (props) => (
     </svg>
 );
 
-export const Cross: SvgFC = (props) => (
+export const CrossIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M509.5 256c0 140.004-113.496 253.5-253.5 253.5C115.996 509.5 2.5 396.004 2.5 256 2.5 115.996 115.996 2.5 256 2.5c140.004 0 253.5 113.496 253.5 253.5z"
@@ -45,7 +45,7 @@ export const Cross: SvgFC = (props) => (
     </svg>
 );
 
-export const Search: SvgFC = (props) => (
+export const SearchIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M225.772 2.5C102.663 2.5 2.5 102.663 2.5 225.772c0 123.116 100.163 223.272 223.272 223.272 123.116 0 223.272-100.156 223.272-223.272C449.044 102.663 348.888 2.5 225.772 2.5zm0 405.326c-100.383 0-182.053-81.67-182.053-182.053S125.39 43.719 225.772 43.719s182.053 81.67 182.053 182.053-81.67 182.054-182.053 182.054z"
@@ -58,7 +58,7 @@ export const Search: SvgFC = (props) => (
     </svg>
 );
 
-export const Chat: SvgFC = (props) => (
+export const ChatIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M244.208.496c37.877-.09 75.223 8.779 109.04 25.84 82.575 41.269 134.844 125.767 134.88 218.08.078 32.778-9.529 64.314-22.366 94.358l46.52 139.615a26.947 26.947 0 01-34.1 34.102L338.564 465.97c-30.059 12.844-61.614 22.451-94.41 22.366-92.253-.057-176.694-52.277-217.975-134.775v-.053C9.092 319.66.19 282.278.288 244.362v-12.734a26.947 26.947 0 01.054-1.474C7.163 106.498 106.29 7.372 229.946.55a26.947 26.947 0 011.474-.053h12.735zm.052 53.889a26.947 26.947 0 01-.052 0h-11.473C136.24 59.82 59.613 136.448 54.177 232.944v11.472a26.947 26.947 0 010 .052 186.993 186.993 0 0020.103 84.78 26.947 26.947 0 01.053.105c32.196 64.422 97.855 105.066 169.875 105.094a26.947 26.947 0 01.052 0 186.978 186.978 0 0084.78-20.103 26.947 26.947 0 0120.682-1.473l94.358 31.417-31.418-94.358a26.947 26.947 0 011.474-20.682 186.977 186.977 0 0020.103-84.78 26.947 26.947 0 010-.052c-.028-72.02-40.672-137.679-105.094-169.876a26.947 26.947 0 01-.105-.052 186.982 186.982 0 00-84.78-20.103z"
@@ -68,7 +68,7 @@ export const Chat: SvgFC = (props) => (
     </svg>
 );
 
-export const Marker: SvgFC = (props) => (
+export const MarkerIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
         <path
             overflow="visible"
@@ -78,7 +78,7 @@ export const Marker: SvgFC = (props) => (
     </svg>
 );
 
-export const User: SvgFC = (props) => (
+export const UserIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M255.992 315.584c-59.93 0-111.747 14.714-152.185 45.576C63.368 392.022 35.587 438.08 20 495.766l50.822 13.732c13.368-49.474 35.166-83.777 64.924-106.488 29.758-22.711 68.752-34.781 120.246-34.781 51.492 0 90.487 12.074 120.246 34.789 29.76 22.714 51.558 57.021 64.926 106.482l50.822-13.736C476.4 438.092 448.62 392.035 408.182 361.17c-40.437-30.865-92.257-45.586-152.19-45.586zm0-313.084c-72.376 0-131.613 59.237-131.613 131.613 0 72.377 59.237 131.616 131.613 131.616 72.377 0 131.615-59.24 131.615-131.616S328.37 2.5 255.992 2.5zm0 52.646c43.925 0 78.969 35.043 78.969 78.967 0 43.925-35.044 78.969-78.969 78.969s-78.967-35.044-78.967-78.969c0-43.924 35.042-78.967 78.967-78.967z"
@@ -88,7 +88,7 @@ export const User: SvgFC = (props) => (
     </svg>
 );
 
-export const Close: SvgFC = (props) => (
+export const CloseIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M302.449 255.999L499.864 58.577c12.848-12.842 12.848-33.604 0-46.446-12.841-12.841-33.604-12.841-46.445 0L255.997 209.553 58.581 12.13C45.734-.71 24.977-.71 12.136 12.131c-12.848 12.842-12.848 33.604 0 46.446L209.55 255.998 12.136 453.42c-12.848 12.842-12.848 33.604 0 46.446 6.4 6.406 14.814 9.623 23.222 9.623a32.756 32.756 0 0023.223-9.623l197.416-197.422 197.422 197.422a32.756 32.756 0 0023.223 9.623 32.756 32.756 0 0023.222-9.623c12.848-12.842 12.848-33.604 0-46.446zm0 0"
@@ -97,7 +97,7 @@ export const Close: SvgFC = (props) => (
     </svg>
 );
 
-export const Menu: SvgFC = (props) => (
+export const MenuIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 12">
         <g fill="none">
             <path stroke="#000" d="M0 6H15.996 0" />
@@ -106,7 +106,7 @@ export const Menu: SvgFC = (props) => (
     </svg>
 );
 
-export const Remove: SvgFC = (props) => (
+export const RemoveIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g>
             <path
@@ -119,7 +119,7 @@ export const Remove: SvgFC = (props) => (
     </svg>
 );
 
-export const NotImplementedYet: SvgFC = (props) => (
+export const NotImplementedYetIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M256 512c-68.38 0-132.667-26.629-181.02-74.98C26.629 388.667 0 324.38 0 256S26.629 123.333 74.98 74.98C123.333 26.629 187.62 0 256 0s132.667 26.629 181.02 74.98C485.371 123.333 512 187.62 512 256s-26.629 132.667-74.98 181.02C388.667 485.371 324.38 512 256 512zm0-472C136.897 40 40 136.897 40 256s96.897 216 216 216 216-96.897 216-216S375.103 40 256 40zm93.737 260.188c-9.319-5.931-21.681-3.184-27.61 6.136-.247.387-25.137 38.737-67.127 38.737s-66.88-38.35-67.127-38.737c-5.93-9.319-18.291-12.066-27.61-6.136s-12.066 18.292-6.136 27.61c1.488 2.338 37.172 57.263 100.873 57.263s99.385-54.924 100.873-57.263c5.93-9.319 3.183-21.68-6.136-27.61zM168 165c13.807 0 25 11.193 25 25s-11.193 25-25 25-25-11.193-25-25 11.193-25 25-25zm150 25c0 13.807 11.193 25 25 25s25-11.193 25-25-11.193-25-25-25-25 11.193-25 25z"
@@ -128,7 +128,7 @@ export const NotImplementedYet: SvgFC = (props) => (
     </svg>
 );
 
-export const Triangle: SvgFC = (props) => (
+export const TriangleIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="m84.125 188.612 252.164-171.93C373.509-8.695 424.253.905 449.63 38.125a81.566 81.566 0 0 1 14.174 45.949v343.86c0 45.048-36.518 81.566-81.566 81.566a81.568 81.568 0 0 1-45.95-14.174L84.126 323.396c-37.22-25.377-46.82-76.122-21.443-113.341a81.57 81.57 0 0 1 21.443-21.443z"
@@ -137,13 +137,13 @@ export const Triangle: SvgFC = (props) => (
     </svg>
 );
 
-export const Sort: SvgFC = (props) => (
+export const SortIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 14">
         <path d="M0 0h21v2H0zm0 6h12.833v2H0zm0 6h17.5v2H0z" fill="currentColor" />
     </svg>
 );
 
-export const RemoveBold: SvgFC = (props) => (
+export const RemoveBoldIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M489.846 394.952L350.899 256.005l138.947-138.947c26.204-26.204 26.204-68.69 0-94.894-26.204-26.204-68.69-26.204-94.894 0L255.994 161.11 117.047 22.153c-26.215-26.204-68.702-26.204-94.894 0-26.204 26.214-26.204 68.701 0 94.894L161.11 255.994 22.153 394.94c-26.204 26.214-26.204 68.701 0 94.894 13.118 13.107 30.274 19.65 47.452 19.65 17.167 0 34.346-6.554 47.453-19.65l138.936-138.936 138.958 138.947c13.118 13.096 30.274 19.65 47.452 19.65 17.179 0 34.346-6.554 47.453-19.65 26.193-26.204 26.193-68.68-.011-94.894z"
@@ -152,7 +152,7 @@ export const RemoveBold: SvgFC = (props) => (
     </svg>
 );
 
-export const RemoveThin: SvgFC = (props) => (
+export const RemoveThinIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M509.5 32.372L479.628 2.5 256 226.128 32.372 2.5 2.5 32.372 226.128 256 2.5 479.628 32.372 509.5 256 285.872 479.628 509.5l29.872-29.872L285.872 256z"
@@ -161,7 +161,7 @@ export const RemoveThin: SvgFC = (props) => (
     </svg>
 );
 
-export const Plus: SvgFC = (props) => (
+export const PlusIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M2.5 287.632h221.868V509.5h63.264V287.632H509.5v-63.264H287.632V2.5h-63.264v221.868H2.5z"
@@ -170,7 +170,7 @@ export const Plus: SvgFC = (props) => (
     </svg>
 );
 
-export const Filter: SvgFC = (props) => (
+export const FilterIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <g transform="matrix(23.04546 0 0 23.04545 -9169.492 -192542.19)">
             <g stroke="none">
@@ -182,7 +182,7 @@ export const Filter: SvgFC = (props) => (
     </svg>
 );
 
-export const Phone: SvgFC = (props) => (
+export const PhoneIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M73.698 2.5c-41.49-.077-74.72 36.314-70.901 77.635a25.353 25.353 0 0 0 0 .346c7.961 74.689 33.436 146.425 74.317 209.435.02.03.03.069.05.1.012.018.037.03.05.049a472.057 472.057 0 0 0 145.118 144.871c.013.009.037-.008.05 0a480.098 480.098 0 0 0 209.039 74.219 25.353 25.353 0 0 0 .445.05c41.33 3.686 77.661-29.557 77.635-71.05v-68.673a25.353 25.353 0 0 0-6.14-16.438c-6.844-27.567-25.942-51.047-55.156-55.156a25.353 25.353 0 0 0-.198 0c-20.099-2.644-39.869-7.59-58.87-14.656h-.098c-25.934-9.696-55.337-3.446-75.06 15.992a25.353 25.353 0 0 0-.1.1l-13.665 13.615c-40.9-26.304-75.362-60.7-101.746-101.549l13.566-13.566a25.353 25.353 0 0 0 .148-.099c19.508-19.704 25.784-49.157 15.993-75.11a269.681 269.681 0 0 1-14.656-58.72 25.353 25.353 0 0 0-.05-.248c-5.022-35.17-35.672-61.504-71.197-61.147H73.697zm-.1 50.7a25.353 25.353 0 0 0 .1 0h68.821a25.353 25.353 0 0 0 .248 0c10.492-.105 19.064 7.24 20.547 17.626a320.18 320.18 0 0 0 17.379 69.614 25.353 25.353 0 0 0 .05.1c2.826 7.492 1.055 15.741-4.605 21.487l-29.064 29.014a25.353 25.353 0 0 0-4.11 30.5 392.043 392.043 0 0 0 147.15 146.901 25.353 25.353 0 0 0 30.45-4.11l29.063-29.013c5.763-5.651 14.127-7.444 21.686-4.605a25.353 25.353 0 0 0 .05 0 320.538 320.538 0 0 0 69.811 17.379c10.54 1.482 17.902 10.215 17.627 20.745a25.353 25.353 0 0 0 0 .644v68.722c.008 12.449-9.947 21.488-22.33 20.449-66.505-7.27-130.39-29.9-186.56-66.247a25.353 25.353 0 0 0-.199-.149c-52.27-33.146-96.627-77.363-129.87-129.572a25.353 25.353 0 0 0-.098-.198C83.194 206.199 60.452 142.06 53.299 75.332 52.257 63.048 61.24 53.168 73.6 53.2z"
@@ -191,7 +191,7 @@ export const Phone: SvgFC = (props) => (
     </svg>
 );
 
-export const Youtube: SvgFC = (props) => (
+export const YoutubeIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M411.826 77.913H111.304C44.522 77.913 0 122.435 0 178.087v155.826c0 55.652 44.522 100.174 111.304 100.174h300.522c55.652 0 100.174-44.522 100.174-100.174V178.087c0-55.652-44.522-100.174-100.174-100.174ZM356.174 256l-144.696 66.783V178.087z"
@@ -200,7 +200,7 @@ export const Youtube: SvgFC = (props) => (
     </svg>
 );
 
-export const Instagram: SvgFC = (props) => (
+export const InstagramIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M365.678 2.307A1731.544 1731.544 0 0 0 95.62 18.19c-31.771 0-47.658 15.886-47.658 31.772-15.886 0-31.772 15.887-31.772 47.658L.307 145.277A1731.544 1731.544 0 0 0 16.19 415.336c0 31.771 15.886 47.656 31.772 47.656 0 15.886 15.887 31.772 47.658 31.772l47.656 15.886a1858.63 1858.63 0 0 0 270.059-15.886c47.657-15.886 63.542-31.77 79.428-79.428l15.886-47.658a1858.63 1858.63 0 0 0 0-222.4L492.764 97.62c0-31.771-15.886-47.658-31.772-47.658 0-15.886-15.885-31.772-47.656-31.772L365.678 2.307zM159.164 49.963A1795.087 1795.087 0 0 1 397.45 65.85l31.772 15.884 15.886 31.772 15.885 47.658a1795.087 1795.087 0 0 1 0 190.629l-15.885 47.656c0 31.772-15.886 47.658-47.658 47.658l-47.656 15.885a1795.087 1795.087 0 0 1-238.287-15.885l-31.772-15.886-15.884-31.772-15.887-47.656A1795.087 1795.087 0 0 1 63.85 113.506l15.884-31.772 31.772-15.884 47.658-15.887z"
@@ -213,13 +213,13 @@ export const Instagram: SvgFC = (props) => (
     </svg>
 );
 
-export const MapMarker: SvgFC = (props) => (
+export const MapMarkerIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 30 38" xmlns="http://www.w3.org/2000/svg">
         <path d="M30,15A15,15,0,1,0,10.089,29.161L15,38l4.911-8.839A14.994,14.994,0,0,0,30,15Z" fill="currentColor" />
     </svg>
 );
 
-export const Checkmark: SvgFC = (props) => (
+export const CheckmarkIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 36 36" xmlns="http://www.w3.org/1999/xlink" aria-hidden="true" role="img">
         <path fill="#77B255" d="M36 32a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V4a4 4 0 0 1 4-4h28a4 4 0 0 1 4 4v28z"></path>
         <path
@@ -229,7 +229,7 @@ export const Checkmark: SvgFC = (props) => (
     </svg>
 );
 
-export const Warning: SvgFC = (props) => (
+export const WarningIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M11.158 3.475c.37-.633 1.305-.633 1.684 0l9.029 15.109c.37.632-.098 1.416-.848 1.416H2.977c-.75 0-1.218-.784-.848-1.416ZM13 15h-2v2h2v-2Zm-1-6c-.55 0-1 .45-1 1v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1Z"
@@ -238,7 +238,7 @@ export const Warning: SvgFC = (props) => (
     </svg>
 );
 
-export const Spinner: SvgFC = (props) => (
+export const SpinnerIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 32 32" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path opacity=".25" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4" />
         <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z">
@@ -254,7 +254,7 @@ export const Spinner: SvgFC = (props) => (
     </svg>
 );
 
-export const Info: SvgFC = (props) => (
+export const InfoIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
         <path
             d="M494.29 256c0 131.604-106.686 238.29-238.29 238.29-131.604 0-238.29-106.686-238.29-238.29C17.71 124.397 124.396 17.71 256 17.71c131.604 0 238.29 106.686 238.29 238.29z"
@@ -280,7 +280,7 @@ export const Info: SvgFC = (props) => (
     </svg>
 );
 
-export const Compare: SvgFC = (props) => (
+export const CompareIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 21">
         <path
             d="m10.117 14.488.083-.053-.083.053Zm.083.132 3.552 5.63h-7.16l3.608-5.63Z"
@@ -313,7 +313,7 @@ export const Compare: SvgFC = (props) => (
     </svg>
 );
 
-export const ArrowSecondary: SvgFC = (props) => (
+export const ArrowSecondaryIcon: SvgFC = (props) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 17">
         <path
             fillRule="evenodd"
@@ -324,7 +324,7 @@ export const ArrowSecondary: SvgFC = (props) => (
     </svg>
 );
 
-export const Play: SvgFC = (props) => (
+export const PlayIcon: SvgFC = (props) => (
     <svg {...props} viewBox="0 0 9 11" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="m1.4218 1.5 6.5 4.3333-6.5 4.3334V1.5Z"
@@ -336,7 +336,7 @@ export const Play: SvgFC = (props) => (
     </svg>
 );
 
-export const Heart: SvgFC<{ isFull: boolean }> = ({ isFull, ...props }) => (
+export const HeartIcon: SvgFC<{ isFull: boolean }> = ({ isFull, ...props }) => (
     <svg {...props} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23 19">
         <path
             clipRule="evenodd"
@@ -350,7 +350,7 @@ export const Heart: SvgFC<{ isFull: boolean }> = ({ isFull, ...props }) => (
     </svg>
 );
 
-export const EmptyCart: SvgFC = (props) => (
+export const EmptyCartIcon: SvgFC = (props) => (
     <svg {...props} width="572" height="512" viewBox="0 0 572 512" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             fillRule="evenodd"

--- a/project-base/storefront/components/Basic/Loader/Loader.tsx
+++ b/project-base/storefront/components/Basic/Loader/Loader.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '../Icon/Icon';
 import { Spinner } from '../Icon/IconsSvg';
 
-export const Loader: FC = ({ className }) => <Icon icon={<Spinner />} className={className} />;
+export const Loader: FC = ({ className }) => <Spinner className={className} />;

--- a/project-base/storefront/components/Basic/Loader/Loader.tsx
+++ b/project-base/storefront/components/Basic/Loader/Loader.tsx
@@ -1,3 +1,3 @@
-import { Spinner } from '../Icon/IconsSvg';
+import { SpinnerIcon } from '../Icon/IconsSvg';
 
-export const Loader: FC = ({ className }) => <Spinner className={className} />;
+export const Loader: FC = ({ className }) => <SpinnerIcon className={className} />;

--- a/project-base/storefront/components/Basic/Loader/LoaderWithOverlay.tsx
+++ b/project-base/storefront/components/Basic/Loader/LoaderWithOverlay.tsx
@@ -1,7 +1,7 @@
-import { Spinner } from '../Icon/IconsSvg';
+import { SpinnerIcon } from '../Icon/IconsSvg';
 
 export const LoaderWithOverlay: FC = ({ className }) => (
     <div className="absolute inset-0 z-overlay flex h-full w-full items-center justify-center bg-greyLighter opacity-50">
-        <Spinner className={className} />
+        <SpinnerIcon className={className} />
     </div>
 );

--- a/project-base/storefront/components/Basic/Loader/LoaderWithOverlay.tsx
+++ b/project-base/storefront/components/Basic/Loader/LoaderWithOverlay.tsx
@@ -1,7 +1,7 @@
-import { Loader } from './Loader';
+import { Spinner } from '../Icon/IconsSvg';
 
 export const LoaderWithOverlay: FC = ({ className }) => (
     <div className="absolute inset-0 z-overlay flex h-full w-full items-center justify-center bg-greyLighter opacity-50">
-        <Loader className={className} />
+        <Spinner className={className} />
     </div>
 );

--- a/project-base/storefront/components/Basic/SeznamMap/SeznamMapMarkerIcon.tsx
+++ b/project-base/storefront/components/Basic/SeznamMap/SeznamMapMarkerIcon.tsx
@@ -1,5 +1,5 @@
 import { twJoin } from 'tailwind-merge';
-import { MapMarker } from '../Icon/IconsSvg';
+import { MapMarkerIcon } from '../Icon/IconsSvg';
 
 interface SeznamMapMarkerIconProps {
     isActive: boolean;
@@ -7,7 +7,7 @@ interface SeznamMapMarkerIconProps {
 }
 
 export const SeznamMapMarkerIcon: FC<SeznamMapMarkerIconProps> = ({ isActive, isClickable }) => (
-    <MapMarker
+    <MapMarkerIcon
         className={twJoin(
             'w-8 transition-transform',
             isActive ? 'origin-bottom scale-125 text-orange' : 'text-greyDark',

--- a/project-base/storefront/components/Basic/SeznamMap/SeznamMapMarkerIcon.tsx
+++ b/project-base/storefront/components/Basic/SeznamMap/SeznamMapMarkerIcon.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '../Icon/Icon';
 import { twJoin } from 'tailwind-merge';
 import { MapMarker } from '../Icon/IconsSvg';
 
@@ -8,8 +7,7 @@ interface SeznamMapMarkerIconProps {
 }
 
 export const SeznamMapMarkerIcon: FC<SeznamMapMarkerIconProps> = ({ isActive, isClickable }) => (
-    <Icon
-        icon={<MapMarker />}
+    <MapMarker
         className={twJoin(
             'w-8 transition-transform',
             isActive ? 'origin-bottom scale-125 text-orange' : 'text-greyDark',

--- a/project-base/storefront/components/Basic/Tabs/Tabs.tsx
+++ b/project-base/storefront/components/Basic/Tabs/Tabs.tsx
@@ -10,7 +10,7 @@ import {
     Tabs as TabsReact,
 } from 'react-tabs';
 import { twJoin } from 'tailwind-merge';
-import { Arrow } from '../Icon/IconsSvg';
+import { ArrowIcon } from '../Icon/IconsSvg';
 
 /**
  * In background of styled tab parts we are using - react-tabs components
@@ -72,7 +72,7 @@ export const TabsContent: TabFC<TabsContentProps & Partial<PropsWithRef<TabPanel
                 onClick={mobileTab}
             >
                 {headingTextMobile}
-                <Arrow className={twJoin('w-4 rotate-0 transition', isActiveOnMobile && '-rotate-180 ')} />
+                <ArrowIcon className={twJoin('w-4 rotate-0 transition', isActiveOnMobile && '-rotate-180 ')} />
             </h3>
             <div className={twJoin('py-5 ', isActiveOnMobile ? 'block' : 'hidden lg:block')}>{children}</div>
         </TabPanel>

--- a/project-base/storefront/components/Basic/Tabs/Tabs.tsx
+++ b/project-base/storefront/components/Basic/Tabs/Tabs.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '../Icon/Icon';
 import React, { useState } from 'react';
 import {
     Tab,
@@ -73,10 +72,7 @@ export const TabsContent: TabFC<TabsContentProps & Partial<PropsWithRef<TabPanel
                 onClick={mobileTab}
             >
                 {headingTextMobile}
-                <Icon
-                    icon={<Arrow />}
-                    className={twJoin('w-4 rotate-0 transition', isActiveOnMobile && '-rotate-180 ')}
-                />
+                <Arrow className={twJoin('w-4 rotate-0 transition', isActiveOnMobile && '-rotate-180 ')} />
             </h3>
             <div className={twJoin('py-5 ', isActiveOnMobile ? 'block' : 'hidden lg:block')}>{children}</div>
         </TabPanel>

--- a/project-base/storefront/components/Blocks/Banners/BannersSlider.tsx
+++ b/project-base/storefront/components/Blocks/Banners/BannersSlider.tsx
@@ -1,4 +1,4 @@
-import { Triangle } from 'components/Basic/Icon/IconsSvg';
+import { TriangleIcon } from 'components/Basic/Icon/IconsSvg';
 import { BannersSliderItem } from 'components/Blocks/Banners/BannersSliderItem';
 import { SliderItemFragmentApi } from 'graphql/generated';
 import { useGetWindowSize } from 'hooks/ui/useGetWindowSize';
@@ -97,7 +97,7 @@ export const BannersSlider: FC<BannersSliderProps> = ({ sliderItems, dataTestId 
                         disabled={index === currentSlide % sliderItems.length}
                         key={sliderItem.uuid}
                     >
-                        <Triangle className="absolute top-1/2 left-3 hidden w-2 -translate-y-1/2 text-primary vl:group-disabled:block" />
+                        <TriangleIcon className="absolute top-1/2 left-3 hidden w-2 -translate-y-1/2 text-primary vl:group-disabled:block" />
                         <span className="hidden vl:inline-block">{sliderItem.name}</span>
                     </button>
                 ))}

--- a/project-base/storefront/components/Blocks/Banners/BannersSlider.tsx
+++ b/project-base/storefront/components/Blocks/Banners/BannersSlider.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Triangle } from 'components/Basic/Icon/IconsSvg';
 import { BannersSliderItem } from 'components/Blocks/Banners/BannersSliderItem';
 import { SliderItemFragmentApi } from 'graphql/generated';
@@ -98,10 +97,7 @@ export const BannersSlider: FC<BannersSliderProps> = ({ sliderItems, dataTestId 
                         disabled={index === currentSlide % sliderItems.length}
                         key={sliderItem.uuid}
                     >
-                        <Icon
-                            icon={<Triangle />}
-                            className="absolute top-1/2 left-3 hidden w-2 -translate-y-1/2 text-primary vl:group-disabled:block"
-                        />
+                        <Triangle className="absolute top-1/2 left-3 hidden w-2 -translate-y-1/2 text-primary vl:group-disabled:block" />
                         <span className="hidden vl:inline-block">{sliderItem.name}</span>
                     </button>
                 ))}

--- a/project-base/storefront/components/Blocks/BlogPreview/BlogPreview.tsx
+++ b/project-base/storefront/components/Blocks/BlogPreview/BlogPreview.tsx
@@ -1,6 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { BlogPreviewMain } from './BlogPreviewMain';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { ListedBlogArticleFragmentApi, useBlogArticlesQueryApi, useBlogUrlQueryApi } from 'graphql/generated';
 import { mapConnectionEdges } from 'helpers/mappers/connection';
 import useTranslation from 'next-translate/useTranslation';
@@ -41,7 +40,7 @@ export const BlogPreview: FC = () => {
                     >
                         <>
                             {t('View all')}
-                            <Icon icon={<ArrowRight />} className="relative top-0 ml-2 text-xs text-creamWhite" />
+                            <ArrowRight className="relative top-0 ml-2 text-xs text-creamWhite" />
                         </>
                     </ExtendedNextLink>
                 )}

--- a/project-base/storefront/components/Blocks/BlogPreview/BlogPreview.tsx
+++ b/project-base/storefront/components/Blocks/BlogPreview/BlogPreview.tsx
@@ -5,7 +5,7 @@ import { mapConnectionEdges } from 'helpers/mappers/connection';
 import useTranslation from 'next-translate/useTranslation';
 import { useMemo } from 'react';
 import { BlogPreviewSide } from './BlogPreviewSide';
-import { ArrowRight } from 'components/Basic/Icon/IconsSvg';
+import { ArrowRightIcon } from 'components/Basic/Icon/IconsSvg';
 
 export const BLOG_PREVIEW_VARIABLES = { first: 6, onlyHomepageArticles: true };
 const TEST_IDENTIFIER = 'blocks-blogpreview';
@@ -40,7 +40,7 @@ export const BlogPreview: FC = () => {
                     >
                         <>
                             {t('View all')}
-                            <ArrowRight className="relative top-0 ml-2 text-xs text-creamWhite" />
+                            <ArrowRightIcon className="relative top-0 ml-2 text-xs text-creamWhite" />
                         </>
                     </ExtendedNextLink>
                 )}

--- a/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpostIcon.tsx
+++ b/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpostIcon.tsx
@@ -1,8 +1,8 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { twJoin } from 'tailwind-merge';
 
 type BlogSignpostIconProps = { isActive: boolean };
 
 export const BlogSignpostIcon: FC<BlogSignpostIconProps> = ({ isActive }) => (
-    <Arrow className={twJoin('mr-1 -rotate-90 text-creamWhite', isActive ? 'text-dark' : 'text-creamWhite')} />
+    <ArrowIcon className={twJoin('mr-1 -rotate-90 text-creamWhite', isActive ? 'text-dark' : 'text-creamWhite')} />
 );

--- a/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpostIcon.tsx
+++ b/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpostIcon.tsx
@@ -1,12 +1,8 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { twJoin } from 'tailwind-merge';
 
 type BlogSignpostIconProps = { isActive: boolean };
 
 export const BlogSignpostIcon: FC<BlogSignpostIconProps> = ({ isActive }) => (
-    <Icon
-        icon={<Arrow />}
-        className={twJoin('mr-1 -rotate-90 text-creamWhite', isActive ? 'text-dark' : 'text-creamWhite')}
-    />
+    <Arrow className={twJoin('mr-1 -rotate-90 text-creamWhite', isActive ? 'text-dark' : 'text-creamWhite')} />
 );

--- a/project-base/storefront/components/Blocks/OrderAction/OrderAction.tsx
+++ b/project-base/storefront/components/Blocks/OrderAction/OrderAction.tsx
@@ -1,5 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Arrow, Spinner } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon, SpinnerIcon } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { useRouter } from 'next/router';
 import { twJoin } from 'tailwind-merge';
@@ -55,7 +55,7 @@ export const OrderAction: FC<OrderActionProps> = ({
                     className="font-bold uppercase text-dark no-underline"
                 >
                     <>
-                        <Arrow className="relative top-0 mr-1 rotate-90 text-greyLight" />
+                        <ArrowIcon className="relative top-0 mr-1 rotate-90 text-greyLight" />
                         {buttonBack}
                     </>
                 </ExtendedNextLink>
@@ -67,9 +67,9 @@ export const OrderAction: FC<OrderActionProps> = ({
                     isWithDisabledLook={hasDisabledLook}
                     onClick={onNextStepHandler}
                 >
-                    {isLoading && <Spinner className="w-5" />}
+                    {isLoading && <SpinnerIcon className="w-5" />}
                     <span>{buttonNext}</span>
-                    <Arrow className="relative top-0 ml-1 -rotate-90 text-white" />
+                    <ArrowIcon className="relative top-0 ml-1 -rotate-90 text-white" />
                 </Button>
             </div>
         </div>

--- a/project-base/storefront/components/Blocks/OrderAction/OrderAction.tsx
+++ b/project-base/storefront/components/Blocks/OrderAction/OrderAction.tsx
@@ -1,7 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Icon } from 'components/Basic/Icon/Icon';
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
-import { Loader } from 'components/Basic/Loader/Loader';
+import { Arrow, Spinner } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { useRouter } from 'next/router';
 import { twJoin } from 'tailwind-merge';
@@ -57,7 +55,7 @@ export const OrderAction: FC<OrderActionProps> = ({
                     className="font-bold uppercase text-dark no-underline"
                 >
                     <>
-                        <Icon icon={<Arrow />} className="relative top-0 mr-1 rotate-90 text-greyLight" />
+                        <Arrow className="relative top-0 mr-1 rotate-90 text-greyLight" />
                         {buttonBack}
                     </>
                 </ExtendedNextLink>
@@ -69,9 +67,9 @@ export const OrderAction: FC<OrderActionProps> = ({
                     isWithDisabledLook={hasDisabledLook}
                     onClick={onNextStepHandler}
                 >
-                    {isLoading && <Loader className="w-5" />}
+                    {isLoading && <Spinner className="w-5" />}
                     <span>{buttonNext}</span>
-                    <Icon icon={<Arrow />} className="relative top-0 ml-1 -rotate-90 text-white" />
+                    <Arrow className="relative top-0 ml-1 -rotate-90 text-white" />
                 </Button>
             </div>
         </div>

--- a/project-base/storefront/components/Blocks/Popup/Login/Login.tsx
+++ b/project-base/storefront/components/Blocks/Popup/Login/Login.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Warning } from 'components/Basic/Icon/IconsSvg';
+import { WarningIcon } from 'components/Basic/Icon/IconsSvg';
 import { Link } from 'components/Basic/Link/Link';
 import { Button } from 'components/Forms/Button/Button';
 import { Form } from 'components/Forms/Form/Form';
@@ -95,7 +95,7 @@ export const Login: FC<LoginProps> = ({ defaultEmail }) => {
                                 </Button>
                             </div>
                             <div className="flex items-center gap-1 whitespace-nowrap rounded border-primary py-2 px-2 text-sm text-primary lg:mt-5 lg:border-2 lg:px-3 lg:py-3">
-                                <Warning className=" h-5 w-9 text-red" />
+                                <WarningIcon className=" h-5 w-9 text-red" />
                                 <ExtendedNextLink href={resetPasswordUrl} type="static">
                                     <div className="block text-sm text-primary underline hover:no-underline">
                                         {t('Lost your password?')}

--- a/project-base/storefront/components/Blocks/Popup/Login/Login.tsx
+++ b/project-base/storefront/components/Blocks/Popup/Login/Login.tsx
@@ -1,6 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Warning } from 'components/Basic/Icon/IconsSvg';
 import { Link } from 'components/Basic/Link/Link';
 import { Button } from 'components/Forms/Button/Button';
@@ -96,7 +95,7 @@ export const Login: FC<LoginProps> = ({ defaultEmail }) => {
                                 </Button>
                             </div>
                             <div className="flex items-center gap-1 whitespace-nowrap rounded border-primary py-2 px-2 text-sm text-primary lg:mt-5 lg:border-2 lg:px-3 lg:py-3">
-                                <Icon icon={<Warning />} className=" h-5 w-9 text-red" />
+                                <Warning className=" h-5 w-9 text-red" />
                                 <ExtendedNextLink href={resetPasswordUrl} type="static">
                                     <div className="block text-sm text-primary underline hover:no-underline">
                                         {t('Lost your password?')}

--- a/project-base/storefront/components/Blocks/Product/AddToCart.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCart.tsx
@@ -1,4 +1,4 @@
-import { Cart } from 'components/Basic/Icon/IconsSvg';
+import { CartIcon } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { Button } from 'components/Forms/Button/Button';
 import { Spinbox } from 'components/Forms/Spinbox/Spinbox';
@@ -68,7 +68,7 @@ export const AddToCart: FC<AddToCartProps> = ({
                 onClick={onAddToCartHandler}
                 dataTestId={TEST_IDENTIFIER}
             >
-                {fetching ? <Loader className="w-4 text-white" /> : <Cart className="text-white" />}
+                {fetching ? <Loader className="w-4 text-white" /> : <CartIcon className="text-white" />}
                 <span>{t('Add to cart')}</span>
             </Button>
 

--- a/project-base/storefront/components/Blocks/Product/AddToCart.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCart.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Cart } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { Button } from 'components/Forms/Button/Button';
@@ -69,7 +68,7 @@ export const AddToCart: FC<AddToCartProps> = ({
                 onClick={onAddToCartHandler}
                 dataTestId={TEST_IDENTIFIER}
             >
-                {fetching ? <Loader className="w-4 text-white" /> : <Icon icon={<Cart />} className="text-white" />}
+                {fetching ? <Loader className="w-4 text-white" /> : <Cart className="text-white" />}
                 <span>{t('Add to cart')}</span>
             </Button>
 

--- a/project-base/storefront/components/Blocks/Product/AddToCartPopup.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCartPopup.tsx
@@ -1,6 +1,6 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Checkmark } from 'components/Basic/Icon/IconsSvg';
+import { CheckmarkIcon } from 'components/Basic/Icon/IconsSvg';
 import { Image } from 'components/Basic/Image/Image';
 import { Link } from 'components/Basic/Link/Link';
 import { Button } from 'components/Forms/Button/Button';
@@ -30,7 +30,7 @@ export const AddToCartPopup: FC<AddToCartPopupProps> = ({ onCloseCallback, added
     return (
         <Popup onCloseCallback={onCloseCallback} className="w-11/12 max-w-2xl" hideCloseButton>
             <div className="mb-4 flex w-full items-center md:mb-6">
-                <Checkmark className="mr-4 w-7" />
+                <CheckmarkIcon className="mr-4 w-7" />
                 <Heading type="h2" className="mb-0 text-xl normal-case text-primary">
                     {t('Great choice! We have added your item to the cart')}
                 </Heading>

--- a/project-base/storefront/components/Blocks/Product/AddToCartPopup.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCartPopup.tsx
@@ -1,6 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Checkmark } from 'components/Basic/Icon/IconsSvg';
 import { Image } from 'components/Basic/Image/Image';
 import { Link } from 'components/Basic/Link/Link';
@@ -31,7 +30,7 @@ export const AddToCartPopup: FC<AddToCartPopupProps> = ({ onCloseCallback, added
     return (
         <Popup onCloseCallback={onCloseCallback} className="w-11/12 max-w-2xl" hideCloseButton>
             <div className="mb-4 flex w-full items-center md:mb-6">
-                <Icon icon={<Checkmark />} className="mr-4 w-7" />
+                <Checkmark className="mr-4 w-7" />
                 <Heading type="h2" className="mb-0 text-xl normal-case text-primary">
                     {t('Great choice! We have added your item to the cart')}
                 </Heading>

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductCompareButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductCompareButton.tsx
@@ -1,4 +1,4 @@
-import { Compare } from 'components/Basic/Icon/IconsSvg';
+import { CompareIcon } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { twMergeCustom } from 'helpers/twMerge';
 
@@ -26,7 +26,7 @@ export const ProductCompareButton: FC<ProductCompareButtonProps> = ({
                 title={isProductInComparison ? t('Remove product from comparison') : t('Add product to comparison')}
                 onClick={toggleProductInComparison}
             >
-                <Compare className={twMergeCustom('m-2 text-grey', isProductInComparison && 'text-green')} />
+                <CompareIcon className={twMergeCustom('m-2 text-grey', isProductInComparison && 'text-green')} />
                 {isWithText && (
                     <span className="ml-1">{isProductInComparison ? t('Remove from comparison') : t('Compare')}</span>
                 )}

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductCompareButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductCompareButton.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Compare } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { twMergeCustom } from 'helpers/twMerge';
@@ -27,10 +26,7 @@ export const ProductCompareButton: FC<ProductCompareButtonProps> = ({
                 title={isProductInComparison ? t('Remove product from comparison') : t('Add product to comparison')}
                 onClick={toggleProductInComparison}
             >
-                <Icon
-                    className={twMergeCustom('m-2 text-grey', isProductInComparison && 'text-green')}
-                    icon={<Compare />}
-                />
+                <Compare className={twMergeCustom('m-2 text-grey', isProductInComparison && 'text-green')} />
                 {isWithText && (
                     <span className="ml-1">{isProductInComparison ? t('Remove from comparison') : t('Compare')}</span>
                 )}

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductComparePopup.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductComparePopup.tsx
@@ -1,5 +1,4 @@
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { ArrowSecondary } from 'components/Basic/Icon/IconsSvg';
 import { Link } from 'components/Basic/Link/Link';
 import { Popup } from 'components/Layout/Popup/Popup';
@@ -25,7 +24,7 @@ export const ProductComparePopup: FC<ProductComparePopupProps> = ({ onCloseCallb
                 <Link isButton href={productComparisonUrl}>
                     <>
                         <span>{t('Show products comparison')}</span>
-                        <Icon className="rotate-90" icon={<ArrowSecondary />} />
+                        <ArrowSecondary className="rotate-90" />
                     </>
                 </Link>
             </div>

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductComparePopup.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductComparePopup.tsx
@@ -1,5 +1,5 @@
 import { Heading } from 'components/Basic/Heading/Heading';
-import { ArrowSecondary } from 'components/Basic/Icon/IconsSvg';
+import { ArrowSecondaryIcon } from 'components/Basic/Icon/IconsSvg';
 import { Link } from 'components/Basic/Link/Link';
 import { Popup } from 'components/Layout/Popup/Popup';
 import { getInternationalizedStaticUrls } from 'helpers/getInternationalizedStaticUrls';
@@ -24,7 +24,7 @@ export const ProductComparePopup: FC<ProductComparePopupProps> = ({ onCloseCallb
                 <Link isButton href={productComparisonUrl}>
                     <>
                         <span>{t('Show products comparison')}</span>
-                        <ArrowSecondary className="rotate-90" />
+                        <ArrowSecondaryIcon className="rotate-90" />
                     </>
                 </Link>
             </div>

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductWishlistButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductWishlistButton.tsx
@@ -1,4 +1,4 @@
-import { Heart } from 'components/Basic/Icon/IconsSvg';
+import { HeartIcon } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { HTMLAttributes } from 'react';
 import { ExtractNativePropsFromDefault } from 'typeHelpers/ExtractNativePropsFromDefault';
@@ -30,7 +30,7 @@ export const ProductWishlistButton: FC<ProductCompareButtonProps & NativeProps> 
                 title={isProductInWishlist ? t('Remove product from wishlist') : t('Add product to wishlist')}
                 onClick={toggleProductInWishlist}
             >
-                <Heart
+                <HeartIcon
                     isFull={isProductInWishlist}
                     className={twMergeCustom('m-2', 'text-grey', isProductInWishlist && 'text-green')}
                 />

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductWishlistButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductWishlistButton.tsx
@@ -1,5 +1,4 @@
-import { Icon } from 'components/Basic/Icon/Icon';
-import { HeartFull, Heart } from 'components/Basic/Icon/IconsSvg';
+import { Heart } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { HTMLAttributes } from 'react';
 import { ExtractNativePropsFromDefault } from 'typeHelpers/ExtractNativePropsFromDefault';
@@ -31,9 +30,9 @@ export const ProductWishlistButton: FC<ProductCompareButtonProps & NativeProps> 
                 title={isProductInWishlist ? t('Remove product from wishlist') : t('Add product to wishlist')}
                 onClick={toggleProductInWishlist}
             >
-                <Icon
+                <Heart
+                    isFull={isProductInWishlist}
                     className={twMergeCustom('m-2', 'text-grey', isProductInWishlist && 'text-green')}
-                    icon={isProductInWishlist ? <HeartFull /> : <Heart />}
                 />
                 {isWithText && (
                     <span className="ml-1">

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupIcon.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupIcon.tsx
@@ -1,10 +1,8 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { twJoin } from 'tailwind-merge';
 
 export const FilterGroupIcon: FC<{ isOpen: boolean }> = ({ isOpen }) => (
-    <Icon
-        icon={<Arrow />}
+    <Arrow
         className={twJoin(
             'absolute right-0 top-1/2 -translate-y-1/2 rotate-0 select-none text-xs transition',
             isOpen && 'rotate-180',

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterGroupIcon.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterGroupIcon.tsx
@@ -1,8 +1,8 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { twJoin } from 'tailwind-merge';
 
 export const FilterGroupIcon: FC<{ isOpen: boolean }> = ({ isOpen }) => (
-    <Arrow
+    <ArrowIcon
         className={twJoin(
             'absolute right-0 top-1/2 -translate-y-1/2 rotate-0 select-none text-xs transition',
             isOpen && 'rotate-180',

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterPanel.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterPanel.tsx
@@ -3,7 +3,6 @@ import { FilterGroupInStock } from './FilterGroupInStock';
 import { FilterGroupParameters } from './FilterGroupParameters';
 import { FilterGroupPrice } from './FilterGroupPrice';
 import { SelectedParameters } from './SelectedParameters';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Remove } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { ProductFilterOptionsFragmentApi, ProductOrderingModeEnumApi } from 'graphql/generated';
@@ -42,7 +41,7 @@ export const FilterPanel = memo<FilterPanelProps>(
                             className="relative inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-full text-primary"
                             onClick={panelCloseHandler}
                         >
-                            <Icon icon={<Remove />} className="w-6 text-primary" />
+                            <Remove className="w-6 text-primary" />
                         </span>
                     </div>
 

--- a/project-base/storefront/components/Blocks/Product/Filter/FilterPanel.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterPanel.tsx
@@ -3,7 +3,7 @@ import { FilterGroupInStock } from './FilterGroupInStock';
 import { FilterGroupParameters } from './FilterGroupParameters';
 import { FilterGroupPrice } from './FilterGroupPrice';
 import { SelectedParameters } from './SelectedParameters';
-import { Remove } from 'components/Basic/Icon/IconsSvg';
+import { RemoveIcon } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { ProductFilterOptionsFragmentApi, ProductOrderingModeEnumApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -41,7 +41,7 @@ export const FilterPanel = memo<FilterPanelProps>(
                             className="relative inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-full text-primary"
                             onClick={panelCloseHandler}
                         >
-                            <Remove className="w-6 text-primary" />
+                            <RemoveIcon className="w-6 text-primary" />
                         </span>
                     </div>
 

--- a/project-base/storefront/components/Blocks/Product/Filter/SelectedParameters.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/SelectedParameters.tsx
@@ -1,6 +1,5 @@
 import { SelectedParametersList, SelectedParametersListItem, SelectedParametersName } from './FilterElements';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { ProductFilterOptionsFragmentApi } from 'graphql/generated';
 import { useFormatPrice } from 'hooks/formatting/useFormatPrice';
 import useTranslation from 'next-translate/useTranslation';
@@ -191,14 +190,14 @@ export const SelectedParameters: FC<SelectedParametersProps> = ({ filterOptions 
             </div>
             <div className="flex cursor-pointer items-center text-sm text-greyLight" onClick={resetAllFilters}>
                 <div className="font-bold uppercase">{t('Clear all')}</div>
-                <Icon icon={<Remove />} className="ml-2 cursor-pointer text-greenLight" />
+                <Remove className="ml-2 cursor-pointer text-greenLight" />
             </div>
         </div>
     );
 };
 
 const SelectedParametersIcon: FC<{ onClick: () => void }> = ({ onClick, dataTestId }) => (
-    <Icon icon={<RemoveThin />} onClick={onClick} className="ml-3 w-3 cursor-pointer" data-testid={dataTestId} />
+    <RemoveThin onClick={onClick} className="ml-3 w-3 cursor-pointer" data-testid={dataTestId} />
 );
 
 const getCheckedFlags = (

--- a/project-base/storefront/components/Blocks/Product/Filter/SelectedParameters.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/SelectedParameters.tsx
@@ -8,7 +8,7 @@ import { useSessionStore } from 'store/useSessionStore';
 import { getHasDefaultFilters } from 'helpers/filterOptions/seoCategories';
 import { DefaultProductFiltersMapType } from 'store/slices/createSeoCategorySlice';
 import { FilterOptionsParameterUrlQueryType } from 'types/productFilter';
-import { Remove, RemoveThin } from 'components/Basic/Icon/IconsSvg';
+import { RemoveIcon, RemoveThinIcon } from 'components/Basic/Icon/IconsSvg';
 
 const TEST_IDENTIFIER = 'blocks-product-filter-selectedparameters';
 
@@ -190,14 +190,14 @@ export const SelectedParameters: FC<SelectedParametersProps> = ({ filterOptions 
             </div>
             <div className="flex cursor-pointer items-center text-sm text-greyLight" onClick={resetAllFilters}>
                 <div className="font-bold uppercase">{t('Clear all')}</div>
-                <Remove className="ml-2 cursor-pointer text-greenLight" />
+                <RemoveIcon className="ml-2 cursor-pointer text-greenLight" />
             </div>
         </div>
     );
 };
 
 const SelectedParametersIcon: FC<{ onClick: () => void }> = ({ onClick, dataTestId }) => (
-    <RemoveThin onClick={onClick} className="ml-3 w-3 cursor-pointer" data-testid={dataTestId} />
+    <RemoveThinIcon onClick={onClick} className="ml-3 w-3 cursor-pointer" data-testid={dataTestId} />
 );
 
 const getCheckedFlags = (

--- a/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
@@ -11,7 +11,6 @@ import { onGtmProductClickEventHandler } from 'gtm/helpers/eventHandlers';
 import { useDomainConfig } from 'hooks/useDomainConfig';
 import { GtmMessageOriginType, GtmProductListNameType } from 'gtm/types/enums';
 import { ProductWishlistButton } from 'components/Blocks/Product/ButtonsAction/ProductWishlistButton';
-import { Icon } from 'components/Basic/Icon/Icon';
 import useTranslation from 'next-translate/useTranslation';
 import { twMergeCustom } from 'helpers/twMerge';
 import { forwardRef } from 'react';
@@ -66,7 +65,7 @@ export const ProductListItem = forwardRef<HTMLDivElement, ProductItemProps>(
                         data-testid={getDataTestId(product.catalogNumber) + '-wishlist-remove'}
                         title={t('Remove from wishlist')}
                     >
-                        <Icon icon={<RemoveBold />} className="mx-auto w-2 basis-2" />
+                        <RemoveBold className="mx-auto w-2 basis-2" />
                     </button>
                 )}
 

--- a/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
@@ -16,7 +16,7 @@ import { twMergeCustom } from 'helpers/twMerge';
 import { forwardRef } from 'react';
 import { FunctionComponentProps } from 'types/globals';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { RemoveBold } from 'components/Basic/Icon/IconsSvg';
+import { RemoveBoldIcon } from 'components/Basic/Icon/IconsSvg';
 
 type ProductItemProps = {
     product: ListedProductFragmentApi;
@@ -65,7 +65,7 @@ export const ProductListItem = forwardRef<HTMLDivElement, ProductItemProps>(
                         data-testid={getDataTestId(product.catalogNumber) + '-wishlist-remove'}
                         title={t('Remove from wishlist')}
                     >
-                        <RemoveBold className="mx-auto w-2 basis-2" />
+                        <RemoveBoldIcon className="mx-auto w-2 basis-2" />
                     </button>
                 )}
 

--- a/project-base/storefront/components/Blocks/Product/ProductsSlider.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsSlider.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { ListedProductFragmentApi } from 'graphql/generated';
 import { RefObject, createRef, useEffect, useRef, useState } from 'react';
 import { GtmMessageOriginType, GtmProductListNameType } from 'gtm/types/enums';
@@ -94,6 +93,6 @@ const SliderButton: FC<SliderButtonProps> = ({ type, isDisabled, onClick, title 
         onClick={onClick}
         disabled={isDisabled}
     >
-        <Icon className={twMergeCustom('rotate-90', type === 'next' && '-rotate-90')} icon={<Arrow />} />
+        <Arrow className={twMergeCustom('rotate-90', type === 'next' && '-rotate-90')} />
     </button>
 );

--- a/project-base/storefront/components/Blocks/Product/ProductsSlider.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsSlider.tsx
@@ -4,7 +4,7 @@ import { GtmMessageOriginType, GtmProductListNameType } from 'gtm/types/enums';
 import { twMergeCustom } from 'helpers/twMerge';
 import useTranslation from 'next-translate/useTranslation';
 import { ProductsListContent } from './ProductsList/ProductsListContent';
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 
 type ProductsSliderProps = {
     products: ListedProductFragmentApi[];
@@ -93,6 +93,6 @@ const SliderButton: FC<SliderButtonProps> = ({ type, isDisabled, onClick, title 
         onClick={onClick}
         disabled={isDisabled}
     >
-        <Arrow className={twMergeCustom('rotate-90', type === 'next' && '-rotate-90')} />
+        <ArrowIcon className={twMergeCustom('-translate-y-[2px] rotate-90', type === 'next' && '-rotate-90')} />
     </button>
 );

--- a/project-base/storefront/components/Blocks/PromoCode/PromoCode.tsx
+++ b/project-base/storefront/components/Blocks/PromoCode/PromoCode.tsx
@@ -1,5 +1,5 @@
 import { PromoCodeInfo } from './PromoCodeInfo';
-import { Plus } from 'components/Basic/Icon/IconsSvg';
+import { PlusIcon } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
 import { Button } from 'components/Forms/Button/Button';
@@ -106,7 +106,7 @@ export const PromoCode: FC = () => {
                             onClick={() => setIsContentVisible(!isContentVisible)}
                             data-testid={TEST_IDENTIFIER + '-add-button'}
                         >
-                            <Plus className="mr-3 w-3" />
+                            <PlusIcon className="mr-3 w-3" />
                             {t('I have a discount coupon')}
                         </div>
                         <Transition

--- a/project-base/storefront/components/Blocks/PromoCode/PromoCode.tsx
+++ b/project-base/storefront/components/Blocks/PromoCode/PromoCode.tsx
@@ -1,5 +1,4 @@
 import { PromoCodeInfo } from './PromoCodeInfo';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Plus } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
@@ -107,7 +106,7 @@ export const PromoCode: FC = () => {
                             onClick={() => setIsContentVisible(!isContentVisible)}
                             data-testid={TEST_IDENTIFIER + '-add-button'}
                         >
-                            <Icon icon={<Plus />} className="mr-3 w-3" />
+                            <Plus className="mr-3 w-3" />
                             {t('I have a discount coupon')}
                         </div>
                         <Transition

--- a/project-base/storefront/components/Blocks/PromoCode/PromoCodeInfo.tsx
+++ b/project-base/storefront/components/Blocks/PromoCode/PromoCodeInfo.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Cross } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 
@@ -23,8 +22,7 @@ export const PromoCodeInfo: FC<PromoCodeInfoProps> = ({ onRemovePromoCodeCallbac
             </div>
             <div className="flex items-center font-bold" data-testid={TEST_IDENTIFIER + '-code'}>
                 {promoCode}
-                <Icon
-                    icon={<Cross />}
+                <Cross
                     onClick={onRemovePromoCodeHandler}
                     className="mr-1 w-4 cursor-pointer text-greyDark hover:text-primary"
                 />

--- a/project-base/storefront/components/Blocks/PromoCode/PromoCodeInfo.tsx
+++ b/project-base/storefront/components/Blocks/PromoCode/PromoCodeInfo.tsx
@@ -1,4 +1,4 @@
-import { Cross } from 'components/Basic/Icon/IconsSvg';
+import { CrossIcon } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 
 type PromoCodeInfoProps = {
@@ -22,7 +22,7 @@ export const PromoCodeInfo: FC<PromoCodeInfoProps> = ({ onRemovePromoCodeCallbac
             </div>
             <div className="flex items-center font-bold" data-testid={TEST_IDENTIFIER + '-code'}>
                 {promoCode}
-                <Cross
+                <CrossIcon
                     onClick={onRemovePromoCodeHandler}
                     className="mr-1 w-4 cursor-pointer text-greyDark hover:text-primary"
                 />

--- a/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
+++ b/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { isElementVisible } from 'helpers/isElementVisible';
 import { Sort } from 'components/Basic/Icon/IconsSvg';
 import { mobileFirstSizes } from 'components/Theme/mediaQueries';
@@ -75,7 +74,7 @@ export const SortingBar: FC<SortingBarProps> = ({ sorting, totalCount, customSor
                             onClick={() => setToggleSortMenu((prev) => !prev)}
                             data-testid={TEST_IDENTIFIER + '-selected'}
                         >
-                            <Icon icon={<Sort />} className="w-5 align-middle" />
+                            <Sort className="w-5 align-middle" />
                             <div className="pl-2 text-justify font-bold text-dark">
                                 <div className="uppercase leading-5">{t('Sort')}</div>
                                 <div

--- a/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
+++ b/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
@@ -1,5 +1,5 @@
 import { isElementVisible } from 'helpers/isElementVisible';
-import { Sort } from 'components/Basic/Icon/IconsSvg';
+import { SortIcon } from 'components/Basic/Icon/IconsSvg';
 import { mobileFirstSizes } from 'components/Theme/mediaQueries';
 import { ProductOrderingModeEnumApi } from 'graphql/generated';
 import { DEFAULT_SORT } from 'helpers/filterOptions/seoCategories';
@@ -74,7 +74,7 @@ export const SortingBar: FC<SortingBarProps> = ({ sorting, totalCount, customSor
                             onClick={() => setToggleSortMenu((prev) => !prev)}
                             data-testid={TEST_IDENTIFIER + '-selected'}
                         >
-                            <Sort className="w-5 align-middle" />
+                            <SortIcon className="w-5 align-middle" />
                             <div className="pl-2 text-justify font-bold text-dark">
                                 <div className="uppercase leading-5">{t('Sort')}</div>
                                 <div

--- a/project-base/storefront/components/Forms/Lib/FormLineError.tsx
+++ b/project-base/storefront/components/Forms/Lib/FormLineError.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Cross } from 'components/Basic/Icon/IconsSvg';
 import { FieldError } from 'react-hook-form';
 import { twJoin } from 'tailwind-merge';
@@ -26,8 +25,7 @@ export const FormLineError: FC<FormLineErrorProps> = ({ inputType, error, dataTe
 
     return (
         <div className="relative mt-2" data-testid={getDataTestId(dataTestId)}>
-            <Icon
-                icon={<Cross />}
+            <Cross
                 className={twJoin(
                     'absolute flex w-4 text-red',
                     isInputOrTextArea && `right-5 -translate-y-1/2 ${isTextInputSmall ? '-top-8' : '-top-9'}`,

--- a/project-base/storefront/components/Forms/Lib/FormLineError.tsx
+++ b/project-base/storefront/components/Forms/Lib/FormLineError.tsx
@@ -1,4 +1,4 @@
-import { Cross } from 'components/Basic/Icon/IconsSvg';
+import { CrossIcon } from 'components/Basic/Icon/IconsSvg';
 import { FieldError } from 'react-hook-form';
 import { twJoin } from 'tailwind-merge';
 
@@ -25,7 +25,7 @@ export const FormLineError: FC<FormLineErrorProps> = ({ inputType, error, dataTe
 
     return (
         <div className="relative mt-2" data-testid={getDataTestId(dataTestId)}>
-            <Cross
+            <CrossIcon
                 className={twJoin(
                     'absolute flex w-4 text-red',
                     isInputOrTextArea && `right-5 -translate-y-1/2 ${isTextInputSmall ? '-top-8' : '-top-9'}`,

--- a/project-base/storefront/components/Forms/Select/Select.tsx
+++ b/project-base/storefront/components/Forms/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { LabelWrapper } from 'components/Forms/Lib/LabelWrapper';
 import { ReactNode } from 'react';
 import SelectReact from 'react-select';
@@ -19,7 +19,7 @@ type SelectProps = NativeProps & {
 const DropdownIndicator = (props: any) => {
     return (
         <components.DropdownIndicator {...props}>
-            <Arrow className="text-greyDark" />
+            <ArrowIcon className="text-greyDark" />
         </components.DropdownIndicator>
     );
 };

--- a/project-base/storefront/components/Forms/Select/Select.tsx
+++ b/project-base/storefront/components/Forms/Select/Select.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { LabelWrapper } from 'components/Forms/Lib/LabelWrapper';
 import { ReactNode } from 'react';
@@ -20,7 +19,7 @@ type SelectProps = NativeProps & {
 const DropdownIndicator = (props: any) => {
     return (
         <components.DropdownIndicator {...props}>
-            <Icon icon={<Arrow />} />
+            <Arrow className="text-greyDark" />
         </components.DropdownIndicator>
     );
 };

--- a/project-base/storefront/components/Forms/TextInput/SearchInput.tsx
+++ b/project-base/storefront/components/Forms/TextInput/SearchInput.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Search } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { LabelWrapper } from 'components/Forms/Lib/LabelWrapper';
@@ -56,7 +55,7 @@ export const SearchInput: FC<SearchInputProps> = ({
                 disabled={isSearchButtonDisabled}
                 title={t('Search')}
             >
-                <Icon icon={<Search />} className="w-5" />
+                <Search className="w-5" />
             </button>
             {isLoading && (
                 <div className="absolute top-[calc(50%-16px)] right-4 flex h-8 w-8 items-center justify-center">

--- a/project-base/storefront/components/Forms/TextInput/SearchInput.tsx
+++ b/project-base/storefront/components/Forms/TextInput/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { Search } from 'components/Basic/Icon/IconsSvg';
+import { SearchIcon } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { LabelWrapper } from 'components/Forms/Lib/LabelWrapper';
 import useTranslation from 'next-translate/useTranslation';
@@ -55,7 +55,7 @@ export const SearchInput: FC<SearchInputProps> = ({
                 disabled={isSearchButtonDisabled}
                 title={t('Search')}
             >
-                <Search className="w-5" />
+                <SearchIcon className="w-5" />
             </button>
             {isLoading && (
                 <div className="absolute top-[calc(50%-16px)] right-4 flex h-8 w-8 items-center justify-center">

--- a/project-base/storefront/components/Layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/project-base/storefront/components/Layout/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { BreadcrumbsMetadata } from 'components/Basic/Head/BreadcrumbsMetadata';
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { Webline } from 'components/Layout/Webline/Webline';
 import { BreadcrumbFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -28,7 +28,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ breadcrumb, type }) => {
                 className="-mx-5 mb-9 flex items-center border-b-2 border-greyLighter py-3 px-5 lg:mx-0 lg:border-none lg:p-0"
                 data-testid={TEST_IDENTIFIER}
             >
-                <Arrow className="mr-3 w-3 rotate-90 text-greyLight lg:hidden" />
+                <ArrowIcon className="mr-3 w-3 rotate-90 text-greyLight lg:hidden" />
                 <BreadcrumbsLink href="/" dataTestId={TEST_IDENTIFIER + '-item-root'}>
                     {t('Home page')}
                 </BreadcrumbsLink>

--- a/project-base/storefront/components/Layout/Breadcrumbs/Breadcrumbs.tsx
+++ b/project-base/storefront/components/Layout/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { BreadcrumbsMetadata } from 'components/Basic/Head/BreadcrumbsMetadata';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { Webline } from 'components/Layout/Webline/Webline';
 import { BreadcrumbFragmentApi } from 'graphql/generated';
@@ -29,7 +28,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({ breadcrumb, type }) => {
                 className="-mx-5 mb-9 flex items-center border-b-2 border-greyLighter py-3 px-5 lg:mx-0 lg:border-none lg:p-0"
                 data-testid={TEST_IDENTIFIER}
             >
-                <Icon icon={<Arrow />} className="mr-3 w-3 rotate-90 text-greyLight lg:hidden" />
+                <Arrow className="mr-3 w-3 rotate-90 text-greyLight lg:hidden" />
                 <BreadcrumbsLink href="/" dataTestId={TEST_IDENTIFIER + '-item-root'}>
                     {t('Home page')}
                 </BreadcrumbsLink>

--- a/project-base/storefront/components/Layout/Footer/FooterBoxInfo.tsx
+++ b/project-base/storefront/components/Layout/Footer/FooterBoxInfo.tsx
@@ -1,5 +1,4 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Phone } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { getInternationalizedStaticUrls } from 'helpers/getInternationalizedStaticUrls';
@@ -34,7 +33,7 @@ export const FooterBoxInfo: FC = () => {
                     {t('Need advice?')}
                 </div>
                 <div className="mb-6 flex flex-wrap items-center lg:mb-0 lg:mr-2 lg:flex-1 vl:justify-center">
-                    <Icon icon={<Phone />} className="mr-3 w-5 text-orange" />
+                    <Phone className="mr-3 w-5 text-orange" />
                     <a
                         className="mr-4 font-bold text-white no-underline hover:text-white lg:text-lg"
                         href={'tel:' + dummyData.phone}

--- a/project-base/storefront/components/Layout/Footer/FooterBoxInfo.tsx
+++ b/project-base/storefront/components/Layout/Footer/FooterBoxInfo.tsx
@@ -1,5 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Phone } from 'components/Basic/Icon/IconsSvg';
+import { PhoneIcon } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { getInternationalizedStaticUrls } from 'helpers/getInternationalizedStaticUrls';
 import useTranslation from 'next-translate/useTranslation';
@@ -33,7 +33,7 @@ export const FooterBoxInfo: FC = () => {
                     {t('Need advice?')}
                 </div>
                 <div className="mb-6 flex flex-wrap items-center lg:mb-0 lg:mr-2 lg:flex-1 vl:justify-center">
-                    <Phone className="mr-3 w-5 text-orange" />
+                    <PhoneIcon className="mr-3 w-5 text-orange" />
                     <a
                         className="mr-4 font-bold text-white no-underline hover:text-white lg:text-lg"
                         href={'tel:' + dummyData.phone}

--- a/project-base/storefront/components/Layout/Footer/FooterContact.tsx
+++ b/project-base/storefront/components/Layout/Footer/FooterContact.tsx
@@ -1,6 +1,6 @@
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Instagram, Youtube } from 'components/Basic/Icon/IconsSvg';
 import { IconImage } from 'components/Basic/Icon/IconImage';
+import { InstagramIcon, YoutubeIcon } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 
 export const FooterContact: FC = () => {
@@ -14,13 +14,13 @@ export const FooterContact: FC = () => {
 
             <div className="flex h-24 w-full max-w-xs overflow-hidden rounded border-2 border-greyLight">
                 <FooterContactSocialsItem href="#" title="Instagram">
-                    <Instagram className="w-8 text-white" />
+                    <InstagramIcon className="w-8 text-white" />
                 </FooterContactSocialsItem>
                 <FooterContactSocialsItem href="#" title="Facebook">
                     <IconImage icon="facebook" className="w-8" alt={t('Facebook')} />
                 </FooterContactSocialsItem>
                 <FooterContactSocialsItem href="#" title="Youtube">
-                    <Youtube className="w-11 text-[#d93738]" />
+                    <YoutubeIcon className="w-11 text-[#d93738]" />
                 </FooterContactSocialsItem>
             </div>
 

--- a/project-base/storefront/components/Layout/Footer/FooterContact.tsx
+++ b/project-base/storefront/components/Layout/Footer/FooterContact.tsx
@@ -14,13 +14,13 @@ export const FooterContact: FC = () => {
 
             <div className="flex h-24 w-full max-w-xs overflow-hidden rounded border-2 border-greyLight">
                 <FooterContactSocialsItem href="#" title="Instagram">
-                    <Icon icon={<Instagram />} className="w-8 text-white" />
+                    <Instagram className="w-8 text-white" />
                 </FooterContactSocialsItem>
                 <FooterContactSocialsItem href="#" title="Facebook">
                     <Icon icon="facebook" className="w-8" alt={t('Facebook')} />
                 </FooterContactSocialsItem>
                 <FooterContactSocialsItem href="#" title="Youtube">
-                    <Icon icon={<Youtube />} className="w-11 text-[#d93738]" />
+                    <Youtube className="w-11 text-[#d93738]" />
                 </FooterContactSocialsItem>
             </div>
 

--- a/project-base/storefront/components/Layout/Footer/FooterContact.tsx
+++ b/project-base/storefront/components/Layout/Footer/FooterContact.tsx
@@ -1,6 +1,6 @@
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Instagram, Youtube } from 'components/Basic/Icon/IconsSvg';
+import { IconImage } from 'components/Basic/Icon/IconImage';
 import useTranslation from 'next-translate/useTranslation';
 
 export const FooterContact: FC = () => {
@@ -17,7 +17,7 @@ export const FooterContact: FC = () => {
                     <Instagram className="w-8 text-white" />
                 </FooterContactSocialsItem>
                 <FooterContactSocialsItem href="#" title="Facebook">
-                    <Icon icon="facebook" className="w-8" alt={t('Facebook')} />
+                    <IconImage icon="facebook" className="w-8" alt={t('Facebook')} />
                 </FooterContactSocialsItem>
                 <FooterContactSocialsItem href="#" title="Youtube">
                     <Youtube className="w-11 text-[#d93738]" />
@@ -26,10 +26,10 @@ export const FooterContact: FC = () => {
 
             <div className="mt-4 flex flex-wrap justify-center gap-5">
                 <FooterContactLangsItem href="#" text={t('Czechia')}>
-                    <Icon icon="cz" width={24} height={16} alt={t('Czechia')} />
+                    <IconImage icon="cz" width={24} height={16} alt={t('Czechia')} />
                 </FooterContactLangsItem>
                 <FooterContactLangsItem href="#" text={t('Slovakia')}>
-                    <Icon icon="sk" width={24} height={16} alt={t('Slovakia')} />
+                    <IconImage icon="sk" width={24} height={16} alt={t('Slovakia')} />
                 </FooterContactLangsItem>
             </div>
         </>

--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/Autocomplete.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/Autocomplete.tsx
@@ -18,7 +18,7 @@ import { forwardRef, useCallback, useMemo } from 'react';
 import { twJoin } from 'tailwind-merge';
 import { FriendlyPagesTypesKeys } from 'types/friendlyUrl';
 import { GtmProductListNameType, GtmSectionType } from 'gtm/types/enums';
-import { Icon } from 'components/Basic/Icon/Icon';
+import { IconImage } from 'components/Basic/Icon/IconImage';
 
 export const AUTOCOMPLETE_PRODUCT_LIMIT = 5 as const;
 export const AUTOCOMPLETE_BRAND_LIMIT = 3 as const;
@@ -87,7 +87,7 @@ export const Autocomplete: FC<AutocompleteProps> = ({
                 if (areAllResultsEmpty(autocompleteSearchResults)) {
                     return (
                         <div className="flex items-center">
-                            <Icon icon="warning" alt="warning" />
+                            <IconImage icon="warning" alt="warning" />
                             <span className="flex-1 pl-4 text-sm">
                                 {t('Could not find any results for the given query.')}
                             </span>

--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/Autocomplete.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/Autocomplete.tsx
@@ -1,5 +1,4 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Image } from 'components/Basic/Image/Image';
 import { Button } from 'components/Forms/Button/Button';
 import {
@@ -19,6 +18,7 @@ import { forwardRef, useCallback, useMemo } from 'react';
 import { twJoin } from 'tailwind-merge';
 import { FriendlyPagesTypesKeys } from 'types/friendlyUrl';
 import { GtmProductListNameType, GtmSectionType } from 'gtm/types/enums';
+import { Icon } from 'components/Basic/Icon/Icon';
 
 export const AUTOCOMPLETE_PRODUCT_LIMIT = 5 as const;
 export const AUTOCOMPLETE_BRAND_LIMIT = 3 as const;

--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
@@ -1,5 +1,4 @@
 import { AUTOCOMPLETE_CATEGORY_LIMIT, AUTOCOMPLETE_PRODUCT_LIMIT } from './Autocomplete';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Close } from 'components/Basic/Icon/IconsSvg';
 import { SearchInput } from 'components/Forms/TextInput/SearchInput';
 import { desktopFirstSizes } from 'components/Theme/mediaQueries';
@@ -115,11 +114,11 @@ export const AutocompleteSearch: FC = () => {
                                 onClick={() => setAutocompleteSearchQueryValue('')}
                             >
                                 {isDesktop ? (
-                                    <Icon icon={<Close />} />
+                                    <Close />
                                 ) : (
                                     <>
                                         <div className="flex w-4 items-center justify-center">
-                                            <Icon icon={<Close />} />
+                                            <Close />
                                         </div>
                                         <span className="ml-1 w-7 text-xs">{t('Close')}</span>
                                     </>

--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
@@ -1,5 +1,5 @@
 import { AUTOCOMPLETE_CATEGORY_LIMIT, AUTOCOMPLETE_PRODUCT_LIMIT } from './Autocomplete';
-import { Close } from 'components/Basic/Icon/IconsSvg';
+import { CloseIcon } from 'components/Basic/Icon/IconsSvg';
 import { SearchInput } from 'components/Forms/TextInput/SearchInput';
 import { desktopFirstSizes } from 'components/Theme/mediaQueries';
 import { useAutocompleteSearchQueryApi } from 'graphql/generated';
@@ -114,11 +114,11 @@ export const AutocompleteSearch: FC = () => {
                                 onClick={() => setAutocompleteSearchQueryValue('')}
                             >
                                 {isDesktop ? (
-                                    <Close />
+                                    <CloseIcon />
                                 ) : (
                                     <>
                                         <div className="flex w-4 items-center justify-center">
-                                            <Close />
+                                            <CloseIcon />
                                         </div>
                                         <span className="ml-1 w-7 text-xs">{t('Close')}</span>
                                     </>

--- a/project-base/storefront/components/Layout/Header/Cart/Cart.tsx
+++ b/project-base/storefront/components/Layout/Header/Cart/Cart.tsx
@@ -1,6 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { ListItem } from './ListItem';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
 import { Button } from 'components/Forms/Button/Button';
@@ -55,7 +54,7 @@ export const Cart: FC = ({ className }) => {
             >
                 <>
                     <span className="relative flex text-lg">
-                        <Icon icon={<CartIcon />} className="w-5" />
+                        <CartIcon className="w-5" />
                         <CartCount dataTestId={TEST_IDENTIFIER + 'itemcount'}>{cart?.items.length ?? 0}</CartCount>
                     </span>
                     <span
@@ -100,7 +99,7 @@ export const Cart: FC = ({ className }) => {
                 ) : (
                     <div className="relative flex h-20 items-center justify-between px-5">
                         <span className="text-dark">{t('Your cart is currently empty.')}</span>
-                        <Icon icon={<EmptyCart />} className={twJoin('w-20 rotate-6 text-orange')} />
+                        <EmptyCart className={twJoin('w-20 rotate-6 text-orange')} />
                     </div>
                 )}
             </div>
@@ -111,7 +110,7 @@ export const Cart: FC = ({ className }) => {
                     className="relative flex h-full w-full items-center justify-center text-white no-underline transition-colors hover:text-white hover:no-underline"
                 >
                     <>
-                        <Icon icon={<CartIcon />} className="w-5 text-white" />
+                        <CartIcon className="w-5 text-white" />
                         <CartCount>{cart?.items.length ?? 0}</CartCount>
                     </>
                 </ExtendedNextLink>

--- a/project-base/storefront/components/Layout/Header/Cart/Cart.tsx
+++ b/project-base/storefront/components/Layout/Header/Cart/Cart.tsx
@@ -15,7 +15,7 @@ import { usePersistStore } from 'store/usePersistStore';
 import { twJoin } from 'tailwind-merge';
 import { GtmProductListNameType } from 'gtm/types/enums';
 import { twMergeCustom } from 'helpers/twMerge';
-import { EmptyCart, Cart as CartIcon } from 'components/Basic/Icon/IconsSvg';
+import { EmptyCartIcon, CartIcon as CartIcon } from 'components/Basic/Icon/IconsSvg';
 
 const TEST_IDENTIFIER = 'layout-header-cart-';
 
@@ -99,7 +99,7 @@ export const Cart: FC = ({ className }) => {
                 ) : (
                     <div className="relative flex h-20 items-center justify-between px-5">
                         <span className="text-dark">{t('Your cart is currently empty.')}</span>
-                        <EmptyCart className={twJoin('w-20 rotate-6 text-orange')} />
+                        <EmptyCartIcon className={twJoin('w-20 rotate-6 text-orange')} />
                     </div>
                 )}
             </div>

--- a/project-base/storefront/components/Layout/Header/Contact/HeaderContact.tsx
+++ b/project-base/storefront/components/Layout/Header/Contact/HeaderContact.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { isElementVisible } from 'helpers/isElementVisible';
 import { Phone } from 'components/Basic/Icon/IconsSvg';
 import { mobileFirstSizes } from 'components/Theme/mediaQueries';
@@ -29,7 +28,7 @@ export const HeaderContact: FC = () => {
         <div className="order-2 ml-auto flex" data-testid={TEST_IDENTIFIER}>
             <div className="relative flex flex-1 flex-col items-start bg-primary py-4 pr-4 lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex flex-wrap items-center lg:flex-1 xl:justify-center">
-                    <Icon icon={<Phone />} className="mr-3 w-5 text-orange" />
+                    <Phone className="mr-3 w-5 text-orange" />
                     <a className="font-bold text-creamWhite no-underline lg:mr-4" href={'tel:' + dummyData.phone}>
                         {dummyData.phone}
                     </a>

--- a/project-base/storefront/components/Layout/Header/Contact/HeaderContact.tsx
+++ b/project-base/storefront/components/Layout/Header/Contact/HeaderContact.tsx
@@ -1,5 +1,5 @@
 import { isElementVisible } from 'helpers/isElementVisible';
-import { Phone } from 'components/Basic/Icon/IconsSvg';
+import { PhoneIcon } from 'components/Basic/Icon/IconsSvg';
 import { mobileFirstSizes } from 'components/Theme/mediaQueries';
 import { useGetWindowSize } from 'hooks/ui/useGetWindowSize';
 import { useResizeWidthEffect } from 'hooks/ui/useResizeWidthEffect';
@@ -28,7 +28,7 @@ export const HeaderContact: FC = () => {
         <div className="order-2 ml-auto flex" data-testid={TEST_IDENTIFIER}>
             <div className="relative flex flex-1 flex-col items-start bg-primary py-4 pr-4 lg:flex-row lg:items-center lg:justify-between">
                 <div className="flex flex-wrap items-center lg:flex-1 xl:justify-center">
-                    <Phone className="mr-3 w-5 text-orange" />
+                    <PhoneIcon className="mr-3 w-5 text-orange" />
                     <a className="font-bold text-creamWhite no-underline lg:mr-4" href={'tel:' + dummyData.phone}>
                         {dummyData.phone}
                     </a>

--- a/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideLeft.tsx
+++ b/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideLeft.tsx
@@ -1,4 +1,4 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { DropdownListLevels } from 'types/dropdown';
 
@@ -18,7 +18,7 @@ export const DropdownSlideLeft: FC<DropdownSlideLeftProps> = ({ goToMenu, onClic
             onClick={() => onClickEvent({ goToMenu })}
             data-testid={TEST_IDENTIFIER}
         >
-            <Arrow className="mr-2 rotate-90" />
+            <ArrowIcon className="mr-2 rotate-90" />
             {t('Back')}
         </span>
     );

--- a/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideLeft.tsx
+++ b/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideLeft.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { DropdownListLevels } from 'types/dropdown';
@@ -19,7 +18,7 @@ export const DropdownSlideLeft: FC<DropdownSlideLeftProps> = ({ goToMenu, onClic
             onClick={() => onClickEvent({ goToMenu })}
             data-testid={TEST_IDENTIFIER}
         >
-            <Icon icon={<Arrow />} className="mr-2 rotate-90" />
+            <Arrow className="mr-2 rotate-90" />
             {t('Back')}
         </span>
     );

--- a/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideRight.tsx
+++ b/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideRight.tsx
@@ -1,4 +1,4 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { DropdownMenuContext } from 'components/Layout/Header/DropdownMenu/DropdownMenuContext';
 import { useContext } from 'react';
 import { DropdownItemType } from 'types/dropdown';
@@ -14,7 +14,7 @@ export const DropdownSlideRight: FC<DropdownItemType> = (dropdownItemProps) => {
             onClick={() => context.slideRight(dropdownItemProps)}
             data-testid={TEST_IDENTIFIER}
         >
-            <Arrow className="w-4 -rotate-90" />
+            <ArrowIcon className="w-4 -rotate-90" />
         </span>
     );
 };

--- a/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideRight.tsx
+++ b/project-base/storefront/components/Layout/Header/DropdownMenu/DropdownSlideRight.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { DropdownMenuContext } from 'components/Layout/Header/DropdownMenu/DropdownMenuContext';
 import { useContext } from 'react';
@@ -15,7 +14,7 @@ export const DropdownSlideRight: FC<DropdownItemType> = (dropdownItemProps) => {
             onClick={() => context.slideRight(dropdownItemProps)}
             data-testid={TEST_IDENTIFIER}
         >
-            <Icon icon={<Arrow />} className="w-4 -rotate-90" />
+            <Arrow className="w-4 -rotate-90" />
         </span>
     );
 };

--- a/project-base/storefront/components/Layout/Header/HamburgerMenu/HamburgerIcon.tsx
+++ b/project-base/storefront/components/Layout/Header/HamburgerMenu/HamburgerIcon.tsx
@@ -1,4 +1,4 @@
-import { Close, Menu } from 'components/Basic/Icon/IconsSvg';
+import { CloseIcon, MenuIcon } from 'components/Basic/Icon/IconsSvg';
 
 type HamburgerIconProps = {
     isMenuOpened: boolean;
@@ -6,8 +6,8 @@ type HamburgerIconProps = {
 
 export const HamburgerIcon: FC<HamburgerIconProps> = ({ isMenuOpened }) => {
     if (isMenuOpened) {
-        return <Close />;
+        return <CloseIcon />;
     }
 
-    return <Menu className="w-4" />;
+    return <MenuIcon className="w-4" />;
 };

--- a/project-base/storefront/components/Layout/Header/HamburgerMenu/HamburgerIcon.tsx
+++ b/project-base/storefront/components/Layout/Header/HamburgerMenu/HamburgerIcon.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Close, Menu } from 'components/Basic/Icon/IconsSvg';
 
 type HamburgerIconProps = {
@@ -7,8 +6,8 @@ type HamburgerIconProps = {
 
 export const HamburgerIcon: FC<HamburgerIconProps> = ({ isMenuOpened }) => {
     if (isMenuOpened) {
-        return <Icon icon={<Close />} />;
+        return <Close />;
     }
 
-    return <Icon icon={<Menu />} className="w-4" />;
+    return <Menu className="w-4" />;
 };

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconic.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconic.tsx
@@ -3,9 +3,9 @@ import { useComparison } from 'hooks/comparison/useComparison';
 import useTranslation from 'next-translate/useTranslation';
 import { useDomainConfig } from 'hooks/useDomainConfig';
 import { useWishlist } from 'hooks/useWishlist';
-import { MenuIconicItem, MenuIconicItemLink, MenuIconicItemIcon } from './MenuIconicElements';
+import { MenuIconicItem, MenuIconicItemLink } from './MenuIconicElements';
 import { MenuIconicItemUser } from './MenuIconicItemUser';
-import { Compare, Heart, HeartFull, Marker } from 'components/Basic/Icon/IconsSvg';
+import { Compare, Heart, Marker } from 'components/Basic/Icon/IconsSvg';
 
 const TEST_IDENTIFIER = 'layout-header-menuiconic';
 
@@ -23,7 +23,7 @@ export const MenuIconic: FC = () => {
         <ul className="flex" data-testid={TEST_IDENTIFIER}>
             <MenuIconicItem dataTestId={TEST_IDENTIFIER + '-stores'} className="max-lg:hidden">
                 <MenuIconicItemLink href={storesUrl}>
-                    <MenuIconicItemIcon icon={<Marker />} />
+                    <Marker className="mr-2 w-4 text-white" />
                     {t('Stores')}
                 </MenuIconicItemLink>
             </MenuIconicItem>
@@ -33,14 +33,14 @@ export const MenuIconic: FC = () => {
             </MenuIconicItem>
             <MenuIconicItem dataTestId={TEST_IDENTIFIER + '-comparison'} className="max-lg:hidden">
                 <MenuIconicItemLink href={productComparisonUrl} title={t('Comparison')}>
-                    <MenuIconicItemIcon icon={<Compare />} />
+                    <Compare className="mr-2 w-4 text-white" />
                     {!!comparison?.products.length && <span>{comparison.products.length}</span>}
                 </MenuIconicItemLink>
             </MenuIconicItem>
 
             <MenuIconicItem dataTestId={TEST_IDENTIFIER + '-wishlist'} className="max-lg:hidden">
                 <MenuIconicItemLink href={wishlistUrl} title={t('Wishlist')}>
-                    <MenuIconicItemIcon icon={wishlist?.products.length ? <HeartFull /> : <Heart />} />
+                    <Heart isFull={!!wishlist?.products.length} className="mr-2 w-4 text-white" />
                     {!!wishlist?.products.length && <span>{wishlist.products.length}</span>}
                 </MenuIconicItemLink>
             </MenuIconicItem>

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconic.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconic.tsx
@@ -5,7 +5,7 @@ import { useDomainConfig } from 'hooks/useDomainConfig';
 import { useWishlist } from 'hooks/useWishlist';
 import { MenuIconicItem, MenuIconicItemLink } from './MenuIconicElements';
 import { MenuIconicItemUser } from './MenuIconicItemUser';
-import { Compare, Heart, Marker } from 'components/Basic/Icon/IconsSvg';
+import { CompareIcon, HeartIcon, MarkerIcon } from 'components/Basic/Icon/IconsSvg';
 
 const TEST_IDENTIFIER = 'layout-header-menuiconic';
 
@@ -23,7 +23,7 @@ export const MenuIconic: FC = () => {
         <ul className="flex" data-testid={TEST_IDENTIFIER}>
             <MenuIconicItem dataTestId={TEST_IDENTIFIER + '-stores'} className="max-lg:hidden">
                 <MenuIconicItemLink href={storesUrl}>
-                    <Marker className="mr-2 w-4 text-white" />
+                    <MarkerIcon className="mr-2 w-4 text-white" />
                     {t('Stores')}
                 </MenuIconicItemLink>
             </MenuIconicItem>
@@ -33,14 +33,14 @@ export const MenuIconic: FC = () => {
             </MenuIconicItem>
             <MenuIconicItem dataTestId={TEST_IDENTIFIER + '-comparison'} className="max-lg:hidden">
                 <MenuIconicItemLink href={productComparisonUrl} title={t('Comparison')}>
-                    <Compare className="mr-2 w-4 text-white" />
+                    <CompareIcon className="mr-2 w-4 text-white" />
                     {!!comparison?.products.length && <span>{comparison.products.length}</span>}
                 </MenuIconicItemLink>
             </MenuIconicItem>
 
             <MenuIconicItem dataTestId={TEST_IDENTIFIER + '-wishlist'} className="max-lg:hidden">
                 <MenuIconicItemLink href={wishlistUrl} title={t('Wishlist')}>
-                    <Heart isFull={!!wishlist?.products.length} className="mr-2 w-4 text-white" />
+                    <HeartIcon isFull={!!wishlist?.products.length} className="mr-2 w-4 text-white" />
                     {!!wishlist?.products.length && <span>{wishlist.products.length}</span>}
                 </MenuIconicItemLink>
             </MenuIconicItem>

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicElements.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicElements.tsx
@@ -1,11 +1,6 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { twMergeCustom } from 'helpers/twMerge';
 import { forwardRef } from 'react';
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-
-export const MenuIconicItemIcon: FC<{ icon: JSX.Element }> = ({ icon, className }) => (
-    <Icon icon={icon} className={twMergeCustom('mr-2 w-4 text-white', className)} />
-);
 
 export const MenuIconicItem: FC<{ title?: string }> = ({ children, className, dataTestId, title }) => (
     <li

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserAuthenticated.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserAuthenticated.tsx
@@ -4,7 +4,7 @@ import { getInternationalizedStaticUrls } from 'helpers/getInternationalizedStat
 import { useDomainConfig } from 'hooks/useDomainConfig';
 import { useAuth } from 'hooks/auth/useAuth';
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { User } from 'components/Basic/Icon/IconsSvg';
+import { UserIcon } from 'components/Basic/Icon/IconsSvg';
 
 export const MenuIconicItemUserAuthenticated: FC = ({ dataTestId }) => {
     const { t } = useTranslation();
@@ -23,7 +23,7 @@ export const MenuIconicItemUserAuthenticated: FC = ({ dataTestId }) => {
                     className="rounded-t p-3 group-hover:bg-white group-hover:text-dark max-lg:hidden"
                     dataTestId={dataTestId + '-my-account'}
                 >
-                    <User className="mr-2 w-4 text-white group-hover:text-dark" />
+                    <UserIcon className="mr-2 w-4 text-white group-hover:text-dark" />
                     {t('My account')}
                 </MenuIconicItemLink>
 
@@ -47,7 +47,7 @@ export const MenuIconicItemUserAuthenticated: FC = ({ dataTestId }) => {
             <div className="order-2 ml-1 flex h-9 w-9 cursor-pointer items-center justify-center text-lg outline-none lg:hidden">
                 <ExtendedNextLink href={customerUrl} type="static">
                     <div className="relative flex h-full w-full items-center justify-center text-white transition-colors">
-                        <User className="w-4 text-white" />
+                        <UserIcon className="w-4 text-white" />
                     </div>
                 </ExtendedNextLink>
             </div>

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserAuthenticated.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserAuthenticated.tsx
@@ -1,5 +1,5 @@
 import useTranslation from 'next-translate/useTranslation';
-import { MenuIconicItemLink, MenuIconicItemIcon, MenuIconicSubItemLink } from './MenuIconicElements';
+import { MenuIconicItemLink, MenuIconicSubItemLink } from './MenuIconicElements';
 import { getInternationalizedStaticUrls } from 'helpers/getInternationalizedStaticUrls';
 import { useDomainConfig } from 'hooks/useDomainConfig';
 import { useAuth } from 'hooks/auth/useAuth';
@@ -23,7 +23,7 @@ export const MenuIconicItemUserAuthenticated: FC = ({ dataTestId }) => {
                     className="rounded-t p-3 group-hover:bg-white group-hover:text-dark max-lg:hidden"
                     dataTestId={dataTestId + '-my-account'}
                 >
-                    <MenuIconicItemIcon icon={<User />} className="group-hover:text-dark" />
+                    <User className="mr-2 w-4 text-white group-hover:text-dark" />
                     {t('My account')}
                 </MenuIconicItemLink>
 
@@ -47,7 +47,7 @@ export const MenuIconicItemUserAuthenticated: FC = ({ dataTestId }) => {
             <div className="order-2 ml-1 flex h-9 w-9 cursor-pointer items-center justify-center text-lg outline-none lg:hidden">
                 <ExtendedNextLink href={customerUrl} type="static">
                     <div className="relative flex h-full w-full items-center justify-center text-white transition-colors">
-                        <MenuIconicItemIcon icon={<User />} className="mr-0" />
+                        <User className="w-4 text-white" />
                     </div>
                 </ExtendedNextLink>
             </div>

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticated.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticated.tsx
@@ -4,7 +4,7 @@ import { Heading } from 'components/Basic/Heading/Heading';
 import { Login } from 'components/Blocks/Popup/Login/Login';
 import { useState } from 'react';
 import dynamic from 'next/dynamic';
-import { User } from 'components/Basic/Icon/IconsSvg';
+import { UserIcon } from 'components/Basic/Icon/IconsSvg';
 
 const Popup = dynamic(() => import('components/Layout/Popup/Popup').then((component) => component.Popup));
 
@@ -20,7 +20,7 @@ export const MenuIconicItemUserUnauthenticated: FC = ({ dataTestId }) => {
                 className="cursor-pointer max-lg:hidden"
                 dataTestId={dataTestId + '-link-popup'}
             >
-                <User className="mr-2 w-4 text-white" />
+                <UserIcon className="mr-2 w-4 text-white" />
                 {t('Login')}
             </MenuIconicItemLink>
 
@@ -29,7 +29,7 @@ export const MenuIconicItemUserUnauthenticated: FC = ({ dataTestId }) => {
                     className="relative flex h-full w-full items-center justify-center text-white transition-colors"
                     onClick={handleLogin}
                 >
-                    <User className="w-4 text-white" />
+                    <UserIcon className="w-4 text-white" />
                 </div>
             </div>
 

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticated.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserUnauthenticated.tsx
@@ -1,5 +1,5 @@
 import useTranslation from 'next-translate/useTranslation';
-import { MenuIconicItemLink, MenuIconicItemIcon } from './MenuIconicElements';
+import { MenuIconicItemLink } from './MenuIconicElements';
 import { Heading } from 'components/Basic/Heading/Heading';
 import { Login } from 'components/Blocks/Popup/Login/Login';
 import { useState } from 'react';
@@ -20,7 +20,7 @@ export const MenuIconicItemUserUnauthenticated: FC = ({ dataTestId }) => {
                 className="cursor-pointer max-lg:hidden"
                 dataTestId={dataTestId + '-link-popup'}
             >
-                <MenuIconicItemIcon icon={<User />} />
+                <User className="mr-2 w-4 text-white" />
                 {t('Login')}
             </MenuIconicItemLink>
 
@@ -29,7 +29,7 @@ export const MenuIconicItemUserUnauthenticated: FC = ({ dataTestId }) => {
                     className="relative flex h-full w-full items-center justify-center text-white transition-colors"
                     onClick={handleLogin}
                 >
-                    <MenuIconicItemIcon icon={<User />} className="mr-0" />
+                    <User className="w-4 text-white" />
                 </div>
             </div>
 

--- a/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
@@ -1,5 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { NavigationLeaf } from 'components/Layout/Header/Navigation/NavigationLeaf';
 import { CategoriesByColumnFragmentApi } from 'graphql/generated';
 import { twJoin } from 'tailwind-merge';
@@ -25,7 +25,7 @@ export const NavigationItem: FC<NavigationItemProps> = (props) => {
                 <>
                     {props.navigationItem.name}
                     {hasChildren && (
-                        <Arrow className="ml-2 text-white group-hover:rotate-180 group-hover:text-orangeLight" />
+                        <ArrowIcon className="ml-2 text-white group-hover:rotate-180 group-hover:text-orangeLight" />
                     )}
                 </>
             </ExtendedNextLink>

--- a/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
@@ -1,5 +1,4 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { NavigationLeaf } from 'components/Layout/Header/Navigation/NavigationLeaf';
 import { CategoriesByColumnFragmentApi } from 'graphql/generated';
@@ -20,16 +19,13 @@ export const NavigationItem: FC<NavigationItemProps> = (props) => {
                 type="category"
                 href={props.navigationItem.link}
                 className={twJoin(
-                    'relative m-0 block px-2 py-4 text-sm font-bold uppercase text-white no-underline after:absolute after:bottom-0 after:left-0 after:right-0 after:hidden after:h-1 after:bg-orange after:content-[""] hover:text-orangeLight hover:no-underline hover:after:block group-hover:text-orangeLight group-hover:no-underline after:group-hover:block vl:text-base',
+                    'relative m-0 flex items-center px-2 py-4 text-sm font-bold uppercase text-white no-underline hover:text-orangeLight hover:no-underline group-hover:text-orangeLight group-hover:no-underline vl:text-base',
                 )}
             >
                 <>
                     {props.navigationItem.name}
                     {hasChildren && (
-                        <Icon
-                            icon={<Arrow />}
-                            className="ml-2 text-white group-hover:rotate-180 group-hover:text-orangeLight"
-                        />
+                        <Arrow className="ml-2 text-white group-hover:rotate-180 group-hover:text-orangeLight" />
                     )}
                 </>
             </ExtendedNextLink>

--- a/project-base/storefront/components/Layout/Popup/Popup.tsx
+++ b/project-base/storefront/components/Layout/Popup/Popup.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Remove } from 'components/Basic/Icon/IconsSvg';
 import { Overlay } from 'components/Basic/Overlay/Overlay';
 import { Portal } from 'components/Basic/Portal/Portal';
@@ -52,7 +51,7 @@ export const Popup: FC<PopupProps> = ({ onCloseCallback, children, hideCloseButt
                             className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border-0 bg-creamWhite text-xs text-grey no-underline outline-none"
                             onClick={onClickCloseActionHandler}
                         >
-                            <Icon icon={<Remove />} className="w-6 text-primary" />
+                            <Remove className="w-6 text-primary" />
                         </button>
                     </div>
                 )}

--- a/project-base/storefront/components/Layout/Popup/Popup.tsx
+++ b/project-base/storefront/components/Layout/Popup/Popup.tsx
@@ -1,4 +1,4 @@
-import { Remove } from 'components/Basic/Icon/IconsSvg';
+import { RemoveIcon } from 'components/Basic/Icon/IconsSvg';
 import { Overlay } from 'components/Basic/Overlay/Overlay';
 import { Portal } from 'components/Basic/Portal/Portal';
 import { canUseDom } from 'helpers/canUseDom';
@@ -51,7 +51,7 @@ export const Popup: FC<PopupProps> = ({ onCloseCallback, children, hideCloseButt
                             className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border-0 bg-creamWhite text-xs text-grey no-underline outline-none"
                             onClick={onClickCloseActionHandler}
                         >
-                            <Remove className="w-6 text-primary" />
+                            <RemoveIcon className="w-6 text-primary" />
                         </button>
                     </div>
                 )}

--- a/project-base/storefront/components/Pages/Cart/CartLoading.tsx
+++ b/project-base/storefront/components/Pages/Cart/CartLoading.tsx
@@ -7,7 +7,7 @@ export const CartLoading: FC = () => {
     return (
         <Webline className="h-96">
             <div className="my-32 text-center text-2xl" data-testid={TEST_IDENTIFIER}>
-                <Loader className="w-10" />
+                <Loader className="h-10 w-10" />
             </div>
         </Webline>
     );

--- a/project-base/storefront/components/Pages/Cart/RemoveCartItemButton.tsx
+++ b/project-base/storefront/components/Pages/Cart/RemoveCartItemButton.tsx
@@ -1,4 +1,4 @@
-import { RemoveBold } from 'components/Basic/Icon/IconsSvg';
+import { RemoveBoldIcon } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { MouseEventHandler } from 'react';
 
@@ -18,7 +18,7 @@ export const RemoveCartItemButton: FC<RemoveCartItemButtonProps> = ({ onItemRemo
             data-testid={TEST_IDENTIFIER}
             title={t('Remove from cart')}
         >
-            <RemoveBold className="mx-auto w-2 basis-2" />
+            <RemoveBoldIcon className="mx-auto w-2 basis-2" />
         </button>
     );
 };

--- a/project-base/storefront/components/Pages/Cart/RemoveCartItemButton.tsx
+++ b/project-base/storefront/components/Pages/Cart/RemoveCartItemButton.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { RemoveBold } from 'components/Basic/Icon/IconsSvg';
 import useTranslation from 'next-translate/useTranslation';
 import { MouseEventHandler } from 'react';
@@ -19,7 +18,7 @@ export const RemoveCartItemButton: FC<RemoveCartItemButtonProps> = ({ onItemRemo
             data-testid={TEST_IDENTIFIER}
             title={t('Remove from cart')}
         >
-            <Icon icon={<RemoveBold />} className="mx-auto w-2 basis-2" />
+            <RemoveBold className="mx-auto w-2 basis-2" />
         </button>
     );
 };

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -2,7 +2,6 @@ import { Heading } from 'components/Basic/Heading/Heading';
 import { AdvancedSeoCategories } from './AdvancedSeoCategories';
 import { CategoryDetailProductsWrapper } from './CategoryDetailProductsWrapper';
 import { MetaRobots } from 'components/Basic/Head/MetaRobots';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Overlay } from 'components/Basic/Overlay/Overlay';
 import { Adverts } from 'components/Blocks/Adverts/Adverts';
 import { FilterPanel } from 'components/Blocks/Product/Filter/FilterPanel';
@@ -87,7 +86,7 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
                             className="relative flex w-full cursor-pointer flex-row items-center justify-center rounded bg-primary py-3 px-8 font-bold uppercase text-white vl:mb-3 vl:hidden"
                             onClick={handlePanelOpenerClick}
                         >
-                            <Icon icon={<Filter />} className="mr-3 w-6 font-bold text-white" />
+                            <Filter className="mr-3 w-6 font-bold text-white" />
                             {t('Filter')}
                         </div>
                         <SortingBar

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -15,8 +15,8 @@ import { useRouter } from 'next/router';
 import { useCallback, useRef, useState } from 'react';
 import { twJoin } from 'tailwind-merge';
 import { useSeoTitleWithPagination } from 'hooks/seo/useSeoTitleWithPagination';
-import { Filter } from 'components/Basic/Icon/IconsSvg';
 import { CategoryBestsellers } from './CategoryBestsellers/CategoryBestsellers';
+import { FilterIcon } from 'components/Basic/Icon/IconsSvg';
 
 type CategoryDetailContentProps = {
     category: CategoryDetailFragmentApi;
@@ -86,7 +86,7 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
                             className="relative flex w-full cursor-pointer flex-row items-center justify-center rounded bg-primary py-3 px-8 font-bold uppercase text-white vl:mb-3 vl:hidden"
                             onClick={handlePanelOpenerClick}
                         >
-                            <Filter className="mr-3 w-6 font-bold text-white" />
+                            <FilterIcon className="mr-3 w-6 font-bold text-white" />
                             {t('Filter')}
                         </div>
                         <SortingBar

--- a/project-base/storefront/components/Pages/Customer/AddressList.tsx
+++ b/project-base/storefront/components/Pages/Customer/AddressList.tsx
@@ -1,4 +1,4 @@
-import { Arrow, Phone, Remove } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon, PhoneIcon, RemoveIcon } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { showErrorMessage, showSuccessMessage } from 'helpers/toasts';
 import { useDeleteDeliveryAddressMutationApi, useSetDefaultDeliveryAddressMutationApi } from 'graphql/generated';
@@ -81,13 +81,13 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
                             <br />
                             {address.telephone && (
                                 <>
-                                    <Phone className="relative top-[2px] mr-1" />
+                                    <PhoneIcon className="relative top-[2px] mr-1" />
                                     {address.telephone}
                                 </>
                             )}
                         </div>
 
-                        <Remove
+                        <RemoveIcon
                             onClick={() => setAddressToBeDeleted(address.uuid)}
                             className="absolute right-5 top-5 w-3 cursor-pointer text-greyLight hover:text-red"
                         />
@@ -100,12 +100,12 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
                         {t('Do you really want to delete this delivery address?')}
                         <div className="mt-4 flex flex-row flex-nowrap justify-between">
                             <Button onClick={() => setAddressToBeDeleted(undefined)}>
-                                <Arrow className="relative mr-4 rotate-90 text-white" />
+                                <ArrowIcon className="relative mr-4 rotate-90 text-white" />
                                 {t('No')}
                             </Button>
                             <Button onClick={() => deleteItemHandler(addressToBeDeleted)}>
                                 {t('Yes')}
-                                <Arrow className="relative ml-4 -rotate-90" />
+                                <ArrowIcon className="relative ml-4 -rotate-90" />
                             </Button>
                         </div>
                     </div>

--- a/project-base/storefront/components/Pages/Customer/AddressList.tsx
+++ b/project-base/storefront/components/Pages/Customer/AddressList.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow, Phone, Remove } from 'components/Basic/Icon/IconsSvg';
 import { Button } from 'components/Forms/Button/Button';
 import { showErrorMessage, showSuccessMessage } from 'helpers/toasts';
@@ -82,14 +81,13 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
                             <br />
                             {address.telephone && (
                                 <>
-                                    <Icon icon={<Phone />} className="relative top-[2px] mr-1" />
+                                    <Phone className="relative top-[2px] mr-1" />
                                     {address.telephone}
                                 </>
                             )}
                         </div>
 
-                        <Icon
-                            icon={<Remove />}
+                        <Remove
                             onClick={() => setAddressToBeDeleted(address.uuid)}
                             className="absolute right-5 top-5 w-3 cursor-pointer text-greyLight hover:text-red"
                         />
@@ -102,12 +100,12 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
                         {t('Do you really want to delete this delivery address?')}
                         <div className="mt-4 flex flex-row flex-nowrap justify-between">
                             <Button onClick={() => setAddressToBeDeleted(undefined)}>
-                                <Icon icon={<Arrow />} className="relative mr-4 rotate-90 text-white" />
+                                <Arrow className="relative mr-4 rotate-90 text-white" />
                                 {t('No')}
                             </Button>
                             <Button onClick={() => deleteItemHandler(addressToBeDeleted)}>
                                 {t('Yes')}
-                                <Icon icon={<Arrow />} className="relative ml-4 -rotate-90" />
+                                <Arrow className="relative ml-4 -rotate-90" />
                             </Button>
                         </div>
                     </div>

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
@@ -2,7 +2,6 @@ import { PickupPlacePopup } from './PickupPlacePopup';
 import { TransportAndPaymentListItem } from './TransportAndPaymentListItem';
 import { TransportAndPaymentSelectItemLabel } from './TransportAndPaymentSelectItemLabel';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
 import { Radiobutton } from 'components/Forms/Radiobutton/Radiobutton';
@@ -315,6 +314,6 @@ const ResetButton: FC<ResetButtonProps> = ({ text, dataTestId, onClick }) => (
         className="flex w-full items-center bg-whitesmoke px-2 py-1 text-sm"
     >
         {text}
-        <Icon icon={<Arrow />} className="ml-2" />
+        <Arrow className="ml-2" />
     </button>
 );

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelect.tsx
@@ -2,7 +2,7 @@ import { PickupPlacePopup } from './PickupPlacePopup';
 import { TransportAndPaymentListItem } from './TransportAndPaymentListItem';
 import { TransportAndPaymentSelectItemLabel } from './TransportAndPaymentSelectItemLabel';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
 import { Radiobutton } from 'components/Forms/Radiobutton/Radiobutton';
 import { PacketeryContainer } from 'components/Pages/Order/TransportAndPayment/PacketeryContainer';
@@ -314,6 +314,6 @@ const ResetButton: FC<ResetButtonProps> = ({ text, dataTestId, onClick }) => (
         className="flex w-full items-center bg-whitesmoke px-2 py-1 text-sm"
     >
         {text}
-        <Arrow className="ml-2" />
+        <ArrowIcon className="ml-2" />
     </button>
 );

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparison.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparison.tsx
@@ -8,7 +8,7 @@ import { useGtmSliderProductListViewEvent } from 'gtm/hooks/productList/useGtmSl
 import { useComparison } from 'hooks/comparison/useComparison';
 import useTranslation from 'next-translate/useTranslation';
 import { GtmProductListNameType } from 'gtm/types/enums';
-import { Info } from 'components/Basic/Icon/IconsSvg';
+import { InfoIcon } from 'components/Basic/Icon/IconsSvg';
 
 type ProductComparisonProps = {
     breadcrumb: BreadcrumbFragmentApi[];
@@ -25,7 +25,7 @@ export const ProductComparison: FC<ProductComparisonProps> = ({ breadcrumb }) =>
             <ProductComparisonContent productsCompare={comparedProducts} />
         ) : (
             <div className="my-[75px] flex items-center">
-                <Info className="mr-4 w-8" />
+                <InfoIcon className="mr-4 w-8" />
 
                 <Heading type="h3" className="!mb-0">
                     {t('Comparison does not contain any products yet.')}

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparison.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparison.tsx
@@ -1,6 +1,5 @@
 import { ProductComparisonContent } from './ProductComparisonContent';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { Breadcrumbs } from 'components/Layout/Breadcrumbs/Breadcrumbs';
 import { Webline } from 'components/Layout/Webline/Webline';
@@ -26,7 +25,7 @@ export const ProductComparison: FC<ProductComparisonProps> = ({ breadcrumb }) =>
             <ProductComparisonContent productsCompare={comparedProducts} />
         ) : (
             <div className="my-[75px] flex items-center">
-                <Icon icon={<Info />} className="mr-4 w-8" />
+                <Info className="mr-4 w-8" />
 
                 <Heading type="h3" className="!mb-0">
                     {t('Comparison does not contain any products yet.')}

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonButtonRemoveAll.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonButtonRemoveAll.tsx
@@ -1,4 +1,4 @@
-import { RemoveThin } from 'components/Basic/Icon/IconsSvg';
+import { RemoveThinIcon } from 'components/Basic/Icon/IconsSvg';
 import { useComparison } from 'hooks/comparison/useComparison';
 import useTranslation from 'next-translate/useTranslation';
 import { twJoin } from 'tailwind-merge';
@@ -20,7 +20,7 @@ export const ProductComparisonButtonRemoveAll: FC<ProductComparisonButtonRemoveA
             onClick={handleCleanComparison}
         >
             <span className="mr-3 text-sm">{t('Delete all')}</span>
-            <RemoveThin className="w-3" />
+            <RemoveThinIcon className="w-3" />
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonButtonRemoveAll.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonButtonRemoveAll.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { RemoveThin } from 'components/Basic/Icon/IconsSvg';
 import { useComparison } from 'hooks/comparison/useComparison';
 import useTranslation from 'next-translate/useTranslation';
@@ -21,7 +20,7 @@ export const ProductComparisonButtonRemoveAll: FC<ProductComparisonButtonRemoveA
             onClick={handleCleanComparison}
         >
             <span className="mr-3 text-sm">{t('Delete all')}</span>
-            <Icon icon={<RemoveThin />} className="w-3" />
+            <RemoveThin className="w-3" />
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonContent.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonContent.tsx
@@ -4,7 +4,6 @@ import { ProductComparisonHead } from './ProductComparisonHead';
 import { ProductComparisonHeadSticky } from './ProductComparisonHeadSticky';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { ComparedProductFragmentApi } from 'graphql/generated';
 import { canUseDom } from 'helpers/canUseDom';
 import { useComparisonTable } from 'hooks/comparison/useComparisonTable';
@@ -123,9 +122,8 @@ const ContentArrow: FC<ContentArrowProps> = ({ isActive, isRight, isShowed, onCl
         disabled={!isActive}
         onClick={onClick}
     >
-        <Icon
+        <Arrow
             className={twJoin('w-5 text-dark', isRight ? '-rotate-90' : 'rotate-90', !isActive && 'text-greyLight')}
-            icon={<Arrow />}
         />
     </button>
 );

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonContent.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonContent.tsx
@@ -2,7 +2,7 @@ import { ProductComparisonBody } from './ProductComparisonBody';
 import { ProductComparisonButtonRemoveAll } from './ProductComparisonButtonRemoveAll';
 import { ProductComparisonHead } from './ProductComparisonHead';
 import { ProductComparisonHeadSticky } from './ProductComparisonHeadSticky';
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { Heading } from 'components/Basic/Heading/Heading';
 import { ComparedProductFragmentApi } from 'graphql/generated';
 import { canUseDom } from 'helpers/canUseDom';
@@ -122,7 +122,7 @@ const ContentArrow: FC<ContentArrowProps> = ({ isActive, isRight, isShowed, onCl
         disabled={!isActive}
         onClick={onClick}
     >
-        <Arrow
+        <ArrowIcon
             className={twJoin('w-5 text-dark', isRight ? '-rotate-90' : 'rotate-90', !isActive && 'text-greyLight')}
         />
     </button>

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadItem.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadItem.tsx
@@ -1,5 +1,4 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Remove } from 'components/Basic/Icon/IconsSvg';
 import { Image } from 'components/Basic/Image/Image';
 import { ProductAction } from 'components/Blocks/Product/ProductAction';
@@ -81,7 +80,7 @@ export const ProductComparisonHeadItem: FC<ProductComparisonItemProps> = ({
                     calcMaxMarginLeft();
                 }}
             >
-                <Icon className="w-4 text-grey" icon={<Remove />} />
+                <Remove className="w-4 text-grey" />
             </div>
 
             {product.flags.length > 0 && (

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadItem.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadItem.tsx
@@ -1,5 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
-import { Remove } from 'components/Basic/Icon/IconsSvg';
+import { RemoveIcon } from 'components/Basic/Icon/IconsSvg';
 import { Image } from 'components/Basic/Image/Image';
 import { ProductAction } from 'components/Blocks/Product/ProductAction';
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
@@ -80,7 +80,7 @@ export const ProductComparisonHeadItem: FC<ProductComparisonItemProps> = ({
                     calcMaxMarginLeft();
                 }}
             >
-                <Remove className="w-4 text-grey" />
+                <RemoveIcon className="w-4 text-grey" />
             </div>
 
             {product.flags.length > 0 && (

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Cart } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { Button } from 'components/Forms/Button/Button';
@@ -68,7 +67,7 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
                                     variant="primary"
                                     dataTestId={TEST_IDENTIFIER + '-button'}
                                 >
-                                    {fetching ? <Loader className="w-7" /> : <Icon icon={<Cart />} />}
+                                    {fetching ? <Loader className="w-7" /> : <Cart />}
 
                                     {t('Add to cart')}
                                 </Button>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart.tsx
@@ -1,4 +1,4 @@
-import { Cart } from 'components/Basic/Icon/IconsSvg';
+import { CartIcon } from 'components/Basic/Icon/IconsSvg';
 import { Loader } from 'components/Basic/Loader/Loader';
 import { Button } from 'components/Forms/Button/Button';
 import { Spinbox } from 'components/Forms/Spinbox/Spinbox';
@@ -67,7 +67,7 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
                                     variant="primary"
                                     dataTestId={TEST_IDENTIFIER + '-button'}
                                 >
-                                    {fetching ? <Loader className="w-7" /> : <Cart />}
+                                    {fetching ? <Loader className="w-7" /> : <CartIcon />}
 
                                     {t('Add to cart')}
                                 </Button>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailability.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailability.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { AvailabilityStatusEnumApi, ProductDetailFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -34,7 +33,7 @@ export const ProductDetailAvailability: FC<ProductDetailAvailabilityProps> = ({ 
                 onClick={scrollOnClickHandler}
             >
                 {product.availability.name}
-                <Icon icon={<Arrow />} className="text-dark" />
+                <Arrow className="text-dark" />
             </a>
             {product.availableStoresCount > 0 && (
                 <span className="mr-1 text-sm" data-testid={TEST_IDENTIFIER + '-availability'}>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailability.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailability.tsx
@@ -1,4 +1,4 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { AvailabilityStatusEnumApi, ProductDetailFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
 import { RefObject } from 'react';
@@ -33,7 +33,7 @@ export const ProductDetailAvailability: FC<ProductDetailAvailabilityProps> = ({ 
                 onClick={scrollOnClickHandler}
             >
                 {product.availability.name}
-                <Arrow className="text-dark" />
+                <ArrowIcon className="text-dark" />
             </a>
             {product.availableStoresCount > 0 && (
                 <span className="mr-1 text-sm" data-testid={TEST_IDENTIFIER + '-availability'}>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailabilityList.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailabilityList.tsx
@@ -1,6 +1,6 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { ArrowRight } from 'components/Basic/Icon/IconsSvg';
+import { ArrowRightIcon } from 'components/Basic/Icon/IconsSvg';
 import { AvailabilityStatusEnumApi, StoreAvailabilityFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
 import { forwardRef } from 'react';
@@ -51,7 +51,7 @@ export const ProductDetailAvailabilityList = forwardRef<HTMLUListElement, Produc
                                     >
                                         <>
                                             {t('Store detail')}
-                                            <ArrowRight />
+                                            <ArrowRightIcon />
                                         </>
                                     </ExtendedNextLink>
                                 </li>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailabilityList.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAvailabilityList.tsx
@@ -1,6 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { ArrowRight } from 'components/Basic/Icon/IconsSvg';
 import { AvailabilityStatusEnumApi, StoreAvailabilityFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -52,7 +51,7 @@ export const ProductDetailAvailabilityList = forwardRef<HTMLUListElement, Produc
                                     >
                                         <>
                                             {t('Store detail')}
-                                            <Icon icon={<ArrowRight />} />
+                                            <ArrowRight />
                                         </>
                                     </ExtendedNextLink>
                                 </li>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailGalleryImages.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailGalleryImages.tsx
@@ -1,5 +1,5 @@
 import { Gallery } from 'components/Basic/Gallery/Gallery';
-import { Play } from 'components/Basic/Icon/IconsSvg';
+import { PlayIcon } from 'components/Basic/Icon/IconsSvg';
 import { Image } from 'components/Basic/Image/Image';
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
 import { ImageSizesFragmentApi, SimpleFlagFragmentApi, VideoTokenFragmentApi } from 'graphql/generated';
@@ -115,7 +115,7 @@ export const ProductDetailGalleryImages: FC<ProductDetailGalleryImagesProps> = (
                                 <Image image={videoImage} type="thumbnailSmall" alt={videoId.description} />
 
                                 <div className="absolute top-4 left-6 flex h-8 w-8 items-center justify-center rounded-full bg-dark bg-opacity-50 text-white">
-                                    <Play className="ml-1" />
+                                    <PlayIcon className="ml-1" />
                                 </div>
                             </div>
                         );

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailGalleryImages.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailGalleryImages.tsx
@@ -1,5 +1,4 @@
 import { Gallery } from 'components/Basic/Gallery/Gallery';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Play } from 'components/Basic/Icon/IconsSvg';
 import { Image } from 'components/Basic/Image/Image';
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
@@ -116,7 +115,7 @@ export const ProductDetailGalleryImages: FC<ProductDetailGalleryImagesProps> = (
                                 <Image image={videoImage} type="thumbnailSmall" alt={videoId.description} />
 
                                 <div className="absolute top-4 left-6 flex h-8 w-8 items-center justify-center rounded-full bg-dark bg-opacity-50 text-white">
-                                    <Icon icon={<Play />} className="ml-1" />
+                                    <Play className="ml-1" />
                                 </div>
                             </div>
                         );

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailGallerySlider.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailGallerySlider.tsx
@@ -1,4 +1,3 @@
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Arrow } from 'components/Basic/Icon/IconsSvg';
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
 import useEmblaCarousel, { EmblaOptionsType } from 'embla-carousel-react';
@@ -130,6 +129,6 @@ const ImageSliderControl: FC<ImageSliderControlProps> = ({ isNext, onClick, enab
         onClick={onClick}
         disabled={!enabled}
     >
-        <Icon icon={<Arrow />} className={isNext ? '-rotate-90' : 'rotate-90'} />
+        <Arrow className={isNext ? '-rotate-90' : 'rotate-90'} />
     </button>
 );

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailGallerySlider.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailGallerySlider.tsx
@@ -1,4 +1,4 @@
-import { Arrow } from 'components/Basic/Icon/IconsSvg';
+import { ArrowIcon } from 'components/Basic/Icon/IconsSvg';
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
 import useEmblaCarousel, { EmblaOptionsType } from 'embla-carousel-react';
 import { ImageSizesFragmentApi, SimpleFlagFragmentApi, VideoTokenFragmentApi } from 'graphql/generated';
@@ -129,6 +129,6 @@ const ImageSliderControl: FC<ImageSliderControlProps> = ({ isNext, onClick, enab
         onClick={onClick}
         disabled={!enabled}
     >
-        <Arrow className={isNext ? '-rotate-90' : 'rotate-90'} />
+        <ArrowIcon className={isNext ? '-rotate-90' : 'rotate-90'} />
     </button>
 );

--- a/project-base/storefront/components/Pages/Search/ProductsSearch.tsx
+++ b/project-base/storefront/components/Pages/Search/ProductsSearch.tsx
@@ -1,6 +1,6 @@
 import { SearchProductsWrapper } from './SearchProductsWrapper';
 import { MetaRobots } from 'components/Basic/Head/MetaRobots';
-import { Filter } from 'components/Basic/Icon/IconsSvg';
+import { FilterIcon } from 'components/Basic/Icon/IconsSvg';
 import { Overlay } from 'components/Basic/Overlay/Overlay';
 import { FilterPanel } from 'components/Blocks/Product/Filter/FilterPanel';
 import { SortingBar } from 'components/Blocks/SortingBar/SortingBar';
@@ -62,7 +62,7 @@ export const ProductsSearch: FC<ProductsSearchProps> = ({ productsSearch }) => {
                         className="relative mb-3 flex h-12 w-full cursor-pointer flex-row justify-center rounded bg-primary py-3 px-8 font-bold uppercase leading-7 text-white vl:hidden"
                         onClick={handlePanelOpenerClick}
                     >
-                        <Filter className="mr-3 w-6 font-bold text-white" />
+                        <FilterIcon className="mr-3 w-6 font-bold text-white" />
                         {t('Filter')}
                     </div>
                     <SortingBar

--- a/project-base/storefront/components/Pages/Search/ProductsSearch.tsx
+++ b/project-base/storefront/components/Pages/Search/ProductsSearch.tsx
@@ -1,6 +1,5 @@
 import { SearchProductsWrapper } from './SearchProductsWrapper';
 import { MetaRobots } from 'components/Basic/Head/MetaRobots';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Filter } from 'components/Basic/Icon/IconsSvg';
 import { Overlay } from 'components/Basic/Overlay/Overlay';
 import { FilterPanel } from 'components/Blocks/Product/Filter/FilterPanel';
@@ -63,7 +62,7 @@ export const ProductsSearch: FC<ProductsSearchProps> = ({ productsSearch }) => {
                         className="relative mb-3 flex h-12 w-full cursor-pointer flex-row justify-center rounded bg-primary py-3 px-8 font-bold uppercase leading-7 text-white vl:hidden"
                         onClick={handlePanelOpenerClick}
                     >
-                        <Icon icon={<Filter />} className="mr-3 w-6 font-bold text-white" />
+                        <Filter className="mr-3 w-6 font-bold text-white" />
                         {t('Filter')}
                     </div>
                     <SortingBar

--- a/project-base/storefront/components/Pages/StoreDetail/StoreDetailContent.tsx
+++ b/project-base/storefront/components/Pages/StoreDetail/StoreDetailContent.tsx
@@ -1,6 +1,5 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Image } from 'components/Basic/Image/Image';
 import { SeznamMap } from 'components/Basic/SeznamMap/SeznamMap';
 import { Webline } from 'components/Layout/Webline/Webline';
@@ -82,7 +81,7 @@ export const StoreDetailContent: FC<StoreDetailContentProps> = ({ store }) => {
 
                     <div className="mt-6 flex items-center justify-between rounded border border-greyLighter py-4 pr-4 pl-6 transition hover:no-underline vl:hover:-translate-x-1 vl:hover:shadow-lg">
                         <div className="flex flex-row items-center text-lg text-primary">
-                            <Icon icon={<Chat />} className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
+                            <Chat className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
                             <ExtendedNextLink
                                 href={contactUrl}
                                 passHref

--- a/project-base/storefront/components/Pages/StoreDetail/StoreDetailContent.tsx
+++ b/project-base/storefront/components/Pages/StoreDetail/StoreDetailContent.tsx
@@ -12,7 +12,7 @@ import { OpeningHours } from 'components/Blocks/OpeningHours/OpeningHours';
 import { OpeningStatus } from 'components/Blocks/OpeningHours/OpeningStatus';
 import { twJoin } from 'tailwind-merge';
 import dynamic from 'next/dynamic';
-import { Chat } from 'components/Basic/Icon/IconsSvg';
+import { ChatIcon } from 'components/Basic/Icon/IconsSvg';
 
 const Gallery = dynamic(() => import('components/Basic/Gallery/Gallery').then((component) => component.Gallery));
 
@@ -81,7 +81,7 @@ export const StoreDetailContent: FC<StoreDetailContentProps> = ({ store }) => {
 
                     <div className="mt-6 flex items-center justify-between rounded border border-greyLighter py-4 pr-4 pl-6 transition hover:no-underline vl:hover:-translate-x-1 vl:hover:shadow-lg">
                         <div className="flex flex-row items-center text-lg text-primary">
-                            <Chat className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
+                            <ChatIcon className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
                             <ExtendedNextLink
                                 href={contactUrl}
                                 passHref

--- a/project-base/storefront/components/Pages/Stores/StoreInfoBox.tsx
+++ b/project-base/storefront/components/Pages/Stores/StoreInfoBox.tsx
@@ -4,7 +4,7 @@ import { ListedStoreFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
 import { OpeningHours } from 'components/Blocks/OpeningHours/OpeningHours';
 import { OpeningStatus } from 'components/Blocks/OpeningHours/OpeningStatus';
-import { Remove } from 'components/Basic/Icon/IconsSvg';
+import { RemoveIcon } from 'components/Basic/Icon/IconsSvg';
 
 type StoreInfoBoxProps = {
     store: ListedStoreFragmentApi;
@@ -16,7 +16,7 @@ export const StoreInfoBox: FC<StoreInfoBoxProps> = ({ store, closeInfoBoxCallbac
 
     return (
         <div className="top-0 left-0 z-above flex h-full w-full flex-col items-center justify-center bg-white py-4 text-center vl:absolute vl:px-10">
-            <Remove
+            <RemoveIcon
                 onClick={closeInfoBoxCallback}
                 className="absolute top-4 right-4 w-5 cursor-pointer text-primary transition-colors hover:text-orangeDarker "
             />

--- a/project-base/storefront/components/Pages/Stores/StoreInfoBox.tsx
+++ b/project-base/storefront/components/Pages/Stores/StoreInfoBox.tsx
@@ -1,5 +1,4 @@
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { Link } from 'components/Basic/Link/Link';
 import { ListedStoreFragmentApi } from 'graphql/generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -17,9 +16,8 @@ export const StoreInfoBox: FC<StoreInfoBoxProps> = ({ store, closeInfoBoxCallbac
 
     return (
         <div className="top-0 left-0 z-above flex h-full w-full flex-col items-center justify-center bg-white py-4 text-center vl:absolute vl:px-10">
-            <Icon
+            <Remove
                 onClick={closeInfoBoxCallback}
-                icon={<Remove />}
                 className="absolute top-4 right-4 w-5 cursor-pointer text-primary transition-colors hover:text-orangeDarker "
             />
 

--- a/project-base/storefront/components/Pages/Stores/StoresContent.tsx
+++ b/project-base/storefront/components/Pages/Stores/StoresContent.tsx
@@ -1,7 +1,6 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { StoreInfoBox } from './StoreInfoBox';
 import { Heading } from 'components/Basic/Heading/Heading';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { SeznamMap } from 'components/Basic/SeznamMap/SeznamMap';
 import { SimpleLayout } from 'components/Layout/SimpleLayout/SimpleLayout';
 import { BreadcrumbFragmentApi, ListedStoreConnectionFragmentApi, ListedStoreFragmentApi } from 'graphql/generated';
@@ -96,7 +95,7 @@ export const StoresContent: FC<StoresContentProps> = ({ stores, breadcrumbs }) =
                                 >
                                     <>
                                         <div className="flex flex-row items-center text-lg text-primary">
-                                            <Icon icon={<Marker />} className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
+                                            <Marker className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
                                             <StoreButton>{store.name}</StoreButton>
                                         </div>
 

--- a/project-base/storefront/components/Pages/Stores/StoresContent.tsx
+++ b/project-base/storefront/components/Pages/Stores/StoresContent.tsx
@@ -12,7 +12,7 @@ import Image from 'next/image';
 import { useCallback, useMemo, useState } from 'react';
 import { twJoin } from 'tailwind-merge';
 import { MapMarker } from 'types/map';
-import { Marker } from 'components/Basic/Icon/IconsSvg';
+import { MarkerIcon } from 'components/Basic/Icon/IconsSvg';
 
 type StoresContentProps = {
     stores: ListedStoreConnectionFragmentApi;
@@ -95,7 +95,7 @@ export const StoresContent: FC<StoresContentProps> = ({ stores, breadcrumbs }) =
                                 >
                                     <>
                                         <div className="flex flex-row items-center text-lg text-primary">
-                                            <Marker className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
+                                            <MarkerIcon className="mr-3 w-6 text-2xl text-orange xl:mr-5" />
                                             <StoreButton>{store.name}</StoreButton>
                                         </div>
 

--- a/project-base/storefront/components/Pages/Wishlist/Wishlist.tsx
+++ b/project-base/storefront/components/Pages/Wishlist/Wishlist.tsx
@@ -9,7 +9,7 @@ import { useDomainConfig } from 'hooks/useDomainConfig';
 import { useRouter } from 'next/router';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
 import { useWishlist } from 'hooks/useWishlist';
-import { RemoveThin } from 'components/Basic/Icon/IconsSvg';
+import { RemoveThinIcon } from 'components/Basic/Icon/IconsSvg';
 
 export const Wishlist: FC = () => {
     const { t } = useTranslation();
@@ -51,7 +51,7 @@ export const Wishlist: FC = () => {
                             }}
                         >
                             <span className="mr-3 text-sm">{t('Delete all from wishlist')}</span>
-                            <RemoveThin className="w-3" />
+                            <RemoveThinIcon className="w-3" />
                         </div>
                         <div className="flex w-full flex-col items-center lg:w-1/2 lg:flex-row">
                             <TextInput

--- a/project-base/storefront/components/Pages/Wishlist/Wishlist.tsx
+++ b/project-base/storefront/components/Pages/Wishlist/Wishlist.tsx
@@ -7,7 +7,6 @@ import { TextInput } from 'components/Forms/TextInput/TextInput';
 import { Button } from 'components/Forms/Button/Button';
 import { useDomainConfig } from 'hooks/useDomainConfig';
 import { useRouter } from 'next/router';
-import { Icon } from 'components/Basic/Icon/Icon';
 import { LoaderWithOverlay } from 'components/Basic/Loader/LoaderWithOverlay';
 import { useWishlist } from 'hooks/useWishlist';
 import { RemoveThin } from 'components/Basic/Icon/IconsSvg';
@@ -52,7 +51,7 @@ export const Wishlist: FC = () => {
                             }}
                         >
                             <span className="mr-3 text-sm">{t('Delete all from wishlist')}</span>
-                            <Icon icon={<RemoveThin />} className="w-3" />
+                            <RemoveThin className="w-3" />
                         </div>
                         <div className="flex w-full flex-col items-center lg:w-1/2 lg:flex-row">
                             <TextInput

--- a/project-base/storefront/styles/globals.css
+++ b/project-base/storefront/styles/globals.css
@@ -72,6 +72,10 @@ input::-webkit-inner-spin-button {
     -webkit-appearance: none;
 }
 
+svg {
+    @apply inline-flex h-full w-[14px] text-center font-normal normal-case leading-none;
+}
+
 /* Firefox */
 input[type='number'] {
     -moz-appearance: textfield;
@@ -88,7 +92,7 @@ input[type='number'] {
 }
 
 .select__indicator {
-    @apply !flex h-12 w-12 !items-center !justify-center !p-0 transition-all [&_i]:!text-greyDark;
+    @apply !flex h-12 w-12 !items-center !justify-center !p-0 transition-all;
 }
 
 .select__menu {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Migrate SVG icons to place where they're used. SVG icon are now separated from Icon component. Because <i> element is removed resulted DOM is smaller. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1677-remove-i-element-from-icon.odin.shopsys.cloud
  - https://cz.tv-fw-1677-remove-i-element-from-icon.odin.shopsys.cloud
<!-- Replace -->
