### PR TITLE
[SSP-2107] removed duplicate update payment mutation call on order payment confirmation page

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1736,8 +1736,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   add hreflang links for flag detail page ([#3022](https://github.com/shopsys/shopsys/pull/3022))
 
 -   add display timezone to FE API SettingsQuery ([#2977](https://github.com/shopsys/shopsys/pull/2977))
+
     -   timezone is now taken from API (part of SettingsQuery)
     -   timezone application was kept in `useFormatDate`
     -   SF falls back to the timezone set in NextJS config if API is unavailable
     -   NextJS config timezone was renamed from `timezone` to `fallbackTimezone`
     -   see #project-base-diff to update your project
+
+-   removed duplicate update payment mutation call on order payment confirmation page ([#3025](https://github.com/shopsys/shopsys/pull/3025))

--- a/project-base/storefront/components/Pages/Order/PaymentConfirmation/helpers.ts
+++ b/project-base/storefront/components/Pages/Order/PaymentConfirmation/helpers.ts
@@ -1,10 +1,11 @@
 import { useUpdatePaymentStatusMutationApi } from 'graphql/generated';
 import { onGtmCreateOrderEventHandler } from 'gtm/helpers/eventHandlers';
 import { getGtmCreateOrderEventFromLocalStorage, removeGtmCreateOrderEventFromLocalStorage } from 'gtm/helpers/helpers';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export const useUpdatePaymentStatus = (orderUuid: string, orderPaymentStatusPageValidityHash: string | null) => {
     const [{ data: paymentStatusData }, updatePaymentStatusMutation] = useUpdatePaymentStatusMutationApi();
+    const wasPaymentStatusUpdatedRef = useRef(false);
 
     const updatePaymentStatus = async () => {
         const updatePaymentStatusActionResult = await updatePaymentStatusMutation({
@@ -30,7 +31,10 @@ export const useUpdatePaymentStatus = (orderUuid: string, orderPaymentStatusPage
     };
 
     useEffect(() => {
-        updatePaymentStatus();
+        if (!wasPaymentStatusUpdatedRef.current) {
+            updatePaymentStatus();
+            wasPaymentStatusUpdatedRef.current = true;
+        }
     }, []);
 
     return paymentStatusData;


### PR DESCRIPTION
…rmation page

| Q             | A
| ------------- | ---
|Description, reason for the PR| Removed duplicate update payment mutation call on order payment confirmation page, which caused duplicate events and other issues.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2107-remove-duplicate-update-payment-call.odin.shopsys.cloud
  - https://cz.sh-ssp-2107-remove-duplicate-update-payment-call.odin.shopsys.cloud
<!-- Replace -->
