### PR TITLE
[project-base] stores tests enhancements

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -608,6 +608,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   docker-compose: add rabbitMQ container for cypress tests on gitlab CI [#2950](https://github.com/shopsys/shopsys/pull/2950)
     -   see #project-base-diff to update your project
+-   enhance your stores tests ([#2835](https://github.com/shopsys/shopsys/pull/2951))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
@@ -206,24 +206,190 @@ class GetStoreTest extends GraphQlTestCase
     }
 
     /**
-     * @return array
+     * @return iterable
      */
-    protected function openingHoursDataProvider(): array
+    protected function openingHoursDataProvider(): iterable
     {
-        return [
-            ['-1 hour', '+1 hour', null, null, null, [], true, '-1 hour', '+1 hour', null, null],
-            [null, null, '-1 hour', '+1 hour', null, [], true, null, null, '-1 hour', '+1 hour'],
-            ['-1 hour', '+1 hour', null, null, $this->getNow(), [1], true, '-1 hour', '+1 hour', null, null],
-            [null, null, '-1 hour', '+1 hour', $this->getNow(), [], false, null, null, null, null],
-            [null, null, null, null, null, [], false, null, null, null, null],
-            ['+1 hour', '+2 hour', null, null, null, [], false, '+1 hour', '+2 hour', null, null],
-            [null, null, '+1 hour', '+2 hour', null, [], false, null, null, '+1 hour', '+2 hour'],
-            ['-2 hour', '-1 hour', null, null, null, [], false, '-2 hour', '-1 hour', null, null],
-            [null, null, '-2 hour', '-1 hour', null, [], false, null, null, '-2 hour', '-1 hour'],
-            ['-1 hour', null, null, '+1 hour', null, [], false, '-1 hour', null, null, '+1 hour'],
-            [null, '+1 hour', '-1 hour', null, null, [], false, null, '+1 hour', '-1 hour', null],
-            ['+1 hour', '-1 hour', null, null, null, [], false, '+1 hour', '-1 hour', null, null],
-            [null, null, '+1 hour', '-1 hour', null, [], false, null, null, '+1 hour', '-1 hour'],
+        yield 'store opened only forenoon' => [
+            'firstOpeningTime' => '-1 hour',
+            'firstClosingTime' => '+1 hour',
+            'secondOpeningTime' => null,
+            'secondClosingTime' => null,
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => true,
+            'expectedDaysFirstOpeningTime' => '-1 hour',
+            'expectedDaysFirstClosingTime' => '+1 hour',
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store opened only afternoon' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => null,
+            'secondOpeningTime' => '-1 hour',
+            'secondClosingTime' => '+1 hour',
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => true,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => '-1 hour',
+            'expectedDaysSecondClosingTime' => '+1 hour',
+        ];
+
+        yield 'store opened only forenoon and excluded from the public holiday' => [
+            'firstOpeningTime' => '-1 hour',
+            'firstClosingTime' => '+1 hour',
+            'secondOpeningTime' => null,
+            'secondClosingTime' => null,
+            'publicHolidayDate' => $this->getNow(),
+            'publicHolidayExcludedStoresIds' => [1],
+            'expectedIsOpen' => true,
+            'expectedDaysFirstOpeningTime' => '-1 hour',
+            'expectedDaysFirstClosingTime' => '+1 hour',
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store opened only afternoon and not excluded from the public holiday' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => null,
+            'secondOpeningTime' => '-1 hour',
+            'secondClosingTime' => '+1 hour',
+            'publicHolidayDate' => $this->getNow(),
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store not opened at all' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => null,
+            'secondOpeningTime' => null,
+            'secondClosingTime' => null,
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store opens in an hour (forenoon)' => [
+            'firstOpeningTime' => '+1 hour',
+            'firstClosingTime' => '+2 hour',
+            'secondOpeningTime' => null,
+            'secondClosingTime' => null,
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => '+1 hour',
+            'expectedDaysFirstClosingTime' => '+2 hour',
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store opens in an hour (afternoon)' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => null,
+            'secondOpeningTime' => '+1 hour',
+            'secondClosingTime' => '+2 hour',
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => '+1 hour',
+            'expectedDaysSecondClosingTime' => '+2 hour',
+        ];
+
+        yield 'store closed an hour ago (forenoon)' => [
+            'firstOpeningTime' => '-2 hour',
+            'firstClosingTime' => '-1 hour',
+            'secondOpeningTime' => null,
+            'secondClosingTime' => null,
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => '-2 hour',
+            'expectedDaysFirstClosingTime' => '-1 hour',
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store closed an hour ago (afternoon)' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => null,
+            'secondOpeningTime' => '-2 hour',
+            'secondClosingTime' => '-1 hour',
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => '-2 hour',
+            'expectedDaysSecondClosingTime' => '-1 hour',
+        ];
+
+        yield 'store with missing first closing time and missing second opening time' => [
+            'firstOpeningTime' => '-1 hour',
+            'firstClosingTime' => null,
+            'secondOpeningTime' => null,
+            'secondClosingTime' => '+1 hour',
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => '-1 hour',
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => '+1 hour',
+        ];
+
+        yield 'store with missing first opening time and missing second closing time' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => '+1 hour',
+            'secondOpeningTime' => '-1 hour',
+            'secondClosingTime' => null,
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => '+1 hour',
+            'expectedDaysSecondOpeningTime' => '-1 hour',
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store that closes sooner then opens (forenoon)' => [
+            'firstOpeningTime' => '+1 hour',
+            'firstClosingTime' => '-1 hour',
+            'secondOpeningTime' => null,
+            'secondClosingTime' => null,
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => '+1 hour',
+            'expectedDaysFirstClosingTime' => '-1 hour',
+            'expectedDaysSecondOpeningTime' => null,
+            'expectedDaysSecondClosingTime' => null,
+        ];
+
+        yield 'store that closes sooner then opens (afternoon)' => [
+            'firstOpeningTime' => null,
+            'firstClosingTime' => null,
+            'secondOpeningTime' => '+1 hour',
+            'secondClosingTime' => '-1 hour',
+            'publicHolidayDate' => null,
+            'publicHolidayExcludedStoresIds' => [],
+            'expectedIsOpen' => false,
+            'expectedDaysFirstOpeningTime' => null,
+            'expectedDaysFirstClosingTime' => null,
+            'expectedDaysSecondOpeningTime' => '+1 hour',
+            'expectedDaysSecondClosingTime' => '-1 hour',
         ];
     }
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
@@ -83,7 +83,6 @@ class GetStoreTest extends GraphQlTestCase
                     'city',
                     'postcode',
                     'country',
-                    'openingHours',
                     'specialMessage',
                     'locationLatitude',
                     'locationLongitude',
@@ -149,7 +148,6 @@ class GetStoreTest extends GraphQlTestCase
                     'city',
                     'postcode',
                     'country',
-                    'openingHours',
                     'specialMessage',
                     'locationLatitude',
                     'locationLongitude',
@@ -464,52 +462,6 @@ class GetStoreTest extends GraphQlTestCase
     private function getExpectedStore(int $storeId): array
     {
         $storesSlug = $this->urlGenerator->generate('front_stores');
-        $openingHours = [
-            'openingHoursOfDays' => [
-                [
-                    'firstOpeningTime' => '06:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '18:00',
-                ],
-                [
-                    'firstOpeningTime' => '07:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '17:00',
-                ],
-                [
-                    'firstOpeningTime' => '08:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '16:00',
-                ],
-                [
-                    'firstOpeningTime' => '09:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '15:00',
-                ],
-                [
-                    'firstOpeningTime' => '10:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '14:00',
-                ],
-                [
-                    'firstOpeningTime' => '08:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => null,
-                    'secondClosingTime' => null,
-                ],
-                [
-                    'firstOpeningTime' => '09:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => null,
-                    'secondClosingTime' => null,
-                ],
-            ],
-        ];
 
         $firstDomainLocale = $this->getLocaleForFirstDomain();
         $data = [
@@ -525,7 +477,6 @@ class GetStoreTest extends GraphQlTestCase
                     'code' => 'CZ',
                 ],
                 'contactInfo' => null,
-                'openingHours' => $openingHours,
                 'specialMessage' => null,
                 'locationLatitude' => '49.8574975',
                 'locationLongitude' => '18.2738861',
@@ -552,7 +503,6 @@ class GetStoreTest extends GraphQlTestCase
                     'code' => 'CZ',
                 ],
                 'contactInfo' => null,
-                'openingHours' => $openingHours,
                 'specialMessage' => null,
                 'locationLatitude' => '50.0346875',
                 'locationLongitude' => '15.7707169',

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
@@ -67,7 +67,9 @@ class GetStoreTest extends GraphQlTestCase
             [$uuid, $expectedStoreData] = $dataSet;
 
             $graphQlType = 'store';
-            $response = $this->getResponseContentForQuery($this->getStoreQueryByUuid($uuid));
+            $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoreQuery.graphql', [
+                'uuid' => $uuid,
+            ]);
             $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
             $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
