### PR TITLE
[framework] fix issues reported by phpstan

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -783,6 +783,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   see classes in the `Shopsys\FrontendApiBundle\Model\Cart` namespace
 -   see #project-base-diff to update your project
 
+#### fix issues reported by phpstan ([#3134](https://github.com/shopsys/shopsys/pull/3134))
+
+-   see #project-base-diff to update your project
+
 #### addProductToListMutation: ensure new product list is created with non-conflicting uuid ([#3126](https://github.com/shopsys/shopsys/pull/3126))
 
 -   add new tests to `ProductListLoggedCustomerTest` and `ProductListNotLoggedCustomerTest` classes

--- a/packages/coding-standards/extension.neon
+++ b/packages/coding-standards/extension.neon
@@ -1,3 +1,5 @@
+rules:
+    - \Shopsys\CodingStandards\Phpstan\EntityShouldHaveFactoryRule
 services:
     -
         class: Shopsys\CodingStandards\Phpstan\InjectedPropertiesInTestsExtension

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -65,6 +65,7 @@
         "jms/metadata": "^2.6.1",
         "jms/translation-bundle": "^1.6.2",
         "knplabs/knp-menu-bundle": "^3.2",
+        "league/csv": "^9.6",
         "league/flysystem": "^3.11",
         "litipk/php-bignumbers": "^0.8.6",
         "league/iso3166": "^4.2.1",

--- a/packages/framework/phpstan.neon
+++ b/packages/framework/phpstan.neon
@@ -31,3 +31,4 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
     - vendor/phpstan/phpstan-symfony/rules.neon
+    - vendor/shopsys/coding-standards/extension.neon

--- a/packages/framework/src/Model/Cart/Cart.php
+++ b/packages/framework/src/Model/Cart/Cart.php
@@ -7,14 +7,13 @@ namespace Shopsys\FrameworkBundle\Model\Cart;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidCartItemException;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
+use Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentData;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct;
 use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
