### PR TITLE
[project-base] added validation to suppliers delivery time

### DIFF
--- a/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
@@ -175,6 +175,11 @@ class ProductFormTypeExtension extends AbstractTypeExtension
             ->add('vendorDeliveryDate', TextType::class, [
                 'required' => false,
                 'label' => t('Supplier\'s delivery time'),
+                'constraints' => [
+                    new Constraints\Type(['type' => 'numeric', 'message' => 'Supplier\'s delivery time must be a number']),
+                    new Constraints\GreaterThanOrEqual(['value' => 0, 'message' => 'Supplier\'s delivery time must be 0 or more']),
+                ],
+
             ])
             ->add('usingStock', YesNoType::class, [
                 'data' => true,

--- a/project-base/app/translations/validators.cs.po
+++ b/project-base/app/translations/validators.cs.po
@@ -316,6 +316,12 @@ msgstr "Ulice a č. popisné nesmí být delší než {{ limit }} znaků"
 msgid "Street name cannot be longer than {{ limit }} characters"
 msgstr "Název ulice nesmí být delší než {{ limit }} znaků"
 
+msgid "Supplier's delivery time must be 0 or more"
+msgstr "Dodací lhůta dodavatele musí být 0 nebo více"
+
+msgid "Supplier's delivery time must be a number"
+msgstr "Dodací lhůta dodavatele musí být číslo"
+
 msgid "Tax number cannot be longer than {{ limit }} characters"
 msgstr "DIČ nesmí být delší než {{ limit }} znaků"
 

--- a/project-base/app/translations/validators.en.po
+++ b/project-base/app/translations/validators.en.po
@@ -316,6 +316,12 @@ msgstr ""
 msgid "Street name cannot be longer than {{ limit }} characters"
 msgstr ""
 
+msgid "Supplier's delivery time must be 0 or more"
+msgstr ""
+
+msgid "Supplier's delivery time must be a number"
+msgstr ""
+
 msgid "Tax number cannot be longer than {{ limit }} characters"
 msgstr ""
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Missing validation allowing to fill text into the `Supplier's delivery time` field, resulting in fatal error.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-product-edit-fix.odin.shopsys.cloud
  - https://cz.mg-product-edit-fix.odin.shopsys.cloud
<!-- Replace -->
