### PR TITLE
[infrastructure] GitHub actions now use default_branch set in repository instead of variable

### DIFF
--- a/.github/cancel-old-reviews.sh
+++ b/.github/cancel-old-reviews.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MAIN_BRANCH_NAME=$1
+DEFAULT_BRANCH=$1
 ACTIONS_TOKEN=$2
 
 current_date=$(date +%Y-%m-%d)
@@ -25,7 +25,7 @@ branches_between_fourteen_and_seven_days_ago=($branches_between_fourteen_and_sev
 IFS=$SAVEIFS
 
 # add main branch to branches between 14 and 7 days ago in order to prevent its cancellation
-branches_between_fourteen_and_seven_days_ago+=($MAIN_BRANCH_NAME)
+branches_between_fourteen_and_seven_days_ago+=($DEFAULT_BRANCH)
 
 filtered_branches=()
 

--- a/.github/workflows/cancel-old-reviews.yaml
+++ b/.github/workflows/cancel-old-reviews.yaml
@@ -16,4 +16,4 @@ jobs:
             -   name: Cancel reviews older than seven days
                 working-directory: cancel-old-reviews
                 run: |
-                    /bin/bash ./.github/cancel-old-reviews.sh ${{ vars.MAIN_BRANCH_NAME }} ${{ secrets.ACTIONS_TOKEN }}
+                    /bin/bash ./.github/cancel-old-reviews.sh ${{ github.event.repository.default_branch }} ${{ secrets.ACTIONS_TOKEN }}

--- a/.github/workflows/clean-up-after-branch-merge.yaml
+++ b/.github/workflows/clean-up-after-branch-merge.yaml
@@ -19,10 +19,10 @@ jobs:
         runs-on: [self-hosted, linux, review-stage]
         needs: variables
         steps:
-            -   name: GIT checkout branch - ${{ vars.MAIN_BRANCH_NAME }}
+            -   name: GIT checkout branch - ${{ github.event.repository.default_branch }}
                 uses: actions/checkout@v4
                 with:
-                    ref: 'refs/heads/${{ vars.MAIN_BRANCH_NAME }}'
+                    ref: 'refs/heads/${{ github.event.repository.default_branch }}'
                     path: cancel-review-after-branch-merge
             -   name: Cancel review
                 working-directory: cancel-review-after-branch-merge
@@ -33,10 +33,10 @@ jobs:
         needs: variables
         runs-on: ubuntu-22.04
         steps:
-            -   name: GIT checkout branch - ${{ vars.MAIN_BRANCH_NAME }}
+            -   name: GIT checkout branch - ${{ github.event.repository.default_branch }}
                 uses: actions/checkout@v4
                 with:
-                    ref: 'refs/heads/${{ vars.MAIN_BRANCH_NAME }}'
+                    ref: 'refs/heads/${{ github.event.repository.default_branch }}'
             -   name: Prepare variables for removing split branches from packages
                 run: |
                     echo "REMOTE_TEMPLATE=https://${{ secrets.ACTIONS_GIT_PUSH_TOKEN }}@github.com/shopsys/" >> $GITHUB_ENV

--- a/.github/workflows/manually-cancel-review.yaml
+++ b/.github/workflows/manually-cancel-review.yaml
@@ -8,14 +8,14 @@ on:
 name: Manually cancel review
 jobs:
     cancel-review:
-        if:  ${{ inputs.branch_name }} != ${{ vars.MAIN_BRANCH_NAME }}
+        if:  ${{ inputs.branch_name }} != ${{ github.event.repository.default_branch }}
         name: Cancel review
         runs-on: [self-hosted, linux, review-stage]
         steps:
-            -   name: GIT checkout branch - ${{ vars.MAIN_BRANCH_NAME }}
+            -   name: GIT checkout branch - ${{ github.event.repository.default_branch }}
                 uses: actions/checkout@v4
                 with:
-                    ref: 'refs/heads/${{ vars.MAIN_BRANCH_NAME }}'
+                    ref: 'refs/heads/${{ github.event.repository.default_branch }}'
                     path: manually-cancel-review
             -   name: Cancel review
                 working-directory: manually-cancel-review


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Removed not necessary variable and replaced with the variable present in GitHub actions.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-github-actions-default-branch.odin.shopsys.cloud
  - https://cz.tl-github-actions-default-branch.odin.shopsys.cloud
<!-- Replace -->
