### PR TITLE
[framework] added auto rendered uuid for entities in administration

### DIFF
--- a/packages/framework/assets/js/common/components/copyToClipboard.js
+++ b/packages/framework/assets/js/common/components/copyToClipboard.js
@@ -1,0 +1,35 @@
+import Register from '../utils/Register';
+import '../../common/bootstrap/tooltip';
+import Translator from 'bazinga-translator';
+
+export default class CopyToClipboard {
+
+    constructor ($container) {
+        const $copyNodes = $container.filterAllNodes('.js-copy-to-clipboard[data-content]');
+
+        $copyNodes.tooltip();
+        $copyNodes.click((event) => _this.onClick(event));
+
+        const _this = this;
+    }
+
+    onClick (event) {
+        const content = $(event.currentTarget).data('content');
+        navigator.clipboard.writeText(content).then(() => {
+            $(event.currentTarget).attr('title', Translator.trans('Copied to clipboard!'));
+
+            $(event.currentTarget).tooltip('destroy');
+            $(event.currentTarget).tooltip('show');
+
+            $(event.currentTarget).attr('title', content);
+            $(event.currentTarget).attr('data-original-title', content);
+        });
+    }
+
+    static init ($container) {
+        // eslint-disable-next-line no-new
+        new CopyToClipboard($container);
+    }
+}
+
+(new Register()).registerCallback(CopyToClipboard.init, 'CopyToClipboard.init');

--- a/packages/framework/assets/js/common/components/index.js
+++ b/packages/framework/assets/js/common/components/index.js
@@ -3,3 +3,4 @@ import './tabs';
 import './ToggleElement';
 import './tooltip';
 import './CheckboxToggle';
+import './copyToClipboard';

--- a/packages/framework/assets/public/admin/svg/duplicate.svg
+++ b/packages/framework/assets/public/admin/svg/duplicate.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+    <path style="stroke:none;stroke-width:1;stroke-dasharray:none;stroke-linecap:butt;stroke-dashoffset:0;stroke-linejoin:miter;stroke-miterlimit:4;fill:#000;fill-rule:nonzero;opacity:1" transform="matrix(1.43 0 0 1.43 .56 1.275)" d="M2.5 1C1.676 1 1 1.676 1 2.5v8c0 .824.676 1.5 1.5 1.5H4v.5c0 .824.676 1.5 1.5 1.5h8c.824 0 1.5-.676 1.5-1.5v-8c0-.824-.676-1.5-1.5-1.5H12v-.5c0-.824-.676-1.5-1.5-1.5Zm0 1h8c.281 0 .5.219.5.5v8c0 .281-.219.5-.5.5h-8a.494.494 0 0 1-.5-.5v-8c0-.281.219-.5.5-.5ZM12 4h1.5c.281 0 .5.219.5.5v8c0 .281-.219.5-.5.5h-8a.494.494 0 0 1-.5-.5V12h5.5c.824 0 1.5-.676 1.5-1.5Z"/>
+</svg>

--- a/packages/framework/assets/styles/admin/todo.less
+++ b/packages/framework/assets/styles/admin/todo.less
@@ -10,3 +10,9 @@
 .table-fixed {
   table-layout: fixed;
 }
+
+.edit-uuid {
+  font-size: 45%;
+  color: grey;
+  margin-left: 5em;
+}

--- a/packages/framework/assets/styles/admin/todo.less
+++ b/packages/framework/assets/styles/admin/todo.less
@@ -14,5 +14,5 @@
 .edit-uuid {
   font-size: 45%;
   color: grey;
-  margin-left: 5em;
+  margin-left: 1em;
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -454,6 +454,9 @@ msgstr "Nastavení informací o cookies"
 msgid "Cookies information settings modified."
 msgstr "Bylo upraveno nastavení informací o cookies."
 
+msgid "Copied to clipboard!"
+msgstr "Zkopírováno do schránky!"
+
 msgid "Countries"
 msgstr "Státy"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -454,6 +454,9 @@ msgstr ""
 msgid "Cookies information settings modified."
 msgstr ""
 
+msgid "Copied to clipboard!"
+msgstr ""
+
 msgid "Countries"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Layout/displayUuid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/displayUuid.html.twig
@@ -1,0 +1,6 @@
+{% set keys = _context|keys %}
+{% if (keys[1] is defined) and (attribute(_context[keys[1]], 'uuid') is defined) %}
+    <span class="edit-uuid">
+        {{ _context[keys[1]].uuid }}
+    </span>
+{% endif %}

--- a/packages/framework/src/Resources/views/Admin/Layout/displayUuid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/displayUuid.html.twig
@@ -1,6 +1,9 @@
 {% set keys = _context|keys %}
 {% if (keys[1] is defined) and (attribute(_context[keys[1]], 'uuid') is defined) %}
-    <span class="edit-uuid">
-        {{ _context[keys[1]].uuid }}
-    </span>
+    {% set uuid = _context[keys[1]].uuid %}
+    <span class="edit-uuid cursor-pointer js-copy-to-clipboard"
+          data-content="{{ uuid }}"
+          data-placement="right"
+          title="{{ uuid }}"
+    >UUID {{ icon('duplicate') }}</span>
 {% endif %}

--- a/packages/framework/src/Resources/views/Admin/Layout/layoutWithPanel.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/layoutWithPanel.html.twig
@@ -23,6 +23,7 @@
                 <div class="wrap-bar">
                     <h1 class="wrap-bar__heading">
                         {% block h1 %}{{ 'Administration'|trans }}{% endblock %}
+                        {% include '@ShopsysFramework/Admin/Layout/displayUuid.html.twig' %}
                     </h1>
                     {% block btn %}{% endblock %}
                 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If rendered page contains an object with the UUID property, this UUID is automatically rendered into the `h1` block. 
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2157  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


https://github.com/shopsys/shopsys/assets/1177414/38a5c48c-d5ed-44b9-bf59-fc8d8f750830












<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-display-uuid.odin.shopsys.cloud
  - https://cz.mg-display-uuid.odin.shopsys.cloud
<!-- Replace -->
