### PR TITLE
[github-actions] improved removing the branches from packages

### DIFF
--- a/.github/monorepo/remove_branch.sh
+++ b/.github/monorepo/remove_branch.sh
@@ -17,21 +17,13 @@ assert_split_branch_is_not_protected
 
 echo -e "${BLUE}Removing branch '$SPLIT_BRANCH'...${NC}"
 
-EXIT_STATUS=0
 for PACKAGE in $(get_all_packages); do
-
     if git push --delete "${REMOTE_TEMPLATE}${PACKAGE}.git" ${SPLIT_BRANCH}; then
-        echo -e "${BLUE}Branch ${GREEN}\"${SPLIT_BRANCH}\" ${BLUE}was removed from the package ${GREEN}\"${PACKAGE}\"${NC}"
+        echo -e "${GREEN}Branch \"${SPLIT_BRANCH}\" was removed from the package ${GREEN}\"${PACKAGE}\"${NC}"
     else
-        echo -e "${RED}Branch \"${SPLIT_BRANCH}\" could not be removed from the package \"${PACKAGE}\"!${NC}"
-        EXIT_STATUS=1
+        echo -e "${BLUE}Branch \"${SPLIT_BRANCH}\" does not exist on the package \"${PACKAGE}\"!${NC}"
+
     fi
 done
 
-if [[ $EXIT_STATUS -eq 0 ]]; then
-    echo -e "${GREEN}Branches from all repositories were removed!${NC}"
-else
-    echo -e "${RED}Some branches were not removed from their remotes due to an error${NC}"
-fi
-
-exit $EXIT_STATUS
+echo -e "${GREEN}Branches from all repositories are removed!${NC}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When the branch is not present in the split repositories after merge, the task to remove them no longer fails as it's a completely valid state (branch does not need to be split)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-improve-remove.odin.shopsys.cloud
  - https://cz.mg-improve-remove.odin.shopsys.cloud
<!-- Replace -->
