### PR TITLE
RFC: different Elastic configurations

### DIFF
--- a/project-base/app/src/Model/Product/Elasticsearch/ElasticProduct.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/ElasticProduct.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Product\Elasticsearch;
+
+class ElasticProduct
+{
+    #[ElasticField(type: 'text')]
+    public string $searchingNames;
+
+
+    #[ElasticField(
+        type: 'text',
+        fields: [
+            new ElasticField(
+                name: 'full_with_diacritic',
+                type: 'text',
+                analyzer: 'full_with_diacritic'
+            ),
+            new ElasticField(
+                name: 'full_without_diacritic',
+                type: 'text',
+                analyzer: 'full_without_diacritic',
+            ),
+            new ElasticField(
+                name: 'edge_ngram_with_diacritic',
+                type: 'text',
+                analyzer: 'edge_ngram_with_diacritic',
+                searchAnalyzer: 'full_with_diacritic'
+            ),
+            new ElasticField(
+                name: 'edge_ngram_without_diacritic',
+                type: 'text',
+                analyzer: 'edge_ngram_without_diacritic',
+                searchAnalyzer: 'full_without_diacritic'
+            ),
+            new ElasticField(
+                name: 'keyword',
+                type: 'icu_collation_keyword',
+                language: '%domain_locale%',
+                index: false
+            ),
+        ]
+    )]
+    public string $name;
+
+    #[ElasticField(type: 'text')]
+    public string $namePrefix;
+
+    #[ElasticField(type: 'text')]
+    public string $nameSufix;
+
+    #[ElasticField(
+        type: 'nested',
+        properties: [
+            new ElasticField(name: 'pricing_group_id', type: 'integer'),
+            new ElasticField(name: 'price_with_vat', type: 'float'),
+            new ElasticField(name: 'price_without_vat', type: 'float'),
+            new ElasticField(name: 'vat', type: 'float'),
+            new ElasticField(name: 'price_from', type: 'boolean'),
+            new ElasticField(name: 'filtering_minimal_price', type: 'float'),
+            new ElasticField(name: 'filtering_maximal_price', type: 'float'),
+        ]
+    )]
+    public array $prices;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $inStock;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $isAvailable;
+
+    #[ElasticField(
+        type: 'nested',
+        properties: [
+            new ElasticField(name: 'parameter_id', type: 'integer'),
+            new ElasticField(name: 'parameter_uuid', type: 'keyword'),
+            new ElasticField(name: 'parameter_name', type: 'text'),
+            new ElasticField(name: 'parameter_unit', type: 'text'),
+            new ElasticField(name: 'parameter_group', type: 'text'),
+            new ElasticField(name: 'parameter_value_id', type: 'integer'),
+            new ElasticField(name: 'parameter_value_uuid', type: 'keyword'),
+            new ElasticField(name: 'parameter_value_text', type: 'text'),
+            new ElasticField(name: 'parameter_is_dimensional', type: 'boolean'),
+            new ElasticField(name: 'parameter_value_for_slider_filter', type: 'float'),
+        ]
+    )]
+    public array $parameters;
+
+    #[ElasticField(type: 'integer')]
+    public int $orderingPriority;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $calculatedSellingDenied;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $sellingDenied;
+
+    #[ElasticField(type: 'text')]
+    public string $availability;
+
+    #[ElasticField(type: 'text')]
+    public string $availabilityStatus;
+
+    #[ElasticField(type: 'integer')]
+    public int $availabilityDispatchTime;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $isVariant;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $isMainVariant;
+
+    #[ElasticField(type: 'text')]
+    public string $detailUrl;
+
+    #[ElasticField(
+        type: 'nested',
+        properties: [
+            new ElasticField(name: 'pricing_group_id', type: 'integer'),
+            new ElasticField(name: 'visible', type: 'boolean'),
+        ]
+    )]
+    public array $visibility;
+
+    #[ElasticField(type: 'keyword')]
+    public string $uuid;
+
+    #[ElasticField(type: 'text')]
+    public string $unit;
+
+    #[ElasticField(type: 'integer')]
+    public int $stockQuantity;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $hasPreorder;
+
+    #[ElasticField(type: 'integer')]
+    public int $variants;
+
+    #[ElasticField(type: 'integer')]
+    public int $mainVariantId;
+
+    #[ElasticField(type: 'text')]
+    public string $seoH1;
+
+    #[ElasticField(type: 'text')]
+    public string $seoTitle;
+
+    #[ElasticField(type: 'text')]
+    public string $seoMetaDescription;
+
+    #[ElasticField(type: 'boolean')]
+    public bool $isSaleExclusion;
+
+    #[ElasticField(type: 'text')]
+    public string $productAvailableStoresCountInformation;
+
+    #[ElasticField(
+        type: 'nested',
+        properties: [
+            new ElasticField(name: 'store_name', type: 'text'),
+            new ElasticField(name: 'store_id', type: 'integer'),
+            new ElasticField(name: 'availability_information', type: 'text'),
+            new ElasticField(name: 'availability_status', type: 'text'),
+        ]
+    )]
+    public array $storeAvailabilitiesInformation;
+
+    #[ElasticField(
+        type: 'nested',
+        properties: [
+            new ElasticField(name: 'anchor_text', type: 'text'),
+            new ElasticField(name: 'url', type: 'text'),
+        ]
+    )]
+    public array $files;
+
+    #[ElasticField(type: 'text')]
+    public string $usps;
+
+    #[ElasticField(type: 'integer')]
+    public int $mainCategoryId;
+
+    #[ElasticField(type: 'text')]
+    public string $mainCategoryPath;
+
+    #[ElasticField(type: 'text')]
+    public string $slug;
+
+    #[ElasticField(type: 'integer')]
+    public int $availableStoresCount;
+
+    #[ElasticField(type: 'integer')]
+    public int $relatedProducts;
+
+    #[ElasticField(properties: [
+        new ElasticField(name: 'name', type: 'text'),
+        new ElasticField(name: 'slug', type: 'keyword'),
+    ])]
+    public array $breadcrumb;
+}

