### PR TITLE
CategoryTreeSorting.init jquery UI performance

### DIFF
--- a/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
+++ b/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
@@ -13,6 +13,16 @@ export default class CategoryTreeSorting {
         this.$rootTree = $rootTree;
         this.$saveButton = $saveButton;
 
+        $.mjs.nestedSortable.prototype._setHandleClassName = function () {
+            this._removeClass(this.element.find('.ui-sortable-handle'), 'ui-sortable-handle');
+            $.each(this.items, function () {
+                (this.instance.options.handle
+                    ? this.item.find(this.instance.options.handle)
+                    : this.item
+                ).addClass('ui-sortable-handle');
+            });
+        };
+
         const _this = this;
         this.$rootTree.nestedSortable({
             listType: 'ul',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There is a perfromace leak when working with category sorting tree. See https://github.com/jquery/jquery-ui/issues/2062. Upgrading Jquery UI to newer version does not work (it would be nice to upgrade all JS dependecies for admin :wink:. It is not part of this PR). On my project with 1K categories `CategoryTreeSorting.init` took 741ms, with CPU throttling (6x slowdown Chrome) it took 5096 ms. After change it was 257ms with CPU throtlling on and 41ms without throttling. There are some points against this solution, discussed in https://github.com/jquery/jquery-ui/pull/2063, so please have a look before accepting PR. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-jquery-ui-performance.odin.shopsys.cloud
  - https://cz.mt-jquery-ui-performance.odin.shopsys.cloud
<!-- Replace -->
