### PR TITLE
[SSP-2233] cypress stability fixes

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -573,4 +573,26 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   you should update all your imports and make sure to apply the new config
 -   you should also regenerate your codegen-generated files to make sure your own files apply the new config
 
-#### Cypress make command fix ([#3090](https://github.com/shopsys/shopsys/pull/3090))
+#### cypress make command fix ([#3090](https://github.com/shopsys/shopsys/pull/3090))
+
+#### cypress stability fixes ([#3093](https://github.com/shopsys/shopsys/pull/3093))
+
+-   make sure all your links which wait for the `href` to be fetched dynamically use the same styling even before the `href` is available
+    -   you can use the newly provided `linkPlaceholderTwClass` as seen below
+
+```diff
+components={{
+   lnk1: privacyPolicyArticleUrl ? (
+       <Link isExternal href={privacyPolicyArticleUrl} target="_blank" />
+   ) : (
+-       <span />
+   ),
+}}
+components={{
+   lnk1: privacyPolicyArticleUrl ? (
+       <Link isExternal href={privacyPolicyArticleUrl} target="_blank" />
+   ) : (
++       <span className={linkPlaceholderTwClass} />
+   ),
+}}
+```

--- a/docs/storefront/cypress.md
+++ b/docs/storefront/cypress.md
@@ -85,6 +85,7 @@ describe('<Domain Specific Functionality> tests', () => {
 Below are some examples of custom commands. We mention only those, that should be used instead of the default cypress commands.
 
 -   `cy.visitAndWaitForStableDOM` (instead of `cy.visit`): Use this command for visiting pages. This command makes sure that the tests wait for the DOM to be stable, ensuring that the tests do not click on non-interactive (yet visible) elements.
+-   `cy.reloadAndWaitForStableDOM` (instead of `cy.reload`): Use this command for reloading pages. This command makes sure that the tests wait for the DOM to be stable, ensuring that the tests do not click on non-interactive (yet visible) elements.
 
 #### How to write a custom cypress command
 

--- a/project-base/storefront/components/Basic/Link/Link.tsx
+++ b/project-base/storefront/components/Basic/Link/Link.tsx
@@ -17,10 +17,17 @@ type LinkProps = NativePropsAnchor & {
     size?: 'small';
 };
 
+const linkPlaceholderTwClassSegments = [
+    'inline-flex cursor-pointer items-center text-greyDark outline-none hover:text-primary',
+    'underline hover:underline',
+];
+
+export const linkPlaceholderTwClass = linkPlaceholderTwClassSegments.join(' ');
+
 export const Link: FC<LinkProps> = ({ isExternal, isButton, children, href, rel, target, className }) => {
     const classNameTwClass = twMergeCustom(
-        'inline-flex cursor-pointer items-center text-greyDark outline-none hover:text-primary',
-        isButton ? 'no-underline hover:no-underline' : 'underline hover:underline',
+        linkPlaceholderTwClassSegments[0],
+        isButton ? 'no-underline hover:no-underline' : linkPlaceholderTwClassSegments[1],
     );
 
     const props = {

--- a/project-base/storefront/components/Layout/Footer/newsletterFormMeta.tsx
+++ b/project-base/storefront/components/Layout/Footer/newsletterFormMeta.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Link } from 'components/Basic/Link/Link';
+import { Link, linkPlaceholderTwClass } from 'components/Basic/Link/Link';
 import { usePrivacyPolicyArticleUrlQuery } from 'graphql/requests/articles/queries/PrivacyPolicyArticleUrlQuery.generated';
 import Trans from 'next-translate/Trans';
 import useTranslation from 'next-translate/useTranslation';
@@ -67,7 +67,7 @@ export const useNewsletterFormMeta = (
                                 lnk1: privacyPolicyArticleUrl ? (
                                     <Link isExternal href={privacyPolicyArticleUrl} target="_blank" />
                                 ) : (
-                                    <span />
+                                    <span className={linkPlaceholderTwClass} />
                                 ),
                             }}
                         />

--- a/project-base/storefront/components/Pages/Contact/ContactContent.tsx
+++ b/project-base/storefront/components/Pages/Contact/ContactContent.tsx
@@ -1,5 +1,5 @@
 import { useContactForm, useContactFormMeta } from './contactFormMeta';
-import { Link } from 'components/Basic/Link/Link';
+import { Link, linkPlaceholderTwClass } from 'components/Basic/Link/Link';
 import { SubmitButton } from 'components/Forms/Button/SubmitButton';
 import { Form } from 'components/Forms/Form/Form';
 import { FormColumn } from 'components/Forms/Lib/FormColumn';
@@ -120,7 +120,7 @@ export const ContactContent: FC = () => {
                                             privacyPolicyArticleUrl !== undefined ? (
                                                 <Link isExternal href={privacyPolicyArticleUrl} target="_blank" />
                                             ) : (
-                                                <span />
+                                                <span className={linkPlaceholderTwClass} />
                                             ),
                                     }}
                                 />

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationSendOrderButton.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationSendOrderButton.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'components/Basic/Link/Link';
+import { Link, linkPlaceholderTwClass } from 'components/Basic/Link/Link';
 import { CheckboxControlled } from 'components/Forms/Checkbox/CheckboxControlled';
 import { ChoiceFormLine } from 'components/Forms/Lib/ChoiceFormLine';
 import { useContactInformationFormMeta } from 'components/Pages/Order/ContactInformation/contactInformationFormMeta';
@@ -22,7 +22,6 @@ export const ContactInformationSendOrderButton: FC = () => {
     const [{ data: termsAndConditionsArticleUrlData }] = useTermsAndConditionsArticleUrlQuery();
     const [{ data: privacyPolicyArticleUrlData }] = usePrivacyPolicyArticleUrlQuery();
     const termsAndConditionsArticleUrl = termsAndConditionsArticleUrlData?.termsAndConditionsArticle?.slug;
-
     const privacyPolicyArticleUrl = privacyPolicyArticleUrlData?.privacyPolicyArticle?.slug;
 
     const isEmailFilledCorrectly = !!emailValue && !formState.errors.email;
@@ -38,13 +37,13 @@ export const ContactInformationSendOrderButton: FC = () => {
                             termsAndConditionsArticleUrl !== undefined ? (
                                 <Link isExternal href={termsAndConditionsArticleUrl} target="_blank" />
                             ) : (
-                                <span />
+                                <span className={linkPlaceholderTwClass} />
                             ),
                         lnk2:
                             privacyPolicyArticleUrl !== undefined ? (
                                 <Link isExternal href={privacyPolicyArticleUrl} target="_blank" />
                             ) : (
-                                <span />
+                                <span className={linkPlaceholderTwClass} />
                             ),
                     }}
                 />

--- a/project-base/storefront/components/Pages/OrderConfirmation/registrationAfterOrderFormMeta.tsx
+++ b/project-base/storefront/components/Pages/OrderConfirmation/registrationAfterOrderFormMeta.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Link } from 'components/Basic/Link/Link';
+import { Link, linkPlaceholderTwClass } from 'components/Basic/Link/Link';
 import { useTermsAndConditionsArticleUrlQuery } from 'graphql/requests/articles/queries/TermsAndConditionsArticleUrlQuery.generated';
 import Trans from 'next-translate/Trans';
 import useTranslation from 'next-translate/useTranslation';
