### PR TITLE
[frontend-api] addProductToListMutation: ensure new product list is created with non-conflicting uuid

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1501,6 +1501,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see #project-base-diff to update your project
 
 -   take promo code into account in priceByTransportQuery and priceByPaymentQuery ([#3118](https://github.com/shopsys/shopsys/pull/3118))
+
+    -   see #project-base-diff to update your project
+
+-   addProductToListMutation: ensure new product list is created with non-conflicting uuid ([#3126](https://github.com/shopsys/shopsys/pull/3126))
+    -   add new tests to `ProductListLoggedCustomerTest` and `ProductListNotLoggedCustomerTest` classes
     -   see #project-base-diff to update your project
 
 ### Storefront

--- a/packages/framework/src/Model/Product/List/ProductListFacade.php
+++ b/packages/framework/src/Model/Product/List/ProductListFacade.php
@@ -109,6 +109,15 @@ class ProductListFacade
     }
 
     /**
+     * @param string $uuid
+     * @return bool
+     */
+    public function existsProductListWithUuid(string $uuid): bool
+    {
+        return $this->productListRepository->existsProductListWithUuid($uuid);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductList $productList
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null

--- a/packages/framework/src/Model/Product/List/ProductListRepository.php
+++ b/packages/framework/src/Model/Product/List/ProductListRepository.php
@@ -119,4 +119,13 @@ class ProductListRepository
     {
         return $this->entityManager->getRepository(ProductList::class);
     }
+
+    /**
+     * @param string $uuid
+     * @return bool
+     */
+    public function existsProductListWithUuid(string $uuid): bool
+    {
+        return $this->getRepository()->count(['uuid' => $uuid]) > 0;
+    }
 }

--- a/packages/frontend-api/src/Model/Mutation/ProductList/ProductListMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/ProductList/ProductListMutation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\ProductList;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\List\Exception\ProductAlreadyInListException;
@@ -60,6 +61,10 @@ class ProductListMutation extends AbstractMutation
         }
 
         if ($productList === null) {
+            if ($productListUuid !== null && $this->productListFacade->existsProductListWithUuid($productListUuid)) {
+                $productListUuid = Uuid::uuid4()->toString();
+            }
+
             $productListData = $this->productListDataFactory->create($productListType, $customerUser, $productListUuid);
             $productList = $this->productListFacade->create($productListData);
         }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductList/ProductListLoggedCustomerTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductList/ProductListLoggedCustomerTest.php
@@ -151,6 +151,28 @@ class ProductListLoggedCustomerTest extends GraphQlWithLoginTestCase
     }
 
     /**
+     * @dataProvider \Tests\FrontendApiBundle\Functional\Product\ProductList\ProductListTypesDataProvider::getProductListTypes
+     * @param string $productListType
+     */
+    public function testAddProductCreatesNewListWithNewUuidWhenUuidOfAnonymousListIsProvided(
+        string $productListType,
+    ): void {
+        $anonymousProductListUuid = $this->getAnonymousProductListUuid($productListType);
+        $productToAddId = 69;
+        $productToAdd = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productToAddId);
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/AddProductToListMutation.graphql', [
+            'productListUuid' => $anonymousProductListUuid,
+            'productUuid' => $productToAdd->getUuid(),
+            'type' => $productListType,
+        ]);
+        $data = $this->getResponseDataForGraphQlType($response, 'AddProductToList');
+
+        $this->assertNotSame($anonymousProductListUuid, $data['uuid']);
+        $this->assertSame($productListType, $data['type']);
+        $this->assertSame([$productToAddId], array_column($data['products'], 'id'));
+    }
+
+    /**
      * @dataProvider productListDataProvider
      * @param string $productListType
      * @param string $uuid
@@ -241,5 +263,18 @@ class ProductListLoggedCustomerTest extends GraphQlWithLoginTestCase
             'expectedUuid' => ProductListDataFixture::PRODUCT_LIST_WISHLIST_LOGGED_CUSTOMER_UUID,
             'expectedProductIds' => [1],
         ];
+    }
+
+    /**
+     * @param string $productListType
+     * @return string
+     */
+    private function getAnonymousProductListUuid(string $productListType): string
+    {
+        return match ($productListType) {
+            ProductListTypeEnum::COMPARISON => ProductListDataFixture::PRODUCT_LIST_COMPARISON_NOT_LOGGED_CUSTOMER_UUID,
+            ProductListTypeEnum::WISHLIST => ProductListDataFixture::PRODUCT_LIST_WISHLIST_NOT_LOGGED_CUSTOMER_UUID,
+            default => throw new UnknownProductListTypeException($productListType),
+        };
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductList/ProductListNotLoggedCustomerTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductList/ProductListNotLoggedCustomerTest.php
@@ -170,6 +170,28 @@ class ProductListNotLoggedCustomerTest extends GraphQlTestCase
      * @dataProvider \Tests\FrontendApiBundle\Functional\Product\ProductList\ProductListTypesDataProvider::getProductListTypes
      * @param string $productListType
      */
+    public function testAddProductCreatesNewListWithNewUuidWhenUuidOfCustomerUserListIsProvided(
+        string $productListType,
+    ): void {
+        $customerUserProductListUuid = $this->getCustomerUserProductListUuid($productListType);
+        $productToAddId = 69;
+        $productToAdd = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productToAddId);
+        $response = $this->getResponseContentForGql(__DIR__ . '/graphql/AddProductToListMutation.graphql', [
+            'productListUuid' => $customerUserProductListUuid,
+            'productUuid' => $productToAdd->getUuid(),
+            'type' => $productListType,
+        ]);
+        $data = $this->getResponseDataForGraphQlType($response, 'AddProductToList');
+
+        $this->assertNotSame($customerUserProductListUuid, $data['uuid']);
+        $this->assertSame($productListType, $data['type']);
+        $this->assertSame([$productToAddId], array_column($data['products'], 'id'));
+    }
+
+    /**
+     * @dataProvider \Tests\FrontendApiBundle\Functional\Product\ProductList\ProductListTypesDataProvider::getProductListTypes
+     * @param string $productListType
+     */
     public function testAddProductCreatesNewList(string $productListType): void
     {
         $productToAddId = 69;
@@ -470,5 +492,18 @@ class ProductListNotLoggedCustomerTest extends GraphQlTestCase
 
         $this->assertTrue($originalAnonymousWishlist === null, 'Original anonymous wishlist should not exist anymore');
         $this->assertTrue($originalAnonymousComparison === null, 'Original anonymous comparison should not exist anymore');
+    }
+
+    /**
+     * @param string $productListType
+     * @return string
+     */
+    private function getCustomerUserProductListUuid(string $productListType): string
+    {
+        return match ($productListType) {
+            ProductListTypeEnum::COMPARISON => ProductListDataFixture::PRODUCT_LIST_COMPARISON_LOGGED_CUSTOMER_UUID,
+            ProductListTypeEnum::WISHLIST => ProductListDataFixture::PRODUCT_LIST_WISHLIST_LOGGED_CUSTOMER_UUID,
+            default => throw new UnknownProductListTypeException($productListType),
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When a customer user is logged out due to the long inactivity, his product list uuids might be kept in the storage, and adding products to the list fails. Therefore, when an anonymous product list with a given uuid is not found, we still need to check whether a customer user's product list with the given uuid exists. If so, a new anonymous product list must be created with another uuid to avoid unique constraint violations. The same applies when the customer user's product list is not found by the given uuid -> we need to check for the existence of an anonymous list with the uuid before creating the new customer user's list
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-product-list-fix.odin.shopsys.cloud
  - https://cz.rv-product-list-fix.odin.shopsys.cloud
<!-- Replace -->
