### PR TITLE
[SSP-2289] cart hydration fix

### DIFF
--- a/project-base/storefront/hooks/cart/useCurrentCart.ts
+++ b/project-base/storefront/hooks/cart/useCurrentCart.ts
@@ -1,12 +1,13 @@
 import {
-    ListedStoreFragmentApi,
+    useCartQueryApi,
     Maybe,
     TransportWithAvailablePaymentsAndStoresFragmentApi,
-    useCartQueryApi,
+    ListedStoreFragmentApi,
 } from 'graphql/generated';
 import { useIsUserLoggedIn } from 'hooks/auth/useIsUserLoggedIn';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { usePersistStore } from 'store/usePersistStore';
+import { useSessionStore } from 'store/useSessionStore';
 import { CurrentCartType } from 'types/cart';
 
 export const useCurrentCart = (fromCache = true): CurrentCartType => {
@@ -14,12 +15,13 @@ export const useCurrentCart = (fromCache = true): CurrentCartType => {
     const authLoading = usePersistStore((s) => s.authLoading);
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const packeteryPickupPoint = usePersistStore((store) => store.packeteryPickupPoint);
+    const isCartHydrated = useSessionStore((s) => s.isCartHydrated);
+    const updatePageLoadingState = useSessionStore((s) => s.updatePageLoadingState);
 
-    const [isCartHydrated, setIsCartHydrated] = useState(false);
     const isWithCart = isUserLoggedIn || !!cartUuid;
 
     useEffect(() => {
-        setIsCartHydrated(true);
+        updatePageLoadingState({ isCartHydrated: true });
     }, []);
 
     const [{ data: fetchedCartData, fetching }, fetchCart] = useCartQueryApi({

--- a/project-base/storefront/store/slices/createPageLoadingStateSlice.ts
+++ b/project-base/storefront/store/slices/createPageLoadingStateSlice.ts
@@ -14,6 +14,7 @@ const CUSTOM_PAGE_TYPES = [
 export type PageType = FriendlyPagesTypesKey | (typeof CUSTOM_PAGE_TYPES)[number];
 
 export type PageLoadingStateSlice = {
+    isCartHydrated: boolean;
     isPageLoading: boolean;
     redirectPageType: PageType | undefined;
 
@@ -21,6 +22,7 @@ export type PageLoadingStateSlice = {
 };
 
 export const createPageLoadingStateSlice: StateCreator<PageLoadingStateSlice> = (set) => ({
+    isCartHydrated: false,
     isPageLoading: false,
     redirectPageType: undefined,
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Cart hook (useCurrentCart) performed "hydration" for every place it was called from. This caused bugs and unexpected behavior. This PR makes the hydration state global, fixing this issue.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2289-cart-hydration-fix.odin.shopsys.cloud
  - https://cz.sh-ssp-2289-cart-hydration-fix.odin.shopsys.cloud
<!-- Replace -->
