### PR TITLE
[monorepo] alpha branch is now automatically split and deployed

### DIFF
--- a/.github/workflows/monorepo-split-alpha.yaml
+++ b/.github/workflows/monorepo-split-alpha.yaml
@@ -1,0 +1,28 @@
+on:
+    push:
+        branches:
+            - 'alpha'
+name: Split alpha branch
+permissions:
+    contents: write
+    actions: write
+jobs:
+    split-branch:
+        runs-on: ubuntu-22.04
+        name: Split ${{ github.ref_name }} branch
+        steps:
+            -   name: GIT checkout branch - ${{ github.ref_name }}
+                uses: actions/checkout@v4
+                with:
+                    ref: ${{ github.ref }}
+            -   name: Ensure ${{ github.ref_name }} branch dependencies in project-base/composer.json
+                run: |
+                    sed -i 's/"14.0.x-dev"/"dev-${{ github.ref_name }} as 14.0.x-dev"/' project-base/app/composer.json
+                    git config --global user.name 'ShopsysBot'
+                    git config --global user.email 'shopsysbot@users.noreply.github.com'
+                    git commit -am "Ensure ${{ github.ref_name }} branch dependencies in project-base/app/composer.json"
+                    git push
+            -   name: Force split ${{ github.ref_name }} branch
+                env:
+                    GH_TOKEN: ${{ github.token }}
+                run: gh workflow run "monorepo-force-split-branch.yaml" --ref "${{ github.ref_name }}" --field branch_name="${{ github.ref_name }}"

--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -296,6 +296,21 @@ deploy:devel:
         kubernetes:
             namespace: ${PROJECT_NAME}
 
+deploy:alpha:
+    <<: *deploy
+    resource_group: deploy_alpha
+    variables:
+        KUBE_CONFIG: ${KUBE_CONFIG_DEVEL}
+    rules:
+        -   if: '$CI_PIPELINE_SOURCE == "schedule"'
+            when: never
+        -   if: '$CI_COMMIT_BRANCH == "alpha" || $CI_COMMIT_BRANCH =~ /^alpha-.*$/'
+    environment:
+        name: devel-alpha
+        url: https://${DOMAIN_HOSTNAME_1}
+        kubernetes:
+            namespace: ${PROJECT_NAME}
+
 test:gatling:
     stage: test
     image:

--- a/project-base/gitlab/mirror-repository/gitlab-stage.yml
+++ b/project-base/gitlab/mirror-repository/gitlab-stage.yml
@@ -11,3 +11,4 @@ mirror-project-from-github:
         - '[[ -f /.dockerenv ]] && echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config'
         - echo "$SSHKEY_MIRROR_PROJECT_BASE" | ssh-add -
         - sh ./gitlab/mirror-repository/mirror.sh "shopsys-project-base" "git@github.com:shopsys/project-base.git" "$MIRROR_SOURCE_BRANCH" "git@gitlab.shopsys.cz:ss6-projects/project-base.git" "$MIRROR_TARGET_BRANCH"
+        - sh ./gitlab/mirror-repository/mirror.sh "shopsys-project-base-alpha" "git@github.com:shopsys/project-base.git" "alpha" "git@gitlab.shopsys.cz:ss6-projects/project-base.git" "alpha"

--- a/project-base/gitlab/scripts/repository-clean.sh
+++ b/project-base/gitlab/scripts/repository-clean.sh
@@ -8,6 +8,7 @@ NO_COLOR='\e[39m'
 declare -A REPOSITORY_NAME_MAP_TO_ENVIRONMENT=(
   ["master"]="production"
   ["devel"]="devel"
+  ["alpha"]="devel-alpha"
 )
 
 containsElement () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| branch named alpha is now automatically split and deployed to cluster via gitlab 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-alpha-build.odin.shopsys.cloud
  - https://cz.mg-alpha-build.odin.shopsys.cloud
<!-- Replace -->
