### PR TITLE
[SSP-2100] added more verbose error messages when using logException on SF

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1551,3 +1551,6 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     ```
     -   static rewrite paths are now not accessed through the Next.js config based on a JS file, but instead a TS file is provided, which can be accessed directly and includes literal type values
         -   the keys for the static rewrite paths object must be defined based on 2 sources (`process.env` or `publicRuntimeConfig`), because one of them is not accessible on the client (`process.env`) and the other one is not accessible in `middleware.ts` (`publicRuntimeConfig`)
+-   added more verbose error messages when using logException on SF ([#3018](https://github.com/shopsys/shopsys/pull/3018))
+    -   messages logged to sentry now contain more context
+    -   when adding error logs using `logException`, make sure you always provide as much context as possible

--- a/docs/storefront/error-handling.md
+++ b/docs/storefront/error-handling.md
@@ -143,12 +143,22 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
     const statusCode = middlewareStatusCode || context.res.statusCode || 500;
     ...
 
-    if (statusCode !== 404) {
-        logException(err);
+    if (statusCode !== 404 && !isWithErrorDebugging) {
+        logException(err, {
+            err,
+            statusCode,
+            initServerSidePropsResonse: JSON.stringify(serverSideProps),
+            location: 'ErrorPage.getInitialProps.isWithErrorDebugging = false',
+        });
     }
 
     if (isWithErrorDebugging) {
-        logException(err);
+        logException(err, {
+            err,
+            statusCode,
+            initServerSidePropsResonse: JSON.stringify(serverSideProps),
+            location: 'ErrorPage.getInitialProps.isWithErrorDebugging = true',
+        });
         showErrorMessage(err);
     }
 

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/helpers.ts
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/helpers.ts
@@ -98,7 +98,7 @@ export const useTransportChangeInSelect = (
             const packeteryApiKey = publicRuntimeConfig.packeteryApiKey;
 
             if (!packeteryApiKey?.length) {
-                logException(new Error(`Packeta API key was not set`));
+                logException('Packeta API key was not set');
                 return;
             }
 

--- a/project-base/storefront/helpers/errors/logException.ts
+++ b/project-base/storefront/helpers/errors/logException.ts
@@ -1,11 +1,16 @@
-import { captureException } from '@sentry/nextjs';
+import { withScope, captureException } from '@sentry/nextjs';
 import { isEnvironment } from 'helpers/isEnvironment';
 
-export const logException = (e: unknown): void => {
+export const logException = (e: unknown, extraData?: Record<string, unknown>): void => {
     if (isEnvironment('development')) {
         // eslint-disable-next-line no-console
         console.error(e);
     }
 
-    captureException(e);
+    withScope((scope) => {
+        if (extraData) {
+            scope.setExtras(extraData);
+        }
+        captureException(e);
+    });
 };

--- a/project-base/storefront/hooks/seznamMap/useSeznamMapLoader.tsx
+++ b/project-base/storefront/hooks/seznamMap/useSeznamMapLoader.tsx
@@ -16,7 +16,7 @@ export const useSeznamMapLoader = (
 
         script.onload = () => {
             if (typeof Loader !== 'object') {
-                logException(new Error(`SMap Loader object was not initialized`));
+                logException('SMap Loader object was not initialized');
 
                 if (onError) {
                     onError();
@@ -35,7 +35,7 @@ export const useSeznamMapLoader = (
                 if (typeof SMap !== 'undefined') {
                     setIsMapLoaded(true);
                 } else {
-                    logException(new Error(`SMap was not initialized`));
+                    logException('SMap was not initialized');
                     if (onError) {
                         onError();
                     }
@@ -44,11 +44,7 @@ export const useSeznamMapLoader = (
         };
 
         script.onerror = (error) => {
-            if (typeof error === 'string') {
-                logException(new Error(error));
-            } else {
-                logException(error);
-            }
+            logException(error);
 
             if (onError) {
                 onError();

--- a/project-base/storefront/hooks/useDomainConfig.ts
+++ b/project-base/storefront/hooks/useDomainConfig.ts
@@ -7,7 +7,7 @@ export const useDomainConfig = (): DomainConfigType => {
     const domainConfig = useSessionStore((state) => state.domainConfig);
 
     if (!domainConfig) {
-        logException(new Error('Domain config was undefined.'));
+        logException('Domain config was undefined.');
     }
 
     return domainConfig!;

--- a/project-base/storefront/pages/_app.tsx
+++ b/project-base/storefront/pages/_app.tsx
@@ -21,8 +21,12 @@ type AppProps = {
     pageProps: ServerSidePropsType;
 } & Omit<NextAppProps, 'pageProps'>;
 
-process.on('unhandledRejection', logException);
-process.on('uncaughtException', logException);
+process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) =>
+    logException({ reason, promise, location: '_app.tsx:unhandledRejection' }),
+);
+process.on('uncaughtException', (error: Error, origin: unknown) =>
+    logException({ error, origin, location: '_app.tsx:uncaughtException' }),
+);
 
 function MyApp({ Component, pageProps }: AppProps): ReactElement | null {
     const { defaultLocale, publicGraphqlEndpoint } = pageProps.domainConfig;

--- a/project-base/storefront/pages/_error.tsx
+++ b/project-base/storefront/pages/_error.tsx
@@ -20,7 +20,7 @@ type ErrorPageProps = {
 
 const ErrorPage: NextPage<ErrorPageProps> = ({ hasGetInitialPropsRun, err, statusCode }): ReactElement => {
     if (!hasGetInitialPropsRun && err) {
-        logException(err);
+        logException(err, { err, statusCode, location: 'ErrorPage' });
     }
 
     return statusCode === 404 ? <Error404Content /> : <Error500Content err={err} />;
@@ -39,11 +39,21 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
     }
 
     if (statusCode !== 404 && !isWithErrorDebugging) {
-        logException(err);
+        logException(err, {
+            err,
+            statusCode,
+            initServerSidePropsResonse: JSON.stringify(serverSideProps),
+            location: 'ErrorPage.getInitialProps.isWithErrorDebugging = false',
+        });
     }
 
     if (isWithErrorDebugging) {
-        logException(err);
+        logException(err, {
+            err,
+            statusCode,
+            initServerSidePropsResonse: JSON.stringify(serverSideProps),
+            location: 'ErrorPage.getInitialProps.isWithErrorDebugging = true',
+        });
         showErrorMessage(err);
     }
 

--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -53,7 +53,10 @@ export const getErrorExchange =
     };
 
 const handleErrorMessagesForDevelopment = (error: CombinedError) => {
-    logException(error);
+    logException(error.message, {
+        originalError: JSON.stringify(error),
+        location: 'getErrorExchange.handleErrorMessagesForDevelopment',
+    });
     error.graphQLErrors
         .map((graphqlError) => mapGraphqlErrorForDevelopment(graphqlError))
         .forEach((simplifiedGraphqlError) => showErrorMessage(JSON.stringify(simplifiedGraphqlError)));
@@ -64,7 +67,11 @@ const handleErrorMessagesForUsers = (error: CombinedError, t: Translate, operati
     const isCartError = operation.query === CartQueryDocumentApi;
 
     if (parsedErrors.userError) {
-        logException(parsedErrors.userError);
+        logException(error.message, {
+            parsedUserError: parsedErrors.userError,
+            originalError: JSON.stringify(error),
+            location: 'getErrorExchange.handleErrorMessagesForUsers',
+        });
     }
 
     if (isCartError) {
@@ -78,7 +85,11 @@ const handleErrorMessagesForUsers = (error: CombinedError, t: Translate, operati
     }
 
     if (!isNoLogError(parsedErrors.applicationError.type)) {
-        logException(parsedErrors.applicationError);
+        logException(error.message, {
+            parsedApplicationError: parsedErrors.applicationError,
+            originalError: JSON.stringify(error),
+            location: 'getErrorExchange.handleErrorMessagesForUsers',
+        });
     }
 
     if (isFlashMessageError(parsedErrors.applicationError.type)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With the current Sentry logging on SF, there were many generic and undistinguishable messages. This PR adds more context to each message, making it easier to debug using Sentry and thus fix bugs.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2100-sf-sentry-messages-improvements.odin.shopsys.cloud
  - https://cz.sh-ssp-2100-sf-sentry-messages-improvements.odin.shopsys.cloud
<!-- Replace -->
