### PR TITLE
[SSP-2021] fix broken drag and drop in GrapesJS in Safari

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -764,6 +764,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   Frontend API `privacyPolicyArticle` query now returns `ArticleSite` type instead of `Article`
     -   Frontend API `cookiesArticle` query now returns `ArticleSite` type instead of `Article`
     -   see #project-base-diff to update your project
+-   fix broken drag and drop in GrapesJS in Safari ([#2966])(https://github.com/shopsys/shopsys/pull/2966)
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
+++ b/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
@@ -86,7 +86,7 @@ export default class InitGrapesJs {
             noticeOnUnload: false,
             avoidInlineStyle: false,
             forceClass: false,
-            nativeDnD: false,
+            nativeDnD: true,
             plugins: plugins,
             pluginsOpts: {
                 [ckeditorPlugin]: {

--- a/project-base/app/package.json
+++ b/project-base/app/package.json
@@ -65,7 +65,7 @@
         "codemirror": "^5.60.0",
         "counterup2": "^1.0.4",
         "grapesjs": "^0.20.3",
-        "grapesjs-plugin-ckeditor": "^0.0.10",
+        "grapesjs-plugin-ckeditor": "^1.0.1",
         "grapesjs-preset-newsletter": "^0.2.21",
         "grapesjs-preset-webpage": "^1.0.2",
         "intersection-observer": "^0.11.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Drag and drop did not work in Safari (from version 17.2). Allowing nativeDnD in GrapesJS fixed the issue
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2031-grapesjs-dnd-fix.odin.shopsys.cloud
  - https://cz.sh-ssp-2031-grapesjs-dnd-fix.odin.shopsys.cloud
<!-- Replace -->
