### PR TITLE
[FW-1848] SEO categories with ignored filters

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -113,6 +113,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   replace custom application bootstrapping with symfony/runtime ([#2914](https://github.com/shopsys/shopsys/pull/2914))
     -   see #project-base-diff to update your project
+-   prevent duplicate color parameters in data fixtures ([#2911](https://github.com/shopsys/shopsys/pull/2911))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -224,3 +224,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   if you have any logic for syncing your events, you can move it to this provider
     -   docs were added, so you can base your changes on those
     -   see #project-base-diff to update your project
+-   improve SEO categories logic in regards to non-SEO-sensitive filters ([#2891](https://github.com/shopsys/shopsys/pull/2891))
+    -   we moved some config from various files to `config/constants` and warmly suggest you do the same, as it improves the app and testing
+    -   we also moved some hooks from `helpers` to `hooks` and suggest you do the same with all hooks, as it again improves the app and testing
+    -   the implemented functionality for dynamic switching between SEO-sensitivity for various filters is only implemented on SF, so applying these changes won't make it work on BE
+    -   if you do not need SEO categories, these changes might be irrelevant altogether
+    -   flag and brand values are now merged after change of default parameters (leaving SEO category) instead of overwritting. This is a bug fix and you should apply it to your changes as well.
+    -   see #project-base-diff to update your project

--- a/docs/storefront/unit-tests.md
+++ b/docs/storefront/unit-tests.md
@@ -144,6 +144,10 @@ export const useModuleValue = () => {
 
 ### How to mock different scenarios
 
+Before showing different mocking scenarios, there are some common known pitfals with mocking which might be a problem for you as well. Below is a list with a simple solution:
+
+-   **If I test function foo and want to mock a function or constant bar from the same module, it will not work as needed** - If this is the case, you should find another way of testing, either by moving one of these files, or by avoiding the mock altogether (for example using IoC and parameters)
+
 #### 1. Default mock of a function
 
 This approach is helpful if you want to mock an exported function in a specific way which stays consistent across the file. If you want this mock function to return the same value for all your test suites inside this file, this is how you do it.

--- a/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ReadyCategorySeoDataFixture.php
@@ -23,6 +23,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
     public const READY_CATEGORY_SEO_TV_IN_SALE = 'ready_category_seo_tv_in_sale';
     public const READY_CATEGORY_SEO_TV_PLASMA_WITH_HDMI = 'ready_category_seo_tv_plasma_with_hdmi';
     public const READY_CATEGORY_SEO_PC_NEW_WITH_USB = 'ready_category_seo_pc_new_with_usb';
+    public const READY_CATEGORY_SEO_BLACK_ELECTRONICS = 'ready_category_seo_black_electronics';
 
     /**
      * @param \App\Model\CategorySeo\ReadyCategorySeoMixDataFactory $readyCategorySeoMixDataFactory
@@ -164,7 +165,7 @@ class ReadyCategorySeoDataFixture extends AbstractReferenceFixture implements De
             t('Electronics in black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
             ['elektro-barva-cerna'],
             $firstDomainId,
-            null,
+            self::READY_CATEGORY_SEO_BLACK_ELECTRONICS,
             t('description of Electronics in black seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
             t('short description of Electronics in black seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
             t('title of Electronics in black seo category', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),

--- a/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
+++ b/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
@@ -243,7 +243,6 @@ class ParameterRepository extends BaseParameterRepository
         $parameterValue = $this->getParameterValueRepository()->findOneBy([
             'text' => $parameterValueData->text,
             'locale' => $parameterValueData->locale,
-            'rgbHex' => $parameterValueData->rgbHex,
         ]);
 
         if ($parameterValue === null) {
@@ -252,6 +251,11 @@ class ParameterRepository extends BaseParameterRepository
             $this->em->persist($parameterValue);
             // Doctrine's identity map is not cache.
             // We have to flush now, so that next findOneBy() finds new ParameterValue.
+            $this->em->flush();
+        }
+
+        if ($parameterValue->getRgbHex() !== $parameterValueData->rgbHex) {
+            $parameterValue->edit($parameterValueData);
             $this->em->flush();
         }
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Category/ReadyCategorySeoMix/ReadyCategorySeoMixTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Category/ReadyCategorySeoMix/ReadyCategorySeoMixTest.php
@@ -405,4 +405,34 @@ class ReadyCategorySeoMixTest extends GraphQlTestCase
 
         return  $this->getResponseDataForGraphQlType($responseForCategory, 'slug');
     }
+
+    public function testCategoryFilterIsCorrectlySetAsSelected(): void
+    {
+        /** @var \App\Model\CategorySeo\ReadyCategorySeoMix $blackElectronicsSeoCategory */
+        $blackElectronicsSeoCategory = $this->getReferenceForDomain(ReadyCategorySeoDataFixture::READY_CATEGORY_SEO_BLACK_ELECTRONICS, 1);
+        $seoMixUrlSlug = $this->urlGenerator->generate('front_category_seo', ['id' => $blackElectronicsSeoCategory->getId()]);
+        $variables = array_merge(['slug' => $seoMixUrlSlug]);
+        $responseForSeoMix = $this->getResponseContentForGql(__DIR__ . '/../../_graphql/query/ReadyCategorySeoMixQuery.graphql', $variables);
+
+        $data = $this->getResponseDataForGraphQlType($responseForSeoMix, 'slug');
+
+        $colorFilter = array_filter(
+            $data['products']['productFilterOptions']['parameters'],
+            static function ($item) {
+                return $item['__typename'] === 'ParameterColorFilterOption';
+            },
+        );
+
+        $colorFilterValues = reset($colorFilter)['values'];
+        $black = t('black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale());
+
+        $blackColorFilter = array_filter(
+            $colorFilterValues,
+            static function ($item) use ($black) {
+                return $item['text'] === $black;
+            },
+        );
+
+        $this->assertTrue(reset($blackColorFilter)['isSelected']);
+    }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/ReadyCategorySeoMixQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/ReadyCategorySeoMixQuery.graphql
@@ -18,6 +18,13 @@ query ReadyCategorySeoMix($slug: String!, $orderingMode: ProductOrderingModeEnum
                         ...on ParameterSliderFilterOption {
                             selectedValue
                         }
+                        ... on ParameterColorFilterOption {
+                            name
+                            values {
+                                text
+                                isSelected
+                            }
+                        }
                     }
                     flags {
                         flag {

--- a/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
+++ b/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
@@ -1,7 +1,7 @@
 import { SortingBarItem } from './SortingBarItem';
 import { SortIcon } from 'components/Basic/Icon/IconsSvg';
+import { DEFAULT_SORT } from 'config/constants';
 import { ProductOrderingModeEnumApi } from 'graphql/generated';
-import { DEFAULT_SORT } from 'helpers/filterOptions/seoCategories';
 import { getUrlQueriesWithoutDynamicPageQueries } from 'helpers/parsing/urlParsing';
 import { twMergeCustom } from 'helpers/twMerge';
 import { useQueryParams } from 'hooks/useQueryParams';

--- a/project-base/storefront/config/constants.ts
+++ b/project-base/storefront/config/constants.ts
@@ -1,1 +1,28 @@
+import { ProductOrderingModeEnumApi } from 'graphql/generated';
+
 export const DEFAULT_PAGE_SIZE = 9;
+export const DEFAULT_SORT = ProductOrderingModeEnumApi.PriorityApi as const;
+/**
+ * For those that are set to "true", we optimistically navigate out from a SEO category when a value of that type is changed
+ * This setting needs to mirror the API functionality in the following way
+ * - if a filter type "blocks" SEO category on API, it needs to be set as SEO sensitive
+ * - if a filter type "allows" SEO category on API, it needs to be set as SEO insensitive
+ *
+ * @example
+ * if the current URL is a SEO category "/my-seo-category" and sorting (which is SEO sensitive)
+ * is changed, we navigate right away to "/my-normal-category?sort=NEW_SORTING"
+ *
+ * if the current URL is a SEO category "/my-seo-category" and availability (which is SEO insensitive)
+ * is changed, we stay in the SEO category and navigate to "/my-seo-category?onlyInStock=true"
+ */
+export const SEO_SENSITIVE_FILTERS = {
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    BRANDS: false,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+};

--- a/project-base/storefront/helpers/arrayUtils.ts
+++ b/project-base/storefront/helpers/arrayUtils.ts
@@ -1,1 +1,8 @@
 export const createEmptyArray = (length: number): null[] => Array(length).fill(null);
+
+export const mergeNullableArrays = <T>(array1: T[] | undefined | null, array2: T[] | undefined | null) => {
+    const nonNullableArray1 = array1 ? array1 : [];
+    const nonNullableArray2 = array2 ? array2 : [];
+
+    return [...nonNullableArray1, ...nonNullableArray2];
+};

--- a/project-base/storefront/helpers/filterOptions/buildNewQueryAfterFilterChange.ts
+++ b/project-base/storefront/helpers/filterOptions/buildNewQueryAfterFilterChange.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_SORT } from 'config/constants';
 import { ProductOrderingModeEnumApi } from 'graphql/generated';
 import {
     PAGE_QUERY_PARAMETER_NAME,
@@ -6,7 +7,6 @@ import {
     SORT_QUERY_PARAMETER_NAME,
 } from 'helpers/queryParamNames';
 import { UrlQueries, FilterQueries } from 'hooks/useQueryParams';
-import { DEFAULT_SORT } from './seoCategories';
 
 export const buildNewQueryAfterFilterChange = (
     currentQuery: UrlQueries,

--- a/project-base/storefront/helpers/filterOptions/buildNewQueryAfterFilterChange.ts
+++ b/project-base/storefront/helpers/filterOptions/buildNewQueryAfterFilterChange.ts
@@ -1,0 +1,37 @@
+import { ProductOrderingModeEnumApi } from 'graphql/generated';
+import {
+    PAGE_QUERY_PARAMETER_NAME,
+    LOAD_MORE_QUERY_PARAMETER_NAME,
+    FILTER_QUERY_PARAMETER_NAME,
+    SORT_QUERY_PARAMETER_NAME,
+} from 'helpers/queryParamNames';
+import { UrlQueries, FilterQueries } from 'hooks/useQueryParams';
+import { DEFAULT_SORT } from './seoCategories';
+
+export const buildNewQueryAfterFilterChange = (
+    currentQuery: UrlQueries,
+    newFilter: FilterQueries,
+    newSort: ProductOrderingModeEnumApi | undefined,
+) => {
+    const isWithFilterParams =
+        !!newFilter &&
+        (!!newFilter.onlyInStock ||
+            !!(newFilter.minimalPrice ?? undefined) ||
+            !!(newFilter.maximalPrice ?? null) ||
+            !!newFilter.brands?.length ||
+            !!newFilter.flags?.length ||
+            !!newFilter.parameters?.length);
+
+    const newQuery: UrlQueries = {
+        ...currentQuery,
+        [PAGE_QUERY_PARAMETER_NAME]: undefined,
+        [LOAD_MORE_QUERY_PARAMETER_NAME]: undefined,
+        [FILTER_QUERY_PARAMETER_NAME]: isWithFilterParams ? JSON.stringify(newFilter) : undefined,
+    } as const;
+
+    if (newSort && newSort !== DEFAULT_SORT) {
+        newQuery[SORT_QUERY_PARAMETER_NAME] = newSort;
+    }
+
+    return newQuery;
+};

--- a/project-base/storefront/helpers/filterOptions/getFilterWithoutEmpty.ts
+++ b/project-base/storefront/helpers/filterOptions/getFilterWithoutEmpty.ts
@@ -1,0 +1,18 @@
+import { FilterOptionsUrlQueryType } from 'types/productFilter';
+
+export const getFilterWithoutEmpty = (filter: FilterOptionsUrlQueryType | undefined | null) => {
+    if (!filter) {
+        return undefined;
+    }
+
+    const updatedFilter = { ...filter };
+
+    (Object.keys(updatedFilter) as Array<keyof typeof updatedFilter>).forEach((key) => {
+        const newFilterValue = updatedFilter[key];
+        if (Array.isArray(newFilterValue) && newFilterValue.length === 0) {
+            delete updatedFilter[key];
+        }
+    });
+
+    return updatedFilter;
+};

--- a/project-base/storefront/helpers/filterOptions/seoCategories.ts
+++ b/project-base/storefront/helpers/filterOptions/seoCategories.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_SORT, SEO_SENSITIVE_FILTERS } from 'config/constants';
 import { ProductFilterOptionsFragmentApi, ProductOrderingModeEnumApi } from 'graphql/generated';
+import { mergeNullableArrays } from 'helpers/arrayUtils';
 import { DefaultProductFiltersMapType } from 'store/slices/createSeoCategorySlice';
 import { FilterOptionsParameterUrlQueryType, FilterOptionsUrlQueryType } from 'types/productFilter';
 
@@ -153,16 +154,18 @@ export const getChangedDefaultFiltersAfterAvailabilityChange = (
 };
 
 export const getChangedDefaultFilters = (
-    updatedProductFiltersMap: DefaultProductFiltersMapType,
-    filter: FilterOptionsUrlQueryType | null,
-) => ({
-    ...filter,
-    brands: Array.from(updatedProductFiltersMap.brands),
-    flags: Array.from(updatedProductFiltersMap.flags),
-    parameters: Array.from(updatedProductFiltersMap.parameters)
-        .map(([updatedParameterUuid, updatedParameterValues]) => ({
-            parameter: updatedParameterUuid,
-            values: Array.from(updatedParameterValues),
+    defaultFilter: DefaultProductFiltersMapType,
+    updatedFilter: FilterOptionsUrlQueryType | null,
+): FilterOptionsUrlQueryType => ({
+    onlyInStock: updatedFilter?.onlyInStock,
+    minimalPrice: updatedFilter?.minimalPrice,
+    maximalPrice: updatedFilter?.maximalPrice,
+    brands: mergeNullableArrays(Array.from(defaultFilter.brands), updatedFilter?.brands),
+    flags: mergeNullableArrays(Array.from(defaultFilter.flags), updatedFilter?.flags),
+    parameters: Array.from(defaultFilter.parameters)
+        .map(([defaultParameterUuid, defaultParameterValues]) => ({
+            parameter: defaultParameterUuid,
+            values: Array.from(defaultParameterValues),
         }))
         .filter(({ values }) => values.length !== 0),
 });

--- a/project-base/storefront/helpers/filterOptions/seoCategories.ts
+++ b/project-base/storefront/helpers/filterOptions/seoCategories.ts
@@ -213,3 +213,43 @@ export const useHandleDefaultFiltersUpdate = (
         );
     }, [productsPreview?.productFilterOptions, productsPreview?.defaultOrderingMode]);
 };
+
+export const getFilterWithoutSeoSensitiveFilters = (
+    currentFilter: FilterOptionsUrlQueryType | undefined | null,
+    currentSort: ProductOrderingModeEnumApi | null,
+) => {
+    const filteredSort = SEO_SENSITIVE_FILTERS.SORT || !currentSort ? undefined : currentSort;
+    if (!currentFilter) {
+        return { filteredFilter: undefined, filteredSort };
+    }
+
+    const filteredFilter: Partial<FilterOptionsUrlQueryType> = { ...currentFilter };
+    if (SEO_SENSITIVE_FILTERS.AVAILABILITY) {
+        delete filteredFilter.onlyInStock;
+    }
+    if (SEO_SENSITIVE_FILTERS.BRANDS) {
+        delete filteredFilter.brands;
+    }
+    if (SEO_SENSITIVE_FILTERS.FLAGS) {
+        delete filteredFilter.flags;
+    }
+    if (SEO_SENSITIVE_FILTERS.PARAMETERS.CHECKBOX) {
+        filteredFilter.parameters = filteredFilter.parameters?.filter(
+            (parameter) => typeof parameter.minimalValue === 'number' && typeof parameter.maximalValue === 'number',
+        );
+    }
+    if (SEO_SENSITIVE_FILTERS.PARAMETERS.SLIDER) {
+        filteredFilter.parameters = filteredFilter.parameters?.filter((parameter) => !!parameter.values?.length);
+    }
+    if (!filteredFilter.parameters?.length) {
+        delete filteredFilter.parameters;
+    }
+    if (SEO_SENSITIVE_FILTERS.PRICE) {
+        delete filteredFilter.minimalPrice;
+    }
+    if (SEO_SENSITIVE_FILTERS.PRICE) {
+        delete filteredFilter.maximalPrice;
+    }
+
+    return { filteredFilter, filteredSort };
+};

--- a/project-base/storefront/helpers/filterOptions/seoCategories.ts
+++ b/project-base/storefront/helpers/filterOptions/seoCategories.ts
@@ -1,39 +1,7 @@
-import {
-    ListedProductConnectionPreviewFragmentApi,
-    ProductFilterOptionsFragmentApi,
-    ProductOrderingModeEnumApi,
-} from 'graphql/generated';
-import { useEffect } from 'react';
+import { DEFAULT_SORT, SEO_SENSITIVE_FILTERS } from 'config/constants';
+import { ProductFilterOptionsFragmentApi, ProductOrderingModeEnumApi } from 'graphql/generated';
 import { DefaultProductFiltersMapType } from 'store/slices/createSeoCategorySlice';
-import { useSessionStore } from 'store/useSessionStore';
 import { FilterOptionsParameterUrlQueryType, FilterOptionsUrlQueryType } from 'types/productFilter';
-
-export const DEFAULT_SORT = ProductOrderingModeEnumApi.PriorityApi as const;
-
-/**
- * For those that are set to "true", we optimistically navigate out from a SEO category when a value of that type is changed
- * This setting needs to mirror the API functionality in the following way
- * - if a filter type "blocks" SEO category on API, it needs to be set as SEO sensitive
- * - if a filter type "allows" SEO category on API, it needs to be set as SEO insensitive
- *
- * @example
- * if the current URL is a SEO category "/my-seo-category" and sorting (which is SEO sensitive)
- * is changed, we navigate right away to "/my-normal-category?sort=NEW_SORTING"
- *
- * if the current URL is a SEO category "/my-seo-category" and availability (which is SEO insensitive)
- * is changed, we stay in the SEO category and navigate to "/my-seo-category?onlyInStock=true"
- */
-export const SEO_SENSITIVE_FILTERS = {
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    BRANDS: false,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-};
 
 export const getEmptyDefaultProductFiltersMap = (): DefaultProductFiltersMapType => ({
     flags: new Set(),
@@ -198,21 +166,6 @@ export const getChangedDefaultFilters = (
         }))
         .filter(({ values }) => values.length !== 0),
 });
-
-export const useHandleDefaultFiltersUpdate = (
-    productsPreview: ListedProductConnectionPreviewFragmentApi | undefined,
-) => {
-    const setDefaultProductFiltersMap = useSessionStore((s) => s.setDefaultProductFiltersMap);
-
-    useEffect(() => {
-        setDefaultProductFiltersMap(
-            getDefaultFilterFromFilterOptions(
-                productsPreview?.productFilterOptions,
-                productsPreview?.defaultOrderingMode,
-            ),
-        );
-    }, [productsPreview?.productFilterOptions, productsPreview?.defaultOrderingMode]);
-};
 
 export const getFilterWithoutSeoSensitiveFilters = (
     currentFilter: FilterOptionsUrlQueryType | undefined | null,

--- a/project-base/storefront/helpers/parsing/urlParsing.ts
+++ b/project-base/storefront/helpers/parsing/urlParsing.ts
@@ -4,10 +4,6 @@ import { UrlQueries } from 'hooks/useQueryParams';
 import { ParsedUrlQuery } from 'querystring';
 import { FriendlyPagesDestinations } from 'types/friendlyUrl';
 
-const ignoredUrlQueries: (string | undefined)[] = Object.values(FriendlyPagesDestinations).map(
-    (pagePath) => pagePath.match(/\[(\w+)\]/)?.[1],
-);
-
 export const getStringFromUrlQuery = (urlQuery: string | string[] | undefined): string => {
     if (urlQuery === undefined || Array.isArray(urlQuery)) {
         return '';
@@ -65,8 +61,24 @@ export const getDynamicPageQueryKey = (pathname: string) => {
 export const getUrlQueriesWithoutDynamicPageQueries = (queries: UrlQueries) => {
     const filteredQueries = { ...queries };
 
+    const friendlyPageDynamicSegments = Object.values(FriendlyPagesDestinations).map(
+        (pagePath) => pagePath.match(/\[(\w+)\]/)?.[1],
+    );
+
     (Object.keys(filteredQueries) as Array<keyof typeof filteredQueries>).forEach((key) => {
-        if (!filteredQueries[key] || ignoredUrlQueries.includes(key)) {
+        if (friendlyPageDynamicSegments.includes(key)) {
+            delete filteredQueries[key];
+        }
+    });
+
+    return filteredQueries;
+};
+
+export const getUrlQueriesWithoutFalsyValues = (queries: UrlQueries) => {
+    const filteredQueries = { ...queries };
+
+    (Object.keys(filteredQueries) as Array<keyof typeof filteredQueries>).forEach((key) => {
+        if (!filteredQueries[key]) {
             delete filteredQueries[key];
         }
     });

--- a/project-base/storefront/hooks/seoCategories/useHandleDefaultFiltersUpdate.ts
+++ b/project-base/storefront/hooks/seoCategories/useHandleDefaultFiltersUpdate.ts
@@ -1,0 +1,19 @@
+import { ListedProductConnectionPreviewFragmentApi } from 'graphql/generated';
+import { getDefaultFilterFromFilterOptions } from 'helpers/filterOptions/seoCategories';
+import { useEffect } from 'react';
+import { useSessionStore } from 'store/useSessionStore';
+
+export const useHandleDefaultFiltersUpdate = (
+    productsPreview: ListedProductConnectionPreviewFragmentApi | undefined,
+) => {
+    const setDefaultProductFiltersMap = useSessionStore((s) => s.setDefaultProductFiltersMap);
+
+    useEffect(() => {
+        setDefaultProductFiltersMap(
+            getDefaultFilterFromFilterOptions(
+                productsPreview?.productFilterOptions,
+                productsPreview?.defaultOrderingMode,
+            ),
+        );
+    }, [productsPreview?.productFilterOptions, productsPreview?.defaultOrderingMode]);
+};

--- a/project-base/storefront/hooks/useQueryParams.ts
+++ b/project-base/storefront/hooks/useQueryParams.ts
@@ -1,8 +1,8 @@
+import { DEFAULT_SORT, SEO_SENSITIVE_FILTERS } from 'config/constants';
 import { ProductOrderingModeEnumApi } from 'graphql/generated';
 import { buildNewQueryAfterFilterChange } from 'helpers/filterOptions/buildNewQueryAfterFilterChange';
 import { getFilterWithoutEmpty } from 'helpers/filterOptions/getFilterWithoutEmpty';
 import {
-    DEFAULT_SORT,
     getChangedDefaultFilters,
     getChangedDefaultFiltersAfterAvailabilityChange,
     getChangedDefaultFiltersAfterBrandChange,
@@ -12,7 +12,6 @@ import {
     getChangedDefaultFiltersAfterParameterChange,
     getChangedDefaultFiltersAfterPriceChange,
     getChangedDefaultFiltersAfterSliderParameterChange,
-    SEO_SENSITIVE_FILTERS,
 } from 'helpers/filterOptions/seoCategories';
 import {
     getQueryWithoutSlugTypeParameterFromParsedUrlQuery,

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -13,7 +13,6 @@ import {
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
 import { getMappedProductFilter } from 'helpers/filterOptions/getMappedProductFilter';
-import { useHandleDefaultFiltersUpdate } from 'helpers/filterOptions/seoCategories';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { getRedirectWithOffsetPage } from 'helpers/loadMore';
 import {
@@ -30,6 +29,7 @@ import {
 import { getServerSidePropsWrapper } from 'helpers/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps } from 'helpers/serverSide/initServerSideProps';
 import { useSeoTitleWithPagination } from 'hooks/seo/useSeoTitleWithPagination';
+import { useHandleDefaultFiltersUpdate } from 'hooks/seoCategories/useHandleDefaultFiltersUpdate';
 import { useQueryParams } from 'hooks/useQueryParams';
 import { NextPage } from 'next';
 import { useSessionStore } from 'store/useSessionStore';

--- a/project-base/storefront/vitest/helpers/filterOptions/buildNewQueryAfterFilterChange.test.ts
+++ b/project-base/storefront/vitest/helpers/filterOptions/buildNewQueryAfterFilterChange.test.ts
@@ -1,0 +1,73 @@
+import { DEFAULT_SORT } from 'config/constants';
+import { ProductOrderingModeEnumApi } from 'graphql/generated';
+import { buildNewQueryAfterFilterChange } from 'helpers/filterOptions/buildNewQueryAfterFilterChange';
+import { describe, expect, test } from 'vitest';
+
+describe('buildNewQueryAfterFilterChange tests', () => {
+    test('building new query after filter change should set page and loadmore to undefined', () => {
+        const newQuery = buildNewQueryAfterFilterChange(
+            { filter: 'foobar', lm: '2', page: '3' },
+            { brands: ['foo'], flags: ['bar'] },
+            ProductOrderingModeEnumApi.NameAscApi,
+        );
+
+        expect(newQuery).toStrictEqual({
+            filter: '{"brands":["foo"],"flags":["bar"]}',
+            lm: undefined,
+            page: undefined,
+            sort: 'NAME_ASC',
+        });
+    });
+
+    test('building new query after filter change with empty filter should set the filter to undefined', () => {
+        const newQuery = buildNewQueryAfterFilterChange(
+            { filter: 'foobar', lm: '2', page: '3' },
+            {
+                onlyInStock: false,
+                minimalPrice: undefined,
+                maximalPrice: undefined,
+                brands: [],
+                flags: [],
+                parameters: [],
+            },
+            ProductOrderingModeEnumApi.NameAscApi,
+        );
+
+        expect(newQuery).toStrictEqual({
+            filter: undefined,
+            lm: undefined,
+            page: undefined,
+            sort: 'NAME_ASC',
+        });
+    });
+
+    test('building new query with undefined new sort should keep the old sort', () => {
+        const newQuery = buildNewQueryAfterFilterChange(
+            { filter: 'foobar', lm: '2', page: '3', sort: ProductOrderingModeEnumApi.PriceAscApi },
+            { brands: ['foo'], flags: ['bar'] },
+            undefined,
+        );
+
+        expect(newQuery).toStrictEqual({
+            filter: '{"brands":["foo"],"flags":["bar"]}',
+            lm: undefined,
+            page: undefined,
+            sort: 'PRICE_ASC',
+        });
+    });
+
+    test('building new query with new sort equal to the default sort should keep the old sort', () => {
+        const newQuery = buildNewQueryAfterFilterChange(
+            { filter: 'foobar', lm: '2', page: '3', sort: ProductOrderingModeEnumApi.PriceAscApi },
+            { brands: ['foo'], flags: ['bar'] },
+            DEFAULT_SORT,
+        );
+
+        expect(newQuery).toStrictEqual({
+            filter: '{"brands":["foo"],"flags":["bar"]}',
+            lm: undefined,
+            page: undefined,
+            sort: 'PRICE_ASC',
+        });
+    });
+});

--- a/project-base/storefront/vitest/helpers/filterOptions/getFilterWithoutEmpty.test.ts
+++ b/project-base/storefront/vitest/helpers/filterOptions/getFilterWithoutEmpty.test.ts
@@ -1,0 +1,51 @@
+import { getFilterWithoutEmpty } from 'helpers/filterOptions/getFilterWithoutEmpty';
+import { describe, expect, test } from 'vitest';
+
+describe('getFilterWithoutEmpty tests', () => {
+    test('undefined or null filter should return undefined', () => {
+        const undefinedFilter = getFilterWithoutEmpty(undefined);
+        const nullFilter = getFilterWithoutEmpty(null);
+
+        expect(undefinedFilter).toBe(undefined);
+        expect(nullFilter).toBe(undefined);
+    });
+
+    test('empty brands should be filtered out from the filter', () => {
+        const filterWithoutBrands = getFilterWithoutEmpty({
+            brands: [],
+            flags: ['foobar'],
+            parameters: [{ parameter: 'barfoo', values: ['FOO'] }],
+        });
+
+        expect(filterWithoutBrands).toStrictEqual({
+            flags: ['foobar'],
+            parameters: [{ parameter: 'barfoo', values: ['FOO'] }],
+        });
+    });
+
+    test('empty flags should be filtered out from the filter', () => {
+        const filterWithoutFlags = getFilterWithoutEmpty({
+            brands: ['foobar'],
+            flags: [],
+            parameters: [{ parameter: 'barfoo', values: ['FOO'] }],
+        });
+
+        expect(filterWithoutFlags).toStrictEqual({
+            brands: ['foobar'],
+            parameters: [{ parameter: 'barfoo', values: ['FOO'] }],
+        });
+    });
+
+    test('empty parameters should be filtered out from the filter', () => {
+        const filterWithoutParameters = getFilterWithoutEmpty({
+            brands: ['barfoo'],
+            flags: ['foobar'],
+            parameters: [],
+        });
+
+        expect(filterWithoutParameters).toStrictEqual({
+            brands: ['barfoo'],
+            flags: ['foobar'],
+        });
+    });
+});

--- a/project-base/storefront/vitest/helpers/filterOptions/seoCategories.getFilterWithoutSeoSensitiveFilters.test.ts
+++ b/project-base/storefront/vitest/helpers/filterOptions/seoCategories.getFilterWithoutSeoSensitiveFilters.test.ts
@@ -1,0 +1,174 @@
+import { ProductOrderingModeEnumApi } from 'graphql/generated';
+import { getFilterWithoutSeoSensitiveFilters } from 'helpers/filterOptions/seoCategories';
+import { FilterOptionsUrlQueryType } from 'types/productFilter';
+import { describe, expect, test, vi } from 'vitest';
+
+const DEFAULT_SEO_SENSITIVE_CONFIG = {
+    SORT: false,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: false,
+    PARAMETERS: {
+        CHECKBOX: false,
+        SLIDER: false,
+    },
+};
+
+const mockSeoSensitiveFiltersGetter = vi.fn(() => DEFAULT_SEO_SENSITIVE_CONFIG);
+
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
+
+    return {
+        ...actualConstantsModule,
+        get SEO_SENSITIVE_FILTERS() {
+            return mockSeoSensitiveFiltersGetter();
+        },
+    };
+});
+
+const getFilterTestValue = (override = {} as FilterOptionsUrlQueryType): FilterOptionsUrlQueryType => ({
+    brands: override.brands || ['foo', 'bar'],
+    flags: override.flags || ['bar', 'foo'],
+    minimalPrice: override.minimalPrice !== undefined ? override.minimalPrice : 100,
+    maximalPrice: override.maximalPrice !== undefined ? override.maximalPrice : 1000,
+    onlyInStock: override.onlyInStock !== undefined ? override.onlyInStock : true,
+    parameters: override.parameters || [
+        { parameter: 'foo', values: ['foov1', 'foov2'] },
+        { parameter: 'bar', values: ['barv1', 'barv2'] },
+        { parameter: 'foobar', minimalValue: 100, maximalValue: 1000 },
+        { parameter: 'barfoo', minimalValue: 200, maximalValue: 2000 },
+    ],
+});
+
+const removeKeysFromFilterTestValue = (
+    testValue: FilterOptionsUrlQueryType,
+    keysToRemove: (keyof FilterOptionsUrlQueryType)[],
+) => {
+    const updatedTestValue = { ...testValue };
+
+    for (const key of keysToRemove) {
+        delete updatedTestValue[key];
+    }
+
+    return updatedTestValue;
+};
+
+describe('seoCategories.getFilterWithoutSeoSensitiveFilters tests', () => {
+    test('should return empty filter if the current filter is undefined or null', () => {
+        const { filteredFilter: undefinedFilter } = getFilterWithoutSeoSensitiveFilters(undefined, null);
+        const { filteredFilter: nullFilter } = getFilterWithoutSeoSensitiveFilters(null, null);
+
+        expect(undefinedFilter).toBe(undefined);
+        expect(nullFilter).toBe(undefined);
+    });
+
+    test('should set sort to undefined if sort is SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ ...DEFAULT_SEO_SENSITIVE_CONFIG, SORT: true }));
+
+        expect(getFilterWithoutSeoSensitiveFilters({}, ProductOrderingModeEnumApi.PriceAscApi).filteredSort).toBe(
+            undefined,
+        );
+    });
+
+    test('should set sort to undefined if current sort is null', () => {
+        expect(getFilterWithoutSeoSensitiveFilters({}, null).filteredSort).toBe(undefined);
+    });
+
+    test('should keep sort if sort is not SEO sensitive and is defined', () => {
+        expect(getFilterWithoutSeoSensitiveFilters({}, ProductOrderingModeEnumApi.PriceAscApi).filteredSort).toBe(
+            ProductOrderingModeEnumApi.PriceAscApi,
+        );
+    });
+
+    test('should keep filters if they are not SEO sensitive', () => {
+        const testValue = getFilterTestValue();
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(testValue);
+    });
+
+    test('should remove availability if it is SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({
+            ...DEFAULT_SEO_SENSITIVE_CONFIG,
+            AVAILABILITY: true,
+        }));
+        const testValue = getFilterTestValue();
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            removeKeysFromFilterTestValue(testValue, ['onlyInStock']),
+        );
+    });
+
+    test('should remove brands if they are SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ ...DEFAULT_SEO_SENSITIVE_CONFIG, BRANDS: true }));
+        const testValue = getFilterTestValue();
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            removeKeysFromFilterTestValue(testValue, ['brands']),
+        );
+    });
+
+    test('should remove flags if they are SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ ...DEFAULT_SEO_SENSITIVE_CONFIG, FLAGS: true }));
+        const testValue = getFilterTestValue();
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            removeKeysFromFilterTestValue(testValue, ['flags']),
+        );
+    });
+
+    test('should remove checkbox parameters if they are SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({
+            ...DEFAULT_SEO_SENSITIVE_CONFIG,
+            PARAMETERS: { CHECKBOX: true, SLIDER: false },
+        }));
+        const testValue = getFilterTestValue();
+        const testValueWithoutCheckboxParams = {
+            ...testValue,
+            parameters: testValue.parameters?.filter(
+                (param) => typeof param.minimalValue === 'number' || typeof param.maximalValue === 'number',
+            ),
+        };
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            testValueWithoutCheckboxParams,
+        );
+    });
+
+    test('should remove slider parameters if they are SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({
+            ...DEFAULT_SEO_SENSITIVE_CONFIG,
+            PARAMETERS: { CHECKBOX: false, SLIDER: true },
+        }));
+        const testValue = getFilterTestValue();
+        const testValueWithoutCheckboxParams = {
+            ...testValue,
+            parameters: testValue.parameters?.filter((param) => param.values),
+        };
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            testValueWithoutCheckboxParams,
+        );
+    });
+
+    test('should remove parameters if after removal there are none left', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({
+            ...DEFAULT_SEO_SENSITIVE_CONFIG,
+            PARAMETERS: { CHECKBOX: true, SLIDER: true },
+        }));
+        const testValue = getFilterTestValue();
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            removeKeysFromFilterTestValue(testValue, ['parameters']),
+        );
+    });
+
+    test('should remove prices if they are SEO sensitive', () => {
+        mockSeoSensitiveFiltersGetter.mockImplementation(() => ({ ...DEFAULT_SEO_SENSITIVE_CONFIG, PRICE: true }));
+        const testValue = getFilterTestValue();
+
+        expect(getFilterWithoutSeoSensitiveFilters(testValue, null).filteredFilter).toStrictEqual(
+            removeKeysFromFilterTestValue(testValue, ['minimalPrice', 'maximalPrice']),
+        );
+    });
+});

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.resetAllFilters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.resetAllFilters.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -33,11 +22,21 @@ const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
 const mockDefaultSort = vi.fn(() => ProductOrderingModeEnumApi.PriorityApi);
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
+        ...actualConstantsModule,
         get DEFAULT_SORT() {
             return mockDefaultSort();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterBrands.test.ts
@@ -55,12 +55,11 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
     },
 }));
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
-
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterFlags.test.ts
@@ -55,12 +55,11 @@ const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
     },
 }));
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
-
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterInStock.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -32,11 +21,22 @@ const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
 const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterParameters.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -32,11 +21,22 @@ const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
 const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brand-1', 'default-brand-2']);
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMaximum.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -32,12 +21,22 @@ const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
 const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
