### PR TITLE
rename reserved database function normalize to non-reserved name normalized

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -458,6 +458,12 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   product variants cache in `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductExportRepository`
 -   see #project-base-diff to update your project
 
+#### rename reserved database function `normalize` to non-reserved name `normalized` ([#3072](https://github.com/shopsys/shopsys/pull/3072))
+
+-   create migration to change `normalize()` function to `normalized()` if you had used it in some indexes, functions, or somewhere else
+-   don't forget to rename this function in SQLs in repositories, commands, or somewhere else where is used
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Component/Doctrine/NormalizedFunction.php
+++ b/packages/framework/src/Component/Doctrine/NormalizedFunction.php
@@ -10,9 +10,9 @@ use Doctrine\ORM\Query\Lexer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\SqlWalker;
 
-class NormalizeFunction extends FunctionNode
+class NormalizedFunction extends FunctionNode
 {
-    protected const FUNCTION_NORMALIZE = 'normalize';
+    protected const FUNCTION_NORMALIZED = 'normalized';
 
     public Node $stringExpression;
 
@@ -33,6 +33,6 @@ class NormalizeFunction extends FunctionNode
      */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return static::FUNCTION_NORMALIZE . '(' . $this->stringExpression->dispatch($sqlWalker) . ')';
+        return static::FUNCTION_NORMALIZED . '(' . $this->stringExpression->dispatch($sqlWalker) . ')';
     }
 }

--- a/packages/framework/src/Migrations/Version20180603135340.php
+++ b/packages/framework/src/Migrations/Version20180603135340.php
@@ -17,7 +17,7 @@ class Version20180603135340 extends AbstractMigration
         $this->createGetDomainIdsByLocaleFunction();
         $this->createGetDomainLocaleFunction();
         $this->createImmutableUnaccentFunction();
-        $this->createNormalizeFunction();
+        $this->createNormalizedFunction();
         $this->createDefaultDbIndexes();
         $this->createProductCatnumTrigger();
         $this->createProductPartnoTrigger();
@@ -69,9 +69,9 @@ class Version20180603135340 extends AbstractMigration
             LANGUAGE SQL IMMUTABLE');
     }
 
