### PR TITLE
database, redis, and elastic is now cleaned after PR merge

### DIFF
--- a/.github/cancel-review.sh
+++ b/.github/cancel-review.sh
@@ -5,6 +5,10 @@ if [ -n "$BRANCH_NAME" ]; then
 
     if [ -d "../$BRANCH_NAME" ]; then
         cd "../$BRANCH_NAME"
+
+        docker compose exec php-fpm php phing -D production.confirm.action=y elasticsearch-index-delete clean-redis clean-redis-old
+        docker compose exec php-fpm php ./bin/console doctrine:database:drop --force
+
         docker compose down -v --remove-orphans
         docker system prune -a -f
         cd ..

--- a/.github/cancel-review.sh
+++ b/.github/cancel-review.sh
@@ -7,6 +7,7 @@ if [ -n "$BRANCH_NAME" ]; then
         cd "../$BRANCH_NAME"
 
         docker compose exec php-fpm php phing -D production.confirm.action=y elasticsearch-index-delete clean-redis clean-redis-old
+        docker compose exec php-fpm php ./bin/console shopsys:redis:clean-storefront-cache --queries --translations
         docker compose exec php-fpm php ./bin/console doctrine:database:drop --force
 
         docker compose down -v --remove-orphans

--- a/project-base/app/config/packages/snc_redis.yaml
+++ b/project-base/app/config/packages/snc_redis.yaml
@@ -18,7 +18,7 @@ snc_redis:
             alias: 'global'
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
-                prefix: '%env(REDIS_PREFIX)%'
+                prefix: '%env(REDIS_PREFIX)%:'
         main_friendly_url_slugs:
             type: 'phpredis'
             alias: 'main_friendly_url_slugs'

--- a/project-base/app/src/Command/CleanStorefrontQueryCacheCommand.php
+++ b/project-base/app/src/Command/CleanStorefrontQueryCacheCommand.php
@@ -7,7 +7,9 @@ namespace App\Command;
 use App\Component\Redis\CleanStorefrontCacheFacade;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CleanStorefrontQueryCacheCommand extends Command
 {
@@ -15,19 +17,23 @@ class CleanStorefrontQueryCacheCommand extends Command
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
-    protected static $defaultName = 'shopsys:redis:clean-storefront-query-cache';
+    protected static $defaultName = 'shopsys:redis:clean-storefront-cache';
 
     /**
      * @param \App\Component\Redis\CleanStorefrontCacheFacade $cleanStorefrontCacheFacade
      */
-    public function __construct(private CleanStorefrontCacheFacade $cleanStorefrontCacheFacade)
-    {
+    public function __construct(
+        private readonly CleanStorefrontCacheFacade $cleanStorefrontCacheFacade,
+    ) {
         parent::__construct();
     }
 
     protected function configure(): void
     {
-        $this->setDescription('Cleans up storefront query cache');
+        $this->setDescription('Cleans up storefront caches');
+
+        $this->addOption('queries', null, InputOption::VALUE_NONE, 'Clean graphql query cache');
+        $this->addOption('translations', null, InputOption::VALUE_NONE, 'Clean translations cache');
     }
 
     /**
@@ -37,7 +43,24 @@ class CleanStorefrontQueryCacheCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->cleanStorefrontCacheFacade->cleanStorefrontGraphqlQueryCache();
+        $shouldCleanQueries = $input->getOption('queries');
+        $shouldCleanTranslations = $input->getOption('translations');
+
+        $symfonyStyle = new SymfonyStyle($input, $output);
+
+        if (!$shouldCleanQueries && !$shouldCleanTranslations) {
+            $symfonyStyle->error('You have to specify at least one of the options: --queries, --translations');
+        }
+
+        if ($shouldCleanQueries) {
+            $this->cleanStorefrontCacheFacade->cleanStorefrontGraphqlQueryCache();
+            $symfonyStyle->success('Storefront graphql query cache cleaned');
+        }
+
+        if ($shouldCleanTranslations) {
+            $this->cleanStorefrontCacheFacade->cleanStorefrontTranslationCache();
+            $symfonyStyle->success('Storefront translations cache cleaned');
+        }
 
         return Command::SUCCESS;
     }

--- a/project-base/app/src/Component/Redis/CleanStorefrontCacheFacade.php
+++ b/project-base/app/src/Component/Redis/CleanStorefrontCacheFacade.php
@@ -23,7 +23,7 @@ class CleanStorefrontCacheFacade
     /**
      * @param string $locale
      */
-    public function cleanStorefrontTranslationCache(string $locale): void
+    public function cleanStorefrontTranslationCache(string $locale = ''): void
     {
         $keyPattern = 'translates:' . $locale . '*';
         $this->cleanStorefrontCacheByKeyPattern($keyPattern);

--- a/project-base/app/tests/App/Functional/Component/Redis/RedisVersionsFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Component/Redis/RedisVersionsFacadeTest.php
@@ -15,7 +15,9 @@ class RedisVersionsFacadeTest extends FunctionalTestCase
         $oldVersionKey = '20190308130158.test';
         $notVersionKey = '2019030813015.test';
 
-        $redisClient = self::getContainer()->get('snc_redis.test');
+        /** @var \Redis $redisClient */
+        $redisClient = self::getContainer()->get('snc_redis.global');
+
         $redisClient->set($currentVersionKey, 'test');
         $redisClient->set($oldVersionKey, 'test');
         $redisClient->set($notVersionKey, 'test');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| To prevent stale data on review server, the services (database, elastic, redis) are now cleaned after PR is merged/closed. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-clean-review.odin.shopsys.cloud
  - https://cz.mg-clean-review.odin.shopsys.cloud
<!-- Replace -->
