### PR TITLE
brands SEO sensitive config

### DIFF
--- a/project-base/storefront/helpers/filterOptions/seoCategories.ts
+++ b/project-base/storefront/helpers/filterOptions/seoCategories.ts
@@ -28,6 +28,7 @@ export const SEO_SENSITIVE_FILTERS = {
     AVAILABILITY: false,
     PRICE: false,
     FLAGS: true,
+    BRANDS: false,
     PARAMETERS: {
         CHECKBOX: true,
         SLIDER: false,
@@ -36,6 +37,7 @@ export const SEO_SENSITIVE_FILTERS = {
 
 export const getEmptyDefaultProductFiltersMap = (): DefaultProductFiltersMapType => ({
     flags: new Set(),
+    brands: new Set(),
     sort: DEFAULT_SORT,
     parameters: new Map(),
 });
@@ -83,6 +85,18 @@ export const getChangedDefaultFiltersAfterFlagChange = (
 ): FilterOptionsUrlQueryType => {
     if (!defaultProductFiltersMap.flags.delete(changedFlagUuid)) {
         defaultProductFiltersMap.flags.add(changedFlagUuid);
+    }
+
+    return getChangedDefaultFilters(defaultProductFiltersMap, filter);
+};
+
+export const getChangedDefaultFiltersAfterBrandChange = (
+    defaultProductFiltersMap: DefaultProductFiltersMapType,
+    filter: FilterOptionsUrlQueryType | null,
+    changedBrandUuid: string,
+): FilterOptionsUrlQueryType => {
+    if (!defaultProductFiltersMap.brands.delete(changedBrandUuid)) {
+        defaultProductFiltersMap.brands.add(changedBrandUuid);
     }
 
     return getChangedDefaultFilters(defaultProductFiltersMap, filter);
@@ -175,6 +189,7 @@ export const getChangedDefaultFilters = (
     filter: FilterOptionsUrlQueryType | null,
 ) => ({
     ...filter,
+    brands: Array.from(updatedProductFiltersMap.brands),
     flags: Array.from(updatedProductFiltersMap.flags),
     parameters: Array.from(updatedProductFiltersMap.parameters)
         .map(([updatedParameterUuid, updatedParameterValues]) => ({

--- a/project-base/storefront/hooks/useQueryParams.ts
+++ b/project-base/storefront/hooks/useQueryParams.ts
@@ -7,6 +7,7 @@ import {
     DEFAULT_SORT,
     getChangedDefaultFilters,
     getChangedDefaultFiltersAfterAvailabilityChange,
+    getChangedDefaultFiltersAfterBrandChange,
     getChangedDefaultFiltersAfterFlagChange,
     getChangedDefaultFiltersAfterMaximumPriceChange,
     getChangedDefaultFiltersAfterMinimumPriceChange,
@@ -158,6 +159,16 @@ export const useQueryParams = () => {
     };
 
     const updateFilterBrands = (selectedUuid: string) => {
+        if (SEO_SENSITIVE_FILTERS.BRANDS && originalCategorySlug) {
+            pushQueryFilter(
+                getChangedDefaultFiltersAfterBrandChange(defaultProductFiltersMap, filter, selectedUuid),
+                originalCategorySlug,
+                defaultProductFiltersMap.sort,
+            );
+
+            return;
+        }
+
         pushQueryFilter({ ...filter, brands: handleUpdateFilter(selectedUuid, filter?.brands) });
     };
 

--- a/project-base/storefront/store/slices/createSeoCategorySlice.ts
+++ b/project-base/storefront/store/slices/createSeoCategorySlice.ts
@@ -4,6 +4,7 @@ import { StateCreator } from 'zustand';
 
 export type DefaultProductFiltersMapType = {
     flags: Set<string>;
+    brands: Set<string>;
     sort: ProductOrderingModeEnumApi;
     parameters: Map<string, Set<string>>;
 };

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.resetAllFilters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.resetAllFilters.test.ts
@@ -24,11 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
 const mockDefaultSort = vi.fn(() => ProductOrderingModeEnumApi.PriorityApi);
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
@@ -80,7 +82,7 @@ describe('useQueryParams().resetAllFilters tests', () => {
                     minimalPrice: 100,
                     maximalPrice: 1000,
                     brands: ['default-brand-1', 'default-brand-2'],
-                    flags: ['default-flag-1', 'default-flag-2'],
+                    flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                     parameters: [
                         {
                             parameter: 'default-parameter-1',
@@ -125,8 +127,8 @@ describe('useQueryParams().resetAllFilters tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -141,7 +143,7 @@ describe('useQueryParams().resetAllFilters tests', () => {
                     onlyInStock: true,
                     minimalPrice: 100,
                     maximalPrice: 1000,
-                    brands: ['default-brand-1', 'default-brand-2'],
+                    brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
                 }),
                 [PAGE_QUERY_PARAMETER_NAME]: '2',
             },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
@@ -13,12 +13,13 @@ import { describe, expect, Mock, test, vi } from 'vitest';
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
@@ -161,9 +162,9 @@ describe('useQueryParams().updateFilterBrands tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -203,9 +204,9 @@ describe('useQueryParams().updateFilterBrands tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -219,8 +220,8 @@ describe('useQueryParams().updateFilterBrands tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: [...Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()), 'test-brand'],
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -239,8 +240,8 @@ describe('useQueryParams().updateFilterBrands tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: [...Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()), 'test-brand'],
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
@@ -3,13 +3,22 @@ import {
     FILTER_QUERY_PARAMETER_NAME,
     LOAD_MORE_QUERY_PARAMETER_NAME,
     PAGE_QUERY_PARAMETER_NAME,
+    SORT_QUERY_PARAMETER_NAME,
 } from 'helpers/queryParamNames';
 import { useQueryParams } from 'hooks/useQueryParams';
 import { useRouter } from 'next/router';
+import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
+const ORIGINAL_CATEGORY_URL = '/original-category-slug';
+const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
+    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+]);
+const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
@@ -33,6 +42,29 @@ vi.mock('store/useSessionStore', () => ({
         });
     }),
 }));
+
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
+    const actualSeoCategoriesModule = await importOriginal<any>();
+
+    return {
+        ...actualSeoCategoriesModule,
+
+        get SEO_SENSITIVE_FILTERS() {
+            return mockSeoSensitiveFiltersGetter();
+        },
+    };
+});
 
 describe('useQueryParams().updateFilterBrands tests', () => {
     test('brand should be added to query if not present', () => {
@@ -116,6 +148,111 @@ describe('useQueryParams().updateFilterBrands tests', () => {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         brands: ['test-brand'],
                     }),
+                },
+            },
+            {
+                shallow: true,
+            },
+        );
+    });
+
+    test('changing brand should not redirect from SEO category if brands are not SEO-sensitive', () => {
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
+                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+            });
+        });
+
+        useQueryParams().updateFilterBrands('test-brand');
+
+        expect(mockPush).toBeCalledWith(
+            {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: ['test-brand'],
+                    }),
+                },
+            },
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: ['test-brand'],
+                    }),
+                },
+            },
+            {
+                shallow: true,
+            },
+        );
+    });
+
+    test('changing brand should redirect from SEO category if brands are SEO-sensitive', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ BRANDS: true }));
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
+                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+            });
+        });
+
+        useQueryParams().updateFilterBrands('test-brand');
+
+        expect(mockPush).toBeCalledWith(
+            {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
+                pathname: ORIGINAL_CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
             {

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
@@ -13,12 +13,13 @@ import { describe, expect, Mock, test, vi } from 'vitest';
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
@@ -164,9 +165,9 @@ describe('useQueryParams().updateFilterFlags tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -203,9 +204,9 @@ describe('useQueryParams().updateFilterFlags tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -219,8 +220,8 @@ describe('useQueryParams().updateFilterFlags tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: [...Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()), 'test-flag'],
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -239,8 +240,8 @@ describe('useQueryParams().updateFilterFlags tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: [...Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()), 'test-flag'],
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
@@ -3,13 +3,22 @@ import {
     FILTER_QUERY_PARAMETER_NAME,
     LOAD_MORE_QUERY_PARAMETER_NAME,
     PAGE_QUERY_PARAMETER_NAME,
+    SORT_QUERY_PARAMETER_NAME,
 } from 'helpers/queryParamNames';
 import { useQueryParams } from 'hooks/useQueryParams';
 import { useRouter } from 'next/router';
+import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
+const ORIGINAL_CATEGORY_URL = '/original-category-slug';
+const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
+    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+]);
+const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
 
 const mockPush = vi.fn();
 vi.mock('next/router', () => ({
@@ -33,6 +42,29 @@ vi.mock('store/useSessionStore', () => ({
         });
     }),
 }));
+
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
+    const actualSeoCategoriesModule = await importOriginal<any>();
+
+    return {
+        ...actualSeoCategoriesModule,
+
+        get SEO_SENSITIVE_FILTERS() {
+            return mockSeoSensitiveFiltersGetter();
+        },
+    };
+});
 
 describe('useQueryParams().updateFilterFlags tests', () => {
     test('flag should be added to query if not present', () => {
@@ -116,6 +148,111 @@ describe('useQueryParams().updateFilterFlags tests', () => {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         flags: ['test-flag'],
                     }),
+                },
+            },
+            {
+                shallow: true,
+            },
+        );
+    });
+
+    test('changing flag should not redirect from SEO category if flags are not SEO-sensitive', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ FLAGS: false }));
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
+                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+            });
+        });
+
+        useQueryParams().updateFilterFlags('test-flag');
+
+        expect(mockPush).toBeCalledWith(
+            {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        flags: ['test-flag'],
+                    }),
+                },
+            },
+            {
+                pathname: CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        flags: ['test-flag'],
+                    }),
+                },
+            },
+            {
+                shallow: true,
+            },
+        );
+    });
+
+    test('changing flag should redirect from SEO category if flags are SEO-sensitive', () => {
+        (useSessionStore as unknown as Mock).mockImplementation((selector) => {
+            return selector({
+                defaultProductFiltersMap: {
+                    sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
+                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                },
+                originalCategorySlug: ORIGINAL_CATEGORY_URL,
+            });
+        });
+
+        useQueryParams().updateFilterFlags('test-flag');
+
+        expect(mockPush).toBeCalledWith(
+            {
+                pathname: CATEGORY_PATHNAME,
+                query: {
+                    categorySlug: ORIGINAL_CATEGORY_URL,
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
+                },
+            },
+            {
+                pathname: ORIGINAL_CATEGORY_URL,
+                query: {
+                    [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        parameters: [
+                            {
+                                parameter: 'default-parameter-1',
+                                values: ['default-parameter-value-1', 'default-parameter-value-2'],
+                            },
+                            {
+                                parameter: 'default-parameter-2',
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
+                            },
+                        ],
+                    }),
+                    [SORT_QUERY_PARAMETER_NAME]: ProductOrderingModeEnumApi.PriceAscApi,
                 },
             },
             {

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
@@ -24,12 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -122,9 +123,9 @@ describe('useQueryParams().updateFilterInStock tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -139,8 +140,8 @@ describe('useQueryParams().updateFilterInStock tests', () => {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         onlyInStock: true,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -160,8 +161,8 @@ describe('useQueryParams().updateFilterInStock tests', () => {
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         onlyInStock: true,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
 ]);
 const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -121,6 +122,7 @@ describe('useQueryParams().updateFilterInStock tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
@@ -137,7 +139,8 @@ describe('useQueryParams().updateFilterInStock tests', () => {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         onlyInStock: true,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -157,7 +160,8 @@ describe('useQueryParams().updateFilterInStock tests', () => {
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         onlyInStock: true,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
 ]);
 const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -516,6 +517,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
@@ -531,7 +533,8 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -550,7 +553,8 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -631,6 +635,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
@@ -645,7 +650,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -669,7 +674,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
@@ -24,12 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -517,9 +518,9 @@ describe('useQueryParams().updateFilterParameters tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -533,8 +534,8 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -553,8 +554,8 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -583,8 +584,8 @@ describe('useQueryParams().updateFilterParameters tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -634,9 +635,9 @@ describe('useQueryParams().updateFilterParameters tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -650,7 +651,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -658,7 +659,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                             },
                             {
                                 parameter: 'default-parameter-2',
-                                values: ['default-parameter-value-3'],
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
                             },
                             {
                                 parameter: 'default-parameter-3',
@@ -674,7 +675,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -682,7 +683,7 @@ describe('useQueryParams().updateFilterParameters tests', () => {
                             },
                             {
                                 parameter: 'default-parameter-2',
-                                values: ['default-parameter-value-3'],
+                                values: ['default-parameter-value-3', 'default-parameter-value-4'],
                             },
                             {
                                 parameter: 'default-parameter-3',
@@ -705,8 +706,8 @@ describe('useQueryParams().updateFilterParameters tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
@@ -24,12 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brands-1', 'default-brands-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -157,8 +158,8 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -198,9 +199,9 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -215,8 +216,8 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         maximalPrice: 1000,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -236,8 +237,8 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         maximalPrice: 1000,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
 ]);
 const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brands-1', 'default-brands-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -197,6 +198,7 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
@@ -213,7 +215,8 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         maximalPrice: 1000,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -233,7 +236,8 @@ describe('useQueryParams().updateFilterPriceMaximum tests', () => {
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         maximalPrice: 1000,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
 ]);
 const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -196,6 +197,7 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
@@ -212,7 +214,8 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -232,7 +235,8 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
@@ -24,12 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -156,8 +157,8 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -197,9 +198,9 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -214,8 +215,8 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -235,8 +236,8 @@ describe('useQueryParams().updateFilterPriceMinimum tests', () => {
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
@@ -24,12 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brands-1', 'default-brands-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -191,8 +192,8 @@ describe('useQueryParams().updateFilterPrices tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -234,9 +235,9 @@ describe('useQueryParams().updateFilterPrices tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -252,8 +253,8 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
                         maximalPrice: 1000,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -274,8 +275,8 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
                         maximalPrice: 1000,
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
 ]);
 const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brands-1', 'default-brands-2']);
 
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
     const actualSeoCategoriesModule = await importOriginal<any>();
@@ -234,6 +235,7 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
@@ -250,7 +252,8 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
                         maximalPrice: 1000,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -271,7 +274,8 @@ describe('useQueryParams().updateFilterPrices tests', () => {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
                         minimalPrice: 100,
                         maximalPrice: 1000,
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
@@ -24,12 +24,13 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
-const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
-    ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
-    ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
-]);
-const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
-const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
+const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
+    new Map([
+        ['default-parameter-1', new Set(['default-parameter-value-1', 'default-parameter-value-2'])],
+        ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
+    ]);
+const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
+const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
 const mockDefaultSort = vi.fn(() => ProductOrderingModeEnumApi.PriorityApi);
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
@@ -109,9 +110,9 @@ describe('useQueryParams().updateSort tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    brands: GET_DEFAULT_SEO_CATEGORY_BRANDS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });
@@ -125,8 +126,8 @@ describe('useQueryParams().updateSort tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -145,8 +146,8 @@ describe('useQueryParams().updateSort tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
-                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
+                        brands: Array.from(GET_DEFAULT_SEO_CATEGORY_BRANDS()),
+                        flags: Array.from(GET_DEFAULT_SEO_CATEGORY_FLAGS()),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -175,8 +176,8 @@ describe('useQueryParams().updateSort tests', () => {
             return selector({
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
-                    flags: DEFAULT_SEO_CATEGORY_FLAGS,
-                    parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
+                    flags: GET_DEFAULT_SEO_CATEGORY_FLAGS(),
+                    parameters: GET_DEFAULT_SEO_CATEGORY_PARAMETERS(),
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
             });

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
@@ -29,6 +29,7 @@ const DEFAULT_SEO_CATEGORY_PARAMETERS = new Map([
     ['default-parameter-2', new Set(['default-parameter-value-3', 'default-parameter-value-4'])],
 ]);
 const DEFAULT_SEO_CATEGORY_FLAGS = new Set(['default-flag-1', 'default-flag-2']);
+const DEFAULT_SEO_CATEGORY_BRANDS = new Set(['default-brand-1', 'default-brand-2']);
 
 const mockDefaultSort = vi.fn(() => ProductOrderingModeEnumApi.PriorityApi);
 vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
@@ -109,6 +110,7 @@ describe('useQueryParams().updateSort tests', () => {
                 defaultProductFiltersMap: {
                     sort: ProductOrderingModeEnumApi.PriceAscApi,
                     flags: DEFAULT_SEO_CATEGORY_FLAGS,
+                    brands: DEFAULT_SEO_CATEGORY_BRANDS,
                     parameters: DEFAULT_SEO_CATEGORY_PARAMETERS,
                 },
                 originalCategorySlug: ORIGINAL_CATEGORY_URL,
@@ -123,7 +125,8 @@ describe('useQueryParams().updateSort tests', () => {
                 query: {
                     categorySlug: ORIGINAL_CATEGORY_URL,
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',
@@ -142,7 +145,8 @@ describe('useQueryParams().updateSort tests', () => {
                 pathname: ORIGINAL_CATEGORY_URL,
                 query: {
                     [FILTER_QUERY_PARAMETER_NAME]: JSON.stringify({
-                        flags: ['default-flag-1', 'default-flag-2'],
+                        brands: Array.from(DEFAULT_SEO_CATEGORY_BRANDS),
+                        flags: Array.from(DEFAULT_SEO_CATEGORY_FLAGS),
                         parameters: [
                             {
                                 parameter: 'default-parameter-1',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Brands were missing from the Storefront SEO config. Even though brands are not enabled as SEO-sensitive by default, by implementing this PR clients are now easily able to set up brands for their SEO categories on Storefront.
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-brands-seo-sensitive-config.odin.shopsys.cloud
  - https://cz.sh-brands-seo-sensitive-config.odin.shopsys.cloud
<!-- Replace -->
