### PR TITLE
[SSP-2206] cart and product lists are not refetched while auth loading is active

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1853,3 +1853,5 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   domainConfig is moved from `SessionStore` to `Context` for easier handling and solve issue with SSR session (see previous comment from cookies refactoring)
 
 -   fix a wrong link type for searched articles ([#3062](https://github.com/shopsys/shopsys/pull/3062))
+
+-   cart and product lists are not refetched while auth loading is active ([#3096](https://github.com/shopsys/shopsys/pull/3096))

--- a/packages/framework/src/Component/ClassExtension/DocBlockParser.php
+++ b/packages/framework/src/Component/ClassExtension/DocBlockParser.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Component\ClassExtension;
 
 use phpDocumentor\Reflection\DocBlock\Tags\TagWithType;
 use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Type;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
@@ -13,7 +14,7 @@ use Shopsys\FrameworkBundle\Component\ClassExtension\Exception\DocBlockParserAmb
 
 class DocBlockParser
 {
-    protected DocBlockFactory $docBlockFactory;
+    protected DocBlockFactory|DocBlockFactoryInterface $docBlockFactory;
 
     public function __construct()
     {

--- a/project-base/storefront/hooks/cart/useCurrentCart.ts
+++ b/project-base/storefront/hooks/cart/useCurrentCart.ts
@@ -11,6 +11,7 @@ import { CurrentCartType } from 'types/cart';
 
 export const useCurrentCart = (fromCache = true): CurrentCartType => {
     const isUserLoggedIn = useIsUserLoggedIn();
+    const authLoading = usePersistStore((s) => s.authLoading);
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const packeteryPickupPoint = usePersistStore((store) => store.packeteryPickupPoint);
 
@@ -23,7 +24,7 @@ export const useCurrentCart = (fromCache = true): CurrentCartType => {
 
     const [{ data: fetchedCartData, fetching }, fetchCart] = useCartQueryApi({
         variables: { cartUuid },
-        pause: !isCartHydrated || !isWithCart,
+        pause: !isCartHydrated || !isWithCart || authLoading !== null,
         requestPolicy: fromCache ? 'cache-first' : 'network-only',
     });
 

--- a/project-base/storefront/hooks/productLists/useProductList.ts
+++ b/project-base/storefront/hooks/productLists/useProductList.ts
@@ -23,6 +23,7 @@ export const useProductList = (
     },
 ) => {
     const productListUuids = usePersistStore((s) => s.productListUuids);
+    const authLoading = usePersistStore((s) => s.authLoading);
     const updateProductListUuid = useUpdateProductListUuid(productListType);
     const productListUuid = productListUuids[productListType] ?? null;
     const isUserLoggedIn = useIsUserLoggedIn();
@@ -38,7 +39,7 @@ export const useProductList = (
                 uuid: productListUuid,
             },
         },
-        pause: !productListUuid && !isUserLoggedIn,
+        pause: (!productListUuid && !isUserLoggedIn) || authLoading !== null,
     });
 
     useEffect(() => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Because product lists UUIDs are removed before login mutation, there was enough time for queries to be refetched which caused errors. This PR fixes that 
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2206-error-after-logout.odin.shopsys.cloud
  - https://cz.sh-ssp-2206-error-after-logout.odin.shopsys.cloud
<!-- Replace -->
