### PR TITLE
[shopsys] product recalculations scoping

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -542,6 +542,8 @@ jobs:
                     docker compose exec -T php-fpm php phing -D production.confirm.action=y cron-list cron-run-all-serially cron-watch maintenance-on maintenance-off elasticsearch-export-changed
                     docker compose exec -T php-fpm php bin/console shopsys:categories:recalculate
                     docker compose exec -T php-fpm php bin/console shopsys:cdn-domain-url:replace
+                    docker compose exec -T php-fpm php bin/console shopsys:list:export-scopes
+                    docker compose exec -T php-fpm php bin/console shopsys:dispatch:recalculations 1
     build-fork-docker-images:
         if: |
             github.event.pull_request.head.repo.full_name != 'shopsys/shopsys' && 
@@ -604,6 +606,8 @@ jobs:
                     docker compose exec -T php-fpm php phing -D production.confirm.action=y frontend-api-enable cron-list cron-run-all-serially cron-watch maintenance-on maintenance-off elasticsearch-export-changed
                     docker compose exec -T php-fpm php bin/console shopsys:categories:recalculate
                     docker compose exec -T php-fpm php bin/console shopsys:cdn-domain-url:replace
+                    docker compose exec -T php-fpm php bin/console shopsys:list:export-scopes
+                    docker compose exec -T php-fpm php bin/console shopsys:dispatch:recalculations 1
             -   name: PHP-FPM container logs
                 if: ${{ failure() }}
                 run: docker compose logs php-fpm

--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -280,6 +280,184 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   see #project-base-diff to update your project
 
+#### product recalculations scoping ([#3051](https://github.com/shopsys/shopsys/pull/3051))
+
+-   `Shopsys\FrameworkBundle\Command\DispatchRecalculationMessageCommand` class was changed:
+    -   `executeAll()` method changed its interface:
+        ```diff
+        -   public function executeAll(SymfonyStyle $symfonyStyle): int
+        +   public function executeAll(SymfonyStyle $symfonyStyle, array $scopes): int
+        ```
+    -   `executeIds()` method changed its interface:
+        ```diff
+            public function executeIds(
+                array $productIds,
+                SymfonyStyle $symfonyStyle,
+                ProductRecalculationPriorityEnumInterface $priority,
+        +       array $scopes,
+        ```
+-   `Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex` class was changed:
+    -   `getExportDataForIds()` method changed its interface:
+        ```diff
+            abstract public function getExportDataForIds(
+                int $domainId,
+                array $restrictToIds,
+        +       array $fields = [],
+        ```
+    -   `getExportDataForBatch()` method changed its interface:
+        ```diff
+            abstract public function getExportDataForBatch(
+                int $domainId,
+                 int $lastProcessedId,
+                 int $batchSize,
+        +        array $fields = [],
+        ```
+-   `Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade` class was changed:
+    -   `exportIds()` method changed its interface:
+        ```diff
+            public function exportIds(
+                AbstractIndex $index,
+                IndexDefinition $indexDefinition,
+                array $restrictToIds,
+        +       array $fields = [],
+        ```
+-   `Shopsys\FrameworkBundle\Model\Article\Elasticsearch\ArticleIndex` class was changed:
+    -   `getExportDataForIds()` method changed its interface:
+        ```diff
+            public function getExportDataForIds(
+                int $domainId,
+                array $restrictToIds,
+        +       array $fields = [],
+        ```
+    -   `getExportDataForBatch()` method changed its interface:
+        ```diff
+            public function getExportDataForBatch(
+                int $domainId,
+                int $lastProcessedId,
+                int $batchSize,
+        +       array $fields = [],
+        ```
+-   `Shopsys\FrameworkBundle\Model\Blog\Article\Elasticsearch\BlogArticleIndex` class was changed:
+    -   `getExportDataForIds()` method changed its interface:
+        ```diff
+            public function getExportDataForIds(
+                int $domainId,
+                array $restrictToIds,
+        +       array $fields = [],
+        ```
+    -   `getExportDataForBatch()` method changed its interface:
+        ```diff
+            public function getExportDataForBatch(
+                int $domainId,
+                int $lastProcessedId,
+                int $batchSize,
+        +       array $fields = [],
+        ```
+-   `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportRepository` class was changed:
+    -   the class now implements `Symfony\Contracts\Service\ResetInterface`
+    -   `__construct()` method changed its interface:
+        ```diff
+            public function __construct(
+                // ...
+                protected readonly HreflangLinksFacade $hreflangLinksFacade,
+        +       protected readonly ProductExportFieldProvider $productExportFieldProvider,
+        +       protected readonly PricingGroupSettingFacade $pricingGroupSettingFacade,
+        +       protected readonly ProductRepository $productRepository,
+        +       protected ?array $variantCache = null,
+        ```
+    -   `getProductsData()` method changed its interface:
+        ```diff
+            public function getProductsData(
+                int $domainId,
+                string $locale,
+                int $lastProcessedId,
+                int $batchSize,
+        +       array $fields = [],
+        ```
+    -   `getProductsDataForIds()` method changed its interface:
+        ```diff
+            public function getProductsDataForIds(
+                int $domainId,
+                string $locale,
+                array $productIds,
+        +       array $fields,
+        ```
+    -   `extractResult()` method changed its interface:
+        ```diff
+            protected function extractResult(
+                Product $product,
+                int $domainId,
+                string $locale,
+        +       array $fields,
+        ```
+-   `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex` class was changed:
+    -   `getExportDataForIds()` method changed its interface:
+        ```diff
+            public function getExportDataForIds(
+                int $domainId,
+                array $restrictToIds,
+        +       array $fields = [],
+        ```
+    -   `getExportDataForBatch()` method changed its interface:
+        ```diff
+            public function getExportDataForBatch(
+                int $domainId,
+                int $lastProcessedId,
+                int $batchSize,
+        +       array $fields = [],
+        ```
+-   `Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage::__construct` changed its interface:
+    ```diff
+        public function __construct(
+            public readonly int $productId,
+    +       public readonly array $exportScopes = [],
+    ```
+-   `Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher` class was changed:
+    -   `dispatchProducts()` method changed its interface:
+        ```diff
+            public function dispatchProducts(
+                array $products,
+                ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        +       array $exportScopes = [],
+        ```
+    -   `dispatchProductIds()` method changed its interface:
+        ```diff
+            public function dispatchProductIds(
+                array $productIds,
+                ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        +       array $exportScopes = [],
+        ```
+    -   `dispatchSingleProductId()` method changed its interface:
+        ```diff
+            public function dispatchSingleProductId(
+                int $productId,
+                ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        +       array $exportScopes = [],
+        ```
+    -   `dispatchAllProducts()` method changed its interface:
+        ```diff
+            public function dispatchAllProducts(
+        +       array $exportScopes = [],
+        ```
+-   `Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationFacade` class was changed:
+    -   `__construct()` method changed its interface:
+        ```diff
+            public function __construct(
+                // ...
+                protected readonly ProductSellingDeniedRecalculator $productSellingDeniedRecalculator,
+        +       protected readonly ProductExportScopeConfigFacade $productExportScopeConfigFacade,
+        +       protected readonly ProductElasticsearchProvider $productElasticsearchProvider,
+        ```
+    -   `recalculate()` method changed its interface:
+        ```diff
+            public function recalculate(
+                array $productIds,
+        +       array $exportScopesIndexedByProductId,
+        ```
+-   [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the framework package:
+    -   product variants cache in `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportRepository`
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/docs/asynchronous-processing/product-recalculations.md
+++ b/docs/asynchronous-processing/product-recalculations.md
@@ -115,11 +115,56 @@ That way we are sure the code works – the message is truly dispatched, thus th
     Calling `handleDispatchedRecalculationMessages()` method creates a snapshot in Elasticsearch before any changes are exported and restores it afterward.<br>
     Tests are not dependent on the changes made or the order of run.
 
+## Recalculation scope
+
+In many occasions, to optimize the application, you might need to restrict the scope of a product recalculation and elastic export.
+Sometimes you do not need to recalculate visibility or selling denied, or you need to export just particular fields into Elasticsearch.
+For example, when launching a new domain, you need to export just the product URLs into Elasticsearch which takes significantly less time than the full recalculation and export.
+On the other hand, it might be hard to keep in mind all the dependencies (e.g. you need to know you need to recalculate visibility after you change `Product::$sellingFrom`,
+or you need to keep in mind that with a change of product URL, you always need to export `hreflang_links` into Elasticsearch as well, etc.).
+
+For this purpose, recalculation scopes are defined as an associative array in the `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfigFacade` class.
+The scopes are represented by instances of the `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeRule` class and indexed by their names.
+Each scope rule defines which fields should be exported to Elasticsearch together (`$productExportFields` property) and whether some actions (recalculations) should be done before the export (`$productExportPreconditions` property).
+
+You can use `./bin/console shopsys:list:export-scopes` command to list and examine all the available scopes.
+
+The scope usage can be seen in action e.g. in `Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAffectedProductsSubscriber` class:
+
+```php
+public function dispatchAffectedByBrand(BrandEvent $brandEvent): void
+{
+    $productIds = $this->affectedProductsFacade->getProductIdsWithBrand($brandEvent->getBrand());
+
+    $this->productRecalculationDispatcher->dispatchProductIds(
+        $productIds,
+        ProductRecalculationPriorityEnum::REGULAR,
+        [ProductExportScopeConfig::SCOPE_BRAND],
+    );
+}
+```
+
+Thanks to the usage of `SCOPE_BRAND` here, no visibility or selling denied recalculations are done after a brand is updated, only the brand-related fields (brand ID, name, and URL) are exported to Elasticsearch for the affected products.
+
+There are several methods that allow you to modify the scopes configuration further to suit your project needs.
+
+-   `addExportFieldsToExistingScopeRule()`
+-   `addNewExportScopeRule()`
+-   `overwriteExportScopeRule()`
+
+You can use the methods in the overridden `App\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig::loadProductExportScopeRules()`.
+
+!!! note
+
+    The export fields restriction is ignored in situations when the product is not present in Elasticsearch (e.g. it was not exported yet) and visibility recalculation needs to be done.
+    In such cases, all the product fields are always exported to Elasticsearch to ensure no data are missing for the product.
+
 ## Invoke recalculations manually
 
 It's possible to invoke recalculations manually with the `./bin/console shopsys:dispatch:recalculations` command.
 
-This command accepts ids of products, that should be dispatched, or `--all` option to dispatch all products. You can also define the priority of the recalculations using `--priority` option.
+This command accepts ids of products, that should be dispatched, or `--all` option to dispatch all products.
+You can also define the priority and/or scopes of the recalculations using `--priority`, and/or `--scope` options.
 
 ```bash
 # dispatch products with ids 1, 2 and 3
@@ -130,4 +175,7 @@ This command accepts ids of products, that should be dispatched, or `--all` opti
 
 # dispatch product with id 22 into the high priority queue
 ./bin/console shopsys:dispatch:recalculations 22 --priority=high
+
+# dispatch all products with the "product_selling_denied_scope" scope
+./bin/console shopsys:dispatch:recalculations --all --scope=product_selling_denied_scope
 ```

--- a/packages/framework/ecs.php
+++ b/packages/framework/ecs.php
@@ -69,6 +69,7 @@ return static function (ECSConfig $ecsConfig): void {
             __DIR__ . '/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php',
             __DIR__ . '/src/Form/Constraints/FileAbstractFilesystemValidator.php',
             __DIR__ . '/tests/Unit/Model/Mail/EnvelopeListenerTest.php',
+            __DIR__ . '/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php',
         ],
         ClassLengthSniff::class => [
             __DIR__ . '/src/Form/Admin/Product/ProductFormType.php',
@@ -119,6 +120,7 @@ return static function (ECSConfig $ecsConfig): void {
             __DIR__ . '/src/Model/Product/Search/ProductElasticsearchConverter.php',
             __DIR__ . '/src/Migrations/Version20231124121921.php',
             __DIR__ . '/src/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcher.php',
+            __DIR__ . '/src/Model/Product/Elasticsearch/ProductExportRepository.php',
         ],
         EmptyStatementSniff::class . '.DetectedCatch' => [
             __DIR__ . '/src/Component/Elasticsearch/Debug/ElasticsearchTracer.php',

--- a/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
+++ b/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
@@ -49,7 +49,7 @@ class DispatchRecalculationMessageCommand extends Command
             ->addOption(
                 'priority',
                 'p',
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 sprintf('Define the message priority. Possible values are: %s', ProductRecalculationPriorityEnum::getPipeSeparatedValues()),
                 ProductRecalculationPriorityEnum::REGULAR->value,
             )

--- a/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
+++ b/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
@@ -52,6 +52,13 @@ class DispatchRecalculationMessageCommand extends Command
                 InputOption::VALUE_OPTIONAL,
                 sprintf('Define the message priority. Possible values are: %s', ProductRecalculationPriorityEnum::getPipeSeparatedValues()),
                 ProductRecalculationPriorityEnum::REGULAR->value,
+            )
+            ->addOption(
+                'scope',
+                's',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'Define the message scopes. Run "shopsys:list:export-scopes" command for listing available scopes',
+                [],
             );
     }
 
@@ -63,6 +70,7 @@ class DispatchRecalculationMessageCommand extends Command
         $symfonyStyle = new SymfonyStyle($input, $output);
 
         $productIds = $input->getArgument('productIds');
+        $scopes = $input->getOption('scope');
         $shouldRecalculateAll = $input->getOption('all');
         $priority = ProductRecalculationPriorityEnum::tryFrom($input->getOption('priority'));
 
@@ -85,20 +93,26 @@ class DispatchRecalculationMessageCommand extends Command
         }
 
         if ($shouldRecalculateAll) {
-            return $this->executeAll($symfonyStyle);
+            return $this->executeAll($symfonyStyle, $scopes);
         }
 
