### PR TITLE
upgrade Node.js and PNPM

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -208,6 +208,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   method `Shopsys\FrameworkBundle\Model\Feed\FeedRegistry::getAllFeeds()` has been replaced with method `Shopsys\FrameworkBundle\Model\Feed\FeedRegistry::getAllFeedConfigs()`
     -   method `Shopsys\FrameworkBundle\Model\Feed\FeedRegistry::getFeedByName()` has been replaced with method `Shopsys\FrameworkBundle\Model\Feed\FeedRegistry::getFeedConfigByName()`
     -   method `Shopsys\FrameworkBundle\Model\Feed\FeedRegistry::assertTypeIsKnown()` has been removed without a replacement
+-   upgrade Storefront docker image ([#2931](https://github.com/shopsys/shopsys/pull/2931))
+    -   now we use Node.js version 20-alpine3.17 and PNPM version 8.10.5
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/open-source-license-acknowledgements-and-third-party-copyrights.md
+++ b/open-source-license-acknowledgements-and-third-party-copyrights.md
@@ -516,7 +516,7 @@ https://github.com/elastic/kibana/blob/v7.6.0/LICENSE.txt
 
 ### Node
 
-Image: `node:18.15.0-alpine`  
+Image: `node:20-alpine3.17`  
 License: MIT  
 https://github.com/nodejs/docker-node/blob/main/LICENSE
 

--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -74,14 +74,14 @@ test:standards-with-graphql-schema-check:
 test:storefront-standards-with-codegen:
     stage: test
     <<: *only-default
-    image: node:18.15.0-alpine
+    image: node:20-alpine3.17
     tags:
         - tests
     needs:
         - build-storefront
     before_script:
         - corepack enable
-        - corepack prepare --activate pnpm@8.6.0
+        - corepack prepare --activate pnpm@8.10.5
         - pnpm config set store-dir .pnpm-store
         - apk add --no-cache grep
         - cp ./app/schema.graphql ./storefront/schema.graphql

--- a/project-base/storefront/docker/Dockerfile
+++ b/project-base/storefront/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18.15.0-alpine AS base
+FROM node:20-alpine3.17 AS base
 
 RUN corepack enable
-RUN corepack prepare --activate pnpm@8.6.7
+RUN corepack prepare --activate pnpm@8.10.5
 
 FROM base as dependencies
 

--- a/project-base/storefront/docker/ci.Dockerfile
+++ b/project-base/storefront/docker/ci.Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18.15.0-alpine as development
+FROM node:20-alpine3.17 as development
 
 RUN corepack enable
-RUN corepack prepare --activate pnpm@8.6.7
+RUN corepack prepare --activate pnpm@8.10.5
 
 ARG APP_DIR=/home/node/app
 WORKDIR $APP_DIR

--- a/project-base/storefront/docker/dev.Dockerfile
+++ b/project-base/storefront/docker/dev.Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18.15.0-alpine as development
+FROM node:20-alpine3.17 as development
 
 RUN corepack enable
-RUN corepack prepare --activate pnpm@8.6.7
+RUN corepack prepare --activate pnpm@8.10.5
 
 ARG HOME_DIR=/home/node
 ARG APP_DIR=$HOME_DIR/app

--- a/utils/license-acknowledgements-generator/template.md
+++ b/utils/license-acknowledgements-generator/template.md
@@ -70,7 +70,7 @@ License: Apache License 2.0
 https://github.com/elastic/kibana/blob/v7.6.0/LICENSE.txt
 
 ### Node
-Image: `node:18.15.0-alpine`  
+Image: `node:20-alpine3.17`  
 License: MIT  
 https://github.com/nodejs/docker-node/blob/main/LICENSE
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| upgrade Node.js (version 20-alpine3.17) and PNPM (version 8.10.5)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-ssp-1950-upgrade-nodejs-and-pnpm.odin.shopsys.cloud
  - https://cz.tv-ssp-1950-upgrade-nodejs-and-pnpm.odin.shopsys.cloud
<!-- Replace -->