--- a/project-base/app/src/Resources/definition/ProductIndexMapping.php
+++ b/project-base/app/src/Resources/definition/ProductIndexMapping.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Resources\definition;
+
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
+
+class ProductIndexMapping extends AbstractIndexMapping
+{
+    const ANALYZER_FULL_WITH_DIACRITIC = 'full_with_diacritic';
+    const ANALYZER_FULL_WITHOUT_DIACRITIC = 'full_without_diacritic';
+    const ANALYZER_EDGE_NGRAM_WITH_DIACRITIC = 'edge_ngram_with_diacritic';
+    const ANALYZER_EDGE_NGRAM_WITHOUT_DIACRITIC = 'edge_ngram_without_diacritic';
+    const ANALYZER_WHITESPACE = 'whitespace';
+    const ANALYZER_WHITESPACE_WITHOUT_DOTS = 'whitespace_without_dots';
+    const ANALYZER_EDGE_NGRAM_UNANALYZED_WORDS = 'edge_ngram_unanalyzed_words';
+
+    public function indexSetting(DomainConfig $domainConfig)
+    {
+        if ($this->container->getParameter('kernel.environment') !== EnvironmentType::DEVELOPMENT) {
+            $this->mappingBuilder->setSetting('number_of_shards', 1);
+            $this->mappingBuilder->setSetting('number_of_replicas', 0);
+        } else {
+            $this->mappingBuilder->setSetting('number_of_shards', 10);
+            $this->mappingBuilder->setSetting('number_of_replicas', 4);
+        }
+    }
+
+    public function analysisSetting(DomainConfig $domainConfig)
+    {
+        if ($domainConfig->getLocale() === 'cs') {
+            $this->analysisCs();
+        }
+
+        if ($domainConfig->getLocale() === 'en') {
+            $this->analysisEn();
+        }
+    }
+
+    private function analysisEn()
+    {
+        $this->mappingBuilder->addFilter(
+            'english_stop',
+            'stop',
+            [
+                'stopwords' => '_english_',
+            ],
+        );
+
+        $this->mappingBuilder->addFilter(
+            'english_stemmer',
+            'stemmer',
+            [
+                'language' => 'english',
+            ],
+        );
+
+        $this->mappingBuilder->addFilter(
+            'edge_ngram',
+            'edgeNGram',
+            [
+                'min_gram' => 2,
+                'max_gram' => 20,
+            ],
+        );
+
+        $this->addTokenizer('keep_special_chars', 'pattern', ['pattern' => '[^\p{L}\d-/]+']);
+
+
+        $this->mappingBuilder->addAnalyzer('full_with_diacritic',
+            ['tokenizer' => 'keep_special_chars',
+                'filter' => ['lowercase'],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('full_without_diacritic',
+            [
+                'tokenizer' => 'keep_special_chars',
+                'filter' => [
+                    'lowercase',
+                    'asciifolding',
+                ],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('stemming',
+            [
+                'tokenizer' => 'standard',
+                'filter' => [
+                    'lowercase',
+                    'english_stemmer',
+                    'english_stop',
+                    'asciifolding',
+                ],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('edge_ngram_with_diacritic',
+            [
+                'tokenizer' => 'keep_special_chars',
+                'filter' => [
+                    'edge_ngram',
+                    'lowercase',
+                ],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('edge_ngram_without_diacritic',
+            [
+                'tokenizer' => 'keep_special_chars',
+                'filter' => [
+                    'edge_ngram',
+                    'lowercase',
+                    'asciifolding',
+                ],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('full_without_diacritic_html',
+            [
+                'char_filter' => 'html_strip',
+                'tokenizer' => 'keep_special_char',
+                'filter' => [
+                    'lowercase',
+                    'asciifolding',
+                ],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('edge_ngram_without_diacritic_html',
+            [
+                'char_filter' => 'html_strip',
+                'tokenizer' => 'keep_special_char',
+                'filter' => [
+                    'edge_ngram',
+                    'lowercase',
+                    'asciifolding',
+                ],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('edge_ngram_unanalyzed',
+            [
+                'tokenizer' => 'keyword',
+                'filter' => ['edge_ngram'],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('edge_ngram_unanalyzed_words',
+            [
+                'tokenizer' => 'whitespace',
+                'filter' => ['edge_ngram'],
+            ],
+        );
+
+        $this->mappingBuilder->addAnalyzer('whitespace_without_dots',
+            [
+                'tokenizer' => 'whitespace',
+                'char_filter' => 'dots_replace_filter',
+            ],
+        );
+
+        $this->mappingBuilder->addCharFilter('dots_replace_filter',
+            [
+                'type' => 'pattern_replace',
+                'pattern' => '\\.',
+                'replacement' => '',
+            ],
+        );
+    }
+
+    private function analysisCs() {
+        // similar to analysisEn()
+    }
+
+    public function indexMapping(DomainConfig $domainConfig)
+    {
+        $searchingNames = $this->mappingBuilder->addField('searching_names', FieldType::TEXT)->setAnalyzer('stemming');
+        $searchingNames->addField('full_with_diacritic', FieldType::TEXT)
+            ->setAnalyzer(self::ANALYZER_FULL_WITH_DIACRITIC);
+        $searchingNames->addField('full_without_diacritic', FieldType::TEXT)
+            ->setAnalyzer(self::ANALYZER_FULL_WITHOUT_DIACRITIC);
+        $searchingNames->addField('edge_ngram_with_diacritic', FieldType::TEXT)
+            ->setAnalyzer(self::ANALYZER_EDGE_NGRAM_WITH_DIACRITIC)
+            ->setSearchAnalyzer(self::ANALYZER_FULL_WITH_DIACRITIC);
+        $searchingNames->addField('edge_ngram_without_diacritic', FieldType::TEXT)
+            ->setAnalyzer(self::ANALYZER_EDGE_NGRAM_WITHOUT_DIACRITIC)
+            ->setSearchAnalyzer(self::ANALYZER_FULL_WITHOUT_DIACRITIC);
+        $searchingNames->addField('keyword', FieldType::ICU_COLLATION_KEYWORD, ['language' => $domainConfig->getLocale()])
+            ->noIndex();
+
+        $name = $this->mappingBuilder->addField('name', FieldType::TEXT);
+        $name->addField('keyword', FieldType::ICU_COLLATION_KEYWORD, ['language' => $domainConfig->getLocale()])
+            ->noIndex();
+
+        $this->mappingBuilder->addField('name_prefix', FieldType::TEXT);
+        $this->mappingBuilder->addField('name_sufix', FieldType::TEXT);
+
+        $searchingCatnums = $this->mappingBuilder->addField('searching_catnums', FieldType::TEXT)
+            ->setAnalyzer(self::ANALYZER_WHITESPACE)
+            ->setSearchAnalyzer(self::ANALYZER_WHITESPACE_WITHOUT_DOTS);
+        $searchingCatnums->addField('edge_ngram_unanalyzed_words', FieldType::TEXT)
+            ->setAnalyzer(self::ANALYZER_EDGE_NGRAM_UNANALYZED_WORDS)
+            ->setSearchAnalyzer(self::ANALYZER_WHITESPACE_WITHOUT_DOTS);
+
+        $this->mappingBuilder->addField('catnum', FieldType::TEXT);
+
+        $prices = $this->mappingBuilder->addNestedField('prices');
+        $prices->addProperty('pricing_group_id', FieldType::INTEGER);
+        $prices->addProperty('price_with_vat', FieldType::FLOAT);
+        $prices->addProperty('price_without_vat', FieldType::FLOAT);
+        $prices->addProperty('vat', FieldType::FLOAT);
+        $prices->addProperty('price_from', FieldType::BOOLEAN);
+        $prices->addProperty('filtering_minimal_price', FieldType::FLOAT);
+        $prices->addProperty('filtering_maximal_price', FieldType::FLOAT);
+
+        $this->mappingBuilder->addField('in_stock', FieldType::BOOLEAN);
+        $this->mappingBuilder->addField('is_available', FieldType::BOOLEAN);
+
+        $parameters = $this->mappingBuilder->addNestedField('parameters');
+        $parameters->addProperty('parameter_id', FieldType::INTEGER);
+        $parameters->addProperty('parameter_uuid', FieldType::KEYWORD);
+        $parameters->addProperty('parameter_name', FieldType::TEXT);
+        $parameters->addProperty('parameter_unit', FieldType::TEXT);
+        $parameters->addProperty('parameter_group', FieldType::TEXT);
+        $parameters->addProperty('parameter_value_id', FieldType::INTEGER);
+        $parameters->addProperty('parameter_value_uuid', FieldType::KEYWORD);
+        $parameters->addProperty('parameter_value_text', FieldType::TEXT);
+        $parameters->addProperty('parameter_is_dimensional', FieldType::BOOLEAN);
+        $parameters->addProperty('parameter_value_for_slider_filter', FieldType::FLOAT);
+
+        $this->mappingBuilder->addField('ordering_priority', FieldType::INTEGER);
+        $this->mappingBuilder->addField('calculated_selling_denied', FieldType::BOOLEAN);
+        $this->mappingBuilder->addField('selling_denied', FieldType::BOOLEAN);
+        $this->mappingBuilder->addField('availability', FieldType::TEXT);
+        $this->mappingBuilder->addField('availability_status', FieldType::TEXT);
+        $this->mappingBuilder->addField('availability_dispatch_time', FieldType::INTEGER);
+        $this->mappingBuilder->addField('is_variant', FieldType::BOOLEAN);
+        $this->mappingBuilder->addField('is_main_variant', FieldType::BOOLEAN);
+        $this->mappingBuilder->addField('detail_url', FieldType::TEXT);
+
+        // ... and so on
+    }
+
+}

--- a/project-base/app/src/Resources/definition/product.yaml
+++ b/project-base/app/src/Resources/definition/product.yaml
@@ -1,0 +1,376 @@
+index:
+    number_of_shards: 1
+    number_of_replicas: 0
+
+index@prod:
+    number_of_shards: 10
+    number_of_replicas: 5
+
+analysis@locale-en:
+    filter:
+        english_stop:
+            type: stop
+            stopwords: _english_
+        english_stemmer:
+            type: stemmer
+            language: english
+        edge_ngram:
+            type: edgeNGram
+            min_gram: 2
+            max_gram: 20
+    tokenizer:
+        keep_special_chars:
+            type: pattern
+            pattern: "[^\\p{L}\\d-/]+"
+    analyzer:
+        full_with_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - lowercase
+        full_without_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - lowercase
+                - asciifolding
+        stemming:
+            tokenizer: standard
+            filter:
+                - lowercase
+                - english_stemmer
+                - english_stop
+                - asciifolding
+        edge_ngram_with_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - edge_ngram
+                - lowercase
+        edge_ngram_without_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - edge_ngram
+                - lowercase
+                - asciifolding
+        full_without_diacritic_html:
+            char_filter: html_strip
+            tokenizer: keep_special_chars
+            filter:
+                - lowercase
+                - asciifolding
+        edge_ngram_without_diacritic_html:
+            char_filter: html_strip
+            tokenizer: keep_special_chars
+            filter:
+                - edge_ngram
+                - lowercase
+                - asciifolding
+        edge_ngram_unanalyzed:
+            tokenizer: keyword
+            filter:
+                - edge_ngram
+        edge_ngram_unanalyzed_words:
+            tokenizer: whitespace
+            filter:
+                - edge_ngram
+        whitespace_without_dots:
+            tokenizer: whitespace
+            char_filter:
+                - dots_replace_filter
+    char_filter:
+        dots_replace_filter:
+            type: pattern_replace
+            pattern: "\\."
+            replacement: ''
+
+analysis@locale-cs:
+    filter:
+        czech_stop:
+            type: stop
+            stopwords: _czech_
+        czech_stemmer:
+            type: stemmer
+            language: czech
+        edge_ngram:
+            type: edgeNGram
+            min_gram: 2
+            max_gram: 20
+    tokenizer:
+        keep_special_chars:
+            type: pattern
+            pattern: "[^\\p{L}\\d-/]+"
+    analyzer:
+        full_with_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - lowercase
+        full_without_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - lowercase
+                - asciifolding
+        stemming:
+            tokenizer: standard
+            filter:
+                - lowercase
+                - czech_stemmer
+                - czech_stop
+                - asciifolding
+        edge_ngram_with_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - edge_ngram
+                - lowercase
+        edge_ngram_without_diacritic:
+            tokenizer: keep_special_chars
+            filter:
+                - edge_ngram
+                - lowercase
+                - asciifolding
+        full_without_diacritic_html:
+            char_filter: html_strip
+            tokenizer: keep_special_chars
+            filter:
+                - lowercase
+                - asciifolding
+        edge_ngram_without_diacritic_html:
+            char_filter: html_strip
+            tokenizer: keep_special_chars
+            filter:
+                - edge_ngram
+                - lowercase
+                - asciifolding
+        edge_ngram_unanalyzed:
+            tokenizer: keyword
+            filter:
+                - edge_ngram
+        edge_ngram_unanalyzed_words:
+            tokenizer: whitespace
+            filter:
+                - edge_ngram
+        whitespace_without_dots:
+            tokenizer: whitespace
+            char_filter:
+                - dots_replace_filter
+    char_filter:
+        dots_replace_filter:
+            type: pattern_replace
+            pattern: "\\."
+            replacement: ''
+
+mappings:
+    searching_names:
+        type: text
+    searching_names@domain-1:
+        type: text
+        analyzer: stemming
+        fields:
+            full_with_diacritic:
+                type: text
+                analyzer: full_with_diacritic
+            full_without_diacritic:
+                type: text
+                analyzer: full_without_diacritic
+            edge_ngram_with_diacritic:
+                type: text
+                analyzer: edge_ngram_with_diacritic
+                search_analyzer: full_with_diacritic
+            edge_ngram_without_diacritic:
+                type: text
+                analyzer: edge_ngram_without_diacritic
+                search_analyzer: full_without_diacritic
+            keyword:
+                type: icu_collation_keyword
+                language: '%domain_locale%'
+                index: false
+    name:
+        type: text
+        fields:
+            keyword:
+                type: icu_collation_keyword
+                language: '%domain_locale%'
+                index: false
+    name_prefix:
+        type: text
+    name_prefix@locale-cs:
+        type: text
+    name_sufix:
+        type: text
+    searching_catnums:
+        type: text
+        analyzer: whitespace
+        search_analyzer: whitespace_without_dots
+        fields:
+            edge_ngram_unanalyzed_words:
+                type: text
+                analyzer: edge_ngram_unanalyzed_words
+                search_analyzer: whitespace_without_dots
+    catnum:
+        type: text
+    searching_partnos:
+        type: text
+        analyzer: whitespace
+        fields:
+            edge_ngram_unanalyzed_words:
+                type: text
+                analyzer: edge_ngram_unanalyzed_words
+                search_analyzer: whitespace
+    partno:
+        type: text
+    searching_eans:
+        type: text
+        analyzer: whitespace
+        fields:
+            edge_ngram_unanalyzed_words:
+                type: text
+                analyzer: edge_ngram_unanalyzed_words
+                search_analyzer: whitespace
+    ean:
+        type: text
+    searching_short_descriptions:
+        type: text
+        analyzer: edge_ngram_without_diacritic
+        search_analyzer: full_without_diacritic
+    short_description:
+        type: text
+    searching_descriptions:
+        type: text
+        analyzer: edge_ngram_without_diacritic_html
+        search_analyzer: full_without_diacritic_html
+    description:
+        type: text
+    flags:
+        type: integer
+    brand:
+        type: integer
+    brand_name:
+        type: text
+    brand_url:
+        type: text
+    categories:
+        type: integer
+    prices:
+        type: nested
+        properties:
+            pricing_group_id:
+                type: integer
+            price_with_vat:
+                type: float
+            price_without_vat:
+                type: float
+            vat:
+                type: float
+            price_from:
+                type: boolean
+            filtering_minimal_price:
+                type: float
+            filtering_maximal_price:
+                type: float
+    in_stock:
+        type: boolean
+    is_available:
+        type: boolean
+    parameters:
+        type: nested
+        properties:
+            parameter_id:
+                type: integer
+            parameter_uuid:
+                type: keyword
+            parameter_name:
+                type: text
+            parameter_unit:
+                type: text
+            parameter_group:
+                type: text
+            parameter_value_id:
+                type: integer
+            parameter_value_uuid:
+                type: keyword
+            parameter_value_text:
+                type: text
+            parameter_is_dimensional:
+                type: boolean
+            parameter_value_for_slider_filter:
+                type: float
+    ordering_priority:
+        type: integer
+    calculated_selling_denied:
+        type: boolean
+    selling_denied:
+        type: boolean
+    availability:
+        type: text
+    availability_status:
+        type: text
+    availability_dispatch_time:
+        type: integer
+    is_variant:
+        type: boolean
+    is_main_variant:
+        type: boolean
+    detail_url:
+        type: text
+    visibility:
+        type: nested
+        properties:
+            pricing_group_id:
+                type: integer
+            visible:
+                type: boolean
+    uuid:
+        type: keyword
+    unit:
+        type: text
+    stock_quantity:
+        type: integer
+    has_preorder:
+        type: boolean
+    variants:
+        type: integer
+    main_variant_id:
+        type: integer
+    seo_h1:
+        type: text
+    seo_title:
+        type: text
+    seo_meta_description:
+        type: text
+    is_sale_exclusion:
+        type: boolean
+    product_available_stores_count_information:
+        type: text
+    store_availabilities_information:
+        type: nested
+        properties:
+            store_name:
+                type: text
+            store_id:
+                type: integer
+            availability_information:
+                type: text
+            availability_status:
+                type: text
+    files:
+        type: nested
+        properties:
+            anchor_text:
+                type: text
+            url:
+                type: text
+    usps:
+        type: text
+    main_category_id:
+        type: integer
+    main_category_path:
+        type: text
+    slug:
+        type: text
+    available_stores_count:
+        type: integer
+    related_products:
+        type: integer
+    breadcrumb:
+        properties:
+            name:
+                type: text
+            slug:
+                type: keyword


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR is RFC (Request for Comments) and is not intended to be merged.
|New feature| Yes/No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes/No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes/No

I have tried to present several different ways to configure elastic search indices. Currently, we use different JSON files for each domain. We have several problems with it:

- it's tedious to add a new field (We need to update a number of files depending on the count of the domains)
- many copy-pasted code
- changes in the field may be easily forgotten in some file
- due to file names, it's hard to find the right one (see #1286)
- it's not possible to set different index settings for different environments

I have these proposals:

## 1. Use a single Yaml file for configuration

see project-base/app/src/Resources/definition/product.yaml

Configuration is split into three main parts:
- index
  - setting for the index (number of shards, number of replicas, ...)
- analysis
  - analysis setting – analyzers, filters, tokenizers, ...
- mappings
  - field mapping. What fields and with what type do we use

only one file per index type is used. Differences for the domains/locales/environments may be achieved with the `@something` suffix. 
For example, the analysis may be different for different languages, so 

```
analysis@locale-en:
    ....
```
will be used for every domain with English locale, while 

```
analysis@domain-1:
    ....
```
will be used only for the first domain.

The `@` suffixes are allowed in the root configurations (index, analysis, mappings) and in the individual fields in the mappings configuration
```
mappings:
    searching_names:
        type: text
    searching_names@domain-1:
       type: text
       analyzer: stemming
```

Suffixes have the priority domain - locale - environment - nothing. So the setting for the domain has a higher priority over locale, and so on. 
Configurations are always overwritten, so when the same configuration exists for domain and locale, only the domain will be used and nothing from the locale will be merged.

Since YAML can be easily converted to JSON, it's possible to use almost any configuration, that is in the current index definition, but the YAML allows us to use only a single (and more readable) file while allowing the differences for domains. 

## 2. Use a PHP configuration

This idea uses PHP for configuration. This expects some kind of builder. 
We can use a builder object to addFields and set analyzers, and configurations. 

We can use PHP to adjust the configuration based on the domain/environment/locale.

The configuration example is available in the `project-base/app/src/Resources/definition/ProductIndexMapping.php` file.

This configuration may be a little chatty and it may be harder to add uncommon configurations... 

## 3. Use Attributes on the object

We may use class, which may be then used in the productExportRepository instead of the array. 
Configuration for the elastic could be added as attributes to the fields. 
That way we ensure that everything we export is properly mapped.
It's a similar concept as we use to configure Doctrine. 

An example is available in `project-base/app/src/Model/Product/Elasticsearch/ElasticProduct.php`

It may be harder to add an uncommon configuration (need to add a new attribute). 
I have currently no idea how to implement differences for the different domains/locales.

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-rfc-es-mapping.odin.shopsys.cloud
  - https://cz.mg-rfc-es-mapping.odin.shopsys.cloud
<!-- Replace -->