-        return $this->executeIds($productIds, $symfonyStyle, $priority);
+        return $this->executeIds($productIds, $symfonyStyle, $priority, $scopes);
     }
 
     /**
      * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyle
+     * @param string[] $scopes
      * @return int
      */
-    protected function executeAll(SymfonyStyle $symfonyStyle): int
+    protected function executeAll(SymfonyStyle $symfonyStyle, array $scopes): int
     {
-        $this->productRecalculationDispatcher->dispatchAllProducts();
-        $symfonyStyle->success('Dispatched all products to recalculate');
+        $this->productRecalculationDispatcher->dispatchAllProducts($scopes);
+        $message = 'Dispatched all products to recalculate';
+
+        if (count($scopes) > 0) {
+            $message .= sprintf(' with scopes: %s', implode(', ', $scopes));
+        }
+        $symfonyStyle->success($message);
 
         return Command::SUCCESS;
     }
@@ -107,12 +121,14 @@ class DispatchRecalculationMessageCommand extends Command
      * @param int[] $productIds
      * @param \Symfony\Component\Console\Style\SymfonyStyle $symfonyStyle
      * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $priority
+     * @param string[] $scopes
      * @return int
      */
     protected function executeIds(
         array $productIds,
         SymfonyStyle $symfonyStyle,
         ProductRecalculationPriorityEnumInterface $priority,
+        array $scopes,
     ): int {
         try {
             Assert::allNumeric($productIds, 'All product IDs must be numeric');
@@ -123,8 +139,12 @@ class DispatchRecalculationMessageCommand extends Command
             return Command::FAILURE;
         }
 
-        $dispatchedProductIds = $this->productRecalculationDispatcher->dispatchProductIds($productIds, $priority);
-        $symfonyStyle->success(['Dispatched message for IDs', implode(', ', $dispatchedProductIds), sprintf('Priority: %s', $priority->value)]);
+        $dispatchedProductIds = $this->productRecalculationDispatcher->dispatchProductIds($productIds, $priority, $scopes);
+        $symfonyStyle->success([
+            'Dispatched message for IDs', implode(', ', $dispatchedProductIds),
+            sprintf('Priority: %s', $priority->value),
+            sprintf('Scopes: %s', count($scopes) > 0 ? implode(', ', $scopes) : '-'),
+        ]);
 
         return Command::SUCCESS;
     }

