### PR TITLE
docker-compose: add rabbitMQ container for cypress tests on gitlab CI

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -606,6 +606,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         )
     ```
     -   see #project-base-diff to update your project
+-   docker-compose: add rabbitMQ container for cypress tests on gitlab CI [#2950](https://github.com/shopsys/shopsys/pull/2950)
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/project-base/gitlab/docker-compose-ci.yml
+++ b/project-base/gitlab/docker-compose-ci.yml
@@ -80,6 +80,12 @@ services:
         ports:
             - "8060:8080"
 
+    rabbitmq:
+        image: rabbitmq:3.12-management-alpine
+        container_name: shopsys-framework-rabbitmq
+        ports:
+            - "15672:15672"
+
 volumes:
     web-volume:
     postgres-data:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| cypress has its own docker-compose for the gitlab build. The rabbitMQ container must be specified there so the storefront cypress tests are able to use the queue and do not fail on the `TransportException` (`Could not connect to the AMQP server`)
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-rabbit.odin.shopsys.cloud
  - https://cz.rv-fix-rabbit.odin.shopsys.cloud
<!-- Replace -->
