### PR TITLE
[SSP-2231] Cypress make command fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,14 @@ check-schema:
 	docker-compose exec -u root storefront chown node:node schema.graphql
 	docker-compose exec storefront sh check-code-gen.sh
 
-prepare-data-for-acceptance-tests:
+define prepare-data-for-acceptance-tests
 	docker compose exec php-fpm php phing -D production.confirm.action=y -D change.environment=test environment-change
 	docker compose exec php-fpm php phing test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export
+endef
+
+.PHONY: prepare-data-for-acceptance-tests
+prepare-data-for-acceptance-tests:
+	$(call prepare-data-for-acceptance-tests)
 
 define run_acceptance_tests
 	$(call prepare-data-for-acceptance-tests)

--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -572,3 +572,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   all codegen-generated GQL types now have a `Type` prefix (suffix did not work as expected)
 -   you should update all your imports and make sure to apply the new config
 -   you should also regenerate your codegen-generated files to make sure your own files apply the new config
+
+#### Cypress make command fix ([#3090](https://github.com/shopsys/shopsys/pull/3090))

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -12,9 +12,14 @@ generate-schema-native:
 	cd storefront; npm run gql
 	rm -rf storefront/schema.graphql
 
-prepare-data-for-acceptance-tests:
+define prepare-data-for-acceptance-tests
 	docker compose exec php-fpm php phing -D production.confirm.action=y -D change.environment=test environment-change
 	docker compose exec php-fpm php phing test-db-demo test-elasticsearch-index-recreate test-elasticsearch-export
+endef
+
+.PHONY: prepare-data-for-acceptance-tests
+prepare-data-for-acceptance-tests:
+	$(call prepare-data-for-acceptance-tests)
 
 define run_acceptance_tests
 	$(call prepare-data-for-acceptance-tests)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Previously, the make command for data preparation before cypress tests was not run as part of the main make command. This PR fixes the issue
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2231-cypress-make-fix.odin.shopsys.cloud
  - https://cz.sh-ssp-2231-cypress-make-fix.odin.shopsys.cloud
<!-- Replace -->
