### PR TITLE
fix Zásilkovna order delivery

### DIFF
--- a/project-base/storefront/components/Blocks/OrderSummary/SingleProduct.tsx
+++ b/project-base/storefront/components/Blocks/OrderSummary/SingleProduct.tsx
@@ -18,7 +18,7 @@ export const SingleProduct: FC<SingleProductProps> = ({ item }) => {
                 image={item.product.mainImage}
                 type="thumbnailExtraSmall"
                 alt={item.product.mainImage?.name || item.product.fullName}
-                className="mr-4 w-14"
+                className="mr-4 h-14 w-14"
             />
 
             <div className="flex flex-1 items-center">

--- a/project-base/storefront/components/Blocks/OrderSummary/TransportAndPayment.tsx
+++ b/project-base/storefront/components/Blocks/OrderSummary/TransportAndPayment.tsx
@@ -30,7 +30,7 @@ export const TransportAndPayment: FC<TransportAndPaymentProps> = ({ payment, tra
                                     image={transport.mainImage}
                                     type="default"
                                     alt={transport.name}
-                                    className="w-9"
+                                    className="h-8 w-8"
                                 />
                             </span>
                         </OrderSummaryTextAndImage>
@@ -44,7 +44,12 @@ export const TransportAndPayment: FC<TransportAndPaymentProps> = ({ payment, tra
                         <OrderSummaryTextAndImage dataTestId={TEST_IDENTIFIER + '-payment-name'}>
                             {payment.name}
                             <span className="inline-block align-bottom">
-                                <Image image={payment.mainImage} type="default" alt={payment.name} className="w-9" />
+                                <Image
+                                    image={payment.mainImage}
+                                    type="default"
+                                    alt={payment.name}
+                                    className="h-8 w-8"
+                                />
                             </span>
                         </OrderSummaryTextAndImage>
                         <OrderSummaryPrice dataTestId={TEST_IDENTIFIER + '-payment-price'}>

--- a/project-base/storefront/components/Forms/Lib/LabelWrapper.tsx
+++ b/project-base/storefront/components/Forms/Lib/LabelWrapper.tsx
@@ -73,7 +73,7 @@ export const LabelWrapper: FC<LabelWrapperProps> = ({
                         {inputType === 'checkbox' ? (
                             <CheckmarkIcon
                                 className={twMergeCustom(
-                                    'h-full w-full opacity-0 transition',
+                                    'h-full opacity-0 transition',
                                     checked && 'opacity-100',
                                     disabled && 'text-grey',
                                 )}

--- a/project-base/storefront/components/Pages/Cart/CartList/CartListItem.tsx
+++ b/project-base/storefront/components/Pages/Cart/CartList/CartListItem.tsx
@@ -59,6 +59,7 @@ export const CartListItem: FC<CartListItemProps> = ({
                             image={product.mainImage}
                             type="thumbnailExtraSmall"
                             alt={product.mainImage?.name || product.fullName}
+                            className="h-14"
                         />
                     </ExtendedNextLink>
                 </div>

--- a/project-base/storefront/components/Pages/Customer/OrdersContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/OrdersContent.tsx
@@ -78,7 +78,9 @@ export const OrdersContent: FC<OrdersContentProps> = ({ isLoading, orders, total
                                         <CellHead isWithoutWrap align="right">
                                             {t('Number of items')}
                                         </CellHead>
-                                        <CellHead isWithoutWrap>{t('Shipping')}</CellHead>
+                                        <CellHead isWithoutWrap className=" min-w-[150px]">
+                                            {t('Shipping')}
+                                        </CellHead>
                                         <CellHead isWithoutWrap>{t('Payment')}</CellHead>
                                         <CellHead isWithoutWrap align="right">
                                             {t('Total price including VAT')}
@@ -114,8 +116,9 @@ export const OrdersContent: FC<OrdersContentProps> = ({ isLoading, orders, total
                                                     alt={order.transport.mainImage?.name || order.transport.name}
                                                     width={36}
                                                     height={20}
+                                                    className="h-9 w-9"
                                                 />
-                                                {order.transport.name}
+                                                <span className="flex-1">{order.transport.name}</span>
                                             </div>
                                         </Cell>
                                         <Cell data-testid={TEST_IDENTIFIER + 'payment'}>{order.payment.name}</Cell>

--- a/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationDeliveryAddress.tsx
@@ -51,7 +51,6 @@ export const ContactInformationDeliveryAddress: FC = () => {
 
                 setValue(formMeta.fields.deliveryFirstName.name, formValues.firstName, { shouldValidate: true });
                 setValue(formMeta.fields.deliveryLastName.name, formValues.lastName, { shouldValidate: true });
-                setValue(formMeta.fields.deliveryCompanyName.name, formValues.companyName, { shouldValidate: true });
                 setValue(formMeta.fields.deliveryTelephone.name, formValues.telephone, { shouldValidate: true });
                 setValue(formMeta.fields.deliveryStreet.name, pickupPlace.street, { shouldValidate: true });
                 setValue(formMeta.fields.deliveryCity.name, pickupPlace.city, { shouldValidate: true });
@@ -61,7 +60,7 @@ export const ContactInformationDeliveryAddress: FC = () => {
                 updateContactInformation({ ...pickupPlace, country: selectedCountryOption });
             }
         }
-    }, [countriesAsSelectOptions]);
+    }, [countriesAsSelectOptions, isDifferentDeliveryAddress]);
 
     useEffect(() => {
         if (user && deliveryAddressUuid) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in case user choose Zásilkovna delivery type (personal pickup) and then wanted to include different delivery information (only phone, name and surname is allowed since delivery place is choosed accroding to user choosen Zásilkovna place) he got validation error for state, city, etc. which were not even shown in the form.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1857-fix-zisilkovna-order-delivery.odin.shopsys.cloud
  - https://cz.tv-fw-1857-fix-zisilkovna-order-delivery.odin.shopsys.cloud
<!-- Replace -->
