### PR TITLE
[documentation] fixed build on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,13 @@
 version: 2
 
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.7"
+
 mkdocs:
     configuration: mkdocs.yml
 
 python:
-    version: 3.7
     install:
         -   requirements: docs/requirements.txt


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Read the Docs changed the format of the configuration file. This PR apply those changes, so the documentation can be built again.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-rtd-build.odin.shopsys.cloud
  - https://cz.mg-fix-rtd-build.odin.shopsys.cloud
<!-- Replace -->
