### PR TITLE
fix Search results Blog Article link type

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -941,3 +941,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         -   in your `next.config.js`, add all your domains names into `images -> remotePatterns` setting
 
 -   improve translation caching ([#2949](https://github.com/shopsys/shopsys/pull/2949))
+-   fix Search results Blog Article link type ([#2961](https://github.com/shopsys/shopsys/pull/2961))
+    -   Wrong link type was causing the link to not work. Solved by replacing "article" with "blogArticle".

--- a/project-base/storefront/components/Pages/Search/SearchContent.tsx
+++ b/project-base/storefront/components/Pages/Search/SearchContent.tsx
@@ -42,7 +42,7 @@ export const SearchContent: FC<SearchContentProps> = ({ searchResults, fetching 
                         {!!searchResults.articlesSearch.length && (
                             <div className="mt-6">
                                 <div className="h3 mb-3">{t('Found articles')}</div>
-                                <SimpleNavigation linkType="article" listedItems={searchResults.articlesSearch} />
+                                <SimpleNavigation linkType="blogArticle" listedItems={searchResults.articlesSearch} />
                             </div>
                         )}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Fix Search results Blog Article link type. Wrong link type was causing link doesn't work.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tv-ssp-2023-fix-search-result-blog-article-link-type.odin.shopsys.cloud
  - https://cz.tv-ssp-2023-fix-search-result-blog-article-link-type.odin.shopsys.cloud
<!-- Replace -->
