### PR TITLE
[shopsys] unset variant is now automatically exported

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1269,6 +1269,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   fix display advert on invisible category ([#2701](https://github.com/shopsys/shopsys/pull/2701))
     -   see #project-base-diff to update your project
+-   unset variant is now automatically recalculated ([#301](https://github.com/shopsys/shopsys/pull/301))
+    -   `Shopsys\FrameworkBundle\Model\Product\Product::unsetRemovedVariants()` now returns int[]
+    -   `Shopsys\FrameworkBundle\Model\Product\Product::refreshVariants()` now returns int[]
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -897,11 +897,14 @@ class Product extends AbstractTranslatableEntity
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $currentVariants
+     * @return int[]
      */
-    public function refreshVariants(array $currentVariants): void
+    public function refreshVariants(array $currentVariants): array
     {
-        $this->unsetRemovedVariants($currentVariants);
+        $removedVariantIds = $this->unsetRemovedVariants($currentVariants);
         $this->addNewVariants($currentVariants);
+
+        return $removedVariantIds;
     }
 
     /**
@@ -918,14 +921,20 @@ class Product extends AbstractTranslatableEntity
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $currentVariants
+     * @return int[]
      */
-    protected function unsetRemovedVariants(array $currentVariants)
+    protected function unsetRemovedVariants(array $currentVariants): array
     {
+        $removedVariantIds = [];
+
         foreach ($this->getVariants() as $originalVariant) {
             if (!in_array($originalVariant, $currentVariants, true)) {
                 $originalVariant->unsetMainVariant();
+                $removedVariantIds[] = $originalVariant->getId();
             }
         }
+
+        return $removedVariantIds;
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -159,7 +159,8 @@ class ProductFacade
         }
 
         if ($product->isMainVariant()) {
-            $product->refreshVariants($productData->variants);
+            $removedVariantIds = $product->refreshVariants($productData->variants);
+            $this->productRecalculationDispatcher->dispatchProductIds($removedVariantIds, $priority ?? ProductRecalculationPriorityEnum::REGULAR);
         }
 
         $this->refreshProductAccessories($product, $productData->accessories);

--- a/project-base/app/src/Model/Product/Product.php
+++ b/project-base/app/src/Model/Product/Product.php
@@ -29,9 +29,9 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
  * @method \App\Model\Product\Product[] getVariants()
  * @method addVariants(\App\Model\Product\Product[] $variants)
  * @method setMainVariant(\App\Model\Product\Product $mainVariant)
- * @method refreshVariants(\App\Model\Product\Product[] $currentVariants)
+ * @method int[] refreshVariants(\App\Model\Product\Product[] $currentVariants)
  * @method addNewVariants(\App\Model\Product\Product[] $currentVariants)
- * @method unsetRemovedVariants(\App\Model\Product\Product[] $currentVariants)
+ * @method int[] unsetRemovedVariants(\App\Model\Product\Product[] $currentVariants)
  * @method \App\Model\Product\ProductTranslation translation(?string $locale = null)
  * @property \Doctrine\Common\Collections\Collection<int,\App\Model\Product\ProductTranslation> $translations
  * @property \Doctrine\Common\Collections\Collection<int,\App\Model\Product\ProductDomain> $domains


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When variant is unset from main variant, this variant is now automatically recalculated, so the detail of the product is properly rendered.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-export-unset-variant.odin.shopsys.cloud
  - https://cz.mg-export-unset-variant.odin.shopsys.cloud
<!-- Replace -->
