### PR TITLE
[shopsys] added core for dispatch/consume system

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -107,6 +107,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   re-enable phing target cron ([#2875](https://github.com/shopsys/shopsys/pull/2875))
     -   see #project-base-diff to update your project
+-   prepare core for dispatch/consume system ([#2907](https://github.com/shopsys/shopsys/pull/2907))
+    -   your custom classes that utilize internal array caching or need to be reset between message consumption should now implement the `\Symfony\Contracts\Service\ResetInterface` interface
+    -   method `Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler::cleanScheduleForImmediateRecalculation()` has been renamed to `reset()`
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,7 @@
         "symfony/proxy-manager-bridge": "^5.4",
         "symfony/rate-limiter": "^5.4",
         "symfony/security-bundle": "^5.4",
+        "symfony/service-contracts": "^2.5.2",
         "symfony/stopwatch": "^5.4",
         "symfony/translation": "^5.4",
         "symfony/twig-bundle": "^5.4",

--- a/docker/conf/docker-compose.github-actions.cypress.yml.dist
+++ b/docker/conf/docker-compose.github-actions.cypress.yml.dist
@@ -46,6 +46,24 @@ services:
         volumes:
             - web-volume:/var/www/html/project-base/app/web
 
+    php-consumer:
+        restart: always
+        image: php-fpm-image
+        container_name: shopsys-framework-php-consumer
+        volumes:
+            - web-volume:/var/www/html/project-base/app/web
+        depends_on:
+            - php-fpm
+            - rabbitmq
+        entrypoint:
+            - /bin/sh
+            - -c
+            - sleep 5 && project-base/app/docker/php-fpm/consumer-entrypoint.sh 600
+
+    rabbitmq:
+        image: rabbitmq:3.12-management-alpine
+        container_name: shopsys-framework-rabbitmq
+
     redis:
         image: redis:5.0-alpine
         container_name: shopsys-framework-redis

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -93,6 +93,7 @@
         "symfony/proxy-manager-bridge": "^5.4",
         "symfony/rate-limiter": "^5.4",
         "symfony/security-bundle": "^5.4",
+        "symfony/service-contracts": "^2.5.2",
         "symfony-cmf/routing": "^2.0.3",
         "symfony-cmf/routing-bundle": "^2.0.3",
         "symfony/polyfill-php80": "^1.24.0",

--- a/packages/framework/src/Component/Elasticsearch/AbstractExportScheduler.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractExportScheduler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Elasticsearch;
 
-abstract class AbstractExportScheduler
+use Symfony\Contracts\Service\ResetInterface;
+
+abstract class AbstractExportScheduler implements ResetInterface
 {
     /**
      * @var int[]
@@ -33,5 +35,10 @@ abstract class AbstractExportScheduler
     public function getRowIdsForImmediateExport(): array
     {
         return array_unique($this->rowIds);
+    }
+
+    public function reset(): void
+    {
+        $this->rowIds = [];
     }
 }

--- a/packages/framework/src/Component/Messenger/AbstractMessageDispatcher.php
+++ b/packages/framework/src/Component/Messenger/AbstractMessageDispatcher.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger;
+
+use Symfony\Component\Messenger\MessageBusInterface;
+
+abstract class AbstractMessageDispatcher
+{
+    protected string $transportDsn;
+
+    protected MessageBusInterface $messageBus;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Messenger\MessageDispatcherDependency $messageDispatcherDependency
+     */
+    public function __construct(
+        MessageDispatcherDependency $messageDispatcherDependency,
+    ) {
+        $this->transportDsn = $messageDispatcherDependency->transportDsn;
+        $this->messageBus = $messageDispatcherDependency->messageBus;
+
+        if ($this->transportDsn === '') {
+            $this->messageBus = new NullMessageBus();
+        }
+    }
+}

--- a/packages/framework/src/Component/Messenger/DelayedEnvelope/DelayEnvelopeMiddleware.php
+++ b/packages/framework/src/Component/Messenger/DelayedEnvelope/DelayEnvelopeMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+
+class DelayEnvelopeMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope\DelayedEnvelopesCollector $delayedEnvelopesCollector
+     */
+    public function __construct(
+        protected readonly DelayedEnvelopesCollector $delayedEnvelopesCollector,
+    ) {
+    }
+
+    /**
+     * @param \Symfony\Component\Messenger\Envelope $envelope
+     * @param \Symfony\Component\Messenger\Middleware\StackInterface $stack
+     * @return \Symfony\Component\Messenger\Envelope
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if ($envelope->last(DelayedEnvelopeStamp::class) !== null || count($envelope->all(ReceivedStamp::class)) > 0) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $envelope = $envelope->with(new DelayedEnvelopeStamp());
+
+        $this->delayedEnvelopesCollector->addEnvelope($envelope);
+
+        return $envelope;
+    }
+}

--- a/packages/framework/src/Component/Messenger/DelayedEnvelope/DelayedEnvelopeStamp.php
+++ b/packages/framework/src/Component/Messenger/DelayedEnvelope/DelayedEnvelopeStamp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class DelayedEnvelopeStamp implements StampInterface
+{
+}

--- a/packages/framework/src/Component/Messenger/DelayedEnvelope/DelayedEnvelopesCollector.php
+++ b/packages/framework/src/Component/Messenger/DelayedEnvelope/DelayedEnvelopesCollector.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope;
+
+use Symfony\Component\Messenger\Envelope;
+
+class DelayedEnvelopesCollector
+{
+    /**
+     * @var \Symfony\Component\Messenger\Envelope[]
+     */
+    protected array $delayedEnvelopes = [];
+
+    /**
+     * @param \Symfony\Component\Messenger\Envelope $envelope
+     */
+    public function addEnvelope(Envelope $envelope): void
+    {
+        $this->delayedEnvelopes[] = $envelope;
+    }
+
+    /**
+     * @return \Symfony\Component\Messenger\Envelope[]
+     */
+    public function popEnvelopes(): array
+    {
+        $envelopes = $this->delayedEnvelopes;
+
+        $this->resetEnvelopes();
+
+        return $envelopes;
+    }
+
+    public function resetEnvelopes(): void
+    {
+        $this->delayedEnvelopes = [];
+    }
+}

--- a/packages/framework/src/Component/Messenger/DelayedEnvelope/DispatchCollectedEnvelopesSubscriber.php
+++ b/packages/framework/src/Component/Messenger/DelayedEnvelope/DispatchCollectedEnvelopesSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class DispatchCollectedEnvelopesSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope\DelayedEnvelopesCollector $delayedEnvelopesCollector
+     * @param \Symfony\Component\Messenger\MessageBusInterface $messageBus
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        protected readonly DelayedEnvelopesCollector $delayedEnvelopesCollector,
+        protected readonly MessageBusInterface $messageBus,
+        protected readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function handleCollectedMessageEnvelopes(): void
+    {
+        foreach ($this->delayedEnvelopesCollector->popEnvelopes() as $envelope) {
+            $this->redispatchEnvelopeIgnoringMailerException($envelope);
+        }
+    }
+
+    public function resetCollectedMessageEnvelopes(): void
+    {
+        $this->delayedEnvelopesCollector->resetEnvelopes();
+    }
+
+    /**
+     * @param \Symfony\Component\Messenger\Envelope $envelope
+     */
+    protected function redispatchEnvelopeIgnoringMailerException(Envelope $envelope): void
+    {
+        try {
+            $this->messageBus->dispatch($envelope);
+        } catch (HandlerFailedException $e) {
+            foreach ($e->getNestedExceptions() as $nested) {
+                if ($nested instanceof TransportExceptionInterface) {
+                    $this->logger->error('There was a failure while sending emails', [
+                        'exception' => $nested,
+                    ]);
+
+                    return;
+                }
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => 'resetCollectedMessageEnvelopes',
+            KernelEvents::RESPONSE => ['handleCollectedMessageEnvelopes', -10],
+            ConsoleEvents::TERMINATE => ['handleCollectedMessageEnvelopes', -10],
+            WorkerMessageHandledEvent::class => ['handleCollectedMessageEnvelopes', 10],
+        ];
+    }
+}

--- a/packages/framework/src/Component/Messenger/ExampleDispatcher.php
+++ b/packages/framework/src/Component/Messenger/ExampleDispatcher.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger;
+
+class ExampleDispatcher extends AbstractMessageDispatcher
+{
+    /**
+     * @param string $value
+     */
+    public function dispatchExampleMessage(string $value): void
+    {
+        $this->messageBus->dispatch(new ExampleMessage($value));
+    }
+}

--- a/packages/framework/src/Component/Messenger/ExampleMessage.php
+++ b/packages/framework/src/Component/Messenger/ExampleMessage.php
@@ -6,4 +6,11 @@ namespace Shopsys\FrameworkBundle\Component\Messenger;
 
 class ExampleMessage
 {
+    /**
+     * @param string $value
+     */
+    public function __construct(
+        public readonly string $value,
+    ) {
+    }
 }

--- a/packages/framework/src/Component/Messenger/MessageDispatcherDependency.php
+++ b/packages/framework/src/Component/Messenger/MessageDispatcherDependency.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger;
+
+use Symfony\Component\Messenger\MessageBusInterface;
+
+class MessageDispatcherDependency
+{
+    /**
+     * @param string $transportDsn
+     * @param \Symfony\Component\Messenger\MessageBusInterface $messageBus
+     */
+    public function __construct(
+        public readonly string $transportDsn,
+        public readonly MessageBusInterface $messageBus,
+    ) {
+    }
+}

--- a/packages/framework/src/Component/Messenger/NullMessageBus.php
+++ b/packages/framework/src/Component/Messenger/NullMessageBus.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * This Message Bus is used when transport DSN is empty to prevent errors
+ *
+ * @internal
+ */
+class NullMessageBus implements MessageBusInterface
+{
+    /**
+     * Dispatch method only wraps the message in Envelope, but does not really dispatch it
+     * For the current implementation see the implementation of MessageBusInterface in Symfony Messenger
+     *
+     * {@inheritdoc}
+     */
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        return new Envelope($message, $stamps);
+    }
+}

--- a/packages/framework/src/Component/Messenger/ResetWorkerOnClosedEntityManagerSubscriber.php
+++ b/packages/framework/src/Component/Messenger/ResetWorkerOnClosedEntityManagerSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger;
+
+use Doctrine\ORM\Exception\EntityManagerClosed;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\StopWorkerException;
+
+class ResetWorkerOnClosedEntityManagerSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param \Symfony\Component\Messenger\Event\WorkerMessageFailedEvent $event
+     */
+    public function onWorkerMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if (!($exception instanceof HandlerFailedException)) {
+            return;
+        }
+
+        foreach ($exception->getNestedExceptions() as $nestedException) {
+            if ($nestedException instanceof EntityManagerClosed) {
+                throw new StopWorkerException();
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => ['onWorkerMessageFailed', 10],
+        ];
+    }
+}

--- a/packages/framework/src/Model/Customer/User/CurrentCustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CurrentCustomerUser.php
@@ -7,8 +7,9 @@ namespace Shopsys\FrameworkBundle\Model\Customer\User;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade;
 use Shopsys\FrontendApiBundle\Model\User\FrontendApiUser;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
-class CurrentCustomerUser
+class CurrentCustomerUser implements ResetInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser[]
@@ -75,5 +76,10 @@ class CurrentCustomerUser
         }
 
         return null;