-
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPriceMinimum.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -32,11 +21,22 @@ const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
 const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateFilterPrices.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -32,11 +21,22 @@ const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
 const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
+        ...actualConstantsModule,
         get SEO_SENSITIVE_FILTERS() {
             return mockSeoSensitiveFiltersGetter();
         },

--- a/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
+++ b/project-base/storefront/vitest/hooks/useQueryParams/useQueryParams.updateSort.test.ts
@@ -10,17 +10,6 @@ import { useRouter } from 'next/router';
 import { useSessionStore } from 'store/useSessionStore';
 import { describe, expect, Mock, test, vi } from 'vitest';
 
-const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
-    SORT: true,
-    AVAILABILITY: false,
-    PRICE: false,
-    FLAGS: true,
-    PARAMETERS: {
-        CHECKBOX: true,
-        SLIDER: false,
-    },
-}));
-
 const CATEGORY_URL = '/category-url';
 const CATEGORY_PATHNAME = '/categories/[categorySlug]';
 const ORIGINAL_CATEGORY_URL = '/original-category-slug';
@@ -32,12 +21,23 @@ const GET_DEFAULT_SEO_CATEGORY_PARAMETERS = () =>
 const GET_DEFAULT_SEO_CATEGORY_FLAGS = () => new Set(['default-flag-1', 'default-flag-2']);
 const GET_DEFAULT_SEO_CATEGORY_BRANDS = () => new Set(['default-brands-1', 'default-brands-2']);
 
+const mockSeoSensitiveFiltersGetter = vi.fn(() => ({
+    SORT: true,
+    AVAILABILITY: false,
+    PRICE: false,
+    FLAGS: true,
+    PARAMETERS: {
+        CHECKBOX: true,
+        SLIDER: false,
+    },
+}));
+
 const mockDefaultSort = vi.fn(() => ProductOrderingModeEnumApi.PriorityApi);
-vi.mock('helpers/filterOptions/seoCategories', async (importOriginal) => {
-    const actualSeoCategoriesModule = await importOriginal<any>();
+vi.mock('config/constants', async (importOriginal) => {
+    const actualConstantsModule = await importOriginal<any>();
 
     return {
-        ...actualSeoCategoriesModule,
+        ...actualConstantsModule,
         get DEFAULT_SORT() {
             return mockDefaultSort();
         },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After adding the option for SEO categories to ignore certain filters, we had to implement this on SF as well.
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-seo-categories-with-ignored-filters.odin.shopsys.cloud
  - https://cz.sh-seo-categories-with-ignored-filters.odin.shopsys.cloud
<!-- Replace -->
