### PR TITLE
[framework] dispatch product stocks export after Setting::TRANSFER_DAYS_BETWEEN_STOCKS is set

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -797,6 +797,15 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   `Shopsys\FrontendApiBundle\Model\Mutation\Order\CreateOrderMutation::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS` constant was renamed to `VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS_WITHOUT_PRESELECTED`
 -   see #project-base-diff to update your project
 
+#### dispatch product stocks export after Setting::TRANSFER_DAYS_BETWEEN_STOCKS is set ([#3104](https://github.com/shopsys/shopsys/pull/3104))
+
+-   `Shopsys\FrameworkBundle\Model\Stock\StockSettingsDataFacade::__construct` interface has changed:
+    ```diff
+        public function __construct(
+            // ...
+    +       protected readonly ProductRecalculationDispatcher $productRecalculationDispatcher,
+    ```
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Model/Stock/StockSettingsDataFacade.php
+++ b/packages/framework/src/Model/Stock/StockSettingsDataFacade.php
@@ -6,16 +6,20 @@ namespace Shopsys\FrameworkBundle\Model\Stock;
 
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher;
 
 class StockSettingsDataFacade
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcher $productRecalculationDispatcher
      */
     public function __construct(
         protected readonly Setting $setting,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
+        protected readonly ProductRecalculationDispatcher $productRecalculationDispatcher,
     ) {
     }
 
@@ -29,5 +33,7 @@ class StockSettingsDataFacade
             (int)$stockSettingsData->transfer,
             $this->adminDomainTabsFacade->getSelectedDomainId(),
         );
+
+        $this->productRecalculationDispatcher->dispatchAllProducts([ProductExportScopeConfig::SCOPE_STOCKS]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When the setting is changed, we do not want to wait until midnight when all the products are re-exported to Elasticsearch, we want to see the changes on the storefront ASAP.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-stock-update.odin.shopsys.cloud
  - https://cz.rv-stock-update.odin.shopsys.cloud
<!-- Replace -->
