### PR TITLE
[FW-1678] search on search page is now not called if search query is empty

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -195,4 +195,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   fix Comparison for not logged in users ([#2905](https://github.com/shopsys/shopsys/pull/2905))
     -   unified code for Comparison and Wishlist
     -   refactored Zustand store to use only one store (User Store) for all cartUuid, wishlistUuid and comparisonUuid
+-   search on search page is now not called if search query is empty ([#2895](https://github.com/shopsys/shopsys/pull/2895))
     -   see #project-base-diff to update your project

--- a/project-base/storefront/components/Pages/Search/SearchContent.tsx
+++ b/project-base/storefront/components/Pages/Search/SearchContent.tsx
@@ -2,7 +2,6 @@ import { ProductsSearch } from './ProductsSearch';
 import { Heading } from 'components/Basic/Heading/Heading';
 import { SimpleNavigation } from 'components/Blocks/SimpleNavigation/SimpleNavigation';
 import { SkeletonPageProductsList } from 'components/Blocks/Skeleton/SkeletonPageProductsList';
-import { Webline } from 'components/Layout/Webline/Webline';
 import { SearchQueryApi, SimpleCategoryFragmentApi } from 'graphql/generated';
 import { mapConnectionEdges } from 'helpers/mappers/connection';
 import { getStringFromUrlQuery } from 'helpers/parsing/urlParsing';
@@ -30,7 +29,7 @@ export const SearchContent: FC<SearchContentProps> = ({ searchResults, fetching 
     const isFetchingInitialData = !searchResults && fetching;
 
     return (
-        <Webline>
+        <>
             <Heading type="h1">{`${t('Search results for')} "${getStringFromUrlQuery(router.query.q)}"`}</Heading>
             {isFetchingInitialData ? (
                 <SkeletonPageProductsList />
@@ -69,6 +68,6 @@ export const SearchContent: FC<SearchContentProps> = ({ searchResults, fetching 
                     </>
                 )
             )}
-        </Webline>
+        </>
     );
 };

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -360,6 +360,7 @@
     "The transport you selected is no longer available.": "Doprava, kterou jste si zvolili, již není dostupná.",
     "There are no products in the shared wishlist.": "Sdílený seznam oblíbených produktů je prázdný.",
     "There are no products in the wishlist. Add some first.": "Seznam oblíbených produktů je prázdný. Nejprve přidejte nějaké produkty do oblíbených.",
+    "There are no results as you have searched with an empty query...": "Vaše vyhledávání nevrátilo žádné výsledky, protože jste nezadali žádný dotaz...",
     "There was an error while adding a promo code to the order.": "Během přidávání slevového kupónu do objednávky se vyskytla chyba.",
     "There was an error while changing your password": "Při změně Vašeho hesla došlo k chybě",
     "There was an error while deleting your delivery address": "Při mazání dodací adresy došlo k chybě",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -346,6 +346,7 @@
     "The transport you selected is no longer available.": "The transport you selected is no longer available.",
     "There are no products in the shared wishlist.": "There are no products in the shared wishlist.",
     "There are no products in the wishlist. Add some first.": "There are no products in the wishlist. Add some first.",
+    "There are no results as you have searched with an empty query...": "There are no results as you have searched with an empty query...",
     "There was an error while adding a promo code to the order.": "There was an error while adding a promo code to the order.",
     "There was an error while changing your password": "There was an error while changing your password",
     "There was an error while deleting your delivery address": "There was an error while deleting your delivery address",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -360,6 +360,7 @@
     "The transport you selected is no longer available.": "The transport you selected is no longer available.",
     "There are no products in the shared wishlist.": "Zdieľaný zoznam obľúbených produktov je prázdny.",
     "There are no products in the wishlist. Add some first.": "Zoznam obľúbených produktov je prázdny. Najskôr pridajte niektoré produkty do svojich obľúbených.",
+    "There are no results as you have searched with an empty query...": "Vaše vyhľadávanie neprinieslo žiadne výsledky, pretože ste nezadali žiadny dotaz...",
     "There was an error while adding a promo code to the order.": "Behom pridávania zľavového kupónu do objednávky sa vyskytla chyba.",
     "There was an error while changing your password": "Pri zmene Vášho hesla došlo k chybe ",
     "There was an error while deleting your delivery address": "Pri mazaní dodacej adresy došlo k chybe",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Search on search page is now not called if search query is empty, which is required because the API treats empty string as null and thus throws an error.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-empty-search-query-bug.odin.shopsys.cloud
  - https://cz.sh-empty-search-query-bug.odin.shopsys.cloud
<!-- Replace -->
