### PR TITLE
[framework] fixed variant creation

### DIFF
--- a/packages/framework/src/Component/Image/ImageFacade.php
+++ b/packages/framework/src/Component/Image/ImageFacade.php
@@ -465,8 +465,8 @@ class ImageFacade
                 $this->imageConfig->getImageEntityConfig($targetEntity)->getEntityName(),
                 $this->getEntityId($targetEntity),
                 $sourceImage->getNames(),
-                $sourceImage->getType(),
                 $sourceImage->getFilename(),
+                $sourceImage->getType(),
             );
 
             $this->em->persist($targetImage);

--- a/project-base/app/tests/App/Functional/Model/Product/ProductVariantCreationTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductVariantCreationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\App\Functional\Model\Product;
 
 use App\DataFixtures\Demo\AvailabilityDataFixture;
+use App\DataFixtures\Demo\ProductDataFixture;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductData;
@@ -135,6 +136,23 @@ final class ProductVariantCreationTest extends TransactionFunctionalTestCase
 
         $this->assertTrue($mainVariant->isMainVariant());
         $this->assertContainsAllVariants([$secondProduct, $thirdProduct], $mainVariant);
+    }
+
+    public function testVariantWithImageCanBeCreated(): void
+    {
+        /** @var \App\Model\Product\Product $mainProduct */
+        $mainProduct = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '7');
+
+        $variants = [
+            $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '8'),
+            $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '88'),
+            $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '89'),
+        ];
+
+        $mainVariant = $this->productVariantFacade->createVariant($mainProduct, $variants);
+
+        $this->assertTrue($mainVariant->isMainVariant());
+        $this->assertContainsAllVariants($variants, $mainVariant);
     }
 
     /**

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -83,3 +83,12 @@ There you can find links to upgrade notes for other versions too.
         - method `loadDataForUrls()` was removed
 - Products - Exposed in Stores, Category - SVG icon, and Category - Short description have been removed ([#2777](https://github.com/shopsys/shopsys/pull/2777))
     - if you use this functionality (e.g. from Commerce Cloud version), you can skip DB migration 20230908095905
+- adjust test for variant creation from products with images ([#2802](https://github.com/shopsys/shopsys/pull/2802))
+    - edit Tests\App\Functional\Model\Product\ProductVariantCreationTest::testVariantWithImageCanBeCreated
+        ```diff
+            $mainVariant = $this->productVariantFacade->createVariant($mainProduct, $variants);
+
+            $this->assertTrue($mainVariant->isMainVariant());
+        -   $this->assertContainsAllVariants([$mainProduct, ...$variants], $mainVariant);
+        +   $this->assertContainsAllVariants($variants, $mainVariant);
+        ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It was not possible to create a variant. This is fixed now. Version 13.0
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-variant-creation-13.odin.shopsys.cloud
  - https://cz.mg-fix-variant-creation-13.odin.shopsys.cloud
<!-- Replace -->
