### PR TITLE
[project-base] [SSP-2260] removed isRedirectedFromSsr as it was unnecessary

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -641,3 +641,7 @@ components={{
 During new project implementation phase it is important for a developer who is adjusting new design to be able to see how those changes affect important/base components. This is why we have Styleguide where we have those base components so implementation is faster and developer has better overview of the changes.
 
 #### fixed fix SEO page title, description and heading H1 ([#3108](https://github.com/shopsys/shopsys/pull/3108))
+
+#### removed isRedirectedFromSsr as it was unnecessary ([#3117](https://github.com/shopsys/shopsys/pull/3117))
+
+-   remove `isRedirectedFromSsr` from all `getServerSideProps` calls, as there is no reason to differentiate between client-side navigation and first page load

--- a/docs/storefront/error-handling.md
+++ b/docs/storefront/error-handling.md
@@ -121,17 +121,14 @@ export const getServerSideProps = getServerSidePropsWrapper(
     ({ redisClient, domainConfig, ssrExchange, t }) =>
         async (context) => {
             ...
-            if (isRedirectedFromSsr(context.req.headers)) {
-                ...
-                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
-                    categoryDetailResponse.error?.graphQLErrors,
-                    categoryDetailResponse.data?.category,
-                    context.res,
-                );
+            const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                categoryDetailResponse.error?.graphQLErrors,
+                categoryDetailResponse.data?.category,
+                context.res,
+            );
 
-                if (serverSideErrorResponse) {
-                    return serverSideErrorResponse;
-                }
+            if (serverSideErrorResponse) {
+                return serverSideErrorResponse;
             }
             ...
         },

--- a/project-base/storefront/pages/stores/[storeSlug].tsx
+++ b/project-base/storefront/pages/stores/[storeSlug].tsx
@@ -13,7 +13,6 @@ import { useRouter } from 'next/router';
 import { OperationResult } from 'urql';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { getSlugFromUrl } from 'utils/parsing/getSlugFromUrl';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
@@ -51,23 +50,20 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 context,
             });
 
-            if (isRedirectedFromSsr(context.req.headers)) {
-                const storeResponse: OperationResult<TypeStoreDetailQuery, TypeStoreDetailQueryVariables> =
-                    await client!
-                        .query(StoreDetailQueryDocument, {
-                            urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
-                        })
-                        .toPromise();
+            const storeResponse: OperationResult<TypeStoreDetailQuery, TypeStoreDetailQueryVariables> = await client!
+                .query(StoreDetailQueryDocument, {
+                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                })
+                .toPromise();
 
-                const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
-                    storeResponse.error?.graphQLErrors,
-                    storeResponse.data?.store,
-                    context.res,
-                );
+            const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
+                storeResponse.error?.graphQLErrors,
+                storeResponse.data?.store,
+                context.res,
+            );
 
-                if (serverSideErrorResponse) {
-                    return serverSideErrorResponse;
-                }
+            if (serverSideErrorResponse) {
+                return serverSideErrorResponse;
             }
 
             const initServerSideData = await initServerSideProps({

--- a/project-base/storefront/utils/isRedirectedFromSsr.ts
+++ b/project-base/storefront/utils/isRedirectedFromSsr.ts
@@ -1,5 +1,0 @@
-import { NextIncomingMessage } from 'next/dist/server/request-meta';
-
-export const isRedirectedFromSsr = (requestHeader: NextIncomingMessage['headers']): boolean => {
-    return requestHeader['x-nextjs-data'] !== '1';
-};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Since we already use optimistic skeletons, we do not need to postpone data fetching to the client and can fetch it on the server. Because of that, there is no reason to differentiate between client-side navigation and first page load.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2260-remove-ssr-condition.odin.shopsys.cloud
  - https://cz.sh-ssp-2260-remove-ssr-condition.odin.shopsys.cloud
<!-- Replace -->
