### PR TITLE
[framework] upgraded doctrine/orm to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,8 +179,7 @@
         "zalas/phpunit-injector": "^2.0"
     },
     "conflict": {
-        "symfony/symfony": "*",
-        "doctrine/orm": "2.12.0 || >=2.16.0"
+        "symfony/symfony": "*"
     },
     "scripts": {
         "post-install-cmd": [

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -117,9 +117,6 @@
             "docker": false
         }
     },
-    "conflict": {
-        "doctrine/orm": "2.12.0 || >=2.16.0"
-    },
     "suggest": {
         "ext-pgsql": "Required for dumping the Postgres database in shopsys:database:dump command"
     },

--- a/packages/framework/src/Model/Order/Order.php
+++ b/packages/framework/src/Model/Order/Order.php
@@ -313,6 +313,7 @@ class Order
         $this->createdAsAdministratorName = $orderData->createdAsAdministratorName;
         $this->origin = $orderData->origin;
         $this->uuid = $orderData->uuid ?: Uuid::uuid4()->toString();
+        $this->setTotalPrice(new OrderTotalPrice(Money::zero(), Money::zero(), Money::zero()));
     }
 
     /**

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -120,17 +120,15 @@ class OrderFacade
             $customerUser,
         );
 
-        $this->fillOrderItems($order, $orderPreview);
+        $this->em->persist($order);
+        $this->em->flush();
 
-        foreach ($order->getItems() as $orderItem) {
-            $this->em->persist($orderItem);
-        }
+        $this->fillOrderItems($order, $orderPreview);
 
         $order->setTotalPrice(
             $this->orderPriceCalculation->getOrderTotalPrice($order),
         );
 
-        $this->em->persist($order);
         $this->em->flush();
 
         return $order;

--- a/upgrade/UPGRADE-v12.0.0-dev.md
+++ b/upgrade/UPGRADE-v12.0.0-dev.md
@@ -866,3 +866,5 @@ There you can find links to upgrade notes for other versions too.
             ```
     - remove setter injection in `App\Controller\Front\RobotsController`
         - see #project-base-diff for more details
+- update doctrine/orm to latest version ([#2774](https://github.com/shopsys/shopsys/pull/2774))
+    - see #project-base-diff for more details

--- a/upgrade/UPGRADE-v12.0.0-dev.md
+++ b/upgrade/UPGRADE-v12.0.0-dev.md
@@ -866,5 +866,3 @@ There you can find links to upgrade notes for other versions too.
             ```
     - remove setter injection in `App\Controller\Front\RobotsController`
         - see #project-base-diff for more details
-- update doctrine/orm to latest version ([#2774](https://github.com/shopsys/shopsys/pull/2774))
-    - see #project-base-diff for more details


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were some problems with the order of Order Items when upgrading to the newest doctrine/orm. This has been fixed and the restriction to older doctrine/orm has been removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
