### PR TITLE
[SSP-2204] added visitAndWaitForStableDOM for visiting pages in cypress

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -295,3 +295,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 #### refactor mobile menu ([#3035](https://github.com/shopsys/shopsys/pull/3035))
 
 -   now the whole component is refactored and is included with new design
+
+#### added visitAndWaitForStableDOM for visiting pages in cypress ([#3071](https://github.com/shopsys/shopsys/pull/3071))
+
+-   change all `cy.visit` to `cy.visitAndWaitForStableDOM`, to make sure that cypress waits for the DOM to be stable before interacting

--- a/docs/storefront/cypress.md
+++ b/docs/storefront/cypress.md
@@ -78,7 +78,13 @@ describe('<Domain Specific Functionality> tests', () => {
 });
 ```
 
-### How to write a custom cypress command
+### Custom cypress commands
+
+Below are some examples of custom commands. We mention only those, that should be used instead of the default cypress commands.
+
+-   `cy.visitAndWaitForStableDOM` (instead of `cy.visit`): Use this command for visiting pages. This command makes sure that the tests wait for the DOM to be stable, ensuring that the tests do not click on non-interactive (yet visible) elements.
+
+#### How to write a custom cypress command
 
 If you want to add a custom cypress command using `Cypress.Commands.add`, which might be helpful if you want to define a command "the cypress way" and allow it to be chained with other commands, you need to add a similar entry in the `/support/index.ts` file. You will need to set its name and interface, together with the actual logic. In the end, you might need to return a suitable cypress object to allow for chaining.
 

--- a/project-base/storefront/cypress/cypress.d.ts
+++ b/project-base/storefront/cypress/cypress.d.ts
@@ -5,6 +5,8 @@ declare global {
         interface Chainable<Subject = any> {
             getByTID(value: ([TIDs, number] | TIDs)[]): Chainable<JQuery<HTMLElement>>;
             storeCartUuidInLocalStorage(cartUuid: string): Cypress.Chainable<undefined>;
+            visitAndWaitForStableDOM(url: string): Cypress.Chainable<JQuery<HTMLElement>>;
+            reloadAndWaitForStableDOM(): Cypress.Chainable<JQuery<HTMLElement>>;
             addProductToCartForTest(productUuid?: string, quantity?: number): Cypress.Chainable<any>;
             preselectTransportForTest(
                 transportUuid: string,

--- a/project-base/storefront/cypress/e2e/authentication/authentication.cy.ts
+++ b/project-base/storefront/cypress/e2e/authentication/authentication.cy.ts
@@ -16,7 +16,7 @@ describe('Authentication tests', () => {
     });
 
     it('should login from header and then log out', () => {
-        cy.visit('/');
+        cy.visitAndWaitForStableDOM('/');
         loginFromHeader(customer1.emailRegistered, customer1.password);
         checkUserIsLoggedIn();
         checkAndHideSuccessToast();
@@ -26,7 +26,7 @@ describe('Authentication tests', () => {
     });
 
     it('should login from login page and then log out', () => {
-        cy.visit(url.login);
+        cy.visitAndWaitForStableDOM(url.login);
         fillInEmailAndPasswordOnLoginPage(customer1.emailRegistered, customer1.password);
         cy.getByTID([TIDs.pages_login_submit]).click();
         checkUserIsLoggedIn();

--- a/project-base/storefront/cypress/e2e/cart/cartPage.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/cartPage.cy.ts
@@ -13,7 +13,7 @@ describe('Cart page tests', () => {
     beforeEach(() => {
         cy.addProductToCartForTest(undefined, 2).then((cartUuid) => cy.storeCartUuidInLocalStorage(cartUuid));
         cy.addProductToCartForTest(products.philips32PFL4308.uuid);
-        cy.visit(url.cart);
+        cy.visitAndWaitForStableDOM(url.cart);
     });
 
     it('should increase and decrease product quantity using spinbox in cart (once if clicked fast)', () => {

--- a/project-base/storefront/cypress/e2e/cart/productAddToCart.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/productAddToCart.cy.ts
@@ -18,7 +18,7 @@ describe('Product add to cart tests', () => {
     });
 
     it('should add product to cart from brand list', () => {
-        cy.visit(url.brandsOverwiev);
+        cy.visitAndWaitForStableDOM(url.brandsOverwiev);
         cy.getByTID([[TIDs.blocks_simplenavigation_, 22]])
             .contains(brandSencor)
             .should('be.visible')
@@ -29,21 +29,21 @@ describe('Product add to cart tests', () => {
     });
 
     it('should add product to cart from product detail', () => {
-        cy.visit(products.helloKitty.url);
+        cy.visitAndWaitForStableDOM(products.helloKitty.url);
         cy.getByTID([TIDs.pages_productdetail_addtocart_button]).click();
 
         checkIfCorrectlyAddedHelloKittyToCart();
     });
 
     it('should add product to cart from product list', () => {
-        cy.visit(url.categoryElectronics);
+        cy.visitAndWaitForStableDOM(url.categoryElectronics);
         addProductToCartFromProductList(products.helloKitty.catnum);
 
         checkIfCorrectlyAddedHelloKittyToCart();
     });
 
     it('should add variant product to cart from product detail', () => {
-        cy.visit(products.philips32PFL4308.url);
+        cy.visitAndWaitForStableDOM(products.philips32PFL4308.url);
         cy.getByTID([
             [TIDs.pages_productdetail_variant_, products.philips54CRT.catnum],
             TIDs.blocks_product_addtocart,
@@ -58,14 +58,14 @@ describe('Product add to cart tests', () => {
     });
 
     it('should add product to cart from promoted products on homepage', () => {
-        cy.visit('/');
+        cy.visitAndWaitForStableDOM('/');
         addProductToCartFromPromotedProductsOnHomepage(products.helloKitty.catnum);
 
         checkIfCorrectlyAddedHelloKittyToCart();
     });
 
     it('should add product to cart from search results list', () => {
-        cy.visit('/');
+        cy.visitAndWaitForStableDOM('/');
         searchProductByNameTypeEnterAndCheckResult(products.helloKitty.name, products.helloKitty.catnum);
         addProductToCartFromProductList(products.helloKitty.catnum);
 

--- a/project-base/storefront/cypress/e2e/order/createOrder.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/createOrder.cy.ts
@@ -21,7 +21,7 @@ describe('Create order tests', () => {
         cy.preselectTransportForTest(transport.czechPost.uuid);
         cy.preselectPaymentForTest(payment.onDelivery.uuid);
 
-        cy.visit(url.order.contactInformation);
+        cy.visitAndWaitForStableDOM(url.order.contactInformation);
         fillEmailInThirdStep(customer1.emailRegistered);
         fillCustomerInformationInThirdStep(customer1.phone, customer1.firstName, customer1.lastName);
         fillBillingAdressInThirdStep(customer1.billingStreet, customer1.billingCity, customer1.billingPostCode);
@@ -44,7 +44,7 @@ describe('Create order tests', () => {
         cy.preselectTransportForTest(transport.czechPost.uuid);
         cy.preselectPaymentForTest(payment.onDelivery.uuid);
 
-        cy.visit(url.order.contactInformation);
+        cy.visitAndWaitForStableDOM(url.order.contactInformation);
         fillEmailInThirdStep(customer1.email);
         fillCustomerInformationInThirdStep(customer1.phone, customer1.firstName, customer1.lastName);
         fillBillingAdressInThirdStep(customer1.billingStreet, customer1.billingCity, customer1.billingPostCode);
@@ -67,7 +67,7 @@ describe('Create order tests', () => {
         cy.preselectTransportForTest(transport.personalCollection.uuid, transport.personalCollection.storeOstrava.uuid);
         cy.preselectPaymentForTest(payment.cash.uuid);
 
-        cy.visit(url.order.contactInformation);
+        cy.visitAndWaitForStableDOM(url.order.contactInformation);
         cy.url().should('contain', url.order.contactInformation);
         fillEmailInThirdStep(customer1.email);
         fillCustomerInformationInThirdStep(customer1.phone, customer1.firstName, customer1.lastName);
@@ -91,7 +91,7 @@ describe('Create order tests', () => {
         cy.preselectTransportForTest(transport.ppl.uuid);
         cy.preselectPaymentForTest(payment.creditCard.uuid);
 
-        cy.visit(url.order.contactInformation);
+        cy.visitAndWaitForStableDOM(url.order.contactInformation);
         cy.url().should('contain', url.order.contactInformation);
         fillEmailInThirdStep(customer1.email);
         fillCustomerInformationInThirdStep(customer1.phone, customer1.firstName, customer1.lastName);

--- a/project-base/storefront/cypress/e2e/transportAndPayment/paymentSelect.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/paymentSelect.cy.ts
@@ -7,7 +7,7 @@ describe('Payment select tests', () => {
     it('should select payment by cash', () => {
         cy.addProductToCartForTest().then((cartUuid) => cy.storeCartUuidInLocalStorage(cartUuid));
         cy.preselectTransportForTest(transport.ppl.uuid);
-        cy.visit(url.order.transportAndPayment);
+        cy.visitAndWaitForStableDOM(url.order.transportAndPayment);
 
         changeSelectionOfPaymentByName(payment.cash.name);
         cy.getByTID([TIDs.loader_overlay]).should('not.exist');
@@ -22,7 +22,7 @@ describe('Payment select tests', () => {
     it('should select a payment, deselect it, and then change the payment option', () => {
         cy.addProductToCartForTest().then((cartUuid) => cy.storeCartUuidInLocalStorage(cartUuid));
         cy.preselectTransportForTest(transport.ppl.uuid);
-        cy.visit(url.order.transportAndPayment);
+        cy.visitAndWaitForStableDOM(url.order.transportAndPayment);
 
         changeSelectionOfPaymentByName(payment.cash.name);
         cy.getByTID([TIDs.loader_overlay]).should('not.exist');

--- a/project-base/storefront/cypress/e2e/transportAndPayment/transportSelect.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/transportSelect.cy.ts
@@ -17,7 +17,7 @@ describe('Transport select tests', () => {
 
     it('should select transport to home', () => {
         cy.addProductToCartForTest().then((cartUuid) => cy.storeCartUuidInLocalStorage(cartUuid));
-        cy.visit(url.order.transportAndPayment);
+        cy.visitAndWaitForStableDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(transport.czechPost.name);
 
@@ -29,7 +29,7 @@ describe('Transport select tests', () => {
         changeDayOfWeekInTransportsApiResponse(1);
         changeDayOfWeekInChangeTransportMutationApiResponse(1);
         cy.addProductToCartForTest().then((cartUuid) => cy.storeCartUuidInLocalStorage(cartUuid));
-        cy.visit(url.order.transportAndPayment);
+        cy.visitAndWaitForStableDOM(url.order.transportAndPayment);
 
         chooseTransportPersonalCollectionAndStore(transport.personalCollection.storeOstrava.name);
 
@@ -39,7 +39,7 @@ describe('Transport select tests', () => {
 
     it('should select a transport, deselect it, and then change the transport option', () => {
         cy.addProductToCartForTest().then((cartUuid) => cy.storeCartUuidInLocalStorage(cartUuid));
-        cy.visit(url.order.transportAndPayment);
+        cy.visitAndWaitForStableDOM(url.order.transportAndPayment);
 
         changeSelectionOfTransportByName(transport.czechPost.name);
         cy.getByTID([TIDs.loader_overlay]).should('not.exist');

--- a/project-base/storefront/cypress/package-lock.json
+++ b/project-base/storefront/cypress/package-lock.json
@@ -12,6 +12,7 @@
                 "cypress-real-events": "^1.10.0",
                 "cypress-set-device-pixel-ratio": "^1.0.4",
                 "cypress-visual-regression": "^3.0.0",
+                "cypress-wait-for-stable-dom": "^0.1.0",
                 "typescript": "^5.1.6"
             }
         },
@@ -52,6 +53,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/@cypress/request/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@cypress/xvfb": {
@@ -642,6 +652,12 @@
             "peerDependencies": {
                 "cypress": ">=9.7.0"
             }
+        },
+        "node_modules/cypress-wait-for-stable-dom": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cypress-wait-for-stable-dom/-/cypress-wait-for-stable-dom-0.1.0.tgz",
+            "integrity": "sha512-iVJc6CDzlu1xUnTcZph+zbkOlImaDelpvRv4G+3naugvjkF6b9EFpDmRCC/16xL1pqpkFq4rFyfhuNw4C3PQjw==",
+            "dev": true
         },
         "node_modules/cypress-wait-until": {
             "version": "3.0.1",
@@ -2078,15 +2094,6 @@
             "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
             "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
             "dev": true
-        },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/verror": {
             "version": "1.10.0",

--- a/project-base/storefront/cypress/package.json
+++ b/project-base/storefront/cypress/package.json
@@ -13,6 +13,7 @@
         "cypress-real-events": "^1.10.0",
         "cypress-set-device-pixel-ratio": "^1.0.4",
         "cypress-visual-regression": "^3.0.0",
+        "cypress-wait-for-stable-dom": "^0.1.0",
         "typescript": "^5.1.6"
     }
 }

--- a/project-base/storefront/cypress/support/index.ts
+++ b/project-base/storefront/cypress/support/index.ts
@@ -1,8 +1,12 @@
+/// <reference types="cypress-wait-for-stable-dom" />
 import 'cypress-real-events';
 import 'cypress-set-device-pixel-ratio';
 import compareSnapshotCommand from 'cypress-visual-regression/dist/command';
+import { registerCommand } from 'cypress-wait-for-stable-dom';
 import { DEFAULT_APP_STORE, products } from 'fixtures/demodata';
 import { TIDs } from 'tids';
+
+registerCommand();
 
 Cypress.Commands.add('getByTID', (selectors: ([TIDs, number] | TIDs)[]) => {
     let selectorString = '';
@@ -151,6 +155,11 @@ Cypress.Commands.add('preselectPaymentForTest', (paymentUuid: string) => {
             expect(cart.uuid).equal(currentAppStore.state.cartUuid);
             expect(cart.payment.uuid).equal(paymentUuid);
         });
+});
+
+Cypress.Commands.add('visitAndWaitForStableDOM', (url: string) => {
+    cy.visit(url);
+    return cy.waitForStableDOM({ pollInterval: 500, timeout: 5000 });
 });
 
 compareSnapshotCommand({


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Adding the new cy.visitAndWaitForStableDOM command, which should be used instead of cy.visit, helps with waiting for the application to be stable (stable DOM) before cypress tests start interacting with it.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2204-cypress-wait-for-stable-dom.odin.shopsys.cloud
  - https://cz.sh-ssp-2204-cypress-wait-for-stable-dom.odin.shopsys.cloud
<!-- Replace -->
