### PR TITLE
[shopsys] include domain sale exclusion in product querying more appropriately

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -838,6 +838,18 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   `Shopsys\FrontendApiBundle\Model\Mutation\Order\CreateOrderMutation::VALIDATION_GROUP_DIFFERENT_DELIVERY_ADDRESS_WITHOUT_PRESELECTED` constant was renamed to `VALIDATION_GROUP_IS_DELIVERY_ADDRESS_DIFFERENT_FROM_BILLING_WITHOUT_PRESELECTED`
 -   see #project-base-diff to update your project
 
+#### include domain sale exclusion in product querying more appropriately ([#3141](https://github.com/shopsys/shopsys/pull/3141))
+
+-   `Shopsys\FrameworkBundle\Model\Product\ProductRepository::__construct` interface has changed:
+
+    ```diff
+        public function __construct(
+            // ...
+    +       protected readonly QueryBuilderExtender $queryBuilderExtender,
+    ```
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -386,6 +386,12 @@ class ProductFormType extends AbstractType
                         'Products excluded from sale can\'t be displayed on lists and can\'t be searched. Product detail is available by direct access from the URL, but it is not possible to add product to cart.',
                     ),
                 ],
+            ])
+            ->add('saleExclusion', MultidomainType::class, [
+                'label' => t('Exclude from sale on domains'),
+                'required' => false,
+                'entry_type' => YesNoType::class,
+                'position' => ['after' => 'sellingDenied'],
             ]);
 
         if (

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1246,6 +1246,9 @@ msgstr "Kurz"
 msgid "Excl. VAT"
 msgstr "Bez DPH"
 
+msgid "Exclude from sale on domains"
+msgstr "Vyřazení z prodeje dle domén"
+
 msgid "Exclude from sale on whole eshop"
 msgstr "Vyřadit z prodeje na celém e-shopu"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1246,6 +1246,9 @@ msgstr ""
 msgid "Excl. VAT"
 msgstr ""
 
+msgid "Exclude from sale on domains"
+msgstr ""
+
 msgid "Exclude from sale on whole eshop"
 msgstr ""
 

--- a/packages/product-feed-luigis-box/src/Model/Product/LuigisBoxProductRepository.php
+++ b/packages/product-feed-luigis-box/src/Model/Product/LuigisBoxProductRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\ProductFeed\LuigisBoxBundle\Model\Product;
 
-use Doctrine\ORM\Query\Expr\Join;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 use Shopsys\FrameworkBundle\Model\Product\Product;
@@ -34,8 +33,6 @@ class LuigisBoxProductRepository
     ): iterable {
         $queryBuilder = $this->productRepository->getAllOfferedQueryBuilder($domainConfig->getId(), $pricingGroup)
             ->addSelect('b, pd')
-            ->join('p.domains', 'pd', Join::WITH, 'pd.domainId = :domainId')
-            ->andWhere('pd.saleExclusion = false')
             ->leftJoin('p.brand', 'b')
             ->addSelect('v')->join('pd.vat', 'v')
             ->andWhere('p.variantType != :variantTypeVariant')

--- a/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
@@ -106,20 +106,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
         $groupBuilder = $builder->get('displayAvailabilityGroup');
 
         $groupBuilder
-            ->add('sellingDenied', YesNoType::class, [
-                'required' => false,
-                'label' => t('Exclude from sale on whole eshop'),
-                'attr' => [
-                    'icon' => true,
-                    'iconTitle' => t('Products excluded from sale can\'t be displayed on lists and can\'t be searched. Product detail is available by direct access from the URL, but it is not possible to add product to cart.'),
-                ],
-            ])
-            ->add('saleExclusion', MultidomainType::class, [
-                'label' => t('Exclude from sale on domains'),
-                'required' => false,
-                'entry_type' => YesNoType::class,
-                'position' => ['after' => 'sellingDenied'],
-            ])
             ->add('domainHidden', MultidomainType::class, [
                 'label' => t('Hide on domain'),
                 'required' => false,

--- a/project-base/app/src/Model/Product/ProductRepository.php
+++ b/project-base/app/src/Model/Product/ProductRepository.php
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Model\Stock\ProductStock;
 
 /**
  * @property \App\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
- * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository)
+ * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository, \App\Component\Doctrine\QueryBuilderExtender $queryBuilderExtender)
  * @method \App\Model\Product\Product|null findById(int $id)
  * @method \Doctrine\ORM\QueryBuilder getListableInCategoryQueryBuilder(int $domainId, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, \App\Model\Category\Category $category)
  * @method \Doctrine\ORM\QueryBuilder getListableForBrandQueryBuilder(int $domainId, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, \App\Model\Product\Brand\Brand $brand)
@@ -159,20 +159,5 @@ class ProductRepository extends BaseProductRepository
         $this->productElasticsearchRepository->filterBySearchText($queryBuilder, $searchText);
 
         return $queryBuilder;
-    }
-
-    /**
-     * @param int $domainId
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    public function getAllSellableQueryBuilder($domainId, PricingGroup $pricingGroup): QueryBuilder
-    {
-        return $this->getAllOfferedQueryBuilder($domainId, $pricingGroup)
-            ->join('p.domains', 'pd', Join::WITH, 'pd.domainId = :domainId')
-            ->andWhere('p.variantType != :variantTypeMain')
-            ->andWhere('pd.saleExclusion = false')
-            ->setParameter('variantTypeMain', Product::VARIANT_TYPE_MAIN)
-            ->setParameter('domainId', $domainId);
     }
 }

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -505,12 +505,6 @@ msgstr "ID entity"
 msgid "Error messages"
 msgstr "Chybové hlášky"
 
-msgid "Exclude from sale on domains"
-msgstr "Vyřazení z prodeje dle domén"
-
-msgid "Exclude from sale on whole eshop"
-msgstr "Vyřadit z prodeje na celém eshopu"
-
 msgid "Extended SEO categories"
 msgstr "Rozšířené SEO kategorie"
 
@@ -1068,9 +1062,6 @@ msgstr "Produkty - zobrazení"
 
 msgid "Products accessories transfer"
 msgstr "Přenos příslušenství produktů"
-
-msgid "Products excluded from sale can't be displayed on lists and can't be searched. Product detail is available by direct access from the URL, but it is not possible to add product to cart."
-msgstr "Zboží vyřazené z prodeje se nezobrazuje ve výpisech ani nelze vyhledat. Detail tohoto zboží je dostupný přímým přístupem z URL, zboží ale nelze vložit do košíku."
 
 msgid "Products flags transfer"
 msgstr "Přenos příznaků produktů"

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -505,12 +505,6 @@ msgstr ""
 msgid "Error messages"
 msgstr ""
 
-msgid "Exclude from sale on domains"
-msgstr ""
-
-msgid "Exclude from sale on whole eshop"
-msgstr ""
-
 msgid "Extended SEO categories"
 msgstr ""
 
@@ -1067,9 +1061,6 @@ msgid "Products - view"
 msgstr ""
 
 msgid "Products accessories transfer"
-msgstr ""
-
-msgid "Products excluded from sale can't be displayed on lists and can't be searched. Product detail is available by direct access from the URL, but it is not possible to add product to cart."
 msgstr ""
 
 msgid "Products flags transfer"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was discrepancy in project base between querying of sellable and listable products where domain sale exclusion was included in sellable products only. Domain sale exclusion is now moved to more generalized offered products which should be more appropriate. Issue stemmed from domain sale excluded products being included in sellable products sitemap which is not desired behavior.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





















































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-sellable-products-in-sitemap.odin.shopsys.cloud
  - https://cz.ab-sellable-products-in-sitemap.odin.shopsys.cloud
<!-- Replace -->
