### PR TITLE
[persoo-feed-article] fix build of the split package

### DIFF
--- a/packages/article-feed-persoo/composer.json
+++ b/packages/article-feed-persoo/composer.json
@@ -28,6 +28,7 @@
         "doctrine/doctrine-bundle": "^2.5.7",
         "doctrine/orm": "^2.11.2",
         "doctrine/persistence": "^2.4",
+        "shopsys/form-types-bundle": "14.0.x-dev",
         "shopsys/framework": "14.0.x-dev",
         "shopsys/migrations": "14.0.x-dev",
         "shopsys/plugin-interface": "14.0.x-dev",

--- a/packages/article-feed-persoo/tests/Unit/PersooArticleFeedItemTest.php
+++ b/packages/article-feed-persoo/tests/Unit/PersooArticleFeedItemTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Tests\ArticleFeed\PersooBundle\Unit;
+
 use Shopsys\ArticleFeed\PersooBundle\Model\PersooArticleFeedItemFactory;
 use Tests\FrameworkBundle\Unit\TestCase;
 

--- a/packages/article-feed-persoo/tests/Unit/PersooArticleFeedItemTest.php
+++ b/packages/article-feed-persoo/tests/Unit/PersooArticleFeedItemTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\ArticleFeed\PersooBundle\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Shopsys\ArticleFeed\PersooBundle\Model\PersooArticleFeedItemFactory;
-use Tests\FrameworkBundle\Unit\TestCase;
 
 class PersooArticleFeedItemTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| To make the installation of the split package work properly with the `dev` shopsys dependencies, all transitive shopsys dependencies must be explicitly added to the `composer.json` file (see https://github.com/shopsys/article-feed-persoo/actions/runs/7396075773/job/20122011389). Moreover, `PersooArticleFeedItemTest` was missing a namespace and was wrongly extending shopsys/framework `TestCase` instead of the one from PHPUnit.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-persoo-article.odin.shopsys.cloud
  - https://cz.rv-fix-persoo-article.odin.shopsys.cloud
<!-- Replace -->
