### PR TITLE
[framework] fixed situation when placeholder was not set for selected locale

### DIFF
--- a/packages/framework/src/Component/DataFixture/AbstractReferenceFixture.php
+++ b/packages/framework/src/Component/DataFixture/AbstractReferenceFixture.php
@@ -21,7 +21,7 @@ abstract class AbstractReferenceFixture implements FixtureInterface
     {
         $middlewaresWithoutLoggingMiddleware = array_values(array_filter(
             $entityManager->getConnection()->getConfiguration()->getMiddlewares(),
-            fn (MiddlewareInterface $middleware) => !($middleware instanceof LoggingMiddleware)
+            fn (MiddlewareInterface $middleware) => !($middleware instanceof LoggingMiddleware),
         ));
         $entityManager->getConnection()->getConfiguration()->setMiddlewares($middlewaresWithoutLoggingMiddleware);
         $entityManager->clear();

--- a/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Brand/BrandFormType.php
@@ -184,8 +184,8 @@ class BrandFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Product\Brand\Brand|null $brand
      * @return string
      */
-    private function getTitlePlaceholder(?Brand $brand = null)
+    private function getTitlePlaceholder(?Brand $brand = null): string
     {
-        return $brand !== null ? $brand->getName() : '';
+        return $brand?->getName() ?? '';
     }
 }

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -667,9 +667,9 @@ class ProductFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Product\Product|null $product
      * @return string
      */
-    private function getTitlePlaceholder($locale, ?Product $product = null): string
+    private function getTitlePlaceholder(string $locale, ?Product $product = null): string
     {
-        return $product !== null ? $product->getName($locale) : '';
+        return $product?->getName($locale) ?? '';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| There was an error thrown when the name of the entity was not set, this PR fixes that.
|New feature| No<!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-nullable-placeholder.odin.shopsys.cloud
  - https://cz.tl-fix-nullable-placeholder.odin.shopsys.cloud
<!-- Replace -->
