### PR TITLE
[shospys] improved feed memory usage, iterated crons are now able to sleep before memory overflow and improved feed generation logging

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -598,6 +598,13 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     +       protected readonly ServicesResetter $servicesResetter,
         )
     ```
+    -   `Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor::__construct()` changed its interface:
+    ```diff
+        public function __construct(
+            protected readonly CronConfig $cronConfig,
+    +       protected readonly Logger $logger,
+        )
+    ```
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -569,6 +569,36 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
             )
         ```
     -   see #project-base-diff to update your project
+-   improve memory usage of feed exports and crons ([#2945](https://github.com/shopsys/shopsys/pull/2945))
+    -   `Shopsys\FrameworkBundle\Model\Feed\FeedExport::__construct()` changed its interface:
+    ```diff
+        public function __construct(
+            protected readonly FeedInterface $feed,
+            protected readonly DomainConfig $domainConfig,
+            protected readonly FeedRenderer $feedRenderer,
+            protected readonly FilesystemOperator $filesystem,
+            protected readonly Filesystem $localFilesystem,
+            protected readonly MountManager $mountManager,
+            protected readonly EntityManagerInterface $em,
+            protected readonly string $feedFilepath,
+            protected readonly string $feedLocalFilepath,
+    +       protected readonly ServicesResetter $servicesResetter,
+            protected ?int $lastSeekId = null,
+        )
+    ```
+    -   `Shopsys\FrameworkBundle\Model\Feed\FeedExportFactory::__construct()` changed its interface:
+    ```diff
+        public function __construct(
+            protected readonly FeedRendererFactory $feedRendererFactory,
+            protected readonly FilesystemOperator $filesystem,
+            protected readonly EntityManagerInterface $em,
+            protected readonly FeedPathProvider $feedPathProvider,
+            protected readonly Filesystem $localFilesystem,
+            protected readonly MountManager $mountManager,
+    +       protected readonly ServicesResetter $servicesResetter,
+        )
+    ```
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/docs/introduction/cron.md
+++ b/docs/introduction/cron.md
@@ -62,3 +62,7 @@ but in some cases, the overall time of the "every 5 minutes" cron modules can be
 Then it's possible, some cron modules will never be run.
 
 It's crucial to monitor your crons and, if necessary, update their periodicity and timeout or split them into [multiple Cron Instances](#multiple-cron-instances).
+
+!!! note
+
+    Crons implementing `Shopsys\Plugin\Cron\IteratedCronModuleInterface` with the correct implementation of iterate, wakeUp, and sleep methods will be checked during every iteration if their memory limit is not approaching and if so, they will be stopped and started again in the next iteration.

--- a/packages/framework/src/Component/Bytes/BytesHelper.php
+++ b/packages/framework/src/Component/Bytes/BytesHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Bytes;
+
+use function intval;
+
+class BytesHelper
+{
+    /**
+     * @return int
+     */
+    public static function getPhpMemoryLimitInBytes(): int
+    {
+        $memoryLimit = ini_get('memory_limit');
+
+        if ($memoryLimit === '-1') {
+            return -1;
+        }
+
+        return self::convertPhpStringByteDefinitionToBytes($memoryLimit);
+    }
+
+    /**
+     * @param string $memoryLimit
+     * @return int
+     */
+    public static function convertPhpStringByteDefinitionToBytes(string $memoryLimit): int
+    {
+        $memoryLimit = strtolower($memoryLimit);
+        $max = ltrim($memoryLimit, '+');
+
+        if (str_starts_with($max, '0x')) {
+            $max = intval($max, 16);
+        } elseif (str_starts_with($max, '0')) {
+            $max = intval($max, 8);
+        } else {
+            $max = (int)$max;
+        }
+
+        switch (substr(rtrim($memoryLimit, 'b'), -1)) {
+            case 't': $max *= 1024;
+            // no break
+            case 'g': $max *= 1024;
+            // no break
+            case 'm': $max *= 1024;
+            // no break
+            case 'k': $max *= 1024;
+        }
+
+        return $max;
+    }
+}

--- a/packages/framework/src/Model/Feed/FeedExport.php
+++ b/packages/framework/src/Model/Feed/FeedExport.php
@@ -10,6 +10,7 @@ use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\String\TransformString;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 
 class FeedExport
 {
@@ -28,6 +29,7 @@ class FeedExport
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param string $feedFilepath
      * @param string $feedLocalFilepath
+     * @param \Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter $servicesResetter
      * @param int|null $lastSeekId
      */
     public function __construct(
@@ -40,6 +42,7 @@ class FeedExport
         protected readonly EntityManagerInterface $em,
         protected readonly string $feedFilepath,
         protected readonly string $feedLocalFilepath,
+        protected readonly ServicesResetter $servicesResetter,
         protected ?int $lastSeekId = null,
     ) {
     }
@@ -90,7 +93,9 @@ class FeedExport
             $this->finishFile();
         }
 
+        $this->servicesResetter->reset();
         $this->em->clear();
+        gc_collect_cycles();
     }
 
     /**

--- a/packages/framework/src/Model/Feed/FeedExportFactory.php
+++ b/packages/framework/src/Model/Feed/FeedExportFactory.php
@@ -9,6 +9,7 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\MountManager;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 
 class FeedExportFactory
 {
@@ -19,6 +20,7 @@ class FeedExportFactory
      * @param \Shopsys\FrameworkBundle\Model\Feed\FeedPathProvider $feedPathProvider
      * @param \Symfony\Component\Filesystem\Filesystem $localFilesystem
      * @param \League\Flysystem\MountManager $mountManager
+     * @param \Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter $servicesResetter
      */
     public function __construct(
         protected readonly FeedRendererFactory $feedRendererFactory,
@@ -27,6 +29,7 @@ class FeedExportFactory
         protected readonly FeedPathProvider $feedPathProvider,
         protected readonly Filesystem $localFilesystem,
         protected readonly MountManager $mountManager,
+        protected readonly ServicesResetter $servicesResetter,
     ) {
     }
 
@@ -53,6 +56,7 @@ class FeedExportFactory
             $this->em,
             $feedFilepath,
             $feedLocalFilepath,
+            $this->servicesResetter,
             $lastSeekId,
         );
     }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -154,7 +154,9 @@ services:
 
     Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig: ~
 
