### PR TITLE
[project-base] order is updated in GoPay only if configuration is set

### DIFF
--- a/project-base/app/.env.test
+++ b/project-base/app/.env.test
@@ -1,3 +1,11 @@
 # define your env variables for the test environment here
 
 DATABASE_NAME=shopsys-test
+
+GOPAY_IS_PRODUCTION_MODE=false
+GOPAY_EN_GOID=test-data
+GOPAY_EN_CLIENTID=test-data
+GOPAY_EN_CLIENTSECRET=test-data
+GOPAY_CS_GOID=test-data
+GOPAY_CS_CLIENTID=test-data
+GOPAY_CS_CLIENTSECRET=test-data

--- a/project-base/app/src/Model/GoPay/GoPayClientFactory.php
+++ b/project-base/app/src/Model/GoPay/GoPayClientFactory.php
@@ -30,10 +30,14 @@ class GoPayClientFactory
      */
     protected function getConfigByLocale(string $locale): array
     {
+        if (!array_key_exists($locale, $this->config)) {
+            throw new GoPayNotConfiguredException();
+        }
+
         $configByLocale = $this->config[$locale];
         $this->config = array_merge($this->config, $configByLocale);
 
-        if ($this->config['goid'] === null) {
+        if ($this->config['goid'] === null || $this->config['goid'] === '') {
             throw new GoPayNotConfiguredException();
         }
 

--- a/project-base/app/src/Model/Payment/Service/PaymentServiceFacade.php
+++ b/project-base/app/src/Model/Payment/Service/PaymentServiceFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Model\Payment\Service;
 
 use App\FrontendApi\Model\Payment\PaymentSetupCreationData;
+use App\Model\GoPay\Exception\GoPayNotConfiguredException;
 use App\Model\GoPay\Exception\GoPayPaymentDownloadException;
 use App\Model\GoPay\GoPayFacade;
 use App\Model\Order\Order;
@@ -98,7 +99,7 @@ class PaymentServiceFacade
                 if ($update) {
                     $this->paymentTransactionFacade->edit($paymentTransaction->getId(), $paymentTransactionData);
                 }
-            } catch (PaymentServiceFacadeNotRegisteredException $exception) {
+            } catch (PaymentServiceFacadeNotRegisteredException | GoPayNotConfiguredException $exception) {
                 $this->logger->error($exception->getMessage());
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| There were calls on GoPay with 409 results. We do not want to spam GoPay servers with incorrect calls so we made this fix.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-gopay-export-fix.odin.shopsys.cloud
  - https://cz.tl-gopay-export-fix.odin.shopsys.cloud
<!-- Replace -->
