### PR TITLE
[infrastructure] fixed path to codeception logs in project-base

### DIFF
--- a/project-base/.github/workflows/run-checks-tests.yaml
+++ b/project-base/.github/workflows/run-checks-tests.yaml
@@ -29,13 +29,13 @@ jobs:
                 run: docker-compose logs php-fpm
             -   name: Copy Codeception logs from container
                 if: ${{ failure() }}
-                run: docker cp shopsys-framework-php-fpm:/var/www/html/var/log ./var/log
+                run: docker cp shopsys-framework-php-fpm:/var/www/html/var/log ./app/var/log
             -   name: Upload Codeception logs to artifacts
                 if: ${{ failure() }}
                 uses: actions/upload-artifact@v2
                 with:
                     name: acceptance-logs
-                    path: ./var/log
+                    path: ./app/var/log
 
             -   name: Build Storefront part of application
                 run: |
@@ -111,13 +111,13 @@ jobs:
                 run: docker-compose logs php-fpm
             -   name: Copy Codeception logs from container
                 if: ${{ failure() }}
-                run: docker cp shopsys-framework-php-fpm:/var/www/html/var/log ./var/log
+                run: docker cp shopsys-framework-php-fpm:/var/www/html/var/log ./app/var/log
             -   name: Upload Codeception logs to artifacts
                 if: ${{ failure() }}
                 uses: actions/upload-artifact@v2
                 with:
                     name: acceptance-logs
-                    path: ./var/log
+                    path: ./app/var/log
 
             -   name: Build Storefront part of application
                 run: |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| There is a wrong path in Codeception logs for project-base tests that causes failure of uploading artifacts.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes/No





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-codeception-logs.odin.shopsys.cloud
  - https://cz.tl-fix-codeception-logs.odin.shopsys.cloud
<!-- Replace -->
