### PR TITLE
open cypress tests is now possible on WSL

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -505,6 +505,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   run `php phing yaml-standards-fix` to apply the new coding standards
 -   see #project-base-diff to update your project
 
+#### allow open Cypress GUI on Windows with WSL2 ([#3116](https://github.com/shopsys/shopsys/pull/3116))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -39,13 +39,21 @@ run-acceptance-tests-base:
 run-acceptance-tests-actual:
 	$(call run_acceptance_tests,actual)
 
+IS_WSL := $(shell uname -r | grep -i microsoft)
+
+ifeq ($(IS_WSL),)
 get_ip = $(shell ifconfig | awk '/^[a-z0-9]+: /{iface=substr($$1, 1, length($$1)-1)} /status: active/{print iface}' | head -1 | xargs -I {} ifconfig {} | awk '/inet /{print $$2; exit}')
+else
+get_ip = $(shell awk '/nameserver / {print $$2; exit}' /etc/resolv.conf)
+endif
 
 define open_acceptance_tests
 	$(call prepare-data-for-acceptance-tests)
 	docker compose stop storefront
 	docker compose up -d --wait storefront-cypress --force-recreate
-	xhost + $(get_ip);
+	@if [ "$(IS_WSL)" = "" ]; then \
+		xhost + $(get_ip); \
+	fi
 	-docker compose run --rm -e TYPE=$(1) -e DISPLAY=$(get_ip):0 -e COMMAND=open cypress;
 	docker compose stop storefront-cypress
 	docker compose up -d storefront


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Since #3069 is possible to run cypress GUI on Linux and MacOS. This PR adds a possibility to run Cypress GUI on Windows with WSL2.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-cypress-open-wsl.odin.shopsys.cloud
  - https://cz.mg-cypress-open-wsl.odin.shopsys.cloud
<!-- Replace -->
