### PR TITLE
[framework] added unique constraint to cart

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1273,6 +1273,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   `Shopsys\FrameworkBundle\Model\Product\Product::unsetRemovedVariants()` now returns int[]
     -   `Shopsys\FrameworkBundle\Model\Product\Product::refreshVariants()` now returns int[]
     -   see #project-base-diff to update your project
+-   add unique index to cart identifiers ([#3017](https://github.com/shopsys/shopsys/pull/3017))
+    -   check `Version20240209114704` migration and if you already have the unique indexes on the cart table, you can skip it
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/packages/framework/src/Migrations/Version20240209114704.php
+++ b/packages/framework/src/Migrations/Version20240209114704.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20240209114704 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('CREATE UNIQUE INDEX cart_identifier ON carts (cart_identifier) WHERE cart_identifier <> \'\';');
+        $this->sql('CREATE UNIQUE INDEX customer_user_id ON carts (customer_user_id) WHERE customer_user_id is not null;');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20240209114704.php
+++ b/packages/framework/src/Migrations/Version20240209114704.php
@@ -15,7 +15,7 @@ class Version20240209114704 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->sql('CREATE UNIQUE INDEX cart_identifier ON carts (cart_identifier) WHERE cart_identifier <> \'\';');
-        $this->sql('CREATE UNIQUE INDEX customer_user_id ON carts (customer_user_id) WHERE customer_user_id is not null;');
+        $this->sql('CREATE UNIQUE INDEX customer_user_id ON carts (customer_user_id);');
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Model/Cart/MergeCartFacade.php
+++ b/project-base/app/src/FrontendApi/Model/Cart/MergeCartFacade.php
@@ -51,11 +51,11 @@ class MergeCartFacade
         $oldCart = $this->cartFacade->getCartCreateIfNotExists(null, $cartUuid);
         $customerCart = $this->cartFacade->getCartCreateIfNotExists($customerUser, null);
 
+        $this->cartFacade->deleteCart($customerCart);
+
         $oldCart->assignCartToCustomerUser($customerUser);
 
         $this->entityManager->flush();
-
-        $this->cartFacade->deleteCart($customerCart);
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Mutation/Cart/CartMutation.php
+++ b/project-base/app/src/FrontendApi/Mutation/Cart/CartMutation.php
@@ -116,7 +116,7 @@ class CartMutation extends AbstractMutation
 
         if (!$shouldMerge) {
             $this->cartFacade->deleteCart($cart);
-            $this->cartFacade->getCartCreateIfNotExists(null, $cartUuid);
+            $cart = $this->cartFacade->getCartCreateIfNotExists(null, $cartUuid);
         }
 
         $notAddedProducts = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| cart has to be unique in a DB. Due to the limitation of schema check is not possible to have the unique index on the entity (schema seems invalid then) 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-unique-cart.odin.shopsys.cloud
  - https://cz.mg-unique-cart.odin.shopsys.cloud
<!-- Replace -->
