### PR TITLE
fix switch custom delivery address validation

### DIFF
--- a/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/ContactInformationDeliveryAddress.tsx
@@ -86,13 +86,13 @@ export const ContactInformationDeliveryAddress: FC = () => {
                 }
             }
         } else if (deliveryAddressUuid === '') {
-            setValue(formMeta.fields.deliveryFirstName.name, '', { shouldValidate: true });
-            setValue(formMeta.fields.deliveryLastName.name, '', { shouldValidate: true });
-            setValue(formMeta.fields.deliveryCompanyName.name, '', { shouldValidate: true });
-            setValue(formMeta.fields.deliveryTelephone.name, '', { shouldValidate: true });
-            setValue(formMeta.fields.deliveryStreet.name, '', { shouldValidate: true });
-            setValue(formMeta.fields.deliveryCity.name, '', { shouldValidate: true });
-            setValue(formMeta.fields.deliveryPostcode.name, '', { shouldValidate: true });
+            setValue(formMeta.fields.deliveryFirstName.name, '');
+            setValue(formMeta.fields.deliveryLastName.name, '');
+            setValue(formMeta.fields.deliveryCompanyName.name, '');
+            setValue(formMeta.fields.deliveryTelephone.name, '');
+            setValue(formMeta.fields.deliveryStreet.name, '');
+            setValue(formMeta.fields.deliveryCity.name, '');
+            setValue(formMeta.fields.deliveryPostcode.name, '');
             setValue(formMeta.fields.deliveryCountry.name, countriesAsSelectOptions[0], { shouldValidate: true });
         }
     }, [deliveryAddressUuid, countriesAsSelectOptions]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|  in case user switch from saved delivery address to custom/new address there was validation on all fields fired, now it validate only one field which is already prefilled
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1794-fix-switch-custom-delivery-adress-validation.odin.shopsys.cloud
  - https://cz.tv-fw-1794-fix-switch-custom-delivery-adress-validation.odin.shopsys.cloud
<!-- Replace -->
