### PR TITLE
[shopsys] adverts restricted by theirs display dates are now correctly displayed at specified dates

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1467,6 +1467,17 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
             protected readonly ProductRepository $productRepository,
     -       EntityNameResolver $entityNameResolver,
     ```
+-   fix not displaying hidden Adverts in frontend API ([#3065](https://github.com/shopsys/shopsys/pull/3065))
+    -   framework classes `AdvertController`, `AdvertFacade` and `AdvertRepository` have now set typehints and return typehints for all methods so you should update your extended project classes accordingly
+    -   method `Shopsys\FrameworkBundle\Model\Advert\AdvertRepository::getAdvertByPositionQueryBuilder()` has been renamed to `Shopsys\FrameworkBundle\Model\Advert\AdvertRepository::getVisibleAdvertByPositionQueryBuilder()` and its visibility has been changed from `protected` to `public`
+    -   constructor `Shopsys\FrontendApiBundle\Model\Advert\AdvertRepository::__constructor()` changed its interface:
+        ```diff
+            public function __construct(
+                protected readonly EntityManagerInterface $em,
+        +       protected readonly FrameworkAdvertRepository $advertRepository,
+            )
+        ```
+    -   methods `getVisibleAdvertsQueryBuilder()` and `getVisibleAdvertsByPositionNameQueryBuilder()` has been removed from `Shopsys\FrontendApiBundle\Model\Advert\AdvertRepository` and code usages has been replaced by usages from framework `AdvertRepository`
 
 ### Storefront
 

--- a/packages/framework/src/Controller/Admin/AdvertController.php
+++ b/packages/framework/src/Controller/Admin/AdvertController.php
@@ -19,6 +19,7 @@ use Shopsys\FrameworkBundle\Model\Advert\AdvertPositionRegistry;
 use Shopsys\FrameworkBundle\Model\Advert\Exception\AdvertNotFoundException;
 use Shopsys\FrameworkBundle\Twig\ImageExtension;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class AdvertController extends AdminBaseController
@@ -51,8 +52,9 @@ class AdvertController extends AdminBaseController
      * @Route("/advert/edit/{id}", requirements={"id" = "\d+"})
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function editAction(Request $request, $id)
+    public function editAction(Request $request, int $id): Response
     {
         $advert = $this->advertFacade->getById($id);
 
@@ -95,8 +97,9 @@ class AdvertController extends AdminBaseController
 
     /**
      * @Route("/advert/list/")
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function listAction()
+    public function listAction(): Response
     {
         /** @var \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator */
         $administrator = $this->getUser();
@@ -146,8 +149,9 @@ class AdvertController extends AdminBaseController
     /**
      * @Route("/advert/new/")
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         $advertData = $this->advertDataFactory->create();
         $advertData->domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
@@ -188,8 +192,9 @@ class AdvertController extends AdminBaseController
      * @Route("/advert/delete/{id}", requirements={"id" = "\d+"})
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function deleteAction($id)
+    public function deleteAction(int $id): Response
     {
         try {
             $fullName = $this->advertFacade->getById($id)->getName();

--- a/packages/framework/src/Model/Advert/AdvertFacade.php
+++ b/packages/framework/src/Model/Advert/AdvertFacade.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Advert;
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
+use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class AdvertFacade
 {
@@ -35,7 +36,7 @@ class AdvertFacade
      * @param int $advertId
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert
      */
-    public function getById($advertId)
+    public function getById(int $advertId): Advert
     {
         return $this->advertRepository->getById($advertId);
     }
@@ -45,8 +46,10 @@ class AdvertFacade
      * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $category
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert|null
      */
-    public function findRandomAdvertByPositionOnCurrentDomain($positionName, $category = null)
-    {
+    public function findRandomAdvertByPositionOnCurrentDomain(
+        string $positionName,
+        ?Category $category = null,
+    ): ?Advert {
         $this->advertPositionRegistry->assertPositionNameIsKnown($positionName);
 
         return $this->advertRepository->findRandomAdvertByPosition($positionName, $this->domain->getId(), $category);
@@ -56,7 +59,7 @@ class AdvertFacade
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertData $advertData
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert
      */
-    public function create(AdvertData $advertData)
+    public function create(AdvertData $advertData): Advert
     {
         $advert = $this->advertFactory->create($advertData);
 
@@ -75,7 +78,7 @@ class AdvertFacade
      * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertData $advertData
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert
      */
-    public function edit($advertId, AdvertData $advertData)
+    public function edit(int $advertId, AdvertData $advertData): Advert
     {
         $advert = $this->advertRepository->getById($advertId);
         $advert->edit($advertData);
@@ -92,7 +95,7 @@ class AdvertFacade
     /**
      * @param int $advertId
      */
-    public function delete($advertId)
+    public function delete(int $advertId): void
     {
         $advert = $this->advertRepository->getById($advertId);
         $this->em->remove($advert);

--- a/packages/framework/src/Model/Advert/AdvertRepository.php
+++ b/packages/framework/src/Model/Advert/AdvertRepository.php
@@ -6,8 +6,11 @@ namespace Shopsys\FrameworkBundle\Model\Advert;
 
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use LogicException;
 use Shopsys\FrameworkBundle\Model\Advert\Exception\AdvertNotFoundException;
+use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class AdvertRepository
 {
@@ -21,16 +24,16 @@ class AdvertRepository
     /**
      * @return \Doctrine\ORM\EntityRepository
      */
-    protected function getAdvertRepository()
+    protected function getAdvertRepository(): EntityRepository
     {
         return $this->em->getRepository(Advert::class);
     }
 
     /**
-     * @param string $advertId
+     * @param int $advertId
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert|null
      */
-    public function findById($advertId)
+    public function findById(int $advertId): ?Advert
     {
         return $this->getAdvertRepository()->find($advertId);
     }
@@ -41,27 +44,18 @@ class AdvertRepository
      * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $category
      * @return \Doctrine\ORM\QueryBuilder
      */
-    protected function getAdvertByPositionQueryBuilder($positionName, $domainId, $category = null)
-    {
-        if (AdvertPositionRegistry::isCategoryPosition($positionName) && $category === null) {
+    public function getVisibleAdvertByPositionQueryBuilder(
+        string $positionName,
+        int $domainId,
+        ? Category $category = null,
+    ): QueryBuilder {
+        if ($category === null && AdvertPositionRegistry::isCategoryPosition($positionName)) {
             throw new LogicException('Cannot retrieve advert on product list page without setting category.');
         }
 
-        $dateToday = (new DateTimeImmutable())->format('Y-m-d 00:00:00');
-
-        $queryBuilder = $this->em->createQueryBuilder()
-            ->select('a')
-            ->from(Advert::class, 'a')
-            ->where('a.positionName = :positionName')
-            ->andWhere('a.hidden = FALSE')
-            ->andWhere('a.domainId = :domainId')
-            ->andWhere('a.datetimeVisibleFrom is NULL or a.datetimeVisibleFrom <= :now')
-            ->andWhere('a.datetimeVisibleTo is NULL or a.datetimeVisibleTo >= :now')
-            ->setParameters([
-                'domainId' => $domainId,
-                'positionName' => $positionName,
-                'now' => $dateToday,
-            ]);
+        $queryBuilder = $this->getVisibleAdvertsQueryBuilder($domainId)
+            ->andWhere('a.positionName = :positionName')
+            ->setParameter('positionName', $positionName);
 
         if ($category !== null) {
             $queryBuilder
@@ -74,14 +68,36 @@ class AdvertRepository
     }
 
     /**
+     * @param int $domainId
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    public function getVisibleAdvertsQueryBuilder(int $domainId): QueryBuilder
+    {
+        $dateToday = (new DateTimeImmutable())->format('Y-m-d 00:00:00');
+
+        return $this->em->createQueryBuilder()
+            ->select('a')
+            ->from(Advert::class, 'a')
+            ->where('a.hidden = FALSE')
+            ->andWhere('a.datetimeVisibleFrom is NULL or a.datetimeVisibleFrom <= :now')
+            ->andWhere('a.datetimeVisibleTo is NULL or a.datetimeVisibleTo >= :now')
+            ->andWhere('a.domainId = :domainId')
+            ->setParameter('domainId', $domainId)
+            ->setParameter('now', $dateToday);
+    }
+
+    /**
      * @param string $positionName
      * @param int $domainId
      * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $category
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert|null
      */
-    public function findRandomAdvertByPosition($positionName, $domainId, $category = null)
-    {
-        $count = $this->getAdvertByPositionQueryBuilder($positionName, $domainId, $category)
+    public function findRandomAdvertByPosition(
+        string $positionName,
+        int $domainId,
+        ?Category $category = null,
+    ): ?Advert {
+        $count = $this->getVisibleAdvertByPositionQueryBuilder($positionName, $domainId, $category)
             ->select('COUNT(a)')
             ->getQuery()->getSingleScalarResult();
 
@@ -90,7 +106,7 @@ class AdvertRepository
             return null;
         }
 
-        return $this->getAdvertByPositionQueryBuilder($positionName, $domainId, $category)
+        return $this->getVisibleAdvertByPositionQueryBuilder($positionName, $domainId, $category)
             ->setFirstResult(random_int(0, $count - 1))
             ->setMaxResults(1)
             ->getQuery()->getSingleResult();
@@ -100,7 +116,7 @@ class AdvertRepository
      * @param int $advertId
      * @return \Shopsys\FrameworkBundle\Model\Advert\Advert
      */
-    public function getById($advertId)
+    public function getById(int $advertId): Advert
     {
         $advert = $this->getAdvertRepository()->find($advertId);
 

--- a/packages/frontend-api/src/Model/Advert/AdvertRepository.php
+++ b/packages/frontend-api/src/Model/Advert/AdvertRepository.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Advert;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\QueryBuilder;
-use Shopsys\FrameworkBundle\Model\Advert\Advert;
+use Shopsys\FrameworkBundle\Model\Advert\AdvertRepository as FrameworkAdvertRepository;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 
 class AdvertRepository
 {
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
+     * @param \Shopsys\FrameworkBundle\Model\Advert\AdvertRepository $advertRepository
      */
-    public function __construct(protected readonly EntityManagerInterface $em)
-    {
+    public function __construct(
+        protected readonly EntityManagerInterface $em,
+        protected readonly FrameworkAdvertRepository $advertRepository,
+    ) {
     }
 
     /**
@@ -29,7 +31,7 @@ class AdvertRepository
         string $positionName,
         ?Category $category = null,
     ): array {
-        return $this->getVisibleAdvertsByPositionNameQueryBuilder($domainId, $positionName, $category)->getQuery()->execute();
+        return $this->advertRepository->getVisibleAdvertByPositionQueryBuilder($positionName, $domainId, $category)->getQuery()->execute();
     }
 
     /**
@@ -38,53 +40,6 @@ class AdvertRepository
      */
     public function getVisibleAdvertsByDomainId(int $domainId): array
     {
-        return $this->getVisibleAdvertsQueryBuilder($domainId)->getQuery()->execute();
-    }
-
-    /**
-     * @return \Doctrine\ORM\EntityRepository
-     */
-    protected function getAdvertRepository()
-    {
-        return $this->em->getRepository(Advert::class);
-    }
-
-    /**
-     * @param int $domainId
-     * @param string $positionName
-     * @param \Shopsys\FrameworkBundle\Model\Category\Category|null $category
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    protected function getVisibleAdvertsByPositionNameQueryBuilder(
-        int $domainId,
-        string $positionName,
-        ?Category $category = null,
-    ) {
-        $queryBuilder = $this->getVisibleAdvertsQueryBuilder($domainId)
-            ->andWhere('a.positionName = :positionName')
-            ->setParameter('positionName', $positionName);
-
-        if ($category !== null) {
-            $queryBuilder
-                ->leftJoin('a.categories', 'c')
-                ->andWhere('c IS NULL OR c = :category')
-                ->setParameter('category', $category);
-        }
-
-        return $queryBuilder;
-    }
-
-    /**
-     * @param int $domainId
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    protected function getVisibleAdvertsQueryBuilder(int $domainId): QueryBuilder
-    {
-        return $this->em->createQueryBuilder()
-            ->select('a')
-            ->from(Advert::class, 'a')
-            ->where('a.hidden = FALSE')
-            ->andWhere('a.domainId = :domainId')
-            ->setParameter('domainId', $domainId);
+        return $this->advertRepository->getVisibleAdvertsQueryBuilder($domainId)->getQuery()->execute();
     }
 }

--- a/project-base/app/src/Controller/Admin/AdvertController.php
+++ b/project-base/app/src/Controller/Admin/AdvertController.php
@@ -7,7 +7,6 @@ namespace App\Controller\Admin;
 use App\Model\Advert\AdvertFacade;
 use Shopsys\FrameworkBundle\Controller\Admin\AdvertController as BaseAdvertController;
 use Shopsys\FrameworkBundle\Form\Admin\Advert\AdvertFormType;
-use Shopsys\FrameworkBundle\Model\Advert\Advert;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -26,7 +25,7 @@ class AdvertController extends BaseAdvertController
      * @param int $id
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      */
-    public function editAction(Request $request, $id): Response
+    public function editAction(Request $request, int $id): Response
     {
         $advert = $this->advertFacade->getById($id);
 

--- a/project-base/app/src/Model/Advert/AdvertRepository.php
+++ b/project-base/app/src/Model/Advert/AdvertRepository.php
@@ -7,10 +7,10 @@ namespace App\Model\Advert;
 use Shopsys\FrameworkBundle\Model\Advert\AdvertRepository as BaseAdvertRepository;
 
 /**
- * @method \App\Model\Advert\Advert|null findById(string $advertId)
+ * @method \App\Model\Advert\Advert|null findById(int $advertId)
  * @method \App\Model\Advert\Advert|null findRandomAdvertByPosition(string $positionName, int $domainId, \App\Model\Category\Category|null $category = null)
  * @method \App\Model\Advert\Advert getById(int $advertId)
- * @method \Doctrine\ORM\QueryBuilder getAdvertByPositionQueryBuilder(string $positionName, int $domainId, \App\Model\Category\Category|null $category = null)
+ * @method \Doctrine\ORM\QueryBuilder getVisibleAdvertByPositionQueryBuilder(string $positionName, int $domainId, \App\Model\Category\Category|null $category = null)
  */
 class AdvertRepository extends BaseAdvertRepository
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| There were incorrect definitions in frontend API AdvertRepository for visible adverts. These methods have been replaced by framework ones and now are adverts returned correctly.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-hidden-adverts.odin.shopsys.cloud
  - https://cz.tl-fix-hidden-adverts.odin.shopsys.cloud
<!-- Replace -->
