### PR TITLE
[monorepo-tools] let the user decide if he wants to proceed with one repo

### DIFF
--- a/packages/monorepo-tools/monorepo_build.sh
+++ b/packages/monorepo-tools/monorepo_build.sh
@@ -14,7 +14,13 @@ if [ "$#" -lt "2" ]; then
     echo 'Please provide at least 2 remotes to be merged into a new monorepo'
     echo 'Usage: monorepo_build.sh <remote-name>[:<subdirectory>] <remote-name>[:<subdirectory>] ...'
     echo 'Example: monorepo_build.sh main-repository package-alpha:packages/alpha package-beta:packages/beta'
-    exit
+    read -p "Do you want to proceed? (y/n) " yn
+    case $yn in 
+    	[yY] ) echo Proceeding;
+    		break;;
+    	* ) echo exiting...;
+    		exit;;
+    esac
 fi
 # Get directory of the other scripts
 MONOREPO_SCRIPT_DIR=$(dirname "$0")


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We are in need of using only 1 repo as an argument
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No, but could break if script is used in automatization where only one repo was provided <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

We're using the [monorepo-tools](https://github.com/shopsys/monorepo-tools) quite frequently and it makes sense, in our context, to build a monorepo with only one repo and add other repos later.
We are currently commenting out the exit to use the tools to fit our needs, but better practice would be to let the user decide if he wants to use only 1 repo.

I had created a [PR](https://github.com/shopsys/monorepo-tools/pull/2) in the monorepo-tools repo before realizing it had to be opened here.