### PR TITLE
Generate command has a new option with generate empty migrations

### DIFF
--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -148,6 +148,13 @@ Generates a new [database migration](database-migrations.md) class when DB schem
 
 When you make changes to ORM entities you should run this command that will generate a new migration file for you.
 
+#### db-migrations-generate-empty
+
+Generates a new empty [database migration](database-migrations.md) class.
+
+When you need to create a database migration that doesn't automatically reflect changes in ORM entities, but rather includes custom SQL or specific schema alterations, you can use this command.
+This will create an empty migration file that you can manually populate with the required database schema changes.
+
 #### db-migrations
 
 Executes [database migrations](database-migrations.md) and checks schema.

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -402,6 +402,15 @@
         </exec>
     </target>
 
+    <target name="db-migrations-generate-empty" description="Generates new empty migration file.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:migrations:generate"/>
+            <arg value="--empty"/>
+            <arg value="--verbose"/>
+        </exec>
+    </target>
+
     <target name="db-performance" depends="production-protection,db-wipe-public-schema,clean,clean-redis,db-import-basic-structure,db-migrations,domains-data-create,db-fixtures-demo,plugin-demo-data-load,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,db-fixtures-performance" description="Drops all data in main database and creates a new one with performance data."/>
 
     <target name="db-rebuild" depends="production-protection,db-wipe-public-schema,db-import-basic-structure,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace" description="Drops all data in database and creates a new one with base data only."/>

--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -44,6 +44,13 @@ class GenerateMigrationCommand extends Command
         parent::__construct();
     }
 
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Generate a new migration')
+            ->addOption('empty', null, null, 'Generate an empty migration');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -53,7 +60,7 @@ class GenerateMigrationCommand extends Command
 
         $filteredSchemaDiffSqlCommands = $this->databaseSchemaFacade->getFilteredSchemaDiffSqlCommands();
 
-        if (count($filteredSchemaDiffSqlCommands) === 0) {
+        if (count($filteredSchemaDiffSqlCommands) === 0 && $input->getOption('empty') === false) {
             $output->writeln('<info>Database schema is satisfying ORM, no migrations were generated.</info>');
 
             return static::RETURN_CODE_OK;

--- a/upgrade-notes/backend_20240814_134056.md
+++ b/upgrade-notes/backend_20240814_134056.md
@@ -1,0 +1,3 @@
+#### Developers now can generate new empty migration ([#2878](https://github.com/shopsys/shopsys/pull/2878))
+
+-   Now, you can call function `php phing upgrade-generate` and empty migration will be generated


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Sometimes is necessary to generate the migration file not related to any change in doctrine schema. For example to update some data without the change in the structure. This PR allows generating the empty migration in the same manner as the standard migrations are generated
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
