### PR TITLE
[project-base] grapesjs product catnums field is now text input

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1139,6 +1139,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   sent emails via async queue ([#2998](https://github.com/shopsys/shopsys/pull/2998))
     -   see #project-base-diff to update your project
+-   change the product catnums field type in GrapesJs to text (([#2994](https://github.com/shopsys/shopsys/pull/2994)))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/framework/src/Component/GrapesJs/GrapesJsParser.php
+++ b/packages/framework/src/Component/GrapesJs/GrapesJsParser.php
@@ -25,7 +25,8 @@ class GrapesJsParser
         }
 
         $newText = preg_replace_callback(static::GJS_PRODUCTS_REGEX, static function (array $matches): string {
-            preg_match('/data-products="(.+?)"/', $matches[0], $productMatches);
+            $gjsProductsDiv = str_replace(["\r", "\n", "\r\n"], '', $matches[0]);
+            preg_match('/data-products="(.+?)"/', $gjsProductsDiv, $productMatches);
             $productArray = explode(',', $productMatches[1]);
             $trimmedProductArray = array_map(static fn ($product) => trim($product), $productArray);
             $productCatnumsString = implode(',', $trimmedProductArray);

--- a/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-products-plugin.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-products-plugin.js
@@ -142,7 +142,7 @@ export default grapesjs.plugins.add('products', editor => {
                 `,
                 traits: [
                     {
-                        type: 'textarea',
+                        type: 'text',
                         name: dataProducts,
                         label: Translator.trans('Catalog numbers delimited by comma')
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| line wrappings in values cannot be processed correctly
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-grapesjs-products-singleline.odin.shopsys.cloud
  - https://cz.mg-grapesjs-products-singleline.odin.shopsys.cloud
<!-- Replace -->
