### PR TITLE
change limit for description in articles and blog articles to no limit

### DIFF
--- a/packages/framework/src/Component/GrapesJs/GrapesJsParser.php
+++ b/packages/framework/src/Component/GrapesJs/GrapesJsParser.php
@@ -63,7 +63,7 @@ class GrapesJsParser
             ->allowStaticElements()
             ->allowRelativeLinks()
             ->allowElement('iframe', '*')
-            ->withMaxInputLength(25000);
+            ->withMaxInputLength(-1);
 
         foreach (array_keys(W3CReference::HEAD_ELEMENTS) as $element) {
             $config->allowElement($element, '*');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Sometimes admins want to add descriptions for articles and blog articles of more than 25000 bytes, so we changed limit to no limit
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pt-blog-article-long-content.odin.shopsys.cloud
  - https://cz.pt-blog-article-long-content.odin.shopsys.cloud
<!-- Replace -->
