### PR TITLE
[coding-standards] removed disallowed PHP 4 constructor type sniff

### DIFF
--- a/packages/coding-standards/ecs.php
+++ b/packages/coding-standards/ecs.php
@@ -14,7 +14,6 @@ use PHP_CodeSniffer\Standards\Generic\Sniffs\Formatting\NoSpaceAfterCastSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Functions\CallTimePassByReferenceSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\CyclomaticComplexitySniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff;
-use PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\ConstructorNameSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DiscourageGotoSniff;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\NoSilencedErrorsSniff;
 use PHP_CodeSniffer\Standards\MySource\Sniffs\PHP\GetRequestDataSniff;
@@ -216,7 +215,6 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->ruleWithConfiguration(CyclomaticComplexitySniff::class, [
         'absoluteComplexity' => CyclomaticComplexitySniffSetting::DEFAULT_ABSOLUTE_COMPLEXITY,
     ]);
-    $ecsConfig->rule(ConstructorNameSniff::class);
     $ecsConfig->rule(CamelCapsFunctionNameSniff::class);
     $ecsConfig->rule(DiscourageGotoSniff::class);
     $ecsConfig->rule(NoSilencedErrorsSniff::class);

--- a/project-base/app/ecs.php
+++ b/project-base/app/ecs.php
@@ -186,9 +186,6 @@ return static function (ECSConfig $ecsConfig): void {
         'SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff.UnusedProperty' => [
             __DIR__ . '/src/Model/Category/LinkedCategory/LinkedCategory.php',
         ],
-        'PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\ConstructorNameSniff.OldStyle' => [
-            __DIR__ . '/src/FrontendApi/Mutation/Login/RefreshTokensMutation.php',
-        ],
         // @deprecated File is excluded as the comments are already missing and deprecated methods will not be in next major
         DeprecatedAnnotationDeclarationSniff::class => [
             __DIR__ . '/tests/App/Test/Codeception/Module/StrictWebDriver.php',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| since PHP 8, methods with the same name are not considered constructors and may be safely used
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-old-construct.odin.shopsys.cloud
  - https://cz.mg-old-construct.odin.shopsys.cloud
<!-- Replace -->
