### PR TITLE
[shopsys] improved permissions handling in admin

### DIFF
--- a/packages/framework/assets/js/admin/components/GridDragAndDrop.js
+++ b/packages/framework/assets/js/admin/components/GridDragAndDrop.js
@@ -103,12 +103,6 @@ export default class GridDragAndDrop {
                 new Window({
                     content: Translator.trans('Order saved')
                 });
-            },
-            error: function () {
-                // eslint-disable-next-line no-new
-                new Window({
-                    content: Translator.trans('Order saving failed')
-                });
             }
         });
         $grid.trigger('save');

--- a/packages/framework/assets/js/common/utils/Ajax.js
+++ b/packages/framework/assets/js/common/utils/Ajax.js
@@ -37,10 +37,16 @@ export default class Ajax {
         $.ajax(options);
     }
 
-    static showDefaultError () {
+    static showDefaultError (response) {
+        let content = Translator.trans('Error occurred, try again please.');
+
+        if (response.status === 403) {
+            content = Translator.trans('You don\'t have permission to perform this action.');
+        }
+
         // eslint-disable-next-line no-new
         new Window({
-            content: Translator.trans('Error occurred, try again please.')
+            content: content
         });
     }
 

--- a/packages/framework/src/Controller/Admin/AccessController.php
+++ b/packages/framework/src/Controller/Admin/AccessController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -22,6 +21,10 @@ class AccessController extends AdminBaseController
             t('You are not allowed to access the requested page. Please ask your administrator to grant you access to the requested page.'),
         );
 
-        return new RedirectResponse($this->generateUrl('admin_default_dashboard'));
+        $response = $this->forward(DefaultController::class . '::dashboardAction');
+
+        $response->setStatusCode(Response::HTTP_FORBIDDEN);
+
+        return $response;
     }
 }

--- a/project-base/app/config/packages/security.yaml
+++ b/project-base/app/config/packages/security.yaml
@@ -273,9 +273,11 @@ security:
         - { path: ^/%admin_url%/category/, roles: ROLE_CATEGORY_VIEW }
         # pricing groups
         - { path: ^/%admin_url%/pricing/group/delete, roles: ROLE_PRICING_GROUP_FULL }
+        - { path: ^/%admin_url%/pricing/group/list, roles: ROLE_PRICING_GROUP_FULL, methods: [POST] }
         - { path: ^/%admin_url%/pricing/group/, roles: ROLE_PRICING_GROUP_VIEW }
         # vats
         - { path: ^/%admin_url%/vat/delete, roles: ROLE_VAT_FULL }
+        - { path: ^/%admin_url%/vat/list, roles: ROLE_VAT_FULL, methods: [POST] }
         - { path: ^/%admin_url%/vat/, roles: ROLE_VAT_VIEW }
         # articles
         - { path: ^/%admin_url%/article/delete, roles: ROLE_ARTICLE_FULL }
@@ -434,6 +436,9 @@ security:
         - { path: ^/%admin_url%/transfer/list/, roles: ROLE_TRANSFER_VIEW }
         # special paths for file manager in wysiwyg, product picker, grid, domain selector, login as user.
         - { path: ^/%admin_url%/product-picker/, roles: ROLE_ADMIN }
+        - { path: ^/%admin_url%/_grid/save-form/, roles: ROLE_ALL }
+        - { path: ^/%admin_url%/_grid/save-ordering/, roles: ROLE_ALL }
+        - { path: ^/%admin_url%/_grid/get-form/, roles: ROLE_ALL }
         - { path: ^/%admin_url%/_grid/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/multidomain/select-domain/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/multidomain/filter-domain/, roles: ROLE_ADMIN }

--- a/project-base/app/src/Form/Admin/AdministratorFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/AdministratorFormTypeExtension.php
@@ -25,8 +25,8 @@ class AdministratorFormTypeExtension extends AbstractTypeExtension
      * @param \App\Model\Administrator\RoleGroup\AdministratorRoleGroupFacade $administratorRoleGroupFacade
      */
     public function __construct(
-        private Security $security,
-        private AdministratorRoleGroupFacade $administratorRoleGroupFacade,
+        private readonly Security $security,
+        private readonly AdministratorRoleGroupFacade $administratorRoleGroupFacade,
     ) {
     }
 
@@ -60,21 +60,21 @@ class AdministratorFormTypeExtension extends AbstractTypeExtension
             'label' => t('Password'),
         ]);
 
-        $builderSettingsGroup->add('roleGroup', ChoiceType::class, [
-            'required' => false,
-            'choices' => $this->administratorRoleGroupFacade->getAll(),
-            'placeholder' => t('Custom'),
-            'multiple' => false,
-            'label' => t('Role Group'),
-            'choice_label' => function (AdministratorRoleGroup $administratorRoleGroup) {
-                return $administratorRoleGroup->getName();
-            },
-            'attr' => [
-                'class' => 'js-role-group-select',
-            ],
-        ]);
-
         if ($this->security->isGranted(Roles::ROLE_ADMINISTRATOR_FULL)) {
+            $builderSettingsGroup->add('roleGroup', ChoiceType::class, [
+                'required' => false,
+                'choices' => $this->administratorRoleGroupFacade->getAll(),
+                'placeholder' => t('Custom'),
+                'multiple' => false,
+                'label' => t('Role Group'),
+                'choice_label' => function (AdministratorRoleGroup $administratorRoleGroup) {
+                    return $administratorRoleGroup->getName();
+                },
+                'attr' => [
+                    'class' => 'js-role-group-select',
+                ],
+            ]);
+
             $builderSettingsGroup->add('roles', ChoiceType::class, [
                 'required' => false,
                 'choices' => Roles::getAvailableAdministratorRolesChoices(),
@@ -86,12 +86,14 @@ class AdministratorFormTypeExtension extends AbstractTypeExtension
                 ],
             ]);
         } elseif ($options['administrator'] !== null) {
-            $builder->add('roles', DisplayOnlyType::class, [
+            $builderSettingsGroup->add('roleGroup', DisplayOnlyType::class, [
+                'label' => t('Role Group'),
+                'data' => $options['administrator']->getRoleGroup()?->getName() ?? t('Custom'),
+            ]);
+
+            $builderSettingsGroup->add('roles', DisplayOnlyType::class, [
                 'label' => t('Role'),
                 'data' => $this->getAdministratorRolesList($options['administrator']),
-                'attr' => [
-                    'class' => 'js-role-group-custom',
-                ],
             ]);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Some permissions were not handled properly in admin. More description follows.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


Highlights in admin:
- ajax calls now can detect the forbidden status and display a proper error message
- grid now does not allow display, save the inline edit form if the admin has no appropriate permission
- ordering in a sortable grid cannot be saved if the admin has no appropriate permission
- the admin cannot change the role group unless he has the appropriate permission
- minor changes in the permission list







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-permissions-fix.odin.shopsys.cloud
  - https://cz.mg-permissions-fix.odin.shopsys.cloud
<!-- Replace -->
