### PR TITLE
[project-base] fixed GetOrdersAsAuthenticatedCustomerUserTest

### DIFF
--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrdersAsUnauthenticatedCustomerUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrdersAsUnauthenticatedCustomerUserTest.php
@@ -10,7 +10,7 @@ class GetOrdersAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
 {
     public function testGetAllCustomerUserOrders(): void
     {
-        $response = $this->getResponseContentForQuery($this->getOrdersWithoutFilterQuery());
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/getOrders.graphql');
         $this->assertResponseContainsArrayOfErrors($response);
         $errors = $this->getErrorsFromResponse($response);
 
@@ -20,26 +20,5 @@ class GetOrdersAsUnauthenticatedCustomerUserTest extends GraphQlTestCase
             'Token is not valid.',
             $errors[0]['message'],
         );
-    }
-
-    /**
-     * @return string
-     */
-    private function getOrdersWithoutFilterQuery(): string
-    {
-        return '
-            {
-                orders {
-                    edges {
-                        node {
-                            status
-                            totalPrice {
-                                priceWithVat
-                            }
-                        }
-                    }
-                }
-            }
-        ';
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/graphql/getOrders.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/graphql/getOrders.graphql
@@ -1,0 +1,12 @@
+query getOrders ($first: Int, $last: Int) {
+    orders (first: $first, last: $last) {
+        edges {
+            node {
+                status
+                totalPrice {
+                    priceWithVat
+                }
+            }
+        }
+    }
+}

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -92,3 +92,5 @@ There you can find links to upgrade notes for other versions too.
         -   $this->assertContainsAllVariants([$mainProduct, ...$variants], $mainVariant);
         +   $this->assertContainsAllVariants($variants, $mainVariant);
         ```
+- rewrite the `GetOrdersAsAuthenticatedCustomerUserTest` test ([#2805](https://github.com/shopsys/shopsys/pull/2805))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The GetOrdersAsAuthenticatedCustomerUserTest is now shorter and does not use manually counted prices, that had to be updated with the demo data or pricing changes.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-test-orders-fix.odin.shopsys.cloud
  - https://cz.mg-test-orders-fix.odin.shopsys.cloud
<!-- Replace -->
