### PR TITLE
[project-base] fixed JS translations

### DIFF
--- a/project-base/app/assets/js/bin/helpers/sources.js
+++ b/project-base/app/assets/js/bin/helpers/sources.js
@@ -1,13 +1,5 @@
 const fs = require('fs');
 
-const getFrameworkVendorDir = () => {
-    if (isMonorepo()) {
-        return '../packages/framework';
-    }
-
-    return './vendor/shopsys/framework';
-};
-
 const getFrameworkNodeModulesDir = () => {
     if (isMonorepo()) {
         return '../packages/framework/assets';
@@ -20,4 +12,4 @@ const isMonorepo = () => {
     return fs.existsSync('../packages');
 };
 
-module.exports = { getFrameworkVendorDir, getFrameworkNodeModulesDir };
+module.exports = { getFrameworkNodeModulesDir };

--- a/project-base/app/assets/js/commands/translations/fileWalker.js
+++ b/project-base/app/assets/js/commands/translations/fileWalker.js
@@ -6,7 +6,13 @@ function fileWalker (dirs, done, ignoreMocks = true) {
     }
 
     const promises = dirs.map(dir => new Promise((resolve, reject) => {
-        glob(dir, { ignore: '**/node_modules/**' }, (err, filePaths) => {
+        let ignore = {};
+
+        if (!dir.match(/\/node_modules\//)) {
+            ignore = { ignore: '**/node_modules/**' };
+        }
+
+        glob(dir, ignore, (err, filePaths) => {
             if (err) {
                 reject(err);
             }

--- a/project-base/app/assets/js/commands/translations/findAndSaveTranslations.js
+++ b/project-base/app/assets/js/commands/translations/findAndSaveTranslations.js
@@ -45,7 +45,13 @@ function findAndSaveTranslations (translations, dirWithJsFiles, dirWithTranslati
                         allTranslations[translatedObject.lang] = [];
                     }
 
-                    allTranslations[translatedObject.lang] = allTranslations[translatedObject.lang].concat(translatedObject.translated);
+                    const filteredTranslated = translatedObject.translated.filter(
+                        item => !allTranslations[translatedObject.lang].some(
+                            translation => translation.msgid === item.msgid
+                        ) && item.msgstr !== ''
+                    );
+
+                    allTranslations[translatedObject.lang] = allTranslations[translatedObject.lang].concat(filteredTranslated);
                 });
 
             fs.writeFile(outputDirForExportedTranslations + 'translations.json', JSON.stringify(allTranslations), (writeErr) => {

--- a/project-base/app/package.json
+++ b/project-base/app/package.json
@@ -36,7 +36,6 @@
         "eslint-plugin-node": "^8.0.1",
         "eslint-plugin-promise": "^4.3.1",
         "eslint-plugin-standard": "^4.1.0",
-        "event-hooks-webpack-plugin": "^2.2.0",
         "format-graphql": "^1.4.0",
         "glob": "^7.1.6",
         "jest": "^27.0.1",

--- a/project-base/app/webpack.config.js
+++ b/project-base/app/webpack.config.js
@@ -1,6 +1,4 @@
 const Encore = require('@symfony/webpack-encore');
-const EventHooksPlugin = require('event-hooks-webpack-plugin');
-const processTrans = require('./assets/js/commands/translations/process');
 const CopyPlugin = require('copy-webpack-plugin');
 const path = require('path');
 const StylelintPlugin = require('stylelint-webpack-plugin');
@@ -33,25 +31,6 @@ Encore
     .configureWatchOptions(function (watchOptions) {
         watchOptions.ignored = '**/*.json';
     })
-    .addPlugin(new EventHooksPlugin({
-        beforeRun: () => {
-            const dirWithJsFiles = [
-                sources.getFrameworkNodeModulesDir() + '/js/**/*.js',
-                './assets/js/**/*.js'
-            ];
-            const dirWithTranslations = [
-                sources.getFrameworkVendorDir() + '/src/Resources/translations/*.po',
-                './translations/*.po',
-            ];
-            const outputDirForExportedTranslations = './assets/js/';
-
-            try {
-                processTrans(dirWithJsFiles, dirWithTranslations, outputDirForExportedTranslations);
-            } catch (e) {
-                console.log('Parsing files for translations has failed.');
-            }
-        }
-    }))
     .addPlugin(new CopyPlugin({
         patterns: [
             {

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -61,3 +61,5 @@ There you can find links to upgrade notes for other versions too.
         +       ?int $domainId = null
             ): void
         ```
+- fix and improve JS translations in administration ([#2779](https://github.com/shopsys/shopsys/pull/2779))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The JS translations now work for monorepo the same way as in the project. In the exported translation JSON are no duplicate msgids and the project-base translation takes precedence over the framework's one.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-js-translations-fix.odin.shopsys.cloud
  - https://cz.mg-js-translations-fix.odin.shopsys.cloud
<!-- Replace -->
