### PR TITLE
fix router server access error on PageGuard

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -199,3 +199,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   fix set default delivery address country ([#2902](https://github.com/shopsys/shopsys/pull/2902))
     -   see #project-base-diff to update your project
+-   fix router server access error on PageGuard ([#2909](https://github.com/shopsys/shopsys/pull/2909))
+    -   see #project-base-diff to update your project

--- a/project-base/storefront/components/Basic/PageGuard/PageGuard.tsx
+++ b/project-base/storefront/components/Basic/PageGuard/PageGuard.tsx
@@ -1,3 +1,4 @@
+import { isClient } from 'helpers/isClient';
 import { useRouter } from 'next/router';
 
 type PageGuardProps = {
@@ -9,7 +10,10 @@ export const PageGuard: FC<PageGuardProps> = ({ isWithAccess, errorRedirectUrl, 
     const router = useRouter();
 
     if (!isWithAccess) {
-        router.replace(errorRedirectUrl);
+        if (isClient) {
+            router.replace(errorRedirectUrl);
+        }
+
         return null;
     }
 

--- a/project-base/storefront/components/Layout/Header/Contact/HeaderContact.tsx
+++ b/project-base/storefront/components/Layout/Header/Contact/HeaderContact.tsx
@@ -15,7 +15,10 @@ export const HeaderContact: FC = () => {
                 <div className="flex flex-wrap items-center gap-3 lg:flex-1 xl:justify-center">
                     <PhoneIcon className="w-5 text-orange" />
 
-                    <a className="font-bold text-creamWhite no-underline" href={'tel:' + dummyData.phone}>
+                    <a
+                        className="font-bold text-creamWhite no-underline hover:text-creamWhite"
+                        href={'tel:' + dummyData.phone}
+                    >
                         {dummyData.phone}
                     </a>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Next was trying to use router.replace on server with PageGuard component. This was causing throwing error instead proper behavior.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1819-fix-access-to-not-valid-order.odin.shopsys.cloud
  - https://cz.tv-fw-1819-fix-access-to-not-valid-order.odin.shopsys.cloud
<!-- Replace -->
