### PR TITLE
[shopsys] graphql-bundle classes are now dumped so they can use composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "autoload": {
         "psr-4": {
             "App\\": "project-base/app/src/",
+            "Overblog\\GraphQLBundle\\__DEFINITIONS__\\": "project-base/app/var/overblogCompiledClasses",
             "Shopsys\\CodingStandards\\": "packages/coding-standards/src/",
             "Shopsys\\FormTypesBundle\\": "packages/form-types-bundle/src/",
             "Shopsys\\FrontendApiBundle\\": "packages/frontend-api/src/",

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -8,6 +8,7 @@
             "App\\": [
                 "src/"
             ],
+            "Overblog\\GraphQLBundle\\__DEFINITIONS__\\": "var/overblogCompiledClasses",
             "Sniffer\\": [
                 "sniffer/"
             ]

--- a/project-base/app/config/directories.yaml
+++ b/project-base/app/config/directories.yaml
@@ -3,3 +3,4 @@ parameters:
         - "%shopsys.product_files_dir%"
     internal_directories:
         - '%kernel.cache_dir%/localeFileUploads'
+        - '%kernel.project_dir%/var/overblogCompiledClasses'

--- a/project-base/app/config/packages/overblog_dataloader.yaml
+++ b/project-base/app/config/packages/overblog_dataloader.yaml
@@ -1,25 +1,3 @@
-overblog_graphql:
-    definitions:
-        schema:
-            query: Query
-            mutation: Mutation
-        mappings:
-            types:
-                -   type: yaml
-                    dir: "%kernel.project_dir%/config/graphql/types"
-        builders:
-            args:
-                -   alias: "PaginatorArgumentsBuilder"
-                    class: App\FrontendApi\Component\Arguments\PaginatorArgumentsBuilder
-                -   alias: "BlogArticlePaginatorArgumentsBuilder"
-                    class: App\FrontendApi\Model\BlogArticle\BlogArticlePaginatorArgumentsBuilder
-    security:
-        handle_cors: true
-        query_max_complexity: 1110
-        enable_introspection: '%kernel.debug%'
-    services:
-        promise_adapter: "webonyx_graphql.sync_promise_adapter"
-
 overblog_dataloader:
     defaults:
         promise_adapter: "overblog_dataloader.webonyx_graphql_sync_promise_adapter"

--- a/project-base/app/config/packages/overblog_graphql.yaml
+++ b/project-base/app/config/packages/overblog_graphql.yaml
@@ -1,0 +1,21 @@
+overblog_graphql:
+    definitions:
+        schema:
+            query: Query
+            mutation: Mutation
+        mappings:
+            types:
+                -   type: yaml
+                    dir: "%kernel.project_dir%/config/graphql/types"
+        builders:
+            args:
+                -   alias: "PaginatorArgumentsBuilder"
+                    class: App\FrontendApi\Component\Arguments\PaginatorArgumentsBuilder
+                -   alias: "BlogArticlePaginatorArgumentsBuilder"
+                    class: App\FrontendApi\Model\BlogArticle\BlogArticlePaginatorArgumentsBuilder
+    security:
+        handle_cors: true
+        query_max_complexity: 1110
+        enable_introspection: '%kernel.debug%'
+    services:
+        promise_adapter: "webonyx_graphql.sync_promise_adapter"

--- a/project-base/app/config/packages/overblog_graphql.yaml
+++ b/project-base/app/config/packages/overblog_graphql.yaml
@@ -13,6 +13,10 @@ overblog_graphql:
                     class: App\FrontendApi\Component\Arguments\PaginatorArgumentsBuilder
                 -   alias: "BlogArticlePaginatorArgumentsBuilder"
                     class: App\FrontendApi\Model\BlogArticle\BlogArticlePaginatorArgumentsBuilder
+        # these settings are suggested by docs: https://github.com/overblog/GraphQLBundle/blob/master/docs/index.md#composer-autoloader-configuration-optional
+        use_classloader_listener: false
+        auto_compile: true
+        cache_dir: '%kernel.project_dir%/var/overblogCompiledClasses'
     security:
         handle_cors: true
         query_max_complexity: 1110

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -243,3 +243,5 @@ You will need to follow these steps:
             ) {
         ```
     - see #project-base-diff to update your project
+- update overblog settings to embrace composer autoloader for faster class loading ([#2830](https://github.com/shopsys/shopsys/pull/2830))
+    - see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| graphql-bundle suggests to use composer autoload for loading its classes - https://github.com/overblog/GraphQLBundle/blob/master/docs/index.md#composer-autoloader-configuration-optional
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-overblog-definitions.odin.shopsys.cloud
  - https://cz.tl-overblog-definitions.odin.shopsys.cloud
<!-- Replace -->
