### PR TITLE
[framework] fixed order editation error due to invalid type in vat object

### DIFF
--- a/packages/framework/src/Form/Admin/Order/OrderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderItemFormType.php
@@ -84,6 +84,7 @@ class OrderItemFormType extends AbstractType
                 ])->addModelTransformer(new InverseTransformer()),
             )
             ->add('vatPercent', NumberType::class, [
+                'input' => 'string',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
                 ],

--- a/packages/framework/src/Form/Admin/Order/OrderPaymentFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderPaymentFormType.php
@@ -41,6 +41,7 @@ class OrderPaymentFormType extends AbstractType
                 'error_bubbling' => true,
             ])
             ->add('vatPercent', NumberType::class, [
+                'input' => 'string',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter unit price without VAT']),
                 ],

--- a/packages/framework/src/Form/Admin/Order/OrderTransportFormType.php
+++ b/packages/framework/src/Form/Admin/Order/OrderTransportFormType.php
@@ -41,6 +41,7 @@ class OrderTransportFormType extends AbstractType
                 'error_bubbling' => true,
             ])
             ->add('vatPercent', NumberType::class, [
+                'input' => 'string',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter VAT rate']),
                 ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This is backport of #2723 to version 12.0
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
