### PR TITLE
[project-base] admin with limited permissions now can use domain filter

### DIFF
--- a/project-base/app/config/packages/security.yaml
+++ b/project-base/app/config/packages/security.yaml
@@ -436,6 +436,7 @@ security:
         - { path: ^/%admin_url%/product-picker/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/_grid/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/multidomain/select-domain/, roles: ROLE_ADMIN }
+        - { path: ^/%admin_url%/multidomain/filter-domain/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/sso/, roles: ROLE_ADMIN }
         - { path: ^/efconnect, roles: ROLE_ADMIN }
         - { path: ^/elfinder, roles: ROLE_ADMIN }

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -164,6 +164,7 @@ You will need to follow these steps:
 - stop wrapping Frontend API queries in database transaction ([#2809](https://github.com/shopsys/shopsys/pull/2809))
     - see #project-base-diff to update your project
 - add order filter by domain in admin ([#2796](https://github.com/shopsys/shopsys/pull/2796))
+    - see also #project-base-diff (#2844) for permission fix
     - `Shopsys\FrameworkBundle\Controller\Admin\CategoryController`
         - method `__construct` changed its interface
             ```diff


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2796 the domain filter was introduced, but the admin with limited permissions was not able to use it. This PR fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-filter.odin.shopsys.cloud
  - https://cz.mg-fix-filter.odin.shopsys.cloud
<!-- Replace -->
