### PR TITLE
[framework] ensure proper entity name is used within getClassMetadata call

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1440,6 +1440,14 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   replace search with SearchInput in search queries in Frontend API ([#3044](https://github.com/shopsys/shopsys/pull/3044))
     -   in `articlesSearch`, `brandSearch`, `categoriesSearch` and `productsSearch` queries, the `search` argument has been replaced with `searchInput` of type `SearchInput` update your usages of these queries appropriately
     -   see #project-base-diff to update your project
+-   ensure proper entity name is used within getClassMetadata call ([#3068](https://github.com/shopsys/shopsys/pull/3068))
+    -   `Shopsys\FrameworkBundle\Model\Category\CategoryRepository::__contruct()` has changed:
+    ```diff
+        public function __construct(
+            protected readonly EntityManagerInterface $em,
+            protected readonly ProductRepository $productRepository,
+    -       EntityNameResolver $entityNameResolver,
+    ```
 
 ### Storefront
 

--- a/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
+++ b/packages/framework/src/Component/EntityExtension/EntityManagerDecorator.php
@@ -117,4 +117,15 @@ class EntityManagerDecorator extends BaseEntityManagerDecorator
 
         return $this->repositoryFactory->getRepository($this, $resolvedClassName);
     }
+
+    /**
+     * @param string $className
+     * @return \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    public function getClassMetadata($className)
+    {
+        $resolvedClassName = $this->entityNameResolver->resolve($className);
+
+        return parent::getClassMetadata($resolvedClassName);
+    }
 }

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
-use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\String\DatabaseSearching;
 use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
@@ -28,15 +27,12 @@ class CategoryRepository extends NestedTreeRepository
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
-     * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly ProductRepository $productRepository,
-        EntityNameResolver $entityNameResolver,
     ) {
-        $resolvedClassName = $entityNameResolver->resolve(Category::class);
-        $classMetadata = $this->em->getClassMetadata($resolvedClassName);
+        $classMetadata = $this->em->getClassMetadata(Category::class);
 
         parent::__construct($this->em, $classMetadata);
     }

--- a/project-base/app/src/Model/Category/CategoryRepository.php
+++ b/project-base/app/src/Model/Category/CategoryRepository.php
@@ -36,7 +36,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
  * @method \App\Model\Category\Category[] getCategoriesByIds(int[] $categoryIds)
  * @method \App\Model\Category\Category[] getCategoriesWithVisibleChildren(\App\Model\Category\Category[] $categories, int $domainId)
  * @property \App\Model\Product\ProductRepository $productRepository
- * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductRepository $productRepository, \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver)
+ * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductRepository $productRepository)
  * @method \App\Model\Category\Category[] getAllTranslatedWithoutBranch(\App\Model\Category\Category $categoryBranch, string $locale)
  * @method \App\Model\Category\Category[] getAllTranslated(string $locale)
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Extended entity name should be used when calling getClassMetadata on the entity manager
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #3066 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-metadata-resolver.odin.shopsys.cloud
  - https://cz.rv-metadata-resolver.odin.shopsys.cloud
<!-- Replace -->
