### PR TITLE
[project-base] fix builds

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -788,6 +788,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   add new tests to `ProductListLoggedCustomerTest` and `ProductListNotLoggedCustomerTest` classes
 -   see #project-base-diff to update your project
 
+#### fix builds ([#3131](https://github.com/shopsys/shopsys/pull/3131))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -81,7 +81,7 @@ test:storefront-standards-with-codegen:
         - build-storefront
     before_script:
         - corepack enable
-        - corepack prepare --activate pnpm@8.10.5
+        - corepack prepare --activate pnpm@9.0.5
         - pnpm config set store-dir .pnpm-store
         - apk add --no-cache grep
         - cp ./app/schema.graphql ./storefront/schema.graphql

--- a/project-base/app/package.json
+++ b/project-base/app/package.json
@@ -79,7 +79,7 @@
         "select2": "^4.0.12",
         "selectric": "^1.13.0",
         "slick-carousel": "1.6.0",
-        "@yaireo/tagify": "^4.19.1"
+        "@yaireo/tagify": "^4.25.1"
     },
     "jest": {
         "testEnvironment": "jsdom"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| gitlab build was failing because of an old pnpm version (we forgot to upgrade it within https://github.com/shopsys/shopsys/commit/d4060bbafab8e51516cdb920af41147c3a1d6949). Also, another build is failing because of an issue in `@yaireo/tagify` library, see https://github.com/yairEO/tagify/pull/1325
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-builds.odin.shopsys.cloud
  - https://cz.rv-fix-builds.odin.shopsys.cloud
<!-- Replace -->
