### PR TITLE
[shopsys] increase speed of Product creation

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -84,6 +84,24 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
     -   reformat your markdown files by running `php phing standards-fix` in php-fpm container
     -   `standards(-fix)` targets runs newly added `markdown-check/markdown-fix` target, so if you have completely changed the `standards(-fix)` target, remember to add those into your `standards(-fix)` target
+-   speed up Product creation in your project ([#2903](https://github.com/shopsys/shopsys/pull/2903))
+    -   method `Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade::resolveUniquenessOfFriendlyUrlAndFlush()` has been renamed to `resolveUniquenessOfFriendlyUrl` as it no longer flushes
+    -   method `Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade::refresh()` has changed its visibility to `protected`
+    -   method `Shopsys\FrameworkBundle\Model\Product\ProductFacade::refreshProductManualInputPrices()` has been moved to `Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade::refreshProductManualInputPrices()` and changed its visibility to `public`
+    -   method `Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade::__construct()` changed its interface:
+    ```diff
+        public function __construct(
+            protected readonly EntityManagerInterface $em,
+            protected readonly ProductManualInputPriceRepository $productManualInputPriceRepository,
+            protected readonly ProductManualInputPriceFactoryInterface $productManualInputPriceFactory,
+    +       protected readonly PricingGroupRepository $pricingGroupRepository,
+        )
+    ```
+    -   method `Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainFacade::saveGoogleProductDomain()` changed its visibility to `protected`
+    -   method `Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainFacade::saveHeurekaProductDomain()` changed its visibility to `protected`
+    -   method `Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainFacade::saveHeurekaProductDomain()` changed its visibility to `protected`
+    -   method `Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainFacade::saveZboziProductDomain()` changed its visibility to `protected`
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -327,6 +327,19 @@
         </exec>
     </target>
 
+    <target name="db-fixtures-performance" depends="production-protection" description="Loads performance data fixtures into main DB." hidden="true">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:performance-data"/>
+            <arg value="--verbose"/>
+        </exec>
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:recalculations"/>
+            <arg value="--verbose"/>
+        </exec>
+    </target>
+
     <target name="db-import-basic-structure" description="Imports basic database structure (without migrations)." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -376,6 +389,8 @@
             <arg value="--verbose"/>
         </exec>
     </target>
+
+    <target name="db-performance" depends="production-protection,db-wipe-public-schema,clean,clean-redis,db-import-basic-structure,db-migrations,domains-data-create,db-fixtures-demo,plugin-demo-data-load,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,db-fixtures-performance" description="Drops all data in main database and creates a new one with performance data."/>
 
     <target name="db-rebuild" depends="production-protection,db-wipe-public-schema,db-import-basic-structure,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace" description="Drops all data in database and creates a new one with base data only."/>
 

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -49,8 +49,10 @@ class FriendlyUrlFacade
 
         foreach ($friendlyUrls as $friendlyUrl) {
             $locale = $this->domain->getDomainConfigById($friendlyUrl->getDomainId())->getLocale();
-            $this->resolveUniquenessOfFriendlyUrlAndFlush($friendlyUrl, $namesByLocale[$locale]);
+            $this->resolveUniquenessOfFriendlyUrl($friendlyUrl, $namesByLocale[$locale]);
         }
+
+        $this->em->flush();
     }
 
     /**
@@ -64,15 +66,17 @@ class FriendlyUrlFacade
         $friendlyUrl = $this->friendlyUrlFactory->createIfValid($routeName, $entityId, (string)$entityName, $domainId);
 
         if ($friendlyUrl !== null) {
-            $this->resolveUniquenessOfFriendlyUrlAndFlush($friendlyUrl, $entityName);
+            $this->resolveUniquenessOfFriendlyUrl($friendlyUrl, $entityName);
         }
+
+        $this->em->flush();
     }
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl $friendlyUrl
      * @param string $entityName
      */
-    protected function resolveUniquenessOfFriendlyUrlAndFlush(FriendlyUrl $friendlyUrl, $entityName)
+    protected function resolveUniquenessOfFriendlyUrl(FriendlyUrl $friendlyUrl, $entityName)
     {
         $attempt = 0;
 
@@ -108,7 +112,6 @@ class FriendlyUrlFacade
         }
 
         $this->em->persist($friendlyUrl);
-        $this->em->flush();
         $this->setFriendlyUrlAsMain($friendlyUrl);
     }
 