-    Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor: ~
+    Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor:
+        arguments:
+            $logger: '@monolog.logger.cron'
 
     Shopsys\FrameworkBundle\Component\Environment\EnvironmentFileSetting:
         arguments:

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -1043,3 +1043,7 @@ services:
     Shopsys\FrameworkBundle\Model\Order\Messenger\HeurekaPlacedOrderMessageHandler:
         arguments:
             $logger: '@monolog.logger.queue'
+
+    Shopsys\FrameworkBundle\Model\Feed\FeedExportFactory:
+        arguments:
+            $servicesResetter: '@services_resetter'

--- a/packages/framework/tests/Unit/Component/Bytes/BytesHelperTest.php
+++ b/packages/framework/tests/Unit/Component/Bytes/BytesHelperTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Bytes;
+
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Bytes\BytesHelper;
+
+class BytesHelperTest extends TestCase
+{
+    /**
+     * @dataProvider phpStringBytesToBytesDataProvider
+     * @param string $phpStringBytes
+     * @param int $expectedBytes
+     */
+    public function testConvertPhpStringByteDefinitionToBytes(string $phpStringBytes, int $expectedBytes): void
+    {
+        $this->assertSame($expectedBytes, BytesHelper::convertPhpStringByteDefinitionToBytes($phpStringBytes));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function phpStringBytesToBytesDataProvider(): array
+    {
+        return [
+            ['phpStringBytes' => '12', 'expectedBytes' => 12],
+            ['phpStringBytes' => '12K', 'expectedBytes' => 12288],
+            ['phpStringBytes' => '12M', 'expectedBytes' => 12582912],
+            ['phpStringBytes' => '12G', 'expectedBytes' => 12884901888],
+            ['phpStringBytes' => '12T', 'expectedBytes' => 13194139533312],
+        ];
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronFacadeTest.php
@@ -120,7 +120,7 @@ class CronFacadeTest extends TestCase
         /** @var \Symfony\Bridge\Monolog\Logger $loggerMock */
         $loggerMock = $this->createMock(Logger::class);
 
-        $cronModuleExecutor = new CronModuleExecutor($cronConfig);
+        $cronModuleExecutor = new CronModuleExecutor($cronConfig, $loggerMock);
 
         return new CronFacade($loggerMock, $cronConfig, $cronModuleFacade, $cronModuleExecutor);
     }

--- a/packages/framework/tests/Unit/Component/Cron/CronModuleExecutorTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronModuleExecutorTest.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronModuleExecutor;
 use Shopsys\FrameworkBundle\Component\Cron\CronTimeResolver;
 use Shopsys\Plugin\Cron\IteratedCronModuleInterface;
+use Symfony\Bridge\Monolog\Logger;
 
 class CronModuleExecutorTest extends TestCase
 {
@@ -87,6 +88,9 @@ class CronModuleExecutorTest extends TestCase
         $cronTimeResolver = new CronTimeResolver();
         $cronConfig = new CronConfig($cronTimeResolver);
 
+        /** @var \Symfony\Bridge\Monolog\Logger $loggerMock */
+        $loggerMock = $this->createMock(Logger::class);
+
         foreach ($servicesIndexedById as $serviceId => $service) {
             $cronConfig->registerCronModuleInstance(
                 $service,
@@ -101,6 +105,6 @@ class CronModuleExecutorTest extends TestCase
             );
         }
 
-        return new CronModuleExecutor($cronConfig);
+        return new CronModuleExecutor($cronConfig, $loggerMock);
     }
 }

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -688,7 +688,9 @@ services:
     App\Model\Customer\Mail\CustomerActivationMail: ~
 
     Shopsys\FrameworkBundle\Model\Feed\FeedExportFactory:
-        alias: App\Model\Feed\FeedExportFactory
+        class: App\Model\Feed\FeedExportFactory
+        arguments:
+            $servicesResetter: '@services_resetter'
 
     Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserPasswordFacade:
         alias: App\Model\Customer\User\CustomerUserPasswordFacade

--- a/project-base/app/src/Model/Feed/FeedExportFactory.php
+++ b/project-base/app/src/Model/Feed/FeedExportFactory.php
@@ -47,6 +47,7 @@ class FeedExportFactory extends BaseFeedExportFactory
             $this->em,
             $feedFilepath,
             $feedLocalFilepath,
+            $this->servicesResetter,
             $lastSeekId,
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were few problems during generation of feed with large amount of data. Most of the problems was caused by reaching PHP memory limit. We have added better memory management to feed generation and improved execution of Iterated crons, that tries to prevent next iteration when memory is reaching its limit. Also feed logging has been improved.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-optimize-feed-generation.odin.shopsys.cloud
  - https://cz.tl-optimize-feed-generation.odin.shopsys.cloud
<!-- Replace -->
