### PR TITLE
[framework] RedisClientFacade::contains() now throws exception when Redis is in multimode

### DIFF
--- a/packages/framework/src/Component/Redis/Exception/RedisMultiModeNotSupportedException.php
+++ b/packages/framework/src/Component/Redis/Exception/RedisMultiModeNotSupportedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Redis\Exception;
+
+use Exception;
+
+class RedisMultiModeNotSupportedException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Using Redis in multi mode is not supported.');
+    }
+}

--- a/packages/framework/src/Component/Redis/RedisClientFacade.php
+++ b/packages/framework/src/Component/Redis/RedisClientFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\Redis;
 
 use Redis;
+use Shopsys\FrameworkBundle\Component\Redis\Exception\RedisMultiModeNotSupportedException;
 
 class RedisClientFacade
 {
@@ -32,6 +33,10 @@ class RedisClientFacade
     public function contains(string $key): bool
     {
         $exists = $this->redisClient->exists($key);
+
+        if ($exists instanceof Redis) {
+            throw new RedisMultiModeNotSupportedException();
+        }
 
         if (is_bool($exists)) {
             return $exists;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Phpstan check was failing (see e.g. https://github.com/shopsys/shopsys/actions/runs/6769274639/job/18395527766) - `Redis::exists` returns an instance of `Redis` when in multimode (https://redis.io/commands/multi/) which was not taken into account
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-phpstan-fix.odin.shopsys.cloud
  - https://cz.rv-phpstan-fix.odin.shopsys.cloud
<!-- Replace -->
