### PR TITLE
[framework] product recalculations priority queue

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -772,6 +772,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   `Shopsys\FrameworkBundle\Controller\Admin\ProductController` class was changed:
         -   `editAction()` is now strictly typed
         -   `newAction()` is now strictly typed
+        -   `deleteAction()` is now strictly typed
     -   `Shopsys\FrameworkBundle\Model\Product\ProductFacade` class was changed:
         -   `create()` method changed its interface:
         ```diff
@@ -790,6 +791,15 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         +       ?ProductRecalculationPriorityEnumInterface $priority = null,
         -   )
         +   ): Product
+        ```
+        -   `delete()` method changed its interface:
+        ```diff
+            public function delete(
+        -       $productId
+        +       int $productId,
+        +       ?ProductRecalculationPriorityEnumInterface $priority = null,
+        -   )
+        +   ): void
         ```
     -   see #project-base-diff to update your project
 

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -768,6 +768,30 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   add Category ID to CategoryHierarchyItem ([#2962](https://github.com/shopsys/shopsys/pull/2962))
     -   see #project-base-diff to update your project
+-   product recalculations priority queue ([#2981](https://github.com/shopsys/shopsys/pull/2981))
+    -   `Shopsys\FrameworkBundle\Controller\Admin\ProductController` class was changed:
+        -   `editAction()` is now strictly typed
+        -   `newAction()` is now strictly typed
+    -   `Shopsys\FrameworkBundle\Model\Product\ProductFacade` class was changed:
+        -   `create()` method changed its interface:
+        ```diff
+            public function create(
+                ProductData $productData
+        +       ?ProductRecalculationPriorityEnumInterface $priority = null,
+        -   )
+        +   ): Product
+        ```
+        -   `edit()` method changed its interface:
+        ```diff
+            public function edit(
+        -       $productId,
+        +       int $productId,
+                ProductData $productData,
+        +       ?ProductRecalculationPriorityEnumInterface $priority = null,
+        -   )
+        +   ): Product
+        ```
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/docs/asynchronous-processing/handling-failed-product-recalculations.md
+++ b/docs/asynchronous-processing/handling-failed-product-recalculations.md
@@ -49,13 +49,13 @@ Failed Message Details
 ======================
 
  ------------- ---------------------------------------------------------------------------------
-  Class         Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage
+  Class         Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityRegularMessage
   Message Id    36
   Failed at     2023-12-27 13:43:15
   Error         Product visibility was not found for product with ID #1.
   Error Code    0
   Error Class   Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException
-  Transport     product_recalculation
+  Transport     product_recalculation_priority_regular
  ------------- ---------------------------------------------------------------------------------
 
  Message history:

--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -28,9 +28,11 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData;
 use Shopsys\FrameworkBundle\Model\Product\ProductDataFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\ProductFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum;
 use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
 use Shopsys\FrameworkBundle\Twig\ProductExtension;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -74,8 +76,9 @@ class ProductController extends AdminBaseController
      * @Route("/product/edit/{id}", requirements={"id" = "\d+"})
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function editAction(Request $request, int $id)
+    public function editAction(Request $request, int $id): Response
     {
         $product = $this->productFacade->getById($id);
         $productData = $this->productDataFactory->createFromProduct($product);
@@ -85,7 +88,7 @@ class ProductController extends AdminBaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->setSellingToUntilEndOfDay($productData);
-            $this->productFacade->edit($id, $productData);
+            $this->productFacade->edit($id, $productData, ProductRecalculationPriorityEnum::HIGH);
 
             $this
                 ->addSuccessFlashTwig(
@@ -119,8 +122,9 @@ class ProductController extends AdminBaseController
     /**
      * @Route("/product/new/")
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         try {
             $productData = $this->productDataFactory->create();
@@ -135,7 +139,7 @@ class ProductController extends AdminBaseController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->setSellingToUntilEndOfDay($productData);
-            $product = $this->productFacade->create($productData);
+            $product = $this->productFacade->create($productData, ProductRecalculationPriorityEnum::HIGH);
 
             $this
                 ->addSuccessFlashTwig(

--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -230,13 +230,14 @@ class ProductController extends AdminBaseController
      * @Route("/product/delete/{id}", requirements={"id" = "\d+"})
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function deleteAction($id)
+    public function deleteAction(int $id): Response
     {
         try {
             $product = $this->productFacade->getById($id);
 
-            $this->productFacade->delete($id);
+            $this->productFacade->delete($id, ProductRecalculationPriorityEnum::HIGH);
 
             $this->addSuccessFlashTwig(
                 t('Product <strong>{{ product|productDisplayName }}</strong> deleted'),

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -180,18 +180,21 @@ class ProductFacade
 
     /**
      * @param int $productId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority nullable because of https://github.com/nikic/PHP-Parser/pull/940
      */
-    public function delete($productId)
-    {
+    public function delete(
+        int $productId,
+        ?ProductRecalculationPriorityEnumInterface $priority = null,
+    ): void {
         $product = $this->productRepository->getById($productId);
         $productDeleteResult = $product->getProductDeleteResult();
         $productsForRecalculations = $productDeleteResult->getProductsForRecalculations();
 
         foreach ($productsForRecalculations as $productForRecalculations) {
-            $this->productRecalculationDispatcher->dispatchSingleProductId($productForRecalculations->getId());
+            $this->productRecalculationDispatcher->dispatchSingleProductId($productForRecalculations->getId(), $priority ?? ProductRecalculationPriorityEnum::REGULAR);
         }
 
-        $this->productRecalculationDispatcher->dispatchSingleProductId($product->getId());
+        $this->productRecalculationDispatcher->dispatchSingleProductId($product->getId(), $priority ?? ProductRecalculationPriorityEnum::REGULAR);
 
         $this->em->remove($product);
         $this->em->flush();

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -21,6 +21,8 @@ use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculation;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductSellingPrice;
 use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnumInterface;
 use Shopsys\FrameworkBundle\Model\Stock\ProductStockData;
 use Shopsys\FrameworkBundle\Model\Stock\ProductStockFacade;
 use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
@@ -84,10 +86,13 @@ class ProductFacade
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority nullable because of https://github.com/nikic/PHP-Parser/pull/940
      * @return \Shopsys\FrameworkBundle\Model\Product\Product
      */
-    public function create(ProductData $productData)
-    {
+    public function create(
+        ProductData $productData,
+        ?ProductRecalculationPriorityEnumInterface $priority = null,
+    ): Product {
         $product = $this->productFactory->create($productData);
 
         $this->em->persist($product);
@@ -98,7 +103,7 @@ class ProductFacade
 
         $this->editProductStockRelation($productData, $product);
 
-        $this->productRecalculationDispatcher->dispatchSingleProductId($product->getId());
+        $this->productRecalculationDispatcher->dispatchSingleProductId($product->getId(), $priority ?? ProductRecalculationPriorityEnum::REGULAR);
 
         return $product;
     }
@@ -131,10 +136,14 @@ class ProductFacade
     /**
      * @param int $productId
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductData $productData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority nullable because of https://github.com/nikic/PHP-Parser/pull/940
      * @return \Shopsys\FrameworkBundle\Model\Product\Product
      */
-    public function edit($productId, ProductData $productData)
-    {
+    public function edit(
+        int $productId,
+        ProductData $productData,
+        ?ProductRecalculationPriorityEnumInterface $priority = null,
+    ): Product {
         $product = $this->productRepository->getById($productId);
 
         $productCategoryDomains = $this->productCategoryDomainFactory->createMultiple(
@@ -164,7 +173,7 @@ class ProductFacade
 
         $this->editProductStockRelation($productData, $product);
 
-        $this->productRecalculationDispatcher->dispatchSingleProductId($product->getId());
+        $this->productRecalculationDispatcher->dispatchSingleProductId($product->getId(), $priority ?? ProductRecalculationPriorityEnum::REGULAR);
 
         return $product;
     }

--- a/packages/framework/src/Model/Product/Recalculation/AbstractProductRecalculationMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/AbstractProductRecalculationMessage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
-class ProductRecalculationMessage
+abstract class AbstractProductRecalculationMessage
 {
     /**
      * @param int $productId

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
@@ -25,11 +25,11 @@ class ProductRecalculationMessageHandler implements BatchHandlerInterface
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage $message
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage $message
      * @param \Symfony\Component\Messenger\Handler\Acknowledger|null $ack
      * @return mixed
      */
-    public function __invoke(ProductRecalculationMessage $message, ?Acknowledger $ack = null): mixed
+    public function __invoke(AbstractProductRecalculationMessage $message, ?Acknowledger $ack = null): mixed
     {
         return $this->handle($message, $ack);
     }
@@ -43,7 +43,7 @@ class ProductRecalculationMessageHandler implements BatchHandlerInterface
         $acknowledgers = [];
 
         /**
-         * @var \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage $message
+         * @var \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage $message
          * @var \Symfony\Component\Messenger\Handler\Acknowledger $ack
          */
         foreach ($jobs as [$message, $ack]) {

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnum.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+enum ProductRecalculationPriorityEnum: string implements ProductRecalculationPriorityEnumInterface
+{
+    case HIGH = 'high';
+    case REGULAR = 'regular';
+
+    /**
+     * @return string
+     */
+    public static function getPipeSeparatedValues(): string
+    {
+        return implode('|', array_column(self::cases(), 'value'));
+    }
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnumInterface.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnumInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+interface ProductRecalculationPriorityEnumInterface
+{
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityHighMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityHighMessage.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+class ProductRecalculationPriorityHighMessage extends AbstractProductRecalculationMessage
+{
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityRegularMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityRegularMessage.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+class ProductRecalculationPriorityRegularMessage extends AbstractProductRecalculationMessage
+{
+}

--- a/project-base/app/config/packages/messenger.yaml
+++ b/project-base/app/config/packages/messenger.yaml
@@ -8,15 +8,24 @@ framework:
                     - 'Shopsys\FrameworkBundle\Component\Messenger\DelayedEnvelope\DelayEnvelopeMiddleware'
         transports:
             failed: 'doctrine://default?queue_name=failed'
-            product_recalculation:
+            product_recalculation_priority_regular:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 options:
                     vhost: '%env(MESSENGER_TRANSPORT_VHOST)%'
                     exchange:
-                        name: product_recalculation
+                        name: product_recalculation_priority_regular
                         type: direct
                     queues:
-                        product_recalculation: ~
+                        product_recalculation_priority_regular: ~
+            product_recalculation_priority_high:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    vhost: '%env(MESSENGER_TRANSPORT_VHOST)%'
+                    exchange:
+                        name: product_recalculation_priority_high
+                        type: direct
+                    queues:
+                        product_recalculation_priority_high: ~
             placed_order_transport:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                 options:
@@ -32,6 +41,7 @@ framework:
                     multiplier: 5
 
         routing:
-            Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage: product_recalculation
-            Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAllProductsMessage: product_recalculation
+            Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityRegularMessage: product_recalculation_priority_regular
+            Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityHighMessage: product_recalculation_priority_high
+            Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAllProductsMessage: product_recalculation_priority_regular
             Shopsys\FrameworkBundle\Model\Order\Messenger\PlacedOrderMessage: placed_order_transport

--- a/project-base/app/deploy/deploy-project.sh
+++ b/project-base/app/deploy/deploy-project.sh
@@ -118,7 +118,7 @@ function merge() {
     # Specify consumers configuration with the default configuration in the format:
     # <consumer-name>:<transport-names-separated-by-space>:<number-of-consumers>
     DEFAULT_CONSUMERS=(
-        "product-recalculation:product_recalculation:1"
+        "product-recalculation:product_recalculation_priority_high product_recalculation_priority_regular:1"
         "placed_order:placed_order_transport:1"
     )
 

--- a/project-base/app/docker/php-fpm/consumer-entrypoint.sh
+++ b/project-base/app/docker/php-fpm/consumer-entrypoint.sh
@@ -3,6 +3,7 @@
 TIME_LIMIT=${1:-60}
 
 php ./bin/console messenger:consume \
-    product_recalculation \
+    product_recalculation_priority_high \
+    product_recalculation_priority_regular \
     placed_order_transport \
     --time-limit=$TIME_LIMIT

--- a/project-base/app/src/Controller/Admin/ProductController.php
+++ b/project-base/app/src/Controller/Admin/ProductController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Controller\Admin\ProductController as BaseProductController;
-use Shopsys\FrameworkBundle\Form\Admin\Product\ProductFormType;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,50 +22,6 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class ProductController extends BaseProductController
 {
-    /**
-     * @Route("/product/edit/{id}", requirements={"id" = "\d+"})
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param mixed $id
-     */
-    public function editAction(Request $request, $id)
-    {
-        $product = $this->productFacade->getById($id);
-        $productData = $this->productDataFactory->createFromProduct($product);
-
-        $form = $this->createForm(ProductFormType::class, $productData, ['product' => $product]);
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $this->productFacade->edit($id, $form->getData());
-
-            $this
-                ->addSuccessFlashTwig(
-                    t('Product <strong><a href="{{ url }}">{{ product|productDisplayName }}</a></strong> modified'),
-                    [
-                        'product' => $product,
-                        'url' => $this->generateUrl('admin_product_edit', ['id' => $product->getId()]),
-                    ],
-                );
-
-            return $this->redirectToRoute('admin_product_list');
-        }
-
-        if ($form->isSubmitted() && !$form->isValid()) {
-            $this->addErrorFlashTwig(t('Please check the correctness of all data filled.'));
-        }
-
-        $this->breadcrumbOverrider->overrideLastItem(t('Editing product - %name%', ['%name%' => $this->productExtension->getProductDisplayName($product)]));
-
-        $viewParameters = [
-            'form' => $form->createView(),
-            'product' => $product,
-            'domains' => $this->domain->getAll(),
-            'productParameterValuesData' => $productData->parameters,
-        ];
-
-        return $this->render('@ShopsysFramework/Admin/Content/Product/edit.html.twig', $viewParameters);
-    }
-
     /**
      * @Route("/product/edit/catnum-exists")
      * @param \Symfony\Component\HttpFoundation\Request $request

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -27,6 +27,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnumInterface;
 use Shopsys\FrameworkBundle\Model\Stock\ProductStockFacade;
 use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
 
@@ -44,7 +45,7 @@ use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
  * @method createProductVisibilities(\App\Model\Product\Product $product)
  * @method \App\Model\Product\Product getOneByCatnumExcludeMainVariants(string $productCatnum)
  * @method \App\Model\Product\Product getByUuid(string $uuid)
- * @method \App\Model\Product\Product create(\App\Model\Product\ProductData $productData)
+ * @method \App\Model\Product\Product create(\App\Model\Product\ProductData $productData, \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority = null)
  * @property \App\Model\Product\ProductFactory $productFactory
  * @method setAdditionalDataAfterCreate(\App\Model\Product\Product $product, \App\Model\Product\ProductData $productData)
  * @method editProductStockRelation(\App\Model\Product\ProductData $productData, \App\Model\Product\Product $product)
@@ -137,12 +138,16 @@ class ProductFacade extends BaseProductFacade
     /**
      * @param int $productId
      * @param \App\Model\Product\ProductData $productData
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority
      * @return \App\Model\Product\Product
      */
-    public function edit($productId, ProductData $productData)
-    {
+    public function edit(
+        int $productId,
+        ProductData $productData,
+        ?ProductRecalculationPriorityEnumInterface $priority = null,
+    ): Product {
         /** @var \App\Model\Product\Product $product */
-        $product = parent::edit($productId, $productData);
+        $product = parent::edit($productId, $productData, $priority);
 
         $this->productVideoFacade->saveProductVideosToProduct($product, $productData->productVideosData);
 

--- a/project-base/app/tests/App/Test/WebTestCase.php
+++ b/project-base/app/tests/App/Test/WebTestCase.php
@@ -156,14 +156,16 @@ abstract class WebTestCase extends BaseWebTestCase implements ServiceContainerTe
 
         $this->dispatchFakeKernelResponseEventToTriggerSendMessageToTransport();
 
-        /** @var \Symfony\Component\Messenger\Transport\InMemoryTransport $transport */
-        $transport = self::getContainer()->get('messenger.transport.product_recalculation');
+        /** @var \Symfony\Component\Messenger\Transport\InMemoryTransport $regularPriorityTransport */
+        $regularPriorityTransport = self::getContainer()->get('messenger.transport.product_recalculation_priority_regular');
+        /** @var \Symfony\Component\Messenger\Transport\InMemoryTransport $highPriorityTransport */
+        $highPriorityTransport = self::getContainer()->get('messenger.transport.product_recalculation_priority_high');
         $handler = $this->productRecalculationMessageHandler;
 
-        $envelopes = $transport->getSent();
+        $envelopes = [...$highPriorityTransport->getSent(), ...$regularPriorityTransport->getSent()];
 
         foreach ($envelopes as $envelope) {
-            /** @var \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessage $message */
+            /** @var \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage $message */
             $message = $envelope->getMessage();
             $handler($message);
         }

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -598,9 +598,6 @@ msgstr "Editace hodnoty parametru typu barva"
 msgid "Editing pararameter value of type color - %name%"
 msgstr "Úprava hodnoty parametru typu barva - %name%"
 
-msgid "Editing product - %name%"
-msgstr "Editace produktu - %name%"
-
 msgid "Editing promo code"
 msgstr "Editace slevového kupónu"
 
@@ -1377,9 +1374,6 @@ msgstr "Nastavení zásad ochrany osobních údajů - zobrazení"
 
 msgid "Product"
 msgstr "Produkt"
-
-msgid "Product <strong><a href=\"{{ url }}\">{{ product|productDisplayName }}</a></strong> modified"
-msgstr "Produkt <strong><a href=\"{{ url }}\">{{ product|productDisplayName }}</a></strong> byl upraven"
 
 msgid "Products - full"
 msgstr "Produkty - vše"

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -598,9 +598,6 @@ msgstr ""
 msgid "Editing pararameter value of type color - %name%"
 msgstr ""
 
-msgid "Editing product - %name%"
-msgstr ""
-
 msgid "Editing promo code"
 msgstr ""
 
@@ -1376,9 +1373,6 @@ msgid "Privacy policy article setting - view"
 msgstr ""
 
 msgid "Product"
-msgstr ""
-
-msgid "Product <strong><a href=\"{{ url }}\">{{ product|productDisplayName }}</a></strong> modified"
 msgstr ""
 
 msgid "Products - full"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We want to be able to use priority queue for products recalculations - when admin saves product, the changes should be processed with higher priority then product changes made by background jobs (e.g. ERP transfers)
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-priority-queue.odin.shopsys.cloud
  - https://cz.rv-priority-queue.odin.shopsys.cloud
<!-- Replace -->