+    }
+
+    public function reset(): void
+    {
+        $this->customerUserCache = [];
     }
 }

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculationScheduler.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityRecalculationScheduler.php
@@ -6,8 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Availability;
 
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductAvailabilityRecalculationScheduler
+class ProductAvailabilityRecalculationScheduler implements ResetInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product[]
@@ -51,6 +52,11 @@ class ProductAvailabilityRecalculationScheduler
     }
 
     public function cleanScheduleForImmediateRecalculation()
+    {
+        $this->products = [];
+    }
+
+    public function reset(): void
     {
         $this->products = [];
     }

--- a/packages/framework/src/Model/Product/Brand/BrandCachedFacade.php
+++ b/packages/framework/src/Model/Product/Brand/BrandCachedFacade.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\Brand;
 
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
+use Symfony\Contracts\Service\ResetInterface;
 
-class BrandCachedFacade
+class BrandCachedFacade implements ResetInterface
 {
     /**
      * @var array<int, array<int, string>>
@@ -39,5 +40,10 @@ class BrandCachedFacade
         }
 
         return $this->brandUrlsIndexedByBrandIdAndDomainId[$brandId][$domainId];
+    }
+
+    public function reset(): void
+    {
+        $this->brandUrlsIndexedByBrandIdAndDomainId = [];
     }
 }

--- a/packages/framework/src/Model/Product/Collection/ProductParametersBatchLoader.php
+++ b/packages/framework/src/Model/Product/Collection/ProductParametersBatchLoader.php
@@ -7,8 +7,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Collection;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Model\Product\Collection\Exception\ProductParametersNotLoadedException;
 use Shopsys\FrameworkBundle\Model\Product\Product;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductParametersBatchLoader
+class ProductParametersBatchLoader implements ResetInterface
 {
     /**
      * @var string[][]|null[][]
@@ -65,5 +66,10 @@ class ProductParametersBatchLoader
     protected function getKey(Product $product, DomainConfig $domainConfig): string
     {
         return $domainConfig->getId() . '-' . $product->getId();
+    }
+
+    public function reset(): void
+    {
+        $this->loadedProductParametersByName = [];
     }
 }

--- a/packages/framework/src/Model/Product/Collection/ProductUrlsBatchLoader.php
+++ b/packages/framework/src/Model/Product/Collection/ProductUrlsBatchLoader.php
@@ -8,8 +8,9 @@ use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Model\Product\Collection\Exception\ProductImageUrlNotLoadedException;
 use Shopsys\FrameworkBundle\Model\Product\Collection\Exception\ProductUrlNotLoadedException;
 use Shopsys\FrameworkBundle\Model\Product\Product;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductUrlsBatchLoader
+class ProductUrlsBatchLoader implements ResetInterface
 {
     /**
      * @var string[]
@@ -89,5 +90,11 @@ class ProductUrlsBatchLoader
     protected function getKey(Product $product, DomainConfig $domainConfig): string
     {
         return $domainConfig->getId() . '-' . $product->getId();
+    }
+
+    public function reset(): void
+    {
+        $this->loadedProductUrls = [];
+        $this->loadedProductImageUrls = [];
     }
 }

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculationScheduler.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculationScheduler.php
@@ -6,8 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Product\Pricing;
 
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductPriceRecalculationScheduler
+class ProductPriceRecalculationScheduler implements ResetInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Product[]
@@ -50,7 +51,7 @@ class ProductPriceRecalculationScheduler
         return $this->productRepository->getProductsForPriceRecalculationIterator();
     }
 
-    public function cleanScheduleForImmediateRecalculation()
+    public function reset(): void
     {
         $this->products = [];
     }

--- a/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductPriceRecalculator.php
@@ -84,7 +84,7 @@ class ProductPriceRecalculator
         foreach ($products as $product) {
             $this->recalculateProductPrices($product);
         }
-        $this->productPriceRecalculationScheduler->cleanScheduleForImmediateRecalculation();
+        $this->productPriceRecalculationScheduler->reset();
         $this->clearCache();
     }
 

--- a/packages/framework/src/Model/Product/ProductCachedAttributesFacade.php
+++ b/packages/framework/src/Model/Product/ProductCachedAttributesFacade.php
@@ -8,8 +8,9 @@ use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\Exception\MainVariantPriceCalculationException;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductCachedAttributesFacade
+class ProductCachedAttributesFacade implements ResetInterface
 {
     /**
      * @var \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice[]
@@ -81,5 +82,11 @@ class ProductCachedAttributesFacade
         $this->parameterValuesByProductId[$product->getId()] = $productParameterValues;
 
         return $productParameterValues;
+    }
+
+    public function reset(): void
+    {
+        $this->sellingPricesByProductId = [];
+        $this->parameterValuesByProductId = [];
     }
 }

--- a/packages/framework/src/Model/Product/ProductVariantFacade.php
+++ b/packages/framework/src/Model/Product/ProductVariantFacade.php
@@ -54,7 +54,7 @@ class ProductVariantFacade
             $this->imageFacade->copyImages($mainProduct, $mainVariant);
         } catch (Exception $exception) {
             $this->productAvailabilityRecalculationScheduler->cleanScheduleForImmediateRecalculation();
-            $this->productPriceRecalculationScheduler->cleanScheduleForImmediateRecalculation();
+            $this->productPriceRecalculationScheduler->reset();
 
             throw $exception;
         }

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -8,8 +8,9 @@ use Doctrine\ORM\QueryBuilder;
 use Elasticsearch\Client;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductElasticsearchRepository
+class ProductElasticsearchRepository implements ResetInterface
 {
     /**
      * @var int[][][]
@@ -186,5 +187,10 @@ class ProductElasticsearchRepository
         $result = $this->client->search($filterQuery->getQuery());
 
         return $this->extractHits($result);
+    }
+
+    public function reset(): void
+    {
+        $this->foundProductIdsCache = [];
     }
 }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -16,7 +16,8 @@ services:
         public: false
 
     Shopsys\FrameworkBundle\:
-        resource: '../../**/*{Calculation,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer}.php'
+        resource: '../../**/*{Calculation,Collector,Dispatcher,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer}.php'
+
         exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
 
     Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\:
@@ -1035,3 +1036,7 @@ services:
         arguments:
             $environment: '%kernel.environment%'
             $forceElasticLimit: '%env(FORCE_ELASTIC_LIMITS)%'
+
+    Shopsys\FrameworkBundle\Component\Messenger\MessageDispatcherDependency:
+        arguments:
+            $transportDsn: '%env(MESSENGER_TRANSPORT_DSN)%'

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -17,7 +17,6 @@ services:
 
     Shopsys\FrameworkBundle\:
         resource: '../../**/*{Calculation,Collector,Dispatcher,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer}.php'
-
         exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
 
     Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\:

--- a/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceRecalculationSchedulerTest.php
+++ b/packages/framework/tests/Unit/Model/Product/Pricing/ProductPriceRecalculationSchedulerTest.php
@@ -43,7 +43,7 @@ class ProductPriceRecalculationSchedulerTest extends TestCase
 
         $productPriceRecalculationScheduler = new ProductPriceRecalculationScheduler($productRepositoryMock);
         $productPriceRecalculationScheduler->scheduleProductForImmediateRecalculation($productMock);
-        $productPriceRecalculationScheduler->cleanScheduleForImmediateRecalculation();
+        $productPriceRecalculationScheduler->reset();
         $products = $productPriceRecalculationScheduler->getProductsForImmediateRecalculation();
 
         $this->assertCount(0, $products);

--- a/packages/product-feed-heureka/composer.json
+++ b/packages/product-feed-heureka/composer.json
@@ -39,6 +39,7 @@
         "symfony/dependency-injection": "^5.4",
         "symfony/form": "^5.4",
         "symfony/http-kernel": "^5.4",
+        "symfony/service-contracts": "^2.5.2",
         "symfony/translation": "^5.4"
     },
     "require-dev": {

--- a/packages/product-feed-heureka/src/Model/FeedItem/HeurekaFeedItemFactory.php
+++ b/packages/product-feed-heureka/src/Model/FeedItem/HeurekaFeedItemFactory.php
@@ -10,8 +10,9 @@ use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacade;
+use Symfony\Contracts\Service\ResetInterface;
 
-class HeurekaFeedItemFactory
+class HeurekaFeedItemFactory implements ResetInterface
 {
     protected HeurekaProductDataBatchLoader $productDataBatchLoader;
 
@@ -126,5 +127,10 @@ class HeurekaFeedItemFactory
         $heurekaCategory = $this->heurekaCategoryFacade->findByCategoryId($categoryId);
 
         return $heurekaCategory !== null ? $heurekaCategory->getFullName() : null;
+    }
+
+    public function reset(): void
+    {
+        $this->heurekaCategoryFullNamesCache = [];
     }
 }

