### PR TITLE
[framework] removed misleading list of url addresses in administration

### DIFF
--- a/packages/framework/src/Controller/Admin/SuperadminController.php
+++ b/packages/framework/src/Controller/Admin/SuperadminController.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
-use Shopsys\FrameworkBundle\Component\Grid\ArrayDataSource;
-use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory;
 use Shopsys\FrameworkBundle\Form\Admin\Module\ModulesFormType;
 use Shopsys\FrameworkBundle\Form\Admin\Superadmin\InputPriceTypeFormType;
@@ -21,7 +19,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Routing\RequestContext;
 
 class SuperadminController extends AdminBaseController
 {
@@ -30,7 +27,6 @@ class SuperadminController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Model\Module\ModuleFacade $moduleFacade
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting
      * @param \Shopsys\FrameworkBundle\Model\Pricing\DelayedPricingSetting $delayedPricingSetting
-     * @param \Shopsys\FrameworkBundle\Component\Grid\GridFactory $gridFactory
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      * @param \Shopsys\FrameworkBundle\Component\Router\LocalizedRouterFactory $localizedRouterFactory
      * @param \Shopsys\FrameworkBundle\Model\Mail\Setting\MailSettingFacade $mailSettingFacade
@@ -42,7 +38,6 @@ class SuperadminController extends AdminBaseController
         protected readonly ModuleFacade $moduleFacade,
         protected readonly PricingSetting $pricingSetting,
         protected readonly DelayedPricingSetting $delayedPricingSetting,
-        protected readonly GridFactory $gridFactory,
         protected readonly Localization $localization,
         protected readonly LocalizedRouterFactory $localizedRouterFactory,
         protected readonly MailSettingFacade $mailSettingFacade,
@@ -95,42 +90,7 @@ class SuperadminController extends AdminBaseController
      */
     public function urlsAction()
     {
-        $allLocales = $this->localization->getLocalesOfAllDomains();
-        $dataSource = new ArrayDataSource($this->loadDataForUrls($allLocales));
-
-        $grid = $this->gridFactory->create('urlsList', $dataSource);
-
-        foreach ($allLocales as $locale) {
-            $grid->addColumn($locale, $locale, $this->localization->getLanguageName($locale));
-        }
-
-        return $this->render('@ShopsysFramework/Admin/Content/Superadmin/urlsListGrid.html.twig', [
-            'gridView' => $grid->createView(),
-        ]);
-    }
-
-    /**
-     * @param array $locales
-     * @return array
-     */
-    protected function loadDataForUrls(array $locales)
-    {
-        $data = [];
-        $requestContext = new RequestContext();
-
-        foreach ($locales as $locale) {
-            $rowIndex = 0;
-            $allRoutes = $this->localizedRouterFactory->getRouter($locale, $requestContext)
-                ->getRouteCollection()
-                ->all();
-
-            foreach ($allRoutes as $route) {
-                $data[$rowIndex][$locale] = $route->getPath();
-                $rowIndex++;
-            }
-        }
-
-        return $data;
+        return $this->render('@ShopsysFramework/Admin/Content/Superadmin/urlsListGrid.html.twig');
     }
 
     /**

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2251,6 +2251,9 @@ msgstr "Obchodní podmínky"
 msgid "The change will be applied to products in 10 minutes"
 msgstr "Změna se u zboží projeví do 10 minut"
 
+msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/staticRewritePaths.js\" file."
+msgstr "Aktuální seznam URL adres lze nalézt v repozitáři projektu v souboru \"storefront/config/staticRewritePaths.js\"."
+
 msgid "The higher the priority, the higher the country will be shown in the listings. Countries with the same priority will be sorted alphabetically."
 msgstr "Čím vyšší priorita, tím bude stát zobrazen výše v seznamech. Státy se stejnou prioritou budou seřazeny abecedně."
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2251,6 +2251,9 @@ msgstr ""
 msgid "The change will be applied to products in 10 minutes"
 msgstr ""
 
+msgid "The current list of URL addresses can be found in the project's repository in the \"storefront/config/staticRewritePaths.js\" file."
+msgstr ""
+
 msgid "The higher the priority, the higher the country will be shown in the listings. Countries with the same priority will be sorted alphabetically."
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Content/Superadmin/urlsListGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Superadmin/urlsListGrid.html.twig
@@ -4,5 +4,5 @@
 {% block h1 %}{{ 'URL addresses'|trans }}{% endblock %}
 
 {% block main_content %}
-    {{ gridView.render() }}
+    {{ 'The current list of URL addresses can be found in the project\'s repository in the "storefront/config/staticRewritePaths.js" file.'|trans }}
 {% endblock%}

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -63,3 +63,21 @@ There you can find links to upgrade notes for other versions too.
         ```
 - fix and improve JS translations in administration ([#2779](https://github.com/shopsys/shopsys/pull/2779))
     - see #project-base-diff to update your project
+- remove misleading url addresses list from administration ([#2782](https://github.com/shopsys/shopsys/pull/2782))
+    - `Shopsys\FrameworkBundle\Controller\Admin\SuperadminController`
+        - method `__construct` changed its interface
+            ```diff
+                public function __construct(
+                    protected readonly ModuleList $moduleList,
+                    protected readonly ModuleFacade $moduleFacade,
+                    protected readonly PricingSetting $pricingSetting,
+                    protected readonly DelayedPricingSetting $delayedPricingSetting,
+            -       protected readonly GridFactory $gridFactory,
+                    protected readonly Localization $localization,
+                    protected readonly LocalizedRouterFactory $localizedRouterFactory,
+                    protected readonly MailSettingFacade $mailSettingFacade,
+                    protected readonly MailerSettingProvider $mailerSettingProvider,
+                    protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
+                ) {
+            ```
+        - method `loadDataForUrls()` was removed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| List of storefront urls can no longer be obtained from the Symfony router. To avoid confusion, the list was replaced with the information, where the accurate list can be found.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-url-addresses.odin.shopsys.cloud
  - https://cz.mg-url-addresses.odin.shopsys.cloud
<!-- Replace -->