-use Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentData;
 use Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportData;
 
 /**
@@ -355,7 +354,7 @@ class Cart
     }
 
     /**
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentData $cartPaymentData
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentData $cartPaymentData
      */
     public function editCartPayment(CartPaymentData $cartPaymentData): void
     {

--- a/packages/framework/src/Model/Cart/Cart.php
+++ b/packages/framework/src/Model/Cart/Cart.php
@@ -10,11 +10,11 @@ use Doctrine\ORM\Mapping as ORM;
 use Shopsys\FrameworkBundle\Model\Cart\Exception\InvalidCartItemException;
 use Shopsys\FrameworkBundle\Model\Cart\Item\CartItem;
 use Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentData;
+use Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportData;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct;
 use Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode;
 use Shopsys\FrameworkBundle\Model\Product\Exception\ProductNotFoundException;
-use Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportData;
 
 /**
  * @ORM\Table(name="carts")
@@ -343,7 +343,7 @@ class Cart
     }
 
     /**
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportData $cartTransportData
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportData $cartTransportData
      */
     public function editCartTransport(CartTransportData $cartTransportData): void
     {

--- a/packages/framework/src/Model/Cart/Payment/CartPaymentData.php
+++ b/packages/framework/src/Model/Cart/Payment/CartPaymentData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrontendApiBundle\Model\Cart\Payment;
+namespace Shopsys\FrameworkBundle\Model\Cart\Payment;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;

--- a/packages/framework/src/Model/Cart/Payment/CartPaymentDataFactory.php
+++ b/packages/framework/src/Model/Cart/Payment/CartPaymentDataFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrontendApiBundle\Model\Cart\Payment;
+namespace Shopsys\FrameworkBundle\Model\Cart\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
@@ -38,7 +38,7 @@ class CartPaymentDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Cart\Cart $cart
      * @param string $paymentUuid
      * @param string|null $goPayBankSwift
-     * @return \Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentData
+     * @return \Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentData
      */
     public function create(Cart $cart, string $paymentUuid, ?string $goPayBankSwift): CartPaymentData
     {

--- a/packages/framework/src/Model/Cart/Payment/CartPaymentFacade.php
+++ b/packages/framework/src/Model/Cart/Payment/CartPaymentFacade.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrontendApiBundle\Model\Cart\Payment;
+namespace Shopsys\FrameworkBundle\Model\Cart\Payment;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Money\Money;
@@ -12,7 +12,7 @@ class CartPaymentFacade
 {
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentDataFactory $cartPaymentDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentDataFactory $cartPaymentDataFactory
      */
     public function __construct(
         protected readonly EntityManagerInterface $entityManager,

--- a/packages/framework/src/Model/Cart/Transport/CartTransportData.php
+++ b/packages/framework/src/Model/Cart/Transport/CartTransportData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrontendApiBundle\Model\Cart\Transport;
+namespace Shopsys\FrameworkBundle\Model\Cart\Transport;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;

--- a/packages/framework/src/Model/Cart/Transport/CartTransportDataFactory.php
+++ b/packages/framework/src/Model/Cart/Transport/CartTransportDataFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrontendApiBundle\Model\Cart\Transport;
+namespace Shopsys\FrameworkBundle\Model\Cart\Transport;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
@@ -38,7 +38,7 @@ class CartTransportDataFactory
      * @param \Shopsys\FrameworkBundle\Model\Cart\Cart $cart
      * @param string $transportUuid
      * @param string|null $pickupPlaceIdentifier
-     * @return \Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportData
+     * @return \Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportData
      */
     public function create(
         Cart $cart,

--- a/packages/framework/src/Model/Cart/Transport/CartTransportFacade.php
+++ b/packages/framework/src/Model/Cart/Transport/CartTransportFacade.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrontendApiBundle\Model\Cart\Transport;
+namespace Shopsys\FrameworkBundle\Model\Cart\Transport;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Shopsys\FrameworkBundle\Component\Money\Money;
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Model\Cart\Cart;
 class CartTransportFacade
 {
     /**
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportDataFactory $cartTransportDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportDataFactory $cartTransportDataFactory
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
      */
     public function __construct(

--- a/packages/frontend-api/src/Model/Cart/TransportAndPaymentWatcherFacade.php
+++ b/packages/frontend-api/src/Model/Cart/TransportAndPaymentWatcherFacade.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrontendApiBundle\Model\Cart;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentFacade;
+use Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
@@ -16,7 +17,6 @@ use Shopsys\FrameworkBundle\Model\Store\Exception\StoreByUuidNotFoundException;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
 use Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade;
-use Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade;
 use Shopsys\FrontendApiBundle\Model\Payment\Exception\PaymentPriceChangedException;
 use Shopsys\FrontendApiBundle\Model\Payment\PaymentValidationFacade;
 use Shopsys\FrontendApiBundle\Model\Transport\Exception\TransportPriceChangedException;
@@ -35,7 +35,7 @@ class TransportAndPaymentWatcherFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade $freeTransportAndPaymentFacade
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade $cartTransportFacade
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportFacade $cartTransportFacade
      * @param \Shopsys\FrontendApiBundle\Model\Transport\TransportValidationFacade $transportValidationFacade
      * @param \Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentFacade $cartPaymentFacade
      * @param \Shopsys\FrontendApiBundle\Model\Payment\PaymentValidationFacade $paymentValidationFacade

--- a/packages/frontend-api/src/Model/Cart/TransportAndPaymentWatcherFacade.php
+++ b/packages/frontend-api/src/Model/Cart/TransportAndPaymentWatcherFacade.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrontendApiBundle\Model\Cart;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
+use Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
@@ -15,7 +16,6 @@ use Shopsys\FrameworkBundle\Model\Store\Exception\StoreByUuidNotFoundException;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
 use Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade;
-use Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentFacade;
 use Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade;
 use Shopsys\FrontendApiBundle\Model\Payment\Exception\PaymentPriceChangedException;
 use Shopsys\FrontendApiBundle\Model\Payment\PaymentValidationFacade;
@@ -37,7 +37,7 @@ class TransportAndPaymentWatcherFacade
      * @param \Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade $freeTransportAndPaymentFacade
      * @param \Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade $cartTransportFacade
      * @param \Shopsys\FrontendApiBundle\Model\Transport\TransportValidationFacade $transportValidationFacade
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentFacade $cartPaymentFacade
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentFacade $cartPaymentFacade
      * @param \Shopsys\FrontendApiBundle\Model\Payment\PaymentValidationFacade $paymentValidationFacade
      */
     public function __construct(

--- a/packages/frontend-api/src/Model/Mutation/Cart/PaymentInCartMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Cart/PaymentInCartMutation.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\Cart;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
 use Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade;
 use Shopsys\FrontendApiBundle\Model\Cart\CartWithModificationsResult;
-use Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentFacade;
 use Shopsys\FrontendApiBundle\Model\Mutation\AbstractMutation;
 
 class PaymentInCartMutation extends AbstractMutation
@@ -18,7 +18,7 @@ class PaymentInCartMutation extends AbstractMutation
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade $cartWatcherFacade
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Payment\CartPaymentFacade $cartPaymentFacade
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Payment\CartPaymentFacade $cartPaymentFacade
      */
     public function __construct(
         protected readonly CurrentCustomerUser $currentCustomerUser,

--- a/packages/frontend-api/src/Model/Mutation/Cart/TransportInCartMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Cart/TransportInCartMutation.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\Cart;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
 use Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade;
 use Shopsys\FrontendApiBundle\Model\Cart\CartWithModificationsResult;
-use Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade;
 use Shopsys\FrontendApiBundle\Model\Mutation\AbstractMutation;
 
 class TransportInCartMutation extends AbstractMutation
@@ -18,7 +18,7 @@ class TransportInCartMutation extends AbstractMutation
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade $cartWatcherFacade
-     * @param \Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade $cartTransportFacade
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportFacade $cartTransportFacade
      */
     public function __construct(
         protected readonly CurrentCustomerUser $currentCustomerUser,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -73,7 +73,6 @@ includes:
     - vendor/phpstan/phpstan-symfony/rules.neon
     - %currentWorkingDirectory%/packages/coding-standards/extension.neon
 rules:
-    - \Shopsys\CodingStandards\Phpstan\EntityShouldHaveFactoryRule
     - \Shopsys\CodingStandards\Phpstan\OrmPropertyGetterAndSetterHasNoTypehintRule
     - \Shopsys\CodingStandards\Phpstan\OrmPropertyHasNoTypehintRule
     - \Shopsys\CodingStandards\Phpstan\EntityDataObjectPropertyHasNoTypehintRule

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -58,7 +58,6 @@
         "intervention/image": "^2.3.14",
         "jms/serializer-bundle": "^4.0.2",
         "jms/translation-bundle": "^1.6.2",
-        "league/csv": "^9.6",
         "league/flysystem": "^3.11.0",
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "nette/utils": "^3.2",

--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/TransportInOrderValidationTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/TransportInOrderValidationTest.php
@@ -11,12 +11,12 @@ use App\Model\Transport\Transport;
 use App\Model\Transport\TransportDataFactory;
 use App\Model\Transport\TransportFacade;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Cart\Transport\CartTransportFacade;
 use Shopsys\FrameworkBundle\Model\Store\Store;
 use Shopsys\FrameworkBundle\Model\Store\StoreFacade;
 use Shopsys\FrontendApiBundle\Component\Constraints\PaymentTransportRelation;
 use Shopsys\FrontendApiBundle\Component\Constraints\TransportInOrder;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
-use Shopsys\FrontendApiBundle\Model\Cart\Transport\CartTransportFacade;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
 class TransportInOrderValidationTest extends GraphQlTestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| After moving logic from `project-base` to packages in https://github.com/shopsys/shopsys/pull/3088, the build is failing with reported PHPStan issues in the split `framework` package, see https://github.com/shopsys/framework/actions/runs/8827578706/job/24235038754
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-packages.odin.shopsys.cloud
  - https://cz.rv-fix-packages.odin.shopsys.cloud
<!-- Replace -->
