### PR TITLE
[project-base] breadcrumb without url is no longer a link

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -52,6 +52,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))
     -   see #project-base-diff to update your project
+-   remove link from administrator and customers breadcrumb ([#2881](https://github.com/shopsys/shopsys/pull/2881))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/project-base/app/src/Controller/Admin/SideMenuConfigurationSubscriber.php
+++ b/project-base/app/src/Controller/Admin/SideMenuConfigurationSubscriber.php
@@ -64,7 +64,7 @@ class SideMenuConfigurationSubscriber implements EventSubscriberInterface
     public function configureCustomersMenu(ConfigureMenuEvent $event): void
     {
         $customersMenu = $event->getMenu();
-        $customersMenu->setUri('');
+        $customersMenu->setUri(null);
         $customersExtras = $customersMenu->getExtras();
         unset($customersExtras['routes']);
         $customersMenu->setExtras($customersExtras);
@@ -258,7 +258,7 @@ class SideMenuConfigurationSubscriber implements EventSubscriberInterface
     {
         $administratorMenu = $event->getMenu();
 
-        $administratorMenu->setUri('');
+        $administratorMenu->setUri(null);
         $administratorExtras = $administratorMenu->getExtras();
         unset($administratorExtras['routes']);
         $administratorMenu->setExtras($administratorExtras);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Breadcrumb `Administrators` and `Customers` are now set without URI (instead of empty URI). On the picture below is a comparison of the previous state and a new one. Without a URI the breadcrumb is rendered as a simple text – the same way as it is already in pricing groups for example.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

![Snímek obrazovky 2023-07-31 v 17 37 08](https://github.com/shopsys/shopsys/assets/1177414/3b6c2101-05d8-46ae-bd69-c5a40c1cdaa2)

<img width="831" alt="Snímek obrazovky 2023-10-16 v 9 43 07" src="https://github.com/shopsys/shopsys/assets/1177414/21127601-9f8c-4da0-aacd-ebff009bf257">





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-breadcrumbs.odin.shopsys.cloud
  - https://cz.mg-fix-breadcrumbs.odin.shopsys.cloud
<!-- Replace -->
