### PR TITLE
[framework] annotation fixer: get property type from typehint when the annotation is missing

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -254,6 +254,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   if you used the backend API, you need to implement it by yourself
     -   `Shopsys\FrameworkBundle\Model\Product\ProductFacade::findByProductQueryParams()` method has been removed
     -   `Shopsys\FrameworkBundle\Model\Product\ProductRepository::findByProductQueryParams()` method has been removed
+-   annotation fixer: get property type from typehint when the annotation is missing ([#2934](https://github.com/shopsys/shopsys/pull/2934))
+    -   run `php phing annotations-fix` in `php-fpm` container to fix the annotations
 
 ### Storefront
 

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacer.php
@@ -58,6 +58,10 @@ class AnnotationsReplacer
         $type = $this->docBlockParser->getPropertyType($reflectionProperty);
 
         if ($type === null) {
+            $type = TypehintHelper::getPropertyTypeFromTypehint($reflectionProperty);
+        }
+
+        if ($type === null) {
             return '';
         }
 

--- a/packages/framework/src/Component/ClassExtension/PropertyAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/PropertyAnnotationsFactory.php
@@ -102,9 +102,11 @@ class PropertyAnnotationsFactory
         ReflectionProperty $reflectionProperty,
         string $frameworkClassPattern,
     ): bool {
+        $propertyTypeString = $reflectionProperty->getDocComment() !== '' ? $reflectionProperty->getDocComment() : TypehintHelper::getPropertyTypeFromTypehint($reflectionProperty);
+
         return (bool)preg_match(
             $frameworkClassPattern,
-            $reflectionProperty->getDocComment(),
+            $propertyTypeString ?? '',
         );
     }
 }

--- a/packages/framework/src/Component/ClassExtension/TypehintHelper.php
+++ b/packages/framework/src/Component/ClassExtension/TypehintHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\ClassExtension;
+
+use Roave\BetterReflection\Reflection\ReflectionNamedType;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
+
+class TypehintHelper
+{
+    /**
+     * @param \Roave\BetterReflection\Reflection\ReflectionProperty $reflectionProperty
+     * @return string|null
+     */
+    public static function getPropertyTypeFromTypehint(ReflectionProperty $reflectionProperty): ?string
+    {
+        $type = $reflectionProperty->getType();
+
+        if (($type instanceof ReflectionNamedType) === false) {
+            return null;
+        }
+
+        return '\\' . $type->getName();
+    }
+}

--- a/packages/framework/tests/Unit/Component/ClassExtension/PropertyAnnotationsFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/PropertyAnnotationsFactoryTest.php
@@ -92,5 +92,9 @@ class PropertyAnnotationsFactoryTest extends TestCase
             '@property \App\Model\Category\CategoryFacade $categoryFacade',
             $annotationLines,
         );
+        $this->assertStringContainsString(
+            '@property \Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\ChildClass $class',
+            $annotationLines,
+        );
     }
 }

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass4.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/PropertyAnnotationsFactoryTest/BaseClass4.php
@@ -12,4 +12,14 @@ class BaseClass4
      * @var \Shopsys\FrameworkBundle\Model\Category\CategoryFacade
      */
     public $categoryFacade;
+
+    /**
+     * This property defined using constructor property promotion is of a type that is registered in the class extension map and hence the "@property" annotation must be added to the child class
+     *
+     * @param \Tests\FrameworkBundle\Unit\Component\ClassExtension\Source\PropertyAnnotationsFactoryTest\BaseClass $class
+     */
+    public function __construct(
+        protected readonly BaseClass $class,
+    ) {
+    }
 }

