### PR TITLE
[framework] fix sending emails with attachments

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1523,6 +1523,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     -   you can use GTM for this purpose, see [our docs](docs/integration/third-party-scripts.md) for more information
     -   see #project-base-diff to update your project
 
+-   fix sending emails with attachments ([#3146](https://github.com/shopsys/shopsys/pull/3146))
+
+    -   see #project-base-diff to update your project
+
 ### Storefront
 
 -   add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -128,19 +128,20 @@ Yes we have, you can easily use [`maildev/maildev`](https://github.com/maildev/m
 
 ```diff
 smtp-server:
--        image: namshi/smtp:latest
+-        image: ixdotai/smtp:latest
 +        image: maildev/maildev
          container_name: shopsys-framework-smtp-server
 +        ports:
-+            - "8025:80"
++            - "1080:1080"
++            - "1025:1025"
 ```
 
 -   Run `docker-compose up -d`
--   add `?verify_peer=false` at the end of the `MAILER_DSN` environment variable value:
+-   change the port in `MAILER_DSN` environment variable value (you can redefine the value in your `.env.local` file):
 
 ```diff
-- MAILER_DSN=smtp://smtp-server:25
-+ MAILER_DSN=smtp://smtp-server:25?verify_peer=false
+- MAILER_DSN=smtp://smtp-server:25?verify_peer=false
++ MAILER_DSN=smtp://smtp-server:1025?verify_peer=false
 ```
 
 -   Now you are able to see all the application emails in the inbox on [`http://127.0.0.1:8025`](http://127.0.0.1:8025).

--- a/packages/framework/src/Component/UploadedFile/UploadedFile.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFile.php
@@ -72,7 +72,7 @@ class UploadedFile implements EntityFileUploadInterface
     protected $type;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $temporaryFilename;
 
@@ -111,15 +111,19 @@ class UploadedFile implements EntityFileUploadInterface
      */
     public function getTemporaryFilesForUpload(): array
     {
-        return [
-            static::UPLOAD_KEY => new FileForUpload(
+        $files = [];
+
+        if ($this->temporaryFilename !== null) {
+            $files[static::UPLOAD_KEY] = new FileForUpload(
                 $this->temporaryFilename,
                 false,
                 $this->entityName,
                 null,
                 FileNamingConvention::TYPE_ID,
-            ),
-        ];
+            );
+        }
+
+        return $files;
     }
 
     /**

--- a/packages/framework/src/Model/Mail/Mailer.php
+++ b/packages/framework/src/Model/Mail/Mailer.php
@@ -79,8 +79,19 @@ class Mailer
 
         foreach ($messageData->attachments as $attachment) {
             try {
-                $email->attachFromPath(
-                    $this->mailTemplateFacade->getMailTemplateAttachmentFilepath($attachment),
+                $attachmentFilepath = $this->mailTemplateFacade->getMailTemplateAttachmentFilepath($attachment);
+                $attachmentContent = file_get_contents($attachmentFilepath);
+
+                if ($attachmentContent === false) {
+                    $this->logger->error('Attachment could not be added - reading the file content failed.', [
+                        'attachment' => $attachment,
+                        'attachmentFilepath' => $attachmentFilepath,
+                    ]);
+
+                    continue;
+                }
+                $email->attach(
+                    $attachmentContent,
                     $attachment->getNameWithExtension(),
                 );
             } catch (FilesystemOperationFailed $exception) {

--- a/project-base/app/src/DataFixtures/Demo/MailTemplateDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/MailTemplateDataFixture.php
@@ -132,7 +132,7 @@ team of {domain}
 
             $this->createMailTemplate($manager, MailTemplate::PERSONAL_DATA_EXPORT_NAME, $mailTemplateData, $domainId);
 
-            $mailTemplateData->subject = t('Registration completion', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
+            $mailTemplateData->subject = t('Customer activation', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
             $mailTemplateData->body = t('Dear customer,<br /><br />you can finish registration and set new password via this link: <a href="{activation_url}">{activation_url}</a>', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
 
             $this->createMailTemplate($manager, CustomerActivationMail::CUSTOMER_ACTIVATION_NAME, $mailTemplateData, $domainId);

--- a/project-base/app/src/Model/Mail/MailTemplateConfiguration.php
+++ b/project-base/app/src/Model/Mail/MailTemplateConfiguration.php
@@ -48,7 +48,7 @@ class MailTemplateConfiguration extends BaseMailTemplateConfiguration
 
     private function registerCustomerActivationMailTemplate(): void
     {
-        $mailTemplate = new MailTemplateVariables(t('Registration completion'));
+        $mailTemplate = new MailTemplateVariables(t('Customer activation'));
         $mailTemplate
             ->addVariable(CustomerActivationMail::VARIABLE_EMAIL, t('Email'))
             ->addVariable(CustomerActivationMail::VARIABLE_ACTIVATION_URL, t('Link to complete the registration'), MailTemplateVariables::CONTEXT_BODY, MailTemplateVariables::REQUIRED_BODY);

--- a/project-base/app/translations/dataFixtures.cs.po
+++ b/project-base/app/translations/dataFixtures.cs.po
@@ -697,6 +697,9 @@ msgstr "Kreditní kartou"
 msgid "Crevice nozzle VP-4290"
 msgstr "Hubice štěrbinová VP-4290"
 
+msgid "Customer activation"
+msgstr "Aktivace zákazníka"
+
 msgid "Cyklocomputer – cyklonavigation with preset maps, color display 3\", training programmes, WiFi"
 msgstr "Cyklocomputer - cyklonavigace s předinstalovanými mapami silnic a cyklotras, barevný dotykový displej 3\"."
 
@@ -1521,9 +1524,6 @@ msgstr "Reflexní páska pro bezpečný pohyb na cestě"
 
 msgid "Registration completed"
 msgstr "Registrace byla dokončena"
-
-msgid "Registration completion"
-msgstr "Dokončení registrace"
 
 msgid "Replacement textile bag for vacuum cleaners CONCEPT Sprinter - VP9070. Package: 1 pc"
 msgstr "Náhradní textilní sáček pro vysavače CONCEPT Sprinter - VP9070. Balení: 1 ks"

--- a/project-base/app/translations/dataFixtures.en.po
+++ b/project-base/app/translations/dataFixtures.en.po
@@ -697,6 +697,9 @@ msgstr ""
 msgid "Crevice nozzle VP-4290"
 msgstr ""
 
+msgid "Customer activation"
+msgstr ""
+
 msgid "Cyklocomputer – cyklonavigation with preset maps, color display 3\", training programmes, WiFi"
 msgstr ""
 
@@ -1520,9 +1523,6 @@ msgid "Reflective tape for safe movement on the road"
 msgstr ""
 
 msgid "Registration completed"
-msgstr ""
-
-msgid "Registration completion"
 msgstr ""
 
 msgid "Replacement textile bag for vacuum cleaners CONCEPT Sprinter - VP9070. Package: 1 pc"

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -409,6 +409,9 @@ msgstr "Přehled cronů"
 msgid "Custom"
 msgstr "Vlastní"
 
+msgid "Customer activation"
+msgstr "Aktivace zákazníka"
+
 msgid "Customer not found."
 msgstr "Zákazník nenalezen."
 
@@ -1332,9 +1335,6 @@ msgstr "Typ přesměrování"
 
 msgid "Registration"
 msgstr "Registrace"
-
-msgid "Registration completion"
-msgstr "Dokončení registrace"
 
 msgid "Related products"
 msgstr "Související produkty"

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -409,6 +409,9 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
+msgid "Customer activation"
+msgstr ""
+
 msgid "Customer not found."
 msgstr ""
 
@@ -1331,9 +1334,6 @@ msgid "Redirect type"
 msgstr ""
 
 msgid "Registration"
-msgstr ""
-
-msgid "Registration completion"
 msgstr ""
 
 msgid "Related products"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The emails are sent asynchronously using Symfony messanger. The problem was, the email attachments were referenced via their local path when the message was created within the php-fpm container/pod. Then, when the message was consumed by the consumer, the attachment was not available as the local storage is not shared across the containers/pods.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-mailer.odin.shopsys.cloud
  - https://cz.rv-fix-mailer.odin.shopsys.cloud
<!-- Replace -->
