### PR TITLE
[frontend-api] cart is now correctly created for current customer user when carts are merged

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1510,6 +1510,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 
 -   enable recommended query from Luigi's Box in your frontend API ([#3099](https://github.com/shopsys/shopsys/pull/3099))
+
+    -   see #project-base-diff to update your project
+
+-   fix order repetition ([#3112](https://github.com/shopsys/shopsys/pull/3112))
+
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/project-base/app/src/FrontendApi/Mutation/Cart/CartMutation.php
+++ b/project-base/app/src/FrontendApi/Mutation/Cart/CartMutation.php
@@ -116,7 +116,7 @@ class CartMutation extends AbstractMutation
 
         if (!$shouldMerge) {
             $this->cartFacade->deleteCart($cart);
-            $cart = $this->cartFacade->getCartCreateIfNotExists(null, $cartUuid);
+            $cart = $this->cartFacade->getCartCreateIfNotExists($customerUser, $cartUuid);
         }
 
         $notAddedProducts = [];

--- a/project-base/app/src/FrontendApi/Mutation/Cart/CartMutation.php
+++ b/project-base/app/src/FrontendApi/Mutation/Cart/CartMutation.php
@@ -123,6 +123,10 @@ class CartMutation extends AbstractMutation
         $addProductResults = [];
 
         foreach ($order->getProductItems() as $orderItem) {
+            if ($orderItem->getPriceWithoutVat()->isNegative()) {
+                continue;
+            }
+
             try {
                 $addProductResults[] = $this->cartFacade->addProductByUuidToCart($orderItem->getProduct()->getUuid(), $orderItem->getQuantity(), false, $cart);
             } catch (InvalidCartItemUserError) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
|Description, the reason for the PR| When carts were merged, new cart was incorrectly created without customer user association.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-order-repeat.odin.shopsys.cloud
  - https://cz.tl-fix-order-repeat.odin.shopsys.cloud
<!-- Replace -->
