### PR TITLE
[framework] added optional option to export data to Elasticsearch only for the specified domain

### DIFF
--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -174,10 +174,16 @@ Especially useful when you need to change the structure and don't need to have f
 Exports all data for index to Elasticsearch.
 
 !!! note
-From v9.1.1 and higher the export command also run migration for Elasticsearch structure when necessary
+    From v9.1.1 and higher the export command also run migration for Elasticsearch structure when necessary
+
+!!! note
+    If you want to export only data of one domain e.g. when you are introducing new domain in production, you can use `php bin/console shopsys:elasticsearch:data-export --domain-id=<DOMAIN_ID>`
 
 #### elasticsearch-export-changed
 Exports only changed data for index to Elasticsearch.
+
+!!! note
+    If you want to export only data of one domain e.g. when you are introducing new domain in production, you can use `php bin/console shopsys:elasticsearch:changed-data-export --domain-id=<DOMAIN_ID>`
 
 ### Coding standards
 

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchDataExportCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchDataExportCommand.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexExportedEvent;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRegistry;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -39,17 +40,31 @@ class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
         parent::__construct($indexRegistry, $indexFacade, $indexDefinitionLoader, $domain);
     }
 
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this->addOption(
+            self::OPTION_DOMAIN_ID,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Limit command to only one domain. Products will not be marked as exported.',
+        );
+    }
+
     /**
      * {@inheritdoc}
      */
-    protected function executeForIndex(OutputInterface $output, AbstractIndex $index): void
+    protected function executeForIndex(OutputInterface $output, AbstractIndex $index, ?int $domainId = null): void
     {
-        parent::executeForIndex($output, $index);
+        parent::executeForIndex($output, $index, $domainId);
 
-        $this->eventDispatcher->dispatch(
-            new IndexExportedEvent($index),
-            IndexExportedEvent::INDEX_EXPORTED,
-        );
+        if ($domainId === null) {
+            $this->eventDispatcher->dispatch(
+                new IndexExportedEvent($index),
+                IndexExportedEvent::INDEX_EXPORTED,
+            );
+        }
     }
 
     /**

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -51,3 +51,13 @@ There you can find links to upgrade notes for other versions too.
     - already existing articles with this placement will be migrated to `Shopsys\FrameworkBundle\Model\Article\Article::PLACEMENT_NONE` placement
         - if you intend to keep using this placement, you can skip DB Migration `Shopsys\FrameworkBundle\Migrations\Version20230907132822` 
     - see #project-base-diff to update your project
+- update your Elasticsearch Commands to support optional domainId ([#2780](https://github.com/shopsys/shopsys/pull/2780))
+    - `\Shopsys\FrameworkBundle\Command\Elasticsearch\AbstractElasticsearchIndexCommand`
+        - `executeForIndex()` changed its interface
+        ```diff
+            protected function executeForIndex(
+                OutputInterface $output,
+                AbstractIndex $index,
+        +       ?int $domainId = null
+            ): void
+        ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Sometimes it is necessary to export data to Elasticsearch only for one specific domain to speed up things. This PR adds the ability to do that.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-export-to-elastic-one-domain.odin.shopsys.cloud
  - https://cz.tl-export-to-elastic-one-domain.odin.shopsys.cloud
<!-- Replace -->
