### PR TITLE
[releaser] UpdateUpgradeReleaseWorker: update instructions

### DIFF
--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/UpdateUpgradeReleaseWorker.php
@@ -55,6 +55,7 @@ final class UpdateUpgradeReleaseWorker extends AbstractShopsysReleaseWorker
             - check whether there are no duplicated instructions for modifying docker related files,
             - check links whether they point to the repository in the "%s" version
             - make sure, that every subsection of UPGRADE notes has link to correct pull request
+            - check "see #project-base-diff to update your project" is added to the all the upgrade notes and add the line where it is missing (at least to all the Storefront entries)
             - replace all occurrences of #project-base-diff with link to project-base commit of the change
                 - you can find the commit hashes quickly by executing following on the project-base repository:
                   git log --oneline --format="%%H %%s" | grep -E \'\(#\d+\)$\'',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR|  "see #project-base-diff..." needs to be added for every storefront upgrade note so we decided to do that only once - during the release
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-releaser.odin.shopsys.cloud
  - https://cz.rv-releaser.odin.shopsys.cloud
<!-- Replace -->