@@ -75,7 +75,7 @@ export const useRegistrationAfterOrderFormMeta = (
                                     termsAndConditionUrl !== undefined ? (
                                         <Link isExternal href={termsAndConditionUrl} target="_blank" />
                                     ) : (
-                                        <span />
+                                        <span className={linkPlaceholderTwClass} />
                                     ),
                             }}
                         />

--- a/project-base/storefront/components/Pages/Registration/registrationFormMeta.tsx
+++ b/project-base/storefront/components/Pages/Registration/registrationFormMeta.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Link } from 'components/Basic/Link/Link';
+import { Link, linkPlaceholderTwClass } from 'components/Basic/Link/Link';
 import {
     validateCity,
     validateCompanyNameRequired,
@@ -219,7 +219,7 @@ export const useRegistrationFormMeta = (
                                     privacyPolicyArticleUrl !== undefined ? (
                                         <Link isExternal href={privacyPolicyArticleUrl} target="_blank" />
                                     ) : (
-                                        <span />
+                                        <span className={linkPlaceholderTwClass} />
                                     ),
                             }}
                         />

--- a/project-base/storefront/cypress/cypress.d.ts
+++ b/project-base/storefront/cypress/cypress.d.ts
@@ -9,6 +9,7 @@ declare global {
             storeCartUuidInLocalStorage(cartUuid: string): Cypress.Chainable<undefined>;
             visitAndWaitForStableDOM(url: string): Cypress.Chainable<JQuery<HTMLElement>>;
             reloadAndWaitForStableDOM(): Cypress.Chainable<JQuery<HTMLElement>>;
+            reloadAndWaitForStableDOM(): Cypress.Chainable<JQuery<HTMLElement>>;
             addProductToCartForTest(productUuid?: string, quantity?: number): Cypress.Chainable<any>;
             preselectTransportForTest(
                 transportUuid: string,

--- a/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
@@ -80,7 +80,7 @@ describe('Contact information page tests', () => {
         fillInNoteInThirdStep(orderNote);
         loseFocus();
 
-        cy.reload();
+        cy.reloadAndWaitForStableDOM();
 
         takeSnapshotAndCompare('keep-filled-contact-information-after-reload');
     });
@@ -121,7 +121,7 @@ describe('Contact information page tests', () => {
         cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
         cy.preselectTransportForTest(transport.czechPost.uuid);
         cy.preselectPaymentForTest(payment.onDelivery.uuid);
-        cy.reload();
+        cy.reloadAndWaitForStableDOM();
 
         takeSnapshotAndCompare('should-remove-contact-information-after-logout');
         checkThatContactInformationWasRemovedFromLocalStorage();

--- a/project-base/storefront/cypress/e2e/order/createOrderWithDeliveryAddress.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/createOrderWithDeliveryAddress.cy.ts
@@ -34,7 +34,7 @@ describe('Create order with delivery address tests', () => {
         clearAndFillDeliveryAdressInThirdStep(deliveryAddress);
         loseFocus();
 
-        cy.reload();
+        cy.reloadAndWaitForStableDOM();
 
         takeSnapshotAndCompare('order-with-delivery-address_basic-1');
 
@@ -103,7 +103,7 @@ describe('Delivery address in order tests (logged-in user)', () => {
         clearAndFillDeliveryAdressInThirdStep(deliveryAddress);
         loseFocus();
 
-        cy.reload();
+        cy.reloadAndWaitForStableDOM();
 
         takeSnapshotAndCompare('order-with-delivery-address_logged-in-1');
 
@@ -172,7 +172,7 @@ describe('Delivery address in order tests (logged-in user)', () => {
             clearAndFillDeliveryAdressInThirdStep(deliveryAddress);
             loseFocus();
 
-            cy.reload();
+            cy.reloadAndWaitForStableDOM();
 
             takeSnapshotAndCompare('order-with-delivery-address_logged-in-3');
 
@@ -244,7 +244,7 @@ describe('Delivery address in order tests (with pickup point)', () => {
         clearAndFillDeliveryContactInThirdStep(deliveryAddress);
         loseFocus();
 
-        cy.reload();
+        cy.reloadAndWaitForStableDOM();
 
         takeSnapshotAndCompare('order-with-delivery-address_pickup-point-1');
 
@@ -316,7 +316,7 @@ describe('Delivery address in order tests (with pickup point, logged-in user)', 
             clearAndFillDeliveryContactInThirdStep(deliveryAddress);
             loseFocus();
 
-            cy.reload();
+            cy.reloadAndWaitForStableDOM();
 
             takeSnapshotAndCompare('order-with-delivery-address_pickup-point-logged-in-1');
 

--- a/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
@@ -38,7 +38,7 @@ describe('Last order transport and payment select tests', () => {
         changeSelectionOfPaymentByName(payment.cash.name);
         cy.getByTID([TIDs.loader_overlay]).should('not.exist');
 
-        cy.reload();
+        cy.reloadAndWaitForStableDOM();
 
         takeSnapshotAndCompare('change-preselected-last-order-transport-and-payment');
 

--- a/project-base/storefront/cypress/support/api.ts
+++ b/project-base/storefront/cypress/support/api.ts
@@ -185,11 +185,6 @@ Cypress.Commands.add('registerAsNewUser', (registrationInput: TypeRegistrationDa
         });
 });
 
-Cypress.Commands.add('visitAndWaitForStableDOM', (url: string) => {
-    cy.visit(url);
-    return cy.waitForStableDOM({ pollInterval: 500, timeout: 5000 });
-});
-
 Cypress.Commands.add('logout', () => {
     const currentAppStoreAsString = window.localStorage.getItem('app-store');
     if (!currentAppStoreAsString) {

--- a/project-base/storefront/cypress/support/index.ts
+++ b/project-base/storefront/cypress/support/index.ts
@@ -36,6 +36,16 @@ Cypress.Commands.add('storeCartUuidInLocalStorage', (cartUuid: string) => {
     });
 });
 
+Cypress.Commands.add('visitAndWaitForStableDOM', (url: string) => {
+    cy.visit(url);
+    return cy.waitForStableDOM({ pollInterval: 500, timeout: 5000 });
+});
+
+Cypress.Commands.add('reloadAndWaitForStableDOM', () => {
+    cy.reload();
+    return cy.waitForStableDOM({ pollInterval: 500, timeout: 5000 });
+});
+
 compareSnapshotCommand({
     capture: 'fullPage',
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| We had some issues with cypress stability which surfaced when running our tests in different environments. This PR fixes two main issues; link styles issues (mismatch between link styles before and after URL fetch), and unstable DOM after cy.reload()
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2233-cypress-stability-fixes.odin.shopsys.cloud
  - https://cz.sh-ssp-2233-cypress-stability-fixes.odin.shopsys.cloud
<!-- Replace -->