@@ -214,8 +217,6 @@ class FriendlyUrlFacade
         }
         $mainFriendlyUrl->setMain(true);
         $this->renewMainFriendlyUrlSlugCache($mainFriendlyUrl);
-
-        $this->em->flush();
     }
 
     /**

--- a/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFacade.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFacade.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Pricing;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
+use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupRepository;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductManualInputPriceFacade
@@ -15,11 +16,13 @@ class ProductManualInputPriceFacade
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceRepository $productManualInputPriceRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFactoryInterface $productManualInputPriceFactory
+     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupRepository $pricingGroupRepository
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly ProductManualInputPriceRepository $productManualInputPriceRepository,
         protected readonly ProductManualInputPriceFactoryInterface $productManualInputPriceFactory,
+        protected readonly PricingGroupRepository $pricingGroupRepository,
     ) {
     }
 
@@ -28,7 +31,7 @@ class ProductManualInputPriceFacade
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @param \Shopsys\FrameworkBundle\Component\Money\Money|null $inputPrice
      */
-    public function refresh(Product $product, PricingGroup $pricingGroup, ?Money $inputPrice)
+    protected function refresh(Product $product, PricingGroup $pricingGroup, ?Money $inputPrice): void
     {
         $manualInputPrice = $this->productManualInputPriceRepository->findByProductAndPricingGroup(
             $product,
@@ -41,6 +44,22 @@ class ProductManualInputPriceFacade
             $manualInputPrice->setInputPrice($inputPrice);
         }
         $this->em->persist($manualInputPrice);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param \Shopsys\FrameworkBundle\Component\Money\Money[]|null[] $manualInputPrices
+     */
+    public function refreshProductManualInputPrices(Product $product, array $manualInputPrices): void
+    {
+        foreach ($this->pricingGroupRepository->getAll() as $pricingGroup) {
+            $this->refresh(
+                $product,
+                $pricingGroup,
+                $manualInputPrices[$pricingGroup->getId()],
+            );
+        }
+
         $this->em->flush();
     }
 }

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -136,7 +136,7 @@ class ProductFacade
 
         $this->saveParameters($product, $productData->parameters);
         $this->createProductVisibilities($product);
-        $this->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
+        $this->productManualInputPriceFacade->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
         $this->refreshProductAccessories($product, $productData->accessories);
         $this->productHiddenRecalculator->calculateHiddenForProduct($product);
         $this->productSellingDeniedRecalculator->calculateSellingDeniedForProduct($product);
@@ -169,7 +169,7 @@ class ProductFacade
         $this->saveParameters($product, $productData->parameters);
 
         if (!$product->isMainVariant()) {
-            $this->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
+            $this->productManualInputPriceFacade->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
         } else {
             $product->refreshVariants($productData->variants);
         }
@@ -292,21 +292,6 @@ class ProductFacade
         }
 
         return $productSellingPrices;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
-     * @param \Shopsys\FrameworkBundle\Component\Money\Money[]|null[] $manualInputPrices
-     */
-    protected function refreshProductManualInputPrices(Product $product, array $manualInputPrices)
-    {
-        foreach ($this->pricingGroupRepository->getAll() as $pricingGroup) {
-            $this->productManualInputPriceFacade->refresh(
-                $product,
-                $pricingGroup,
-                $manualInputPrices[$pricingGroup->getId()],
-            );
-        }
     }
 
     /**

--- a/packages/product-feed-google/src/Model/Product/GoogleProductDomainFacade.php
+++ b/packages/product-feed-google/src/Model/Product/GoogleProductDomainFacade.php
@@ -43,6 +43,8 @@ class GoogleProductDomainFacade
         foreach ($googleProductDomainsData as $googleProductDomainData) {
             $this->saveGoogleProductDomain($productId, $googleProductDomainData);
         }
+
+        $this->em->flush();
     }
 
     /**
@@ -72,7 +74,7 @@ class GoogleProductDomainFacade
      * @param int $productId
      * @param \Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomainData $googleProductDomainData
      */
-    public function saveGoogleProductDomain($productId, GoogleProductDomainData $googleProductDomainData)
+    protected function saveGoogleProductDomain($productId, GoogleProductDomainData $googleProductDomainData)
     {
         $product = $this->productRepository->getById($productId);
         $googleProductDomainData->product = $product;
@@ -88,8 +90,6 @@ class GoogleProductDomainFacade
             $newGoogleProductDomain = new GoogleProductDomain($googleProductDomainData);
             $this->em->persist($newGoogleProductDomain);
         }
