### PR TITLE
[shopsys] luigis box product feed now correctly exports all products

### DIFF
--- a/packages/framework/src/Model/Feed/FeedCronModule.php
+++ b/packages/framework/src/Model/Feed/FeedCronModule.php
@@ -85,7 +85,9 @@ class FeedCronModule implements IteratedCronModuleInterface
                 $this->getFeedExportCreationDataQueue()->getCurrentFeedName(),
                 $this->getFeedExportCreationDataQueue()->getCurrentDomain()->getId(),
             );
+
             $this->feedFacade->markFeedModuleAsUnscheduled($currentFeedModule);
+            $this->cleanSettingsValues();
 
             $this->logger->info(sprintf(
                 'Feed "%s" generated on domain "%s" into "%s".',
@@ -166,9 +168,7 @@ class FeedCronModule implements IteratedCronModuleInterface
             }
 
             if ($queue->isEmpty()) {
-                $this->setting->set(Setting::FEED_NAME_TO_CONTINUE, null);
-                $this->setting->set(Setting::FEED_DOMAIN_ID_TO_CONTINUE, null);
-
+                $this->cleanSettingsValues();
 
                 return;
             }
@@ -234,5 +234,12 @@ class FeedCronModule implements IteratedCronModuleInterface
         }
 
         return $this->feedExportCreationDataQueue;
+    }
+
+    protected function cleanSettingsValues(): void
+    {
+        $this->setting->set(Setting::FEED_NAME_TO_CONTINUE, null);
+        $this->setting->set(Setting::FEED_DOMAIN_ID_TO_CONTINUE, null);
+        $this->setting->set(Setting::FEED_ITEM_ID_TO_CONTINUE, null);
     }
 }

--- a/packages/product-feed-luigis-box/src/Model/FeedItem/LuigisBoxProductFeedItemFacade.php
+++ b/packages/product-feed-luigis-box/src/Model/FeedItem/LuigisBoxProductFeedItemFacade.php
@@ -44,7 +44,16 @@ class LuigisBoxProductFeedItemFacade
         $this->productUrlsBatchLoader->loadForProducts($products, $domainConfig);
 
         foreach ($products as $product) {
-            yield $this->luigisBoxProductFeedItemFactory->create($product, $domainConfig);
+            if ($product->isMainVariant()) {
+                $variants = $this->luigisBoxProductRepository->getAllVariantsByMainVariantId($product, $domainConfig->getId(), $pricingGroup);
+                $this->productUrlsBatchLoader->loadForProducts($variants, $domainConfig);
+
+                foreach ($variants as $variant) {
+                    yield $this->luigisBoxProductFeedItemFactory->create($variant, $domainConfig);
+                }
+            } else {
+                yield $this->luigisBoxProductFeedItemFactory->create($product, $domainConfig);
+            }
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Current implementation did not export all the products.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-generating-luigis-box-feed.odin.shopsys.cloud
  - https://cz.tl-fix-generating-luigis-box-feed.odin.shopsys.cloud
<!-- Replace -->
