### PR TITLE
[coding-standards] attributes are now allowed after phpdoc block

### DIFF
--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/MissingParamAnnotationsFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/MissingParamAnnotationsFixerTest.php
@@ -55,6 +55,8 @@ final class MissingParamAnnotationsFixerTest extends AbstractFixerTestCase
 
         yield [__DIR__ . '/fixed/fixed6.php', __DIR__ . '/wrong/wrong6.php'];
 
+        yield [__DIR__ . '/fixed/fixed7.php', __DIR__ . '/wrong/wrong7.php'];
+
         yield [__DIR__ . '/correct/correct.php'];
     }
 }

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/correct/correct.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/correct/correct.php
@@ -2,8 +2,11 @@
 
 namespace Shopsys\ProductFeed\ZboziBundle\Form;
 
+use Override;
+use ReturnTypeWillChange;
 use Shopsys\FormTypesBundle\MultidomainType;
 use Shopsys\FormTypesBundle\YesNoType;
+use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\EntityLogIdentify;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Form\Constraints\MoneyRange;
 use Symfony\Component\Form\AbstractType;
@@ -29,9 +32,18 @@ class ZboziProductFormType extends AbstractType
     }
 
     /**
+     * @param string $bar
+     */
+    #[EntityLogIdentify(isLocalized: true)]
+    public function foo(string $bar): void
+    {
+    }
+
+    /**
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
      * @param array $options
      */
+    #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/fixed/fixed7.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/fixed/fixed7.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Tests;
+
+class SomeParentClassWithAttribute
+{
+    /**
+     * @param string $bar
+     */
+    public function foo(string $bar): void
+    {
+    }
+}
+
+class SomeClass extends SomeParentClassWithAttribute
+{
+    /**
+     * @param string $bar
+     */
+    #[\Override]
+    public function foo(string $bar): void
+    {
+    }
+
+    /**
+     * @param string $foo
+     * @param string $bar
+     */
+    #[\ReturnTypeWillChange]
+    public function bar(string $foo, string $bar): void
+    {
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/wrong/wrong7.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingParamAnnotationsFixer/wrong/wrong7.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\CodingStandards\Tests;
+
+class SomeParentClassWithAttribute
+{
+    /**
+     * @param string $bar
+     */
+    public function foo(string $bar): void
+    {
+    }
+}
+
+class SomeClass extends SomeParentClassWithAttribute
+{
+    #[\Override]
+    public function foo(string $bar): void
+    {
+    }
+
+    /**
+     * @param string $bar
+     */
+    #[\ReturnTypeWillChange]
+    public function bar(string $foo, string $bar): void
+    {
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/MissingReturnAnnotationFixerTest.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/MissingReturnAnnotationFixerTest.php
@@ -47,6 +47,8 @@ final class MissingReturnAnnotationFixerTest extends AbstractFixerTestCase
 
         yield [__DIR__ . '/fixed/fixed2.php', __DIR__ . '/wrong/wrong2.php'];
 
+        yield [__DIR__ . '/fixed/fixed3.php', __DIR__ . '/wrong/wrong3.php'];
+
         yield [__DIR__ . '/correct/correct.php'];
     }
 }

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/correct/correct.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/correct/correct.php
@@ -18,6 +18,15 @@ class EnvironmentType
     {
         return $environment === self::DEVELOPMENT;
     }
+
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
+    public function foo(): bool
+    {
+        return true;
+    }
 }
 
 

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/fixed/fixed3.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/fixed/fixed3.php
@@ -1,0 +1,13 @@
+<?php
+
+class SomeClass
+{
+    /**
+     * @return int
+     */
+    #[\ReturnTypeWillChange]
+    public function function1(): int
+    {
+        return 0;
+    }
+}

--- a/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/wrong/wrong3.php
+++ b/packages/coding-standards/tests/Unit/CsFixer/Phpdoc/MissingReturnAnnotationFixer/wrong/wrong3.php
@@ -1,0 +1,10 @@
+<?php
+
+class SomeClass
+{
+    #[\ReturnTypeWillChange]
+    public function function1(): int
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| With PHP 8 we can use attributes and this PR allows them to be placed between the function and phpdoc block. That way it will be also generated if phpdoc block is missing and --fix is run.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-improve-standards-attributes.odin.shopsys.cloud
  - https://cz.mg-improve-standards-attributes.odin.shopsys.cloud
<!-- Replace -->
