### PR TITLE
[project-base] reduced image url redis cache size

### DIFF
--- a/project-base/app/src/Component/Image/ImageFacade.php
+++ b/project-base/app/src/Component/Image/ImageFacade.php
@@ -271,7 +271,6 @@ class ImageFacade extends BaseImageFacade
         $cacheId = $this->getCacheIdForImageUrl(
             $image->getId(),
             $domainConfig->getId(),
-            $additionalSizeIndex,
         );
 
         $friendlyUrlSeoEntityName = $this->cache->get(
@@ -414,19 +413,16 @@ class ImageFacade extends BaseImageFacade
     /**
      * @param int $imageId
      * @param int $domainId
-     * @param int|null $additionalIndex
      * @return string
      */
     private function getCacheIdForImageUrl(
         int $imageId,
         int $domainId,
-        ?int $additionalIndex = null,
     ): string {
         return sprintf(
-            'ImageUrl_imageId-%d_domainId-%d_type-%s',
+            'ImageUrl_imageId-%d_domainId-%d',
             $imageId,
             $domainId,
-            $additionalIndex,
         );
     }
 }

--- a/project-base/app/src/Component/Image/ImageFacade.php
+++ b/project-base/app/src/Component/Image/ImageFacade.php
@@ -105,23 +105,24 @@ class ImageFacade extends BaseImageFacade
         ?string $type = null,
     ): string {
         $image = $this->getImageByObject($imageOrEntity, $type);
-        $cacheId = $this->getCacheIdForImageUrl($image->getId(), $domainConfig->getId(), $type, $sizeName);
+        $cacheId = $this->getCacheIdForImageUrl($image->getId(), $domainConfig->getId());
 
-        return $this->cache->get(
+        $friendlyUrlSeoEntityName = $this->cache->get(
             $cacheId,
-            function () use ($image, $domainConfig, $sizeName) {
+            function () use ($image, $domainConfig) {
                 if (!$this->imageLocator->imageExists($image)) {
                     throw new ImageNotFoundException();
                 }
 
                 $seoEntityName = $this->getSeoNameByImageAndLocale($image, $domainConfig->getLocale());
-                $friendlyUrlSeoEntityName = $this->getFriendlyUrlSlug($seoEntityName);
 
-                return $this->cdnFacade->resolveDomainUrlForAssets($domainConfig)
-                    . $this->imageUrlPrefix
-                    . $this->imageLocator->getRelativeImageFilepathWithSlug($image, $sizeName, $friendlyUrlSeoEntityName);
+                return $this->getFriendlyUrlSlug($seoEntityName);
             },
         );
+
+        return $this->cdnFacade->resolveDomainUrlForAssets($domainConfig)
+            . $this->imageUrlPrefix
+            . $this->imageLocator->getRelativeImageFilepathWithSlug($image, $sizeName, $friendlyUrlSeoEntityName);
     }
 
     /**
@@ -270,26 +271,25 @@ class ImageFacade extends BaseImageFacade
         $cacheId = $this->getCacheIdForImageUrl(
             $image->getId(),
             $domainConfig->getId(),
-            $image->getType(),
-            $sizeName,
             $additionalSizeIndex,
         );
 
-        return $this->cache->get(
+        $friendlyUrlSeoEntityName = $this->cache->get(
             $cacheId,
-            function () use ($image, $domainConfig, $additionalSizeIndex, $sizeName) {
+            function () use ($image, $domainConfig) {
                 if (!$this->imageLocator->imageExists($image)) {
                     throw new ImageNotFoundException();
                 }
 
                 $seoEntityName = $this->getSeoNameByImageAndLocale($image, $domainConfig->getLocale());
-                $friendlyUrlSeoEntityName = $this->getFriendlyUrlSlug($seoEntityName);
 
-                return $this->cdnFacade->resolveDomainUrlForAssets($domainConfig)
-                    . $this->imageUrlPrefix
-                    . $this->imageLocator->getRelativeAdditionalImageFilepathWithSlug($image, $additionalSizeIndex, $sizeName, $friendlyUrlSeoEntityName);
+                return $this->getFriendlyUrlSlug($seoEntityName);
             },
         );
+
+        return $this->cdnFacade->resolveDomainUrlForAssets($domainConfig)
+            . $this->imageUrlPrefix
+            . $this->imageLocator->getRelativeAdditionalImageFilepathWithSlug($image, $additionalSizeIndex, $sizeName, $friendlyUrlSeoEntityName);
     }
 
     /**
@@ -412,34 +412,20 @@ class ImageFacade extends BaseImageFacade
     }
 
     /**
-     * @return bool
-     */
-    public function clearImageCache(): bool
-    {
-        return $this->cache->clear();
-    }
-
-    /**
      * @param int $imageId
      * @param int $domainId
-     * @param string|null $type
-     * @param string|null $sizeName
      * @param int|null $additionalIndex
      * @return string
      */
     private function getCacheIdForImageUrl(
         int $imageId,
         int $domainId,
-        ?string $type,
-        ?string $sizeName,
         ?int $additionalIndex = null,
     ): string {
         return sprintf(
-            'ImageUrl_imageId-%d_domainId-%d_type-%s_size-%s_additionalIndex-%s',
+            'ImageUrl_imageId-%d_domainId-%d_type-%s',
             $imageId,
             $domainId,
-            $type,
-            $sizeName,
             $additionalIndex,
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Only information about the source image is saved into the Redis cache as nothing else is necessary.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-reduce-redis-cache-size.odin.shopsys.cloud
  - https://cz.tl-reduce-redis-cache-size.odin.shopsys.cloud
<!-- Replace -->
