### PR TITLE
[framework] changed email from which contact form is sent so emails are not catched by spam filters

### DIFF
--- a/packages/framework/src/Model/ContactForm/ContactFormFacade.php
+++ b/packages/framework/src/Model/ContactForm/ContactFormFacade.php
@@ -31,13 +31,14 @@ class ContactFormFacade
      */
     public function sendMail(ContactFormData $contactFormData)
     {
+        $mainAdminMail = $this->mailSettingFacade->getMainAdminMail($this->domain->getId());
         $messageData = new MessageData(
-            $this->mailSettingFacade->getMainAdminMail($this->domain->getId()),
+            $mainAdminMail,
             null,
             $this->getMailBody($contactFormData),
             t('Contact form'),
-            $contactFormData->email,
-            $contactFormData->name,
+            $mainAdminMail,
+            $this->mailSettingFacade->getMainAdminMailName($this->domain->getId()),
         );
         $this->mailer->sendForDomain($messageData, $this->domain->getId());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| spam filters were catching contact mails sent from website if email from was not matching domain, so now we use main website mail there
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-change-contact-form-mail.odin.shopsys.cloud
  - https://cz.ab-change-contact-form-mail.odin.shopsys.cloud
<!-- Replace -->
