### PR TITLE
move migration 20200219145345

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -574,7 +574,7 @@ jobs:
                     docker compose up -d --force-recreate
                     docker cp ./ shopsys-framework-php-fpm:/var/www/html
                     docker compose exec -T --user root php-fpm chown -R www-data:www-data /var/www/html
-                    docker compose exec -T php-fpm rm -rf /var/www/html/composer.lock /var/www/html/project-base/package-lock.json /var/www/html/project-base/migrations-lock.yml
+                    docker compose exec -T php-fpm rm -rf /var/www/html/composer.lock /var/www/html/project-base/package-lock.json /var/www/html/project-base/migrations-lock.yml /var/www/html/project-base/storefront
                     docker compose exec -T php-fpm composer install --optimize-autoloader --no-interaction
                     docker compose exec -T php-fpm php phing -D production.confirm.action=y -D change.environment=dev environment-change dirs-create test-dirs-create assets npm build-version-generate db-create test-db-create db-demo elasticsearch-index-recreate elasticsearch-export error-pages-generate test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export tests-acceptance-build
             -   name: Check standards

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1478,6 +1478,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
             )
         ```
     -   methods `getVisibleAdvertsQueryBuilder()` and `getVisibleAdvertsByPositionNameQueryBuilder()` has been removed from `Shopsys\FrontendApiBundle\Model\Advert\AdvertRepository` and code usages has been replaced by usages from framework `AdvertRepository`
+-   moved migration `Version20200219145345` from project to framework ([#2975](https://github.com/shopsys/shopsys/pull/2975))
+    -   migration `App\Migrations\Version20200219145345` was moved to framework. You can safety delete it.
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/framework/src/Migrations/Version20200219145345.php
+++ b/packages/framework/src/Migrations/Version20200219145345.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Migrations;
+namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
@@ -14,8 +14,10 @@ class Version20200219145345 extends AbstractMigration
      */
     public function up(Schema $schema): void
     {
-        $this->sql('ALTER TABLE adverts ADD datetime_visible_from TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
-        $this->sql('ALTER TABLE adverts ADD datetime_visible_to TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        if ($this->isAppMigrationNotInstalledRemoveIfExists('Version20200219145345')) {
+            $this->sql('ALTER TABLE adverts ADD datetime_visible_from TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+            $this->sql('ALTER TABLE adverts ADD datetime_visible_to TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Move migration Version 20200219145345 has wrong namespace. Entity Adverts has properties $datetimeVisibleFrom and $datetimeVisibleTo in entity on framework package.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

