### PR TITLE
fix sizes of product actions buttons

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -189,3 +189,6 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   added USPs on product detail page ([#2887](https://github.com/shopsys/shopsys/pull/2887))
     -   see #project-base-diff to update your project
+-   fix sizes of product actions buttons ([#2896](https://github.com/shopsys/shopsys/pull/2896))
+    -   now we have unified sizes of add to cart buttons
+    -   see #project-base-diff to update your project

--- a/project-base/storefront/components/Blocks/Product/AddToCart.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCart.tsx
@@ -68,7 +68,7 @@ export const AddToCart: FC<AddToCartProps> = ({
                 size="small"
                 onClick={onAddToCartHandler}
             >
-                {fetching ? <Loader className="w-4 text-white" /> : <CartIcon className="text-white" />}
+                {fetching ? <Loader className="w-4 text-white" /> : <CartIcon className="w-4 text-white" />}
                 <span>{t('Add to cart')}</span>
             </Button>
 

--- a/project-base/storefront/components/Blocks/Product/ProductAction.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductAction.tsx
@@ -25,9 +25,10 @@ export const ProductAction: FC<ProductActionProps> = ({ product, gtmProductListN
         return (
             <div className={wrapperTwClass}>
                 <Button
-                    className="!w-full"
+                    className="!w-full py-2"
                     dataTestId={TEST_IDENTIFIER + '-choose-variant'}
                     name="choose-variant"
+                    size="small"
                     onClick={() =>
                         router.push(
                             {

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
@@ -52,7 +52,7 @@ export const ProductVariantsTable: FC<ProductVariantsTableProps> = ({ isSellingD
 
                         <div className="lg:w-40 lg:text-right">{formatPrice(variant.price.priceWithVat)}</div>
 
-                        <div className="text-right max-lg:clear-both max-lg:pl-0 lg:w-60">
+                        <div className="text-right max-lg:clear-both">
                             {isSellingDenied ? (
                                 t('This item can no longer be purchased')
                             ) : (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| fix sizes of product actions buttons, which were having different height according to if some action was happening
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-1672-fix-sizes-of-add-to-cart-button.odin.shopsys.cloud
  - https://cz.tv-1672-fix-sizes-of-add-to-cart-button.odin.shopsys.cloud
<!-- Replace -->
