### PR TITLE
fixed redis cache on storefront

### DIFF
--- a/docs/storefront/caching.md
+++ b/docs/storefront/caching.md
@@ -62,7 +62,7 @@ This cache is used for selected queries and is intended for server-side only. Th
 
 ### How does it work
 
-The cache is set via a graphql directive `@_redisCache`, which accepts TTL in seconds.
+The cache is set via a graphql directive `@redisCache`, which accepts TTL in seconds.
 
 The custom URQL fetcher tries to read the data from the cache, if it does not find it, it calls the API.
 
@@ -70,7 +70,7 @@ The cache can be deactivated (e.g. for development purposes) by setting `GRAPHQL
 
 ### How to use it
 
-To apply cache to a query, simply set the `@_redisCache` directive on it.
+To apply cache to a query, simply set the `@redisCache` directive on it.
 
 #### Example
 
@@ -89,7 +89,7 @@ query NavigationQuery {
 query is cached for 1 hour
 
 ```graphql
-query NavigationQuery @_redisCache(ttl: 3600) {
+query NavigationQuery @redisCache(ttl: 3600) {
   navigation {
     name
     link

--- a/project-base/storefront/.eslintrc.js
+++ b/project-base/storefront/.eslintrc.js
@@ -92,7 +92,16 @@ module.exports = {
                 "name": "next/link",
                 "message": "Please use ExtendedNextLink instead"
             },
-
+            {
+                "name": "urql",
+                "importNames": ["createClient"],
+                "message": "Please use the custom createClient function from storefront/urql/fetcher.ts"
+            },
+            {
+                "name": "next-urql",
+                "importNames": ["initUrqlClient"],
+                "message": "Please use the custom createClient function from storefront/urql/fetcher.ts"
+            }
         ],
         'react-hooks/rules-of-hooks': 'error',
         'react/no-unknown-property': [

--- a/project-base/storefront/graphql/generated/index.tsx
+++ b/project-base/storefront/graphql/generated/index.tsx
@@ -5230,7 +5230,7 @@ export function useTermsAndConditionsArticleUrlQueryApi(options?: Omit<Urql.UseQ
   return Urql.useQuery<TermsAndConditionsArticleUrlQueryApi, TermsAndConditionsArticleUrlQueryVariablesApi>({ query: TermsAndConditionsArticleUrlQueryDocumentApi, ...options });
 };
 export const ArticlesQueryDocumentApi = gql`
-    query ArticlesQuery($placement: [ArticlePlacementTypeEnum!], $first: Int) @_redisCache(ttl: 3600) {
+    query ArticlesQuery($placement: [ArticlePlacementTypeEnum!], $first: Int) @redisCache(ttl: 3600) {
   articles(placement: $placement, first: $first) {
     edges {
       __typename
@@ -5257,7 +5257,7 @@ export function useBlogArticleDetailQueryApi(options?: Omit<Urql.UseQueryArgs<Bl
   return Urql.useQuery<BlogArticleDetailQueryApi, BlogArticleDetailQueryVariablesApi>({ query: BlogArticleDetailQueryDocumentApi, ...options });
 };
 export const BlogArticlesQueryDocumentApi = gql`
-    query BlogArticlesQuery($first: Int, $onlyHomepageArticles: Boolean) @_redisCache(ttl: 3600) {
+    query BlogArticlesQuery($first: Int, $onlyHomepageArticles: Boolean) @redisCache(ttl: 3600) {
   blogArticles(first: $first, onlyHomepageArticles: $onlyHomepageArticles) {
     ...BlogArticleConnectionFragment
   }
@@ -5610,7 +5610,7 @@ export function useFlagDetailQueryApi(options?: Omit<Urql.UseQueryArgs<FlagDetai
   return Urql.useQuery<FlagDetailQueryApi, FlagDetailQueryVariablesApi>({ query: FlagDetailQueryDocumentApi, ...options });
 };
 export const NavigationQueryDocumentApi = gql`
-    query NavigationQuery @_redisCache(ttl: 3600) {
+    query NavigationQuery @redisCache(ttl: 3600) {
   navigation {
     ...CategoriesByColumnFragment
   }
@@ -5630,7 +5630,7 @@ export function useNewsletterSubscribeMutationApi() {
   return Urql.useMutation<NewsletterSubscribeMutationApi, NewsletterSubscribeMutationVariablesApi>(NewsletterSubscribeMutationDocumentApi);
 };
 export const NotificationBarsDocumentApi = gql`
-    query NotificationBars @_redisCache(ttl: 3600) {
+    query NotificationBars @redisCache(ttl: 3600) {
   notificationBars {
     ...NotificationBarsFragment
   }
@@ -6132,7 +6132,7 @@ export function useSeoPageQueryApi(options: Omit<Urql.UseQueryArgs<SeoPageQueryV
   return Urql.useQuery<SeoPageQueryApi, SeoPageQueryVariablesApi>({ query: SeoPageQueryDocumentApi, ...options });
 };
 export const SettingsQueryDocumentApi = gql`
-    query SettingsQuery @_redisCache(ttl: 3600) {
+    query SettingsQuery @redisCache(ttl: 3600) {
   settings {
     pricing {
       ...PricingSettingFragment

--- a/project-base/storefront/graphql/requests/articlesInterface/articles/queries/ArticlesQuery.graphql
+++ b/project-base/storefront/graphql/requests/articlesInterface/articles/queries/ArticlesQuery.graphql
@@ -1,7 +1,7 @@
 query ArticlesQuery(
     $placement: [ArticlePlacementTypeEnum!],
     $first: Int
-) @_redisCache(ttl: 3600) {
+) @redisCache(ttl: 3600) {
     articles(placement: $placement, first: $first) {
         edges {
             __typename

--- a/project-base/storefront/graphql/requests/articlesInterface/blogArticles/queries/BlogArticlesQuery.graphql
+++ b/project-base/storefront/graphql/requests/articlesInterface/blogArticles/queries/BlogArticlesQuery.graphql
@@ -1,7 +1,7 @@
 query BlogArticlesQuery (
     $first: Int,
     $onlyHomepageArticles: Boolean
-) @_redisCache(ttl: 3600) {
+) @redisCache(ttl: 3600) {
     blogArticles(first: $first, onlyHomepageArticles: $onlyHomepageArticles) {
         ...BlogArticleConnectionFragment
     }

--- a/project-base/storefront/graphql/requests/directives.graphql
+++ b/project-base/storefront/graphql/requests/directives.graphql
@@ -1,2 +1,2 @@
 # directive to cache the query server side in Redis, ttl is set in seconds
-directive @_redisCache(ttl: Int) on QUERY
+directive @redisCache(ttl: Int) on QUERY

--- a/project-base/storefront/graphql/requests/navigation/queries/NavigationQuery.graphql
+++ b/project-base/storefront/graphql/requests/navigation/queries/NavigationQuery.graphql
@@ -1,4 +1,4 @@
-query NavigationQuery @_redisCache(ttl: 3600) {
+query NavigationQuery @redisCache(ttl: 3600) {
     navigation {
         ...CategoriesByColumnFragment
     }

--- a/project-base/storefront/graphql/requests/notificationBars/queries/NotificationBarsQuery.graphql
+++ b/project-base/storefront/graphql/requests/notificationBars/queries/NotificationBarsQuery.graphql
@@ -1,4 +1,4 @@
-query NotificationBars @_redisCache(ttl: 3600) {
+query NotificationBars @redisCache(ttl: 3600) {
     notificationBars {
         ...NotificationBarsFragment
     }

--- a/project-base/storefront/graphql/requests/settings/queries/SettingsQuery.graphql
+++ b/project-base/storefront/graphql/requests/settings/queries/SettingsQuery.graphql
@@ -1,4 +1,4 @@
-query SettingsQuery @_redisCache(ttl: 3600) {
+query SettingsQuery @redisCache(ttl: 3600) {
     settings {
         pricing {
             ...PricingSettingFragment

--- a/project-base/storefront/helpers/serverSide/initServerSideProps.ts
+++ b/project-base/storefront/helpers/serverSide/initServerSideProps.ts
@@ -67,13 +67,13 @@ export const initServerSideProps = async ({
         const currentSsrCache = ssrExchangeOverride ?? ssrExchange({ isClient: false });
         const currentClient =
             client ??
-            (await createClient({
+            createClient({
                 ssrExchange: currentSsrCache,
                 redisClient,
                 context,
                 t,
                 publicGraphqlEndpoint: domainConfig.publicGraphqlEndpoint,
-            }));
+            });
 
         const seoPageSlug = extractSeoPageSlugFromUrl(context.resolvedUrl, domainConfig.url);
 

--- a/project-base/storefront/urql/createClient.ts
+++ b/project-base/storefront/urql/createClient.ts
@@ -1,5 +1,6 @@
 import { GetServerSidePropsContext, NextPageContext } from 'next';
 import { Translate } from 'next-translate';
+// eslint-disable-next-line no-restricted-imports
 import { initUrqlClient } from 'next-urql';
 import getConfig from 'next/config';
 import { RedisClientType, RedisModules, RedisScripts } from 'redis';
@@ -23,7 +24,6 @@ export const createClient = ({
     const { serverRuntimeConfig } = getConfig();
     const internalGraphqlEndpoint = serverRuntimeConfig?.internalGraphqlEndpoint ?? undefined;
     const publicGraphqlEndpointObject = new URL(publicGraphqlEndpoint);
-    const fetch = redisClient ? fetcher(redisClient) : undefined;
 
     return initUrqlClient(
         {
@@ -35,7 +35,7 @@ export const createClient = ({
                     'X-Forwarded-Proto': publicGraphqlEndpointObject.protocol === 'https:' ? 'on' : 'off',
                 },
             },
-            fetch,
+            fetch: fetcher(redisClient),
         },
         false,
     );

--- a/project-base/storefront/urql/fetcher.ts
+++ b/project-base/storefront/urql/fetcher.ts
@@ -5,7 +5,7 @@ import { RedisClientType, RedisModules, RedisScripts } from 'redis';
 
 const CACHE_REGEXP = `@redisCache\\(\\s?ttl:\\s?([0-9]*)\\s?\\)`;
 const QUERY_NAME_REGEXP = `query\\s([A-z]*)(\\([A-z:!0-9$,\\s]*\\))?\\s@redisCache`;
-const REDIS_PREFIX_PATTERN = `${process.env.REDIS_PREFIX}:fe:queryCache:`;
+const getRedisPrefixPattern = () => `${process.env.REDIS_PREFIX}:fe:queryCache:`;
 
 const removeDirectiveFromQuery = (query: string) => query.replace(new RegExp(CACHE_REGEXP), '');
 
@@ -41,7 +41,7 @@ export const fetcher =
             const body = removeDirectiveFromQuery(init.body);
             const host = (init.headers ? new Headers(init.headers) : new Headers()).get('OriginalHost');
             const [, queryName] = init.body.match(QUERY_NAME_REGEXP) ?? [];
-            const hash = `${REDIS_PREFIX_PATTERN}${queryName}:${host}:${md5(body).toString().substring(0, 7)}`;
+            const hash = `${getRedisPrefixPattern()}${queryName}:${host}:${md5(body).toString().substring(0, 7)}`;
 
             const fromCache = await redisClient.get(hash);
 

--- a/project-base/storefront/vitest.config.js
+++ b/project-base/storefront/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
         testMatch: ['vitest/**/*.test.js'],
         clearMocks: true,
         restoreMocks: true,
+        setupFiles: 'dotenv/config',
     },
     resolve: {
         moduleDirectories: [

--- a/project-base/storefront/vitest/helpers/urql/createClient.test.tsx
+++ b/project-base/storefront/vitest/helpers/urql/createClient.test.tsx
@@ -1,0 +1,96 @@
+import { RedisClientType } from 'redis';
+import { Mock, afterEach, describe, expect, test, vi } from 'vitest';
+import { isServer } from 'helpers/isServer';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { createClient } from 'urql/createClient';
+import { Provider, ssrExchange, useQuery } from 'urql';
+import gql from 'graphql-tag';
+
+const mockRequestWithFetcher = vi.fn(async () => undefined);
+
+vi.mock('urql/fetcher', () => ({
+    fetcher: vi.fn(() => mockRequestWithFetcher),
+}));
+
+vi.mock('helpers/isServer', () => ({
+    isServer: vi.fn(),
+}));
+
+vi.mock('next/config', () => ({
+    default: () => ({ serverRuntimeConfig: { internalGraphqlEndpoint: TEST_URL } }),
+}));
+
+const mockRedisClientGet: Mock<[], null | string> = vi.fn(() => null);
+const mockRedisClient = {
+    get: mockRedisClientGet,
+    set: vi.fn(() => null),
+} as unknown as RedisClientType;
+
+const TEST_URL = 'https://test.ts/graphql/';
+const QUERY_OBJECT = gql`
+    query NotificationBars @redisCache(ttl: 3600) {
+        notificationBars {
+            text
+        }
+    }
+`;
+const REQUEST_BODY =
+    '{"operationName":"NotificationBars","query":"query NotificationBars @redisCache(ttl: 3600) {\\n  notificationBars {\\n    text\\n    __typename\\n  }\\n}","variables":{}}';
+
+describe('createClient test', () => {
+    afterEach(cleanup);
+
+    test('created client (and URQL) do not filter out Redis cache directive on the client (in component)', async () => {
+        (isServer as Mock).mockImplementation(() => false);
+
+        const UrqlWrapper: FC = ({ children }) => {
+            const publicGraphqlEndpoint = TEST_URL;
+
+            return (
+                <Provider
+                    value={createClient({
+                        t: () => 'foo' as any,
+                        ssrExchange: ssrExchange(),
+                        publicGraphqlEndpoint,
+                        redisClient: mockRedisClient,
+                    })}
+                >
+                    {children}
+                </Provider>
+            );
+        };
+
+        const InnerComponentWithUrqlClient: FC = () => {
+            useQuery({
+                query: QUERY_OBJECT,
+            });
+
+            return null;
+        };
+
+        render(
+            <UrqlWrapper>
+                <InnerComponentWithUrqlClient />
+            </UrqlWrapper>,
+        );
+
+        await waitFor(() => {
+            expect(mockRequestWithFetcher).toBeCalledWith(TEST_URL, expect.objectContaining({ body: REQUEST_BODY }));
+        });
+    });
+
+    test('created client (and URQL) do not filter out Redis cache directive on the server', async () => {
+        (isServer as Mock).mockImplementation(() => true);
+
+        const client = createClient({
+            t: () => 'foo' as any,
+            ssrExchange: ssrExchange(),
+            publicGraphqlEndpoint: TEST_URL,
+            redisClient: mockRedisClient,
+        });
+
+        await client.query(QUERY_OBJECT, undefined).toPromise();
+
+        expect(mockRequestWithFetcher).toBeCalledWith(TEST_URL, expect.objectContaining({ body: REQUEST_BODY }));
+    });
+});

--- a/project-base/storefront/vitest/helpers/urql/fetcher.test.ts
+++ b/project-base/storefront/vitest/helpers/urql/fetcher.test.ts
@@ -1,0 +1,135 @@
+import { RedisClientType } from 'redis';
+import { fetcher } from 'urql/fetcher';
+import { Mock, describe, expect, test, vi } from 'vitest';
+import { isServer } from 'helpers/isServer';
+import { captureException } from '@sentry/nextjs';
+
+vi.mock('helpers/isServer', () => ({
+    isServer: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+    captureException: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockRedisClientGet: Mock<[], null | string> = vi.fn(() => null);
+const mockRedisClient = {
+    get: mockRedisClientGet,
+    set: vi.fn(() => null),
+} as unknown as RedisClientType;
+
+const REQUEST_WITH_DIRECTIVE = {
+    headers: {
+        accept: 'application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed',
+        originalhost: '127.0.0.1:8000',
+        'x-forwarded-proto': 'off',
+        'content-type': 'application/json',
+    },
+    method: 'POST',
+    body: '{"operationName":"TestQuery","query":"query TestQuery @redisCache(ttl: 3600) {\\n foobar\\n}"}',
+    signal: {},
+} as unknown as RequestInit;
+
+const REQUEST_WITHOUT_DIRECTIVE = {
+    headers: {
+        accept: 'application/graphql-response+json, application/graphql+json, application/json, text/event-stream, multipart/mixed',
+        originalhost: '127.0.0.1:8000',
+        'x-forwarded-proto': 'off',
+        'content-type': 'application/json',
+    },
+    method: 'POST',
+    body: '{"operationName":"TestQuery","query":"query TestQuery  {\\n foobar\\n}"}',
+    signal: {},
+} as unknown as RequestInit;
+
+const TEST_URL = 'https://test.ts/graphql/';
+const TEST_RESPONSE_BODY = { testBody: 'test data' };
+
+describe('fetcher test', () => {
+    test('using fetcher on the server without Redis should capture an exception in Sentry but still make a request', () => {
+        (isServer as Mock).mockImplementation(() => true);
+
+        const testFetcher = fetcher(undefined);
+        testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE);
+
+        expect(captureException).toBeCalledWith(
+            'Redis client was missing on server. This will cause the Redis cache to not work properly.',
+        );
+        expect(mockFetch).toBeCalledWith(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+    });
+
+    test('using fetcher on the client should filter out the cache directive even if used with a Redis client', () => {
+        (isServer as Mock).mockImplementation(() => false);
+
+        const testFetcher = fetcher(mockRedisClient);
+        testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE);
+
+        expect(mockFetch).toBeCalledWith(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+    });
+
+    test('using fetcher without the Redis cache should filter out the cache directive', () => {
+        (isServer as Mock).mockImplementation(() => true);
+        vi.stubEnv('GRAPHQL_REDIS_CACHE', '0');
+
+        const testFetcher = fetcher(mockRedisClient);
+        testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE);
+
+        expect(mockFetch).toBeCalledWith(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+        vi.unstubAllEnvs();
+    });
+
+    test('using fetcher without the Redis client should filter out the cache directive', () => {
+        (isServer as Mock).mockImplementation(() => true);
+
+        const testFetcher = fetcher(undefined);
+        testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE);
+
+        expect(mockFetch).toBeCalledWith(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+    });
+
+    test('using fetcher on a non-cached query should not call Redis', () => {
+        (isServer as Mock).mockImplementation(() => true);
+
+        const testFetcher = fetcher(mockRedisClient);
+        testFetcher(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+
+        expect(mockFetch).toBeCalledWith(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+        expect(mockRedisClient.get).not.toBeCalled();
+        expect(mockRedisClient.set).not.toBeCalled();
+    });
+
+    test('using fetcher on a not-yet cached query for the first time should set it in Redis', async () => {
+        (isServer as Mock).mockImplementation(() => true);
+        vi.stubEnv('REDIS_PREFIX', 'TEST_PREFIX');
+        mockFetch.mockImplementation(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({ data: TEST_RESPONSE_BODY }),
+            }),
+        );
+
+        const testFetcher = fetcher(mockRedisClient);
+        await testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE);
+
+        expect(mockFetch).toBeCalledWith(TEST_URL, REQUEST_WITHOUT_DIRECTIVE);
+        expect(mockRedisClient.get).toBeCalledWith('TEST_PREFIX:fe:queryCache:TestQuery:127.0.0.1:8000:e0df376');
+        expect(mockRedisClient.set).toBeCalledWith(
+            'TEST_PREFIX:fe:queryCache:TestQuery:127.0.0.1:8000:e0df376',
+            JSON.stringify(TEST_RESPONSE_BODY),
+            { EX: 3600 },
+        );
+        vi.unstubAllEnvs();
+    });
+
+    test('using fetcher on an already cached query should get it from Redis', async () => {
+        mockRedisClientGet.mockImplementation(() => JSON.stringify(TEST_RESPONSE_BODY));
+        (isServer as Mock).mockImplementation(() => true);
+
+        const testFetcher = fetcher(mockRedisClient);
+        const responseBodyFromRedis = await (await testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE)).json();
+
+        expect(responseBodyFromRedis).toStrictEqual({ data: TEST_RESPONSE_BODY });
+    });
+});


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The directive name was changed from _redisCache back to redisCache because the former was completely omitted, even on Storefront. Now, a custom createClient is used everywhere with a custom fetch function. This custom function is important as it takes care of directive handling. During Server Side Rendering (SSR), it utilizes the directive and subsequently cleans it on the client. Additionally, two new ESLint forbidden imports were added specifically for default client creation functions. This addition is crucial as using those functions would result in errors with our directive. The term "await" was removed from initServerSideProps where it was previously used for client creation, but it was found to be unnecessary. Lastly, if the Redis client is not provided on the server, an exception is captured (but not thrown) to Sentry. Capturing this exception will assist us in discovering bugs in the logic in the future.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-redis-cache-fix.odin.shopsys.cloud
  - https://cz.sh-redis-cache-fix.odin.shopsys.cloud
<!-- Replace -->
