### PR TITLE
restrict limit of requests how many can robot ask from eshop

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -488,6 +488,17 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   `$country`
 -   see #project-base-diff to update your project
 
+#### restrict limit of requests how many can robot ask from eshop ([#2820](https://github.com/shopsys/shopsys/pull/2820))
+
+-   this change adds migration `Version20230919173422` that adds SEO robot limits to your `robots.txt` file. If you do not want to change it in your project, add it as skipped migration to `migrations-lock.yaml`
+-   if you have defined rules for all robots (`User-agent: *`), then you have to manually add these lines to your robots.txt
+    ```diff
+        User-agent: *
+    +   Crawl-delay: 3
+    +   Request-rate: 300/1m
+    ```
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Migrations/Version20230919173422.php
+++ b/packages/framework/src/Migrations/Version20230919173422.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+class Version20230919173422 extends AbstractMigration implements ContainerAwareInterface
+{
+    use MultidomainMigrationTrait;
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        foreach ($this->getAllDomainIds() as $domainId) {
+            $seoRobotsTxtContent = $this->sql('SELECT value FROM setting_values where name = \'seoRobotsTxtContent\' AND domain_id = :domainId', ['domainId' => $domainId])->fetchOne();
+
+            $seoRobotsTxtLines = explode("\n", $seoRobotsTxtContent);
+
+            if (count(preg_grep('/User-agent: \*/', $seoRobotsTxtLines)) !== 0) {
+                continue;
+            }
+
+            $seoRobotsTxtContent .= "\n\nUser-agent: *\nCrawl-delay: 3\nRequest-rate: 300/1m";
+            $this->sql('UPDATE setting_values SET value = :value where name = \'seoRobotsTxtContent\'  AND domain_id = :domainId', [
+                'value' => $seoRobotsTxtContent,
+                'domainId' => $domainId,
+            ]);
+        }
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/SettingValueDataFixture.php
@@ -117,7 +117,7 @@ class SettingValueDataFixture extends AbstractReferenceFixture implements Depend
             );
             $this->setting->setForDomain(
                 SeoSettingFacade::SEO_ROBOTS_TXT_CONTENT,
-                'Disallow: *?filter=',
+                "Disallow: *?filter=\n\nUser-agent: *\nCrawl-delay: 3\nRequest-rate: 300/1m",
                 $domainId,
             );
             $this->setting->setForDomain(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Hello, I recommend you restrict robots on how many requests can ask from eshop. These changes are not officially supported but some robots accept them...it's better as nothing, right? 😅 Thanks 🤝
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