--- a/packages/framework/src/Command/ListExportScopesCommand.php
+++ b/packages/framework/src/Command/ListExportScopesCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'shopsys:list:export-scopes')]
+class ListExportScopesCommand extends Command
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig $productExportScopeConfig
+     */
+    public function __construct(
+        protected readonly ProductExportScopeConfig $productExportScopeConfig,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $rows = [];
+        $productExportScopeRules = $this->productExportScopeConfig->getProductExportScopeRules();
+        $rulesCount = count($productExportScopeRules);
+        $counter = 0;
+
+        foreach ($productExportScopeRules as $productExportScope => $rule) {
+            $rows[] = [
+                $productExportScope,
+                implode(', ', $rule->productExportFields),
+                implode(', ', $rule->productExportPreconditions),
+            ];
+
+            if ($counter < $rulesCount - 1) {
+                $rows[] = new TableSeparator();
+            }
+            $counter++;
+        }
+
+        $table = new Table($output);
+        $table
+            ->setHeaders(['Export Scope Name', 'Elasticsearch Field Names', 'Preconditions'])
+            ->setRows($rows)
+            ->setColumnMaxWidth(0, 30)
+            ->setColumnMaxWidth(1, 80)
+            ->setColumnMaxWidth(2, 50)
+            ->setStyle('box-double')
+            ->render();
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/framework/src/Component/Elasticsearch/AbstractIndex.php
+++ b/packages/framework/src/Component/Elasticsearch/AbstractIndex.php
@@ -22,17 +22,24 @@ abstract class AbstractIndex
     /**
      * @param int $domainId
      * @param array $restrictToIds
+     * @param string[] $fields
      * @return array
      */
-    abstract public function getExportDataForIds(int $domainId, array $restrictToIds): array;
+    abstract public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array;
 
     /**
      * @param int $domainId
      * @param int $lastProcessedId
      * @param int $batchSize
+     * @param string[] $fields
      * @return array
      */
-    abstract public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array;
+    abstract public function getExportDataForBatch(
+        int $domainId,
+        int $lastProcessedId,
+        int $batchSize,
+        array $fields = [],
+    ): array;
 
     /**
      * @return int

--- a/packages/framework/src/Component/Elasticsearch/Exception/UnsupportedFeatureException.php
+++ b/packages/framework/src/Component/Elasticsearch/Exception/UnsupportedFeatureException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Elasticsearch\Exception;
+
+use Exception;
+
+class UnsupportedFeatureException extends Exception
+{
+    /**
+     * @param string $message
+     */
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/packages/framework/src/Component/Reflection/ReflectionHelper.php
+++ b/packages/framework/src/Component/Reflection/ReflectionHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Reflection;
+
+use ReflectionClass;
+use ReflectionClassConstant;
+
+class ReflectionHelper
+{
+    /**
+     * @var array<string, string[]>
+     */
+    protected static array $constantsIndexedByFqcn = [];
+
+    /**
+     * @param string $fqcn
+     * @return string[]
+     */
+    public static function getAllPublicClassConstants(string $fqcn): array
+    {
+        if (!array_key_exists($fqcn, self::$constantsIndexedByFqcn)) {
+            self::$constantsIndexedByFqcn[$fqcn] = array_values((new ReflectionClass($fqcn))->getConstants(ReflectionClassConstant::IS_PUBLIC));
+        }
+
+        return self::$constantsIndexedByFqcn[$fqcn];
+    }
+}

--- a/packages/framework/src/Model/Article/Elasticsearch/ArticleIndex.php
+++ b/packages/framework/src/Model/Article/Elasticsearch/ArticleIndex.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Article\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\UnsupportedFeatureException;
 
 class ArticleIndex extends AbstractIndex
 {
@@ -32,10 +33,18 @@ class ArticleIndex extends AbstractIndex
      * @param int $domainId
      * @param int $lastProcessedId
      * @param int $batchSize
+     * @param string[] $fields
      * @return array
      */
-    public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
-    {
+    public function getExportDataForBatch(
+        int $domainId,
+        int $lastProcessedId,
+        int $batchSize,
+        array $fields = [],
+    ): array {
+        if ($fields !== []) {
+            throw new UnsupportedFeatureException('Scoping export by fields is not supported for articles.');
+        }
         $results = [];
 
         foreach ($this->articleExportRepository->getAllVisibleArticleSitesByDomainId($domainId, $batchSize, $lastProcessedId) as $article) {
@@ -48,10 +57,14 @@ class ArticleIndex extends AbstractIndex
     /**
      * @param int $domainId
      * @param array $restrictToIds
+     * @param string[] $fields
      * @return array
      */
-    public function getExportDataForIds(int $domainId, array $restrictToIds): array
+    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
     {
+        if ($fields !== []) {
+            throw new UnsupportedFeatureException('Scoping export by fields is not supported for articles.');
+        }
         $results = [];
 
         foreach ($this->articleExportRepository->getVisibleArticleSitesByDomainIdAndArticleIds($domainId, $restrictToIds) as $article) {

--- a/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleIndex.php
+++ b/packages/framework/src/Model/Blog/Article/Elasticsearch/BlogArticleIndex.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Model\Blog\Article\Elasticsearch;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\AbstractIndex;
+use Shopsys\FrameworkBundle\Component\Elasticsearch\Exception\UnsupportedFeatureException;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexSupportChangesOnlyInterface;
 
 class BlogArticleIndex extends AbstractIndex implements IndexSupportChangesOnlyInterface
@@ -38,10 +39,18 @@ class BlogArticleIndex extends AbstractIndex implements IndexSupportChangesOnlyI
      * @param int $domainId
      * @param int $lastProcessedId
      * @param int $batchSize
+     * @param string[] $fields
      * @return array
      */
-    public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
-    {
+    public function getExportDataForBatch(
+        int $domainId,
+        int $lastProcessedId,
+        int $batchSize,
+        array $fields = [],
+    ): array {
+        if ($fields !== []) {
+            throw new UnsupportedFeatureException('Scoping export by fields is not supported for blog articles.');
+        }
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
 
         $results = [];
@@ -56,10 +65,14 @@ class BlogArticleIndex extends AbstractIndex implements IndexSupportChangesOnlyI
     /**
      * @param int $domainId
      * @param array $restrictToIds
+     * @param string[] $fields
      * @return array
      */
-    public function getExportDataForIds(int $domainId, array $restrictToIds): array
+    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
     {
+        if ($fields !== []) {
+            throw new UnsupportedFeatureException('Scoping export by fields is not supported for blog articles.');
+        }
         $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
 
         $results = [];

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use InvalidArgumentException;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository;
@@ -14,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Accessory\ProductAccessoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandCachedFacade;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
 use Shopsys\FrameworkBundle\Model\Product\Product;
@@ -36,6 +38,7 @@ class ProductExportRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\BrandCachedFacade $brandCachedFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityFacade $productAvailabilityFacade
      * @param \Shopsys\FrameworkBundle\Model\Seo\HreflangLinksFacade $hreflangLinksFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider $productExportFieldProvider
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
@@ -49,6 +52,7 @@ class ProductExportRepository
         protected readonly BrandCachedFacade $brandCachedFacade,
         protected readonly ProductAvailabilityFacade $productAvailabilityFacade,
         protected readonly HreflangLinksFacade $hreflangLinksFacade,
+        protected readonly ProductExportFieldProvider $productExportFieldProvider,
     ) {
     }
 
@@ -57,47 +61,38 @@ class ProductExportRepository
      * @param string $locale
      * @param int $lastProcessedId
      * @param int $batchSize
+     * @param string[] $fields
      * @return array
      */
-    public function getProductsData(int $domainId, string $locale, int $lastProcessedId, int $batchSize): array
-    {
+    public function getProductsData(
+        int $domainId,
+        string $locale,
+        int $lastProcessedId,
+        int $batchSize,
+        array $fields = [],
+    ): array {
         $queryBuilder = $this->createQueryBuilder($domainId)
             ->andWhere('p.id > :lastProcessedId')
             ->setParameter('lastProcessedId', $lastProcessedId)
             ->setMaxResults($batchSize);
 
-        $query = $queryBuilder->getQuery();
-
-        $results = [];
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
-        foreach ($query->getResult() as $product) {
-            $results[$product->getId()] = $this->extractResult($product, $domainId, $locale);
-        }
-
-        return $results;
+        return $this->getResults($queryBuilder, $fields, $domainId, $locale);
     }
 
     /**
      * @param int $domainId
      * @param string $locale
      * @param int[] $productIds
+     * @param string[] $fields
      * @return array
      */
-    public function getProductsDataForIds(int $domainId, string $locale, array $productIds): array
+    public function getProductsDataForIds(int $domainId, string $locale, array $productIds, array $fields): array
     {
         $queryBuilder = $this->createQueryBuilder($domainId)
             ->andWhere('p.id IN (:productIds)')
             ->setParameter('productIds', $productIds);
 
-        $query = $queryBuilder->getQuery();
-
-        $result = [];
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
-        foreach ($query->getResult() as $product) {
-            $result[$product->getId()] = $this->extractResult($product, $domainId, $locale);
-        }
-
-        return $result;
+        return $this->getResults($queryBuilder, $fields, $domainId, $locale);
     }
 
     /**
@@ -115,58 +110,70 @@ class ProductExportRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param int $domainId
      * @param string $locale
+     * @param string[] $fields
      * @return array
      */
-    protected function extractResult(Product $product, int $domainId, string $locale): array
+    protected function extractResult(Product $product, int $domainId, string $locale, array $fields): array
     {
-        $flagIds = $this->extractFlags($domainId, $product);
-        $categoryIds = $this->extractCategories($domainId, $product);
-        $parameters = $this->extractParameters($locale, $product);
-        $prices = $this->extractPrices($domainId, $product);
-        $visibility = $this->extractVisibility($domainId, $product);
-        $detailUrl = $this->extractDetailUrl($domainId, $product);
-        $variantIds = $this->extractVariantIds($product);
+        $exportedResult = [];
 
-        return [
-            'id' => $product->getId(),
-            'catnum' => $product->getCatnum(),
-            'partno' => $product->getPartno(),
-            'ean' => $product->getEan(),
-            'name' => $product->getName($locale),
-            'description' => $product->getDescription($domainId),
-            'short_description' => $product->getShortDescription($domainId),
-            'brand' => $product->getBrand() ? $product->getBrand()->getId() : '',
-            'brand_name' => $product->getBrand() ? $product->getBrand()->getName() : '',
-            'brand_url' => $this->getBrandUrlForDomainByProduct($product, $domainId),
-            'flags' => $flagIds,
-            'categories' => $categoryIds,
-            'main_category_id' => $this->categoryFacade->getProductMainCategoryByDomainId(
+        foreach ($fields as $field) {
+            $exportedResult[$field] = $this->getExportedFieldValue($domainId, $product, $locale, $field);
+        }
+
+        return $exportedResult;
+    }
+
+    /**
+     * @param int $domainId
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @param string $locale
+     * @param string $field
+     * @return mixed
+     */
+    protected function getExportedFieldValue(int $domainId, Product $product, string $locale, string $field): mixed
+    {
+        return match ($field) {
+            ProductExportFieldProvider::ID => $product->getId(),
+            ProductExportFieldProvider::CATNUM => $product->getCatnum(),
+            ProductExportFieldProvider::PARTNO => $product->getPartno(),
+            ProductExportFieldProvider::EAN => $product->getEan(),
+            ProductExportFieldProvider::NAME => $product->getName($locale),
+            ProductExportFieldProvider::DESCRIPTION => $product->getDescription($domainId),
+            ProductExportFieldProvider::SHORT_DESCRIPTION => $product->getShortDescription($domainId),
+            ProductExportFieldProvider::BRAND => $product->getBrand() ? $product->getBrand()->getId() : '',
+            ProductExportFieldProvider::BRAND_NAME => $product->getBrand() ? $product->getBrand()->getName() : '',
+            ProductExportFieldProvider::BRAND_URL => $this->getBrandUrlForDomainByProduct($product, $domainId),
+            ProductExportFieldProvider::FLAGS => $this->extractFlags($domainId, $product),
+            ProductExportFieldProvider::CATEGORIES => $this->extractCategories($domainId, $product),
+            ProductExportFieldProvider::MAIN_CATEGORY_ID => $this->categoryFacade->getProductMainCategoryByDomainId(
                 $product,
                 $domainId,
             )->getId(),
-            'in_stock' => $this->productAvailabilityFacade->isProductAvailableOnDomainCached($product, $domainId),
-            'prices' => $prices,
-            'parameters' => $parameters,
-            'ordering_priority' => $product->getOrderingPriority($domainId),
-            'calculated_selling_denied' => $product->getCalculatedSellingDenied(),
-            'selling_denied' => $product->isSellingDenied(),
-            'availability' => $this->productAvailabilityFacade->getProductAvailabilityInformationByDomainId($product, $domainId),
-            'availability_dispatch_time' => $this->productAvailabilityFacade->getProductAvailabilityDaysByDomainId($product, $domainId),
-            'is_main_variant' => $product->isMainVariant(),
-            'is_variant' => $product->isVariant(),
-            'detail_url' => $detailUrl,
-            'visibility' => $visibility,
-            'uuid' => $product->getUuid(),
-            'unit' => $product->getUnit()->getName($locale),
-            'stock_quantity' => $this->productAvailabilityFacade->getGroupedStockQuantityByProductAndDomainId($product, $domainId),
-            'variants' => $variantIds,
-            'main_variant_id' => $product->isVariant() ? $product->getMainVariant()->getId() : null,
-            'seo_h1' => $product->getSeoH1($domainId),
-            'seo_title' => $product->getSeoTitle($domainId),
-            'seo_meta_description' => $product->getSeoMetaDescription($domainId),
-            'accessories' => $this->extractAccessoriesIds($product),
-            'hreflang_links' => $this->hreflangLinksFacade->getForProduct($product, $domainId),
-        ];
+            ProductExportFieldProvider::IN_STOCK => $this->productAvailabilityFacade->isProductAvailableOnDomainCached($product, $domainId),
+            ProductExportFieldProvider::PRICES => $this->extractPrices($domainId, $product),
+            ProductExportFieldProvider::PARAMETERS => $this->extractParameters($locale, $product),
+            ProductExportFieldProvider::ORDERING_PRIORITY => $product->getOrderingPriority($domainId),
+            ProductExportFieldProvider::CALCULATED_SELLING_DENIED => $product->getCalculatedSellingDenied(),
+            ProductExportFieldProvider::SELLING_DENIED => $product->isSellingDenied(),
+            ProductExportFieldProvider::AVAILABILITY => $this->productAvailabilityFacade->getProductAvailabilityInformationByDomainId($product, $domainId),
+            ProductExportFieldProvider::AVAILABILITY_DISPATCH_TIME => $this->productAvailabilityFacade->getProductAvailabilityDaysByDomainId($product, $domainId),
+            ProductExportFieldProvider::IS_MAIN_VARIANT => $product->isMainVariant(),
+            ProductExportFieldProvider::IS_VARIANT => $product->isVariant(),
+            ProductExportFieldProvider::DETAIL_URL => $this->extractDetailUrl($domainId, $product),
+            ProductExportFieldProvider::VISIBILITY => $this->extractVisibility($domainId, $product),
+            ProductExportFieldProvider::UUID => $product->getUuid(),
+            ProductExportFieldProvider::UNIT => $product->getUnit()->getName($locale),
+            ProductExportFieldProvider::STOCK_QUANTITY => $this->productAvailabilityFacade->getGroupedStockQuantityByProductAndDomainId($product, $domainId),
+            ProductExportFieldProvider::VARIANTS => $this->extractVariantIds($product),
+            ProductExportFieldProvider::MAIN_VARIANT_ID => $product->isVariant() ? $product->getMainVariant()->getId() : null,
+            ProductExportFieldProvider::SEO_H1 => $product->getSeoH1($domainId),
+            ProductExportFieldProvider::SEO_TITLE => $product->getSeoTitle($domainId),
+            ProductExportFieldProvider::SEO_META_DESCRIPTION => $product->getSeoMetaDescription($domainId),
+            ProductExportFieldProvider::ACCESSORIES => $this->extractAccessoriesIds($product),
+            ProductExportFieldProvider::HREFLANG_LINKS => $this->hreflangLinksFacade->getForProduct($product, $domainId),
+            default => throw new InvalidArgumentException(sprintf('There is no definition for exporting "%s" field to Elasticsearch', $field)),
+        };
     }
 
     /**
@@ -371,5 +378,29 @@ class ProductExportRepository
         }
 
         return $accessoriesIds;
+    }
+
+    /**
+     * @param \Doctrine\ORM\QueryBuilder $queryBuilder
+     * @param array $fields
+     * @param int $domainId
+     * @param string $locale
+     * @return array
+     */
+    protected function getResults(QueryBuilder $queryBuilder, array $fields, int $domainId, string $locale): array
+    {
+        $query = $queryBuilder->getQuery();
+
+        if (count($fields) === 0) {
+            $fields = $this->productExportFieldProvider->getAll();
+        }
+
+        $results = [];
+        /** @var \Shopsys\FrameworkBundle\Model\Product\Product $product */
+        foreach ($query->getResult() as $product) {
+            $results[$product->getId()] = $this->extractResult($product, $domainId, $locale, $fields);
+        }
+
+        return $results;
     }
 }

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductIndex.php
@@ -30,25 +30,31 @@ class ProductIndex extends AbstractIndex
     /**
      * {@inheritdoc}
      */
-    public function getExportDataForIds(int $domainId, array $restrictToIds): array
+    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
     {
         return $this->productExportRepository->getProductsDataForIds(
             $domainId,
             $this->domain->getDomainConfigById($domainId)->getLocale(),
             $restrictToIds,
+            $fields,
         );
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
-    {
+    public function getExportDataForBatch(
+        int $domainId,
+        int $lastProcessedId,
+        int $batchSize,
+        array $fields = [],
+    ): array {
         return $this->productExportRepository->getProductsData(
             $domainId,
             $this->domain->getDomainConfigById($domainId)->getLocale(),
             $lastProcessedId,
             $batchSize,
+            $fields,
         );
     }
 

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/Exception/InvalidScopeException.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/Exception/InvalidScopeException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\Exception;
+
+use Exception;
+
+class InvalidScopeException extends Exception
+{
+    /**
+     * @param string $scopeName
+     */
+    public function __construct(string $scopeName)
+    {
+        parent::__construct(sprintf('Scope "%s" does not exist in the current configuration. Run "php bin/console shopsys:list:export-scopes" to see all the available scopes.', $scopeName));
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/Exception/ScopeRuleAlreadyExistsException.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/Exception/ScopeRuleAlreadyExistsException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\Exception;
+
+use Exception;
+
+class ScopeRuleAlreadyExistsException extends Exception
+{
+    /**
+     * @param string $scopeName
+     */
+    public function __construct(string $scopeName)
+    {
+        parent::__construct(sprintf('Scope rule "%s" already exists in the current configuration. You should probably rather use "addExportFieldsToExistingScopeRule" or "overwriteExportScopeRule" function.', $scopeName));
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/Exception/ScopeRuleDoesNotExistException.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/Exception/ScopeRuleDoesNotExistException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\Exception;
+
+use Exception;
+
+class ScopeRuleDoesNotExistException extends Exception
+{
+    /**
+     * @param string $scopeName
+     */
+    public function __construct(string $scopeName)
+    {
+        parent::__construct(sprintf('Scope rule "%s" does not exist in the current configuration. You should probably rather use "addNewExportScopeRule" function.', $scopeName));
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportFieldProvider.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportFieldProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope;
+
+use Shopsys\FrameworkBundle\Component\Reflection\ReflectionHelper;
+
+class ProductExportFieldProvider
+{
+    public const string ID = 'id';
+    public const string CATNUM = 'catnum';
+    public const string PARTNO = 'partno';
+    public const string EAN = 'ean';
+    public const string NAME = 'name';
+    public const string DESCRIPTION = 'description';
+    public const string SHORT_DESCRIPTION = 'short_description';
+    public const string BRAND = 'brand';
+    public const string BRAND_NAME = 'brand_name';
+    public const string BRAND_URL = 'brand_url';
+    public const string FLAGS = 'flags';
+    public const string CATEGORIES = 'categories';
+    public const string MAIN_CATEGORY_ID = 'main_category_id';
+    public const string IN_STOCK = 'in_stock';
+    public const string PRICES = 'prices';
+    public const string PARAMETERS = 'parameters';
+    public const string ORDERING_PRIORITY = 'ordering_priority';
+    public const string CALCULATED_SELLING_DENIED = 'calculated_selling_denied';
+    public const string SELLING_DENIED = 'selling_denied';
+    public const string AVAILABILITY = 'availability';
+    public const string AVAILABILITY_DISPATCH_TIME = 'availability_dispatch_time';
+    public const string IS_MAIN_VARIANT = 'is_main_variant';
+    public const string IS_VARIANT = 'is_variant';
+    public const string DETAIL_URL = 'detail_url';
+    public const string VISIBILITY = 'visibility';
+    public const string UUID = 'uuid';
+    public const string UNIT = 'unit';
+    public const string STOCK_QUANTITY = 'stock_quantity';
+    public const string VARIANTS = 'variants';
+    public const string MAIN_VARIANT_ID = 'main_variant_id';
+    public const string SEO_H1 = 'seo_h1';
+    public const string SEO_TITLE = 'seo_title';
+    public const string SEO_META_DESCRIPTION = 'seo_meta_description';
+    public const string ACCESSORIES = 'accessories';
+    public const string HREFLANG_LINKS = 'hreflang_links';
+
+    /**
+     * @return string[]
+     */
+    public function getAll(): array
+    {
+        return ReflectionHelper::getAllPublicClassConstants(static::class);
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
@@ -47,6 +47,14 @@ class ProductExportScopeConfig
         return $this->productExportScopeRules;
     }
 
+    /**
+     * @return string[]
+     */
+    public function getAllProductExportScopes(): array
+    {
+        return array_keys($this->getProductExportScopeRules());
+    }
+
     protected function loadProductExportScopeRules(): void
     {
         $this->productExportScopeRules = [];

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope;
 
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\Exception\ScopeRuleAlreadyExistsException;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\Exception\ScopeRuleDoesNotExistException;
+
 class ProductExportScopeConfig
 {
     public const string SCOPE_NAME = 'product_name_scope';
@@ -38,86 +41,138 @@ class ProductExportScopeConfig
     public function getProductExportScopeRules(): array
     {
         if ($this->productExportScopeRules === null) {
-            $this->productExportScopeRules = [
-                self::SCOPE_SELLING_DENIED => new ProductExportScopeRule([
-                    ProductExportFieldProvider::SELLING_DENIED,
-                    ProductExportFieldProvider::CALCULATED_SELLING_DENIED,
-                ], [
-                    self::PRECONDITION_SELLING_DENIED_RECALCULATION,
-                ]),
-                self::SCOPE_UNIT => new ProductExportScopeRule([
-                    ProductExportFieldProvider::UNIT,
-                ]),
-                self::SCOPE_BRAND => new ProductExportScopeRule([
-                    ProductExportFieldProvider::BRAND,
-                    ProductExportFieldProvider::BRAND_NAME,
-                    ProductExportFieldProvider::BRAND_URL,
-                ]),
-                self::SCOPE_STOCKS => new ProductExportScopeRule([
-                    ProductExportFieldProvider::AVAILABILITY,
-                    ProductExportFieldProvider::AVAILABILITY_DISPATCH_TIME,
-                    ProductExportFieldProvider::IN_STOCK,
-                    ProductExportFieldProvider::STOCK_QUANTITY,
-                ]),
-                self::SCOPE_URL => new ProductExportScopeRule([
-                    ProductExportFieldProvider::DETAIL_URL,
-                    ProductExportFieldProvider::HREFLANG_LINKS,
-                ]),
-                self::SCOPE_FLAGS => new ProductExportScopeRule([
-                    ProductExportFieldProvider::FLAGS,
-                ]),
-                self::SCOPE_PARAMETERS => new ProductExportScopeRule([
-                    ProductExportFieldProvider::PARAMETERS,
-                ]),
-                self::SCOPE_NAME => new ProductExportScopeRule([
-                    ProductExportFieldProvider::NAME,
-                    ProductExportFieldProvider::DETAIL_URL,
-                    ProductExportFieldProvider::HREFLANG_LINKS,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                ]),
-                self::SCOPE_HIDDEN => new ProductExportScopeRule([
-                    ProductExportFieldProvider::VISIBILITY,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                ]),
-                self::SCOPE_SELLING_FROM => new ProductExportScopeRule([
-                    ProductExportFieldProvider::VISIBILITY,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                ]),
-                self::SCOPE_SELLING_TO => new ProductExportScopeRule([
-                    ProductExportFieldProvider::VISIBILITY,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                ]),
-                self::SCOPE_PRICE => new ProductExportScopeRule([
-                    ProductExportFieldProvider::PRICES,
-                    ProductExportFieldProvider::VISIBILITY,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                ]),
-                self::SCOPE_CATEGORIES => new ProductExportScopeRule([
-                    ProductExportFieldProvider::CATEGORIES,
-                    ProductExportFieldProvider::MAIN_CATEGORY_ID,
-                    ProductExportFieldProvider::VISIBILITY,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                ]),
-                self::SCOPE_VARIANTS => new ProductExportScopeRule([
-                    ProductExportFieldProvider::CALCULATED_SELLING_DENIED,
-                    ProductExportFieldProvider::VISIBILITY,
-                    ProductExportFieldProvider::VARIANTS,
-                    ProductExportFieldProvider::IS_VARIANT,
-                    ProductExportFieldProvider::IS_MAIN_VARIANT,
-                    ProductExportFieldProvider::MAIN_VARIANT_ID,
-                ], [
-                    self::PRECONDITION_VISIBILITY_RECALCULATION,
-                    self::PRECONDITION_SELLING_DENIED_RECALCULATION,
-                ]),
-            ];
+            $this->loadProductExportScopeRules();
         }
 
         return $this->productExportScopeRules;
+    }
+
+    protected function loadProductExportScopeRules(): void
+    {
+        $this->productExportScopeRules = [];
+
+        $this->addNewExportScopeRule(self::SCOPE_SELLING_DENIED, [
+            ProductExportFieldProvider::SELLING_DENIED,
+            ProductExportFieldProvider::CALCULATED_SELLING_DENIED,
+        ], [
+            self::PRECONDITION_SELLING_DENIED_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_UNIT, [
+            ProductExportFieldProvider::UNIT,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_BRAND, [
+            ProductExportFieldProvider::BRAND,
+            ProductExportFieldProvider::BRAND_NAME,
+            ProductExportFieldProvider::BRAND_URL,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_STOCKS, [
+            ProductExportFieldProvider::AVAILABILITY,
+            ProductExportFieldProvider::AVAILABILITY_DISPATCH_TIME,
+            ProductExportFieldProvider::IN_STOCK,
+            ProductExportFieldProvider::STOCK_QUANTITY,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_URL, [
+            ProductExportFieldProvider::DETAIL_URL,
+            ProductExportFieldProvider::HREFLANG_LINKS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_FLAGS, [
+            ProductExportFieldProvider::FLAGS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_PARAMETERS, [
+            ProductExportFieldProvider::PARAMETERS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_NAME, [
+            ProductExportFieldProvider::NAME,
+            ProductExportFieldProvider::DETAIL_URL,
+            ProductExportFieldProvider::HREFLANG_LINKS,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_HIDDEN, [
+            ProductExportFieldProvider::VISIBILITY,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_SELLING_FROM, [
+            ProductExportFieldProvider::VISIBILITY,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_SELLING_TO, [
+            ProductExportFieldProvider::VISIBILITY,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_PRICE, [
+            ProductExportFieldProvider::PRICES,
+            ProductExportFieldProvider::VISIBILITY,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_CATEGORIES, [
+            ProductExportFieldProvider::CATEGORIES,
+            ProductExportFieldProvider::MAIN_CATEGORY_ID,
+            ProductExportFieldProvider::VISIBILITY,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_VARIANTS, [
+            ProductExportFieldProvider::CALCULATED_SELLING_DENIED,
+            ProductExportFieldProvider::VISIBILITY,
+            ProductExportFieldProvider::VARIANTS,
+            ProductExportFieldProvider::IS_VARIANT,
+            ProductExportFieldProvider::IS_MAIN_VARIANT,
+            ProductExportFieldProvider::MAIN_VARIANT_ID,
+        ], [
+            self::PRECONDITION_VISIBILITY_RECALCULATION,
+            self::PRECONDITION_SELLING_DENIED_RECALCULATION,
+        ]);
+    }
+
+    /**
+     * @param string $scopeName
+     * @param string[] $exportFields
+     * @param string[] $preconditions
+     */
+    protected function addNewExportScopeRule(string $scopeName, array $exportFields, array $preconditions = []): void
+    {
+        if (array_key_exists($scopeName, $this->productExportScopeRules)) {
+            throw new ScopeRuleAlreadyExistsException($scopeName);
+        }
+
+        $this->productExportScopeRules[$scopeName] = new ProductExportScopeRule($exportFields, $preconditions);
+    }
+
+    /**
+     * @param string $scopeName
+     * @param string[] $exportFields
+     */
+    protected function addExportFieldsToExistingScopeRule(string $scopeName, array $exportFields): void
+    {
+        if (!array_key_exists($scopeName, $this->productExportScopeRules)) {
+            throw new ScopeRuleDoesNotExistException($scopeName);
+        }
+        $scopeRule = $this->productExportScopeRules[$scopeName];
+        $this->productExportScopeRules[$scopeName] = new ProductExportScopeRule(
+            [...$scopeRule->productExportFields, ...$exportFields],
+            $scopeRule->productExportPreconditions,
+        );
+    }
+
+    /**
+     * @param string $scopeName
+     * @param array $exportFields
+     * @param array $preconditions
+     */
+    protected function overwriteExportScopeRule(
+        string $scopeName,
+        array $exportFields,
+        array $preconditions = [],
+    ): void {
+        if (!array_key_exists($scopeName, $this->productExportScopeRules)) {
+            throw new ScopeRuleDoesNotExistException($scopeName);
+        }
+
+        $this->productExportScopeRules[$scopeName] = new ProductExportScopeRule($exportFields, $preconditions);
     }
 }

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope;
+
+class ProductExportScopeConfig
+{
+    public const string SCOPE_NAME = 'product_name_scope';
+    public const string SCOPE_UNIT = 'product_unit_scope';
+    public const string SCOPE_BRAND = 'product_brand_scope';
+    public const string SCOPE_STOCKS = 'product_stocks_scope';
+    public const string SCOPE_FLAGS = 'product_flags_scope';
+    public const string SCOPE_PARAMETERS = 'product_parameters_scope';
+    public const string SCOPE_URL = 'product_url_scope';
+    public const string SCOPE_SELLING_DENIED = 'product_selling_denied_scope';
+    public const string SCOPE_VARIANTS = 'product_variants_scope';
+    public const string SCOPE_HIDDEN = 'product_hidden_scope';
+    public const string SCOPE_SELLING_FROM = 'product_selling_from_scope';
+    public const string SCOPE_SELLING_TO = 'product_selling_to_scope';
+    public const string SCOPE_PRICE = 'product_price_scope';
+    public const string SCOPE_CATEGORIES = 'product_categories_scope';
+
+    public const string PRECONDITION_VISIBILITY_RECALCULATION = 'visibility_recalculation';
+    public const string PRECONDITION_SELLING_DENIED_RECALCULATION = 'selling_denied_recalculation';
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeRule[]|null $productExportScopeRules
+     */
+    public function __construct(
+        protected ?array $productExportScopeRules = null,
+    ) {
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeRule[]
+     */
+    public function getProductExportScopeRules(): array
+    {
+        if ($this->productExportScopeRules === null) {
+            $this->productExportScopeRules = [
+                self::SCOPE_SELLING_DENIED => new ProductExportScopeRule([
+                    ProductExportFieldProvider::SELLING_DENIED,
+                    ProductExportFieldProvider::CALCULATED_SELLING_DENIED,
+                ], [
+                    self::PRECONDITION_SELLING_DENIED_RECALCULATION,
+                ]),
+                self::SCOPE_UNIT => new ProductExportScopeRule([
+                    ProductExportFieldProvider::UNIT,
+                ]),
+                self::SCOPE_BRAND => new ProductExportScopeRule([
+                    ProductExportFieldProvider::BRAND,
+                    ProductExportFieldProvider::BRAND_NAME,
+                    ProductExportFieldProvider::BRAND_URL,
+                ]),
+                self::SCOPE_STOCKS => new ProductExportScopeRule([
+                    ProductExportFieldProvider::AVAILABILITY,
+                    ProductExportFieldProvider::AVAILABILITY_DISPATCH_TIME,
+                    ProductExportFieldProvider::IN_STOCK,
+                    ProductExportFieldProvider::STOCK_QUANTITY,
+                ]),
+                self::SCOPE_URL => new ProductExportScopeRule([
+                    ProductExportFieldProvider::DETAIL_URL,
+                    ProductExportFieldProvider::HREFLANG_LINKS,
+                ]),
+                self::SCOPE_FLAGS => new ProductExportScopeRule([
+                    ProductExportFieldProvider::FLAGS,
+                ]),
+                self::SCOPE_PARAMETERS => new ProductExportScopeRule([
+                    ProductExportFieldProvider::PARAMETERS,
+                ]),
+                self::SCOPE_NAME => new ProductExportScopeRule([
+                    ProductExportFieldProvider::NAME,
+                    ProductExportFieldProvider::DETAIL_URL,
+                    ProductExportFieldProvider::HREFLANG_LINKS,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                ]),
+                self::SCOPE_HIDDEN => new ProductExportScopeRule([
+                    ProductExportFieldProvider::VISIBILITY,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                ]),
+                self::SCOPE_SELLING_FROM => new ProductExportScopeRule([
+                    ProductExportFieldProvider::VISIBILITY,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                ]),
+                self::SCOPE_SELLING_TO => new ProductExportScopeRule([
+                    ProductExportFieldProvider::VISIBILITY,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                ]),
+                self::SCOPE_PRICE => new ProductExportScopeRule([
+                    ProductExportFieldProvider::PRICES,
+                    ProductExportFieldProvider::VISIBILITY,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                ]),
+                self::SCOPE_CATEGORIES => new ProductExportScopeRule([
+                    ProductExportFieldProvider::CATEGORIES,
+                    ProductExportFieldProvider::MAIN_CATEGORY_ID,
+                    ProductExportFieldProvider::VISIBILITY,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                ]),
+                self::SCOPE_VARIANTS => new ProductExportScopeRule([
+                    ProductExportFieldProvider::CALCULATED_SELLING_DENIED,
+                    ProductExportFieldProvider::VISIBILITY,
+                    ProductExportFieldProvider::VARIANTS,
+                    ProductExportFieldProvider::IS_VARIANT,
+                    ProductExportFieldProvider::IS_MAIN_VARIANT,
+                    ProductExportFieldProvider::MAIN_VARIANT_ID,
+                ], [
+                    self::PRECONDITION_VISIBILITY_RECALCULATION,
+                    self::PRECONDITION_SELLING_DENIED_RECALCULATION,
+                ]),
+            ];
+        }
+
+        return $this->productExportScopeRules;
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfigFacade.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfigFacade.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope;
+
+class ProductExportScopeConfigFacade
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig $productExportScopeConfig
+     */
+    public function __construct(
+        protected readonly ProductExportScopeConfig $productExportScopeConfig,
+    ) {
+    }
+
+    /**
+     * @param string[] $exportScopes
+     * @return string[]
+     */
+    public function getExportFieldsByScopes(array $exportScopes): array
+    {
+        $fields = [];
+
+        foreach ($this->getMatchingRules($exportScopes) as $rule) {
+            $fields = [...$fields, ...$rule->productExportFields];
+        }
+
+        return array_values(array_unique($fields));
+    }
+
+    /**
+     * @param string[] $exportScopes
+     * @return bool
+     */
+    public function shouldRecalculateVisibility(array $exportScopes): bool
+    {
+        if (count($exportScopes) === 0) {
+            return true;
+        }
+
+        foreach ($this->getMatchingRules($exportScopes) as $rule) {
+            if (in_array(ProductExportScopeConfig::PRECONDITION_VISIBILITY_RECALCULATION, $rule->productExportPreconditions, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string[] $exportScopes
+     * @return bool
+     */
+    public function shouldRecalculateSellingDenied(array $exportScopes): bool
+    {
+        if (count($exportScopes) === 0) {
+            return true;
+        }
+
+        foreach ($this->getMatchingRules($exportScopes) as $rule) {
+            if (in_array(ProductExportScopeConfig::PRECONDITION_SELLING_DENIED_RECALCULATION, $rule->productExportPreconditions, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string[] $exportScopes
+     * @return \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeRule[]
+     */
+    protected function getMatchingRules(array $exportScopes): array
+    {
+        if (count($exportScopes) === 0) {
+            return [];
+        }
+
+        $allRules = $this->productExportScopeConfig->getProductExportScopeRules();
+
+        $matchingRules = [];
+
+        foreach ($allRules as $productExportScope => $productExportRule) {
+            if (in_array($productExportScope, $exportScopes, true)) {
+                $matchingRules[] = $productExportRule;
+            }
+        }
+
+        return $matchingRules;
+    }
+}

--- a/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeRule.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/Scope/ProductExportScopeRule.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope;
+
+class ProductExportScopeRule
+{
+    /**
+     * @param string[] $productExportFields
+     * @param string[] $productExportPreconditions
+     */
+    public function __construct(
+        public readonly array $productExportFields,
+        public readonly array $productExportPreconditions = [],
+    ) {
+    }
+}

--- a/packages/framework/src/Model/Product/MassAction/ProductMassActionFacade.php
+++ b/packages/framework/src/Model/Product/MassAction/ProductMassActionFacade.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Product\MassAction;
 
 use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
 use Shopsys\FrameworkBundle\Model\Product\MassAction\Exception\UnsupportedSelectionType;
 use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum;
 
 class ProductMassActionFacade
 {
@@ -48,7 +50,7 @@ class ProductMassActionFacade
             $selectedProductIds,
             $productMassActionData->value === ProductMassActionData::VALUE_PRODUCT_HIDE,
         );
-        $this->productRecalculationDispatcher->dispatchProductIds($selectedProductIds);
+        $this->productRecalculationDispatcher->dispatchProductIds($selectedProductIds, ProductRecalculationPriorityEnum::REGULAR, [ProductExportScopeConfig::SCOPE_HIDDEN]);
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductElasticsearchProvider.php
+++ b/packages/framework/src/Model/Product/ProductElasticsearchProvider.php
@@ -76,4 +76,14 @@ class ProductElasticsearchProvider
             $this->filterQueryFactory->createSellableProductsByProductUuidsFilter($productUuids),
         );
     }
+
+    /**
+     * @param int[] $productIds
+     * @param int $domainId
+     * @return int[]
+     */
+    public function getOnlyExistingProductsIds(array $productIds, int $domainId): array
+    {
+        return $this->productElasticsearchRepository->getOnlyExistingProductIds($productIds, $domainId);
+    }
 }

--- a/packages/framework/src/Model/Product/Recalculation/AbstractProductRecalculationMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/AbstractProductRecalculationMessage.php
@@ -8,9 +8,11 @@ abstract class AbstractProductRecalculationMessage
 {
     /**
      * @param int $productId
+     * @param string[] $exportScopes
      */
     public function __construct(
         public readonly int $productId,
+        public readonly array $exportScopes = [],
     ) {
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/DispatchAffectedProductsSubscriber.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchAffectedProductsSubscriber.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyEvent;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupEvent;
 use Shopsys\FrameworkBundle\Model\Product\AffectedProductsFacade;
 use Shopsys\FrameworkBundle\Model\Product\Brand\BrandEvent;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
 use Shopsys\FrameworkBundle\Model\Product\Flag\FlagEvent;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterEvent;
 use Shopsys\FrameworkBundle\Model\Product\Unit\UnitEvent;
@@ -37,7 +38,11 @@ class DispatchAffectedProductsSubscriber implements EventSubscriberInterface
     {
         $productIds = $this->affectedProductsFacade->getProductIdsWithBrand($brandEvent->getBrand());
 
-        $this->productRecalculationDispatcher->dispatchProductIds($productIds);
+        $this->productRecalculationDispatcher->dispatchProductIds(
+            $productIds,
+            ProductRecalculationPriorityEnum::REGULAR,
+            [ProductExportScopeConfig::SCOPE_BRAND],
+        );
     }
 
     /**
@@ -47,7 +52,11 @@ class DispatchAffectedProductsSubscriber implements EventSubscriberInterface
     {
         $productIds = $this->affectedProductsFacade->getProductIdsWithCategory($categoryEvent->getCategory());
 
-        $this->productRecalculationDispatcher->dispatchProductIds($productIds);
+        $this->productRecalculationDispatcher->dispatchProductIds(
+            $productIds,
+            ProductRecalculationPriorityEnum::REGULAR,
+            [ProductExportScopeConfig::SCOPE_CATEGORIES],
+        );
     }
 
     /**
@@ -57,7 +66,11 @@ class DispatchAffectedProductsSubscriber implements EventSubscriberInterface
     {
         $productIds = $this->affectedProductsFacade->getProductIdsWithFlag($flagEvent->getFlag());
 
-        $this->productRecalculationDispatcher->dispatchProductIds($productIds);
+        $this->productRecalculationDispatcher->dispatchProductIds(
+            $productIds,
+            ProductRecalculationPriorityEnum::REGULAR,
+            [ProductExportScopeConfig::SCOPE_FLAGS],
+        );
     }
 
     /**
@@ -67,7 +80,11 @@ class DispatchAffectedProductsSubscriber implements EventSubscriberInterface
     {
         $productIds = $this->affectedProductsFacade->getProductIdsWithParameter($parameterEvent->getParameter());
 
-        $this->productRecalculationDispatcher->dispatchProductIds($productIds);
+        $this->productRecalculationDispatcher->dispatchProductIds(
+            $productIds,
+            ProductRecalculationPriorityEnum::REGULAR,
+            [ProductExportScopeConfig::SCOPE_PARAMETERS],
+        );
     }
 
     /**
@@ -87,7 +104,11 @@ class DispatchAffectedProductsSubscriber implements EventSubscriberInterface
     {
         $productIds = $this->affectedProductsFacade->getProductIdsWithUnit($unitEvent->getUnit());
 
-        $this->productRecalculationDispatcher->dispatchProductIds($productIds);
+        $this->productRecalculationDispatcher->dispatchProductIds(
+            $productIds,
+            ProductRecalculationPriorityEnum::REGULAR,
+            [ProductExportScopeConfig::SCOPE_UNIT],
+        );
     }
 
     public function dispatchAllProducts(): void
@@ -107,6 +128,7 @@ class DispatchAffectedProductsSubscriber implements EventSubscriberInterface
     {
         return [
             BrandEvent::DELETE => 'dispatchAffectedByBrand',
+            BrandEvent::UPDATE => 'dispatchAffectedByBrand',
             CategoryEvent::UPDATE => 'dispatchAffectedByCategory',
             CategoryEvent::DELETE => 'dispatchAffectedByCategory',
             CurrencyEvent::UPDATE => [

--- a/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessage.php
@@ -6,4 +6,10 @@ namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
 class DispatchAllProductsMessage
 {
+    /**
+     * @param string[] $exportScopes
+     */
+    public function __construct(public readonly array $exportScopes = [])
+    {
+    }
 }

--- a/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessageHandler.php
@@ -27,7 +27,7 @@ class DispatchAllProductsMessageHandler implements MessageHandlerInterface
         $productIds = $this->productFacade->iterateAllProductIds();
 
         foreach ($productIds as $productId) {
-            $this->productRecalculationDispatcher->dispatchSingleProductId($productId['id']);
+            $this->productRecalculationDispatcher->dispatchSingleProductId($productId['id'], ProductRecalculationPriorityEnum::REGULAR, $message->exportScopes);
         }
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
@@ -12,33 +12,38 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
      * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $productRecalculationPriorityEnum
+     * @param string[] $exportScopes
      * @return int[]
      */
     public function dispatchProducts(
         array $products,
         ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        array $exportScopes = [],
     ): array {
         return $this->dispatchProductIds(
             array_map(static fn (Product $product) => $product->getId(), $products),
             $productRecalculationPriorityEnum,
+            $exportScopes,
         );
     }
 
     /**
      * @param int[] $productIds
      * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $productRecalculationPriorityEnum
+     * @param string[] $exportScopes
      * @return int[]
      */
     public function dispatchProductIds(
         array $productIds,
         ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        array $exportScopes = [],
     ): array {
         $productIds = array_unique($productIds);
 
         foreach ($productIds as $productId) {
             $message = match ($productRecalculationPriorityEnum) {
-                ProductRecalculationPriorityEnum::HIGH => new ProductRecalculationPriorityHighMessage((int)$productId),
-                ProductRecalculationPriorityEnum::REGULAR => new ProductRecalculationPriorityRegularMessage((int)$productId),
+                ProductRecalculationPriorityEnum::HIGH => new ProductRecalculationPriorityHighMessage((int)$productId, $exportScopes),
+                ProductRecalculationPriorityEnum::REGULAR => new ProductRecalculationPriorityRegularMessage((int)$productId, $exportScopes),
             };
             $this->messageBus->dispatch($message);
         }
@@ -49,16 +54,21 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
     /**
      * @param int $productId
      * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $productRecalculationPriorityEnum
+     * @param string[] $exportScopes
      */
     public function dispatchSingleProductId(
         int $productId,
         ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        array $exportScopes = [],
     ): void {
-        $this->dispatchProductIds([$productId], $productRecalculationPriorityEnum);
+        $this->dispatchProductIds([$productId], $productRecalculationPriorityEnum, $exportScopes);
     }
 
-    public function dispatchAllProducts(): void
+    /**
+     * @param string[] $exportScopes
+     */
+    public function dispatchAllProducts(array $exportScopes = []): void
     {
-        $this->messageBus->dispatch(new DispatchAllProductsMessage());
+        $this->messageBus->dispatch(new DispatchAllProductsMessage($exportScopes));
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationFacade.php
@@ -9,11 +9,15 @@ use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRegistry;
 use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfigFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 
 class ProductRecalculationFacade
 {
+    protected const string KEY_PRODUCT_IDS = 'productIds';
+    protected const string KEY_SCOPES = 'scopes';
+
     /**
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade $indexFacade
      * @param \Shopsys\FrameworkBundle\Component\Elasticsearch\IndexRegistry $indexRegistry
@@ -22,6 +26,7 @@ class ProductRecalculationFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade $productVisibilityFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationRepository $productRecalculationRepository
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator
+     * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfigFacade $productExportScopeConfigFacade
      */
     public function __construct(
         protected readonly IndexFacade $indexFacade,
@@ -31,26 +36,72 @@ class ProductRecalculationFacade
         protected readonly ProductVisibilityFacade $productVisibilityFacade,
         protected readonly ProductRecalculationRepository $productRecalculationRepository,
         protected readonly ProductSellingDeniedRecalculator $productSellingDeniedRecalculator,
+        protected readonly ProductExportScopeConfigFacade $productExportScopeConfigFacade,
     ) {
     }
 
     /**
-     * @param int[] $productIds
+     * @param array<int, string[]> $exportScopesIndexedByProductId
      */
-    public function recalculate(array $productIds): void
+    public function recalculate(array $exportScopesIndexedByProductId): void
     {
-        $idsToRecalculate = $this->productRecalculationRepository->getIdsToRecalculate($productIds);
+        foreach ($this->groupProductIdsWithSameScopes($exportScopesIndexedByProductId) as $productIdsWithScopes) {
+            $idsToRecalculate = $this->productRecalculationRepository->getIdsToRecalculate($productIdsWithScopes[self::KEY_PRODUCT_IDS]);
+            $this->recalculateWithScope($idsToRecalculate, $productIdsWithScopes[self::KEY_SCOPES]);
+        }
+    }
 
-        $this->productVisibilityFacade->calculateProductVisibilityForIds($idsToRecalculate);
+    /**
+     * @param int[] $productIds
+     * @param string[] $exportScopes
+     */
+    protected function recalculateWithScope(array $productIds, array $exportScopes): void
+    {
+        if ($this->productExportScopeConfigFacade->shouldRecalculateVisibility($exportScopes)) {
+            $this->productVisibilityFacade->calculateProductVisibilityForIds($productIds);
+        }
 
-        $this->productSellingDeniedRecalculator->calculateSellingDeniedForProductIds($idsToRecalculate);
+        if ($this->productExportScopeConfigFacade->shouldRecalculateSellingDenied($exportScopes)) {
+            $this->productSellingDeniedRecalculator->calculateSellingDeniedForProductIds($productIds);
+        }
+
+        $fields = $this->productExportScopeConfigFacade->getExportFieldsByScopes($exportScopes);
 
         foreach ($this->domain->getAllIds() as $domainId) {
             $this->indexFacade->exportIds(
                 $this->indexRegistry->getIndexByIndexName(ProductIndex::getName()),
                 $this->indexDefinitionLoader->getIndexDefinition(ProductIndex::getName(), $domainId),
-                $idsToRecalculate,
+                $productIds,
+                $fields,
             );
         }
+    }
+
+    /**
+     * @param array<int, string[]> $exportScopesIndexedByProductId
+     * @return array<int, array{productIds: int[], scopes: string[]}>
+     */
+    protected function groupProductIdsWithSameScopes(array $exportScopesIndexedByProductId): array
+    {
+        $scopeToProductIds = [];
+        $emptyKey = 'empty';
+
+        foreach ($exportScopesIndexedByProductId as $productId => $scopes) {
+            sort($scopes);
+            $scopesKey = $scopes ? implode(',', $scopes) : $emptyKey;
+            $scopeToProductIds[$scopesKey][] = $productId;
+        }
+
+        $result = [];
+
+        foreach ($scopeToProductIds as $key => $productIds) {
+            $scopes = $key === $emptyKey ? [] : explode(',', $key);
+            $result[] = [
+                self::KEY_PRODUCT_IDS => $productIds,
+                self::KEY_SCOPES => $scopes,
+            ];
+        }
+
+        return $result;
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
@@ -61,7 +61,10 @@ class ProductRecalculationMessageHandler implements BatchHandlerInterface
             return;
         }
 
-        $this->logger->info('Product recalculated', ['product_ids' => json_encode(array_keys($exportScopesIndexedByProductId), JSON_THROW_ON_ERROR)]);
+        $this->logger->info('Product recalculated', [
+            'product_ids' => json_encode(array_keys($exportScopesIndexedByProductId), JSON_THROW_ON_ERROR),
+            'export_scopes' => json_encode($exportScopesIndexedByProductId, JSON_THROW_ON_ERROR),
+        ]);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -35,6 +35,11 @@ class FilterQuery
     protected ?int $from = null;
 
     /**
+     * @var string[]
+     */
+    protected array $fields = [];
+
+    /**
      * @param string $indexName
      */
     public function __construct(protected readonly string $indexName)
@@ -508,7 +513,7 @@ class FilterQuery
      */
     public function getQuery(): array
     {
-        return [
+        $query = [
             'index' => $this->indexName,
             'body' => [
                 'from' => $this->from !== null ? $this->from : $this->countFrom($this->page, $this->limit),
@@ -522,6 +527,13 @@ class FilterQuery
                 ],
             ],
         ];
+
+        if ($this->fields !== []) {
+            $query['body']['_source'] = false;
+            $query['body']['fields'] = $this->fields;
+        }
+
+        return $query;
     }
 
     /**
@@ -841,5 +853,18 @@ class FilterQuery
         unset($query['body']['aggs']['parameters']);
 
         return $query;
+    }
+
+    /**
+     * @param string[] $fields
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function restrictFields(array $fields): self
+    {
+        $clone = clone $this;
+
+        $clone->fields = $fields;
+
+        return $clone;
     }
 }

--- a/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
+++ b/packages/framework/src/Model/Product/Search/FilterQueryFactory.php
@@ -292,4 +292,18 @@ class FilterQueryFactory
 
         return $filterQuery;
     }
+
+    /**
+     * @param int[] $productIds
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery
+     */
+    public function createOnlyExistingProductIdsFilterQuery(array $productIds, int $domainId): FilterQuery
+    {
+        $indexDefinition = $this->indexDefinitionLoader->getIndexDefinition(ProductIndex::getName(), $domainId);
+
+        return $this->create($indexDefinition->getIndexAlias())
+            ->filterByProductIds($productIds)
+            ->restrictFields(['id']);
+    }
 }

--- a/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
+++ b/packages/framework/src/Model/Product/Search/ProductElasticsearchRepository.php
@@ -192,6 +192,36 @@ class ProductElasticsearchRepository implements ResetInterface
         return $this->extractHits($result);
     }
 
+    /**
+     * @param int[] $productIds
+     * @param int $domainId
+     * @return int[]
+     */
+    public function getOnlyExistingProductIds(array $productIds, int $domainId): array
+    {
+        $filterQuery = $this->filterQueryFactory->createOnlyExistingProductIdsFilterQuery($productIds, $domainId);
+        $result = $this->client->search($filterQuery->getQuery());
+
+        return $this->extractIdsFromFields($result);
+    }
+
+    /**
+     * @param array $result
+     * @return int[]
+     */
+    protected function extractIdsFromFields(array $result): array
+    {
+        $ids = [];
+
+        foreach ($result['hits']['hits'] as $hit) {
+            foreach ($hit['fields']['id'] as $id) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
     public function reset(): void
     {
         $this->foundProductIdsCache = [];

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -1054,3 +1054,5 @@ services:
     Shopsys\FrameworkBundle\Model\GoPay\GoPayClientFactory:
         arguments:
             - '%gopay_config%'
+
+    Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig: ~

--- a/packages/framework/tests/Unit/Component/Elasticsearch/__fixtures/CategoryIndex.php
+++ b/packages/framework/tests/Unit/Component/Elasticsearch/__fixtures/CategoryIndex.php
@@ -28,7 +28,7 @@ class CategoryIndex extends AbstractIndex
     /**
      * {@inheritdoc}
      */
-    public function getExportDataForIds(int $domainId, array $restrictToIds): array
+    public function getExportDataForIds(int $domainId, array $restrictToIds, array $fields = []): array
     {
         throw new RuntimeException(sprintf('The %s() is not implemented.', __METHOD__));
     }
@@ -36,8 +36,12 @@ class CategoryIndex extends AbstractIndex
     /**
      * {@inheritdoc}
      */
-    public function getExportDataForBatch(int $domainId, int $lastProcessedId, int $batchSize): array
-    {
+    public function getExportDataForBatch(
+        int $domainId,
+        int $lastProcessedId,
+        int $batchSize,
+        array $fields = [],
+    ): array {
         throw new RuntimeException(sprintf('The %s() is not implemented.', __METHOD__));
     }
 }

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -797,3 +797,11 @@ services:
 
     Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory:
         alias: App\Model\Product\Filter\ProductFilterDataFactory
+
+    Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider:
+        alias: App\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider
+
+    App\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig:
+        alias: App\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig

--- a/project-base/app/ecs.php
+++ b/project-base/app/ecs.php
@@ -137,6 +137,7 @@ return static function (ECSConfig $ecsConfig): void {
             __DIR__ . '/src/Model/Blog/Article/Elasticsearch/BlogArticleElasticsearchDataFetcher.php',
             __DIR__ . '/src/Model/Product/Transfer/Akeneo/ProductTransferAkeneoMapper.php',
             __DIR__ . '/src/Model/Product/Transfer/Akeneo/ProductTransferAkeneoValidator.php',
+            __DIR__ . '/src/Model/Product/Elasticsearch/ProductExportRepository.php',
         ],
         CamelCapsFunctionNameSniff::class => [
             __DIR__ . '/tests/App/Test/Codeception/ActorInterface.php',

--- a/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -178,7 +178,6 @@ class ProductExportRepository extends BaseProductExportRepository
         return match ($field) {
             BaseProductExportFieldProvider::FLAGS => $this->extractFlagsForDomain($domainId, $product),
             ProductExportFieldProvider::MAIN_CATEGORY_PATH => $this->extractMainCategoryPath($product, $domainId, $locale),
-            ProductExportFieldProvider::IS_AVAILABLE => $this->productAvailabilityFacade->isProductAvailableOnDomainCached($product, $domainId),
             BaseProductExportFieldProvider::PARAMETERS => $this->extractParametersIncludedVariants($product, $locale, $domainId),
             BaseProductExportFieldProvider::CALCULATED_SELLING_DENIED => $product->getCalculatedSaleExclusion($domainId),
             ProductExportFieldProvider::AVAILABILITY_STATUS => $this->productAvailabilityFacade->getProductAvailabilityStatusByDomainId($product, $domainId)->value,

--- a/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportFieldProvider.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportFieldProvider.php
@@ -9,7 +9,6 @@ use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportField
 class ProductExportFieldProvider extends BaseProductExportFieldProvider
 {
     public const string MAIN_CATEGORY_PATH = 'main_category_path';
-    public const string IS_AVAILABLE = 'is_available';
     public const string AVAILABILITY_STATUS = 'availability_status';
     public const string NAME_PREFIX = 'name_prefix';
     public const string NAME_SUFIX = 'name_sufix';

--- a/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportFieldProvider.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportFieldProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Product\Elasticsearch\Scope;
+
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider as BaseProductExportFieldProvider;
+
+class ProductExportFieldProvider extends BaseProductExportFieldProvider
+{
+    public const string MAIN_CATEGORY_PATH = 'main_category_path';
+    public const string IS_AVAILABLE = 'is_available';
+    public const string AVAILABILITY_STATUS = 'availability_status';
+    public const string NAME_PREFIX = 'name_prefix';
+    public const string NAME_SUFIX = 'name_sufix';
+    public const string IS_SALE_EXCLUSION = 'is_sale_exclusion';
+    public const string PRODUCT_AVAILABLE_STORES_COUNT_INFORMATION = 'product_available_stores_count_information';
+    public const string STORE_AVAILABILITIES_INFORMATION = 'store_availabilities_information';
+    public const string USPS = 'usps';
+    public const string SEARCHING_NAMES = 'searching_names';
+    public const string SEARCHING_DESCRIPTIONS = 'searching_descriptions';
+    public const string SEARCHING_CATNUMS = 'searching_catnums';
+    public const string SEARCHING_EANS = 'searching_eans';
+    public const string SEARCHING_PARTNOS = 'searching_partnos';
+    public const string SEARCHING_SHORT_DESCRIPTIONS = 'searching_short_descriptions';
+    public const string SLUG = 'slug';
+    public const string AVAILABLE_STORES_COUNT = 'available_stores_count';
+    public const string RELATED_PRODUCTS = 'related_products';
+    public const string BREADCRUMB = 'breadcrumb';
+    public const string PRODUCT_VIDEOS = 'product_videos';
+}

--- a/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Model\Product\Elasticsearch\Scope;
+
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportFieldProvider as BaseProductExportFieldProvider;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig as BaseProductExportScopeConfig;
+
+class ProductExportScopeConfig extends BaseProductExportScopeConfig
+{
+    public const string SCOPE_DESCRIPTION = 'product_description_scope';
+    public const string SCOPE_SHORT_DESCRIPTION = 'product_short_description_scope';
+    public const string SCOPE_CATNUM = 'product_catnum_scope';
+    public const string SCOPE_EAN = 'product_ean_scope';
+    public const string SCOPE_PARTNO = 'product_partno_scope';
+
+    protected function loadProductExportScopeRules(): void
+    {
+        parent::loadProductExportScopeRules();
+
+        $this->addExportFieldsToExistingScopeRule(self::SCOPE_CATEGORIES, [
+            ProductExportFieldProvider::MAIN_CATEGORY_PATH,
+            ProductExportFieldProvider::BREADCRUMB,
+        ]);
+        $this->addExportFieldsToExistingScopeRule(self::SCOPE_STOCKS, [
+            ProductExportFieldProvider::IS_AVAILABLE,
+            ProductExportFieldProvider::AVAILABILITY_STATUS,
+            ProductExportFieldProvider::PRODUCT_AVAILABLE_STORES_COUNT_INFORMATION,
+            ProductExportFieldProvider::STORE_AVAILABILITIES_INFORMATION,
+            ProductExportFieldProvider::AVAILABLE_STORES_COUNT,
+        ]);
+        $this->addExportFieldsToExistingScopeRule(self::SCOPE_VARIANTS, [
+            BaseProductExportFieldProvider::PARAMETERS,
+            ProductExportFieldProvider::SEARCHING_NAMES,
+            ProductExportFieldProvider::SEARCHING_DESCRIPTIONS,
+            ProductExportFieldProvider::SEARCHING_CATNUMS,
+            ProductExportFieldProvider::SEARCHING_EANS,
+            ProductExportFieldProvider::SEARCHING_PARTNOS,
+            ProductExportFieldProvider::SEARCHING_SHORT_DESCRIPTIONS,
+        ]);
+        $this->addExportFieldsToExistingScopeRule(self::SCOPE_SELLING_DENIED, [ProductExportFieldProvider::IS_SALE_EXCLUSION]);
+        $this->addExportFieldsToExistingScopeRule(self::SCOPE_NAME, [
+            ProductExportFieldProvider::SEARCHING_NAMES,
+            ProductExportFieldProvider::SLUG,
+            ProductExportFieldProvider::BREADCRUMB,
+            ProductExportFieldProvider::NAME_PREFIX,
+            ProductExportFieldProvider::NAME_SUFIX,
+        ]);
+
+        $this->addNewExportScopeRule(self::SCOPE_DESCRIPTION, [
+            BaseProductExportFieldProvider::DESCRIPTION,
+            ProductExportFieldProvider::SEARCHING_DESCRIPTIONS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_SHORT_DESCRIPTION, [
+            BaseProductExportFieldProvider::SHORT_DESCRIPTION,
+            ProductExportFieldProvider::SEARCHING_SHORT_DESCRIPTIONS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_CATNUM, [
+            BaseProductExportFieldProvider::CATNUM,
+            ProductExportFieldProvider::SEARCHING_CATNUMS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_EAN, [
+            BaseProductExportFieldProvider::EAN,
+            ProductExportFieldProvider::SEARCHING_EANS,
+        ]);
+        $this->addNewExportScopeRule(self::SCOPE_PARTNO, [
+            BaseProductExportFieldProvider::PARTNO,
+            ProductExportFieldProvider::SEARCHING_PARTNOS,
+        ]);
+    }
+}

--- a/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/Scope/ProductExportScopeConfig.php
@@ -24,7 +24,6 @@ class ProductExportScopeConfig extends BaseProductExportScopeConfig
             ProductExportFieldProvider::BREADCRUMB,
         ]);
         $this->addExportFieldsToExistingScopeRule(self::SCOPE_STOCKS, [
-            ProductExportFieldProvider::IS_AVAILABLE,
             ProductExportFieldProvider::AVAILABILITY_STATUS,
             ProductExportFieldProvider::PRODUCT_AVAILABLE_STORES_COUNT_INFORMATION,
             ProductExportFieldProvider::STORE_AVAILABILITIES_INFORMATION,

--- a/project-base/app/src/Model/Product/Search/FilterQuery.php
+++ b/project-base/app/src/Model/Product/Search/FilterQuery.php
@@ -24,6 +24,8 @@ use stdClass;
  * @method \App\Model\Product\Search\FilterQuery filterByProductIds(int[] $productIds)
  * @method \App\Model\Product\Search\FilterQuery filterByProductUuids(string[] $productUuids)
  * @method \App\Model\Product\Search\FilterQuery filterOutVariants()
+ * @method \App\Model\Product\Search\FilterQuery getExistingProductsIdsFilterQuery(int $productIds)
+ * @method \App\Model\Product\Search\FilterQuery restrictFields(string[] $fields)
  */
 class FilterQuery extends BaseFilterQuery
 {

--- a/project-base/app/src/Model/Product/Search/FilterQueryFactory.php
+++ b/project-base/app/src/Model/Product/Search/FilterQueryFactory.php
@@ -27,6 +27,7 @@ use Shopsys\FrameworkBundle\Model\Product\Search\FilterQueryFactory as BaseFilte
  * @method \App\Model\Product\Search\FilterQuery createSellableProductsByProductUuidsFilter(string[] $productUuids)
  * @method \App\Model\Product\Search\FilterQuery createListableWithProductFilter(\Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData)
  * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+ * @method \App\Model\Product\Search\FilterQuery createOnlyExistingProductIdsFilterQuery(int[] $productIds, int $domainId)
  */
 class FilterQueryFactory extends BaseFilterQueryFactory
 {

--- a/project-base/app/src/Model/Product/Search/ProductElasticsearchConverter.php
+++ b/project-base/app/src/Model/Product/Search/ProductElasticsearchConverter.php
@@ -31,7 +31,6 @@ class ProductElasticsearchConverter extends BaseProductElasticsearchConverter
         $result['searching_eans'] = $product['searching_eans'] ?? '';
         $result['searching_short_descriptions'] = $product['searching_short_descriptions'] ?? '';
         $result['searching_descriptions'] = $product['searching_descriptions'] ?? '';
-        $result['is_available'] = $product['is_available'] ?? false;
         $result['availability_dispatch_time'] = $product['availability_dispatch_time'] ?? null;
         $result['uuid'] = $product['uuid'] ?? '00000000-0000-0000-0000-000000000000';
         $result['unit'] = $product['unit'] ?? '';

--- a/project-base/app/src/Resources/definition/product/1.json
+++ b/project-base/app/src/Resources/definition/product/1.json
@@ -262,9 +262,6 @@
       "in_stock": {
         "type": "boolean"
       },
-      "is_available": {
-        "type": "boolean"
-      },
       "parameters": {
         "type": "nested",
         "properties": {

--- a/project-base/app/src/Resources/definition/product/2.json
+++ b/project-base/app/src/Resources/definition/product/2.json
@@ -262,9 +262,6 @@
       "in_stock": {
         "type": "boolean"
       },
-      "is_available": {
-        "type": "boolean"
-      },
       "parameters": {
         "type": "nested",
         "properties": {

--- a/project-base/app/tests/App/Functional/Model/Product/Elasticsearch/ProductExportRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Elasticsearch/ProductExportRepositoryTest.php
@@ -50,7 +50,6 @@ class ProductExportRepositoryTest extends TransactionFunctionalTestCase
             'main_category_id',
             'main_category_path',
             'in_stock',
-            'is_available',
             'prices',
             'parameters',
             'ordering_priority',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| In many occasions, to optimize the application, you need to restrict the scope of a product recalculation and elastic export - sometimes you do not need to recalculate visibility or selling denied, or you need to export just particular fields into Elasticsearch. For example, when launching a new domain, you need to export just the product URLs into Elasticsearch which takes significantly less time than the full recalculation and export. On the other hand, it might be hard to keep in mind all the dependencies (e.g. you need to know you need to recalculate visibility after you change `Product::$sellingFrom`, or you need to keep in mind that with a change of product URL, you always need to export `hreflang_links` into Elasticsearch as well, etc.). This PR provides the recalculation scoping feature and defines all the scope dependencies (see the table below which is an output of a new `shopsys:list:export-scopes` CLI command) which provides wide possibilities for optimizing the application.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

![image](https://github.com/shopsys/shopsys/assets/10401898/06a96b8c-4970-4aeb-99a3-7218341f49c8)
































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-scopes-without-enums.odin.shopsys.cloud
  - https://cz.rv-scopes-without-enums.odin.shopsys.cloud
<!-- Replace -->
