### PR TITLE
[frontend-api] addProductToListMutation: ensure new product list is created with non-conflicting uuid (v15.0)

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -783,6 +783,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see classes in the `Shopsys\FrontendApiBundle\Model\Cart` namespace
 -   see #project-base-diff to update your project
 
+#### addProductToListMutation: ensure new product list is created with non-conflicting uuid ([#3126](https://github.com/shopsys/shopsys/pull/3126))
+
+-   add new tests to `ProductListLoggedCustomerTest` and `ProductListNotLoggedCustomerTest` classes
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Model/Product/List/ProductListFacade.php
+++ b/packages/framework/src/Model/Product/List/ProductListFacade.php
@@ -109,6 +109,15 @@ class ProductListFacade
     }
 
     /**
+     * @param string $uuid
+     * @return bool
+     */
+    public function existsProductListWithUuid(string $uuid): bool
+    {
+        return $this->productListRepository->existsProductListWithUuid($uuid);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Product\List\ProductList $productList
      * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
      * @return \Shopsys\FrameworkBundle\Model\Product\List\ProductList|null

--- a/packages/framework/src/Model/Product/List/ProductListRepository.php
+++ b/packages/framework/src/Model/Product/List/ProductListRepository.php
@@ -119,4 +119,13 @@ class ProductListRepository
     {
         return $this->entityManager->getRepository(ProductList::class);
     }
+
+    /**
+     * @param string $uuid
+     * @return bool
+     */
+    public function existsProductListWithUuid(string $uuid): bool
+    {
+        return $this->getRepository()->count(['uuid' => $uuid]) > 0;
+    }
 }

--- a/packages/frontend-api/src/Model/Mutation/ProductList/ProductListMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/ProductList/ProductListMutation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\ProductList;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
 use Shopsys\FrameworkBundle\Model\Product\List\Exception\ProductAlreadyInListException;
@@ -60,6 +61,10 @@ class ProductListMutation extends AbstractMutation
         }
 
         if ($productList === null) {
+            if ($productListUuid !== null && $this->productListFacade->existsProductListWithUuid($productListUuid)) {
+                $productListUuid = Uuid::uuid4()->toString();
+            }
+
             $productListData = $this->productListDataFactory->create($productListType, $customerUser, $productListUuid);
             $productList = $this->productListFacade->create($productListData);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| port of https://github.com/shopsys/shopsys/pull/3126 to v15.0
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-product-list-fix.odin.shopsys.cloud
  - https://cz.rv-product-list-fix.odin.shopsys.cloud
<!-- Replace -->
