### PR TITLE
[framework] change monolog error context key for cron error messages

### DIFF
--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -97,7 +97,7 @@ class CronFacade
         } catch (Throwable $throwable) {
             $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
             $this->logger->error('End of ' . $cronModuleConfig->getServiceId() . ' because of error', [
-                'throwable' => $throwable,
+                'exception' => $throwable,
             ]);
 
             throw $throwable;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Log exception within cron error message to Sentry.  
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-sentry-exception.odin.shopsys.cloud
  - https://cz.mt-sentry-exception.odin.shopsys.cloud
<!-- Replace -->
