### PR TITLE
Add phing option to hide progress bars in CI logs

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -572,7 +572,7 @@ jobs:
                     docker compose exec -T php-fpm composer install --optimize-autoloader --no-interaction
                     docker compose exec -T php-fpm php phing -D production.confirm.action=y -D change.environment=dev environment-change dirs-create test-dirs-create assets npm build-version-generate db-create test-db-create db-demo elasticsearch-index-recreate elasticsearch-export error-pages-generate test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export tests-acceptance-build
             -   name: Check standards
-                run: docker compose exec -T php-fpm php phing standards
+                run: docker compose exec -T php-fpm php phing -D no-progress-bar=true standards
             -   name: Run tests
                 run: docker compose exec -T php-fpm php phing tests
             -   name: Run acceptance tests

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Shopsys Platform" default="list">
 
+    <property name="no-progress-bar" value="false"/>
     <property name="check-and-fix-annotations" value="true"/>
     <property name="npm.framework" value="@shopsys/framework"/>
     <property name="path.root" value="${project.basedir}/project-base/app"/>
@@ -39,9 +40,20 @@
     </target>
 
     <target name="ecs" description="Checks coding standards in all files in the whole monorepo by PHP easy coding standards." depends="entities-dump" hidden="true">
+        <if>
+            <istrue value="${no-progress-bar}"/>
+            <then>
+                <property name="ecs.no-progress-bar" value="--no-progress-bar" />
+            </then>
+            <else>
+                <property name="ecs.no-progress-bar" value="" />
+            </else>
+        </if>
+
         <exec executable="${path.ecs.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="check"/>
             <arg value="--clear-cache"/>
+            <arg value="${ecs.no-progress-bar}"/>
             <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
@@ -231,7 +243,18 @@
     </target>
 
     <target name="phplint" description="Checks syntax of PHP files in the whole monorepo." hidden="true">
+        <if>
+            <istrue value="${no-progress-bar}"/>
+            <then>
+                <property name="phplint.no-progress-bar" value="--no-progress" />
+            </then>
+            <else>
+                <property name="phplint.no-progress-bar" value="" />
+            </else>
+        </if>
+
         <exec executable="${path.phplint.executable}" logoutput="true" passthru="true" checkreturn="true">
+            <arg value="${phplint.no-progress-bar}"/>
             <arg path="${path.app}"/>
             <arg path="${path.src}"/>
             <arg path="${path.tests}"/>
@@ -248,6 +271,16 @@
     </target>
 
     <target name="phpstan" depends="warmup,tests-acceptance-build" description="Performs static analysis of PHP files using PHPStan on all packages." hidden="true">
+        <if>
+            <istrue value="${no-progress-bar}"/>
+            <then>
+                <property name="phpstan.no-progress-bar" value="--no-progress" />
+            </then>
+            <else>
+                <property name="phpstan.no-progress-bar" value="" />
+            </else>
+        </if>
+
         <exec executable="${path.phpstan.executable}" logoutput="true" passthru="true" checkreturn="true">
             <arg value="analyze"/>
             <arg value="-c"/>
@@ -261,6 +294,7 @@
             <arg path="${path.utils}/*/tests"/>
             <arg value="--level=${phpstan.level}"/>
             <arg value="--memory-limit=${phpstan.memory-limit}"/>
+            <arg value="${phpstan.no-progress-bar}"/>
             <arg value="-vvv"/>
         </exec>
     </target>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| As mentioned in #2676 progress bars in CI logs are mess. This is mainly proof of concept how to include the optional argument for various CI tools (currently not all of them. I.e. https://github.com/sspooky13/yaml-standards does not yet support this option. I have made pull request into yaml standards project as well
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... closes #2676 
Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
