### PR TITLE
[project-base] added missing cron instances to deploy-project.sh

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1421,6 +1421,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         +       protected readonly FlagRepository $flagRepository,
         ```
     -   see #project-base-diff to update your project
+-   add missing cron instances to `deploy-project-sh` ([#3036](https://github.com/shopsys/shopsys/pull/3036))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/project-base/app/deploy/deploy-project.sh
+++ b/project-base/app/deploy/deploy-project.sh
@@ -98,6 +98,10 @@ function deploy() {
         ["cron-service"]='*/5 * * * *'
         ["cron-export"]='*/5 * * * *'
         ["cron-products"]='*/5 * * * *'
+        ["cron-importAkeneoProduct"]='*/5 * * * *'
+        ["cron-gopay"]='*/5 * * * *'
+        ["cron-dataBridgeImport"]='*/5 * * * *'
+        ["cron-packetery"]='*/5 * * * *'
     )
 
     VARS=(

--- a/project-base/app/deploy/deploy-project.sh
+++ b/project-base/app/deploy/deploy-project.sh
@@ -98,9 +98,9 @@ function deploy() {
         ["cron-service"]='*/5 * * * *'
         ["cron-export"]='*/5 * * * *'
         ["cron-products"]='*/5 * * * *'
-        ["cron-importAkeneoProduct"]='*/5 * * * *'
+        ["cron-import-akeneo-product"]='*/5 * * * *'
         ["cron-gopay"]='*/5 * * * *'
-        ["cron-dataBridgeImport"]='*/5 * * * *'
+        ["cron-data-bridge-import"]='*/5 * * * *'
         ["cron-packetery"]='*/5 * * * *'
     )
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Some cron instances were missing in deploy-project.sh, so this PR adds them.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-add-missing-cron-instances-to-deploy.odin.shopsys.cloud
  - https://cz.tl-add-missing-cron-instances-to-deploy.odin.shopsys.cloud
<!-- Replace -->
