### PR TITLE
[project-base] removed no longer used code from CartMutation

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -806,6 +806,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     +       protected readonly ProductRecalculationDispatcher $productRecalculationDispatcher,
     ```
 
+#### remove no longer necessary code from CartMutation ([#3135](https://github.com/shopsys/shopsys/pull/3135))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/frontend-api/src/Model/Mutation/Cart/CartMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Cart/CartMutation.php
@@ -120,10 +120,6 @@ class CartMutation extends AbstractMutation
         $addProductResults = [];
 
         foreach ($order->getProductItems() as $orderItem) {
-            if ($orderItem->getPriceWithoutVat()->isNegative()) {
-                continue;
-            }
-
             try {
                 $addProductResults[] = $this->cartApiFacade->addProductByUuidToCart($orderItem->getProduct()->getUuid(), $orderItem->getQuantity(), false, $cart);
             } catch (InvalidCartItemUserError) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| After the merge of fixed cart creation for logged users to version 15.0 there was no longer needed code because of cart refactoring done in version 15.0. This has been removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-remove-necessary-code.odin.shopsys.cloud
  - https://cz.tl-remove-necessary-code.odin.shopsys.cloud
<!-- Replace -->
