### PR TITLE
[shopsys] all commands are now named via attribute

### DIFF
--- a/packages/framework/src/Command/ChangeAdminPasswordCommand.php
+++ b/packages/framework/src/Command/ChangeAdminPasswordCommand.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Exception;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,15 +14,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:administrator:change-password')]
 class ChangeAdminPasswordCommand extends Command
 {
     private const ARG_USERNAME = 'username';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:administrator:change-password';
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorFacade $administratorFacade

--- a/packages/framework/src/Command/ChangeEnvironmentCommand.php
+++ b/packages/framework/src/Command/ChangeEnvironmentCommand.php
@@ -7,21 +7,17 @@ namespace Shopsys\FrameworkBundle\Command;
 use Exception;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentFileSetting;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:environment:change')]
 class ChangeEnvironmentCommand extends Command
 {
     private const ARG_ENVIRONMENT = 'environment';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:environment:change';
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Environment\EnvironmentFileSetting $environmentFileSetting

--- a/packages/framework/src/Command/CheckRedisCommand.php
+++ b/packages/framework/src/Command/CheckRedisCommand.php
@@ -6,19 +6,15 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use RedisException;
 use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:redis:check-availability')]
 class CheckRedisCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:redis:check-availability';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Redis\RedisFacade $redisFacade
      */

--- a/packages/framework/src/Command/CheckTimezonesCommand.php
+++ b/packages/framework/src/Command/CheckTimezonesCommand.php
@@ -6,18 +6,14 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Doctrine\DBAL\Connection;
 use Shopsys\FrameworkBundle\Command\Exception\DifferentTimezonesException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:check-timezones')]
 class CheckTimezonesCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:check-timezones';
-
     /**
      * @param \Doctrine\DBAL\Connection $connection
      */

--- a/packages/framework/src/Command/CleanOpcacheCommand.php
+++ b/packages/framework/src/Command/CleanOpcacheCommand.php
@@ -6,19 +6,15 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use CacheTool\Adapter\FastCGI;
 use CacheTool\CacheTool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:clean-opcache')]
 class CleanOpcacheCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:clean-opcache';
-
     /**
      * {@inheritdoc}
      */

--- a/packages/framework/src/Command/ConfigureDomainsUrlsCommand.php
+++ b/packages/framework/src/Command/ConfigureDomainsUrlsCommand.php
@@ -4,19 +4,15 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(name: 'shopsys:domains-urls:configure')]
 class ConfigureDomainsUrlsCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:domains-urls:configure';
-
     /**
      * @param \Symfony\Component\Filesystem\Filesystem $localFilesystem
      * @param string $configFilepath

--- a/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
+++ b/packages/framework/src/Command/CreateApplicationDirectoriesCommand.php
@@ -9,11 +9,13 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Visibility;
 use Shopsys\FrameworkBundle\Component\Image\DirectoryStructureCreator as ImageDirectoryStructureCreator;
 use Shopsys\FrameworkBundle\Component\UploadedFile\DirectoryStructureCreator as UploadedFileDirectoryStructureCreator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(name: 'shopsys:create-directories')]
 class CreateApplicationDirectoriesCommand extends Command
 {
     /**
@@ -35,12 +37,6 @@ class CreateApplicationDirectoriesCommand extends Command
      * @var string[]|null
      */
     private ?array $publicDirectories = null;
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:create-directories';
 
     /**
      * @param array $defaultInternalDirectories

--- a/packages/framework/src/Command/CreateDatabaseCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseCommand.php
@@ -7,20 +7,16 @@ namespace Shopsys\FrameworkBundle\Command;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:database:create')]
 class CreateDatabaseCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:database:create';
-
     private ?Connection $connection = null;
 
     private ManagerRegistry $doctrineRegistry;

--- a/packages/framework/src/Command/CreateDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/CreateDatabaseSchemaCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:schema:create')]
 class CreateDatabaseSchemaCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:schema:create';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade $databaseSchemaFacade
      */

--- a/packages/framework/src/Command/CreateDomainsDataCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDataCommand.php
@@ -9,18 +9,14 @@ use RuntimeException;
 use Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator;
 use Shopsys\FrameworkBundle\Component\Domain\Multidomain\MultidomainEntityClassFinderFacade;
 use Shopsys\FrameworkBundle\Model\Localization\DbIndexesFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:domains-data:create')]
 class CreateDomainsDataCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:domains-data:create';
-
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator $domainDataCreator

--- a/packages/framework/src/Command/CreateDomainsDbFunctionsCommand.php
+++ b/packages/framework/src/Command/CreateDomainsDbFunctionsCommand.php
@@ -6,18 +6,14 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:domains-db-functions:create')]
 class CreateDomainsDbFunctionsCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:domains-db-functions:create';
-
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade $domainDbFunctionsFacade

--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Command\Exception\CronCommandException;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,18 +20,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
+#[AsCommand(name: 'shopsys:cron')]
 class CronCommand extends Command
 {
     private const OPTION_MODULE = 'module';
     private const OPTION_LIST = 'list';
     private const OPTION_INSTANCE_NAME = 'instance-name';
     private const OPTION_RUN_ALL_SERIALLY = 'run-all-serially';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:cron';
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Cron\CronFacade $cronFacade

--- a/packages/framework/src/Command/CronLockCommand.php
+++ b/packages/framework/src/Command/CronLockCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use NinjaMutex\Lock\LockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'deploy:cron:lock')]
 class CronLockCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'deploy:cron:lock';
