### PR TITLE
[FW-1879] removed unnecessary default value for domainConfig

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -73,3 +73,6 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))
     -   see #project-base-diff to update your project
+- remove unnecessary default value for domain config in zustand ([#2888](https://github.com/shopsys/shopsys/pull/2888))
+  - you probably do not need the default value as well, as we set it right at the beginning of page load
+  - see #project-base-diff to update your project

--- a/project-base/storefront/hooks/useDomainConfig.ts
+++ b/project-base/storefront/hooks/useDomainConfig.ts
@@ -1,11 +1,16 @@
 import { DomainConfigType } from 'helpers/domain/domainConfig';
+import { logException } from 'helpers/errors/logException';
 import { useState } from 'react';
 import { useSessionStore } from 'store/useSessionStore';
 
 export const useDomainConfig = (): DomainConfigType => {
     const domainConfig = useSessionStore((state) => state.domainConfig);
 
-    return domainConfig;
+    if (!domainConfig) {
+        logException(new Error('Domain config was undefined.'));
+    }
+
+    return domainConfig!;
 };
 
 export const useSetDomainConfig = (initialDomainConfig: DomainConfigType) => {

--- a/project-base/storefront/store/slices/createDomainSlice.ts
+++ b/project-base/storefront/store/slices/createDomainSlice.ts
@@ -2,24 +2,12 @@ import { DomainConfigType } from 'helpers/domain/domainConfig';
 import { StateCreator } from 'zustand';
 
 export type DomainSlice = {
-    domainConfig: DomainConfigType;
+    domainConfig: DomainConfigType | undefined;
     setDomainConfig: (value: DomainConfigType) => void;
 };
 
 export const createDomainSlice: StateCreator<DomainSlice> = (set) => ({
-    domainConfig: {
-        url: process.env.DOMAIN_HOSTNAME_1!,
-        publicGraphqlEndpoint: process.env.PUBLIC_GRAPHQL_ENDPOINT_HOSTNAME_1!,
-        timezone: 'Europe/Prague',
-        defaultLocale: 'cs',
-        currencyCode: 'CZK',
-        domainId: 1,
-        mapSetting: {
-            latitude: 49.8175,
-            longitude: 15.473,
-            zoom: 7,
-        },
-    },
+    domainConfig: undefined,
 
     setDomainConfig: (value: DomainConfigType) => {
         set({ domainConfig: value });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The value is now initially set to undefined, not to first-domain data. If the value is not available when used, an exception is logged (to Sentry). The value is null-assured inside the useDomainConfig hook as we know we are setting it correctly before.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-remove-default-domain-config.odin.shopsys.cloud
  - https://cz.sh-remove-default-domain-config.odin.shopsys.cloud
<!-- Replace -->
