### PR TITLE
[shopsys] all relevant entities are now created with factory

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1140,6 +1140,19 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   sent emails via async queue ([#2998](https://github.com/shopsys/shopsys/pull/2998))
     -   see #project-base-diff to update your project
 -   change the product catnums field type in GrapesJs to text (([#2994](https://github.com/shopsys/shopsys/pull/2994)))
+
+    -   see #project-base-diff to update your project
+
+-   leverage added missing entity factories ([#3004](https://github.com/shopsys/shopsys/pull/3004))
+    -   `Shopsys\FrameworkBundle\Model\Category\CategoryParameterFacade::__construct()` changed its interface:
+    ```diff
+        public function __construct(
+            protected readonly EntityManagerInterface $em,
+            protected readonly CategoryParameterRepository $categoryParameterRepository,
+            protected readonly ParameterFacade $parameterFacade,
+    +       protected readonly CategoryParameterFactory $categoryParameterFactory,
+        )
+    ```
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1153,6 +1153,15 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     +       protected readonly CategoryParameterFactory $categoryParameterFactory,
         )
     ```
+    -   `\Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFacade::__construct()` changed its interface:
+    ```diff
+        public function __construct(
+            protected readonly EntityManagerInterface $em,
+            protected readonly HeurekaCategoryRepository $heurekaCategoryRepository,
+            protected readonly CategoryRepository $categoryRepository,
+    +       protected readonly HeurekaCategoryFactory $heurekaCategoryFactory,
+        )
+    ```
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/packages/coding-standards/src/Phpstan/EntityShouldHaveFactoryRule.php
+++ b/packages/coding-standards/src/Phpstan/EntityShouldHaveFactoryRule.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Phpstan;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use ReflectionClass;
+
+class EntityShouldHaveFactoryRule implements Rule
+{
+    private const CHECKED_NAMESPACE = 'Shopsys\\';
+    private const IGNORED_SUFFIXES = [
+        'Domain',
+        'Translation',
+    ];
+
+    /**
+     * @return string
+     */
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    /**
+     * @param \PhpParser\Node $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof InClassNode) {
+            return [];
+        }
+
+        $entityClassName = $scope->getClassReflection()?->getName() ?? '';
+        $factoryClassName = $entityClassName . 'Factory';
+
+        if (!str_starts_with($entityClassName, self::CHECKED_NAMESPACE)) {
+            return [];
+        }
+
+        if (!$this->isCheckedEntity($entityClassName, $node)) {
+            return [];
+        }
+
+        if (class_exists($factoryClassName)) {
+            if ($this->factoryUsesEntityNameResolver($factoryClassName)) {
+                return [];
+            }
+
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Factory %s do not use entity name resolver',
+                    $factoryClassName,
+                ))->build(),
+            ];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Entity %s is missing a factory (don\'t forget to use entity name resolver)',
+                $scope->getClassReflection()?->getDisplayName(),
+            ))->build(),
+        ];
+    }
+
+    /**
+     * @param string $className
+     * @param \PHPStan\Node\InClassNode $node
+     * @return bool
+     */
+    private function isCheckedEntity(string $className, InClassNode $node): bool
+    {
+        foreach (self::IGNORED_SUFFIXES as $ignoredSuffix) {
+            if (str_ends_with($className, $ignoredSuffix)) {
+                return false;
+            }
+        }
+
+        return str_contains($node->getDocComment()?->getText() ?? '', '@ORM\Entity');
+    }
+
+    /**
+     * @param string $className
+     * @return bool
+     */
+    private function factoryUsesEntityNameResolver(string $className): bool
+    {
+        $reflectionClass = new ReflectionClass($className);
+        $constructorParameters = $reflectionClass->getConstructor()?->getParameters();
+
+        if ($constructorParameters === null || count($constructorParameters) === 0) {
+            return false;
+        }
+
+        foreach ($constructorParameters as $constructorParameter) {
+            $type = $constructorParameter->getType()?->getName() ?? '';
+
+            if ($type === 'Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/framework/src/Component/Cron/CronModuleFactory.php
+++ b/packages/framework/src/Component/Cron/CronModuleFactory.php
@@ -21,8 +21,8 @@ class CronModuleFactory implements CronModuleFactoryInterface
      */
     public function create(string $serviceId): CronModule
     {
-        $classData = $this->entityNameResolver->resolve(CronModule::class);
+        $entityClassName = $this->entityNameResolver->resolve(CronModule::class);
 
-        return new $classData($serviceId);
+        return new $entityClassName($serviceId);
     }
 }

--- a/packages/framework/src/Component/Cron/CronModuleRunFactory.php
+++ b/packages/framework/src/Component/Cron/CronModuleRunFactory.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Cron;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class CronModuleRunFactory
 {
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Component\Cron\CronModule $cronModule
      * @return \Shopsys\FrameworkBundle\Component\Cron\CronModuleRun
      */
     public function createFromFinishedCronModule(CronModule $cronModule): CronModuleRun
     {
-        return new CronModuleRun(
+        $classData = $this->entityNameResolver->resolve(CronModuleRun::class);
+
+        return new $classData(
             $cronModule,
             $cronModule->getStatus(),
             $cronModule->getLastStartedAt(),

--- a/packages/framework/src/Component/Cron/CronModuleRunFactory.php
+++ b/packages/framework/src/Component/Cron/CronModuleRunFactory.php
@@ -22,9 +22,9 @@ class CronModuleRunFactory
      */
     public function createFromFinishedCronModule(CronModule $cronModule): CronModuleRun
     {
-        $classData = $this->entityNameResolver->resolve(CronModuleRun::class);
+        $entityClassName = $this->entityNameResolver->resolve(CronModuleRun::class);
 
-        return new $classData(
+        return new $entityClassName(
             $cronModule,
             $cronModule->getStatus(),
             $cronModule->getLastStartedAt(),

--- a/packages/framework/src/Component/DataFixture/PersistentReferenceFactory.php
+++ b/packages/framework/src/Component/DataFixture/PersistentReferenceFactory.php
@@ -26,8 +26,8 @@ class PersistentReferenceFactory implements PersistentReferenceFactoryInterface
         string $entityName,
         int $entityId,
     ): PersistentReference {
-        $classData = $this->entityNameResolver->resolve(PersistentReference::class);
+        $entityClassName = $this->entityNameResolver->resolve(PersistentReference::class);
 
-        return new $classData($referenceName, $entityName, $entityId);
+        return new $entityClassName($referenceName, $entityName, $entityId);
     }
 }

--- a/packages/framework/src/Component/Image/ImageFactory.php
+++ b/packages/framework/src/Component/Image/ImageFactory.php
@@ -42,9 +42,9 @@ class ImageFactory implements ImageFactoryInterface
         $temporaryFilePath = $this->fileUpload->getTemporaryFilepath($temporaryFilename);
         $convertedFilePath = $this->imageProcessor->convertToShopFormatAndGetNewFilename($temporaryFilePath);
 
-        $classData = $this->entityNameResolver->resolve(Image::class);
+        $entityClassName = $this->entityNameResolver->resolve(Image::class);
 
-        return new $classData($entityName, $entityId, $namesIndexedByLocale, $convertedFilePath, $type);
+        return new $entityClassName($entityName, $entityId, $namesIndexedByLocale, $convertedFilePath, $type);
     }
 
     /**

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
@@ -33,9 +33,9 @@ class FriendlyUrlFactory implements FriendlyUrlFactoryInterface
         int $domainId,
         string $slug,
     ): FriendlyUrl {
-        $classData = $this->entityNameResolver->resolve(FriendlyUrl::class);
+        $entityClassName = $this->entityNameResolver->resolve(FriendlyUrl::class);
 
-        return new $classData($routeName, $entityId, $domainId, $slug);
+        return new $entityClassName($routeName, $entityId, $domainId, $slug);
     }
 
     /**

--- a/packages/framework/src/Component/Setting/SettingValueFactory.php
+++ b/packages/framework/src/Component/Setting/SettingValueFactory.php
@@ -26,8 +26,8 @@ class SettingValueFactory implements SettingValueFactoryInterface
         $value,
         int $domainId,
     ): SettingValue {
-        $classData = $this->entityNameResolver->resolve(SettingValue::class);
+        $entityClassName = $this->entityNameResolver->resolve(SettingValue::class);
 
-        return new $classData($name, $value, $domainId);
+        return new $entityClassName($name, $value, $domainId);
     }
 }

--- a/packages/framework/src/Component/UploadedFile/UploadedFileFactory.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileFactory.php
@@ -38,9 +38,9 @@ class UploadedFileFactory implements UploadedFileFactoryInterface
     ): UploadedFile {
         $temporaryFilepath = $this->fileUpload->getTemporaryFilepath($temporaryFilename);
 
-        $classData = $this->entityNameResolver->resolve(UploadedFile::class);
+        $entityClassName = $this->entityNameResolver->resolve(UploadedFile::class);
 
-        return new $classData($entityName, $entityId, $type, pathinfo(
+        return new $entityClassName($entityName, $entityId, $type, pathinfo(
             $temporaryFilepath,
             PATHINFO_BASENAME,
         ), $uploadedFilename, $position);

--- a/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFactory.php
+++ b/packages/framework/src/Model/Administrator/Activity/AdministratorActivityFactory.php
@@ -23,8 +23,8 @@ class AdministratorActivityFactory implements AdministratorActivityFactoryInterf
      */
     public function create(Administrator $administrator, string $ipAddress): AdministratorActivity
     {
-        $classData = $this->entityNameResolver->resolve(AdministratorActivity::class);
+        $entityClassName = $this->entityNameResolver->resolve(AdministratorActivity::class);
 
-        return new $classData($administrator, $ipAddress);
+        return new $entityClassName($administrator, $ipAddress);
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorFactory.php
@@ -21,8 +21,8 @@ class AdministratorFactory implements AdministratorFactoryInterface
      */
     public function create(AdministratorData $data): Administrator
     {
-        $classData = $this->entityNameResolver->resolve(Administrator::class);
+        $entityClassName = $this->entityNameResolver->resolve(Administrator::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorGridLimitFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorGridLimitFactory.php
@@ -23,8 +23,8 @@ class AdministratorGridLimitFactory implements AdministratorGridLimitFactoryInte
      */
     public function create(Administrator $administrator, string $gridId, int $limit): AdministratorGridLimit
     {
-        $classData = $this->entityNameResolver->resolve(AdministratorGridLimit::class);
+        $entityClassName = $this->entityNameResolver->resolve(AdministratorGridLimit::class);
 
-        return new $classData($administrator, $gridId, $limit);
+        return new $entityClassName($administrator, $gridId, $limit);
     }
 }

--- a/packages/framework/src/Model/Administrator/Role/AdministratorRoleFactory.php
+++ b/packages/framework/src/Model/Administrator/Role/AdministratorRoleFactory.php
@@ -21,8 +21,8 @@ class AdministratorRoleFactory implements AdministratorRoleFactoryInterface
      */
     public function create(AdministratorRoleData $administratorRoleData): AdministratorRole
     {
-        $classData = $this->entityNameResolver->resolve(AdministratorRole::class);
+        $entityClassName = $this->entityNameResolver->resolve(AdministratorRole::class);
 
-        return new $classData($administratorRoleData);
+        return new $entityClassName($administratorRoleData);
     }
 }

--- a/packages/framework/src/Model/Advert/AdvertFactory.php
+++ b/packages/framework/src/Model/Advert/AdvertFactory.php
@@ -21,8 +21,8 @@ class AdvertFactory implements AdvertFactoryInterface
      */
     public function create(AdvertData $data): Advert
     {
-        $classData = $this->entityNameResolver->resolve(Advert::class);
+        $entityClassName = $this->entityNameResolver->resolve(Advert::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Article/ArticleFactory.php
+++ b/packages/framework/src/Model/Article/ArticleFactory.php
@@ -21,8 +21,8 @@ class ArticleFactory implements ArticleFactoryInterface
      */
     public function create(ArticleData $data): Article
     {
-        $classData = $this->entityNameResolver->resolve(Article::class);
+        $entityClassName = $this->entityNameResolver->resolve(Article::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Cart/CartFactory.php
+++ b/packages/framework/src/Model/Cart/CartFactory.php
@@ -22,8 +22,8 @@ class CartFactory
      */
     public function create(CustomerUserIdentifier $customerUserIdentifier): Cart
     {
-        $classData = $this->entityNameResolver->resolve(Cart::class);
+        $entityClassName = $this->entityNameResolver->resolve(Cart::class);
 
-        return new $classData($customerUserIdentifier->getCartIdentifier(), $customerUserIdentifier->getCustomerUser());
+        return new $entityClassName($customerUserIdentifier->getCartIdentifier(), $customerUserIdentifier->getCustomerUser());
     }
 }

--- a/packages/framework/src/Model/Cart/Item/CartItemFactory.php
+++ b/packages/framework/src/Model/Cart/Item/CartItemFactory.php
@@ -31,8 +31,8 @@ class CartItemFactory implements CartItemFactoryInterface
         int $quantity,
         ?Money $watchedPrice,
     ): CartItem {
-        $classData = $this->entityNameResolver->resolve(CartItem::class);
+        $entityClassName = $this->entityNameResolver->resolve(CartItem::class);
 
-        return new $classData($cart, $product, $quantity, $watchedPrice);
+        return new $entityClassName($cart, $product, $quantity, $watchedPrice);
     }
 }

--- a/packages/framework/src/Model/Category/CategoryFactory.php
+++ b/packages/framework/src/Model/Category/CategoryFactory.php
@@ -22,8 +22,8 @@ class CategoryFactory implements CategoryFactoryInterface
      */
     public function create(CategoryData $data, ?Category $rootCategory): Category
     {
-        $classData = $this->entityNameResolver->resolve(Category::class);
-        $category = new $classData($data);
+        $entityClassName = $this->entityNameResolver->resolve(Category::class);
+        $category = new $entityClassName($data);
 
         if ($rootCategory !== null && $category->getParent() === null) {
             $category->setParent($rootCategory);

--- a/packages/framework/src/Model/Category/CategoryParameterFacade.php
+++ b/packages/framework/src/Model/Category/CategoryParameterFacade.php
@@ -13,11 +13,13 @@ class CategoryParameterFacade
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryParameterRepository $categoryParameterRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade $parameterFacade
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryParameterFactory $categoryParameterFactory
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly CategoryParameterRepository $categoryParameterRepository,
         protected readonly ParameterFacade $parameterFacade,
+        protected readonly CategoryParameterFactory $categoryParameterFactory,
     ) {
     }
 
@@ -67,7 +69,7 @@ class CategoryParameterFacade
             }
 
             $parameter = $this->parameterFacade->getById($parameterId);
-            $categoryParameter = new CategoryParameter($category, $parameter, $collapsed, $position);
+            $categoryParameter = $this->categoryParameterFactory->create($category, $parameter, $collapsed, $position);
             $this->em->persist($categoryParameter);
             $catFlushAfterSaveRelation = true;
         }

--- a/packages/framework/src/Model/Category/CategoryParameterFactory.php
+++ b/packages/framework/src/Model/Category/CategoryParameterFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Category;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter;
+
+class CategoryParameterFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Category\Category $category
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter
+     * @param bool $collapsed
+     * @param int $position
+     * @return \Shopsys\FrameworkBundle\Model\Category\CategoryParameter
+     */
+    public function create(Category $category, Parameter $parameter, bool $collapsed, int $position): CategoryParameter
+    {
+        $classData = $this->entityNameResolver->resolve(CategoryParameter::class);
+
+        return new $classData($category, $parameter, $collapsed, $position);
+    }
+}

--- a/packages/framework/src/Model/Category/CategoryParameterFactory.php
+++ b/packages/framework/src/Model/Category/CategoryParameterFactory.php
@@ -26,8 +26,8 @@ class CategoryParameterFactory
      */
     public function create(Category $category, Parameter $parameter, bool $collapsed, int $position): CategoryParameter
     {
-        $classData = $this->entityNameResolver->resolve(CategoryParameter::class);
+        $entityClassName = $this->entityNameResolver->resolve(CategoryParameter::class);
 
-        return new $classData($category, $parameter, $collapsed, $position);
+        return new $entityClassName($category, $parameter, $collapsed, $position);
     }
 }

--- a/packages/framework/src/Model/Category/TopCategory/TopCategoryFactory.php
+++ b/packages/framework/src/Model/Category/TopCategory/TopCategoryFactory.php
@@ -27,8 +27,8 @@ class TopCategoryFactory implements TopCategoryFactoryInterface
         int $domainId,
         int $position,
     ): TopCategory {
-        $classData = $this->entityNameResolver->resolve(TopCategory::class);
+        $entityClassName = $this->entityNameResolver->resolve(TopCategory::class);
 
-        return new $classData($category, $domainId, $position);
+        return new $entityClassName($category, $domainId, $position);
     }
 }

--- a/packages/framework/src/Model/Country/CountryFactory.php
+++ b/packages/framework/src/Model/Country/CountryFactory.php
@@ -21,8 +21,8 @@ class CountryFactory implements CountryFactoryInterface
      */
     public function create(CountryData $data): Country
     {
-        $classData = $this->entityNameResolver->resolve(Country::class);
+        $entityClassName = $this->entityNameResolver->resolve(Country::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Customer/BillingAddressFactory.php
+++ b/packages/framework/src/Model/Customer/BillingAddressFactory.php
@@ -21,8 +21,8 @@ class BillingAddressFactory implements BillingAddressFactoryInterface
      */
     public function create(BillingAddressData $data): BillingAddress
     {
-        $classData = $this->entityNameResolver->resolve(BillingAddress::class);
+        $entityClassName = $this->entityNameResolver->resolve(BillingAddress::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Customer/CustomerFactory.php
+++ b/packages/framework/src/Model/Customer/CustomerFactory.php
@@ -21,8 +21,8 @@ class CustomerFactory implements CustomerFactoryInterface
      */
     public function create(CustomerData $customerData): Customer
     {
-        $classData = $this->entityNameResolver->resolve(Customer::class);
+        $entityClassName = $this->entityNameResolver->resolve(Customer::class);
 
-        return new $classData($customerData);
+        return new $entityClassName($customerData);
     }
 }

--- a/packages/framework/src/Model/Customer/DeliveryAddressFactory.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddressFactory.php
@@ -25,8 +25,8 @@ class DeliveryAddressFactory implements DeliveryAddressFactoryInterface
             return null;
         }
 
-        $classData = $this->entityNameResolver->resolve(DeliveryAddress::class);
+        $entityClassName = $this->entityNameResolver->resolve(DeliveryAddress::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Customer/User/CustomerUserFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserFactory.php
@@ -24,9 +24,9 @@ class CustomerUserFactory implements CustomerUserFactoryInterface
      */
     public function create(CustomerUserData $customerUserData): CustomerUser
     {
-        $classData = $this->entityNameResolver->resolve(CustomerUser::class);
+        $entityClassName = $this->entityNameResolver->resolve(CustomerUser::class);
 
-        $customerUser = new $classData($customerUserData);
+        $customerUser = new $entityClassName($customerUserData);
 
         $this->customerUserPasswordFacade->changePassword($customerUser, $customerUserData->password);
 

--- a/packages/framework/src/Model/Customer/User/CustomerUserRefreshTokenChainFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserRefreshTokenChainFactory.php
@@ -22,8 +22,8 @@ class CustomerUserRefreshTokenChainFactory implements CustomerUserRefreshTokenCh
     public function create(
         CustomerUserRefreshTokenChainData $customerUserRefreshTokenChainData,
     ): CustomerUserRefreshTokenChain {
-        $classData = $this->entityNameResolver->resolve(CustomerUserRefreshTokenChain::class);
+        $entityClassName = $this->entityNameResolver->resolve(CustomerUserRefreshTokenChain::class);
 
-        return new $classData($customerUserRefreshTokenChainData);
+        return new $entityClassName($customerUserRefreshTokenChainData);
     }
 }

--- a/packages/framework/src/Model/Mail/MailTemplateFactory.php
+++ b/packages/framework/src/Model/Mail/MailTemplateFactory.php
@@ -23,8 +23,8 @@ class MailTemplateFactory implements MailTemplateFactoryInterface
      */
     public function create(string $name, int $domainId, MailTemplateData $data): MailTemplate
     {
-        $classData = $this->entityNameResolver->resolve(MailTemplate::class);
+        $entityClassName = $this->entityNameResolver->resolve(MailTemplate::class);
 
-        return new $classData($name, $domainId, $data);
+        return new $entityClassName($name, $domainId, $data);
     }
 }

--- a/packages/framework/src/Model/Module/EnabledModuleFactory.php
+++ b/packages/framework/src/Model/Module/EnabledModuleFactory.php
@@ -21,8 +21,8 @@ class EnabledModuleFactory implements EnabledModuleFactoryInterface
      */
     public function create(string $name): EnabledModule
     {
-        $classData = $this->entityNameResolver->resolve(EnabledModule::class);
+        $entityClassName = $this->entityNameResolver->resolve(EnabledModule::class);
 
-        return new $classData($name);
+        return new $entityClassName($name);
     }
 }

--- a/packages/framework/src/Model/Newsletter/NewsletterSubscriberFactory.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterSubscriberFactory.php
@@ -24,8 +24,8 @@ class NewsletterSubscriberFactory implements NewsletterSubscriberFactoryInterfac
      */
     public function create(string $email, DateTimeImmutable $createdAt, int $domainId): NewsletterSubscriber
     {
-        $classData = $this->entityNameResolver->resolve(NewsletterSubscriber::class);
+        $entityClassName = $this->entityNameResolver->resolve(NewsletterSubscriber::class);
 
-        return new $classData($email, $createdAt, $domainId);
+        return new $entityClassName($email, $createdAt, $domainId);
     }
 }

--- a/packages/framework/src/Model/Order/Item/OrderItemFactory.php
+++ b/packages/framework/src/Model/Order/Item/OrderItemFactory.php
@@ -41,9 +41,9 @@ class OrderItemFactory implements OrderItemFactoryInterface
         ?string $catnum,
         ?Product $product = null,
     ): OrderItem {
-        $classData = $this->entityNameResolver->resolve(OrderItem::class);
+        $entityClassName = $this->entityNameResolver->resolve(OrderItem::class);
 
-        $orderProduct = new $classData(
+        $orderProduct = new $entityClassName(
             $order,
             $name,
             $price,
@@ -76,9 +76,9 @@ class OrderItemFactory implements OrderItemFactoryInterface
         int $quantity,
         Payment $payment,
     ): OrderItem {
-        $classData = $this->entityNameResolver->resolve(OrderItem::class);
+        $entityClassName = $this->entityNameResolver->resolve(OrderItem::class);
 
-        $orderPayment = new $classData(
+        $orderPayment = new $entityClassName(
             $order,
             $name,
             $price,
@@ -111,9 +111,9 @@ class OrderItemFactory implements OrderItemFactoryInterface
         int $quantity,
         Transport $transport,
     ): OrderItem {
-        $classData = $this->entityNameResolver->resolve(OrderItem::class);
+        $entityClassName = $this->entityNameResolver->resolve(OrderItem::class);
 
-        $orderTransport = new $classData(
+        $orderTransport = new $entityClassName(
             $order,
             $name,
             $price,

--- a/packages/framework/src/Model/Order/OrderFactory.php
+++ b/packages/framework/src/Model/Order/OrderFactory.php
@@ -29,8 +29,8 @@ class OrderFactory implements OrderFactoryInterface
         string $urlHash,
         ?CustomerUser $customerUser,
     ): Order {
-        $classData = $this->entityNameResolver->resolve(Order::class);
+        $entityClassName = $this->entityNameResolver->resolve(Order::class);
 
-        return new $classData($orderData, $orderNumber, $urlHash, $customerUser);
+        return new $entityClassName($orderData, $orderNumber, $urlHash, $customerUser);
     }
 }

--- a/packages/framework/src/Model/Order/OrderNumberSequenceFactory.php
+++ b/packages/framework/src/Model/Order/OrderNumberSequenceFactory.php
@@ -22,8 +22,8 @@ class OrderNumberSequenceFactory implements OrderNumberSequenceFactoryInterface
      */
     public function create(int $id, string $number): OrderNumberSequence
     {
-        $classData = $this->entityNameResolver->resolve(OrderNumberSequence::class);
+        $entityClassName = $this->entityNameResolver->resolve(OrderNumberSequence::class);
 
-        return new $classData($id, $number);
+        return new $entityClassName($id, $number);
     }
 }

--- a/packages/framework/src/Model/Order/PromoCode/PromoCodeFactory.php
+++ b/packages/framework/src/Model/Order/PromoCode/PromoCodeFactory.php
@@ -21,8 +21,8 @@ class PromoCodeFactory implements PromoCodeFactoryInterface
      */
     public function create(PromoCodeData $data): PromoCode
     {
-        $classData = $this->entityNameResolver->resolve(PromoCode::class);
+        $entityClassName = $this->entityNameResolver->resolve(PromoCode::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Order/Status/OrderStatusFactory.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatusFactory.php
@@ -22,8 +22,8 @@ class OrderStatusFactory implements OrderStatusFactoryInterface
      */
     public function create(OrderStatusData $data, int $type): OrderStatus
     {
-        $classData = $this->entityNameResolver->resolve(OrderStatus::class);
+        $entityClassName = $this->entityNameResolver->resolve(OrderStatus::class);
 
-        return new $classData($data, $type);
+        return new $entityClassName($data, $type);
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentFactory.php
@@ -21,8 +21,8 @@ class PaymentFactory implements PaymentFactoryInterface
      */
     public function create(PaymentData $data): Payment
     {
-        $classData = $this->entityNameResolver->resolve(Payment::class);
+        $entityClassName = $this->entityNameResolver->resolve(Payment::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentPriceFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceFactory.php
@@ -27,8 +27,8 @@ class PaymentPriceFactory implements PaymentPriceFactoryInterface
         Money $price,
         int $domainId,
     ): PaymentPrice {
-        $classData = $this->entityNameResolver->resolve(PaymentPrice::class);
+        $entityClassName = $this->entityNameResolver->resolve(PaymentPrice::class);
 
-        return new $classData($payment, $price, $domainId);
+        return new $entityClassName($payment, $price, $domainId);
     }
 }

--- a/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestFactory.php
+++ b/packages/framework/src/Model/PersonalData/PersonalDataAccessRequestFactory.php
@@ -21,8 +21,8 @@ class PersonalDataAccessRequestFactory implements PersonalDataAccessRequestFacto
      */
     public function create(PersonalDataAccessRequestData $data): PersonalDataAccessRequest
     {
-        $classData = $this->entityNameResolver->resolve(PersonalDataAccessRequest::class);
+        $entityClassName = $this->entityNameResolver->resolve(PersonalDataAccessRequest::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Pricing/Currency/CurrencyFactory.php
+++ b/packages/framework/src/Model/Pricing/Currency/CurrencyFactory.php
@@ -21,8 +21,8 @@ class CurrencyFactory implements CurrencyFactoryInterface
      */
     public function create(CurrencyData $data): Currency
     {
-        $classData = $this->entityNameResolver->resolve(Currency::class);
+        $entityClassName = $this->entityNameResolver->resolve(Currency::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Pricing/Group/PricingGroupFactory.php
+++ b/packages/framework/src/Model/Pricing/Group/PricingGroupFactory.php
@@ -22,8 +22,8 @@ class PricingGroupFactory implements PricingGroupFactoryInterface
      */
     public function create(PricingGroupData $data, int $domainId): PricingGroup
     {
-        $classData = $this->entityNameResolver->resolve(PricingGroup::class);
+        $entityClassName = $this->entityNameResolver->resolve(PricingGroup::class);
 
-        return new $classData($data, $domainId);
+        return new $entityClassName($data, $domainId);
     }
 }

--- a/packages/framework/src/Model/Pricing/Vat/VatFactory.php
+++ b/packages/framework/src/Model/Pricing/Vat/VatFactory.php
@@ -22,8 +22,8 @@ class VatFactory implements VatFactoryInterface
      */
     public function create(VatData $data, int $domainId): Vat
     {
-        $classData = $this->entityNameResolver->resolve(Vat::class);
+        $entityClassName = $this->entityNameResolver->resolve(Vat::class);
 
-        return new $classData($data, $domainId);
+        return new $entityClassName($data, $domainId);
     }
 }

--- a/packages/framework/src/Model/Product/Accessory/ProductAccessoryFactory.php
+++ b/packages/framework/src/Model/Product/Accessory/ProductAccessoryFactory.php
@@ -27,8 +27,8 @@ class ProductAccessoryFactory implements ProductAccessoryFactoryInterface
         Product $accessory,
         int $position,
     ): ProductAccessory {
-        $classData = $this->entityNameResolver->resolve(ProductAccessory::class);
+        $entityClassName = $this->entityNameResolver->resolve(ProductAccessory::class);
 
-        return new $classData($product, $accessory, $position);
+        return new $entityClassName($product, $accessory, $position);
     }
 }

--- a/packages/framework/src/Model/Product/Availability/AvailabilityFactory.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityFactory.php
@@ -21,8 +21,8 @@ class AvailabilityFactory implements AvailabilityFactoryInterface
      */
     public function create(AvailabilityData $data): Availability
     {
-        $classData = $this->entityNameResolver->resolve(Availability::class);
+        $entityClassName = $this->entityNameResolver->resolve(Availability::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProductFactory.php
+++ b/packages/framework/src/Model/Product/BestsellingProduct/ManualBestsellingProductFactory.php
@@ -30,8 +30,8 @@ class ManualBestsellingProductFactory implements ManualBestsellingProductFactory
         Product $product,
         int $position,
     ): ManualBestsellingProduct {
-        $classData = $this->entityNameResolver->resolve(ManualBestsellingProduct::class);
+        $entityClassName = $this->entityNameResolver->resolve(ManualBestsellingProduct::class);
 
-        return new $classData($domainId, $category, $product, $position);
+        return new $entityClassName($domainId, $category, $product, $position);
     }
 }

--- a/packages/framework/src/Model/Product/Brand/BrandFactory.php
+++ b/packages/framework/src/Model/Product/Brand/BrandFactory.php
@@ -21,8 +21,8 @@ class BrandFactory implements BrandFactoryInterface
      */
     public function create(BrandData $data): Brand
     {
-        $classData = $this->entityNameResolver->resolve(Brand::class);
+        $entityClassName = $this->entityNameResolver->resolve(Brand::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Product/Flag/FlagFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagFactory.php
@@ -21,8 +21,8 @@ class FlagFactory implements FlagFactoryInterface
      */
     public function create(FlagData $data): Flag
     {
-        $classData = $this->entityNameResolver->resolve(Flag::class);
+        $entityClassName = $this->entityNameResolver->resolve(Flag::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Product/List/ProductListFacade.php
+++ b/packages/framework/src/Model/Product/List/ProductListFacade.php
@@ -18,12 +18,14 @@ class ProductListFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListFactory $productListFactory
      * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListRepository $productListRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListDataFactory $productListDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListItemFactory $productListItemFactory
      */
     public function __construct(
         protected readonly EntityManagerInterface $entityManager,
         protected readonly ProductListFactory $productListFactory,
         protected readonly ProductListRepository $productListRepository,
         protected readonly ProductListDataFactory $productListDataFactory,
+        protected readonly ProductListItemFactory $productListItemFactory,
     ) {
     }
 
@@ -50,7 +52,7 @@ class ProductListFacade
         if ($productList->findProductListItemByProduct($product) !== null) {
             throw new ProductAlreadyInListException(sprintf('Product with UUID %s already exists in the list.', $product->getUuid()));
         }
-        $newProductListItem = new ProductListItem($productList, $product);
+        $newProductListItem = $this->productListItemFactory->create($productList, $product);
         $this->entityManager->persist($newProductListItem);
 
         $productList->addItem($newProductListItem);

--- a/packages/framework/src/Model/Product/List/ProductListItemFactory.php
+++ b/packages/framework/src/Model/Product/List/ProductListItemFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\List;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+
+class ProductListItemFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductList $productList
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductListItem
+     */
+    public function create(ProductList $productList, Product $product): ProductListItem
+    {
+        $productListClassName = $this->entityNameResolver->resolve(ProductListItem::class);
+
+        return new $productListClassName($productList, $product);
+    }
+}

--- a/packages/framework/src/Model/Product/Parameter/ParameterFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFactory.php
@@ -21,8 +21,8 @@ class ParameterFactory implements ParameterFactoryInterface
      */
     public function create(ParameterData $data): Parameter
     {
-        $classData = $this->entityNameResolver->resolve(Parameter::class);
+        $entityClassName = $this->entityNameResolver->resolve(Parameter::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Product/Parameter/ParameterValueFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterValueFactory.php
@@ -21,8 +21,8 @@ class ParameterValueFactory implements ParameterValueFactoryInterface
      */
     public function create(ParameterValueData $data): ParameterValue
     {
-        $classData = $this->entityNameResolver->resolve(ParameterValue::class);
+        $entityClassName = $this->entityNameResolver->resolve(ParameterValue::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Product/Parameter/ProductParameterValueFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ProductParameterValueFactory.php
@@ -27,8 +27,8 @@ class ProductParameterValueFactory implements ProductParameterValueFactoryInterf
         Parameter $parameter,
         ParameterValue $value,
     ): ProductParameterValue {
-        $classData = $this->entityNameResolver->resolve(ProductParameterValue::class);
+        $entityClassName = $this->entityNameResolver->resolve(ProductParameterValue::class);
 
-        return new $classData($product, $parameter, $value);
+        return new $entityClassName($product, $parameter, $value);
     }
 }

--- a/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFactory.php
+++ b/packages/framework/src/Model/Product/Pricing/ProductManualInputPriceFactory.php
@@ -29,8 +29,8 @@ class ProductManualInputPriceFactory implements ProductManualInputPriceFactoryIn
         PricingGroup $pricingGroup,
         ?Money $inputPrice,
     ): ProductManualInputPrice {
-        $classData = $this->entityNameResolver->resolve(ProductManualInputPrice::class);
+        $entityClassName = $this->entityNameResolver->resolve(ProductManualInputPrice::class);
 
-        return new $classData($product, $pricingGroup, $inputPrice);
+        return new $entityClassName($product, $pricingGroup, $inputPrice);
     }
 }

--- a/packages/framework/src/Model/Product/ProductCategoryDomainFactory.php
+++ b/packages/framework/src/Model/Product/ProductCategoryDomainFactory.php
@@ -27,9 +27,9 @@ class ProductCategoryDomainFactory implements ProductCategoryDomainFactoryInterf
         Category $category,
         int $domainId,
     ): ProductCategoryDomain {
-        $classData = $this->entityNameResolver->resolve(ProductCategoryDomain::class);
+        $entityClassName = $this->entityNameResolver->resolve(ProductCategoryDomain::class);
 
-        return new $classData($product, $category, $domainId);
+        return new $entityClassName($product, $category, $domainId);
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductFactory.php
+++ b/packages/framework/src/Model/Product/ProductFactory.php
@@ -25,9 +25,9 @@ class ProductFactory implements ProductFactoryInterface
      */
     public function create(ProductData $data): Product
     {
-        $classData = $this->entityNameResolver->resolve(Product::class);
+        $entityClassName = $this->entityNameResolver->resolve(Product::class);
 
-        $product = $classData::create($data);
+        $product = $entityClassName::create($data);
 
         return $product;
     }
@@ -42,9 +42,9 @@ class ProductFactory implements ProductFactoryInterface
     {
         $variants[] = $mainProduct;
 
-        $classData = $this->entityNameResolver->resolve(Product::class);
+        $entityClassName = $this->entityNameResolver->resolve(Product::class);
 
-        $mainVariant = $classData::createMainVariant($data, $variants);
+        $mainVariant = $entityClassName::createMainVariant($data, $variants);
 
         return $mainVariant;
     }

--- a/packages/framework/src/Model/Product/ProductVisibilityFactory.php
+++ b/packages/framework/src/Model/Product/ProductVisibilityFactory.php
@@ -27,8 +27,8 @@ class ProductVisibilityFactory implements ProductVisibilityFactoryInterface
         PricingGroup $pricingGroup,
         int $domainId,
     ): ProductVisibility {
-        $classData = $this->entityNameResolver->resolve(ProductVisibility::class);
+        $entityClassName = $this->entityNameResolver->resolve(ProductVisibility::class);
 
-        return new $classData($product, $pricingGroup, $domainId);
+        return new $entityClassName($product, $pricingGroup, $domainId);
     }
 }

--- a/packages/framework/src/Model/Product/TopProduct/TopProductFactory.php
+++ b/packages/framework/src/Model/Product/TopProduct/TopProductFactory.php
@@ -27,8 +27,8 @@ class TopProductFactory implements TopProductFactoryInterface
         int $domainId,
         int $position,
     ): TopProduct {
-        $classData = $this->entityNameResolver->resolve(TopProduct::class);
+        $entityClassName = $this->entityNameResolver->resolve(TopProduct::class);
 
-        return new $classData($product, $domainId, $position);
+        return new $entityClassName($product, $domainId, $position);
     }
 }

--- a/packages/framework/src/Model/Product/Unit/UnitFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitFactory.php
@@ -21,8 +21,8 @@ class UnitFactory implements UnitFactoryInterface
      */
     public function create(UnitData $data): Unit
     {
-        $classData = $this->entityNameResolver->resolve(Unit::class);
+        $entityClassName = $this->entityNameResolver->resolve(Unit::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Script/ScriptFactory.php
+++ b/packages/framework/src/Model/Script/ScriptFactory.php
@@ -21,8 +21,8 @@ class ScriptFactory implements ScriptFactoryInterface
      */
     public function create(ScriptData $data): Script
     {
-        $classData = $this->entityNameResolver->resolve(Script::class);
+        $entityClassName = $this->entityNameResolver->resolve(Script::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Seo/Page/SeoPageFacade.php
+++ b/packages/framework/src/Model/Seo/Page/SeoPageFacade.php
@@ -21,6 +21,7 @@ class SeoPageFacade
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
      * @param \Shopsys\FrameworkBundle\Model\Seo\Page\SeoPageRepository $seoPageRepository
      * @param \Shopsys\FrameworkBundle\Component\Image\ImageFacade $imageFacade
+     * @param \Shopsys\FrameworkBundle\Model\Seo\Page\SeoPageFactory $seoPageFactory
      */
     public function __construct(
         protected readonly Domain $domain,
@@ -28,6 +29,7 @@ class SeoPageFacade
         protected readonly FriendlyUrlFacade $friendlyUrlFacade,
         protected readonly SeoPageRepository $seoPageRepository,
         protected readonly ImageFacade $imageFacade,
+        protected readonly SeoPageFactory $seoPageFactory,
     ) {
     }
 
@@ -37,7 +39,7 @@ class SeoPageFacade
      */
     public function create(SeoPageData $seoPageData): SeoPage
     {
-        $seoPage = new SeoPage($seoPageData);
+        $seoPage = $this->seoPageFactory->create($seoPageData);
 
         $this->em->persist($seoPage);
         $this->em->flush();

--- a/packages/framework/src/Model/Seo/Page/SeoPageFactory.php
+++ b/packages/framework/src/Model/Seo/Page/SeoPageFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Seo\Page;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class SeoPageFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Seo\Page\SeoPageData $data
+     * @return \Shopsys\FrameworkBundle\Model\Seo\Page\SeoPage
+     */
+    public function create(SeoPageData $data): SeoPage
+    {
+        $classData = $this->entityNameResolver->resolve(SeoPage::class);
+
+        return new $classData($data);
+    }
+}

--- a/packages/framework/src/Model/Seo/Page/SeoPageFactory.php
+++ b/packages/framework/src/Model/Seo/Page/SeoPageFactory.php
@@ -22,8 +22,8 @@ class SeoPageFactory
      */
     public function create(SeoPageData $data): SeoPage
     {
-        $classData = $this->entityNameResolver->resolve(SeoPage::class);
+        $entityClassName = $this->entityNameResolver->resolve(SeoPage::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Slider/SliderItemFactory.php
+++ b/packages/framework/src/Model/Slider/SliderItemFactory.php
@@ -21,8 +21,8 @@ class SliderItemFactory implements SliderItemFactoryInterface
      */
     public function create(SliderItemData $data): SliderItem
     {
-        $classData = $this->entityNameResolver->resolve(SliderItem::class);
+        $entityClassName = $this->entityNameResolver->resolve(SliderItem::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Stock/ProductStockFacade.php
+++ b/packages/framework/src/Model/Stock/ProductStockFacade.php
@@ -12,10 +12,12 @@ class ProductStockFacade
     /**
      * @param \Shopsys\FrameworkBundle\Model\Stock\ProductStockRepository $productStockRepository
      * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Model\Stock\ProductStockFactory $productStockFactory
      */
     public function __construct(
         protected readonly ProductStockRepository $productStockRepository,
         protected readonly EntityManagerInterface $em,
+        protected readonly ProductStockFactory $productStockFactory,
     ) {
     }
 
@@ -105,7 +107,7 @@ class ProductStockFacade
      */
     protected function createProductStock(Product $product, Stock $stock): ProductStock
     {
-        $productStock = new ProductStock($stock, $product);
+        $productStock = $this->productStockFactory->create($stock, $product);
         $this->em->persist($productStock);
 
         return $productStock;

--- a/packages/framework/src/Model/Stock/ProductStockFactory.php
+++ b/packages/framework/src/Model/Stock/ProductStockFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Stock;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Model\Product\Product;
+
+class ProductStockFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Stock\Stock $stock
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Stock\ProductStock
+     */
+    public function create(Stock $stock, Product $product): ProductStock
+    {
+        $classData = $this->entityNameResolver->resolve(ProductStock::class);
+
+        return new $classData($stock, $product);
+    }
+}

--- a/packages/framework/src/Model/Stock/ProductStockFactory.php
+++ b/packages/framework/src/Model/Stock/ProductStockFactory.php
@@ -24,8 +24,8 @@ class ProductStockFactory
      */
     public function create(Stock $stock, Product $product): ProductStock
     {
-        $classData = $this->entityNameResolver->resolve(ProductStock::class);
+        $entityClassName = $this->entityNameResolver->resolve(ProductStock::class);
 
-        return new $classData($stock, $product);
+        return new $entityClassName($stock, $product);
     }
 }

--- a/packages/framework/src/Model/Stock/StockFacade.php
+++ b/packages/framework/src/Model/Stock/StockFacade.php
@@ -15,12 +15,14 @@ class StockFacade
      * @param \Shopsys\FrameworkBundle\Model\Stock\StockRepository $stockRepository
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
      * @param \Shopsys\FrameworkBundle\Model\Stock\ProductStockFacade $productStockFacade
+     * @param \Shopsys\FrameworkBundle\Model\Stock\StockFactory $stockFactory
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly StockRepository $stockRepository,
         protected readonly EventDispatcherInterface $eventDispatcher,
         protected readonly ProductStockFacade $productStockFacade,
+        protected readonly StockFactory $stockFactory,
     ) {
     }
 
@@ -30,7 +32,7 @@ class StockFacade
      */
     public function create(StockData $stockData): Stock
     {
-        $stock = new Stock($stockData);
+        $stock = $this->stockFactory->create($stockData);
         $this->em->persist($stock);
         $this->em->flush();
 

--- a/packages/framework/src/Model/Stock/StockFactory.php
+++ b/packages/framework/src/Model/Stock/StockFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Stock;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class StockFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Stock\StockData $stockData
+     * @return \Shopsys\FrameworkBundle\Model\Stock\Stock
+     */
+    public function create(StockData $stockData): Stock
+    {
+        $classData = $this->entityNameResolver->resolve(Stock::class);
+
+        return new $classData($stockData);
+    }
+}

--- a/packages/framework/src/Model/Stock/StockFactory.php
+++ b/packages/framework/src/Model/Stock/StockFactory.php
@@ -22,8 +22,8 @@ class StockFactory
      */
     public function create(StockData $stockData): Stock
     {
-        $classData = $this->entityNameResolver->resolve(Stock::class);
+        $entityClassName = $this->entityNameResolver->resolve(Stock::class);
 
-        return new $classData($stockData);
+        return new $entityClassName($stockData);
     }
 }

--- a/packages/framework/src/Model/Store/ClosedDay/ClosedDayFacade.php
+++ b/packages/framework/src/Model/Store/ClosedDay/ClosedDayFacade.php
@@ -12,10 +12,12 @@ class ClosedDayFacade
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDayRepository $closedDayRepository
+     * @param \Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDayFactory $closedDayFactory
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly ClosedDayRepository $closedDayRepository,
+        protected readonly ClosedDayFactory $closedDayFactory,
     ) {
     }
 
@@ -44,7 +46,7 @@ class ClosedDayFacade
      */
     public function create(ClosedDayData $closedDayData): ClosedDay
     {
-        $closedDay = new ClosedDay($closedDayData);
+        $closedDay = $this->closedDayFactory->create($closedDayData);
         $this->em->persist($closedDay);
         $this->em->flush();
 

--- a/packages/framework/src/Model/Store/ClosedDay/ClosedDayFactory.php
+++ b/packages/framework/src/Model/Store/ClosedDay/ClosedDayFactory.php
@@ -22,8 +22,8 @@ class ClosedDayFactory
      */
     public function create(ClosedDayData $data): ClosedDay
     {
-        $classData = $this->entityNameResolver->resolve(ClosedDay::class);
+        $entityClassName = $this->entityNameResolver->resolve(ClosedDay::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Store/ClosedDay/ClosedDayFactory.php
+++ b/packages/framework/src/Model/Store/ClosedDay/ClosedDayFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Store\ClosedDay;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class ClosedDayFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDayData $data
+     * @return \Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDay
+     */
+    public function create(ClosedDayData $data): ClosedDay
+    {
+        $classData = $this->entityNameResolver->resolve(ClosedDay::class);
+
+        return new $classData($data);
+    }
+}

--- a/packages/framework/src/Model/Store/OpeningHours/OpeningHours.php
+++ b/packages/framework/src/Model/Store/OpeningHours/OpeningHours.php
@@ -67,6 +67,14 @@ class OpeningHours
     }
 
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData $openingHourData
+     */
+    public function edit(OpeningHoursData $openingHourData): void
+    {
+        $this->setData($openingHourData);
+    }
+
+    /**
      * @return int
      */
     public function getId()

--- a/packages/framework/src/Model/Store/OpeningHours/OpeningHoursFactory.php
+++ b/packages/framework/src/Model/Store/OpeningHours/OpeningHoursFactory.php
@@ -22,8 +22,8 @@ class OpeningHoursFactory
      */
     public function create(OpeningHoursData $data): OpeningHours
     {
-        $classData = $this->entityNameResolver->resolve(OpeningHours::class);
+        $entityClassName = $this->entityNameResolver->resolve(OpeningHours::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Store/OpeningHours/OpeningHoursFactory.php
+++ b/packages/framework/src/Model/Store/OpeningHours/OpeningHoursFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Store\OpeningHours;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class OpeningHoursFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData $data
+     * @return \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours
+     */
+    public function create(OpeningHoursData $data): OpeningHours
+    {
+        $classData = $this->entityNameResolver->resolve(OpeningHours::class);
+
+        return new $classData($data);
+    }
+}

--- a/packages/framework/src/Model/Store/Store.php
+++ b/packages/framework/src/Model/Store/Store.php
@@ -16,7 +16,6 @@ use Shopsys\FrameworkBundle\Model\Stock\Stock;
 use Shopsys\FrameworkBundle\Model\Store\Exception\StoreDomainNotFoundException;
 use Shopsys\FrameworkBundle\Model\Store\OpeningHours\Exception\OpeningHoursNotFoundException;
 use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours;
-use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData;
 
 /**
  * @ORM\Table(name="stores")
@@ -104,7 +103,7 @@ class Store implements OrderableEntityInterface
 
     /**
      * @var \Doctrine\Common\Collections\Collection<int,\Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours>
-     * @ORM\OneToMany(targetEntity="\Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours", mappedBy="store", cascade={"persist", "remove"}, orphanRemoval=true, fetch="EAGER")
+     * @ORM\OneToMany(targetEntity="\Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours", mappedBy="store", cascade={"persist", "remove"}, orphanRemoval=true)
      * @ORM\OrderBy({"dayOfWeek" = "ASC"})
      */
     protected $openingHours;
@@ -160,6 +159,18 @@ class Store implements OrderableEntityInterface
     {
         $this->setDomains($storeData);
         $this->setData($storeData);
+
+        foreach ($this->openingHours as $index => $openingHours) {
+            $openingHours->edit($storeData->openingHours[$index]);
+        }
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours[] $openingHours
+     */
+    public function setOpeningHours(array $openingHours): void
+    {
+        $this->openingHours = new ArrayCollection($openingHours);
     }
 
     /**
@@ -176,7 +187,6 @@ class Store implements OrderableEntityInterface
         $this->city = $storeData->city;
         $this->postcode = $storeData->postcode;
         $this->country = $storeData->country;
-        $this->openingHours = $this->createOpeningHours($storeData->openingHours);
         $this->contactInfo = $storeData->contactInfo;
         $this->specialMessage = $storeData->specialMessage;
         $this->locationLatitude = $storeData->locationLatitude;
@@ -442,21 +452,5 @@ class Store implements OrderableEntityInterface
     public function setDefault(): void
     {
         $this->isDefault = true;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData[] $openingHours
-     * @return \Doctrine\Common\Collections\ArrayCollection
-     */
-    protected function createOpeningHours(array $openingHours): ArrayCollection
-    {
-        $openingHours = array_map(function (OpeningHoursData $openingHourData): OpeningHours {
-            $openingHours = new OpeningHours($openingHourData);
-            $openingHours->setStore($this);
-
-            return $openingHours;
-        }, $openingHours);
-
-        return new ArrayCollection($openingHours);
     }
 }

--- a/packages/framework/src/Model/Store/StoreFactory.php
+++ b/packages/framework/src/Model/Store/StoreFactory.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Store;
 
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours;
+use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData;
+use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursFactory;
 
 class StoreFactory
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursFactory $openingHoursFactory
      */
     public function __construct(
         protected readonly EntityNameResolver $entityNameResolver,
+        protected readonly OpeningHoursFactory $openingHoursFactory,
     ) {
     }
 
@@ -24,6 +29,31 @@ class StoreFactory
     {
         $classData = $this->entityNameResolver->resolve(Store::class);
 
-        return new $classData($storeData);
+        /** @var \Shopsys\FrameworkBundle\Model\Store\Store $store */
+        $store = new $classData($storeData);
+
+        $store->setOpeningHours(
+            $this->createOpeningHours($storeData->openingHours, $store),
+        );
+
+        return $store;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursData[] $openingHoursData
+     * @param \Shopsys\FrameworkBundle\Model\Store\Store $store
+     * @return \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours[]
+     */
+    protected function createOpeningHours(array $openingHoursData, Store $store): array
+    {
+        return array_map(
+            function (OpeningHoursData $openingHourData) use ($store): OpeningHours {
+                $openingHours = $this->openingHoursFactory->create($openingHourData);
+                $openingHours->setStore($store);
+
+                return $openingHours;
+            },
+            $openingHoursData,
+        );
     }
 }

--- a/packages/framework/src/Model/Store/StoreFactory.php
+++ b/packages/framework/src/Model/Store/StoreFactory.php
@@ -27,10 +27,10 @@ class StoreFactory
      */
     public function create(StoreData $storeData): Store
     {
-        $classData = $this->entityNameResolver->resolve(Store::class);
+        $entityClassName = $this->entityNameResolver->resolve(Store::class);
 
         /** @var \Shopsys\FrameworkBundle\Model\Store\Store $store */
-        $store = new $classData($storeData);
+        $store = new $entityClassName($storeData);
 
         $store->setOpeningHours(
             $this->createOpeningHours($storeData->openingHours, $store),

--- a/packages/framework/src/Model/Store/StoreFactory.php
+++ b/packages/framework/src/Model/Store/StoreFactory.php
@@ -4,14 +4,26 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Store;
 
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
 class StoreFactory
 {
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Store\StoreData $storeData
      * @return \Shopsys\FrameworkBundle\Model\Store\Store
      */
     public function create(StoreData $storeData): Store
     {
-        return new Store($storeData);
+        $classData = $this->entityNameResolver->resolve(Store::class);
+
+        return new $classData($storeData);
     }
 }

--- a/packages/framework/src/Model/Transport/TransportFactory.php
+++ b/packages/framework/src/Model/Transport/TransportFactory.php
@@ -21,8 +21,8 @@ class TransportFactory implements TransportFactoryInterface
      */
     public function create(TransportData $data): Transport
     {
-        $classData = $this->entityNameResolver->resolve(Transport::class);
+        $entityClassName = $this->entityNameResolver->resolve(Transport::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/framework/src/Model/Transport/TransportPriceFactory.php
+++ b/packages/framework/src/Model/Transport/TransportPriceFactory.php
@@ -27,8 +27,8 @@ class TransportPriceFactory implements TransportPriceFactoryInterface
         Money $price,
         int $domainId,
     ): TransportPrice {
-        $classData = $this->entityNameResolver->resolve(TransportPrice::class);
+        $entityClassName = $this->entityNameResolver->resolve(TransportPrice::class);
 
-        return new $classData($transport, $price, $domainId);
+        return new $entityClassName($transport, $price, $domainId);
     }
 }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFacade.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFacade.php
@@ -13,11 +13,13 @@ class HeurekaCategoryFacade
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryRepository $heurekaCategoryRepository
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryRepository $categoryRepository
+     * @param \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryFactory $heurekaCategoryFactory
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly HeurekaCategoryRepository $heurekaCategoryRepository,
         protected readonly CategoryRepository $categoryRepository,
+        protected readonly HeurekaCategoryFactory $heurekaCategoryFactory,
     ) {
     }
 
@@ -32,7 +34,7 @@ class HeurekaCategoryFacade
 
         foreach ($newHeurekaCategoriesData as $newHeurekaCategoryData) {
             if (!array_key_exists($newHeurekaCategoryData->id, $existingHeurekaCategories)) {
-                $newHeurekaCategory = new HeurekaCategory($newHeurekaCategoryData);
+                $newHeurekaCategory = $this->heurekaCategoryFactory->create($newHeurekaCategoryData);
                 $this->em->persist($newHeurekaCategory);
             } else {
                 $existingHeurekaCategory = $existingHeurekaCategories[$newHeurekaCategoryData->id];

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFactory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFactory.php
@@ -22,8 +22,8 @@ class HeurekaCategoryFactory
      */
     public function create(HeurekaCategoryData $data): HeurekaCategory
     {
-        $classData = $this->entityNameResolver->resolve(HeurekaCategory::class);
+        $entityClassName = $this->entityNameResolver->resolve(HeurekaCategory::class);
 
-        return new $classData($data);
+        return new $entityClassName($data);
     }
 }

--- a/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFactory.php
+++ b/packages/product-feed-heureka/src/Model/HeurekaCategory/HeurekaCategoryFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory;
+
+use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+
+class HeurekaCategoryFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
+     */
+    public function __construct(
+        protected readonly EntityNameResolver $entityNameResolver,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategoryData $data
+     * @return \Shopsys\ProductFeed\HeurekaBundle\Model\HeurekaCategory\HeurekaCategory
+     */
+    public function create(HeurekaCategoryData $data): HeurekaCategory
+    {
+        $classData = $this->entityNameResolver->resolve(HeurekaCategory::class);
+
+        return new $classData($data);
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -72,3 +72,5 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
     - %currentWorkingDirectory%/packages/coding-standards/extension.neon
+rules:
+    - \Shopsys\CodingStandards\Phpstan\EntityShouldHaveFactoryRule

--- a/project-base/app/src/DataFixtures/Demo/ParameterDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ParameterDataFixture.php
@@ -17,7 +17,7 @@ use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
-use Shopsys\FrameworkBundle\Model\Category\CategoryParameter;
+use Shopsys\FrameworkBundle\Model\Category\CategoryParameterFactory;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueFactory;
 
 class ParameterDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
@@ -101,15 +101,17 @@ class ParameterDataFixture extends AbstractReferenceFixture implements Dependent
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValueFactory $productParameterValueFactory
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityManagerDecorator $entityManager
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Category\CategoryParameterFactory $categoryParameterFactory
      */
     public function __construct(
-        private ParameterDataFactory $parameterDataFactory,
-        private ParameterFacade $parameterFacade,
-        private ParameterValueDataFactory $parameterValueDataFactory,
-        private ParameterRepository $parameterRepository,
-        private ProductParameterValueFactory $productParameterValueFactory,
-        private EntityManagerDecorator $entityManager,
-        private Domain $domain,
+        private readonly ParameterDataFactory $parameterDataFactory,
+        private readonly ParameterFacade $parameterFacade,
+        private readonly ParameterValueDataFactory $parameterValueDataFactory,
+        private readonly ParameterRepository $parameterRepository,
+        private readonly ProductParameterValueFactory $productParameterValueFactory,
+        private readonly EntityManagerDecorator $entityManager,
+        private readonly Domain $domain,
+        private readonly CategoryParameterFactory $categoryParameterFactory,
     ) {
     }
 
@@ -216,7 +218,7 @@ class ParameterDataFixture extends AbstractReferenceFixture implements Dependent
         $counter = 0;
 
         foreach ($asFilterInCategories as $category) {
-            $categoryParameter = new CategoryParameter($category, $parameter, false, $counter);
+            $categoryParameter = $this->categoryParameterFactory->create($category, $parameter, false, $counter);
             $this->entityManager->persist($categoryParameter);
             $counter++;
         }

--- a/project-base/app/src/FrontendApi/Resolver/Store/OpeningHours/OpeningHoursResolverMap.php
+++ b/project-base/app/src/FrontendApi/Resolver/Store/OpeningHours/OpeningHoursResolverMap.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDayFacade;
 use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHours;
 use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursDataFactory;
+use Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursFactory;
 use Shopsys\FrameworkBundle\Model\Store\Store;
 
 class OpeningHoursResolverMap extends ResolverMap
@@ -23,11 +24,13 @@ class OpeningHoursResolverMap extends ResolverMap
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Store\ClosedDay\ClosedDayFacade $closedDayFacade
      * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursDataFactory $openingHoursDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Store\OpeningHours\OpeningHoursFactory $openingHoursFactory
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly ClosedDayFacade $closedDayFacade,
         protected readonly OpeningHoursDataFactory $openingHoursDataFactory,
+        protected readonly OpeningHoursFactory $openingHoursFactory,
     ) {
     }
 
@@ -61,7 +64,7 @@ class OpeningHoursResolverMap extends ResolverMap
                         $openingHoursData = $this->openingHoursDataFactory->create();
                         $openingHoursData->dayOfWeek = $openingHours->getDayOfWeek();
 
-                        return $this->mapOpeningHoursToArray(new OpeningHours($openingHoursData));
+                        return $this->mapOpeningHoursToArray($this->openingHoursFactory->create($openingHoursData));
                     }
 
                     return $this->mapOpeningHoursToArray($openingHours);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Added PhpStan rule to ensure that each relevant entity has its own factory that uses entity name resolver. This rule is applied.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-extensibility.odin.shopsys.cloud
  - https://cz.mg-fix-extensibility.odin.shopsys.cloud
<!-- Replace -->
