### PR TITLE
[project-base] fixed standards

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1273,6 +1273,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   `Shopsys\FrameworkBundle\Model\Product\Product::unsetRemovedVariants()` now returns int[]
     -   `Shopsys\FrameworkBundle\Model\Product\Product::refreshVariants()` now returns int[]
     -   see #project-base-diff to update your project
+-   fix standards in PaymentServiceFacade ([#3026](https://github.com/shopsys/shopsys/pull/3026))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/project-base/app/src/Model/Payment/Service/PaymentServiceFacade.php
+++ b/project-base/app/src/Model/Payment/Service/PaymentServiceFacade.php
@@ -40,7 +40,8 @@ class PaymentServiceFacade
         private readonly PaymentTransactionDataFactory $paymentTransactionDataFactory,
         GoPayFacade $goPayFacade,
         private readonly LoggerInterface $logger,
-        private readonly ContainerInterface $container,
+        // intentionally protected to avoid error in phpstan in project-base
+        protected readonly ContainerInterface $container,
     ) {
         $this->paymentServices = [];
         $this->paymentServices[Payment::TYPE_GOPAY] = $goPayFacade;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in project-base the private container property seems unused while used in trait. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
