### PR TITLE
[framework] fixed money type with null value in entity log

### DIFF
--- a/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/MoneyDataTypeFormatter.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/Formatter/MoneyDataTypeFormatter.php
@@ -14,8 +14,8 @@ class MoneyDataTypeFormatter
      */
     public function formatChanges(array $changes): string
     {
-        $changes['oldReadableValue'] = Money::create($changes['oldReadableValue'])->round(2)->getAmount();
-        $changes['newReadableValue'] = Money::create($changes['newReadableValue'])->round(2)->getAmount();
+        $changes['oldReadableValue'] = $changes['oldReadableValue'] ? Money::create($changes['oldReadableValue'])->round(2)->getAmount() : t('empty value');
+        $changes['newReadableValue'] = $changes['newReadableValue'] ? Money::create($changes['newReadableValue'])->round(2)->getAmount() : t('empty value');
 
         return t('from "oldReadableValue" to "newReadableValue"', $changes);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| For nullable money types in entity log, the output grid no longer fails on error
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fixed-price-fix.odin.shopsys.cloud
  - https://cz.mg-fixed-price-fix.odin.shopsys.cloud
<!-- Replace -->
