### PR TITLE
[shopsys] changed default db server in adminer in local environment

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -97,10 +97,12 @@ services:
         shm_size: '2GB'
 
     adminer:
-        image: adminer:4.7.6
+        image: adminer:latest
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
+        environment:
+            ADMINER_DEFAULT_SERVER: postgres
 
     smtp-server:
         image: ixdotai/smtp:latest

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -98,10 +98,12 @@ services:
         shm_size: '2GB'
 
     adminer:
-        image: adminer:4.7.6
+        image: adminer:latest
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
+        environment:
+            ADMINER_DEFAULT_SERVER: postgres
 
     smtp-server:
         image: ixdotai/smtp:latest

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -99,10 +99,12 @@ services:
         shm_size: '2GB'
 
     adminer:
-        image: adminer:4.7.6
+        image: adminer:latest
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
+        environment:
+            ADMINER_DEFAULT_SERVER: postgres
 
     smtp-server:
         image: ixdotai/smtp:latest

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -100,10 +100,12 @@ services:
         shm_size: '2GB'
 
     adminer:
-        image: adminer:4.7.6
+        image: adminer:latest
         container_name: shopsys-framework-adminer
         ports:
             - "1100:8080"
+        environment:
+            ADMINER_DEFAULT_SERVER: postgres
 
     smtp-server:
         image: ixdotai/smtp:latest

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -94,3 +94,5 @@ There you can find links to upgrade notes for other versions too.
         ```
 - rewrite the `GetOrdersAsAuthenticatedCustomerUserTest` test ([#2805](https://github.com/shopsys/shopsys/pull/2805))
     - see #project-base-diff to update your project
+- change default db server in adminer in local environment ([#2803](https://github.com/shopsys/shopsys/pull/2803))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The default prefilled server name was `db`, but the PostgreSQL container in our environment is named `postgres`. This PR automatically prefills the `postgres` into the server, so the developer has one less place to change when he needs to check the database.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-local-adminer-db-name.odin.shopsys.cloud
  - https://cz.mg-local-adminer-db-name.odin.shopsys.cloud
<!-- Replace -->
