### PR TITLE
[infrastructure] added information about GitHub limits and increased verbosity of composer install on CI servers

### DIFF
--- a/project-base/app/docker/php-fpm/Dockerfile
+++ b/project-base/app/docker/php-fpm/Dockerfile
@@ -51,7 +51,12 @@ FROM base as ci
 
 COPY --chown=www-data:www-data / /var/www/html
 
-RUN composer install --optimize-autoloader --no-interaction --no-progress --dev
+RUN curl -L \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      https://api.github.com/rate_limit
+
+RUN composer install --optimize-autoloader --no-interaction --no-progress --dev -vvv
 
 RUN php phing build-deploy-part-1-db-independent
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| We are currently running into problems with limits on GitHub API during composer install so we added some more info into running composer install on the CI server in order to be able to debug these problems in the future.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-github-composer-limits.odin.shopsys.cloud
  - https://cz.tl-github-composer-limits.odin.shopsys.cloud
<!-- Replace -->