--- a/packages/product-feed-heureka/src/Model/FeedItem/HeurekaProductDataBatchLoader.php
+++ b/packages/product-feed-heureka/src/Model/FeedItem/HeurekaProductDataBatchLoader.php
@@ -47,6 +47,8 @@ class HeurekaProductDataBatchLoader
             $domainConfig,
         );
 
+        $this->loadedProductCpcs = [];
+
         foreach ($products as $product) {
             $key = $this->getKey($product, $domainConfig);
             $productId = $product->getId();

--- a/project-base/app/.env.test
+++ b/project-base/app/.env.test
@@ -2,6 +2,8 @@
 
 DATABASE_NAME=shopsys-test
 
+MAILER_DSN=null://null
+
 GOPAY_IS_PRODUCTION_MODE=false
 GOPAY_EN_GOID=test-data
 GOPAY_EN_CLIENTID=test-data

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -108,6 +108,7 @@
         "symfony/property-info": "^5.4",
         "symfony/proxy-manager-bridge": "^5.4",
         "symfony/security-bundle": "^5.4",
+        "symfony/service-contracts": "^2.5.2",
         "symfony/stopwatch": "^5.4",
         "symfony/translation": "^5.4",
         "symfony/twig-bundle": "^5.4",

--- a/project-base/app/config/packages/messenger.yaml
+++ b/project-base/app/config/packages/messenger.yaml
@@ -1,6 +1,10 @@
 framework:
     messenger:
         reset_on_message: true
+        buses:
+            messenger.bus.default:
+                middleware:
+                    - 'Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope\DelayEnvelopeMiddleware'
         transports:
             example_transport:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -27,7 +27,7 @@ services:
         resource: '../src/Twig/'
 
     App\:
-        resource: '../src/**/*{Calculation,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,Validator,Transfer,Helper,Converter,DataFetcher}.php'
+        resource: '../src/**/*{Calculation,Collector,Dispatcher,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,Validator,Transfer,Helper,Converter,DataFetcher}.php'
         exclude:
             - '../src/{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
             - '../src/FrontendApi/**/*{Resolver,Mapper}.php'

--- a/project-base/app/src/Component/FileUpload/FileUpload.php
+++ b/project-base/app/src/Component/FileUpload/FileUpload.php
@@ -15,8 +15,9 @@ use Shopsys\FrameworkBundle\Component\FileUpload\FileNamingConvention;
 use Shopsys\FrameworkBundle\Component\FileUpload\FileUpload as BaseFileUpload;
 use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFile as ShopsysUploadedFile;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
-class FileUpload extends BaseFileUpload
+class FileUpload extends BaseFileUpload implements ResetInterface
 {
     /**
      * @var array<string, array<int, array<string, array<string|null, int>>>>
@@ -123,5 +124,10 @@ class FileUpload extends BaseFileUpload
         }
 
         return $uploadEntityType;
+    }
+
+    public function reset(): void
+    {
+        $this->positionByEntityAndType = [];
     }
 }

--- a/project-base/app/src/DataFixtures/Performance/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Performance/ProductDataFixture.php
@@ -199,7 +199,7 @@ class ProductDataFixture
     private function clearResources()
     {
         $this->productAvailabilityRecalculationScheduler->cleanScheduleForImmediateRecalculation();
-        $this->productPriceRecalculationScheduler->cleanScheduleForImmediateRecalculation();
+        $this->productPriceRecalculationScheduler->reset();
         $this->em->clear();
         gc_collect_cycles();
     }

--- a/project-base/app/src/Model/Category/Transfer/Akeneo/AkeneoImportCategoryFacade.php
+++ b/project-base/app/src/Model/Category/Transfer/Akeneo/AkeneoImportCategoryFacade.php
@@ -13,8 +13,9 @@ use Generator;
 use Shopsys\FrameworkBundle\Model\Category\CategoryNestedSetCalculator;
 use Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
+use Symfony\Contracts\Service\ResetInterface;
 
-class AkeneoImportCategoryFacade extends AbstractAkeneoImportTransfer
+class AkeneoImportCategoryFacade extends AbstractAkeneoImportTransfer implements ResetInterface
 {
     public const ROOT_CATEGORY_CODE = 'eshop__ecommere';
     public const ROOT_CATEGORY_CODE_PROD = 'eshop__ecommerce';
@@ -202,5 +203,12 @@ class AkeneoImportCategoryFacade extends AbstractAkeneoImportTransfer
     public function getTransferName(): string
     {
         return t('Categories transfer');
+    }
+
+    public function reset(): void
+    {
+        $this->akeneoCategoriesDataForOrdering = [];
+        $this->notTransferredCategoriesIds = [];
+        $this->categoriesFromAkeneoCountBeforeTransfer = 0;
     }
 }

--- a/project-base/app/src/Model/CategorySeo/ReadyCategorySeoMixRepository.php
+++ b/project-base/app/src/Model/CategorySeo/ReadyCategorySeoMixRepository.php
@@ -11,9 +11,10 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ObjectRepository;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter;
+use Symfony\Contracts\Service\ResetInterface;
 use function GuzzleHttp\json_encode;
 
-class ReadyCategorySeoMixRepository
+class ReadyCategorySeoMixRepository implements ResetInterface
 {
     /**
      * @var string[][][]
@@ -215,5 +216,10 @@ class ReadyCategorySeoMixRepository
             ->getArrayResult();
 
         return array_column($result, 'categoryId');
+    }
+
+    public function reset(): void
+    {
+        $this->readySeoCategorySetup = [];
     }
 }

--- a/project-base/app/src/Model/Customer/User/ClearCurrentCustomerUserCacheDoctrineSubscriber.php
+++ b/project-base/app/src/Model/Customer/User/ClearCurrentCustomerUserCacheDoctrineSubscriber.php
@@ -23,7 +23,7 @@ class ClearCurrentCustomerUserCacheDoctrineSubscriber implements EventSubscriber
      */
     public function onClear(OnClearEventArgs $args): void
     {
-        $this->currentCustomerUser->invalidateCache();
+        $this->currentCustomerUser->reset();
     }
 
     /**

--- a/project-base/app/src/Model/Customer/User/CurrentCustomerUser.php
+++ b/project-base/app/src/Model/Customer/User/CurrentCustomerUser.php
@@ -13,8 +13,4 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser as BaseCurre
  */
 class CurrentCustomerUser extends BaseCurrentCustomerUser
 {
-    public function invalidateCache(): void
-    {
-        $this->customerUserCache = [];
-    }
 }

--- a/project-base/app/src/Model/Product/Availability/ProductAvailabilityFacade.php
+++ b/project-base/app/src/Model/Product/Availability/ProductAvailabilityFacade.php
@@ -12,15 +12,16 @@ use App\Model\Store\StoreFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct;
+use Symfony\Contracts\Service\ResetInterface;
 
-class ProductAvailabilityFacade
+class ProductAvailabilityFacade implements ResetInterface
 {
     private const DAYS_IN_WEEK = 7;
 
     /**
      * @var array<string, bool>
      */
-    private array $productAvailabilityDomainCache;
+    private array $productAvailabilityDomainCache = [];
 
     /**
      * @param \App\Component\Setting\Setting $setting
@@ -34,7 +35,6 @@ class ProductAvailabilityFacade
         private readonly StoreFacade $storeFacade,
         private readonly Domain $domain,
     ) {
-        $this->productAvailabilityDomainCache = [];
     }
 
     /**
@@ -548,5 +548,10 @@ class ProductAvailabilityFacade
         }
 
         return $this->getDeliveryDaysByDomainId($product, $domainId);
+    }
+
+    public function reset(): void
+    {
+        $this->productAvailabilityDomainCache = [];
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/AuthenticatedCartModificationsResultTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/AuthenticatedCartModificationsResultTest.php
@@ -553,7 +553,7 @@ class AuthenticatedCartModificationsResultTest extends GraphQlWithLoginTestCase
         }
 
         $this->productFacade->editProductStockRelation($productData, $this->testingProduct);
-        $this->productPriceRecalculationScheduler->cleanScheduleForImmediateRecalculation();
+        $this->productPriceRecalculationScheduler->reset();
         $this->productAvailabilityRecalculationScheduler->cleanScheduleForImmediateRecalculation();
         $this->em->clear();
     }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/CartModificationsResultTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/CartModificationsResultTest.php
@@ -581,7 +581,7 @@ class CartModificationsResultTest extends GraphQlTestCase
             $stockProductData->productQuantity = 0;
         }
         $this->productFacade->editProductStockRelation($productData, $this->testingProduct);
-        $this->productPriceRecalculationScheduler->cleanScheduleForImmediateRecalculation();
+        $this->productPriceRecalculationScheduler->reset();
         $this->productAvailabilityRecalculationScheduler->cleanScheduleForImmediateRecalculation();
         $this->em->clear();
         gc_collect_cycles();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Prepares the message dispatch/consume for future usage. More description follows
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

What is done:
- `AbstractMessageDispatcher` should be used as a base class for all future dispatchers. Provides the necessary dependencies and is configured automatically
- messages are truly sent to the queue at the end of the request/console-command/processed-message – after the master transaction is committed
- services using internal cache now implement `ResetInterface`, so they are automatically cleared on each message (prevent stale in-memory data)
- when entity manager is closed, the worker is automatically restarted































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-messenger-messages.odin.shopsys.cloud
  - https://cz.mg-messenger-messages.odin.shopsys.cloud
<!-- Replace -->
