### PR TITLE
Product recalculation command is more durable for changes in application

### DIFF
--- a/packages/framework/src/Command/RecalculationsCommand.php
+++ b/packages/framework/src/Command/RecalculationsCommand.php
@@ -65,15 +65,15 @@ class RecalculationsCommand extends Command
         $output->writeln('<fg=green>Products visibility.</fg=green>');
         $this->productVisibilityFacade->refreshProductsVisibilityForMarked();
 
+        $output->writeln('<fg=green>Calculate selling (because of main variant price recalculation)</fg=green>');
+        $this->productSellingDeniedRecalculator->calculateSellingDeniedForAll();
+
         $output->writeln('<fg=green>Products price again (because of variants).</fg=green>');
         // Main variant is set for recalculations after change of variants visibility.
         $this->productPriceRecalculator->runAllScheduledRecalculations();
 
         $output->writeln('<fg=green>Products availability.</fg=green>');
         $this->productAvailabilityRecalculator->runAllScheduledRecalculations();
-
-        $output->writeln('<fg=green>Products selling denial.</fg=green>');
-        $this->productSellingDeniedRecalculator->calculateSellingDeniedForAll();
 
         return Command::SUCCESS;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR is inspired by our project. We removed selling denied recalculation from `ProdcutFacade::create`. When product is created, it is denied from selling. When `shopsys:recalculations` runs, it calculates selling denied flag, before second  product price recalculation. Main variant price recalculation works with sellable variants. Using this order of commands, makes `shopsys:recalculations` command independent from changes in application. It makes it more durable.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-recalculation-command.odin.shopsys.cloud
  - https://cz.mt-recalculation-command.odin.shopsys.cloud
<!-- Replace -->
