### PR TITLE
[project-base] SEO categories are now returned even when ignored filters are set

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
@@ -156,7 +156,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
         $choseCategorySeoMixCombinationArray['flagId'] = null;
         $choseCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
             // 'Colour' => 'Black'
-            62 => 199,
+            63 => 210,
         ];
         $this->createReadyCategorySeoMix(
             ChoseCategorySeoMixCombination::createFromArray($choseCategorySeoMixCombinationArray),
@@ -172,7 +172,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
 
         $choseCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
             // 'Colour' => 'Red'
-            62 => 197,
+            63 => 206,
         ];
         $this->createReadyCategorySeoMix(
             ChoseCategorySeoMixCombination::createFromArray($choseCategorySeoMixCombinationArray),

--- a/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
@@ -132,6 +132,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
             t('meta description of Electronics from most expensive seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
         );
 
+        $choseCategorySeoMixCombinationArray['ordering'] = ProductListOrderingConfig::ORDER_BY_PRIORITY;
         $choseCategorySeoMixCombinationArray['flagId'] = null;
         $choseCategorySeoMixCombinationArray['parameterValueIdsByParameterIds'] = [
             // 'USB' => 'Yes'

--- a/project-base/app/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
+++ b/project-base/app/src/Model/CategorySeo/ReadyCategorySeoMixFacade.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\UrlListData;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\Exception\ParameterNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter;
 
 class ReadyCategorySeoMixFacade
@@ -311,6 +312,13 @@ class ReadyCategorySeoMixFacade
         $parameterValueIdsByParameterId = [];
 
         foreach ($parametersFilterData as $parameterFilterData) {
+            if (array_key_exists($parameterFilterData['parameter'], $parameterIdsByUuids) === false) {
+                throw new ParameterNotFoundException(sprintf(
+                    'Parameter with uuid "%s" was not found',
+                    $parameterFilterData['parameter'],
+                ));
+            }
+
             $parameterId = $parameterIdsByUuids[$parameterFilterData['parameter']];
 
             if (count($parameterFilterData['values']) === 0) {
@@ -319,7 +327,16 @@ class ReadyCategorySeoMixFacade
                 $text = $parameterFilterData['minimalValue'];
                 $parameterValueId = $this->parameterFacade->getParameterValueIdByText((string)$text, $currentLocale);
             } else {
-                $parameterValueId = $parameterValueIdsByUuids[reset($parameterFilterData['values'])];
+                $parameterUuid = reset($parameterFilterData['values']);
+
+                if (array_key_exists($parameterUuid, $parameterValueIdsByUuids) === false) {
+                    throw new ParameterValueNotFoundException(sprintf(
+                        'Parameter value with uuid "%s" was not found',
+                        $parameterUuid,
+                    ));
+                }
+
+                $parameterValueId = $parameterValueIdsByUuids[$parameterUuid];
             }
             $parameterValueIdsByParameterId[$parameterId] = $parameterValueId;
         }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Category/ReadyCategorySeoMix/ReadyCategorySeoMixTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Category/ReadyCategorySeoMix/ReadyCategorySeoMixTest.php
@@ -286,7 +286,7 @@ class ReadyCategorySeoMixTest extends GraphQlTestCase
         $categoryPc = $this->getReference(CategoryDataFixture::CATEGORY_PC);
         $categoryPcSlug = $this->urlGenerator->generate('front_product_list', ['id' => $categoryPc->getId()]);
         $data = $this->getDataForCategorySeoMixPcNewWithUsb(__DIR__ . '/../../_graphql/query/ReadyCategorySeoMixQuery.graphql', [
-            'orderingMode' => 'PRIORITY',
+            'orderingMode' => 'NAME_ASC',
         ]);
 
         $this->assertNull($data['originalCategorySlug']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| SEO categories are now returned even when ignored filters (price, brand and availability) are set.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-correct-seo-mix-category-url.odin.shopsys.cloud
  - https://cz.tl-correct-seo-mix-category-url.odin.shopsys.cloud
<!-- Replace -->