-
-        $this->em->flush();
     }
 
     /**

--- a/packages/product-feed-heureka/src/DataFixtures/HeurekaProductDataFixture.php
+++ b/packages/product-feed-heureka/src/DataFixtures/HeurekaProductDataFixture.php
@@ -31,94 +31,69 @@ class HeurekaProductDataFixture implements PluginDataFixtureInterface
 
     public function load()
     {
+        $firstProductHeurekaDomainData = [];
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(12);
-
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_FIRST,
-            $heurekaProductDomainData,
-        );
+        $firstProductHeurekaDomainData[] = $heurekaProductDomainData;
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(5);
+        $firstProductHeurekaDomainData[] = $heurekaProductDomainData;
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_FIRST,
-            $heurekaProductDomainData,
-        );
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomainsForProductId(static::PRODUCT_ID_FIRST, $firstProductHeurekaDomainData);
 
+        $secondProductHeurekaDomainData = [];
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(3);
-
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_SECOND,
-            $heurekaProductDomainData,
-        );
+        $secondProductHeurekaDomainData[] = $heurekaProductDomainData;
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(2);
+        $secondProductHeurekaDomainData[] = $heurekaProductDomainData;
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_SECOND,
-            $heurekaProductDomainData,
-        );
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomainsForProductId(static::PRODUCT_ID_SECOND, $secondProductHeurekaDomainData);
 
+        $thirdProductHeurekaDomainData = [];
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(1);
-
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_THIRD,
-            $heurekaProductDomainData,
-        );
+        $thirdProductHeurekaDomainData[] = $heurekaProductDomainData;
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(1);
+        $thirdProductHeurekaDomainData[] = $heurekaProductDomainData;
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_THIRD,
-            $heurekaProductDomainData,
-        );
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomainsForProductId(static::PRODUCT_ID_THIRD, $thirdProductHeurekaDomainData);
 
+        $fourthProductHeurekaDomainData = [];
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(5);
-
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_FOURTH,
-            $heurekaProductDomainData,
-        );
+        $fourthProductHeurekaDomainData[] = $heurekaProductDomainData;
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(8);
+        $fourthProductHeurekaDomainData[] = $heurekaProductDomainData;
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_FOURTH,
-            $heurekaProductDomainData,
-        );
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomainsForProductId(static::PRODUCT_ID_FOURTH, $fourthProductHeurekaDomainData);
 
+        $fifthProductHeurekaDomainData = [];
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_FIRST;
         $heurekaProductDomainData->cpc = Money::create(10);
-
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_FIFTH,
-            $heurekaProductDomainData,
-        );
+        $fifthProductHeurekaDomainData[] = $heurekaProductDomainData;
 
         $heurekaProductDomainData = $this->heurekaProductDomainDataFactory->create();
         $heurekaProductDomainData->domainId = static::DOMAIN_ID_SECOND;
         $heurekaProductDomainData->cpc = Money::create(5);
+        $fifthProductHeurekaDomainData[] = $heurekaProductDomainData;
 
-        $this->heurekaProductDomainFacade->saveHeurekaProductDomain(
-            static::PRODUCT_ID_FIFTH,
-            $heurekaProductDomainData,
-        );
+        $this->heurekaProductDomainFacade->saveHeurekaProductDomainsForProductId(static::PRODUCT_ID_FIFTH, $fifthProductHeurekaDomainData);
     }
 }

--- a/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomainFacade.php
+++ b/packages/product-feed-heureka/src/Model/Product/HeurekaProductDomainFacade.php
@@ -78,13 +78,15 @@ class HeurekaProductDomainFacade
         foreach ($heurekaProductDomainsData as $heurekaProductDomainData) {
             $this->saveHeurekaProductDomain($productId, $heurekaProductDomainData);
         }
+
+        $this->em->flush();
     }
 
     /**
      * @param int $productId
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\Product\HeurekaProductDomainData $heurekaProductDomainData
      */
-    public function saveHeurekaProductDomain($productId, HeurekaProductDomainData $heurekaProductDomainData)
+    protected function saveHeurekaProductDomain($productId, HeurekaProductDomainData $heurekaProductDomainData)
     {
         $product = $this->productRepository->getById($productId);
         $heurekaProductDomainData->product = $product;
@@ -100,8 +102,6 @@ class HeurekaProductDomainFacade
             $newHeurekaProductDomain = new HeurekaProductDomain($heurekaProductDomainData);
             $this->em->persist($newHeurekaProductDomain);
         }
