### PR TITLE
[shopsys] renamed blog article publishedAt elastic field to fix elasticsearch migration

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1423,6 +1423,9 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   add missing cron instances to `deploy-project-sh` ([#3036](https://github.com/shopsys/shopsys/pull/3036))
     -   see #project-base-diff to update your project
+-   rename blog article elasticsearch field `publishedAt` to `publishDate` ([#3038](https://github.com/shopsys/shopsys/pull/3038))
+    -   check your custom code for usage of `publishedAt` field on blog article elasticsearch data and replace it with `publishDate`
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1425,6 +1425,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 -   rename blog article elasticsearch field `publishedAt` to `publishDate` ([#3038](https://github.com/shopsys/shopsys/pull/3038))
     -   check your custom code for usage of `publishedAt` field on blog article elasticsearch data and replace it with `publishDate`
+    -   remember to immediately export blog articles to elasticsearch after the update using the `php bin/console shopsys:elasticsearch:data-export blog_article` command
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcher.php
+++ b/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcher.php
@@ -22,7 +22,7 @@ class BlogArticleElasticsearchDataFetcher extends AbstractElasticsearchDataFetch
         $result['uuid'] = $data['uuid'] ?? '';
         $result['createdAt'] = $data['createdAt'] ?? '1970-01-01 00:00:00';
         $result['visibleOnHomepage'] = $data['visibleOnHomepage'] ?? false;
-        $result['publishedAt'] = $data['publishedAt'] ?? '1970-01-01';
+        $result['publishDate'] = $data['publishDate'] ?? '1970-01-01 00:00:00';
         $result['perex'] = $data['perex'] ?? null;
         $result['seoTitle'] = $data['seoTitle'] ?? null;
         $result['seoMetaDescription'] = $data['seoMetaDescription'] ?? null;

--- a/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleExportRepository.php
+++ b/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleExportRepository.php
@@ -128,7 +128,7 @@ class BlogArticleExportRepository
             'uuid' => $blogArticle->getUuid(),
             'createdAt' => $blogArticle->getCreatedAt()->format('Y-m-d H:i:s'),
             'visibleOnHomepage' => $blogArticle->isVisibleOnHomepage(),
-            'publishedAt' => $blogArticle->getPublishDate()->format('Y-m-d H:i:s'),
+            'publishDate' => $blogArticle->getPublishDate()->format('Y-m-d H:i:s'),
             'perex' => $blogArticle->getPerex($locale),
             'seoTitle' => $blogArticle->getSeoTitle($domainId),
             'seoMetaDescription' => $blogArticle->getSeoMetaDescription($domainId),

--- a/packages/framework/src/Model/Blog/Article/Elasticsearch/FilterQuery.php
+++ b/packages/framework/src/Model/Blog/Article/Elasticsearch/FilterQuery.php
@@ -17,7 +17,7 @@ class FilterQuery extends AbstractFilterQuery
         parent::__construct($indexName);
 
         $this->sorting = [
-            'publishedAt' => 'desc',
+            'publishDate' => 'desc',
             'createdAt' => 'desc',
             'name.keyword' => 'asc',
         ];

--- a/packages/framework/tests/Unit/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcherTest.php
+++ b/packages/framework/tests/Unit/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcherTest.php
@@ -88,7 +88,7 @@ class BlogArticleElasticsearchDataFetcherTest extends TestCase
             'uuid' => '',
             'createdAt' => '1970-01-01 00:00:00',
             'visibleOnHomepage' => false,
-            'publishedAt' => '1970-01-01',
+            'publishDate' => '1970-01-01 00:00:00',
             'perex' => null,
             'seoTitle' => null,
             'seoMetaDescription' => null,

--- a/packages/framework/tests/Unit/Model/Blog/Article/Elasticsearch/FilterQueryTest.php
+++ b/packages/framework/tests/Unit/Model/Blog/Article/Elasticsearch/FilterQueryTest.php
@@ -25,7 +25,7 @@ class FilterQueryTest extends TestCase
                 'from' => 0,
                 'size' => 1000,
                 'sort' => [
-                    'publishedAt' => 'desc',
+                    'publishDate' => 'desc',
                     'createdAt' => 'desc',
                     'name.keyword' => 'asc',
                 ],
@@ -61,7 +61,7 @@ class FilterQueryTest extends TestCase
                 'from' => 0,
                 'size' => 1000,
                 'sort' => [
-                    'publishedAt' => 'desc',
+                    'publishDate' => 'desc',
                     'createdAt' => 'desc',
                     'name.keyword' => 'asc',
                 ],
@@ -97,7 +97,7 @@ class FilterQueryTest extends TestCase
                 'from' => 0,
                 'size' => 1000,
                 'sort' => [
-                    'publishedAt' => 'desc',
+                    'publishDate' => 'desc',
                     'createdAt' => 'desc',
                     'name.keyword' => 'asc',
                 ],
@@ -140,7 +140,7 @@ class FilterQueryTest extends TestCase
                 'from' => $expectedFrom,
                 'size' => $expectedSize,
                 'sort' => [
-                    'publishedAt' => 'desc',
+                    'publishDate' => 'desc',
                     'createdAt' => 'desc',
                     'name.keyword' => 'asc',
                 ],

--- a/packages/frontend-api/src/Model/Blog/Article/BlogArticleResolverMap.php
+++ b/packages/frontend-api/src/Model/Blog/Article/BlogArticleResolverMap.php
@@ -29,7 +29,7 @@ class BlogArticleResolverMap extends ResolverMap
                     return $this->blogCategoryFacade->getByIds($blogArticleData['categories']);
                 },
                 'publishDate' => static function (array $blogArticleData) {
-                    return new DateTime($blogArticleData['publishedAt']);
+                    return new DateTime($blogArticleData['publishDate']);
                 },
                 'createdAt' => static function (array $blogArticleData) {
                     return new DateTime($blogArticleData['createdAt']);

--- a/project-base/app/src/Resources/definition/blog_article/1.json
+++ b/project-base/app/src/Resources/definition/blog_article/1.json
@@ -170,7 +170,7 @@
       "visibleOnHomepage": {
         "type": "boolean"
       },
-      "publishedAt": {
+      "publishDate": {
         "type": "date",
         "format": "yyyy-MM-dd HH:mm:ss"
       },

--- a/project-base/app/src/Resources/definition/blog_article/2.json
+++ b/project-base/app/src/Resources/definition/blog_article/2.json
@@ -168,7 +168,7 @@
       "visibleOnHomepage": {
         "type": "boolean"
       },
-      "publishedAt": {
+      "publishDate": {
         "type": "date",
         "format": "yyyy-MM-dd HH:mm:ss"
       },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In #2977 the publishedAt elasticsearch field on blog_article changed its type. This type of change breaks elasticsearch migration. This is now fixed by renaming the field
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-deploy.odin.shopsys.cloud
  - https://cz.mg-fix-deploy.odin.shopsys.cloud
<!-- Replace -->
