### PR TITLE
[infrastructure] upgrade Kubernetes Buildpack version

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -236,7 +236,7 @@ service:merge_request:
 
 .deploy: &deploy
     image:
-        name: shopsys/kubernetes-buildpack:0.9
+        name: shopsys/kubernetes-buildpack:1.1
     stage: deploy
     needs:
         - build
@@ -296,7 +296,7 @@ deploy:devel:
 test:gatling:
     stage: test
     image:
-        name: shopsys/kubernetes-buildpack:0.9
+        name: shopsys/kubernetes-buildpack:1.1
     tags:
         - tests
     variables:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After upgrade docker version on internal Gitlab Runners you will be not able to deploy because of older version of Buildpack
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://upgrade-buildpack.odin.shopsys.cloud
  - https://cz.upgrade-buildpack.odin.shopsys.cloud
<!-- Replace -->