-
-        $this->em->flush();
     }
 
     /**

--- a/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php
+++ b/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php
@@ -31,114 +31,89 @@ class ZboziPluginDataFixture implements PluginDataFixtureInterface
 
     public function load()
     {
-        $firstZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $firstZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
-        $firstZboziProductDomainData->cpc = Money::create(15);
-        $firstZboziProductDomainData->cpcSearch = Money::create(8);
-        $firstZboziProductDomainData->show = true;
+        $firstProductZboziDomainData = [];
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
+        $zboziProductDomainData->cpc = Money::create(15);
+        $zboziProductDomainData->cpcSearch = Money::create(8);
+        $zboziProductDomainData->show = true;
+        $firstProductZboziDomainData[] = $zboziProductDomainData;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_FIRST,
-            $firstZboziProductDomainData,
-        );
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
+        $zboziProductDomainData->cpc = Money::create(12);
+        $zboziProductDomainData->cpcSearch = Money::create(15);
+        $zboziProductDomainData->show = true;
+        $firstProductZboziDomainData[] = $zboziProductDomainData;
 
-        $secondZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $secondZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
-        $secondZboziProductDomainData->cpc = Money::create(12);
-        $secondZboziProductDomainData->cpcSearch = Money::create(15);
-        $secondZboziProductDomainData->show = true;
+        $this->zboziProductDomainFacade->saveZboziProductDomainsForProductId(static::PRODUCT_ID_FIRST, $firstProductZboziDomainData);
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_FIRST,
-            $secondZboziProductDomainData,
-        );
+        $secondProductZboziDomainData = [];
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
+        $zboziProductDomainData->cpc = Money::create(5);
+        $zboziProductDomainData->cpcSearch = Money::create(3);
+        $zboziProductDomainData->show = false;
+        $secondProductZboziDomainData[] = $zboziProductDomainData;
 
-        $thirdZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $thirdZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
-        $thirdZboziProductDomainData->cpc = Money::create(5);
-        $thirdZboziProductDomainData->cpcSearch = Money::create(3);
-        $thirdZboziProductDomainData->show = false;
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
+        $zboziProductDomainData->cpc = Money::create(20);
+        $zboziProductDomainData->cpcSearch = Money::create(5);
+        $zboziProductDomainData->show = true;
+        $secondProductZboziDomainData[] = $zboziProductDomainData;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_SECOND,
-            $thirdZboziProductDomainData,
-        );
+        $this->zboziProductDomainFacade->saveZboziProductDomainsForProductId(static::PRODUCT_ID_SECOND, $secondProductZboziDomainData);
 
-        $fourthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $fourthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
-        $fourthZboziProductDomainData->cpc = Money::create(20);
-        $fourthZboziProductDomainData->cpcSearch = Money::create(5);
-        $fourthZboziProductDomainData->show = true;
+        $thirdProductZboziDomainData = [];
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
+        $zboziProductDomainData->cpc = Money::create(10);
+        $zboziProductDomainData->cpcSearch = Money::create(5);
+        $zboziProductDomainData->show = false;
+        $thirdProductZboziDomainData[] = $zboziProductDomainData;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_SECOND,
-            $fourthZboziProductDomainData,
-        );
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
+        $zboziProductDomainData->cpc = Money::create(15);
+        $zboziProductDomainData->cpcSearch = Money::create(7);
+        $zboziProductDomainData->show = false;
+        $thirdProductZboziDomainData[] = $zboziProductDomainData;
 
-        $fifthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $fifthZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
-        $fifthZboziProductDomainData->cpc = Money::create(10);
-        $fifthZboziProductDomainData->cpcSearch = Money::create(5);
-        $fifthZboziProductDomainData->show = false;
+        $this->zboziProductDomainFacade->saveZboziProductDomainsForProductId(static::PRODUCT_ID_THIRD, $thirdProductZboziDomainData);
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_THIRD,
-            $fifthZboziProductDomainData,
-        );
+        $fourthProductZboziDomainData = [];
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
+        $zboziProductDomainData->cpc = Money::create(9);
+        $zboziProductDomainData->cpcSearch = Money::create(8);
+        $zboziProductDomainData->show = true;
+        $fourthProductZboziDomainData[] = $zboziProductDomainData;
 
-        $sixthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $sixthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
-        $sixthZboziProductDomainData->cpc = Money::create(15);
-        $sixthZboziProductDomainData->cpcSearch = Money::create(7);
-        $sixthZboziProductDomainData->show = false;
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
+        $zboziProductDomainData->cpc = Money::create(4);
+        $zboziProductDomainData->cpcSearch = Money::create(3);
+        $zboziProductDomainData->show = true;
+        $fourthProductZboziDomainData[] = $zboziProductDomainData;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_THIRD,
-            $sixthZboziProductDomainData,
-        );
+        $this->zboziProductDomainFacade->saveZboziProductDomainsForProductId(static::PRODUCT_ID_FOURTH, $fourthProductZboziDomainData);
 
-        $seventhZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $seventhZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
-        $seventhZboziProductDomainData->cpc = Money::create(9);
-        $seventhZboziProductDomainData->cpcSearch = Money::create(8);
-        $seventhZboziProductDomainData->show = true;
+        $fifthProductZboziDomainData = [];
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
+        $zboziProductDomainData->cpc = Money::create(4);
+        $zboziProductDomainData->cpcSearch = Money::create(2);
+        $zboziProductDomainData->show = true;
+        $fifthProductZboziDomainData[] = $zboziProductDomainData;
 
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_FOURTH,
-            $seventhZboziProductDomainData,
-        );
+        $zboziProductDomainData = $this->zboziProductDomainDataFactory->create();
+        $zboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
+        $zboziProductDomainData->cpc = Money::create(5);
+        $zboziProductDomainData->cpcSearch = Money::create(6);
+        $zboziProductDomainData->show = false;
+        $fifthProductZboziDomainData[] = $zboziProductDomainData;
 
-        $eighthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $eighthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
-        $eighthZboziProductDomainData->cpc = Money::create(4);
-        $eighthZboziProductDomainData->cpcSearch = Money::create(3);
-        $eighthZboziProductDomainData->show = true;
-
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_FOURTH,
-            $eighthZboziProductDomainData,
-        );
-
-        $ninthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $ninthZboziProductDomainData->domainId = static::DOMAIN_ID_FIRST;
-        $ninthZboziProductDomainData->cpc = Money::create(4);
-        $ninthZboziProductDomainData->cpcSearch = Money::create(2);
-        $ninthZboziProductDomainData->show = true;
-
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_FIFTH,
-            $ninthZboziProductDomainData,
-        );
-
-        $tenthZboziProductDomainData = $this->zboziProductDomainDataFactory->create();
-        $tenthZboziProductDomainData->domainId = static::DOMAIN_ID_SECOND;
-        $tenthZboziProductDomainData->cpc = Money::create(5);
-        $tenthZboziProductDomainData->cpcSearch = Money::create(6);
-        $tenthZboziProductDomainData->show = false;
-
-        $this->zboziProductDomainFacade->saveZboziProductDomain(
-            static::PRODUCT_ID_FIFTH,
-            $tenthZboziProductDomainData,
-        );
+        $this->zboziProductDomainFacade->saveZboziProductDomainsForProductId(static::PRODUCT_ID_FIFTH, $fifthProductZboziDomainData);
     }
 }

--- a/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomainFacade.php
+++ b/packages/product-feed-zbozi/src/Model/Product/ZboziProductDomainFacade.php
@@ -63,6 +63,8 @@ class ZboziProductDomainFacade
         foreach ($zboziProductDomainsData as $zboziProductDomainData) {
             $this->saveZboziProductDomain($productId, $zboziProductDomainData);
         }
+
+        $this->em->flush();
     }
 
     /**
@@ -90,7 +92,7 @@ class ZboziProductDomainFacade
      * @param int $productId
      * @param \Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomainData $zboziProductDomainData
      */