-
     public const CRON_MUTEX_LOCK_NAME = 'cronLocker';
 
     protected const SLEEP_TIME = 600;

--- a/packages/framework/src/Command/CronWatchCommand.php
+++ b/packages/framework/src/Command/CronWatchCommand.php
@@ -6,18 +6,14 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'deploy:cron:watch')]
 class CronWatchCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'deploy:cron:watch';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Cron\CronFacade $cronFacade
      * @param \Shopsys\FrameworkBundle\Component\Cron\MutexFactory $mutexFactory

--- a/packages/framework/src/Command/DatabaseDumpCommand.php
+++ b/packages/framework/src/Command/DatabaseDumpCommand.php
@@ -5,22 +5,18 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Doctrine\DatabaseConnectionCredentialsProvider;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:database:dump')]
 class DatabaseDumpCommand extends Command
 {
     private const ARG_OUTPUT_FILE = 'outputFile';
     private const OPT_PGDUMP_BIN = 'pgdump-bin';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:database:dump';
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\DatabaseConnectionCredentialsProvider $databaseConnectionCredentialsProvider

--- a/packages/framework/src/Command/DomainInfoCommand.php
+++ b/packages/framework/src/Command/DomainInfoCommand.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Command;
 use InvalidArgumentException;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,6 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 
+#[AsCommand(name: 'shopsys:domains:info')]
 class DomainInfoCommand extends Command
 {
     protected const ARG_PROPERTY_NAME = 'propertyName';
@@ -23,12 +25,6 @@ class DomainInfoCommand extends Command
 
     protected const OPTION_DEDUPLICATE = 'deduplicate';
     protected const OPTION_ONELINE = 'oneline';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:domains:info';
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain

--- a/packages/framework/src/Command/DropDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/DropDatabaseSchemaCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:schema:drop')]
 class DropDatabaseSchemaCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:schema:drop';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade $databaseSchemaFacade
      */

--- a/packages/framework/src/Command/ElFinderInstallerCommand.php
+++ b/packages/framework/src/Command/ElFinderInstallerCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -16,6 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * copy of \FM\ElfinderBundle\Command\ElFinderInstallerCommand and updated to work properly in monorepo
  * replaces default `elfinder:install` command
  */
+#[AsCommand(name: 'elfinder:install')]
 final class ElFinderInstallerCommand extends Command
 {
     private const ELFINDER_CSS_DIR = 'studio-42/elfinder/css';
@@ -25,12 +27,6 @@ final class ElFinderInstallerCommand extends Command
     private const ELFINDER_SOUNDS_DIR = 'studio-42/elfinder/sounds';
 
     private const ELFINDER_IMG_DIR = 'studio-42/elfinder/img';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'elfinder:install';
 
     /**
      * @param \Symfony\Component\Filesystem\Filesystem $filesystem

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchChangedDataExportCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchChangedDataExportCommand.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinition;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:elasticsearch:changed-data-export')]
 class ElasticsearchChangedDataExportCommand extends ElasticsearchDataExportCommand
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:elasticsearch:changed-data-export';
-
     /**
      * {@inheritdoc}
      */

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchDataExportCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchDataExportCommand.php
@@ -11,18 +11,14 @@ use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexExportedEvent;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(name: 'shopsys:elasticsearch:data-export')]
 class ElasticsearchDataExportCommand extends AbstractElasticsearchIndexCommand
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:elasticsearch:data-export';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRegistry $indexRegistry
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade $indexFacade

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesDeleteCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesDeleteCommand.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinition;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:elasticsearch:indexes-delete')]
 class ElasticsearchIndexesDeleteCommand extends AbstractElasticsearchIndexCommand
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:elasticsearch:indexes-delete';
-
     /**
      * {@inheritdoc}
      */

--- a/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesMigrateCommand.php
+++ b/packages/framework/src/Command/Elasticsearch/ElasticsearchIndexesMigrateCommand.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinition;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:elasticsearch:indexes-migrate')]
 class ElasticsearchIndexesMigrateCommand extends AbstractElasticsearchIndexCommand
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:elasticsearch:indexes-migrate';
-
     /**
      * {@inheritdoc}
      */

--- a/packages/framework/src/Command/EntitiesDumpCommand.php
+++ b/packages/framework/src/Command/EntitiesDumpCommand.php
@@ -6,19 +6,15 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use ReflectionClass;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:entities:dump')]
 class EntitiesDumpCommand extends Command
 {
     private const OUTPUT_FILE = 'entities-dump.json';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:entities:dump';
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\ClassExtension\AnnotationsReplacer;
 use Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry;
 use Shopsys\FrameworkBundle\Component\ClassExtension\MethodAnnotationsFactory;
 use Shopsys\FrameworkBundle\Component\ClassExtension\PropertyAnnotationsFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,15 +19,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
 
+#[AsCommand(name: 'shopsys:extended-classes:annotations')]
 class ExtendedClassesAnnotationsCommand extends Command
 {
     protected const DRY_RUN = 'dry-run';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:extended-classes:annotations';
 
     /**
      * {@inheritdoc}

--- a/packages/framework/src/Command/GenerateErrorPagesCommand.php
+++ b/packages/framework/src/Command/GenerateErrorPagesCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:error-page:generate-all')]
 class GenerateErrorPagesCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:error-page:generate-all';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Error\ErrorPagesFacade $errorPagesFacade
      */

--- a/packages/framework/src/Command/GenerateFriendlyUrlCommand.php
+++ b/packages/framework/src/Command/GenerateFriendlyUrlCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlGeneratorFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:generate:friendly-url')]
 class GenerateFriendlyUrlCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:generate:friendly-url';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlGeneratorFacade $friendlyUrlGeneratorFacade
      */

--- a/packages/framework/src/Command/ImportDefaultDatabaseSchemaCommand.php
+++ b/packages/framework/src/Command/ImportDefaultDatabaseSchemaCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:schema:import-default')]
 class ImportDefaultDatabaseSchemaCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:schema:import-default';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade $databaseSchemaFacade
      */

--- a/packages/framework/src/Command/LoadPluginDataFixturesCommand.php
+++ b/packages/framework/src/Command/LoadPluginDataFixturesCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Plugin\PluginDataFixtureFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:plugin-data-fixtures:load')]
 class LoadPluginDataFixturesCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:plugin-data-fixtures:load';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Plugin\PluginDataFixtureFacade $pluginDataFixtureFacade
      */

--- a/packages/framework/src/Command/MaintenanceModeCommand.php
+++ b/packages/framework/src/Command/MaintenanceModeCommand.php
@@ -6,20 +6,16 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeSubscriber;
 use Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'deploy:maintenance')]
 class MaintenanceModeCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'deploy:maintenance';
-
     /**
      * @var string
      */

--- a/packages/framework/src/Command/PhingConfigFixerCommand.php
+++ b/packages/framework/src/Command/PhingConfigFixerCommand.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use RuntimeException;
 use SimpleXMLElement;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -13,16 +14,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:phing-config:fix')]
 class PhingConfigFixerCommand extends Command
 {
     protected const ARG_XML_PATH = 'xml';
     protected const OPTION_ONLY_CHECK = 'check';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:phing-config:fix';
 
     protected function configure(): void
     {

--- a/packages/framework/src/Command/RecalculateCategoryTreeCommand.php
+++ b/packages/framework/src/Command/RecalculateCategoryTreeCommand.php
@@ -5,19 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:categories:recalculate')]
 class RecalculateCategoryTreeCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:categories:recalculate';
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      */

--- a/packages/framework/src/Command/RecalculationsCommand.php
+++ b/packages/framework/src/Command/RecalculationsCommand.php
@@ -10,18 +10,14 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:recalculations')]
 class RecalculationsCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:recalculations';
-
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryVisibilityRepository $categoryVisibilityRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator $productHiddenRecalculator

--- a/packages/framework/src/Command/RedisCleanCacheCommand.php
+++ b/packages/framework/src/Command/RedisCleanCacheCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:redis:clean-cache')]
 class RedisCleanCacheCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:redis:clean-cache';
-
     /**
      * RedisCleanCacheCommand constructor.
      *

--- a/packages/framework/src/Command/RedisCleanCacheOldCommand.php
+++ b/packages/framework/src/Command/RedisCleanCacheOldCommand.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Shopsys\FrameworkBundle\Component\Redis\RedisVersionsFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:redis:clean-cache-old')]
 class RedisCleanCacheOldCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:redis:clean-cache-old';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Redis\RedisVersionsFacade $redisVersionsFacade
      */

--- a/packages/framework/src/Command/ReplaceDomainsUrlsCommand.php
+++ b/packages/framework/src/Command/ReplaceDomainsUrlsCommand.php
@@ -7,18 +7,14 @@ namespace Shopsys\FrameworkBundle\Command;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\DomainUrlReplacer;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:domains-urls:replace')]
 class ReplaceDomainsUrlsCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:domains-urls:replace';
-
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainUrlReplacer $domainUrlReplacer

--- a/packages/framework/src/Command/RouterDebugCommandForDomain.php
+++ b/packages/framework/src/Command/RouterDebugCommandForDomain.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Command;
 use Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler;
 use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
@@ -17,14 +18,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+#[AsCommand(name: 'debug:router')]
 class RouterDebugCommandForDomain extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'debug:router';
-
     /**
      * @var string
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint

--- a/packages/framework/src/Command/RouterMatchCommandForDomain.php
+++ b/packages/framework/src/Command/RouterMatchCommandForDomain.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Command;
 use Shopsys\FrameworkBundle\Component\Console\DomainChoiceHandler;
 use Symfony\Bundle\FrameworkBundle\Command\RouterMatchCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,14 +16,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+#[AsCommand(name: 'router:match')]
 class RouterMatchCommandForDomain extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'router:match';
-
     /**
      * @var string
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint

--- a/packages/framework/src/Command/TranslationReplaceSourceCommand.php
+++ b/packages/framework/src/Command/TranslationReplaceSourceCommand.php
@@ -10,11 +10,13 @@ use RecursiveIteratorIterator;
 use Shopsys\FrameworkBundle\Command\Exception\TranslationReplaceSourceCommandException;
 use Shopsys\FrameworkBundle\Component\Translation\TranslationSourceReplacement;
 use SplFileInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:translation:replace-source')]
 class TranslationReplaceSourceCommand extends Command
 {
     private const ARG_TRANSLATIONS_DIR = 'translationsDir';
@@ -22,12 +24,6 @@ class TranslationReplaceSourceCommand extends Command
     private const ARG_TARGET_LOCALE = 'targetLocale';
 
     private const FILE_NAME_REPLACEMENT_ERRORS = 'replacement_errors.log';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:translation:replace-source';
 
     protected function configure(): void
     {

--- a/packages/framework/src/Command/YamlLintCommand.php
+++ b/packages/framework/src/Command/YamlLintCommand.php
@@ -8,6 +8,7 @@ use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -22,24 +23,14 @@ use Traversable;
 use function count;
 use function in_array;
 
+#[AsCommand(name: 'lint:yaml')]
 class YamlLintCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'lint:yaml';
-
     private ?Parser $parser = null;
 
     private string $format;
 
     private bool $displayCorrectFiles;
-
-    public function __construct()
-    {
-        parent::__construct(self::$defaultName);
-    }
 
     protected function configure(): void
     {

--- a/packages/migrations/src/Command/CheckDatabaseSchemaCommand.php
+++ b/packages/migrations/src/Command/CheckDatabaseSchemaCommand.php
@@ -5,20 +5,16 @@ declare(strict_types=1);
 namespace Shopsys\MigrationBundle\Command;
 
 use Shopsys\MigrationBundle\Component\Doctrine\DatabaseSchemaFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:migrations:check-schema')]
 class CheckDatabaseSchemaCommand extends Command
 {
     protected const RETURN_CODE_OK = 0;
     protected const RETURN_CODE_ERROR = 1;
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:migrations:check-schema';
 
     /**
      * @param \Shopsys\MigrationBundle\Component\Doctrine\DatabaseSchemaFacade $databaseSchemaFacade

--- a/packages/migrations/src/Command/CheckOrmMappingCommand.php
+++ b/packages/migrations/src/Command/CheckOrmMappingCommand.php
@@ -6,20 +6,16 @@ namespace Shopsys\MigrationBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaValidator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:migrations:check-mapping')]
 class CheckOrmMappingCommand extends Command
 {
     protected const RETURN_CODE_OK = 0;
     protected const RETURN_CODE_ERROR = 1;
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:migrations:check-mapping';
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em

--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -10,21 +10,17 @@ use Shopsys\MigrationBundle\Command\Exception\NoMigrationLocationException;
 use Shopsys\MigrationBundle\Component\Doctrine\DatabaseSchemaFacade;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\MigrationsLocation;
 use Shopsys\MigrationBundle\Component\Generator\MigrationsGenerator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:migrations:generate')]
 class GenerateMigrationCommand extends Command
 {
     protected const RETURN_CODE_OK = 0;
     protected const RETURN_CODE_ERROR = 1;
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:migrations:generate';
 
     protected Configuration $configuration;
 

--- a/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
+++ b/packages/migrations/src/Command/GetCountOfMigrationsToExecuteCommand.php
@@ -7,20 +7,16 @@ namespace Shopsys\MigrationBundle\Command;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Version\AliasResolver;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\MigrationLockPlanCalculator;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:migrations:count')]
 class GetCountOfMigrationsToExecuteCommand extends Command
 {
     protected const OPTION_SIMPLE = 'simple';
-
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:migrations:count';
 
     protected AliasResolver $aliasResolver;
 

--- a/packages/migrations/src/Command/MigrateCommand.php
+++ b/packages/migrations/src/Command/MigrateCommand.php
@@ -10,19 +10,15 @@ use Shopsys\MigrationBundle\Command\Exception\CheckSchemaCommandException;
 use Shopsys\MigrationBundle\Command\Exception\MigrateCommandException;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\MigrationLockPlanCalculator;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\MigrationsLock;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:migrations:migrate')]
 class MigrateCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     */
-    protected static $defaultName = 'shopsys:migrations:migrate';
-
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\MigrationBundle\Component\Doctrine\Migrations\MigrationsLock $migrationsLock

--- a/project-base/app/src/Command/CheckUnusedFriendlyUrlRouteNameListCommand.php
+++ b/project-base/app/src/Command/CheckUnusedFriendlyUrlRouteNameListCommand.php
@@ -6,19 +6,15 @@ namespace App\Command;
 
 use App\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use App\Component\Router\FriendlyUrl\FriendlyUrlRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:friendly-urls:check-entity-mapping')]
 class CheckUnusedFriendlyUrlRouteNameListCommand extends Command
 {
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     * @var string
-     */
-    protected static $defaultName = 'shopsys:friendly-urls:check-entity-mapping';
-
     /**
      * @param \App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      */

--- a/project-base/app/src/Command/CleanStorefrontQueryCacheCommand.php
+++ b/project-base/app/src/Command/CleanStorefrontQueryCacheCommand.php
@@ -5,20 +5,16 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Component\Redis\CleanStorefrontCacheFacade;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(name: 'shopsys:redis:clean-storefront-cache')]
 class CleanStorefrontQueryCacheCommand extends Command
 {
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     * @var string
-     */
-    protected static $defaultName = 'shopsys:redis:clean-storefront-cache';
-
     /**
      * @param \App\Component\Redis\CleanStorefrontCacheFacade $cleanStorefrontCacheFacade
      */

--- a/project-base/app/src/Command/ImportPoFilesCommand.php
+++ b/project-base/app/src/Command/ImportPoFilesCommand.php
@@ -10,12 +10,14 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Translation\PoDumper;
 use Shopsys\FrameworkBundle\Component\Translation\PoFileLoader;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(name: 'translation:import')]
 class ImportPoFilesCommand extends Command
 {
     public const SOURCE_TRANSLATION_DIR = 'sourceTranslationDir';
@@ -24,12 +26,6 @@ class ImportPoFilesCommand extends Command
     public const TYPE = 'po';
 
     private SymfonyLoaderAdapter $fileLoader;
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     * @var string
-     */
-    protected static $defaultName = 'translation:import';
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Translation\PoFileLoader $fileLoader

--- a/project-base/app/src/Command/PerformanceDataCommand.php
+++ b/project-base/app/src/Command/PerformanceDataCommand.php
@@ -8,19 +8,14 @@ use App\DataFixtures\Performance\CategoryDataFixture;
 use App\DataFixtures\Performance\CustomerUserDataFixture;
 use App\DataFixtures\Performance\OrderDataFixture;
 use App\DataFixtures\Performance\ProductDataFixture;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:performance-data')]
 class PerformanceDataCommand extends Command
 {
-    /**
-     * @var string
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnlySniff.ReferenceViaFullyQualifiedName
-     */
-    protected static $defaultName = 'shopsys:performance-data';
-
     /**
      * @param \App\DataFixtures\Performance\CategoryDataFixture $categoryDataFixture
      * @param \App\DataFixtures\Performance\ProductDataFixture $productDataFixture

--- a/project-base/app/src/Command/ReplaceCdnDomainUrlCommand.php
+++ b/project-base/app/src/Command/ReplaceCdnDomainUrlCommand.php
@@ -6,18 +6,14 @@ namespace App\Command;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\DomainUrlReplacer;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'shopsys:cdn-domain-url:replace')]
 class ReplaceCdnDomainUrlCommand extends Command
 {
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
-     * @var string
-     */
-    protected static $defaultName = 'shopsys:cdn-domain-url:replace';
-
     /**
      * @param string $cdnDomainUrl
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| set the command default name via the `$defaultName` is deprecated since Symfony 6.1. The recommended way to set the command name is with attribute. This PR changes all commands to the new way.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-commands-name.odin.shopsys.cloud
  - https://cz.mg-commands-name.odin.shopsys.cloud
<!-- Replace -->
