### PR TITLE
[SSP-2206] cart and product lists are not refetched while auth loading is active

### DIFF
--- a/project-base/storefront/utils/cart/useCurrentCart.ts
+++ b/project-base/storefront/utils/cart/useCurrentCart.ts
@@ -9,6 +9,7 @@ import { isStoreHydrated } from 'utils/store/isStoreHydrated';
 
 export const useCurrentCart = (fromCache = true): CurrentCartType => {
     const isUserLoggedIn = useIsUserLoggedIn();
+    const authLoading = usePersistStore((s) => s.authLoading);
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const packeteryPickupPoint = usePersistStore((store) => store.packeteryPickupPoint);
 
@@ -16,7 +17,7 @@ export const useCurrentCart = (fromCache = true): CurrentCartType => {
 
     const [{ data: fetchedCartData, fetching }, fetchCart] = useCartQuery({
         variables: { cartUuid },
-        pause: !isWithCart,
+        pause: !isWithCart || authLoading !== null,
         requestPolicy: fromCache ? 'cache-first' : 'network-only',
     });
 

--- a/project-base/storefront/utils/productLists/useProductList.ts
+++ b/project-base/storefront/utils/productLists/useProductList.ts
@@ -21,6 +21,7 @@ export const useProductList = (
     },
 ) => {
     const productListUuids = usePersistStore((s) => s.productListUuids);
+    const authLoading = usePersistStore((s) => s.authLoading);
     const updateProductListUuid = useUpdateProductListUuid(productListType);
     const productListUuid = productListUuids[productListType] ?? null;
     const isUserLoggedIn = useIsUserLoggedIn();
@@ -36,7 +37,7 @@ export const useProductList = (
                 uuid: productListUuid,
             },
         },
-        pause: !productListUuid && !isUserLoggedIn,
+        pause: (!productListUuid && !isUserLoggedIn) || authLoading !== null,
     });
 
     useEffect(() => {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Because product lists UUIDs are removed before login mutation, there was enough time for queries to be refetched which caused errors. This PR fixes that 
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-error-after-logout-fix.odin.shopsys.cloud
  - https://cz.sh-error-after-logout-fix.odin.shopsys.cloud
<!-- Replace -->
