### PR TITLE
[framework] fixed running cron module when memory limit set to -1

### DIFF
--- a/packages/framework/src/Component/Cron/CronModuleExecutor.php
+++ b/packages/framework/src/Component/Cron/CronModuleExecutor.php
@@ -85,8 +85,9 @@ class CronModuleExecutor
         );
 
         $memoryUsage = memory_get_usage(true);
+        $memoryLimit = BytesHelper::getPhpMemoryLimitInBytes();
 
-        if ($memoryUsage >= BytesHelper::getPhpMemoryLimitInBytes() * 0.9) {
+        if ($memoryLimit !== -1 && $memoryUsage >= $memoryLimit * 0.9) {
             $this->logger->info('Cron was running out of memory, so it was put to sleep to prevent failure.');
 
             return false;

--- a/packages/framework/tests/Unit/Component/Bytes/BytesHelperTest.php
+++ b/packages/framework/tests/Unit/Component/Bytes/BytesHelperTest.php
@@ -25,6 +25,7 @@ class BytesHelperTest extends TestCase
     public function phpStringBytesToBytesDataProvider(): array
     {
         return [
+            ['phpStringBytes' => '-1', 'expectedBytes' => -1],
             ['phpStringBytes' => '12', 'expectedBytes' => 12],
             ['phpStringBytes' => '12K', 'expectedBytes' => 12288],
             ['phpStringBytes' => '12M', 'expectedBytes' => 12582912],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If a PHP memory limit was set to -1 (unlimited), the safety-net mechanism incorrectly assumed that the memory usage was already too high and prevented cron from running. This is fixed now. The unlimited memory is a default value in Ubuntu that is used for running tests for the split framework package, see https://github.com/shopsys/shopsys/blob/14.0/packages/framework/.github/workflows/run-checks-tests.yaml
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-cron-memory-safenet.odin.shopsys.cloud
  - https://cz.mg-fix-cron-memory-safenet.odin.shopsys.cloud
<!-- Replace -->
