### PR TITLE
docker-compose: remove img proxy container name for CI review

### DIFF
--- a/docker/conf/docker-compose.github-actions.review.simplified.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.simplified.yml.dist
@@ -133,9 +133,6 @@ services:
 
     img-proxy:
         image: darthsim/imgproxy:latest
-        container_name: shopsys-framework-img-proxy
-        ports:
-            - "8060:8080"
 
 volumes:
     web-volume:

--- a/docker/conf/docker-compose.github-actions.review.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.yml.dist
@@ -183,9 +183,6 @@ services:
 
     img-proxy:
         image: darthsim/imgproxy:latest
-        container_name: shopsys-framework-img-proxy
-        ports:
-            - "8060:8080"
 
 volumes:
     web-volume:

--- a/project-base/gitlab/docker-compose-ci-review.yml
+++ b/project-base/gitlab/docker-compose-ci-review.yml
@@ -54,9 +54,6 @@ services:
 
     img-proxy:
         image: darthsim/imgproxy:latest
-        container_name: shopsys-framework-img-proxy
-        ports:
-            - "8060:8080"
 
 volumes:
     web-volume:


### PR DESCRIPTION
- to avoid container name conflicts
- see https://gitlab.shopsys.cz/ss6-projects/project-base/-/jobs/1061111

| Q             | A
| ------------- | ---
|Description, reason for the PR| When multiple branches are running, the container names are in conflict
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-review-compose.odin.shopsys.cloud
  - https://cz.rv-fix-review-compose.odin.shopsys.cloud
<!-- Replace -->
