### PR TITLE
[project-base] fixed argument passing to productsByCatnum query

### DIFF
--- a/project-base/app/config/graphql/types/Query/Product/ProductQuery.types.yaml
+++ b/project-base/app/config/graphql/types/Query/Product/ProductQuery.types.yaml
@@ -13,7 +13,7 @@ ProductQuery:
                 description: "Returns list of ordered products that can be paginated using `first`, `last`, `before` and `after` keywords"
             productsByCatnums:
                 type: "[Product!]!"
-                resolve: '@=query("productsByCatnumsQuery", [args["catnums"]])'
+                resolve: '@=query("productsByCatnumsQuery", args["catnums"])'
                 args:
                     catnums:
                         type: "[String!]!"

--- a/project-base/app/src/FrontendApi/Resolver/Products/ProductsQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/ProductsQuery.php
@@ -294,7 +294,7 @@ class ProductsQuery extends BaseProductsQuery
      * @param string[] $catnums
      * @return \GraphQL\Executor\Promise\Promise
      */
-    public function productsByCatnumsQuery($catnums): Promise
+    public function productsByCatnumsQuery(array $catnums): Promise
     {
         $productIds = $this->productRepository->getProductIdsByCatnums($catnums);
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsByCatnumsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsByCatnumsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrontendApiBundle\Functional\Product;
+
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
+
+class ProductsByCatnumsTest extends ProductsGraphQlTestCase
+{
+    public function testProductsByCatnums(): void
+    {
+        $firstDomainLocale = $this->getLocaleForFirstDomain();
+
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/graphql/productsByCatnums.graphql',
+            [
+                'catnums' => [
+                    '9177759',
+                    '532564',
+                    'non-existing', // non-existing product – should be ignored
+                    '9176544M', // main variant – should be present in the result
+                    '5964035', // non-visible product – should be ignored
+                    '9176522', // variant product – should be present in the result
+                ],
+            ],
+        );
+        $data = $this->getResponseDataForGraphQlType($response, 'productsByCatnums');
+
+        $productsExpected = [
+            ['name' => t('Canon EH-22L', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
+            ['name' => t('22" Sencor SLE 22F46DM4 HELLO KITTY', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
+            ['name' => t('Philips 32PFL4308', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
+            ['name' => t('24" Philips 32PFL4308', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
+        ];
+
+        $this->assertSameSize($productsExpected, $data);
+
+        foreach ($data as $resultProduct) {
+            $this->assertContains($resultProduct, $productsExpected);
+        }
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/graphql/productsByCatnums.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/graphql/productsByCatnums.graphql
@@ -1,0 +1,5 @@
+query SharedWishlistQuery($catnums: [String!]!) {
+    productsByCatnums(catnums: $catnums) {
+        name
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| argument catnums was wrapped in an array, resulting in wrong parameters sent to doctrine, ergo bad results. Fixed
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-query-by-catnum-fix.odin.shopsys.cloud
  - https://cz.mg-query-by-catnum-fix.odin.shopsys.cloud
<!-- Replace -->
