### PR TITLE
[framework] feed modules are now removed if appropriate feed no longer exists

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1246,6 +1246,26 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         -   https://www.php.net/manual/en/migration82.php
         -   https://www.php.net/manual/en/migration83.php
     -   see #project-base-diff to update your project
+-   prevent cron failure after feed removal ([#3024](https://github.com/shopsys/shopsys/pull/3024))
+
+    -   `Shopsys\FrameworkBundle\Model\Feed\FeedCronModule::__construct` changed its interface:
+
+    ```diff
+        public function __construct(
+            protected readonly FeedFacade $feedFacade,
+            protected readonly Domain $domain,
+            protected readonly Setting $setting,
+            protected readonly FeedModuleRepository $feedModuleRepository,
+    +       protected readonly FeedModuleFacade $feedModuleFacade,
+        )
+    ```
+
+    -   `Shopsys\FrameworkBundle\Model\Feed\FeedCronModule::createCurrentFeedExport` changed its interface:
+
+    ```diff
+    -   protected function createCurrentFeedExport(?int $lastSeekId = null): FeedExport
+    +   protected function createCurrentFeedExport(?int $lastSeekId = null): ?FeedExport
+    ```
 
 ### Storefront
 

--- a/packages/framework/src/Model/Feed/FeedModuleFacade.php
+++ b/packages/framework/src/Model/Feed/FeedModuleFacade.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Feed;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class FeedModuleFacade
+{
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Model\Feed\FeedModuleRepository $feedModuleRepository
+     */
+    public function __construct(
+        protected readonly EntityManagerInterface $em,
+        protected readonly FeedModuleRepository $feedModuleRepository,
+    ) {
+    }
+
+    /**
+     * @param string $feedName
+     */
+    public function deleteFeedCronModulesByName(string $feedName): void
+    {
+        $feedModules = $this->feedModuleRepository->findFeedModulesByName($feedName);
+
+        foreach ($feedModules as $feedModule) {
+            $this->em->remove($feedModule);
+        }
+
+        $this->em->flush();
+    }
+}

--- a/packages/framework/src/Model/Feed/FeedModuleRepository.php
+++ b/packages/framework/src/Model/Feed/FeedModuleRepository.php
@@ -86,4 +86,15 @@ class FeedModuleRepository
     {
         return $this->getFeedModuleRepository()->findBy(['scheduled' => true]);
     }
+
+    /**
+     * @param string $feedName
+     * @return \Shopsys\FrameworkBundle\Model\Feed\FeedModule[]
+     */
+    public function findFeedModulesByName(string $feedName): array
+    {
+        return $this->getFeedModuleRepository()->findBy([
+            'name' => $feedName,
+        ]);
+    }
 }

--- a/packages/framework/tests/Unit/Model/Feed/FeedCronModuleTest.php
+++ b/packages/framework/tests/Unit/Model/Feed/FeedCronModuleTest.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Feed\FeedExport;
 use Shopsys\FrameworkBundle\Model\Feed\FeedFacade;
 use Shopsys\FrameworkBundle\Model\Feed\FeedInfoInterface;
 use Shopsys\FrameworkBundle\Model\Feed\FeedModule;
+use Shopsys\FrameworkBundle\Model\Feed\FeedModuleFacade;
 use Shopsys\FrameworkBundle\Model\Feed\FeedModuleRepository;
 use Symfony\Bridge\Monolog\Logger;
 use Tests\FrameworkBundle\Unit\TestCase;
@@ -67,7 +68,12 @@ class FeedCronModuleTest extends TestCase
         $feedFacadeMock->expects($this->any())->method('scheduleFeedsForCurrentTime');
         $feedFacadeMock->expects($this->any())->method('markFeedModuleAsUnscheduled');
 
-        $feedCronModule = new FeedCronModule($feedFacadeMock, $domain, $settingMock, $feedModuleRepositoryMock);
+        $feedModuleFacadeMock = $this->getMockBuilder(FeedModuleFacade::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['deleteFeedCronModulesByName'])
+            ->getMock();
+
+        $feedCronModule = new FeedCronModule($feedFacadeMock, $domain, $settingMock, $feedModuleRepositoryMock, $feedModuleFacadeMock);
         $feedCronModule->setLogger($logger);
 
         $feedCronModule->iterate();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| If you have installed some feed, its removal could lead to potential errors. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-remove-no-longer-existing-cron-modules.odin.shopsys.cloud
  - https://cz.tl-remove-no-longer-existing-cron-modules.odin.shopsys.cloud
<!-- Replace -->
