### PR TITLE
[project-base] gitlab-ci: updated grep to next_public check works

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -83,6 +83,7 @@ test:storefront-standards-with-codegen:
         - corepack enable
         - corepack prepare --activate pnpm@8.6.0
         - pnpm config set store-dir .pnpm-store
+        - apk add --no-cache grep
         - cp ./app/schema.graphql ./storefront/schema.graphql
         - cd ./storefront
     script:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Default version of grep in nodejs-alpine image does not allow --exclude option. This PR updates the grep before the check for NEXT_PUBLIC_* variables is performed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-gitlab-next-fix.odin.shopsys.cloud
  - https://cz.mg-gitlab-next-fix.odin.shopsys.cloud
<!-- Replace -->
