### PR TITLE
[framework] fixed variant creation

### DIFF
--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -465,8 +465,8 @@ class ImageFacade
                 $this->imageConfig->getImageEntityConfig($targetEntity)->getEntityName(),
                 $this->getEntityId($targetEntity),
                 $sourceImage->getNames(),
-                $sourceImage->getType(),
                 $sourceImage->getFilename(),
+                $sourceImage->getType(),
             );
 
             $this->em->persist($targetImage);

--- a/project-base/tests/App/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/tests/App/Functional/Model/Product/ProductVariantCreationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\App\Functional\Model\Product;
 
 use App\DataFixtures\Demo\AvailabilityDataFixture;
+use App\DataFixtures\Demo\ProductDataFixture;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductData;
@@ -128,6 +129,23 @@ final class ProductVariantCreationTest extends TransactionFunctionalTestCase
 
         $this->assertTrue($mainVariant->isMainVariant());
         $this->assertContainsAllVariants([$mainProduct, $secondProduct, $thirdProduct], $mainVariant);
+    }
+
+    public function testVariantWithImageCanBeCreated(): void
+    {
+        /** @var \App\Model\Product\Product $mainProduct */
+        $mainProduct = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '7');
+
+        $variants = [
+            $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '8'),
+            $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '88'),
+            $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '89'),
+        ];
+
+        $mainVariant = $this->productVariantFacade->createVariant($mainProduct, $variants);
+
+        $this->assertTrue($mainVariant->isMainVariant());
+        $this->assertContainsAllVariants([$mainProduct, ...$variants], $mainVariant);
     }
 
     /**

--- a/upgrade/UPGRADE-v12.0.0-dev.md
+++ b/upgrade/UPGRADE-v12.0.0-dev.md
@@ -870,3 +870,5 @@ There you can find links to upgrade notes for other versions too.
         - see #project-base-diff for more details
 - update installation of NodeJS and Postgres in your Dockerfile ([#2792](https://github.com/shopsys/shopsys/pull/2792))
     - see #project-base-diff for more details
+- add test for variant creation from products with images ([#2801](https://github.com/shopsys/shopsys/pull/2801))
+    - see #project-base-diff for more details


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It was not possible to create a variant. This is fixed now. Version 12.0
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
