### PR TITLE
[project-base] fixed wrong PageType for articles in search

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1840,3 +1840,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         -   `createUserConsentSlice` is removed and `userConsent` data is part of `createUserSlice`
         -   we have discovered issue with Zustand store session during SSR, when setting values on server session was not destroyed and was used also for next session, this was solved by moving `CookiesStore` to `Context`, as it is the recommended way to handle such cases
     -   domainConfig is moved from `SessionStore` to `Context` for easier handling and solve issue with SSR session (see previous comment from cookies refactoring)
+
+-   fix a wrong link type for searched articles ([#3062](https://github.com/shopsys/shopsys/pull/3062))

--- a/project-base/storefront/components/Blocks/Categories/PromotedCategories.tsx
+++ b/project-base/storefront/components/Blocks/Categories/PromotedCategories.tsx
@@ -13,5 +13,5 @@ export const PromotedCategories: FC = () => {
         return null;
     }
 
-    return <SimpleNavigation linkType="category" listedItems={promotedCategoriesData.promotedCategories} />;
+    return <SimpleNavigation listedItems={promotedCategoriesData.promotedCategories} />;
 };

--- a/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigation.tsx
+++ b/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigation.tsx
@@ -8,7 +8,7 @@ type SimpleNavigationProps = {
     listedItems: ListedItemPropType[];
     isWithoutSlider?: true;
     itemClassName?: string;
-    linkType: PageType;
+    linkTypeOverride?: PageType;
 };
 
 export const SimpleNavigation: FC<SimpleNavigationProps> = ({
@@ -16,7 +16,7 @@ export const SimpleNavigation: FC<SimpleNavigationProps> = ({
     isWithoutSlider,
     className,
     itemClassName,
-    linkType,
+    linkTypeOverride,
 }) => {
     return (
         <ul
@@ -31,7 +31,7 @@ export const SimpleNavigation: FC<SimpleNavigationProps> = ({
                 <SimpleNavigationListItem
                     key={index}
                     className={itemClassName}
-                    linkType={linkType}
+                    linkTypeOverride={linkTypeOverride}
                     listedItem={listedItem}
                     tid={TIDs.blocks_simplenavigation_ + index}
                 >

--- a/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigationListItem.tsx
+++ b/project-base/storefront/components/Blocks/SimpleNavigation/SimpleNavigationListItem.tsx
@@ -1,3 +1,4 @@
+import { getLinkType } from './helpers';
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Image } from 'components/Basic/Image/Image';
 import { getStringWithoutTrailingSlash } from 'helpers/parsing/stringWIthoutSlash';
@@ -9,17 +10,18 @@ import { ListedItemPropType } from 'types/simpleNavigation';
 type SimpleNavigationListItemProps = {
     listedItem: ListedItemPropType;
     imageType?: string;
-    linkType: PageType;
+    linkTypeOverride?: PageType;
 };
 
 export const SimpleNavigationListItem: FC<SimpleNavigationListItemProps> = ({
     listedItem,
-    linkType,
+    linkTypeOverride,
     tid,
     className,
 }) => {
     const itemImage = 'mainImage' in listedItem ? listedItem.mainImage : null;
     const href = getStringWithoutTrailingSlash(listedItem.slug) + '/';
+    const linkType = linkTypeOverride ?? getLinkType(listedItem.__typename);
 
     return (
         <li tid={tid}>

--- a/project-base/storefront/components/Blocks/SimpleNavigation/helpers.ts
+++ b/project-base/storefront/components/Blocks/SimpleNavigation/helpers.ts
@@ -1,0 +1,17 @@
+import { PageType } from 'store/slices/createPageLoadingStateSlice';
+import { ListedItemPropTypeTypename } from 'types/simpleNavigation';
+
+export const getLinkType = (type: ListedItemPropTypeTypename | undefined): PageType => {
+    switch (type) {
+        case 'ArticleSite':
+            return 'article';
+        case 'BlogArticle':
+            return 'blogArticle';
+        case 'Brand':
+            return 'brand';
+        case 'Category':
+            return 'category';
+        default:
+            throw new Error('Link type ' + type + ' could not be resolved.');
+    }
+};

--- a/project-base/storefront/components/Blocks/Skeleton/SkeletonManager.tsx
+++ b/project-base/storefront/components/Blocks/Skeleton/SkeletonManager.tsx
@@ -40,6 +40,7 @@ export const SkeletonManager: FC<SkeletonManagerProps> = ({ isFetchingData, isPa
         case 'productMainVariant':
             return <SkeletonPageProductDetailMainVariant />;
         case 'category':
+        case 'seo_category':
             return <SkeletonPageProductsList />;
         case 'brand':
         case 'flag':

--- a/project-base/storefront/components/Pages/Brands/BrandsContent.tsx
+++ b/project-base/storefront/components/Pages/Brands/BrandsContent.tsx
@@ -16,7 +16,7 @@ export const BrandsContent: FC = () => {
 
     return (
         <Webline>
-            <SimpleNavigation isWithoutSlider linkType="brand" listedItems={brandsData.brands} />
+            <SimpleNavigation isWithoutSlider listedItems={brandsData.brands} />
         </Webline>
     );
 };

--- a/project-base/storefront/components/Pages/CategoryDetail/AdvancedSeoCategories.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/AdvancedSeoCategories.tsx
@@ -16,7 +16,7 @@ export const AdvancedSeoCategories: FC<AdvancedSeoCategoriesProps> = ({ readyCat
             <div className="mb-3 mt-6 break-words font-bold text-dark lg:text-lg">{t('Favorite categories')}</div>
             <SimpleNavigation
                 itemClassName={simpleNavigationItemTwClass}
-                linkType="category"
+                linkTypeOverride="category"
                 listedItems={readyCategorySeoMixLinks}
             />
         </>

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -78,7 +78,7 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
 
                     <SimpleNavigation
                         className="mt-6"
-                        linkType="category"
+                        linkTypeOverride="category"
                         listedItems={[...category.children, ...category.linkedCategories]}
                     />
 

--- a/project-base/storefront/components/Pages/Search/SearchContent.tsx
+++ b/project-base/storefront/components/Pages/Search/SearchContent.tsx
@@ -41,21 +41,21 @@ export const SearchContent: FC<SearchContentProps> = ({ searchResults, fetching 
                         {!!searchResults.articlesSearch.length && (
                             <div className="mt-6">
                                 <div className="h3 mb-3">{t('Found articles')}</div>
-                                <SimpleNavigation linkType="blogArticle" listedItems={searchResults.articlesSearch} />
+                                <SimpleNavigation listedItems={searchResults.articlesSearch} />
                             </div>
                         )}
 
                         {!!searchResults.brandSearch.length && (
                             <div className="mt-6">
                                 <div className="h3 mb-3">{t('Found brands')}</div>
-                                <SimpleNavigation linkType="brand" listedItems={searchResults.brandSearch} />
+                                <SimpleNavigation listedItems={searchResults.brandSearch} />
                             </div>
                         )}
 
                         {!!mappedCategoriesSearchResults?.length && (
                             <div className="mt-6">
                                 <div className="h3 mb-3">{t('Found categories')}</div>
-                                <SimpleNavigation linkType="category" listedItems={mappedCategoriesSearchResults} />
+                                <SimpleNavigation listedItems={mappedCategoriesSearchResults} />
                             </div>
                         )}
 

--- a/project-base/storefront/types/simpleNavigation.ts
+++ b/project-base/storefront/types/simpleNavigation.ts
@@ -1,5 +1,7 @@
 import { ImageFragmentApi } from 'graphql/generated';
 
+export type ListedItemPropTypeTypename = 'ArticleSite' | 'BlogArticle' | 'Category' | 'Brand' | 'Link';
+
 export type ListedItemPropType = (
     | {
           slug: string;
@@ -17,5 +19,5 @@ export type ListedItemPropType = (
           name: string;
       }
 ) & {
-    __typename?: 'ArticleSite' | 'BlogArticle' | 'Category' | 'Brand' | 'Link';
+    __typename?: ListedItemPropTypeTypename;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Simple navigation in search for articles was explicitly defining the type of link as BlogArticle even thought it might have been ArticleSite. This led to an error when accessing article details of type ArticleSite.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-rv-fix-search-article-navigation.odin.shopsys.cloud
  - https://cz.tl-rv-fix-search-article-navigation.odin.shopsys.cloud
<!-- Replace -->
