### PR TITLE
[infrastructure] commands not used during installation, standards checking and running tests are now run on GitHub Actions to ensure all our commands are passing

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -506,6 +506,36 @@ jobs:
                         echo "All translations are dumped";
                         exit 0;
                     fi
+    check-console-commands:
+        name: Check that all console commands that are not used during installation are passing
+        needs: build-php-fpm-image
+        if: |
+            always() && !failure() && !cancelled() &&
+            (
+                github.event.pull_request.head.repo.full_name == 'shopsys/shopsys' ||
+                github.ref_protected == true
+            ) &&
+            (needs.build-php-fpm-image.result == 'success' || needs.build-php-fpm-image.result == 'skipped')
+        runs-on: ubuntu-22.04
+        steps:
+            -   name: GIT checkout branch - ${{ github.ref }}
+                uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.ref }}
+            -   name: Download docker-compose.yml from artifacts
+                uses: actions/download-artifact@v3
+                with:
+                    name: docker-compose
+            -   name: Build application
+                run: |
+                    docker compose up -d
+                    docker compose exec -T php-fpm composer install --optimize-autoloader --no-interaction --dev
+                    docker compose exec -T php-fpm php phing -D production.confirm.action=y db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate elasticsearch-index-recreate elasticsearch-export
+            -   name: Check all commands are passing
+                run: |
+                    docker compose exec -T php-fpm php phing -D production.confirm.action=y cron-list cron-run-all-serially cron-watch maintenance-on maintenance-off elasticsearch-export-changed
+                    docker compose exec -T php-fpm php bin/console shopsys:categories:recalculate
+                    docker compose exec -T php-fpm php bin/console shopsys:cdn-domain-url:replace
     build-fork-docker-images:
         if: |
             github.event.pull_request.head.repo.full_name != 'shopsys/shopsys' && 
@@ -563,6 +593,11 @@ jobs:
                         echo "All translations are dumped";
                         exit 0;
                     fi
+            -   name: Check all not previously used commands are passing
+                run: |
+                    docker compose exec -T php-fpm php phing -D production.confirm.action=y frontend-api-enable cron-list cron-run-all-serially cron-watch maintenance-on maintenance-off elasticsearch-export-changed
+                    docker compose exec -T php-fpm php bin/console shopsys:categories:recalculate
+                    docker compose exec -T php-fpm php bin/console shopsys:cdn-domain-url:replace
             -   name: PHP-FPM container logs
                 if: ${{ failure() }}
                 run: docker compose logs php-fpm

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -105,6 +105,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   add consumers and RabbitMQ to deployed application ([#2904](https://github.com/shopsys/shopsys/pull/2904))
     -   set new environment variables `RABBITMQ_DEFAULT_USER`, `RABBITMQ_DEFAULT_PASS`, `RABBITMQ_IP_WHITELIST` in your deployment tool (with use of the default config it will be Gitlab CI)
     -   see #project-base-diff to update your project
+-   re-enable phing target cron ([#2875](https://github.com/shopsys/shopsys/pull/2875))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/build.xml
+++ b/build.xml
@@ -38,10 +38,6 @@
         </exec>
     </target>
 
-    <target name="cron" description="Disabled - use new cron instances instead.">
-        <fail message="Default cron instance is disabled. All modules are in new instances."/>
-    </target>
-
     <target name="ecs" description="Checks coding standards in all files in the whole monorepo by PHP easy coding standards." depends="entities-dump" hidden="true">
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>

--- a/docs/cookbook/working-with-multiple-cron-instances.md
+++ b/docs/cookbook/working-with-multiple-cron-instances.md
@@ -26,7 +26,7 @@ services:
     App\Model\Product\ImportProductsCronModule:
         tags:
 -            - { name: shopsys.cron, hours: '*/3', minutes: '0' }
-+            - { name: shopsys.cron, hours: '*/3', minutes: '0', instanceName: products}
++            - { name: shopsys.cron, hours: '*/3', minutes: '0', instanceName: products }
 ```
 
 !!! note

--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -3,9 +3,9 @@
 ## Basics
 
 Cron is a tool to run background jobs and is essential for the production environment.
-Periodically executed Cron modules recalculate visibility, generate XML feeds and sitemaps, provide error reporting etc.
+Periodically executed Cron modules recalculate visibility, generate XML feeds and sitemaps, provide error reporting, etc.
 
-By default you can configure your own cron configurations in `config/services/cron.yaml` file.
+By default, you can configure your own cron configurations in `config/services/cron.yaml` file.
 
 If you want to show Cron overview table for non-superadmin users you need add parameter `shopsys.display_cron_overview_for_superadmin_only` set to `false` in your `config/parameters.yaml`:
 
@@ -39,9 +39,13 @@ The instance of cron is actually a named group of cron jobs.
 
 You can learn how to set up multiple cron instances in [Working with Multiple Cron Instances](../cookbook/working-with-multiple-cron-instances.md) cookbook.
 
+!!! note
+
+    For testing purposes (e.g., on CI server) there is a special phing target `run-all-crons-serially` that allows you to run all the CRON modules serially.
+
 ## Cron Limitations
 
-One cron run can only be run for a limited time by default to prevent high memory usage of long-running jobs in PHP.
+One cron run can only be run for a limited time by default to prevent high-memory usage of long-running jobs in PHP.
 In `shopsys/framework/src/Resources/config/cron.yaml` is set the default timeout to `240 seconds`:
 
 ```yaml
@@ -57,4 +61,4 @@ That's usually not a problem as long-running cron modules are not executed every
 but in some cases, the overall time of the "every 5 minutes" cron modules can be higher (for example, considerable amount of products to export to Elasticsearch).
 Then it's possible, some cron modules will never be run.
 
-It's crucial to monitor your crons and, if necessary update their periodicity and timeout or split them into [multiple Cron Instances](#multiple-cron-instances).
+It's crucial to monitor your crons and, if necessary, update their periodicity and timeout or split them into [multiple Cron Instances](#multiple-cron-instances).

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -253,7 +253,7 @@
         </exec>
     </target>
 
-    <target name="cron" description="Runs background jobs. Should be executed periodically by system Cron every 5 minutes.">
+    <target name="cron" description="Runs background jobs.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:cron"/>

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -278,6 +278,15 @@
         </exec>
     </target>
 
+    <target name="cron-run-all-serially" depends="production-protection" description="This target will run all crons serially. It is not supposed to be run in the production environment but on CI servers to test that all crons run without errors.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:cron"/>
+            <arg value="--run-all-serially"/>
+            <arg value="--verbose"/>
+        </exec>
+    </target>
+
     <target name="cron-watch" description="Cron watch target is running until cron instance ends, then is terminated.">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>

--- a/project-base/app/build.xml
+++ b/project-base/app/build.xml
@@ -16,8 +16,4 @@
     <import file="${path.frontend-api}/build.xml"/>
     <import file="${path.root}/build-cron.xml"/>
 
-    <target name="cron" description="Disabled - use new cron instances instead.">
-        <fail message="Default cron instance is disabled. All modules are in new instances."/>
-    </target>
-
 </project>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| We want to test as much of our application automatically as possible. This PR ensures that all our commands are passing.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes









































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-phing-targets-ci.odin.shopsys.cloud
  - https://cz.tl-phing-targets-ci.odin.shopsys.cloud
<!-- Replace -->
