### PR TITLE
[SSP-2144] fixed non-working sentry logging on SF

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1744,3 +1744,6 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 
 -   removed duplicate update payment mutation call on order payment confirmation page ([#3025](https://github.com/shopsys/shopsys/pull/3025))
+
+-   fixed non-working sentry logging on SF ([#3034]https://github.com/shopsys/shopsys/pull/3034)
+    -   change any call to `logException` to only pass one argument, which should be a complete error with all of its context

--- a/docs/storefront/error-handling.md
+++ b/docs/storefront/error-handling.md
@@ -144,8 +144,8 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
     ...
 
     if (statusCode !== 404 && !isWithErrorDebugging) {
-        logException(err, {
-            err,
+        logException({
+            message: err,
             statusCode,
             initServerSidePropsResonse: JSON.stringify(serverSideProps),
             location: 'ErrorPage.getInitialProps.isWithErrorDebugging = false',
@@ -153,8 +153,8 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
     }
 
     if (isWithErrorDebugging) {
-        logException(err, {
-            err,
+        logException({
+            message: err,
             statusCode,
             initServerSidePropsResonse: JSON.stringify(serverSideProps),
             location: 'ErrorPage.getInitialProps.isWithErrorDebugging = true',

--- a/project-base/storefront/helpers/errors/logException.ts
+++ b/project-base/storefront/helpers/errors/logException.ts
@@ -1,16 +1,11 @@
-import { withScope, captureException } from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 import { isEnvironment } from 'helpers/isEnvironment';
 
-export const logException = (e: unknown, extraData?: Record<string, unknown>): void => {
+export const logException = (e: unknown): void => {
     if (isEnvironment('development')) {
         // eslint-disable-next-line no-console
         console.error(e);
     }
 
-    withScope((scope) => {
-        if (extraData) {
-            scope.setExtras(extraData);
-        }
-        captureException(e);
-    });
+    captureException(e);
 };

--- a/project-base/storefront/hooks/seznamMap/useSeznamMapLoader.tsx
+++ b/project-base/storefront/hooks/seznamMap/useSeznamMapLoader.tsx
@@ -44,7 +44,7 @@ export const useSeznamMapLoader = (
         };
 
         script.onerror = (error) => {
-            logException(error);
+            logException({ error, location: 'useSeznamMapLoader.onerror' });
 
             if (onError) {
                 onError();

--- a/project-base/storefront/pages/_app.tsx
+++ b/project-base/storefront/pages/_app.tsx
@@ -21,11 +21,16 @@ type AppProps = {
     pageProps: ServerSidePropsType;
 } & Omit<NextAppProps, 'pageProps'>;
 
-process.on('unhandledRejection', (reason: unknown, promise: Promise<unknown>) =>
-    logException({ reason, promise, location: '_app.tsx:unhandledRejection' }),
+process.on('unhandledRejection', (reason: unknown) =>
+    logException({ reason, location: '_app.tsx:unhandledRejection' }),
 );
 process.on('uncaughtException', (error: Error, origin: unknown) =>
-    logException({ error, origin, location: '_app.tsx:uncaughtException' }),
+    logException({
+        message: error.message,
+        originalError: JSON.stringify(error),
+        origin,
+        location: '_app.tsx:uncaughtException',
+    }),
 );
 
 function MyApp({ Component, pageProps }: AppProps): ReactElement | null {

--- a/project-base/storefront/pages/_error.tsx
+++ b/project-base/storefront/pages/_error.tsx
@@ -20,7 +20,7 @@ type ErrorPageProps = {
 
 const ErrorPage: NextPage<ErrorPageProps> = ({ hasGetInitialPropsRun, err, statusCode }): ReactElement => {
     if (!hasGetInitialPropsRun && err) {
-        logException(err, { err, statusCode, location: 'ErrorPage' });
+        logException({ message: err, statusCode, location: 'ErrorPage' });
     }
 
     return statusCode === 404 ? <Error404Content /> : <Error500Content err={err} />;
@@ -39,8 +39,8 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
     }
 
     if (statusCode !== 404 && !isWithErrorDebugging) {
-        logException(err, {
-            err,
+        logException({
+            message: err,
             statusCode,
             initServerSidePropsResonse: JSON.stringify(serverSideProps),
             location: 'ErrorPage.getInitialProps.isWithErrorDebugging = false',
@@ -48,8 +48,8 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
     }
 
     if (isWithErrorDebugging) {
-        logException(err, {
-            err,
+        logException({
+            message: err,
             statusCode,
             initServerSidePropsResonse: JSON.stringify(serverSideProps),
             location: 'ErrorPage.getInitialProps.isWithErrorDebugging = true',

--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -53,7 +53,8 @@ export const getErrorExchange =
     };
 
 const handleErrorMessagesForDevelopment = (error: CombinedError) => {
-    logException(error.message, {
+    logException({
+        message: error.message,
         originalError: JSON.stringify(error),
         location: 'getErrorExchange.handleErrorMessagesForDevelopment',
     });
@@ -67,7 +68,8 @@ const handleErrorMessagesForUsers = (error: CombinedError, t: Translate, operati
     const isCartError = operation.query === CartQueryDocumentApi;
 
     if (parsedErrors.userError) {
-        logException(error.message, {
+        logException({
+            message: error.message,
             parsedUserError: parsedErrors.userError,
             originalError: JSON.stringify(error),
             location: 'getErrorExchange.handleErrorMessagesForUsers',
@@ -85,7 +87,8 @@ const handleErrorMessagesForUsers = (error: CombinedError, t: Translate, operati
     }
 
     if (!isNoLogError(parsedErrors.applicationError.type)) {
-        logException(error.message, {
+        logException({
+            message: error.message,
             parsedApplicationError: parsedErrors.applicationError,
             originalError: JSON.stringify(error),
             location: 'getErrorExchange.handleErrorMessagesForUsers',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Previous implementation of Sentry logging on SF caused Sentry errors to be unreadable and lacked any information. This PR aims to fix it.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2144-fix-sentry-logging.odin.shopsys.cloud
  - https://cz.sh-ssp-2144-fix-sentry-logging.odin.shopsys.cloud
<!-- Replace -->
