### PR TITLE
[github-actions] run review job is now killed after 10 minutes

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -691,6 +691,7 @@ jobs:
             (needs.build-storefront-image.result == 'success' || needs.build-storefront-image.result == 'skipped') &&
             (needs.build-elasticsearch-image.result == 'success' || needs.build-elasticsearch-image.result == 'skipped')
         runs-on: [self-hosted, linux, review-stage]
+        timeout-minutes: 10
         env:
             BRANCH_NAME: ${{ needs.variables.outputs.BRANCH_NAME }}
             BRANCH_NAME_ESCAPED: ${{ needs.variables.outputs.BRANCH_NAME_ESCAPED }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Sometimes the start review job is running several hours without a reason. This PR kills such jobs after 10 minutes to not block the queue.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://grossmannmartin-patch-1.odin.shopsys.cloud
  - https://cz.grossmannmartin-patch-1.odin.shopsys.cloud
<!-- Replace -->
