### PR TITLE
[shopsys] hotfix: locked php-cs-fixer in version lower than 3.50 as new version causes errors in tests with current easy-coding-standards

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1427,6 +1427,8 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   check your custom code for usage of `publishedAt` field on blog article elasticsearch data and replace it with `publishDate`
     -   remember to immediately export blog articles to elasticsearch after the update using the `php bin/console shopsys:elasticsearch:data-export blog_article` command
     -   see #project-base-diff to update your project
+-   set version of `friendsofphp/php-cs-fixer` >= `3.50` as conflicting to resolve problems in tests ([#3042](https://github.com/shopsys/shopsys/pull/3042))
+    -   see #project-base-diff to update your project
 
 ### Storefront
 

--- a/composer.json
+++ b/composer.json
@@ -208,7 +208,7 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "friendsofphp/php-cs-fixer": "2.19.0",
+        "friendsofphp/php-cs-fixer": "2.19.0 | >=3.50.0",
         "guzzlehttp/psr7": "<=1.8.3, >=2.0.0, <=2.1.0"
     },
     "scripts": {

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -26,6 +26,9 @@
         "phpunit/phpunit": "^9.5.20",
         "nikic/php-parser": "^4.0"
     },
+    "conflict": {
+        "friendsofphp/php-cs-fixer": ">=3.50.0"
+    },
     "autoload": {
         "psr-4": {
             "Shopsys\\CodingStandards\\": "src/"

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -144,7 +144,7 @@
     },
     "conflict": {
         "symfony/symfony": "*",
-        "friendsofphp/php-cs-fixer": "2.19.0",
+        "friendsofphp/php-cs-fixer": "2.19.0 | >=3.50.0",
         "guzzlehttp/psr7": "<=1.8.3, >=2.0.0, <=2.1.0"
     },
     "scripts": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Newest version of PHPCSFixer is not fully compatible with the installed version of easy-coding-standards, so it has been set as conflicting until solved properly.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-phpcs-fixer.odin.shopsys.cloud
  - https://cz.tl-fix-phpcs-fixer.odin.shopsys.cloud
<!-- Replace -->