-    private function createNormalizeFunction(): void
+    private function createNormalizedFunction(): void
     {
-        $this->sql('CREATE OR REPLACE FUNCTION normalize(text)
+        $this->sql('CREATE OR REPLACE FUNCTION normalized(text)
             RETURNS text AS
             $$
             SELECT pg_catalog.lower(public.immutable_unaccent($1))
@@ -82,19 +82,19 @@ class Version20180603135340 extends AbstractMigration
     private function createDefaultDbIndexes(): void
     {
         $this->sql('CREATE INDEX IF NOT EXISTS product_translations_name_normalize_idx
-            ON product_translations (NORMALIZE(name))');
+            ON product_translations (NORMALIZED(name))');
         $this->sql('CREATE INDEX IF NOT EXISTS product_catnum_normalize_idx
-            ON products (NORMALIZE(catnum))');
+            ON products (NORMALIZED(catnum))');
         $this->sql('CREATE INDEX IF NOT EXISTS product_partno_normalize_idx
-            ON products (NORMALIZE(partno))');
+            ON products (NORMALIZED(partno))');
         $this->sql('CREATE INDEX IF NOT EXISTS order_email_normalize_idx
-            ON orders (NORMALIZE(email))');
+            ON orders (NORMALIZED(email))');
         $this->sql('CREATE INDEX IF NOT EXISTS order_last_name_normalize_idx
-            ON orders (NORMALIZE(last_name))');
+            ON orders (NORMALIZED(last_name))');
         $this->sql('CREATE INDEX IF NOT EXISTS order_company_name_normalize_idx
-            ON orders (NORMALIZE(company_name))');
+            ON orders (NORMALIZED(company_name))');
         $this->sql('CREATE INDEX IF NOT EXISTS user_email_normalize_idx
-            ON users (NORMALIZE(email))');
+            ON users (NORMALIZED(email))');
     }
 
     private function createProductCatnumTrigger(): void

--- a/packages/framework/src/Migrations/Version20240318162418.php
+++ b/packages/framework/src/Migrations/Version20240318162418.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20240318162418 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $postgresqlVersion = $this->sql('SELECT version();')->fetchOne();
+        $postgresqlVersion = substr($postgresqlVersion, 11, 2);
+        $existsNormalizeFunction = $this->sql('SELECT 1 FROM pg_proc WHERE proname = \'normalize\'')->fetchOne();
+
+        if ($postgresqlVersion > 12 || $existsNormalizeFunction !== 1) {
+            return;
+        }
+
+        $this->sql('ALTER FUNCTION normalize(text) RENAME TO normalized;');
+
+        $this->editDefaultDbIndexes();
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+
+    private function editDefaultDbIndexes(): void
+    {
+        $this->sql('DROP INDEX IF EXISTS product_translations_name_normalize_idx;');
+        $this->sql('DROP INDEX IF EXISTS product_catnum_normalize_idx;');
+        $this->sql('DROP INDEX IF EXISTS product_partno_normalize_idx;');
+        $this->sql('DROP INDEX IF EXISTS order_email_normalize_idx;');
+        $this->sql('DROP INDEX IF EXISTS order_last_name_normalize_idx;');
+        $this->sql('DROP INDEX IF EXISTS order_company_name_normalize_idx;');
+
+        $this->sql('CREATE INDEX IF NOT EXISTS product_translations_name_normalized_idx
+            ON product_translations (NORMALIZED(name))');
+        $this->sql('CREATE INDEX IF NOT EXISTS product_catnum_normalized_idx
+            ON products (NORMALIZED(catnum))');
+        $this->sql('CREATE INDEX IF NOT EXISTS product_partno_normalized_idx
+            ON products (NORMALIZED(partno))');
+        $this->sql('CREATE INDEX IF NOT EXISTS order_email_normalized_idx
+            ON orders (NORMALIZED(email))');
+        $this->sql('CREATE INDEX IF NOT EXISTS order_last_name_normalized_idx
+            ON orders (NORMALIZED(last_name))');
+        $this->sql('CREATE INDEX IF NOT EXISTS order_company_name_normalized_idx
+            ON orders (NORMALIZED(company_name))');
+    }
+}

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCatnumFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCatnumFilter.php
@@ -70,7 +70,7 @@ class ProductCatnumFilter implements AdvancedSearchFilterInterface
 
                 $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
                 $parameterName = 'productCatnum_' . $index;
-                $queryBuilder->andWhere('NORMALIZE(p.catnum) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')');
+                $queryBuilder->andWhere('NORMALIZED(p.catnum) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')');
                 $queryBuilder->setParameter($parameterName, $searchValue);
             }
         }

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductNameFilter.php
@@ -62,7 +62,7 @@ class ProductNameFilter implements AdvancedSearchFilterInterface
             }
             $dqlOperator = $this->getDqlOperator($ruleData->operator);
             $parameterName = 'productName_' . $index;
-            $queryBuilder->andWhere('NORMALIZE(pt.name) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')');
+            $queryBuilder->andWhere('NORMALIZED(pt.name) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')');
             $queryBuilder->setParameter($parameterName, $searchValue);
         }
     }

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductPartnoFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductPartnoFilter.php
@@ -70,7 +70,7 @@ class ProductPartnoFilter implements AdvancedSearchFilterInterface
 
                 $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
                 $parameterName = 'productPartno_' . $index;
-                $queryBuilder->andWhere('NORMALIZE(p.partno) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')');
+                $queryBuilder->andWhere('NORMALIZED(p.partno) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')');
                 $queryBuilder->setParameter($parameterName, $searchValue);
             }
         }

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderCityFilter.php
@@ -63,7 +63,7 @@ class OrderCityFilter implements AdvancedSearchFilterInterface
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
             $parameterName = 'city_' . $index;
             $queryBuilder->andWhere(
-                'NORMALIZE(o.deliveryCity) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ') OR NORMALIZE(o.city) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')',
+                'NORMALIZED(o.deliveryCity) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ') OR NORMALIZED(o.city) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')',
             );
             $queryBuilder->setParameter($parameterName, $searchValue);
         }

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderEmailFilter.php
@@ -59,7 +59,7 @@ class OrderEmailFilter implements AdvancedSearchFilterInterface
             }
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
             $parameterName = 'email_' . $index;
-            $queryBuilder->andWhere('NORMALIZE(o.email) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')');
+            $queryBuilder->andWhere('NORMALIZED(o.email) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')');
             $queryBuilder->setParameter($parameterName, $searchValue);
         }
     }

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderLastNameFilter.php
@@ -63,7 +63,7 @@ class OrderLastNameFilter implements AdvancedSearchFilterInterface
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
             $parameterName = 'lastName_' . $index;
             $queryBuilder->andWhere(
-                'NORMALIZE(o.lastName) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ') OR NORMALIZE(o.deliveryLastName) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')',
+                'NORMALIZED(o.lastName) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ') OR NORMALIZED(o.deliveryLastName) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')',
             );
             $queryBuilder->setParameter($parameterName, $searchValue);
         }

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderNameFilter.php
@@ -63,7 +63,7 @@ class OrderNameFilter implements AdvancedSearchFilterInterface
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
             $parameterName = 'name_' . $index;
             $queryBuilder->andWhere(
-                'NORMALIZE(o.firstName) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ') OR NORMALIZE(o.deliveryFirstName) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')',
+                'NORMALIZED(o.firstName) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ') OR NORMALIZED(o.deliveryFirstName) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')',
             );
             $queryBuilder->setParameter($parameterName, $searchValue);
         }

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderPhoneNumberFilter.php
@@ -62,7 +62,7 @@ class OrderPhoneNumberFilter implements AdvancedSearchFilterInterface
             }
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
             $parameterName = 'phoneNumber_' . $index;
