### PR TITLE
[framework] added optional manual readable frequency to crons.yaml

### DIFF
--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -11,6 +11,9 @@ If you want to show Cron overview table for non-superadmin users you need add pa
 !!! note
     All default crons are translated only to English. If you want to translate it to another language, you need to set `readableName` property for cron in `config/services/cron.yaml`.
 
+!!! note
+    If you have different cron frequency set using crontab and you want to set readable frequency manually, you can use `readableFrequency` property for cron in `config/services/cron.yaml`.
+
 ## Default Cron Commands
 There is some prepared configuration in a file [`config/services/cron.yaml`](https://github.com/shopsys/project-base/blob/master/config/services/cron.yaml) in `project-base`.
 !!! note

--- a/packages/framework/src/Component/Cron/Config/CronConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronConfig.php
@@ -33,6 +33,7 @@ class CronConfig
      * @param string $timeMinutes
      * @param string $instanceName
      * @param string|null $readableName
+     * @param string|null $readableFrequency
      * @param int $runEveryMin
      * @param int $timeoutIteratedCronSec
      */
@@ -43,6 +44,7 @@ class CronConfig
         string $timeMinutes,
         string $instanceName,
         ?string $readableName = null,
+        ?string $readableFrequency = null,
         int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
         int $timeoutIteratedCronSec = CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
     ): void {
@@ -52,7 +54,7 @@ class CronConfig
         $this->cronTimeResolver->validateTimeString($timeHours, 23, 1);
         $this->cronTimeResolver->validateTimeString($timeMinutes, 55, 5);
 
-        $cronModuleConfig = new CronModuleConfig($service, $serviceId, $timeHours, $timeMinutes, $readableName, $runEveryMin, $timeoutIteratedCronSec);
+        $cronModuleConfig = new CronModuleConfig($service, $serviceId, $timeHours, $timeMinutes, $readableName, $readableFrequency, $runEveryMin, $timeoutIteratedCronSec);
         $cronModuleConfig->assignToInstance($instanceName);
 
         $this->cronModuleConfigs[] = $cronModuleConfig;

--- a/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
+++ b/packages/framework/src/Component/Cron/Config/CronModuleConfig.php
@@ -22,6 +22,7 @@ class CronModuleConfig implements CronTimeInterface
      * @param string $timeHours
      * @param string $timeMinutes
      * @param string|null $readableName
+     * @param string|null $readableFrequency
      * @param int $runEveryMin
      * @param int $timeoutIteratedCronSec
      */
@@ -31,6 +32,7 @@ class CronModuleConfig implements CronTimeInterface
         protected readonly string $timeHours,
         protected readonly string $timeMinutes,
         protected readonly ?string $readableName = null,
+        protected readonly ?string $readableFrequency = null,
         protected readonly int $runEveryMin = self::RUN_EVERY_MIN_DEFAULT,
         protected readonly int $timeoutIteratedCronSec = self::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
     ) {
@@ -98,6 +100,10 @@ class CronModuleConfig implements CronTimeInterface
      */
     public function getReadableFrequency(): string
     {
+        if ($this->readableFrequency !== null) {
+            return $this->readableFrequency;
+        }
+
         if ($this->timeHours === '*' && $this->timeMinutes === '*') {
             return t('On each run (usually every 5 minutes)');
         }

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterCronModulesCompilerPass.php
@@ -37,6 +37,7 @@ class RegisterCronModulesCompilerPass implements CompilerPassInterface
                         $tag['minutes'],
                         $instanceName,
                         $tag['readableName'] ?? null,
+                        $tag['readableFrequency'] ?? null,
                         $instanceConfig['run_every_min'],
                         $instanceConfig['timeout_iterated_cron_sec'],
                     ],

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -151,6 +151,7 @@ class CronFacadeTest extends TestCase
                 '*',
                 CronModuleConfig::DEFAULT_INSTANCE_NAME,
                 'testing cron',
+                'every minute',
                 CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
                 CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
             );

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleExecutorTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleExecutorTest.php
@@ -95,6 +95,7 @@ class CronModuleExecutorTest extends TestCase
                 '*',
                 CronModuleConfig::DEFAULT_INSTANCE_NAME,
                 'testing cron',
+                'every minute',
                 CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
                 1,
             );

--- a/upgrade/UPGRADE-v13.0.0-dev.md
+++ b/upgrade/UPGRADE-v13.0.0-dev.md
@@ -246,3 +246,31 @@ You will need to follow these steps:
     - see #project-base-diff to update your project
 - update overblog settings to embrace composer autoloader for faster class loading ([#2830](https://github.com/shopsys/shopsys/pull/2830))
     - see #project-base-diff to update your project
+- add ability to set readable frequency name to your cron ([#2854](https://github.com/shopsys/shopsys/pull/2854))
+    - method `Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig::registerCronModuleInstance()` changed its interface
+        ```diff
+            public function registerCronModuleInstance(
+                $service,
+                string $serviceId,
+                string $timeHours,
+                string $timeMinutes,
+                string $instanceName,
+                ?string $readableName = null,
+        +       ?string $readableFrequency = null,
+                int $runEveryMin = CronModuleConfig::RUN_EVERY_MIN_DEFAULT,
+                int $timeoutIteratedCronSec = CronModuleConfig::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            ) {
+        ```
+    - method `Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig::__construct()` changed its interface
+        ```diff
+            public function __construct(
+                protected readonly SimpleCronModuleInterface|IteratedCronModuleInterface $service,
+                protected readonly string $serviceId,
+                protected readonly string $timeHours,
+                protected readonly string $timeMinutes,
+                protected readonly ?string $readableName = null,
+        +       protected readonly ?string $readableFrequency = null,
+                protected readonly int $runEveryMin = self::RUN_EVERY_MIN_DEFAULT,
+                protected readonly int $timeoutIteratedCronSec = self::TIMEOUT_ITERATED_CRON_SEC_DEFAULT,
+            ) {
+        ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| It is possible to set crontab differently and thus change the frequency of cron. For such cases, we have added manual readable frequency so your cron settings are correctly displayed to administrators.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-cron-readable-frequency.odin.shopsys.cloud
  - https://cz.tl-cron-readable-frequency.odin.shopsys.cloud
<!-- Replace -->
