### PR TITLE
comparison popup is now visible after adding a product from product detail

### DIFF
--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailContent.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailContent.tsx
@@ -13,10 +13,17 @@ import { useComparison } from 'hooks/comparison/useComparison';
 import { useGtmProductDetailViewEvent } from 'gtm/hooks/useGtmProductDetailViewEvent';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
-import { Fragment, useRef } from 'react';
+import { useRef } from 'react';
 import { ProductWishlistButton } from 'components/Blocks/Product/ButtonsAction/ProductWishlistButton';
 import { useWishlist } from 'hooks/useWishlist';
 import { ProductDetailGallery } from './ProductDetailGallery';
+import dynamic from 'next/dynamic';
+
+const ProductComparePopup = dynamic(() =>
+    import('components/Blocks/Product/ButtonsAction/ProductComparePopup').then(
+        (component) => component.ProductComparePopup,
+    ),
+);
 
 type ProductDetailContentProps = {
     product: ProductDetailFragmentApi;
@@ -29,7 +36,8 @@ export const ProductDetailContent: FC<ProductDetailContentProps> = ({ product, f
     const { t } = useTranslation();
     const scrollTarget = useRef<HTMLUListElement>(null);
     const router = useRouter();
-    const { isProductInComparison, toggleProductInComparison } = useComparison();
+    const { isProductInComparison, toggleProductInComparison, isPopupCompareOpen, setIsPopupCompareOpen } =
+        useComparison();
     const { toggleProductInWishlist, isProductInWishlist } = useWishlist();
 
     useGtmProductDetailViewEvent(product, getUrlWithoutGetParameters(router.asPath), fetching);
@@ -93,6 +101,7 @@ export const ProductDetailContent: FC<ProductDetailContentProps> = ({ product, f
 
                 {!!product.accessories.length && <ProductDetailAccessories accessories={product.accessories} />}
             </Webline>
+            {isPopupCompareOpen && <ProductComparePopup onCloseCallback={() => setIsPopupCompareOpen(false)} />}
         </>
     );
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Previously, the popup was only visible after adding a product from product list. This caused inconsistency in the behavior.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-comparison-from-detail-popup.odin.shopsys.cloud
  - https://cz.sh-comparison-from-detail-popup.odin.shopsys.cloud
<!-- Replace -->