--- a/project-base/app/src/Controller/Admin/CustomerController.php
+++ b/project-base/app/src/Controller/Admin/CustomerController.php
@@ -24,6 +24,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @method __construct(\App\Model\Customer\User\CustomerUserDataFactory $customerUserDataFactory, \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserListAdminFacade $customerUserListAdminFacade, \App\Model\Customer\User\CustomerUserFacade $customerUserFacade, \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider, \Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade $administratorGridFacade, \Shopsys\FrameworkBundle\Component\Grid\GridFactory $gridFactory, \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade, \App\Model\Order\OrderFacade $orderFacade, \App\Model\Security\LoginAsUserFacade $loginAsUserFacade, \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory, \App\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain)
  * @method string getSsoLoginAsCustomerUserUrl(\App\Model\Customer\User\CustomerUser $customerUser)
  * @property \App\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory
+ * @property \App\Model\Customer\User\CustomerUserFacade $customerUserFacade
  */
 class CustomerController extends BaseCustomerController
 {

--- a/project-base/app/src/FrontendApi/Model/Component/Constraints/AppPaymentTransportRelationValidator.php
+++ b/project-base/app/src/FrontendApi/Model/Component/Constraints/AppPaymentTransportRelationValidator.php
@@ -17,6 +17,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * The class need the prefix because of the conflicting name in GraphQL generated classes
  *
  * @see https://github.com/overblog/GraphQLBundle/issues/863
+ * @property \App\Model\Payment\PaymentFacade $paymentFacade
+ * @property \App\Model\Transport\TransportFacade $transportFacade
  */
 class AppPaymentTransportRelationValidator extends PaymentTransportRelationValidator
 {

--- a/project-base/app/src/FrontendApi/Model/Image/ImageFacade.php
+++ b/project-base/app/src/FrontendApi/Model/Image/ImageFacade.php
@@ -10,6 +10,7 @@ use Shopsys\FrontendApiBundle\Component\Image\ImageFacade as BaseImageFacade;
 
 /**
  * @method \App\Component\Image\Image[] getImagesByEntityIdAndNameIndexedById(int $entityId, string $entityName, string|null $type)
+ * @property \App\Component\Image\ImageRepository $imageRepository
  */
 class ImageFacade extends BaseImageFacade
 {

--- a/project-base/app/src/FrontendApi/Model/Order/OrderApiFacade.php
+++ b/project-base/app/src/FrontendApi/Model/Order/OrderApiFacade.php
@@ -18,6 +18,7 @@ use Shopsys\FrontendApiBundle\Model\Order\OrderRepository;
  * @method int getCustomerUserOrderCount(\App\Model\Customer\User\CustomerUser $customerUser)
  * @method \App\Model\Order\Order getByUuidAndCustomerUser(string $uuid, \App\Model\Customer\User\CustomerUser $customerUser)
  * @method \App\Model\Order\Order getByUuid(string $orderUuid)
+ * @property \App\Model\Order\OrderFacade $orderFacade
  */
 class OrderApiFacade extends BaseOrderApiFacade
 {

--- a/project-base/app/src/FrontendApi/Model/Order/PlaceOrderFacade.php
+++ b/project-base/app/src/FrontendApi/Model/Order/PlaceOrderFacade.php
@@ -29,6 +29,7 @@ use Shopsys\FrontendApiBundle\Model\Order\PlaceOrderFacade as BasePlaceOrderFaca
  * @property \App\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory
  * @method \Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreview createOrderPreview(\Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct[] $quantifiedProducts, \App\Model\Transport\Transport|null $transport, \App\Model\Payment\Payment|null $payment, \App\Model\Customer\User\CustomerUser|null $customerUser)
  * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+ * @property \App\Model\Customer\User\CustomerUserFacade $customerUserFacade
  */
 class PlaceOrderFacade extends BasePlaceOrderFacade
 {

--- a/project-base/app/src/FrontendApi/Mutation/Login/RefreshTokensMutation.php
+++ b/project-base/app/src/FrontendApi/Mutation/Login/RefreshTokensMutation.php
@@ -15,6 +15,7 @@ use Shopsys\FrontendApiBundle\Model\User\FrontendApiUser;
  * @property \App\Model\Customer\User\CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade
  * @property \App\FrontendApi\Model\Token\TokenFacade $tokenFacade
  * @method __construct(\App\FrontendApi\Model\Token\TokenFacade $tokenFacade, \App\Model\Customer\User\CustomerUserFacade $customerUserFacade, \App\Model\Customer\User\CustomerUserRefreshTokenChainFacade $customerUserRefreshTokenChainFacade)
+ * @property \App\Model\Customer\User\CustomerUserFacade $customerUserFacade
  */
 class RefreshTokensMutation extends BaseRefreshTokensMutation
 {

--- a/project-base/app/src/FrontendApi/Resolver/Article/ArticleQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Article/ArticleQuery.php
@@ -18,6 +18,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Article\Exception\ArticleNotFoundUs
  * @method \App\Model\Article\Article articleByUuidOrUrlSlugQuery(string|null $uuid = null, string|null $urlSlug = null)
  * @method \App\Model\Article\Article getVisibleByDomainIdAndUuid(string $uuid)
  * @method \App\Model\Article\Article getVisibleByDomainIdAndSlug(string $urlSlug)
+ * @property \App\Model\LegalConditions\LegalConditionsFacade $legalConditionsFacade
  */
 class ArticleQuery extends AbstractQuery
 {

--- a/project-base/app/src/FrontendApi/Resolver/Category/CategoriesQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Category/CategoriesQuery.php
@@ -8,6 +8,9 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrontendApiBundle\Model\Resolver\Category\CategoriesQuery as BaseCategoriesQuery;
 
+/**
+ * @property \App\Model\Category\CategoryFacade $categoryFacade
+ */
 class CategoriesQuery extends BaseCategoriesQuery
 {
     /**
@@ -32,7 +35,7 @@ class CategoriesQuery extends BaseCategoriesQuery
         /** @var \App\Model\Category\Category $rootCategory */
         $rootCategory = $this->categoryFacade->getRootCategory();
 
-        return $this->categoryFacade->getAllVisibleChildrenByCategoryAndDomainConfig( // @phpstan-ignore-line
+        return $this->categoryFacade->getAllVisibleChildrenByCategoryAndDomainConfig(
             $rootCategory,
             $this->domain->getCurrentDomainConfig(),
         );

--- a/project-base/app/src/FrontendApi/Resolver/Customer/User/CurrentCustomerUserQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Customer/User/CurrentCustomerUserQuery.php
@@ -10,6 +10,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Customer\User\CurrentCustomerUserQu
 /**
  * @method __construct(\App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser)
  * @method \App\Model\Customer\User\CustomerUser currentCustomerUserQuery()
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  */
 class CurrentCustomerUserQuery extends BaseCurrentCustomerUserQuery
 {

--- a/project-base/app/src/FrontendApi/Resolver/Order/OrderQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Order/OrderQuery.php
@@ -15,6 +15,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Order\OrderQuery as BaseOrderQuery;
  * @property \App\Model\Order\OrderFacade $orderFacade
  * @method __construct(\App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser, \App\Model\Order\OrderFacade $orderFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\FrontendApi\Model\Order\OrderApiFacade $orderApiFacade)
  * @method \App\Model\Order\Order getOrderForCustomerUserByUuid(\App\Model\Customer\User\CustomerUser $customerUser, string $uuid)
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  */
 class OrderQuery extends BaseOrderQuery
 {

--- a/project-base/app/src/FrontendApi/Resolver/Order/OrdersQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Order/OrdersQuery.php
@@ -10,6 +10,10 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrontendApiBundle\Model\Order\OrderApiFacade;
 use Shopsys\FrontendApiBundle\Model\Resolver\Order\OrdersQuery as BaseOrdersQuery;
 
+/**
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+ * @property \App\FrontendApi\Model\Order\OrderApiFacade $orderApiFacade
+ */
 class OrdersQuery extends BaseOrdersQuery
 {
     /**

--- a/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductArrayFieldMapper.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductArrayFieldMapper.php
@@ -23,6 +23,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\DataMapper\ProductArrayFie
  * @method \App\Model\Category\Category[] getCategories(array $data)
  * @method \App\Model\Product\Flag\Flag[] getFlags(array $data)
  * @method \App\Model\Product\Brand\Brand|null getBrand(array $data)
+ * @property \App\Model\Product\ProductElasticsearchProvider $productElasticsearchProvider
  */
 class ProductArrayFieldMapper extends BaseProductArrayFieldMapper
 {

--- a/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
@@ -37,6 +37,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\DataMapper\ProductEntityFi
  * @method string|null getSeoH1(\App\Model\Product\Product $product)
  * @method string|null getSeoTitle(\App\Model\Product\Product $product)
  * @method string|null getSeoMetaDescription(\App\Model\Product\Product $product)
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  */
 class ProductEntityFieldMapper extends BaseProductEntityFieldMapper
 {

--- a/project-base/app/src/FrontendApi/Resolver/Products/ProductResolverMap.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/ProductResolverMap.php
@@ -15,12 +15,12 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\ProductResolverMap as Base
 /**
  * @property \App\Model\Product\Flag\FlagFacade $flagFacade
  * @property \App\Model\Category\CategoryFacade $categoryFacade
- * @property \App\FrontendApi\Resolver\Products\DataMapper\ProductArrayFieldMapper|null $productArrayFieldMapper
+ * @property \App\FrontendApi\Resolver\Products\DataMapper\ProductArrayFieldMapper $productArrayFieldMapper
  * @method __construct(\App\FrontendApi\Resolver\Products\DataMapper\ProductEntityFieldMapper $productEntityFieldMapper, \App\FrontendApi\Resolver\Products\DataMapper\ProductArrayFieldMapper $productArrayFieldMapper)
  * @method setProductArrayFieldMapper(\App\FrontendApi\Resolver\Products\DataMapper\ProductArrayFieldMapper $productArrayFieldMapper)
  * @method \App\Model\Product\Flag\Flag[] getFlagsForData(\App\Model\Product\Product|array $data)
  * @method \App\Model\Category\Category[] getCategoriesForData(array $data)
- * @property \App\FrontendApi\Resolver\Products\DataMapper\ProductEntityFieldMapper|null $productEntityFieldMapper
+ * @property \App\FrontendApi\Resolver\Products\DataMapper\ProductEntityFieldMapper $productEntityFieldMapper
  * @method setProductEntityFieldMapper(\App\FrontendApi\Resolver\Products\DataMapper\ProductEntityFieldMapper $productEntityFieldMapper)
  */
 class ProductResolverMap extends BaseProductResolverMap

--- a/project-base/app/src/FrontendApi/Resolver/Products/ProductsQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/ProductsQuery.php
@@ -34,9 +34,9 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\ProductsQuery as BaseProdu
 
 /**
  * @property \App\Model\Product\ProductOnCurrentDomainElasticFacade $productOnCurrentDomainFacade
- * @property \App\FrontendApi\Model\Product\ProductFacade|null $productFacade
- * @property \App\FrontendApi\Model\Product\Filter\ProductFilterFacade|null $productFilterFacade
- * @property \App\FrontendApi\Model\Product\Connection\ProductConnectionFactory|null $productConnectionFactory
+ * @property \App\FrontendApi\Model\Product\ProductFacade $productFacade
+ * @property \App\FrontendApi\Model\Product\Filter\ProductFilterFacade $productFilterFacade
+ * @property \App\FrontendApi\Model\Product\Connection\ProductConnectionFactory $productConnectionFactory
  * @method setProductFacade(\App\FrontendApi\Model\Product\ProductFacade $productFacade)
  * @method setProductFilterFacade(\App\FrontendApi\Model\Product\Filter\ProductFilterFacade $productFilterFacade)
  * @method setProductConnectionFactory(\App\FrontendApi\Model\Product\Connection\ProductConnectionFactory $productConnectionFactory)

--- a/project-base/app/src/FrontendApi/Resolver/Products/PromotedProductsQuery.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/PromotedProductsQuery.php
@@ -13,6 +13,7 @@ use Shopsys\FrontendApiBundle\Model\Resolver\Products\PromotedProductsQuery as B
 
 /**
  * @property \Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade $topProductFacade
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  */
 class PromotedProductsQuery extends BasePromotedProductsQuery
 {

--- a/project-base/app/src/Model/Advert/AdvertFacade.php
+++ b/project-base/app/src/Model/Advert/AdvertFacade.php
@@ -12,6 +12,9 @@ use Shopsys\FrameworkBundle\Model\Advert\AdvertFacade as BaseAdvertFacade;
  * @method \App\Model\Advert\Advert|null findRandomAdvertByPositionOnCurrentDomain(string $positionName, \App\Model\Category\Category|null $category = null)
  * @method \App\Model\Advert\Advert create(\App\Model\Advert\AdvertData $advertData)
  * @method \App\Model\Advert\Advert edit(int $advertId, \App\Model\Advert\AdvertData $advertData)
+ * @property \App\Model\Advert\AdvertRepository $advertRepository
+ * @property \App\Component\Image\ImageFacade $imageFacade
+ * @property \App\Model\Advert\AdvertPositionRegistry $advertPositionRegistry
  */
 class AdvertFacade extends BaseAdvertFacade
 {

--- a/project-base/app/src/Model/Article/ArticleDataFactory.php
+++ b/project-base/app/src/Model/Article/ArticleDataFactory.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Article\ArticleDataFactory as BaseArticleDataF
 /**
  * @method fillNew(\App\Model\Article\ArticleData $articleData)
  * @method __construct(\App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade)
+ * @property \App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
  */
 class ArticleDataFactory extends BaseArticleDataFactory
 {

--- a/project-base/app/src/Model/Cart/Watcher/CartWatcherFacade.php
+++ b/project-base/app/src/Model/Cart/Watcher/CartWatcherFacade.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcherFacade as BaseCartWatc
  * however, we are not able to get rid of it completely because it is required in Shopsys\FrameworkBundle\Model\Cart\CartFacade
  * @see \App\FrontendApi\Model\Cart\CartWatcherFacade
  * @see https://github.com/shopsys/shopsys/pull/2497
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  */
 class CartWatcherFacade extends BaseCartWatcherFacade
 {

--- a/project-base/app/src/Model/Category/CategoryDataFactory.php
+++ b/project-base/app/src/Model/Category/CategoryDataFactory.php
@@ -14,6 +14,9 @@ use Shopsys\FrameworkBundle\Model\Category\Category as BaseCategory;
 use Shopsys\FrameworkBundle\Model\Category\CategoryData as BaseCategoryData;
 use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactory as BaseCategoryDataFactory;
 
+/**
+ * @property \App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
+ */
 class CategoryDataFactory extends BaseCategoryDataFactory
 {
     /**

--- a/project-base/app/src/Model/Customer/User/CurrentCustomerUser.php
+++ b/project-base/app/src/Model/Customer/User/CurrentCustomerUser.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser as BaseCurre
  * @property \App\Model\Customer\User\CustomerUser[] $customerUserCache
  * @method \App\Model\Customer\User\CustomerUser|null findCurrentCustomerUser()
  * @method __construct(\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupSettingFacade $pricingGroupSettingFacade, \App\Model\Customer\User\CustomerUserFacade $customerUserFacade)
+ * @property \App\Model\Customer\User\CustomerUserFacade $customerUserFacade
  */
 class CurrentCustomerUser extends BaseCurrentCustomerUser
 {

--- a/project-base/app/src/Model/Customer/User/CustomerUserFacade.php
+++ b/project-base/app/src/Model/Customer/User/CustomerUserFacade.php
@@ -39,6 +39,10 @@ use Shopsys\FrameworkBundle\Model\Newsletter\NewsletterFacade;
  * @method amendCustomerUserDataFromOrder(\App\Model\Customer\User\CustomerUser $customerUser, \App\Model\Order\Order $order, \App\Model\Customer\DeliveryAddress|null $deliveryAddress)
  * @method setEmail(string $email, \App\Model\Customer\User\CustomerUser $customerUser)
  * @method \Shopsys\FrameworkBundle\Model\Customer\Customer createCustomerWithBillingAddress(int $domainId, \App\Model\Customer\BillingAddressData $billingAddressData)
+ * @property \App\Model\Customer\User\CustomerUserUpdateDataFactory $customerUserUpdateDataFactory
+ * @property \App\Model\Customer\BillingAddressDataFactory $billingAddressDataFactory
+ * @property \App\Model\Customer\User\CustomerUserPasswordFacade $customerUserPasswordFacade
+ * @property \App\Model\Customer\DeliveryAddressFacade $deliveryAddressFacade
  */
 class CustomerUserFacade extends BaseCustomerUserFacade
 {

--- a/project-base/app/src/Model/Customer/User/CustomerUserIdentifierFactory.php
+++ b/project-base/app/src/Model/Customer/User/CustomerUserIdentifierFactory.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifierFactory as
 
 /**
  * @method __construct(\App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser, \Symfony\Component\HttpFoundation\RequestStack $requestStack)
+ * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  */
 class CustomerUserIdentifierFactory extends BaseCustomerUserIdentifierFactory
 {

--- a/project-base/app/src/Model/Feed/FeedFacade.php
+++ b/project-base/app/src/Model/Feed/FeedFacade.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\Feed\FeedFacade as BaseFeedFacade;
 /**
  * @property \App\Model\Feed\FeedExportFactory $feedExportFactory
  * @method __construct(\Shopsys\FrameworkBundle\Model\Feed\FeedRegistry $feedRegistry, \App\Model\Product\ProductVisibilityFacade $productVisibilityFacade, \App\Model\Feed\FeedExportFactory $feedExportFactory, \Shopsys\FrameworkBundle\Model\Feed\FeedPathProvider $feedPathProvider, \League\Flysystem\FilesystemOperator $filesystem, \Shopsys\FrameworkBundle\Model\Feed\FeedModuleRepository $feedModuleRepository, \Doctrine\ORM\EntityManagerInterface $em)
+ * @property \App\Model\Product\ProductVisibilityFacade $productVisibilityFacade
  */
 class FeedFacade extends BaseFeedFacade
 {

--- a/project-base/app/src/Model/Mail/MailTemplateFacade.php
+++ b/project-base/app/src/Model/Mail/MailTemplateFacade.php
@@ -22,6 +22,7 @@ use Shopsys\FrameworkBundle\Model\Mail\MailTemplateRepository;
  * @property \App\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
  * @method \App\Model\Mail\MailTemplate getById(int $id)
  * @method \App\Model\Mail\MailTemplate edit(int $id, \App\Model\Mail\MailTemplateData $mailTemplateData)
+ * @property \App\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory
  */
 class MailTemplateFacade extends BaseMailTemplateFacade
 {

--- a/project-base/app/src/Model/Product/Availability/ProductAvailabilityCalculation.php
+++ b/project-base/app/src/Model/Product/Availability/ProductAvailabilityCalculation.php
@@ -15,6 +15,8 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
  * @method __construct(\App\Model\Product\Availability\AvailabilityFacade $availabilityFacade, \App\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator, \App\Model\Product\ProductVisibilityFacade $productVisibilityFacade, \Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductRepository $productRepository)
  * @property \App\Model\Product\Availability\AvailabilityFacade $availabilityFacade
  * @method \Shopsys\FrameworkBundle\Model\Product\Availability\Availability calculateAvailabilityForUsingStockProduct(\App\Model\Product\Product $product)
+ * @property \App\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator
+ * @property \App\Model\Product\ProductVisibilityFacade $productVisibilityFacade
  */
 class ProductAvailabilityCalculation extends BaseProductAvailabilityCalculation
 {

--- a/project-base/app/src/Model/Product/Brand/BrandDataFactory.php
+++ b/project-base/app/src/Model/Product/Brand/BrandDataFactory.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\BrandDataFactory as BaseBrandDat
  * @method fillNew(\App\Model\Product\Brand\BrandData $brandData)
  * @method fillFromBrand(\App\Model\Product\Brand\BrandData $brandData, \App\Model\Product\Brand\Brand $brand)
  * @method __construct(\App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Component\FileUpload\ImageUploadDataFactory $imageUploadDataFactory)
+ * @property \App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
  */
 class BrandDataFactory extends BaseBrandDataFactory
 {

--- a/project-base/app/src/Model/Product/ProductDataFactory.php
+++ b/project-base/app/src/Model/Product/ProductDataFactory.php
@@ -30,6 +30,11 @@ use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
 /**
  * @method \App\Model\Product\Product[] getAccessoriesData(\App\Model\Product\Product $product)
  * @method \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueData[] getParametersData(\App\Model\Product\Product $product)
+ * @property \App\Model\Product\Pricing\ProductInputPriceFacade $productInputPriceFacade
+ * @property \App\Model\Product\Unit\UnitFacade $unitFacade
+ * @property \App\Model\Product\Parameter\ParameterRepository $parameterRepository
+ * @property \App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
+ * @property \App\Model\Product\Availability\AvailabilityFacade $availabilityFacade
  */
 class ProductDataFactory extends BaseProductDataFactory
 {

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -61,6 +61,8 @@ use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
  * @method \App\Model\Product\Product[] getProductsWithUnit(\App\Model\Product\Unit\Unit $unit)
  * @method createFriendlyUrlsWhenRenamed(\App\Model\Product\Product $product, array $originalNames)
  * @method array getChangedNamesByLocale(\App\Model\Product\Product $product, array $originalNames)
+ * @property \App\Model\Product\ProductVisibilityFacade $productVisibilityFacade
+ * @property \App\Model\Product\ProductFactory $productFactory
  */
 class ProductFacade extends BaseProductFacade
 {

--- a/project-base/app/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
+++ b/project-base/app/src/Model/Product/ProductOnCurrentDomainElasticFacade.php
@@ -34,6 +34,8 @@ use Shopsys\FrameworkBundle\Model\Product\Search\ProductFilterCountDataElasticse
  * @method \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterCountData getProductFilterCountDataForAll(\App\Model\Product\Filter\ProductFilterData $productFilterData)
  * @method \Shopsys\FrameworkBundle\Component\Paginator\PaginationResult getPaginatedProductsInCategory(\App\Model\Product\Filter\ProductFilterData $productFilterData, string $orderingModeId, int $page, int $limit, int $categoryId)
  * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+ * @property \App\Model\Category\CategoryRepository $categoryRepository
+ * @property \App\Model\Product\Brand\BrandRepository $brandRepository
  */
 class ProductOnCurrentDomainElasticFacade extends BaseProductOnCurrentDomainElasticFacade
 {

--- a/project-base/app/src/Model/Product/ProductVariantFacade.php
+++ b/project-base/app/src/Model/Product/ProductVariantFacade.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade as BaseProductVar
  * @property \App\Model\Product\ProductDataFactory $productDataFactory
  * @property \App\Component\Image\ImageFacade $imageFacade
  * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductFacade $productFacade, \App\Model\Product\ProductDataFactory $productDataFactory, \App\Component\Image\ImageFacade $imageFacade, \App\Model\Product\ProductFactory $productFactory, \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceRecalculationScheduler $productPriceRecalculationScheduler, \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityRecalculationScheduler $productAvailabilityRecalculationScheduler, \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportScheduler $productExportScheduler)
+ * @property \App\Model\Product\ProductFactory $productFactory
  */
 class ProductVariantFacade extends BaseProductVariantFacade
 {

--- a/project-base/app/src/Model/Product/ProductVisibilityFacade.php
+++ b/project-base/app/src/Model/Product/ProductVisibilityFacade.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 /**
  * @method __construct(\App\Model\Product\ProductVisibilityRepository $productVisibilityRepository)
  * @method markProductsForRecalculationAffectedByCategory(\App\Model\Category\Category $category)
+ * @property \App\Model\Product\ProductVisibilityRepository $productVisibilityRepository
  */
 class ProductVisibilityFacade extends BaseProductVisibilityFacade
 {

--- a/project-base/app/src/ProductFeed/Google/Model/Product/GoogleProductRepository.php
+++ b/project-base/app/src/ProductFeed/Google/Model/Product/GoogleProductRepository.php
@@ -12,7 +12,7 @@ use Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductDomain;
 use Shopsys\ProductFeed\GoogleBundle\Model\Product\GoogleProductRepository as BaseGoogleProductRepository;
 
 /**
- * @property \App\Model\Product\ProductRepository $productRepository;
+ * @property \App\Model\Product\ProductRepository $productRepository
  * @method __construct(\App\Model\Product\ProductRepository $productRepository)
  */
 class GoogleProductRepository extends BaseGoogleProductRepository

--- a/project-base/app/src/ProductFeed/Heureka/Model/FeedItem/HeurekaFeedItemFactory.php
+++ b/project-base/app/src/ProductFeed/Heureka/Model/FeedItem/HeurekaFeedItemFactory.php
@@ -18,6 +18,7 @@ use Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacad
  * @method string|null getBrandName(\App\Model\Product\Product $product)
  * @method \Shopsys\FrameworkBundle\Model\Pricing\Price getPrice(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
  * @method string|null getHeurekaCategoryFullName(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
+ * @property \App\Model\Category\CategoryFacade $categoryFacade
  */
 class HeurekaFeedItemFactory extends BaseHeurekaFeedItemFactory
 {

--- a/project-base/app/src/ProductFeed/HeurekaDelivery/Model/FeedItem/HeurekaDeliveryDataRepository.php
+++ b/project-base/app/src/ProductFeed/HeurekaDelivery/Model/FeedItem/HeurekaDeliveryDataRepository.php
@@ -12,6 +12,7 @@ use Shopsys\ProductFeed\HeurekaDeliveryBundle\Model\FeedItem\HeurekaDeliveryData
 
 /**
  * @method __construct(\App\Model\Product\ProductRepository $productRepository)
+ * @property \App\Model\Product\ProductRepository $productRepository
  */
 class HeurekaDeliveryDataRepository extends BaseHeurekaDeliveryDataRepository
 {

--- a/project-base/app/src/ProductFeed/Zbozi/Model/FeedItem/ZboziFeedItemFactory.php
+++ b/project-base/app/src/ProductFeed/Zbozi/Model/FeedItem/ZboziFeedItemFactory.php
@@ -19,6 +19,7 @@ use Shopsys\ProductFeed\ZboziBundle\Model\Product\ZboziProductDomain;
  * @method string|null getBrandName(\App\Model\Product\Product $product)
  * @method \Shopsys\FrameworkBundle\Model\Pricing\Price getPrice(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
  * @method string[] getPathToMainCategory(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
+ * @property \App\Model\Category\CategoryFacade $categoryFacade
  */
 class ZboziFeedItemFactory extends BaseZboziFeedItemFactory
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When defining properties using constructor property promotion, there are no doc blocks from which to take the property type. Hence, we need to try to get the type from typehint. In the future, this might be the preferred way (after adding typehints everywhere :slightly_smiling_face: )
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes










<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-annotation-fixer.odin.shopsys.cloud
  - https://cz.rv-annotation-fixer.odin.shopsys.cloud
<!-- Replace -->
