### PR TITLE
[SSP-1902] removed error logging for GTM safe push

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -213,3 +213,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   it was replaced with general H tags and styles were put into globals.css, styles were also included with new classes (`h1`, `h2`, `h3`, `h4`) which we can use to style text which suppose to look like heading but it is not important enough for mark with H tag
     -   also from those headings and heading classes was remove margin bottom since spacing should be set in exact place where this component is used, not everywhere
     -   see #project-base-diff to update your project
+-   remove error logging for when gtmSafePush is called outside of the client ([#2920](https://github.com/shopsys/shopsys/pull/2920))
+    -   logging this type of error brought no business value, thus it was removed
+    -   if you want to treat this ignorable event in a more strict way, you might want to keep the logging, but then you have to improve its behavior yourself
+    -   see #project-base-diff to update your project

--- a/docs/storefront/gtm/intro.md
+++ b/docs/storefront/gtm/intro.md
@@ -160,8 +160,6 @@ export const gtmSafePushEvent = (event: GtmEventInterface<GtmEventType, unknown>
     if (isClient) {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push(event);
-    } else {
-        logException(new Error('Tried to use GTM safe push without available window. Please, fix this behavior.'));
     }
 };
 ```

--- a/project-base/storefront/gtm/helpers/gtm.ts
+++ b/project-base/storefront/gtm/helpers/gtm.ts
@@ -30,7 +30,6 @@ import {
     GtmUserInfoType,
 } from 'gtm/types/objects';
 import { DomainConfigType } from 'helpers/domain/domainConfig';
-import { logException } from 'helpers/errors/logException';
 import { getInternationalizedStaticUrls } from 'helpers/getInternationalizedStaticUrls';
 import { isClient } from 'helpers/isClient';
 import { getStringWithoutLeadingSlash } from 'helpers/parsing/stringWIthoutSlash';
@@ -195,8 +194,6 @@ export const gtmSafePushEvent = (event: GtmEventInterface<GtmEventType, unknown>
     if (isClient) {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push(event);
-    } else {
-        logException(new Error('Tried to use GTM safe push without available window. Please, fix this behavior.'));
     }
 };
 


### PR DESCRIPTION
- logging this type of error brought no business value and thus it was removed

| Q             | A
| ------------- | ---
|Description, reason for the PR| Logging the fact that gtmSafePushEvent was called outside of the client into Sentry as an error brought no business value. Because of that it was removed.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-1902-remove-gtmsafepush-error-log.odin.shopsys.cloud
  - https://cz.sh-ssp-1902-remove-gtmsafepush-error-log.odin.shopsys.cloud
<!-- Replace -->
