### PR TITLE
[php-image] added cron package to base image

### DIFF
--- a/packages/php-image/Dockerfile
+++ b/packages/php-image/Dockerfile
@@ -10,6 +10,7 @@ ARG DEBIAN_VERSION
 # autoconf needed to install "Redis" extension
 # bash-completion for Phing target completion
 # ca-certificates to ensure certificates are up to date
+# cron to be able to schedule and automate recurring tasks and jobs
 # gnupg and g++ for gd extension
 # git for computing diffs and for npm to download packages
 # htop for quick monitoring
@@ -31,6 +32,7 @@ RUN apt-get update && \
         autoconf \
         bash-completion \
         ca-certificates \
+        cron \
         g++ \
         git \
         gnupg \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Cron was previously installed as a dependency of `postgresql-12` package. This package is no longer installed as it's not necessary, but `cron` has to be installed to be able to run scheduled tasks.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://grossmannmartin-patch-1.odin.shopsys.cloud
  - https://cz.grossmannmartin-patch-1.odin.shopsys.cloud
<!-- Replace -->
