### PR TITLE
[framework] remove enums from the packages

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -836,7 +836,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         ```diff
             public function create(
                 ProductData $productData
-        +       ?ProductRecalculationPriorityEnumInterface $priority = null,
+        +       string $priority = ProductRecalculationPriorityEnum::REGULAR,
         -   )
         +   ): Product
         ```
@@ -846,7 +846,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
         -       $productId,
         +       int $productId,
                 ProductData $productData,
-        +       ?ProductRecalculationPriorityEnumInterface $priority = null,
+        +       string $priority = ProductRecalculationPriorityEnum::REGULAR,
         -   )
         +   ): Product
         ```
@@ -855,7 +855,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
             public function delete(
         -       $productId
         +       int $productId,
-        +       ?ProductRecalculationPriorityEnumInterface $priority = null,
+        +       string $priority = ProductRecalculationPriorityEnum::REGULAR,
         -   )
         +   ): void
         ```

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -184,3 +184,12 @@ You can set this hostname in your `docker-compose` file like this:
       image: namshi/smtp:latest
 +     hostname: my-host-machine-hostname.provider.org
 ```
+
+## Why I see Enum classes in the Framework that are not actually PHP enums?
+
+The main reason, why we do not use PHP enums, is that [they are not extensible](https://www.php.net/manual/en/language.enumerations.object-differences.inheritance.php).
+The class inheritance is one of the main approaches how to extend the Shopsys Framework functionality on a project, so we decided to use classes instead of enums to enable the extensibility.
+Therefore, you can see e.g. `ProductListTypeEnum` which is a class with constants instead of the PHP enum.
+Moreover, the class extends `AbstractEnum` that provides `getAllCases()` method.
+The method uses reflection to return all the public constants of the class which simulates the behavior of `cases()` method of the PHP enums.
+The key factor here is that the method is not static, and therefore it would include also the constants of the child class when the "enum" class is extended on a project.

--- a/packages/framework/src/Component/EntityLog/Detection/DetectionFacade.php
+++ b/packages/framework/src/Component/EntityLog/Detection/DetectionFacade.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\EntityLog\Detection;
 
 use Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum;
-use Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnumInterface;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Symfony\Component\Security\Core\Security;
 
 class DetectionFacade
 {
-    /**
-     * @var \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum|null
-     */
-    protected ?EntityLogSourceEnumInterface $source = null;
+    protected ?string $source = null;
 
     protected ?string $userIdentifier = null;
 
@@ -55,13 +51,13 @@ class DetectionFacade
             return $administrator->getUserIdentifier();
         }
 
-        return EntityLogSourceEnum::SYSTEM->value;
+        return EntityLogSourceEnum::SYSTEM;
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum
+     * @return string
      */
-    public function getEntityLogSource(): EntityLogSourceEnumInterface
+    public function getEntityLogSource(): string
     {
         if ($this->source !== null) {
             return $this->source;

--- a/packages/framework/src/Component/EntityLog/Enum/EntityLogActionEnum.php
+++ b/packages/framework/src/Component/EntityLog/Enum/EntityLogActionEnum.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\EntityLog\Enum;
 
-enum EntityLogActionEnum: string implements EntityLogActionEnumInterface
+use Shopsys\FrameworkBundle\Component\Enum\AbstractEnum;
+
+class EntityLogActionEnum extends AbstractEnum
 {
-    case CREATE = 'create';
-    case UPDATE = 'update';
-    case DELETE = 'delete';
+    public const string CREATE = 'create';
+    public const string UPDATE = 'update';
+    public const string DELETE = 'delete';
 }

--- a/packages/framework/src/Component/EntityLog/Enum/EntityLogActionEnumInterface.php
+++ b/packages/framework/src/Component/EntityLog/Enum/EntityLogActionEnumInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Shopsys\FrameworkBundle\Component\EntityLog\Enum;
-
-interface EntityLogActionEnumInterface
-{
-}

--- a/packages/framework/src/Component/EntityLog/Enum/EntityLogSourceEnum.php
+++ b/packages/framework/src/Component/EntityLog/Enum/EntityLogSourceEnum.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\EntityLog\Enum;
 
-enum EntityLogSourceEnum: string implements EntityLogSourceEnumInterface
+use Shopsys\FrameworkBundle\Component\Enum\AbstractEnum;
+
+class EntityLogSourceEnum extends AbstractEnum
 {
-    case USER = 'user';
-    case ADMIN = 'admin';
-    case API = 'api';
-    case SYSTEM = 'system';
+    public const string USER = 'user';
+    public const string ADMIN = 'admin';
+    public const string API = 'api';
+    public const string SYSTEM = 'system';
 }

--- a/packages/framework/src/Component/EntityLog/Enum/EntityLogSourceEnumInterface.php
+++ b/packages/framework/src/Component/EntityLog/Enum/EntityLogSourceEnumInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Shopsys\FrameworkBundle\Component\EntityLog\Enum;
-
-interface EntityLogSourceEnumInterface
-{
-}

--- a/packages/framework/src/Component/EntityLog/EventListener/EntityLogEventListener.php
+++ b/packages/framework/src/Component/EntityLog/EventListener/EntityLogEventListener.php
@@ -14,7 +14,6 @@ use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfig;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfigFactory;
 use Shopsys\FrameworkBundle\Component\EntityLog\ChangeSet\ChangeSetResolver;
 use Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum;
-use Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnumInterface;
 use Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogFacade;
 use Symfony\Contracts\Service\ResetInterface;
 use Throwable;
@@ -93,10 +92,10 @@ class EntityLogEventListener implements ResetInterface
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum $actionEnum
+     * @param string $action
      * @param object $entity
      */
-    protected function log(EntityLogActionEnumInterface $actionEnum, object $entity): void
+    protected function log(string $action, object $entity): void
     {
         $loggableSetup = $this->loggableEntityConfigFactory->getLoggableSetupByEntity($entity);
 
@@ -105,7 +104,7 @@ class EntityLogEventListener implements ResetInterface
                 return;
             }
 
-            $this->registerLog($entity, $loggableSetup, $actionEnum);
+            $this->registerLog($entity, $loggableSetup, $action);
         } catch (Throwable $exception) {
             $this->monolog->error($exception->getMessage());
         }
@@ -114,16 +113,16 @@ class EntityLogEventListener implements ResetInterface
     /**
      * @param object $entity
      * @param \Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfig $loggableSetup
-     * @param \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum $actionEnum
+     * @param string $action
      */
     protected function registerLog(
         object $entity,
         LoggableEntityConfig $loggableSetup,
-        EntityLogActionEnumInterface $actionEnum,
+        string $action,
     ): void {
         $resolvedChangeSet = [];
 
-        if ($actionEnum === EntityLogActionEnum::UPDATE) {
+        if ($action === EntityLogActionEnum::UPDATE) {
             $resolvedChangeSet = $this->resolveUpdateChangeSet($entity);
 
             if (count($resolvedChangeSet) === 0) {
@@ -131,7 +130,7 @@ class EntityLogEventListener implements ResetInterface
             }
         }
 
-        $this->logs[] = $this->entityLogFacade->createEntityLog($entity, $loggableSetup, $actionEnum, $resolvedChangeSet);
+        $this->logs[] = $this->entityLogFacade->createEntityLog($entity, $loggableSetup, $action, $resolvedChangeSet);
     }
 
     /**

--- a/packages/framework/src/Component/EntityLog/Model/EntityLog.php
+++ b/packages/framework/src/Component/EntityLog/Model/EntityLog.php
@@ -30,8 +30,8 @@ class EntityLog
     protected $id;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum
-     * @ORM\Column(type="string", enumType="Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum")
+     * @var string
+     * @ORM\Column(type="string", length=255)
      */
     protected $action;
 
@@ -140,7 +140,7 @@ class EntityLog
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum
+     * @return string
      */
     public function getAction()
     {

--- a/packages/framework/src/Component/EntityLog/Model/EntityLog.php
+++ b/packages/framework/src/Component/EntityLog/Model/EntityLog.php
@@ -60,8 +60,8 @@ class EntityLog
     protected $entityIdentifier;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum
-     * @ORM\Column(type="string", enumType="Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum")
+     * @var string
+     * @ORM\Column(type="string", length=255)
      */
     protected $source;
 
@@ -180,7 +180,7 @@ class EntityLog
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum
+     * @return string
      */
     public function getSource()
     {

--- a/packages/framework/src/Component/EntityLog/Model/EntityLogData.php
+++ b/packages/framework/src/Component/EntityLog/Model/EntityLogData.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\EntityLog\Model;
 class EntityLogData
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum|null
+     * @var string|null
      */
     public $action = null;
 

--- a/packages/framework/src/Component/EntityLog/Model/EntityLogData.php
+++ b/packages/framework/src/Component/EntityLog/Model/EntityLogData.php
@@ -32,7 +32,7 @@ class EntityLogData
     public $entityIdentifier = null;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum|null
+     * @var string|null
      */
     public $source = null;
 

--- a/packages/framework/src/Component/EntityLog/Model/EntityLogFacade.php
+++ b/packages/framework/src/Component/EntityLog/Model/EntityLogFacade.php
@@ -6,7 +6,6 @@ namespace Shopsys\FrameworkBundle\Component\EntityLog\Model;
 
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfig;
 use Shopsys\FrameworkBundle\Component\EntityLog\Detection\DetectionFacade;
-use Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnumInterface;
 use Shopsys\FrameworkBundle\Component\EntityLog\Exception\NotLoggableException;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
@@ -58,14 +57,14 @@ class EntityLogFacade
     /**
      * @param object $entity
      * @param \Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfig $loggableEntityConfig
-     * @param \Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogActionEnum $actionEnum
+     * @param string $action
      * @param array $changes
      * @return \Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLog
      */
     public function createEntityLog(
         object $entity,
         LoggableEntityConfig $loggableEntityConfig,
-        EntityLogActionEnumInterface $actionEnum,
+        string $action,
         array $changes = [],
     ): EntityLog {
         $userIdentifier = $this->detectionFacade->getUserIdentifier();
@@ -75,7 +74,7 @@ class EntityLogFacade
         $parentEntity = $parentEntityFunctionName ? call_user_func([$entity, $parentEntityFunctionName]) : null;
 
         $entityLogData = $this->entityLogDataFactory->create();
-        $entityLogData->action = $actionEnum;
+        $entityLogData->action = $action;
         $entityLogData->userIdentifier = $userIdentifier;
         $entityLogData->entityName = $loggableEntityConfig->getEntityName();
         $entityLogData->entityId = $this->getEntityIdentifierByEntityAndLoggableSetup($entity);

--- a/packages/framework/src/Component/Enum/AbstractEnum.php
+++ b/packages/framework/src/Component/Enum/AbstractEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Enum;
+
+use Shopsys\FrameworkBundle\Component\Reflection\ReflectionHelper;
+
+class AbstractEnum
+{
+    /**
+     * @return string[]
+     */
+    public function getAllCases(): array
+    {
+        return ReflectionHelper::getAllPublicClassConstants(static::class);
+    }
+}

--- a/packages/framework/src/Component/Reflection/ReflectionHelper.php
+++ b/packages/framework/src/Component/Reflection/ReflectionHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Reflection;
+
+use ReflectionClass;
+use ReflectionClassConstant;
+
+class ReflectionHelper
+{
+    /**
+     * @var array<string, string[]>
+     */
+    protected static array $constantsIndexedByFqcn = [];
+
+    /**
+     * @param string $fqcn
+     * @return string[]
+     */
+    public static function getAllPublicClassConstants(string $fqcn): array
+    {
+        if (array_key_exists($fqcn, self::$constantsIndexedByFqcn) === false) {
+            self::$constantsIndexedByFqcn[$fqcn] = array_values((new ReflectionClass($fqcn))->getConstants(ReflectionClassConstant::IS_PUBLIC));
+        }
+
+        return self::$constantsIndexedByFqcn[$fqcn];
+    }
+}

--- a/packages/framework/src/Model/Product/Availability/AvailabilityStatusEnum.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityStatusEnum.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Availability;
 
-enum AvailabilityStatusEnum: string implements AvailabilityStatusEnumInterface
+use Shopsys\FrameworkBundle\Component\Enum\AbstractEnum;
+
+class AvailabilityStatusEnum extends AbstractEnum
 {
-    case InStock = 'in-stock';
-    case OutOfStock = 'out-of-stock';
+    public const string IN_STOCK = 'InStock';
+    public const string OUT_OF_STOCK = 'OutOfStock';
 }

--- a/packages/framework/src/Model/Product/Availability/AvailabilityStatusEnumInterface.php
+++ b/packages/framework/src/Model/Product/Availability/AvailabilityStatusEnumInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Shopsys\FrameworkBundle\Model\Product\Availability;
-
-interface AvailabilityStatusEnumInterface
-{
-}

--- a/packages/framework/src/Model/Product/Availability/ProductAvailabilityFacade.php
+++ b/packages/framework/src/Model/Product/Availability/ProductAvailabilityFacade.php
@@ -68,17 +68,17 @@ class ProductAvailabilityFacade implements ResetInterface
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @param int $domainId
-     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityStatusEnum
+     * @return string
      */
     public function getProductAvailabilityStatusByDomainId(
         Product $product,
         int $domainId,
-    ): AvailabilityStatusEnumInterface {
+    ): string {
         if ($this->isProductAvailableOnDomainCached($product, $domainId)) {
-            return AvailabilityStatusEnum::InStock;
+            return AvailabilityStatusEnum::IN_STOCK;
         }
 
-        return AvailabilityStatusEnum::OutOfStock;
+        return AvailabilityStatusEnum::OUT_OF_STOCK;
     }
 
     /**
@@ -154,11 +154,11 @@ class ProductAvailabilityFacade implements ResetInterface
         $domainLocale = $this->domain->getDomainConfigById($domainId)->getLocale();
 
         foreach ($stores as $store) {
-            $availabilityStatus = AvailabilityStatusEnum::InStock;
+            $availabilityStatus = AvailabilityStatusEnum::IN_STOCK;
             $availabilityInformation = t('Available immediately', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $domainLocale);
 
             if (!$isAvailable) {
-                $availabilityStatus = AvailabilityStatusEnum::OutOfStock;
+                $availabilityStatus = AvailabilityStatusEnum::OUT_OF_STOCK;
                 $availabilityInformation = t('Unavailable', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $domainLocale);
             } else {
                 $stock = $store->getStock();

--- a/packages/framework/src/Model/Product/Availability/ProductStoreAvailabilityInformation.php
+++ b/packages/framework/src/Model/Product/Availability/ProductStoreAvailabilityInformation.php
@@ -10,13 +10,13 @@ class ProductStoreAvailabilityInformation
      * @param string $storeName
      * @param int $storeId
      * @param string $availabilityInformation
-     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityStatusEnum $availabilityStatus
+     * @param string $availabilityStatus
      */
     public function __construct(
         protected readonly string $storeName,
         protected readonly int $storeId,
         protected readonly string $availabilityInformation,
-        protected readonly AvailabilityStatusEnumInterface $availabilityStatus,
+        protected readonly string $availabilityStatus,
     ) {
     }
 
@@ -45,9 +45,9 @@ class ProductStoreAvailabilityInformation
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityStatusEnum
+     * @return string
      */
-    public function getAvailabilityStatus(): AvailabilityStatusEnumInterface
+    public function getAvailabilityStatus(): string
     {
         return $this->availabilityStatus;
     }

--- a/packages/framework/src/Model/Product/List/Exception/UnknownProductListTypeException.php
+++ b/packages/framework/src/Model/Product/List/Exception/UnknownProductListTypeException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\List\Exception;
+
+use Exception;
+
+class UnknownProductListTypeException extends Exception
+{
+    /**
+     * @param string $productListType
+     */
+    public function __construct(string $productListType)
+    {
+        parent::__construct(sprintf('Unknown product list type "%s"', $productListType));
+    }
+}

--- a/packages/framework/src/Model/Product/List/ProductList.php
+++ b/packages/framework/src/Model/Product/List/ProductList.php
@@ -59,8 +59,8 @@ class ProductList
     protected $updatedAt;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum
-     * @ORM\Column(type="string", length=20, nullable=false, enumType="Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum")
+     * @var string
+     * @ORM\Column(type="string", length=20, nullable=false)
      */
     protected $type;
 
@@ -118,7 +118,7 @@ class ProductList
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum
+     * @return string
      */
     public function getType()
     {

--- a/packages/framework/src/Model/Product/List/ProductListData.php
+++ b/packages/framework/src/Model/Product/List/ProductListData.php
@@ -7,7 +7,7 @@ namespace Shopsys\FrameworkBundle\Model\Product\List;
 class ProductListData
 {
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum
+     * @var string
      */
     public $type;
 

--- a/packages/framework/src/Model/Product/List/ProductListDataFactory.php
+++ b/packages/framework/src/Model/Product/List/ProductListDataFactory.php
@@ -17,13 +17,13 @@ class ProductListDataFactory
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser|null $customerUser
      * @param string|null $uuid
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductListData
      */
     public function create(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
         ?CustomerUser $customerUser,
         ?string $uuid,
     ): ProductListData {

--- a/packages/framework/src/Model/Product/List/ProductListFacade.php
+++ b/packages/framework/src/Model/Product/List/ProductListFacade.php
@@ -71,13 +71,13 @@ class ProductListFacade
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
      * @param string|null $uuid
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null
      */
     public function findProductListByTypeAndCustomerUser(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
         CustomerUser $customerUser,
         ?string $uuid = null,
     ): ?ProductList {
@@ -85,12 +85,12 @@ class ProductListFacade
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList[]
      */
     public function getProductListsByTypeAndCustomerUser(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
         CustomerUser $customerUser,
     ): array {
         return $this->productListRepository->getProductListsByTypeAndCustomerUser($productListType, $customerUser);
@@ -98,12 +98,12 @@ class ProductListFacade
 
     /**
      * @param string $uuid
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum|null $productListType
+     * @param string|null $productListType
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null
      */
     public function findAnonymousProductList(
         string $uuid,
-        ?ProductListTypeEnumInterface $productListType = null,
+        ?string $productListType = null,
     ): ?ProductList {
         return $this->productListRepository->findAnonymousProductList($uuid, $productListType);
     }

--- a/packages/framework/src/Model/Product/List/ProductListRepository.php
+++ b/packages/framework/src/Model/Product/List/ProductListRepository.php
@@ -40,13 +40,13 @@ class ProductListRepository
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
      * @param string|null $uuid
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null
      */
     public function findProductListByTypeAndCustomerUser(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
         CustomerUser $customerUser,
         ?string $uuid = null,
     ): ?ProductList {
@@ -63,12 +63,12 @@ class ProductListRepository
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList[]
      */
     public function getProductListsByTypeAndCustomerUser(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
         CustomerUser $customerUser,
     ): array {
         return $this->getRepository()->findBy([
@@ -79,12 +79,12 @@ class ProductListRepository
 
     /**
      * @param string $uuid
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum|null $productListType
+     * @param string|null $productListType
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null
      */
     public function findAnonymousProductList(
         string $uuid,
-        ?ProductListTypeEnumInterface $productListType = null,
+        ?string $productListType = null,
     ): ?ProductList {
         $criteria = [
             'uuid' => $uuid,

--- a/packages/framework/src/Model/Product/List/ProductListTypeEnum.php
+++ b/packages/framework/src/Model/Product/List/ProductListTypeEnum.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\List;
 
-enum ProductListTypeEnum: string implements ProductListTypeEnumInterface
+use Shopsys\FrameworkBundle\Component\Enum\AbstractEnum;
+
+class ProductListTypeEnum extends AbstractEnum
 {
-    case WISHLIST = 'wishlist';
-    case COMPARISON = 'comparison';
+    public const string WISHLIST = 'WISHLIST';
+    public const string COMPARISON = 'COMPARISON';
 }

--- a/packages/framework/src/Model/Product/List/ProductListTypeEnumInterface.php
+++ b/packages/framework/src/Model/Product/List/ProductListTypeEnumInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Shopsys\FrameworkBundle\Model\Product\List;
-
-interface ProductListTypeEnumInterface
-{
-}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
@@ -11,34 +11,35 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
-     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $productRecalculationPriorityEnum
+     * @param string $productRecalculationPriority
      * @return int[]
      */
     public function dispatchProducts(
         array $products,
-        ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        string $productRecalculationPriority = ProductRecalculationPriorityEnum::REGULAR,
     ): array {
         return $this->dispatchProductIds(
             array_map(static fn (Product $product) => $product->getId(), $products),
-            $productRecalculationPriorityEnum,
+            $productRecalculationPriority,
         );
     }
 
     /**
      * @param int[] $productIds
-     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $productRecalculationPriorityEnum
+     * @param string $productRecalculationPriority
      * @return int[]
      */
     public function dispatchProductIds(
         array $productIds,
-        ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        string $productRecalculationPriority = ProductRecalculationPriorityEnum::REGULAR,
     ): array {
         $productIds = array_unique($productIds);
 
         foreach ($productIds as $productId) {
-            $message = match ($productRecalculationPriorityEnum) {
+            $message = match ($productRecalculationPriority) {
                 ProductRecalculationPriorityEnum::HIGH => new ProductRecalculationPriorityHighMessage((int)$productId),
                 ProductRecalculationPriorityEnum::REGULAR => new ProductRecalculationPriorityRegularMessage((int)$productId),
+                default => throw new UnknownProductRecalculationPriorityException($productRecalculationPriority),
             };
             $this->messageBus->dispatch($message);
         }
@@ -48,13 +49,13 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
 
     /**
      * @param int $productId
-     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum $productRecalculationPriorityEnum
+     * @param string $productRecalculationPriority
      */
     public function dispatchSingleProductId(
         int $productId,
-        ProductRecalculationPriorityEnumInterface $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        string $productRecalculationPriority = ProductRecalculationPriorityEnum::REGULAR,
     ): void {
-        $this->dispatchProductIds([$productId], $productRecalculationPriorityEnum);
+        $this->dispatchProductIds([$productId], $productRecalculationPriority);
     }
 
     public function dispatchAllProducts(): void

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnum.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnum.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
-enum ProductRecalculationPriorityEnum: string implements ProductRecalculationPriorityEnumInterface
+use Shopsys\FrameworkBundle\Component\Enum\AbstractEnum;
+
+class ProductRecalculationPriorityEnum extends AbstractEnum
 {
-    case HIGH = 'high';
-    case REGULAR = 'regular';
+    public const string HIGH = 'high';
+    public const string REGULAR = 'regular';
 
     /**
      * @return string
      */
-    public static function getPipeSeparatedValues(): string
+    public function getPipeSeparatedValues(): string
     {
-        return implode('|', array_column(self::cases(), 'value'));
+        return implode('|', $this->getAllCases());
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnumInterface.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationPriorityEnumInterface.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
-
-interface ProductRecalculationPriorityEnumInterface
-{
-}

--- a/packages/framework/src/Model/Product/Recalculation/UnknownProductRecalculationPriorityException.php
+++ b/packages/framework/src/Model/Product/Recalculation/UnknownProductRecalculationPriorityException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+use Exception;
+
+class UnknownProductRecalculationPriorityException extends Exception
+{
+    /**
+     * @param string $productRecalculationPriority
+     */
+    public function __construct(string $productRecalculationPriority)
+    {
+        parent::__construct(sprintf('Unknown product recalculation priority "%s"', $productRecalculationPriority));
+    }
+}

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -16,7 +16,7 @@ services:
         public: false
 
     Shopsys\FrameworkBundle\:
-        resource: '../../**/*{Calculation,Dispatcher,Facade,Factory,Formatter,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,DataFetcher}.php'
+        resource: '../../**/*{Calculation,Dispatcher,Enum,Facade,Factory,Formatter,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,DataFetcher}.php'
         exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
 
     Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\:

--- a/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductAlreadyInListUserError.php
+++ b/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductAlreadyInListUserError.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\ProductList\Exception;
 
 use Overblog\GraphQLBundle\Error\UserError;
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnumInterface;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
 class ProductAlreadyInListUserError extends UserError implements UserErrorWithCodeInterface
@@ -14,11 +13,11 @@ class ProductAlreadyInListUserError extends UserError implements UserErrorWithCo
 
     /**
      * @param string $message
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      */
     public function __construct(
         string $message,
-        protected readonly ProductListTypeEnumInterface $productListType,
+        protected readonly string $productListType,
     ) {
         parent::__construct($message);
     }

--- a/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductListNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductListNotFoundUserError.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\ProductList\Exception;
 
 use Overblog\GraphQLBundle\Error\UserError;
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnumInterface;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
 class ProductListNotFoundUserError extends UserError implements UserErrorWithCodeInterface
@@ -14,11 +13,11 @@ class ProductListNotFoundUserError extends UserError implements UserErrorWithCod
 
     /**
      * @param string $message
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      */
     public function __construct(
         string $message,
-        protected readonly ProductListTypeEnumInterface $productListType,
+        protected readonly string $productListType,
     ) {
         parent::__construct($message);
     }

--- a/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductListUserErrorCodeHelper.php
+++ b/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductListUserErrorCodeHelper.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Mutation\ProductList\Exception;
 
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnumInterface;
-
 class ProductListUserErrorCodeHelper
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param string $code
      * @return string
      */
-    public static function getUserErrorCode(ProductListTypeEnumInterface $productListType, string $code): string
+    public static function getUserErrorCode(string $productListType, string $code): string
     {
-        return $productListType->value . '-' . $code;
+        return $productListType . '-' . $code;
     }
 }

--- a/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductNotInListUserError.php
+++ b/packages/frontend-api/src/Model/Mutation/ProductList/Exception/ProductNotInListUserError.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\ProductList\Exception;
 
 use Overblog\GraphQLBundle\Error\UserError;
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnumInterface;
 use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
 
 class ProductNotInListUserError extends UserError implements UserErrorWithCodeInterface
@@ -14,11 +13,11 @@ class ProductNotInListUserError extends UserError implements UserErrorWithCodeIn
 
     /**
      * @param string $message
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      */
     public function __construct(
         string $message,
-        protected readonly ProductListTypeEnumInterface $productListType,
+        protected readonly string $productListType,
     ) {
         parent::__construct($message);
     }

--- a/packages/frontend-api/src/Model/Product/ProductList/ProductListApiFacade.php
+++ b/packages/frontend-api/src/Model/Product/ProductList/ProductListApiFacade.php
@@ -23,7 +23,7 @@ class ProductListApiFacade
     }
 
     /**
-     * @param array{uuid:string|null, type:\Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum} $input
+     * @param array{uuid:string|null, type:string} $input
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null
      */
     public function findProductListByInputData(array $input): ?ProductList

--- a/packages/frontend-api/src/Model/Product/ProductList/ProductListInputValidationFactory.php
+++ b/packages/frontend-api/src/Model/Product/ProductList/ProductListInputValidationFactory.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrontendApiBundle\Model\Product\ProductList;
 
+use Shopsys\FrameworkBundle\Model\Product\List\Exception\UnknownProductListTypeException;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum;
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnumInterface;
 
 class ProductListInputValidationFactory
 {
@@ -20,15 +20,16 @@ class ProductListInputValidationFactory
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @return \Shopsys\FrontendApiBundle\Model\Product\ProductList\ProductListInputValidatorInterface
      */
     public function createForProductListType(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
     ): ProductListInputValidatorInterface {
         return match ($productListType) {
             ProductListTypeEnum::WISHLIST => $this->productListInputValidator,
             ProductListTypeEnum::COMPARISON => $this->comparisonInputValidator,
+            default => throw new UnknownProductListTypeException($productListType),
         };
     }
 }

--- a/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductArrayFieldMapper.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductArrayFieldMapper.php
@@ -73,7 +73,7 @@ class ProductArrayFieldMapper
     {
         return [
             'name' => $data['availability'],
-            'status' => $data['availability_status'], // after update graphql bundle we can expose availability status as enum: AvailabilityStatusEnum::from($data['availability_status'])
+            'status' => $data['availability_status'],
         ];
     }
 

--- a/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
@@ -81,7 +81,7 @@ class ProductEntityFieldMapper
             'status' => $this->productAvailabilityFacade->getProductAvailabilityStatusByDomainId(
                 $product,
                 $this->domain->getId(),
-            )->value,
+            ),
         ];
     }
 

--- a/packages/frontend-api/src/Model/Resolver/Products/ProductList/ProductListQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductList/ProductListQuery.php
@@ -8,7 +8,6 @@ use Overblog\GraphQLBundle\Definition\Argument;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductList;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductListFacade;
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum;
 use Shopsys\FrontendApiBundle\Model\Product\ProductList\ProductListApiFacade;
 use Shopsys\FrontendApiBundle\Model\Resolver\AbstractQuery;
 use Shopsys\FrontendApiBundle\Model\Resolver\Products\ProductList\Exception\CustomerUserNotLoggedUserError;
@@ -39,10 +38,10 @@ class ProductListQuery extends AbstractQuery
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListTypeEnum
+     * @param string $productListType
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList[]
      */
-    public function productListsByTypeQuery(ProductListTypeEnum $productListTypeEnum): array
+    public function productListsByTypeQuery(string $productListType): array
     {
         $customerUser = $this->currentCustomerUser->findCurrentCustomerUser();
 
@@ -50,6 +49,6 @@ class ProductListQuery extends AbstractQuery
             throw new CustomerUserNotLoggedUserError('You have to be logged in to get your product lists by type');
         }
 
-        return $this->productListFacade->getProductListsByTypeAndCustomerUser($productListTypeEnum, $customerUser);
+        return $this->productListFacade->getProductListsByTypeAndCustomerUser($productListType, $customerUser);
     }
 }

--- a/packages/frontend-api/src/Resources/config/graphql-types/EnumType/ProductListTypeEnumDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/EnumType/ProductListTypeEnumDecorator.types.yaml
@@ -3,4 +3,8 @@ ProductListTypeEnumDecorator:
     decorator: true
     config:
         description: "One of possible types of the product list"
-        enumClass: "Shopsys\\FrameworkBundle\\Model\\Product\\List\\ProductListTypeEnum"
+        values:
+            WISHLIST:
+                value: '@=constant("Shopsys\\FrameworkBundle\\Model\\Product\\List\\ProductListTypeEnum::WISHLIST")'
+            COMPARISON:
+                value: '@=constant("Shopsys\\FrameworkBundle\\Model\\Product\\List\\ProductListTypeEnum::COMPARISON")'

--- a/project-base/app/config/graphql/types/EnumType/AvailabilityStatusEnum.types.yaml
+++ b/project-base/app/config/graphql/types/EnumType/AvailabilityStatusEnum.types.yaml
@@ -4,8 +4,8 @@ AvailabilityStatusEnum:
         description: "Product Availability statuses"
         values:
             InStock:
-                value: "in-stock"
+                value: '@=constant("Shopsys\\FrameworkBundle\\Model\\Product\\Availability\\AvailabilityStatusEnum::IN_STOCK")'
                 description: "Product availability status in stock"
             OutOfStock:
-                value: "out-of-stock"
+                value: '@=constant("Shopsys\\FrameworkBundle\\Model\\Product\\Availability\\AvailabilityStatusEnum::OUT_OF_STOCK")'
                 description: "Product availability status out of stock"

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -28,7 +28,7 @@ services:
         resource: '../src/Twig/'
 
     App\:
-        resource: '../src/**/*{Calculation,Collector,Dispatcher,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,Validator,Transfer,Helper,Converter,DataFetcher}.php'
+        resource: '../src/**/*{Calculation,Collector,Dispatcher,Enum,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,Validator,Transfer,Helper,Converter,DataFetcher}.php'
         exclude:
             - '../src/{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
             - '../src/FrontendApi/**/*{Resolver,Mapper}.php'

--- a/project-base/app/src/DataFixtures/Demo/ProductListDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ProductListDataFixture.php
@@ -11,7 +11,6 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductListDataFactory;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductListFacade;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum;
-use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnumInterface;
 
 class ProductListDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
@@ -57,13 +56,14 @@ class ProductListDataFixture extends AbstractReferenceFixture implements Depende
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum $productListType
+     * @param string $productListType
      * @param \App\Model\Customer\User\CustomerUser|null $customerUser
      * @param string $uuid
      * @param \App\Model\Product\Product[] $products
+     * @throws \Shopsys\FrameworkBundle\Model\Product\List\Exception\ProductAlreadyInListException
      */
     private function createProductList(
-        ProductListTypeEnumInterface $productListType,
+        string $productListType,
         ?CustomerUser $customerUser,
         string $uuid,
         array $products,

--- a/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductArrayFieldMapper.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductArrayFieldMapper.php
@@ -143,11 +143,6 @@ class ProductArrayFieldMapper extends BaseProductArrayFieldMapper
      */
     public function getStoreAvailabilities(array $data): array
     {
-        // after update graphql bundle (to v1 - support php8.1) we can expose availability status as enum
-        //        foreach ($data['store_availabilities_information'] as $storeIndex => $storeAvailabilitiesInformation) {
-        //            $data['store_availabilities_information'][$storeIndex]['availability_status'] = AvailabilityStatusEnum::from($storeAvailabilitiesInformation['availability_status']);
-        //        }
-
         return $data['store_availabilities_information'];
     }
 

--- a/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
+++ b/project-base/app/src/FrontendApi/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
@@ -239,7 +239,7 @@ class ProductEntityFieldMapper extends BaseProductEntityFieldMapper
                 'store_name' => $storeAvailabilityInformation->getStoreName(),
                 'store_id' => $storeAvailabilityInformation->getStoreId(),
                 'availability_information' => $storeAvailabilityInformation->getAvailabilityInformation(),
-                'availability_status' => $storeAvailabilityInformation->getAvailabilityStatus()->value,
+                'availability_status' => $storeAvailabilityInformation->getAvailabilityStatus(),
             ];
         }
 

--- a/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -204,7 +204,7 @@ class ProductExportRepository extends BaseProductExportRepository
             'calculated_selling_denied' => $product->getCalculatedSaleExclusion($domainId),
             'selling_denied' => $product->isSellingDenied(),
             'availability' => $this->productAvailabilityFacade->getProductAvailabilityInformationByDomainId($product, $domainId),
-            'availability_status' => $this->productAvailabilityFacade->getProductAvailabilityStatusByDomainId($product, $domainId)->value,
+            'availability_status' => $this->productAvailabilityFacade->getProductAvailabilityStatusByDomainId($product, $domainId),
             'availability_dispatch_time' => $this->productAvailabilityFacade->getProductAvailabilityDaysByDomainId($product, $domainId),
             'is_main_variant' => $product->isMainVariant(),
             'is_variant' => $product->isVariant(),
@@ -571,7 +571,7 @@ class ProductExportRepository extends BaseProductExportRepository
                 'store_name' => $item->getStoreName(),
                 'store_id' => $item->getStoreId(),
                 'availability_information' => $item->getAvailabilityInformation(),
-                'availability_status' => $item->getAvailabilityStatus()->value,
+                'availability_status' => $item->getAvailabilityStatus(),
             ];
         }
 

--- a/project-base/app/src/Model/Product/ProductFacade.php
+++ b/project-base/app/src/Model/Product/ProductFacade.php
@@ -27,7 +27,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFacade;
 use Shopsys\FrameworkBundle\Model\Product\ProductVisibilityFactoryInterface;
 use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher;
-use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnumInterface;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum;
 use Shopsys\FrameworkBundle\Model\Stock\ProductStockFacade;
 use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
 
@@ -45,7 +45,7 @@ use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
  * @method createProductVisibilities(\App\Model\Product\Product $product)
  * @method \App\Model\Product\Product getOneByCatnumExcludeMainVariants(string $productCatnum)
  * @method \App\Model\Product\Product getByUuid(string $uuid)
- * @method \App\Model\Product\Product create(\App\Model\Product\ProductData $productData, \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority = null)
+ * @method \App\Model\Product\Product create(\App\Model\Product\ProductData $productData, string $priority = \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum::REGULAR)
  * @property \App\Model\Product\ProductFactory $productFactory
  * @method setAdditionalDataAfterCreate(\App\Model\Product\Product $product, \App\Model\Product\ProductData $productData)
  * @method editProductStockRelation(\App\Model\Product\ProductData $productData, \App\Model\Product\Product $product)
@@ -138,13 +138,13 @@ class ProductFacade extends BaseProductFacade
     /**
      * @param int $productId
      * @param \App\Model\Product\ProductData $productData
-     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum|null $priority
+     * @param string $priority
      * @return \App\Model\Product\Product
      */
     public function edit(
         int $productId,
         ProductData $productData,
-        ?ProductRecalculationPriorityEnumInterface $priority = null,
+        string $priority = ProductRecalculationPriorityEnum::REGULAR,
     ): Product {
         /** @var \App\Model\Product\Product $product */
         $product = parent::edit($productId, $productData, $priority);

--- a/project-base/app/src/Model/ProductFeed/Mergado/FeedItem/MergadoFeedItemFactory.php
+++ b/project-base/app/src/Model/ProductFeed/Mergado/FeedItem/MergadoFeedItemFactory.php
@@ -167,13 +167,13 @@ class MergadoFeedItemFactory
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityStatusEnum $availabilityStatus
+     * @param string $availabilityStatus
      * @return string
      */
-    private function mapStockStatusToAvailability(AvailabilityStatusEnum $availabilityStatus): string
+    private function mapStockStatusToAvailability(string $availabilityStatus): string
     {
         return match ($availabilityStatus) {
-            AvailabilityStatusEnum::InStock => 'in stock',
+            AvailabilityStatusEnum::IN_STOCK => 'in stock',
             default => 'out of stock'
         };
     }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/RetrieveCartTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/RetrieveCartTest.php
@@ -350,7 +350,7 @@ class RetrieveCartTest extends GraphQlTestCase
             ],
             'availability' => [
                 'name' => t('In stock', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
-                'status' => AvailabilityStatusEnum::InStock->name,
+                'status' => AvailabilityStatusEnum::IN_STOCK,
             ],
             'stockQuantity' => 2700,
             'categories' => [
@@ -544,13 +544,13 @@ class RetrieveCartTest extends GraphQlTestCase
                         'name' => 'Ostrava',
                     ],
                     'availabilityInformation' => t('Available immediately', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
-                    'availabilityStatus' => AvailabilityStatusEnum::InStock->name,
+                    'availabilityStatus' => AvailabilityStatusEnum::IN_STOCK,
                 ], [
                     'store' => [
                         'name' => 'Pardubice',
                     ],
                     'availabilityInformation' => t('{0,1} Available in one week|[2,Inf] Available in %count% weeks', ['%count%' => 1], Translator::DEFAULT_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
-                    'availabilityStatus' => AvailabilityStatusEnum::InStock->name,
+                    'availabilityStatus' => AvailabilityStatusEnum::IN_STOCK,
                 ],
             ],
             'availableStoresCount' => 1,

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductList/ProductListTypesDataProvider.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductList/ProductListTypesDataProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\FrontendApiBundle\Functional\Product\ProductList;
 
 use Iterator;
+use Shopsys\FrameworkBundle\Component\Reflection\ReflectionHelper;
 use Shopsys\FrameworkBundle\Model\Product\List\ProductListTypeEnum;
 
 class ProductListTypesDataProvider
@@ -14,7 +15,7 @@ class ProductListTypesDataProvider
      */
     public static function getProductListTypes(): Iterator
     {
-        foreach (ProductListTypeEnum::cases() as $productListType) {
+        foreach (ReflectionHelper::getAllPublicClassConstants(ProductListTypeEnum::class) as $productListType) {
             yield [$productListType];
         }
     }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductTest.php
@@ -194,7 +194,7 @@ class ProductTest extends GraphQlTestCase
                     ],
                     'availability' => [
                         'name' => t('In stock', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
-                        'status' => AvailabilityStatusEnum::InStock->name,
+                        'status' => AvailabilityStatusEnum::IN_STOCK,
                     ],
                     'stockQuantity' => 2700,
                     'categories' => [
@@ -388,13 +388,13 @@ class ProductTest extends GraphQlTestCase
                                 'name' => 'Ostrava',
                             ],
                             'availabilityInformation' => t('Available immediately', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $firstDomainLocale),
-                            'availabilityStatus' => AvailabilityStatusEnum::InStock->name,
+                            'availabilityStatus' => AvailabilityStatusEnum::IN_STOCK,
                         ], [
                             'store' => [
                                 'name' => 'Pardubice',
                             ],
                             'availabilityInformation' => t('{0,1} Available in one week|[2,Inf] Available in %count% weeks', ['%count%' => 1], Translator::DEFAULT_TRANSLATION_DOMAIN, $firstDomainLocale),
-                            'availabilityStatus' => AvailabilityStatusEnum::InStock->name,
+                            'availabilityStatus' => AvailabilityStatusEnum::IN_STOCK,
                         ],
                     ],
                     'availableStoresCount' => 1,

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -148,7 +148,7 @@ class ProductsTest extends ProductsGraphQlTestCase
                 ],
                 'availability' => [
                     'name' => t('In stock', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
-                    'status' => AvailabilityStatusEnum::InStock->name,
+                    'status' => AvailabilityStatusEnum::IN_STOCK,
                 ],
                 'stockQuantity' => 900,
                 'categories' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is not possible to extend PHP enums (see https://www.php.net/manual/en/language.enumerations.object-differences.inheritance.php) so we should avoid their usage in the Shopsys packages that are meant to be extended
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes






































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-goodbye-enums.odin.shopsys.cloud
  - https://cz.rv-goodbye-enums.odin.shopsys.cloud
<!-- Replace -->
