### PR TITLE
[project-base] fixed elasticsearch definition to have correct languages set by default domain languages

### DIFF
--- a/project-base/app/src/Resources/definition/article/1.json
+++ b/project-base/app/src/Resources/definition/article/1.json
@@ -6,13 +6,13 @@
     },
     "analysis": {
       "filter": {
-        "czech_stop": {
+        "english_stop": {
           "type": "stop",
-          "stopwords": "_czech_"
+          "stopwords": "_english_"
         },
-        "czech_stemmer": {
+        "english_stemmer": {
           "type": "stemmer",
-          "language": "czech"
+          "language": "english"
         },
         "edge_ngram": {
           "type": "edgeNGram",
@@ -44,8 +44,8 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "czech_stemmer",
-            "czech_stop",
+            "english_stemmer",
+            "english_stop",
             "asciifolding"
           ]
         },
@@ -135,7 +135,7 @@
           },
           "keyword": {
             "type": "icu_collation_keyword",
-            "language": "cs",
+            "language": "en",
             "index": false
           }
         }
@@ -146,7 +146,9 @@
         "search_analyzer": "full_without_diacritic"
       },
       "text": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "edge_ngram_without_diacritic_html",
+        "search_analyzer": "full_without_diacritic_html"
       },
       "url": {
         "type": "text"

--- a/project-base/app/src/Resources/definition/article/2.json
+++ b/project-base/app/src/Resources/definition/article/2.json
@@ -6,22 +6,13 @@
     },
     "analysis": {
       "filter": {
-        "slovak_stop": {
+        "czech_stop": {
           "type": "stop",
-          "stopwords": ["﻿a", "aby", "aj", "ak", "ako", "ale", "alebo", "and", "ani", "áno", "asi", "až", "bez", "bude",
-            "budem", "budeš", "budeme", "budete", "budú", "by", "bol", "bola", "boli", "bolo", "byť", "cez",
-            "čo", "či", "ďalší", "ďalšia", "ďalšie", "dnes", "do", "ho", "ešte", "for", "i", "ja", "je", "jeho", "jej",
-            "ich", "iba", "iné", "iný", "som", "si", "sme", "sú", "k", "kam", "každý", "každá", "každé", "každí", "kde",
-            "keď", "kto", "ktorá", "ktoré", "ktorou", "ktorý", "ktorí", "ku", "lebo", "len", "ma", "mať", "má", "máte",
-            "medzi", "mi", "mna", "mne", "mnou", "musieť", "môcť", "môj", "môže", "my", "na", "nad", "nám", "náš",
-            "naši", "nie", "nech", "než", "nič", "niektorý", "nové", "nový", "nová", "nové", "noví", "o", "od", "odo",
-            "of", "on", "ona", "ono", "oni", "ony", "po", "pod", "podľa", "pokiaľ", "potom", "práve", "pre", "prečo",
-            "preto", "pretože", "prvý", "prvá", "prvé", "prví", "pred", "predo", "pri", "pýta", "s", "sa", "so", "si",
-            "svoje", "svoj", "svojich", "svojím", "svojími", "ta", "tak", "takže", "táto", "teda", "te", "tě", "ten",
-            "tento", "the", "tieto", "tým", "týmto", "tiež", "to", "toto", "toho", "tohoto", "tom", "tomto", "tomuto",
-            "toto", "tu", "tú", "túto", "tvoj", "ty", "tvojími", "už", "v", "vám", "váš", "vaše", "vo", "viac", "však",
-            "všetok", "vy", "z", "za", "zo", "že"
-          ]
+          "stopwords": "_czech_"
+        },
+        "czech_stemmer": {
+          "type": "stemmer",
+          "language": "czech"
         },
         "edge_ngram": {
           "type": "edgeNGram",
@@ -53,8 +44,9 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "asciifolding",
-            "slovak_stop"
+            "czech_stemmer",
+            "czech_stop",
+            "asciifolding"
           ]
         },
         "edge_ngram_with_diacritic": {
@@ -154,9 +146,7 @@
         "search_analyzer": "full_without_diacritic"
       },
       "text": {
-        "type": "text",
-        "analyzer": "edge_ngram_without_diacritic_html",
-        "search_analyzer": "full_without_diacritic_html"
+        "type": "text"
       },
       "url": {
         "type": "text"

--- a/project-base/app/src/Resources/definition/blog_article/1.json
+++ b/project-base/app/src/Resources/definition/blog_article/1.json
@@ -6,13 +6,13 @@
     },
     "analysis": {
       "filter": {
-        "czech_stop": {
+        "english_stop": {
           "type": "stop",
-          "stopwords": "_czech_"
+          "stopwords": "_english_"
         },
-        "czech_stemmer": {
+        "english_stemmer": {
           "type": "stemmer",
-          "language": "czech"
+          "language": "english"
         },
         "edge_ngram": {
           "type": "edgeNGram",
@@ -44,8 +44,8 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "czech_stemmer",
-            "czech_stop",
+            "english_stemmer",
+            "english_stop",
             "asciifolding"
           ]
         },
@@ -135,7 +135,7 @@
           },
           "keyword": {
             "type": "icu_collation_keyword",
-            "language": "cs",
+            "language": "en",
             "index": false
           }
         }
@@ -147,13 +147,15 @@
         "fields": {
           "keyword": {
             "type": "icu_collation_keyword",
-            "language": "cs",
+            "language": "en",
             "index": false
           }
         }
       },
       "text": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "edge_ngram_without_diacritic_html",
+        "search_analyzer": "full_without_diacritic_html"
       },
       "url": {
         "type": "text"
@@ -198,7 +200,7 @@
           "name": {
             "type": "text"
           },
-          "slug":  {
+          "slug": {
             "type": "keyword"
           }
         }

--- a/project-base/app/src/Resources/definition/blog_article/2.json
+++ b/project-base/app/src/Resources/definition/blog_article/2.json
@@ -6,22 +6,13 @@
     },
     "analysis": {
       "filter": {
-        "slovak_stop": {
+        "czech_stop": {
           "type": "stop",
-          "stopwords": ["﻿a", "aby", "aj", "ak", "ako", "ale", "alebo", "and", "ani", "áno", "asi", "až", "bez", "bude",
-            "budem", "budeš", "budeme", "budete", "budú", "by", "bol", "bola", "boli", "bolo", "byť", "cez",
-            "čo", "či", "ďalší", "ďalšia", "ďalšie", "dnes", "do", "ho", "ešte", "for", "i", "ja", "je", "jeho", "jej",
-            "ich", "iba", "iné", "iný", "som", "si", "sme", "sú", "k", "kam", "každý", "každá", "každé", "každí", "kde",
-            "keď", "kto", "ktorá", "ktoré", "ktorou", "ktorý", "ktorí", "ku", "lebo", "len", "ma", "mať", "má", "máte",
-            "medzi", "mi", "mna", "mne", "mnou", "musieť", "môcť", "môj", "môže", "my", "na", "nad", "nám", "náš",
-            "naši", "nie", "nech", "než", "nič", "niektorý", "nové", "nový", "nová", "nové", "noví", "o", "od", "odo",
-            "of", "on", "ona", "ono", "oni", "ony", "po", "pod", "podľa", "pokiaľ", "potom", "práve", "pre", "prečo",
-            "preto", "pretože", "prvý", "prvá", "prvé", "prví", "pred", "predo", "pri", "pýta", "s", "sa", "so", "si",
-            "svoje", "svoj", "svojich", "svojím", "svojími", "ta", "tak", "takže", "táto", "teda", "te", "tě", "ten",
-            "tento", "the", "tieto", "tým", "týmto", "tiež", "to", "toto", "toho", "tohoto", "tom", "tomto", "tomuto",
-            "toto", "tu", "tú", "túto", "tvoj", "ty", "tvojími", "už", "v", "vám", "váš", "vaše", "vo", "viac", "však",
-            "všetok", "vy", "z", "za", "zo", "že"
-          ]
+          "stopwords": "_czech_"
+        },
+        "czech_stemmer": {
+          "type": "stemmer",
+          "language": "czech"
         },
         "edge_ngram": {
           "type": "edgeNGram",
@@ -53,8 +44,9 @@
           "tokenizer": "standard",
           "filter": [
             "lowercase",
-            "asciifolding",
-            "slovak_stop"
+            "czech_stemmer",
+            "czech_stop",
+            "asciifolding"
           ]
         },
         "edge_ngram_with_diacritic": {
@@ -161,9 +153,7 @@
         }
       },
       "text": {
-        "type": "text",
-        "analyzer": "edge_ngram_without_diacritic_html",
-        "search_analyzer": "full_without_diacritic_html"
+        "type": "text"
       },
       "url": {
         "type": "text"
@@ -208,7 +198,7 @@
           "name": {
             "type": "text"
           },
-          "slug": {
+          "slug":  {
             "type": "keyword"
           }
         }

--- a/project-base/app/src/Resources/definition/product/1.json
+++ b/project-base/app/src/Resources/definition/product/1.json
@@ -135,7 +135,7 @@
           },
           "keyword": {
             "type": "icu_collation_keyword",
-            "language": "cs",
+            "language": "en",
             "index": false
           }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After the merge of Shopsys Framework and Commerce Cloud were these definitions omitted, this PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-elastiscearch-definitions.odin.shopsys.cloud
  - https://cz.tl-fix-elastiscearch-definitions.odin.shopsys.cloud
<!-- Replace -->