-            $queryBuilder->andWhere('NORMALIZE(o.telephone) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')');
+            $queryBuilder->andWhere('NORMALIZED(o.telephone) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')');
             $queryBuilder->setParameter($parameterName, $searchValue);
         }
     }

--- a/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
+++ b/packages/framework/src/Model/AdvancedSearchOrder/Filter/OrderStreetFilter.php
@@ -63,7 +63,7 @@ class OrderStreetFilter implements AdvancedSearchFilterInterface
             $dqlOperator = $this->getContainsDqlOperator($ruleData->operator);
             $parameterName = 'city_' . $index;
             $queryBuilder->andWhere(
-                'NORMALIZE(o.street) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ') OR NORMALIZE(o.deliveryStreet) ' . $dqlOperator . ' NORMALIZE(:' . $parameterName . ')',
+                'NORMALIZED(o.street) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ') OR NORMALIZED(o.deliveryStreet) ' . $dqlOperator . ' NORMALIZED(:' . $parameterName . ')',
             );
             $queryBuilder->setParameter($parameterName, $searchValue);
         }

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -433,7 +433,7 @@ class CategoryRepository extends NestedTreeRepository
     public function filterBySearchText(QueryBuilder $queryBuilder, $searchText)
     {
         $queryBuilder->andWhere(
-            'NORMALIZE(ct.name) LIKE NORMALIZE(:searchText)',
+            'NORMALIZED(ct.name) LIKE NORMALIZED(:searchText)',
         );
         $queryBuilder->setParameter('searchText', DatabaseSearching::getFullTextLikeSearchString($searchText));
     }

