### PR TITLE
[project-base] seo category mix slug now includes trailing slash and is consistent with other slugs

### DIFF
--- a/project-base/app/src/FrontendApi/Model/Category/ReadyCategorySeoMixBatchLoader.php
+++ b/project-base/app/src/FrontendApi/Model/Category/ReadyCategorySeoMixBatchLoader.php
@@ -41,7 +41,7 @@ class ReadyCategorySeoMixBatchLoader
             $result[] = array_map(
                 fn (ReadyCategorySeoMix $readyCategorySeoMix) => [
                     'name' => $readyCategorySeoMix->getH1(),
-                    'slug' => $this->friendlyUrlFacade->getMainFriendlyUrlSlug(
+                    'slug' => '/' . $this->friendlyUrlFacade->getMainFriendlyUrlSlug(
                         $this->domain->getId(),
                         'front_category_seo',
                         $readyCategorySeoMix->getId(),

--- a/project-base/app/tests/FrontendApiBundle/Functional/Category/CategoryTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Category/CategoryTest.php
@@ -60,27 +60,27 @@ class CategoryTest extends GraphQlTestCase
         $readyCategorySeoMixLinks = [
             [
                 'name' => t('Electronics from most expensive', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-od-nejdrazsiho',
+                'slug' => '/elektro-od-nejdrazsiho',
             ],
             [
                 'name' => t('Electronics in black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-barva-cerna',
+                'slug' => '/elektro-barva-cerna',
             ],
             [
                 'name' => t('Electronics in red', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-barva-cervena',
+                'slug' => '/elektro-barva-cervena',
             ],
             [
                 'name' => t('Electronics with LED technology and size 30 inch in sale', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-led-uhlopricka-30-akce',
+                'slug' => '/elektro-led-uhlopricka-30-akce',
             ],
             [
                 'name' => t('Electronics without HDMI in sale', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-bez-hdmi-akce',
+                'slug' => '/elektro-bez-hdmi-akce',
             ],
             [
                 'name' => t('Full HD Electronics with LED technology and USB', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-full-hd-led-usb',
+                'slug' => '/elektro-full-hd-led-usb',
             ],
         ];
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Category/ReadyCategorySeoMix/ReadyCategorySeoMixTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Category/ReadyCategorySeoMix/ReadyCategorySeoMixTest.php
@@ -61,27 +61,27 @@ class ReadyCategorySeoMixTest extends GraphQlTestCase
         $readyCategorySeoMixLinks = [
             [
                 'name' => t('Electronics from most expensive', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-od-nejdrazsiho',
+                'slug' => '/elektro-od-nejdrazsiho',
             ],
             [
                 'name' => t('Electronics in black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-barva-cerna',
+                'slug' => '/elektro-barva-cerna',
             ],
             [
                 'name' => t('Electronics in red', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-barva-cervena',
+                'slug' => '/elektro-barva-cervena',
             ],
             [
                 'name' => t('Electronics with LED technology and size 30 inch in sale', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-led-uhlopricka-30-akce',
+                'slug' => '/elektro-led-uhlopricka-30-akce',
             ],
             [
                 'name' => t('Electronics without HDMI in sale', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-bez-hdmi-akce',
+                'slug' => '/elektro-bez-hdmi-akce',
             ],
             [
                 'name' => t('Full HD Electronics with LED technology and USB', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getLocaleForFirstDomain()),
-                'slug' => 'elektro-full-hd-led-usb',
+                'slug' => '/elektro-full-hd-led-usb',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| see PR title
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-seo-category-links.odin.shopsys.cloud
  - https://cz.tl-fix-seo-category-links.odin.shopsys.cloud
<!-- Replace -->
