### PR TITLE
[docs] added coding standards upgrade notes

### DIFF
--- a/upgrade/UPGRADE-v12.0.0-dev.md
+++ b/upgrade/UPGRADE-v12.0.0-dev.md
@@ -562,6 +562,9 @@ There you can find links to upgrade notes for other versions too.
             )
         ```
 - apply new coding standards in your application
+   - during run of `composer install` you will run into errors and warnings about not compatible types in your app because of introduction of typed properties and parameters in vendor classes, and you have to fix these problems manually
+   - go through all of your `Command` classes that extend `\Symfony\Component\Console\Command\Command` and add `@phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint` annotation to `$defaultName` property
+   - if you have any `Constraints` implemented in your project add `@phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint` annotation to your `$errorNames` property
    - run `php phing standards-fix` multiple times after no problems are found or after only problems that need to be fixed manually are found
        - fix all manually fixable problems
    - run `php phing phpstan` and fix all problems found


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We got feedback about upgrading to 12.0-dev and we wanted to use it to improve our upgrade notes.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
