### PR TITLE
[project-base] filtering in ready category seo mix is now working with provided filters by API

### DIFF
--- a/project-base/app/src/FrontendApi/Resolver/Products/ProductsQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/ProductsQuery.php
@@ -102,7 +102,14 @@ class ProductsQuery extends BaseProductsQuery
         } elseif ($categoryOrReadyCategorySeoMix instanceof ReadyCategorySeoMix) {
             $category = $categoryOrReadyCategorySeoMix->getCategory();
             $readyCategorySeoMix = $categoryOrReadyCategorySeoMix;
-            $productFilterData = $this->productFilterDataFactory->createProductFilterDataFromReadyCategorySeoMix($categoryOrReadyCategorySeoMix);
+
+            $productFilterData = $this->productFilterFacade->getValidatedProductFilterDataForCategory(
+                $argument,
+                $category,
+            );
+
+            $this->productFilterDataFactory->updateProductFilterDataFromReadyCategorySeoMix($categoryOrReadyCategorySeoMix, $productFilterData);
+
             $orderingMode = $categoryOrReadyCategorySeoMix->getOrdering();
             $defaultOrderingMode = $orderingMode;
         } else {

--- a/project-base/app/src/Model/Product/Filter/ProductFilterDataFactory.php
+++ b/project-base/app/src/Model/Product/Filter/ProductFilterDataFactory.php
@@ -18,15 +18,15 @@ class ProductFilterDataFactory
 
     /**
      * @param \App\Model\CategorySeo\ReadyCategorySeoMix $readyCategorySeoMix
-     * @return \App\Model\Product\Filter\ProductFilterData
+     * @param \App\Model\Product\Filter\ProductFilterData $productFilterData
      */
-    public function createProductFilterDataFromReadyCategorySeoMix(
+    public function updateProductFilterDataFromReadyCategorySeoMix(
         ReadyCategorySeoMix $readyCategorySeoMix,
-    ): ProductFilterData {
-        $productFilterData = $this->create();
-
+        ProductFilterData $productFilterData,
+    ): void {
         if ($readyCategorySeoMix->getFlag() !== null) {
-            $productFilterData->flags = [$readyCategorySeoMix->getFlag()];
+            $productFilterData->flags[] = $readyCategorySeoMix->getFlag();
+            $productFilterData->flags = array_values($productFilterData->flags);
         }
 
         foreach ($readyCategorySeoMix->getReadyCategorySeoMixParameterParameterValues() as $readyCategorySeoMixParameterParameterValue) {
@@ -35,7 +35,5 @@ class ProductFilterDataFactory
             $parameterFilterData->values = [$readyCategorySeoMixParameterParameterValue->getParameterValue()];
             $productFilterData->parameters[] = $parameterFilterData;
         }
-
-        return $productFilterData;
     }
 }

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -33,3 +33,5 @@ There you can find links to upgrade notes for other versions too.
     - see #project-base-diff to update your project
 - fix product video UX ([#2746](https://github.com/shopsys/shopsys/pull/2746))
     - see #project-base-diff to update your project
+- fix filtering in ReadyCategorySeoMix ([#2747](https://github.com/shopsys/shopsys/pull/2747))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ReadyCategorySeoMix filter was created only for RCSM settings, but now correctly includes filters send via API
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-seo-mix-filters.odin.shopsys.cloud
  - https://cz.tl-fix-seo-mix-filters.odin.shopsys.cloud
<!-- Replace -->
