### PR TITLE
[shopsys] fixed project-base on packagist

### DIFF
--- a/project-base/app/check-composer-json.sh
+++ b/project-base/app/check-composer-json.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ -h "composer.json" ]; then
+    echo 'Please run composer install in the app/ subfolder.'
+    exit 1
+fi

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -146,6 +146,12 @@
         "guzzlehttp/psr7": "<=1.8.3, >=2.0.0, <=2.1.0"
     },
     "scripts": {
+        "pre-install-cmd": [
+            "./check-composer-json.sh"
+        ],
+        "pre-update-cmd": [
+            "./check-composer-json.sh"
+        ],
         "post-install-cmd": [
             "App\\Environment::checkEnvironment",
             "@auto-scripts"

--- a/project-base/check-composer-json.sh
+++ b/project-base/check-composer-json.sh
@@ -1,0 +1,1 @@
+app/check-composer-json.sh

--- a/project-base/composer.json
+++ b/project-base/composer.json
@@ -1,0 +1,1 @@
+app/composer.json


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| after moving the php app into the `app/` subfolder, the packagist was not able to find the composer.json file. This PR adds a symlink to it, while preventing running the `composer install` from the root
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-project-base-packagist.odin.shopsys.cloud
  - https://cz.mg-fix-project-base-packagist.odin.shopsys.cloud
<!-- Replace -->