--- a/packages/framework/src/Model/Customer/User/CustomerUserRepository.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserRepository.php
@@ -140,13 +140,13 @@ class CustomerUserRepository
             $queryBuilder
                 ->andWhere('
                     (
-                        NORMALIZE(u.lastName) LIKE NORMALIZE(:text)
+                        NORMALIZED(u.lastName) LIKE NORMALIZED(:text)
                         OR
-                        NORMALIZE(u.email) LIKE NORMALIZE(:text)
+                        NORMALIZED(u.email) LIKE NORMALIZED(:text)
                         OR
-                        NORMALIZE(ba.companyName) LIKE NORMALIZE(:text)
+                        NORMALIZED(ba.companyName) LIKE NORMALIZED(:text)
                         OR
-                        NORMALIZE(u.telephone) LIKE :text
+                        NORMALIZED(u.telephone) LIKE :text
                     )');
             $querySearchText = DatabaseSearching::getFullTextLikeSearchString($quickSearchData->text);
             $queryBuilder->setParameter('text', $querySearchText);

--- a/packages/framework/src/Model/Newsletter/NewsletterRepository.php
+++ b/packages/framework/src/Model/Newsletter/NewsletterRepository.php
@@ -71,7 +71,7 @@ class NewsletterRepository
             ->setParameter('domainId', $domainId);
 
         if ($searchData->text !== null && $searchData->text !== '') {
-            $queryBuilder->andWhere('NORMALIZE(ns.email) LIKE NORMALIZE(:searchData)')
+            $queryBuilder->andWhere('NORMALIZED(ns.email) LIKE NORMALIZED(:searchData)')
                 ->setParameter('searchData', DatabaseSearching::getFullTextLikeSearchString($searchData->text));
         }
 

--- a/packages/framework/src/Model/Order/OrderRepository.php
+++ b/packages/framework/src/Model/Order/OrderRepository.php
@@ -148,13 +148,13 @@ class OrderRepository
                     (
                         o.number LIKE :text
                         OR
-                        NORMALIZE(o.email) LIKE NORMALIZE(:text)
+                        NORMALIZED(o.email) LIKE NORMALIZED(:text)
                         OR
-                        NORMALIZE(o.lastName) LIKE NORMALIZE(:text)
+                        NORMALIZED(o.lastName) LIKE NORMALIZED(:text)
                         OR
-                        NORMALIZE(o.companyName) LIKE NORMALIZE(:text)
+                        NORMALIZED(o.companyName) LIKE NORMALIZED(:text)
                         OR
-                        NORMALIZE(u.email) LIKE NORMALIZE(:text)
+                        NORMALIZED(u.email) LIKE NORMALIZED(:text)
                     )');
             $querySearchText = DatabaseSearching::getFullTextLikeSearchString($quickSearchData->text);
             $queryBuilder->setParameter('text', $querySearchText);

--- a/packages/framework/src/Model/Product/Brand/BrandRepository.php
+++ b/packages/framework/src/Model/Product/Brand/BrandRepository.php
@@ -103,7 +103,7 @@ class BrandRepository
         $queryBuilder = $this->getBrandRepository()
             ->createQueryBuilder('b')
             ->andWhere(
-                'NORMALIZE(b.name) LIKE NORMALIZE(:searchText)',
+                'NORMALIZED(b.name) LIKE NORMALIZED(:searchText)',
             );
         $queryBuilder->setParameter('searchText', DatabaseSearching::getFullTextLikeSearchString($searchText));
         $queryBuilder->orderBy(OrderByCollationHelper::createOrderByForLocale('b.name', $this->domain->getLocale()));

--- a/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
@@ -61,11 +61,11 @@ class ProductListAdminRepository
         if ($quickSearchData->text !== null && $quickSearchData->text !== '') {
             $queryBuilder->andWhere('
                 (
-                    NORMALIZE(pt.name) LIKE NORMALIZE(:text)
+                    NORMALIZED(pt.name) LIKE NORMALIZED(:text)
                     OR
-                    NORMALIZE(p.catnum) LIKE NORMALIZE(:text)
+                    NORMALIZED(p.catnum) LIKE NORMALIZED(:text)
                     OR
-                    NORMALIZE(p.partno) LIKE NORMALIZE(:text)
+                    NORMALIZED(p.partno) LIKE NORMALIZED(:text)
                 )');
             $querySearchText = DatabaseSearching::getFullTextLikeSearchString($quickSearchData->text);
             $queryBuilder->setParameter('text', $querySearchText);

--- a/project-base/app/config/packages/doctrine.yaml
+++ b/project-base/app/config/packages/doctrine.yaml
@@ -20,7 +20,7 @@ doctrine:
             string_functions:
                 bool_and: App\Component\Doctrine\BoolAndFunction
                 collate: Shopsys\FrameworkBundle\Component\Doctrine\CollateFunction
-                normalize: Shopsys\FrameworkBundle\Component\Doctrine\NormalizeFunction
+                normalized: Shopsys\FrameworkBundle\Component\Doctrine\NormalizedFunction
                 field: Shopsys\FrameworkBundle\Component\Doctrine\FieldFunction
         naming_strategy: doctrine.orm.naming_strategy.underscore
         metadata_cache_driver:

--- a/project-base/app/src/Component/Router/FriendlyUrl/FriendlyUrlRepository.php
+++ b/project-base/app/src/Component/Router/FriendlyUrl/FriendlyUrlRepository.php
@@ -49,7 +49,7 @@ class FriendlyUrlRepository extends BaseFriendlyUrlRepository
 
         if ($quickSearchData->text !== null && $quickSearchData->text !== '') {
             $queryBuilder
-                ->andWhere('NORMALIZE(fu.slug) LIKE NORMALIZE(:text)');
+                ->andWhere('NORMALIZED(fu.slug) LIKE NORMALIZED(:text)');
             $querySearchText = DatabaseSearching::getFullTextLikeSearchString($quickSearchData->text);
             $queryBuilder->setParameter('text', $querySearchText);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| From Postgres 13 and higher is function `normalize` reserved by Postgres, so we need to rename it to non-reserved name
|New feature| No 
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes
|Fixes issues| closes #3064 
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pt-postgres-normalize.odin.shopsys.cloud
  - https://cz.pt-postgres-normalize.odin.shopsys.cloud
<!-- Replace -->