-    public function saveZboziProductDomain($productId, ZboziProductDomainData $zboziProductDomainData)
+    protected function saveZboziProductDomain($productId, ZboziProductDomainData $zboziProductDomainData)
     {
         $product = $this->productRepository->getById($productId);
         $zboziProductDomainData->product = $product;
@@ -106,8 +108,6 @@ class ZboziProductDomainFacade
             $newZboziProductDomain = new ZboziProductDomain($zboziProductDomainData);
             $this->em->persist($newZboziProductDomain);
         }
-
-        $this->em->flush();
     }
 
     /**

--- a/project-base/app/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
+++ b/project-base/app/src/Component/Router/FriendlyUrl/FriendlyUrlFacade.php
@@ -16,7 +16,7 @@ use Shopsys\FrameworkBundle\Form\Admin\QuickSearch\QuickSearchFormData;
  * @property \App\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository
  * @property \App\Component\Router\FriendlyUrl\FriendlyUrlFactory $friendlyUrlFactory
  * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory, \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlUniqueResultFactory $friendlyUrlUniqueResultFactory, \App\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Component\Router\FriendlyUrl\FriendlyUrlFactory $friendlyUrlFactory, \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlCacheKeyProvider $friendlyUrlCacheKeyProvider, \Symfony\Contracts\Cache\CacheInterface $mainFriendlyUrlSlugCache)
- * @method resolveUniquenessOfFriendlyUrlAndFlush(\App\Component\Router\FriendlyUrl\FriendlyUrl $friendlyUrl, string $entityName)
+ * @method resolveUniquenessOfFriendlyUrl(\App\Component\Router\FriendlyUrl\FriendlyUrl $friendlyUrl, string $entityName)
  * @method \App\Component\Router\FriendlyUrl\FriendlyUrl[] getAllByRouteNameAndEntityId(string $routeName, int $entityId)
  * @method \App\Component\Router\FriendlyUrl\FriendlyUrl|null findMainFriendlyUrl(int $domainId, string $routeName, int $entityId)
  * @method setFriendlyUrlAsMain(\App\Component\Router\FriendlyUrl\FriendlyUrl $mainFriendlyUrl)

--- a/project-base/app/src/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Performance/ProductDataFixture.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProductDataFixture
 {
-    private const BATCH_SIZE = 1000;
-
     public const FIRST_PERFORMANCE_PRODUCT = 'first_performance_product';
 
     private int $productTotalCount;
@@ -98,7 +96,6 @@ class ProductDataFixture
             if ($productTemplate === false) {
                 $this->createVariants($variantCatnumsByMainVariantCatnum);
                 $productTemplate = reset($this->productTemplates);
-                $this->demoDataIterationCounter++;
             }
             $productData = $this->productDataFactory->createFromProduct($productTemplate);
             $this->makeProductDataUnique($productData);
@@ -115,9 +112,7 @@ class ProductDataFixture
                 $this->productsByCatnum[$product->getCatnum()] = $product;
             }
 
-            if ($this->countImported % self::BATCH_SIZE === 0) {
-                $this->cleanAndLoadReferences();
-            }
+            $this->cleanAndLoadReferences();
 
             $this->countImported++;
 
@@ -196,6 +191,8 @@ class ProductDataFixture
      */
     private function getUniqueIndex()
     {
+        $this->demoDataIterationCounter++;
+
         return ' #' . $this->demoDataIterationCounter;
     }
 

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -197,7 +197,7 @@ class ProductFacade extends BaseProductFacade
         $this->saveParameters($product, $productData->parameters);
 
         if (!$product->isMainVariant()) {
-            $this->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
+            $this->productManualInputPriceFacade->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
         }
 
         if ($product->isMainVariant()) {
@@ -263,7 +263,7 @@ class ProductFacade extends BaseProductFacade
 
         $this->saveParameters($product, $productData->parameters);
         $this->createProductVisibilities($product);
-        $this->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
+        $this->productManualInputPriceFacade->refreshProductManualInputPrices($product, $productData->manualInputPricesByPricingGroupId);
         $this->refreshProductAccessories($product, $productData->accessories);
         $this->imageFacade->manageImages($product, $productData->images);
         $this->productHiddenRecalculator->calculateHiddenForProduct($product);

--- a/project-base/app/src/Model/Stock/ProductStockFacade.php
+++ b/project-base/app/src/Model/Stock/ProductStockFacade.php
@@ -110,7 +110,6 @@ class ProductStockFacade
     {
         $productStock = new ProductStock($stock, $product);
         $this->em->persist($productStock);
-        $this->em->flush();
 
         return $productStock;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| There were some unnecessary flushes fired during the creation of the Product. These flushes were moved after all data of each product-related entity were created (e.g. domain data). This significantly improves the speed of the Product creation. For big batches, like performance data creation of 40000 products this is up to 24 times faster.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-improve-performance-data.odin.shopsys.cloud
  - https://cz.tl-improve-performance-data.odin.shopsys.cloud
<!-- Replace -->
