### PR TITLE
[project-base] colour parameters are no longer duplicit

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1489,6 +1489,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   enable product filters provided by Luigi's Box when using Luigi's Box ([#3074](https://github.com/shopsys/shopsys/pull/3074))
     -   `Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterOptionsFactory::createProductFilterOptions()` has changed its visibility to `public`
     -   see #project-base-diff to update your project
+-   prevent duplicate color parameters in data fixtures ([#2911](https://github.com/shopsys/shopsys/pull/2911))
+    - see #project-base-diff to update your project
 
 ### Storefront
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| We are loading parameters via their names in some cases, and duplicity in color parameters caused problems, for example, in the black electronics SEO category.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-colour-parameters.odin.shopsys.cloud
  - https://cz.tl-fix-colour-parameters.odin.shopsys.cloud
<!-- Replace -->
