### PR TITLE
[docs] updated PHPStorm settings to use absolute paths for TypeScript

### DIFF
--- a/project-base/app/config/phpstorm/phpstorm.xml
+++ b/project-base/app/config/phpstorm/phpstorm.xml
@@ -35,6 +35,7 @@
     <option name="ENFORCE_TRAILING_COMMA" value="WhenMultiline" />
     <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
     <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    <option name="IMPORT_PREFER_ABSOLUTE_PATH" value="true" />
   </TypeScriptCodeStyleSettings>
   <codeStyleSettings language="JSON">
     <indentOptions>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| TypeScript setting in phpstorm.xml were outdated
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-updated-typescript-phpstorm-setting.odin.shopsys.cloud
  - https://cz.tl-updated-typescript-phpstorm-setting.odin.shopsys.cloud
<!-- Replace -->
