### PR TITLE
fix Cart list unit text

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -201,3 +201,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   fix router server access error on PageGuard ([#2909](https://github.com/shopsys/shopsys/pull/2909))
     -   see #project-base-diff to update your project
+-   fix Cart list unit text ([#2910](https://github.com/shopsys/shopsys/pull/2910))
+    -   see #project-base-diff to update your project

--- a/project-base/storefront/components/Pages/Cart/CartList/CartListItem.tsx
+++ b/project-base/storefront/components/Pages/Cart/CartList/CartListItem.tsx
@@ -106,7 +106,7 @@ export const CartListItem: FC<CartListItemProps> = ({
             </div>
 
             <div className="flex items-center justify-end text-sm vl:w-32" data-testid={TEST_IDENTIFIER + 'itemprice'}>
-                {formatPrice(product.price.priceWithVat) + '\u00A0/\u00A0' + t('pc')}
+                {formatPrice(product.price.priceWithVat) + '\u00A0/\u00A0' + product.unit.name}
             </div>
 
             <div

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -212,7 +212,6 @@
     "Passwords must match": "Hesla se musí shodovat",
     "Pay with GoPay": "Zaplatit pomocí GoPay",
     "Payment": "Platba",
-    "pc": "ks",
     "Personal data": "Osobní údaje",
     "Personal Data Export": "Export osobních údajů",
     "Personal Data Overview": "Přehled osobních údajů",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -204,7 +204,6 @@
     "Passwords must match": "Passwords must match",
     "Pay with GoPay": "Pay with GoPay",
     "Payment": "Payment",
-    "pc": "pc",
     "Personal data": "Personal data",
     "Personal Data Export": "Personal Data Export",
     "Personal Data Overview": "Personal Data Overview",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -212,7 +212,6 @@
     "Passwords must match": "Heslá sa musia zhodovať",
     "Pay with GoPay": "Plaťte cez GoPay",
     "Payment": "Platba",
-    "pc": "ks",
     "Personal data": "Osobné údaje ",
     "Personal Data Export": "Export osobných údajov",
     "Personal Data Overview": "Prehľad osobných údajov",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We were displaying wrong unit text in cart list item. This fixes it.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-fw-1462-fix-cart-list-unit-text.odin.shopsys.cloud
  - https://cz.tv-fw-1462-fix-cart-list-unit-text.odin.shopsys.cloud
<!-- Replace -->
