### PR TITLE
added more info about error types to SF middleware

### DIFF
--- a/project-base/storefront/middleware.ts
+++ b/project-base/storefront/middleware.ts
@@ -43,7 +43,7 @@ export const middleware: NextMiddleware = async (request) => {
         });
 
         if (!pageTypeResponse.ok) {
-            return NextResponse.rewrite(new URL(ERROR_PAGE_ROUTE, request.url));
+            return NextResponse.rewrite(new URL(ERROR_PAGE_ROUTE, request.url), { status: 404 });
         }
 
         const pageTypeParsedResponse: { route: FriendlyPageTypesValue; redirectTo: string } =
@@ -60,7 +60,10 @@ export const middleware: NextMiddleware = async (request) => {
     } catch (e) {
         logException(e);
 
-        return NextResponse.rewrite(new URL(ERROR_PAGE_ROUTE, request.url));
+        return NextResponse.rewrite(new URL(ERROR_PAGE_ROUTE, request.url), {
+            status: 500,
+            statusText: 'Middleware runtime error',
+        });
     }
 };
 
@@ -81,7 +84,7 @@ const rewriteDynamicPages = (pageType: FriendlyPageTypesValue, rewriteUrl: strin
         host,
     );
 
-    return NextResponse.rewrite(newUrl);
+    return NextResponse.rewrite(newUrl, pageTypeKey ? undefined : { status: 404 });
 };
 
 const getHostFromRequest = (request: NextRequest): string => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|adding more infor to middleware errors allowed for better error filtration in _error.tsx. Since errors from middleware do not contain `err` in context, the condition in _error.tsx which was logging errors for all 404s caused by the middleware is now removed.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-middleware-errors.odin.shopsys.cloud
  - https://cz.sh-middleware-errors.odin.shopsys.cloud
<!-- Replace -->
