### PR TITLE
[shopsys] added dead letter queue

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -627,6 +627,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   define elasticsearch type for ID in structure ([#2495](https://github.com/shopsys/shopsys/pull/2495))
     -   see #project-base-diff to update your project
+-   add failure transport for unprocessable messages ([#2958](https://github.com/shopsys/shopsys/pull/2958))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/docs/asynchronous-processing/handling-failed-product-recalculations.md
+++ b/docs/asynchronous-processing/handling-failed-product-recalculations.md
@@ -1,0 +1,83 @@
+# Handling failed product recalculations
+
+Products are recalculated in batches.
+Because the batch is processed always as a whole, some products may fail to be recalculated, but it's not possible to determine which products failed.
+If a batch fails, the whole batch will be retried (up to three times).
+If the batch still fails even after the last retry, it will be marked as failed and sent to the failure transport.
+For the complete documentation of the configuration, see the [Symfony Messenger documentation](https://symfony.com/doc/current/messenger.html#retries-failures).
+
+This transport is defined in the `config/packages/messenger.yaml` file:
+
+```yaml
+framework:
+    messenger:
+        failure_transport: failed
+
+        transports:
+            failed: 'doctrine://default?queue_name=failed'
+```
+
+By default, the failure transport is configured to use the `doctrine` transport,
+which means that the failed batches will be stored in the database – in the `messenger_messages` table.
+
+To see the failed batches, you can use the `messenger:failed:show` command to see an output like this:
+
+```shell
+php ./bin/console messenger:failed:show
+
+There are 3 messages pending in the failure transport.
+ ---- --------------------------------------------------------------------------------- --------------------- ----------------------------------------------------------
+  Id   Class                                                                             Failed at             Error
+ ---- --------------------------------------------------------------------------------- --------------------- ----------------------------------------------------------
+  36   Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage   2023-12-27 13:43:15   Product visibility was not found for product with ID #1.
+  37   Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage   2023-12-27 13:43:15   Product visibility was not found for product with ID #1.
+  38   Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage   2023-12-27 13:43:15   Product visibility was not found for product with ID #1.
+ ---- --------------------------------------------------------------------------------- --------------------- ----------------------------------------------------------
+
+ // Run messenger:failed:show {id} --transport=failed -vv to see message details.
+```
+
+The batches will be here split into individual messages for each product.
+
+You can see the details of a specific message using the `messenger:failed:show` command with the `--transport` and `--id` options and see similar output:
+
+```shell
+php ./bin/console  messenger:failed:show 36 --transport=failed
+There are 3 messages pending in the failure transport.
+
+Failed Message Details
+======================
+
+ ------------- ---------------------------------------------------------------------------------
+  Class         Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage
+  Message Id    36
+  Failed at     2023-12-27 13:43:15
+  Error         Product visibility was not found for product with ID #1.
+  Error Code    0
+  Error Class   Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException
+  Transport     product_recalculation
+ ------------- ---------------------------------------------------------------------------------
+
+ Message history:
+  * Message failed at 2023-12-27 13:43:08 and was redelivered
+  * Message failed at 2023-12-27 13:43:09 and was redelivered
+  * Message failed at 2023-12-27 13:43:11 and was redelivered
+  * Message failed at 2023-12-27 13:43:15 and was redelivered
+
+ Re-run command with -vv to see more message & error details.
+
+ Run messenger:failed:retry 36 --transport=failed to retry this message.
+ Run messenger:failed:remove 36 --transport=failed to delete it.
+```
+
+!!! note
+
+    If you run the command with the `-vv` option, you will see the full stack trace of the error.
+
+You can retry the failed message(s) using the `messenger:failed:retry` command.
+At each failed message, you can retry it (by answering `yes`) or delete it (by answering `no`).
+
+If you retry the message, it will be immediately processed again.
+That way you can consume all possible products and only the ones that are really not possible to process will be left in the failure transport.
+
+If you delete the message, it will be removed from the failure transport and may not be recovered.

--- a/docs/asynchronous-processing/index.md
+++ b/docs/asynchronous-processing/index.md
@@ -1,0 +1,3 @@
+# Asynchronous processing
+
+-   [Handling failed product recalculations](./handling-failed-product-recalculations.md)

--- a/docs/asynchronous-processing/navigation.yml
+++ b/docs/asynchronous-processing/navigation.yml
@@ -1,0 +1,3 @@
+arrange:
+    - index.md
+    - handling-failed-product-recalculations.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ If you are struggling with Docker, [Docker Troubleshooting](./docker/docker-trou
     * Documentation for demo frontend client.
 * [Extensibility](./extensibility/index.md)
     * How to customize the behavior of Shopsys Platform to suit your needs.
+* [Asynchronous processing](./asynchronous-processing/index.md)
+    * How to use and implement asynchronous processing in Shopsys Platform.
 * [Automated Testing](./automated-testing/index.md)
     * Information about available types of tests and how to run them.
 * [Contributing](./contributing/index.md)

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -10,5 +10,6 @@ arrange:
     - frontend-api
     - storefront
     - extensibility
+    - asynchronous-processing
     - automated-testing
     - contributing

--- a/project-base/app/config/packages/messenger.yaml
+++ b/project-base/app/config/packages/messenger.yaml
@@ -1,11 +1,13 @@
 framework:
     messenger:
         reset_on_message: true
+        failure_transport: failed
         buses:
             messenger.bus.default:
                 middleware:
                     - 'Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope\DelayEnvelopeMiddleware'
         transports:
+            failed: 'doctrine://default?queue_name=failed'
             product_recalculation:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 options:

--- a/project-base/app/src/Migrations/Version20231227143511.php
+++ b/project-base/app/src/Migrations/Version20231227143511.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20231227143511 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('
+            CREATE TABLE messenger_messages (
+                id BIGSERIAL NOT NULL,
+                body TEXT NOT NULL,
+                headers TEXT NOT NULL,
+                queue_name VARCHAR(190) NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                available_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                delivered_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                PRIMARY KEY(id)
+            )');
+        $this->sql('CREATE INDEX IDX_75EA56E0FB7336F0 ON messenger_messages (queue_name)');
+        $this->sql('CREATE INDEX IDX_75EA56E0E3BD61CE ON messenger_messages (available_at)');
+        $this->sql('CREATE INDEX IDX_75EA56E016BA31DB ON messenger_messages (delivered_at)');
+        $this->sql('
+            CREATE
+            OR REPLACE FUNCTION notify_messenger_messages() RETURNS TRIGGER AS $$ BEGIN PERFORM pg_notify(
+                \'messenger_messages\', NEW.queue_name :: text
+            ); RETURN NEW; END; $$ LANGUAGE plpgsql;');
+        $this->sql('DROP TRIGGER IF EXISTS notify_trigger ON messenger_messages;');
+        $this->sql('
+            CREATE TRIGGER notify_trigger
+            AFTER
+                INSERT
+                OR
+            UPDATE
+                ON messenger_messages FOR EACH ROW EXECUTE PROCEDURE notify_messenger_messages();');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| dead letted queue (failure transport) is now automatically used for every transport. Also, the product recalculation handler was improved to leverage the failure transport.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-dead-letter-queue.odin.shopsys.cloud
  - https://cz.mg-dead-letter-queue.odin.shopsys.cloud
<!-- Replace -->
