### PR TITLE
[project-base] fixed ProductsQuery Gatling simulation to wait for http response

### DIFF
--- a/project-base/gatling/gatling/simulations/graphql/ProductsQuery.scala
+++ b/project-base/gatling/gatling/simulations/graphql/ProductsQuery.scala
@@ -24,14 +24,15 @@ class ProductsQuery extends Simulation {
     val scn = scenario("ProductsQuery")
         .exec(
             http(f"page__$users%s__products_query")
-                .post("graphql/")
+                .post("/graphql/")
                 .header("Content-Type","application/graphql")
                 .body(RawFileBody("productsQuery.graphql"))
-            )
+                .check(status.is(200))
+        )
 
     setUp(
-      scn.inject(
-        constantConcurrentUsers(users.toInt) during (duration.toInt.seconds),
-      ).protocols(httpProtocol)
+        scn.inject(
+            constantConcurrentUsers(users.toInt) during (duration.toInt.seconds),
+        ).protocols(httpProtocol)
     )
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| ProductsQuery was failing sooner than simulation has been finished because of not waiting for 200 HTTP status.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-gatling.odin.shopsys.cloud
  - https://cz.tl-fix-gatling.odin.shopsys.cloud
<!-- Replace -->
