### PR TITLE
[project-base] added doctrine backtrace collecting in dev mode

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -164,6 +164,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   see #project-base-diff to update your project
 
+#### add doctrine backtrace collecting ([#3055](https://github.com/shopsys/shopsys/pull/3055))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/project-base/app/config/packages/dev/doctrine.yaml
+++ b/project-base/app/config/packages/dev/doctrine.yaml
@@ -1,3 +1,5 @@
 doctrine:
+    dbal:
+        profiling_collect_backtrace: true
     orm:
         auto_generate_proxy_classes: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR enables backtrace profiling in doctrine in dev mode, so it's possible to determine the source of the sql query. See the example image below
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


![Snímek obrazovky 2024-03-05 v 12 39 46](https://github.com/shopsys/shopsys/assets/1177414/c0c4d78c-e910-4e55-8e9e-b986547b7fab)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://grossmannmartin-patch-1.odin.shopsys.cloud
  - https://cz.grossmannmartin-patch-1.odin.shopsys.cloud
<!-- Replace -->
