### PR TITLE
fix Empty cart icon height

### DIFF
--- a/project-base/storefront/components/Basic/Icon/IconsSvg.tsx
+++ b/project-base/storefront/components/Basic/Icon/IconsSvg.tsx
@@ -353,7 +353,7 @@ export const HeartIcon: SvgFC<{ isFull: boolean }> = ({ isFull, ...props }) => (
 );
 
 export const EmptyCartIcon: SvgFC = (props) => (
-    <svg {...props} width="572" height="512" viewBox="0 0 572 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg {...props} viewBox="0 0 572 512" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             fillRule="evenodd"
             clipRule="evenodd"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| fix Empty cart icon height
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1781-fix-empty-cart-icon-height.odin.shopsys.cloud
  - https://cz.tv-fw-1781-fix-empty-cart-icon-height.odin.shopsys.cloud
<!-- Replace -->
