### PR TITLE
[shopsys] forbidden private visibility now takes into account constructor property promotion

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -541,6 +541,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     +   public function getProductParameterValues(Product $product, ?string $locale = null)
     ```
     -   see #project-base-diff to update your project
+-   check the visibility of properties ([#2944](https://github.com/shopsys/shopsys/pull/2944))
+    -   `Shopsys\FrameworkBundle\Form\Transformers\WysiwygCdnDataTransformer::$cdnFacade` is now protected
+    -   `Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapCronModule::$imageSitemapFacade` is now protected
 
 ### Storefront
 

--- a/packages/coding-standards/src/CsFixer/ForbiddenPrivateVisibilityFixer.php
+++ b/packages/coding-standards/src/CsFixer/ForbiddenPrivateVisibilityFixer.php
@@ -12,6 +12,7 @@ use PhpCsFixer\FixerConfiguration\FixerOption;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Shopsys\CodingStandards\Exception\NamespaceNotFoundException;
@@ -105,7 +106,7 @@ private function method()
      */
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAllTokenKindsFound([T_PRIVATE]) && $this->checkNamespace($tokens);
+        return $tokens->isAnyTokenKindsFound([T_PRIVATE, CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE]) && $this->checkNamespace($tokens);
     }
 
     /**
@@ -167,6 +168,10 @@ private function method()
     {
         foreach (array_keys($tokens->findGivenKind(T_PRIVATE)) as $index) {
             $tokens[$index] = new Token([T_PROTECTED, 'protected']);
+        }
+
+        foreach (array_keys($tokens->findGivenKind(CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PRIVATE)) as $index) {
+            $tokens[$index] = new Token([CT::T_CONSTRUCTOR_PROPERTY_PROMOTION_PROTECTED, 'protected']);
         }
     }
 

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/ForbiddenPrivateVisibilityFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/ForbiddenPrivateVisibilityFixerTest.php
@@ -27,6 +27,8 @@ final class ForbiddenPrivateVisibilityFixerTest extends AbstractFixerTestCase
      */
     public function getTestingFiles(): iterable
     {
+        yield [__DIR__ . '/fixed/constructor_property_promotion.php', __DIR__ . '/wrong/constructor_property_promotion.php'];
+
         yield [__DIR__ . '/fixed/fixed.php', __DIR__ . '/wrong/wrong.php'];
 
         yield [__DIR__ . '/correct/correct.php'];

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/fixed/constructor_property_promotion.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/fixed/constructor_property_promotion.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestNamespace\TestSubNamespace;
+
+class SomeClass
+{
+    public function __construct(
+        protected readonly string $property1,
+        protected readonly string $property2,
+        public readonly string $property3,
+        protected string $property4,
+        protected string $property5,
+        public string $property6,
+    ) {
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/wrong/constructor_property_promotion.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/ForbiddenPrivateVisibilityFixer/wrong/constructor_property_promotion.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestNamespace\TestSubNamespace;
+
+class SomeClass
+{
+    public function __construct(
+        private readonly string $property1,
+        protected readonly string $property2,
+        public readonly string $property3,
+        private string $property4,
+        protected string $property5,
+        public string $property6,
+    ) {
+    }
+}

--- a/packages/framework/src/Form/Transformers/WysiwygCdnDataTransformer.php
+++ b/packages/framework/src/Form/Transformers/WysiwygCdnDataTransformer.php
@@ -12,7 +12,7 @@ class WysiwygCdnDataTransformer implements DataTransformerInterface
     /**
      * @param \Shopsys\FrameworkBundle\Component\Cdn\CdnFacade $cdnFacade
      */
-    public function __construct(private readonly CdnFacade $cdnFacade)
+    public function __construct(protected readonly CdnFacade $cdnFacade)
     {
     }
 

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapCronModule.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapCronModule.php
@@ -13,7 +13,7 @@ class ImageSitemapCronModule implements SimpleCronModuleInterface
      * @param \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapFacade $imageSitemapFacade
      */
     public function __construct(
-        private readonly ImageSitemapFacade $imageSitemapFacade,
+        protected readonly ImageSitemapFacade $imageSitemapFacade,
     ) {
     }
 

--- a/packages/framework/src/Model/Store/StoreDataFactory.php
+++ b/packages/framework/src/Model/Store/StoreDataFactory.php
@@ -18,10 +18,10 @@ class StoreDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursDataFactory $openingHourDataFactory
      */
     public function __construct(
-        private readonly Domain $domain,
-        private readonly FriendlyUrlFacade $friendlyUrlFacade,
-        private readonly ImageUploadDataFactory $imageUploadDataFactory,
-        private readonly OpeningHoursDataFactory $openingHourDataFactory,
+        protected readonly Domain $domain,
+        protected readonly FriendlyUrlFacade $friendlyUrlFacade,
+        protected readonly ImageUploadDataFactory $imageUploadDataFactory,
+        protected readonly OpeningHoursDataFactory $openingHourDataFactory,
     ) {
     }
 

--- a/packages/framework/src/Model/Store/StoreFacade.php
+++ b/packages/framework/src/Model/Store/StoreFacade.php
@@ -21,12 +21,12 @@ class StoreFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
      */
     public function __construct(
-        private readonly StoreRepository $storeRepository,
-        private readonly StoreFactory $storeFactory,
-        private readonly FriendlyUrlFacade $friendlyUrlFacade,
-        private readonly ImageFacade $imageFacade,
-        private readonly EntityManagerInterface $em,
-        private readonly ProductRepository $productRepository,
+        protected readonly StoreRepository $storeRepository,
+        protected readonly StoreFactory $storeFactory,
+        protected readonly FriendlyUrlFacade $friendlyUrlFacade,
+        protected readonly ImageFacade $imageFacade,
+        protected readonly EntityManagerInterface $em,
+        protected readonly ProductRepository $productRepository,
     ) {
     }
 

--- a/packages/framework/src/Model/Store/StoreIdsToStoresTransformer.php
+++ b/packages/framework/src/Model/Store/StoreIdsToStoresTransformer.php
@@ -11,7 +11,7 @@ class StoreIdsToStoresTransformer implements DataTransformerInterface
     /**
      * @param \Shopsys\FrameworkBundle\Model\Store\StoreRepository $storeRepository
      */
-    public function __construct(private readonly StoreRepository $storeRepository)
+    public function __construct(protected readonly StoreRepository $storeRepository)
     {
     }
 

--- a/packages/frontend-api/src/Model/Logger/FrontendApiLogger.php
+++ b/packages/frontend-api/src/Model/Logger/FrontendApiLogger.php
@@ -16,8 +16,8 @@ class FrontendApiLogger implements LoggerInterface
      * @param bool $isValidationLoggedAsError
      */
     public function __construct(
-        private readonly LoggerInterface $logger,
-        private readonly bool $isValidationLoggedAsError,
+        protected readonly LoggerInterface $logger,
+        protected readonly bool $isValidationLoggedAsError,
     ) {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fixer for forbidden private visibility was ignoring the private constructor property promotion. This is fixed now
|New feature| Yes (kinda) <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes (visibility change) <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mb-fix-cpp-private-fix.odin.shopsys.cloud
  - https://cz.mb-fix-cpp-private-fix.odin.shopsys.cloud
<!-- Replace -->
