### PR TITLE
changed link URL for Catalog navigation element

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -256,6 +256,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   method `getProductItemsCount()` was removed
 -   see #project-base-diff to update your project
 
+#### changed link URL for Catalog navigation element ([#3057](https://github.com/shopsys/shopsys/pull/3057))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/project-base/app/src/DataFixtures/Demo/NavigationItemDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/NavigationItemDataFixture.php
@@ -46,7 +46,10 @@ class NavigationItemDataFixture extends AbstractReferenceFixture implements Depe
 
             $navigationItemData = $this->navigationItemDataFactory->createNew();
             $navigationItemData->name = t('Catalog', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
-            $navigationItemData->url = '#';
+            $navigationItemData->url = $this->generateUrlForCategoryOnDomain(
+                CategoryDataFixture::CATEGORY_ELECTRONICS,
+                $domainId,
+            );
             $navigationItemData->domainId = $domainId;
             $this->addCategoriesToNavigationItem($navigationItemData);
             $this->createItem($navigationItemData);

--- a/project-base/app/tests/FrontendApiBundle/Functional/Navigation/NavigationTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Navigation/NavigationTest.php
@@ -33,7 +33,7 @@ class NavigationTest extends GraphQlTestCase
                 "navigation": [
                     {
                         "name": "' . t('Catalog', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()) . '",
-                        "link": "/#",
+                        "link": "' . $this->getLink(CategoryDataFixture::CATEGORY_ELECTRONICS) . '",
                         "categoriesByColumns": [
                             {
                                 "columnNumber": 1,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| empty anchor in navigation item does not make sense. This PR changes navigation in demo data
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes
|Fixes issues| ...
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pt-catalog-url.odin.shopsys.cloud
  - https://cz.pt-catalog-url.odin.shopsys.cloud
<!-- Replace -->
