### PR TITLE
[shopsys] emails are now sent via queue

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1137,6 +1137,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
     -   see #project-base-diff to update your project
 
+-   sent emails via async queue ([#2998](https://github.com/shopsys/shopsys/pull/2998))
+    -   see #project-base-diff to update your project
+
 ### Storefront
 
 -   add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Model/Mail/Email.php
+++ b/packages/framework/src/Model/Mail/Email.php
@@ -30,4 +30,24 @@ class Email extends BaseEmail
     {
         return $this->domainId;
     }
+
+    /**
+     * @internal
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        return [$this->domainId, parent::__serialize()];
+    }
+
+    /**
+     * @internal
+     * @param array $data
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->domainId, $parentData] = $data;
+
+        parent::__unserialize($parentData);
+    }
 }

--- a/project-base/app/config/packages/messenger.yaml
+++ b/project-base/app/config/packages/messenger.yaml
@@ -39,9 +39,19 @@ framework:
                     max_retries: 5
                     delay: 60000
                     multiplier: 5
+            send_email_transport:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    vhost: '%env(MESSENGER_TRANSPORT_VHOST)%'
+                    exchange:
+                        name: send_email_exchange
+                        type: direct
+                    queues:
+                        send_email: ~
 
         routing:
             Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityRegularMessage: product_recalculation_priority_regular
             Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityHighMessage: product_recalculation_priority_high
             Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAllProductsMessage: product_recalculation_priority_regular
             Shopsys\FrameworkBundle\Model\Order\Messenger\PlacedOrderMessage: placed_order_transport
+            Symfony\Component\Mailer\Messenger\SendEmailMessage: send_email_transport

--- a/project-base/app/deploy/deploy-project.sh
+++ b/project-base/app/deploy/deploy-project.sh
@@ -129,6 +129,7 @@ function merge() {
     DEFAULT_CONSUMERS=(
         "product-recalculation:product_recalculation_priority_high product_recalculation_priority_regular:1"
         "placed_order:placed_order_transport:1"
+        "send_email:send_email_transport:1"
     )
 
     source "${BASE_PATH}/vendor/shopsys/deployment/deploy/functions.sh"

--- a/project-base/app/docker/php-fpm/consumer-entrypoint.sh
+++ b/project-base/app/docker/php-fpm/consumer-entrypoint.sh
@@ -6,4 +6,5 @@ php ./bin/console messenger:consume \
     product_recalculation_priority_high \
     product_recalculation_priority_regular \
     placed_order_transport \
+    send_email_transport \
     --time-limit=$TIME_LIMIT


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Emails are now sent via an async queue to prevent losing messages when a mail server is unavailable.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-mail-async.odin.shopsys.cloud
  - https://cz.mg-mail-async.odin.shopsys.cloud
<!-- Replace -->
