### PR TITLE
[framework] load products iteratively while generating image sitemaps

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -826,6 +826,12 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   see #project-base-diff to update your project
 
+#### load products iteratively while generating image sitemaps ([#3144](https://github.com/shopsys/shopsys/pull/3144))
+
+-   `Shopsys\FrameworkBundle\Model\Product\ProductRepository` class was changed:
+    -   `getAllOfferedProducts()` method was removed, use `getAllOfferedProductsPaginated()` instead
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -451,11 +451,21 @@ class ProductRepository
     /**
      * @param int $domainId
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
-     * @return array
+     * @param int $offset
+     * @param int $limit
+     * @return \App\Model\Product\Product[]
      */
-    public function getAllOfferedProducts(int $domainId, PricingGroup $pricingGroup): array
-    {
-        return $this->getAllOfferedQueryBuilder($domainId, $pricingGroup)->getQuery()->execute();
+    public function getAllOfferedProductsPaginated(
+        int $domainId,
+        PricingGroup $pricingGroup,
+        int $offset,
+        int $limit,
+    ): array {
+        return $this->getAllOfferedQueryBuilder($domainId, $pricingGroup)
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Image sitemap generation was failing on memory if there was large number of products loaded at once. Now products are loaded iteratively which should help with the issue. Rewriting cron into iterative one would solve the problem completely regardless of data size, however Presta bundle does not support iterative data load, so we decided to go with this compromise for now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Yes<!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2618 <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-generate-image-sitemap-iteratively.odin.shopsys.cloud
  - https://cz.ab-generate-image-sitemap-iteratively.odin.shopsys.cloud
<!-- Replace -->
