### PR TITLE
monorepo coding standards: ensure all packages use the same cyclomatic complexity setting

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff;
 use PhpCsFixer\Fixer\FunctionNotation\PhpdocToPropertyTypeFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use Shopsys\CodingStandards\Helper\CyclomaticComplexitySniffSetting;
 use Shopsys\CodingStandards\Sniffs\ConstantVisibilityRequiredSniff;
 use Shopsys\CodingStandards\Sniffs\ForceLateStaticBindingForProtectedConstantsSniff;
 use SlevomatCodingStandard\Sniffs\Functions\FunctionLengthSniff;
@@ -37,12 +38,13 @@ return static function (ECSConfig $ecsConfig): void {
             FunctionLengthSniff::class => [
                 __DIR__ . '/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php',
             ],
-            CyclomaticComplexitySniff::class . '.MaxExceeded' => [
-                __DIR__ . '/packages/framework/src/Model/Product/Search/ProductElasticsearchConverter.php',
-            ],
         ]
     );
 
     $ecsConfig->import(__DIR__ . '/packages/*/ecs.php');
     $ecsConfig->import(__DIR__ . '/project-base/app/ecs.php');
+
+    $ecsConfig->ruleWithConfiguration(CyclomaticComplexitySniff::class, [
+        'absoluteComplexity' => CyclomaticComplexitySniffSetting::DEFAULT_ABSOLUTE_COMPLEXITY,
+    ]);
 };

--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -107,6 +107,7 @@ use Shopsys\CodingStandards\CsFixer\Phpdoc\MissingReturnAnnotationFixer;
 use Shopsys\CodingStandards\CsFixer\Phpdoc\OrderedParamAnnotationsFixer;
 use Shopsys\CodingStandards\CsFixer\RedundantMarkDownTrailingSpacesFixer;
 use Shopsys\CodingStandards\Finder\FileFinder;
+use Shopsys\CodingStandards\Helper\CyclomaticComplexitySniffSetting;
 use Shopsys\CodingStandards\Helper\FqnNameResolver;
 use Shopsys\CodingStandards\Helper\PhpToDocTypeTransformer;
 use Shopsys\CodingStandards\Sniffs\ForbiddenDoctrineDefaultValueSniff;
@@ -213,7 +214,7 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->rule(NoSpaceAfterCastSniff::class);
     $ecsConfig->rule(CallTimePassByReferenceSniff::class);
     $ecsConfig->ruleWithConfiguration(CyclomaticComplexitySniff::class, [
-        'absoluteComplexity' => 13,
+        'absoluteComplexity' => CyclomaticComplexitySniffSetting::DEFAULT_ABSOLUTE_COMPLEXITY,
     ]);
     $ecsConfig->rule(ConstructorNameSniff::class);
     $ecsConfig->rule(CamelCapsFunctionNameSniff::class);

--- a/packages/coding-standards/src/Helper/CyclomaticComplexitySniffSetting.php
+++ b/packages/coding-standards/src/Helper/CyclomaticComplexitySniffSetting.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Helper;
+
+class CyclomaticComplexitySniffSetting
+{
+    public const DEFAULT_ABSOLUTE_COMPLEXITY = 13;
+}

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -87,6 +87,7 @@
         "symfony/error-handler": "^5.4",
         "symfony/event-dispatcher": "^5.4",
         "symfony/mailer": "^5.4",
+        "symfony/messenger": "^5.4",
         "symfony/monolog-bundle": "^3.5.0",
         "symfony/property-info": "^5.4",
         "symfony/proxy-manager-bridge": "^5.4",

--- a/packages/framework/ecs.php
+++ b/packages/framework/ecs.php
@@ -120,6 +120,7 @@ return static function (ECSConfig $ecsConfig): void {
         CyclomaticComplexitySniff::class . '.MaxExceeded' => [
             __DIR__ . '/src/Form/Constraints/FileAbstractFilesystemValidator.php',
             __DIR__ . '/src/Model/Product/Search/ProductElasticsearchConverter.php',
+            __DIR__ . '/src/Migrations/Version20231124121921.php',
         ],
         EmptyStatementSniff::class . '.DetectedCatch' => [
             __DIR__ . '/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php',

--- a/project-base/app/ecs.php
+++ b/project-base/app/ecs.php
@@ -133,6 +133,9 @@ return static function (ECSConfig $ecsConfig): void {
             __DIR__ . '/src/Model/Order/OrderFacade.php',
             __DIR__ . '/src/Model/Product/Search/ProductElasticsearchConverter.php',
             __DIR__ . '/src/FrontendApi/Resolver/Category/CategoryResolverMap.php',
+            __DIR__ . '/src/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcher.php',
+            __DIR__ . '/src/Model/Product/Transfer/Akeneo/ProductTransferAkeneoMapper.php',
+            __DIR__ . '/src/Model/Product/Transfer/Akeneo/ProductTransferAkeneoValidator.php',
         ],
         CamelCapsFunctionNameSniff::class => [
             __DIR__ . '/tests/App/Test/Codeception/ActorInterface.php',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Project base less strict cyclomatic complexity setting was applied in the monorepo which led to failing build on split framework package (see https://github.com/shopsys/framework/actions/runs/7060484708/job/19220109244)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-ecs-fix.odin.shopsys.cloud
  - https://cz.rv-ecs-fix.odin.shopsys.cloud
<!-- Replace -->