@@ -101,7 +103,9 @@ class GetStoreTest extends GraphQlTestCase
         /** @var \Shopsys\FrameworkBundle\Model\Store\Store $storeOnSecondDomain */
         $storeOnSecondDomain = $this->getReference(StoreDataFixture::STORE_PREFIX . 3);
 
-        $response = $this->getResponseContentForQuery($this->getStoreQueryByUuid($storeOnSecondDomain->getUuid()));
+        $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoreQuery.graphql', [
+            'uuid' => $storeOnSecondDomain->getUuid(),
+        ]);
         $this->assertResponseContainsArrayOfErrors($response);
         $errors = $response['errors'][0];
         self::assertArrayHasKey('message', $errors, Json::encode($errors));
@@ -111,7 +115,9 @@ class GetStoreTest extends GraphQlTestCase
         );
 
         $urlSlug = 'zilina';
-        $response = $this->getResponseContentForQuery($this->getStoreQueryByUrlSlug($urlSlug));
+        $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoreQuery.graphql', [
+            'slug' => $urlSlug,
+        ]);
         $this->assertResponseContainsArrayOfErrors($response);
         $errors = $response['errors'][0];
         self::assertArrayHasKey('message', $errors, Json::encode($errors));
@@ -127,7 +133,9 @@ class GetStoreTest extends GraphQlTestCase
             [$urlSlug, $expectedStoreData] = $dataSet;
 
             $graphQlType = 'store';
