### PR TITLE
[SSP-2034] improve error handling for friendly URL pages based on API status codes

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -946,4 +946,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   fix Search results Blog Article link type ([#2961](https://github.com/shopsys/shopsys/pull/2961))
     -   Wrong link type was causing the link to not work. Solved by replacing "article" with "blogArticle".
 -   add categoryHierarchy to Category query ([#2962](https://github.com/shopsys/shopsys/pull/2962))
+
     -   in order to have proper category tree for GTM (and Persoo) we need to add proper category hierarchy tree, now we send whole tree instead of last category id
+
+-   improve error handling for friendly URL pages based on API status codes ([#2973](https://github.com/shopsys/shopsys/pull/2973))
+    -   API now returns a 500 code if there is a server error
+    -   friendly URL pages now react to API 500 errors and API not found errors, and display the correct pages based on this datapoint

--- a/packages/frontend-api/src/Model/Error/ErrorCodeSubscriber.php
+++ b/packages/frontend-api/src/Model/Error/ErrorCodeSubscriber.php
@@ -33,7 +33,7 @@ class ErrorCodeSubscriber implements EventSubscriberInterface
         }
 
         if ($userCode === null && $code === null) {
-            return;
+            $code = 500;
         }
 
         $formattedError = $event->getFormattedError();

--- a/project-base/storefront/helpers/errors/handleServerSideErrorResponseForFriendlyUrls.ts
+++ b/project-base/storefront/helpers/errors/handleServerSideErrorResponseForFriendlyUrls.ts
@@ -1,0 +1,20 @@
+import { GraphQLError } from 'graphql';
+import { IncomingMessage, ServerResponse } from 'http';
+
+export const handleServerSideErrorResponseForFriendlyUrls = (
+    graphQLErrors: GraphQLError[] | undefined,
+    data: unknown,
+    res: ServerResponse<IncomingMessage>,
+) => {
+    if (graphQLErrors?.[0]?.extensions.code === 500) {
+        throw new Error('Internal Server Error');
+    }
+
+    if (!data && !(res.statusCode === 503)) {
+        return {
+            notFound: true as const,
+        };
+    }
+
+    return null;
+};

--- a/project-base/storefront/pages/articles/[articleSlug].tsx
+++ b/project-base/storefront/pages/articles/[articleSlug].tsx
@@ -9,6 +9,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { parseCatnums } from 'helpers/parsing/grapesJsParser';
 import { getSlugFromServerSideUrl, getSlugFromUrl } from 'helpers/parsing/urlParsing';
@@ -67,10 +68,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     })
                     .toPromise();
 
-                if ((!articleResponse.data || !articleResponse.data.article) && !(context.res.statusCode === 503)) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    articleResponse.error?.graphQLErrors,
+                    articleResponse.data?.article,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
+++ b/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
@@ -9,6 +9,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { parseCatnums } from 'helpers/parsing/grapesJsParser';
 import { getSlugFromServerSideUrl, getSlugFromUrl } from 'helpers/parsing/urlParsing';
@@ -71,13 +72,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     })
                     .toPromise();
 
-                if (
-                    (!blogArticleResponse.data || !blogArticleResponse.data.blogArticle) &&
-                    !(context.res.statusCode === 503)
-                ) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    blogArticleResponse.error?.graphQLErrors,
+                    blogArticleResponse.data?.blogArticle,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
+++ b/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
@@ -11,6 +11,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { getNumberFromUrlQuery, getSlugFromServerSideUrl, getSlugFromUrl } from 'helpers/parsing/urlParsing';
 import { PAGE_QUERY_PARAMETER_NAME } from 'helpers/queryParamNames';
@@ -78,13 +79,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     })
                     .toPromise();
 
-                if (
-                    (!blogCategoryResponse.data || !blogCategoryResponse.data.blogCategory) &&
-                    !(context.res.statusCode === 503)
-                ) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    blogCategoryResponse.error?.graphQLErrors,
+                    blogCategoryResponse.data?.blogCategory,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -13,6 +13,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { getMappedProductFilter } from 'helpers/filterOptions/getMappedProductFilter';
 import { mapParametersFilter } from 'helpers/filterOptions/mapParametersFilter';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
@@ -116,13 +117,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     brandProductsResponsePromise,
                 ]);
 
-                if (
-                    (!brandDetailResponse.data || !brandDetailResponse.data.brand) &&
-                    !(context.res.statusCode === 503)
-                ) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    brandDetailResponse.error?.graphQLErrors,
+                    brandDetailResponse.data?.brand,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -12,6 +12,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { getMappedProductFilter } from 'helpers/filterOptions/getMappedProductFilter';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { getRedirectWithOffsetPage } from 'helpers/loadMore';
@@ -112,10 +113,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     categoryProductsResponsePromise,
                 ]);
 
-                if (!categoryDetailResponse.data?.category && !(context.res.statusCode === 503)) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    categoryDetailResponse.error?.graphQLErrors,
+                    categoryDetailResponse.data?.category,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -13,6 +13,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { getMappedProductFilter } from 'helpers/filterOptions/getMappedProductFilter';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { getRedirectWithOffsetPage } from 'helpers/loadMore';
@@ -112,10 +113,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     flagProductsResponsePromise,
                 ]);
 
-                if ((!flagDetailResponse.data || !flagDetailResponse.data.flag) && !(context.res.statusCode === 503)) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    flagDetailResponse.error?.graphQLErrors,
+                    flagDetailResponse.data?.flag,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 

--- a/project-base/storefront/pages/stores/[storeSlug].tsx
+++ b/project-base/storefront/pages/stores/[storeSlug].tsx
@@ -8,6 +8,7 @@ import {
 } from 'graphql/generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/helpers/eventFactories';
 import { useGtmPageViewEvent } from 'gtm/hooks/useGtmPageViewEvent';
+import { handleServerSideErrorResponseForFriendlyUrls } from 'helpers/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { isRedirectedFromSsr } from 'helpers/isRedirectedFromSsr';
 import { getSlugFromServerSideUrl, getSlugFromUrl } from 'helpers/parsing/urlParsing';
 import { getServerSidePropsWrapper } from 'helpers/serverSide/getServerSidePropsWrapper';
@@ -56,10 +57,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
                     })
                     .toPromise();
 
-                if ((!storeResponse.data || !storeResponse.data.store) && !(context.res.statusCode === 503)) {
-                    return {
-                        notFound: true,
-                    };
+                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                    storeResponse.error?.graphQLErrors,
+                    storeResponse.data?.store,
+                    context.res,
+                );
+
+                if (serverSideErrorResponse) {
+                    return serverSideErrorResponse;
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to show a 500/404 page for friendly URL pages if the data is not available or the API throws an 500 error
|New feature| Yes/No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2034-friendly-url-status-codes.odin.shopsys.cloud
  - https://cz.sh-ssp-2034-friendly-url-status-codes.odin.shopsys.cloud
<!-- Replace -->
