### PR TITLE
[shopsys] graphql validation errors now contain violation list in the additional data and allow change the log level

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -77,6 +77,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   add Symfony Messenger along with RabbitMQ ([#2898](https://github.com/shopsys/shopsys/pull/2898))
     -   install application to create new necessary containers (run again `./scripts/install.sh`) – this will overwrite your local `docker-compose.yml` file
     -   see #project-base-diff to update your project
+-   set the custom logger to the Frontend API ([#2882](https://github.com/shopsys/shopsys/pull/2882))
+    -   you can set `shopsys.frontend_api.validation_logged_as_error` parameter to `true` to log validation errors with log level ERROR instead of INFO
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/frontend-api/src/Model/Logger/FrontendApiLogger.php
+++ b/packages/frontend-api/src/Model/Logger/FrontendApiLogger.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Logger;
+
+use Overblog\GraphQLBundle\Validator\Exception\ArgumentsValidationException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\Validator\ConstraintViolation;
+
+class FrontendApiLogger implements LoggerInterface
+{
+    /**
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param bool $isValidationLoggedAsError
+     */
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly bool $isValidationLoggedAsError,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        if (isset($context['exception'])) {
+            $throwable = $context['exception'];
+
+            if ($throwable instanceof ArgumentsValidationException) {
+                $level = $this->isValidationLoggedAsError ? LogLevel::ERROR : LogLevel::INFO;
+                $context['violations'] = [];
+
+                foreach ($throwable->getViolations() as $violation) {
+                    if ($violation instanceof ConstraintViolation) {
+                        $context['violations'][] = $violation->getPropertyPath() . ': ' . $violation->getMessage();
+
+                        continue;
+                    }
+
+                    $context['violations'][] = $violation;
+                }
+            }
+        }
+
+        $this->logger->log($level, $message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function emergency($message, array $context = []): void
+    {
+        $this->logger->emergency($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alert($message, array $context = []): void
+    {
+        $this->logger->alert($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function critical($message, array $context = []): void
+    {
+        $this->logger->critical($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = []): void
+    {
+        $this->logger->error($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warning($message, array $context = []): void
+    {
+        $this->logger->warning($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notice($message, array $context = []): void
+    {
+        $this->logger->notice($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info($message, array $context = []): void
+    {
+        $this->logger->info($message, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function debug($message, array $context = []): void
+    {
+        $this->logger->debug($message, $context);
+    }
+}

--- a/packages/frontend-api/src/Resources/config/parameters.yaml
+++ b/packages/frontend-api/src/Resources/config/parameters.yaml
@@ -1,2 +1,3 @@
 parameters:
     shopsys.frontend_api.domains: []
+    shopsys.frontend_api.validation_logged_as_error: false

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -43,3 +43,8 @@ services:
 
     Lcobucci\JWT\Configuration:
         factory: ['@Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationFactory', create]
+
+    Shopsys\FrontendApiBundle\Model\Logger\FrontendApiLogger:
+        arguments:
+            $logger: '@monolog.logger'
+            $isValidationLoggedAsError: '%shopsys.frontend_api.validation_logged_as_error%'

--- a/project-base/app/config/packages/overblog_graphql.yaml
+++ b/project-base/app/config/packages/overblog_graphql.yaml
@@ -23,3 +23,5 @@ overblog_graphql:
         enable_introspection: '%kernel.debug%'
     services:
         promise_adapter: "webonyx_graphql.sync_promise_adapter"
+    errors_handler:
+        logger_service: Shopsys\FrontendApiBundle\Model\Logger\FrontendApiLogger

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -25,3 +25,6 @@ parameters:
     shopsys.cron_timezone: Europe/Prague
     shopsys.image.enable_lazy_load: true
     admin_url: 'admin'
+
+    # Set to true to log validation errors with log level ERROR instead of INFO
+    shopsys.frontend_api.validation_logged_as_error: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| ArgumentsValidationError is by default logged, but without any information about the exact violation that caused the validation to fail. This PR adds a list of violations to the log message context, so it's clear what caused the validation error. Additionally a new parameter `shopsys.frontend_api.validation_logged_as_error` was introduced to allow changing the log level easily.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fe-api-logging.odin.shopsys.cloud
  - https://cz.mg-fe-api-logging.odin.shopsys.cloud
<!-- Replace -->