-            $response = $this->getResponseContentForQuery($this->getStoreQueryByUrlSlug($urlSlug));
+            $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoreQuery.graphql', [
+                'slug' => $urlSlug,
+            ]);
             $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
             $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
@@ -187,7 +195,7 @@ class GetStoreTest extends GraphQlTestCase
             $this->createClosedDay($publicHolidayDate, $publicHolidayExcludedStoresIds);
         }
 
-        $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoreQuery.graphql', [
+        $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoreOpeningHoursQuery.graphql', [
             'uuid' => $store->getUuid(),
         ]);
 
@@ -447,67 +455,6 @@ class GetStoreTest extends GraphQlTestCase
         }
 
         return $data;
-    }
-
-    /**
-     * @param string $uuid
-     * @return string
-     */
-    public function getStoreQueryByUuid(string $uuid): string
-    {
-        $graphQlTypeWithFilters = 'store (uuid:"' . $uuid . '")';
-
-        return $this->getStoreQuery($graphQlTypeWithFilters);
-    }
-
-    /**
-     * @param string $urlSlug
-     * @return string
-     */
-    public function getStoreQueryByUrlSlug(string $urlSlug): string
-    {
-        $graphQlTypeWithFilters = 'store (urlSlug:"' . $urlSlug . '")';
-
-        return $this->getStoreQuery($graphQlTypeWithFilters);
-    }
-
-    /**
-     * @param string $graphQlTypeWithFilters
-     * @return string
-     */
-    private function getStoreQuery(string $graphQlTypeWithFilters): string
-    {
-        return '
-            query {
-                ' . $graphQlTypeWithFilters . ' { 
-                    name
-                    slug
-                    isDefault
-                    description
-                    street
-                    city
-                    postcode
-                    country {
-                        code
-                    }
-                    openingHours {
-                        openingHoursOfDays {
-                            firstOpeningTime
-                            firstClosingTime
-                            secondOpeningTime
-                            secondClosingTime
-                        }
-                    }
-                    specialMessage
-                    locationLatitude
-                    locationLongitude
-                    breadcrumb {
-                        name
-                        slug
-                    }
-                }
-            }
-        ';
     }
 
     /**

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoresTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoresTest.php
@@ -13,10 +13,9 @@ class GetStoresTest extends GraphQlTestCase
     public function testGetStores(): void
     {
         foreach ($this->getStoresDataProvider() as $dataSet) {
-            [$query, $expectedStoresData] = $dataSet;
+            [$response, $expectedStoresData] = $dataSet;
 
             $graphQlType = 'stores';
-            $response = $this->getResponseContentForQuery($query);
             $this->assertResponseContainsArrayOfDataForGraphQlType($response, $graphQlType);
             $responseData = $this->getResponseDataForGraphQlType($response, $graphQlType);
 
@@ -71,82 +70,22 @@ class GetStoresTest extends GraphQlTestCase
     {
         return [
             [
-                $this->getAllStoresQuery(),
+                $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoresQuery.graphql'),
                 $this->getExpectedStores(),
             ],
             [
-                $this->getFirstStoreQuery(),
+                $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoresQuery.graphql', [
+                    'first' => 1,
+                ]),
                 array_slice($this->getExpectedStores(), 0, 1),
             ],
             [
-                $this->getLastStoreQuery(),
+                $this->getResponseContentForGql(__DIR__ . '/../_graphql/query/StoresQuery.graphql', [
+                    'last' => 1,
+                ]),
                 array_slice($this->getExpectedStores(), 1, 1),
             ],
         ];
-    }
-
-    /**
-     * @return string
-     */
-    private function getAllStoresQuery(): string
-    {
-        return $this->getStoresQuery('stores');
-    }
-
-    /**
-     * @return string
-     */
-    private function getFirstStoreQuery(): string
-    {
-        return $this->getStoresQuery('stores (first: 1)');
-    }
-
-    /**
-     * @return string
-     */
-    private function getLastStoreQuery(): string
-    {
-        return $this->getStoresQuery('stores (last: 1)');
-    }
-
-    /**
-     * @param string $graphQlTypeWithFilters
-     * @return string
-     */
-    private function getStoresQuery(string $graphQlTypeWithFilters): string
-    {
-        return '
-            {
-                ' . $graphQlTypeWithFilters . ' {
-                    edges {
-                        node {
-                            uuid
-                            name
-                            isDefault
-                            description
-                            contactInfo
-                            street
-                            city
-                            postcode
-                            country {
-                                code
-                            }
-                            openingHours {
-                                openingHoursOfDays {
-                                    firstOpeningTime
-                                    firstClosingTime
-                                    secondOpeningTime
-                                    secondClosingTime
-                                }
-                            }
-                            specialMessage
-                            locationLatitude
-                            locationLongitude
-                        }
-                    }
-                }
-            }
-        ';
     }
 
     /**

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoresTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoresTest.php
@@ -38,7 +38,6 @@ class GetStoresTest extends GraphQlTestCase
                         'city',
                         'postcode',
                         'country',
-                        'openingHours',
                         'specialMessage',
                         'locationLatitude',
                         'locationLongitude',
@@ -94,46 +93,6 @@ class GetStoresTest extends GraphQlTestCase
     private function getExpectedStores(): array
     {
         $firstDomainLocale = $this->getLocaleForFirstDomain();
-        $openingHours = [
-            'openingHoursOfDays' => [
-                [
-                    'firstOpeningTime' => '06:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '18:00',
-                ], [
-                    'firstOpeningTime' => '07:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '17:00',
-                ], [
-                    'firstOpeningTime' => '08:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '16:00',
-                ], [
-                    'firstOpeningTime' => '09:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '15:00',
-                ], [
-                    'firstOpeningTime' => '10:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => '13:00',
-                    'secondClosingTime' => '14:00',
-                ], [
-                    'firstOpeningTime' => '08:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => null,
-                    'secondClosingTime' => null,
-                ], [
-                    'firstOpeningTime' => '09:00',
-                    'firstClosingTime' => '11:00',
-                    'secondOpeningTime' => null,
-                    'secondClosingTime' => null,
-                ],
-            ],
-        ];
 
         return [
             [
@@ -147,7 +106,6 @@ class GetStoresTest extends GraphQlTestCase
                     'code' => 'CZ',
                 ],
                 'contactInfo' => null,
-                'openingHours' => $openingHours,
                 'specialMessage' => null,
                 'locationLatitude' => '49.8574975',
                 'locationLongitude' => '18.2738861',
@@ -162,7 +120,6 @@ class GetStoresTest extends GraphQlTestCase
                     'code' => 'CZ',
                 ],
                 'contactInfo' => null,
-                'openingHours' => $openingHours,
                 'specialMessage' => null,
                 'locationLatitude' => '50.0346875',
                 'locationLongitude' => '15.7707169',

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoreOpeningHoursQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoreOpeningHoursQuery.graphql
@@ -1,0 +1,14 @@
+query StoreOpeningHoursQuery($uuid: Uuid!) {
+    store(uuid: $uuid) {
+        openingHours {
+            isOpen
+            openingHoursOfDays {
+                dayOfWeek
+                firstOpeningTime
+                firstClosingTime
+                secondOpeningTime
+                secondClosingTime
+            }
+        }
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoreQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoreQuery.graphql
@@ -10,14 +10,6 @@ query StoreQuery($uuid: Uuid, $slug: String) {
         country {
             code
         }
-        openingHours {
-            openingHoursOfDays {
-                firstOpeningTime
-                firstClosingTime
-                secondOpeningTime
-                secondClosingTime
-            }
-        }
         specialMessage
         locationLatitude
         locationLongitude

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoreQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoreQuery.graphql
@@ -1,14 +1,29 @@
-query StoreQuery($uuid: Uuid!) {
-    store(uuid: $uuid) {
+query StoreQuery($uuid: Uuid, $slug: String) {
+    store(uuid: $uuid, urlSlug: $slug) {
+        name
+        slug
+        isDefault
+        description
+        street
+        city
+        postcode
+        country {
+            code
+        }
         openingHours {
-            isOpen
             openingHoursOfDays {
-                dayOfWeek
                 firstOpeningTime
                 firstClosingTime
                 secondOpeningTime
                 secondClosingTime
             }
+        }
+        specialMessage
+        locationLatitude
+        locationLongitude
+        breadcrumb {
+            name
+            slug
         }
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoresQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoresQuery.graphql
@@ -13,14 +13,6 @@ query Stores ($first: Int, $last: Int) {
                 country {
                     code
                 }
-                openingHours {
-                    openingHoursOfDays {
-                        firstOpeningTime
-                        firstClosingTime
-                        secondOpeningTime
-                        secondClosingTime
-                    }
-                }
                 specialMessage
                 locationLatitude
                 locationLongitude

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoresQuery.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/query/StoresQuery.graphql
@@ -1,0 +1,30 @@
+query Stores ($first: Int, $last: Int) {
+    stores (first: $first, last: $last) {
+        edges {
+            node {
+                uuid
+                name
+                isDefault
+                description
+                contactInfo
+                street
+                city
+                postcode
+                country {
+                    code
+                }
+                openingHours {
+                    openingHoursOfDays {
+                        firstOpeningTime
+                        firstClosingTime
+                        secondOpeningTime
+                        secondClosingTime
+                    }
+                }
+                specialMessage
+                locationLatitude
+                locationLongitude
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The data-fixture-based stores' tests are not time-agnostic, i.e. they are affected by the current time of the test execution. The tests started to fail during the Christmas week as in data fixtures, the Ostrava store is open on Christmas Sunday, while the Pardubice store is closed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-store-test.odin.shopsys.cloud
  - https://cz.rv-fix-store-test.odin.shopsys.cloud
<!-- Replace -->
