### PR TITLE
remove product stock from calculated sale exclusion calculation

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -863,6 +863,7 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 #### remove product stock from calculated sale exclusion calculation ([#3159](https://github.com/shopsys/shopsys/pull/3159))
 
+-   all the add to cart buttons are now disabled when product quantity is zero or negative
 -   see #project-base-diff to update your project
 
 ### Storefront
@@ -1049,3 +1050,8 @@ We want to implement more usable UI design which will be better base for upcomin
 
 -   simple navgation images are now blacked-out during cypress tests
 -   make sure you add the blackout everywhere where your snapshots contain simple navigation with images
+
+#### remove product stock from calculated sale exclusion calculation ([#3159](https://github.com/shopsys/shopsys/pull/3159))
+
+-   all the add to cart buttons are now disabled when product quantity is zero or negative
+-   see #project-base-diff to update your project

--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -861,6 +861,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   ParameterColorValueDataFixture is added to handle assigning hex values to color parameters
 -   see #project-base-diff to update your project
 
+#### remove product stock from calculated sale exclusion calculation ([#3159](https://github.com/shopsys/shopsys/pull/3159))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/project-base/app/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/OrderDataFixture.php
@@ -262,7 +262,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
             [
                 ProductDataFixture::PRODUCT_PREFIX . '7' => 1,
                 ProductDataFixture::PRODUCT_PREFIX . '8' => 1,
-                ProductDataFixture::PRODUCT_PREFIX . '12' => 2,
+                ProductDataFixture::PRODUCT_PREFIX . '34' => 2,
             ],
         );
 

--- a/project-base/app/src/Model/Product/ProductSellingDeniedRecalculator.php
+++ b/project-base/app/src/Model/Product/ProductSellingDeniedRecalculator.php
@@ -64,18 +64,6 @@ class ProductSellingDeniedRecalculator extends BaseProductSellingDeniedRecalcula
                         OR
                         pd.domain_hidden = TRUE
                         OR (
-                            p.variant_type != :variantTypeMain
-                            AND
-                            NOT EXISTS(
-                                SELECT 1
-                                FROM product_stocks as ps
-                                JOIN stocks as s ON s.id = ps.stock_id
-                                JOIN stock_domains sd ON s.id = sd.stock_id AND sd.domain_id = :domainId
-                                WHERE ps.product_id = p.id AND sd.is_enabled = TRUE
-                                HAVING SUM(ps.product_quantity) > 0
-                            )
-                        )
-                        OR (
                             pd.sale_exclusion = TRUE
                             AND                        
                             p.variant_type = :variantTypeMain

--- a/project-base/app/tests/App/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Filter/BrandFilterChoiceRepositoryTest.php
@@ -52,7 +52,7 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
         $brandFilterChoices = $this->getChoicesForSearchText('phone');
 
-        $this->assertCount(3, $brandFilterChoices);
+        $this->assertCount(4, $brandFilterChoices);
 
         $ids = array_map(
             static function (Brand $brand) {
@@ -63,6 +63,7 @@ class BrandFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
         $this->assertContains(1, $ids);
         $this->assertContains(3, $ids);
+        $this->assertContains(19, $ids);
         $this->assertContains(20, $ids);
     }
 

--- a/project-base/app/tests/App/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Filter/FlagFilterChoiceRepositoryTest.php
@@ -49,7 +49,7 @@ class FlagFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
 
         $flagFilterChoices = $this->getChoicesForSearchText('phone');
 
-        $this->assertCount(2, $flagFilterChoices);
+        $this->assertCount(3, $flagFilterChoices);
 
         $ids = array_map(
             static function (Flag $flag) {
@@ -58,7 +58,7 @@ class FlagFilterChoiceRepositoryTest extends TransactionFunctionalTestCase
             $flagFilterChoices,
         );
 
-        $this->assertContains(2, $ids);
+        $this->assertContains(3, $ids);
     }
 
     public function testGetFlagFilterChoicesForBook(): void

--- a/project-base/app/tests/App/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductOnCurrentDomainElasticFacadeCountDataTest.php
@@ -139,45 +139,45 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
 
         $countData->countInStock = 7;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 4,
-            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 6,
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 2,
         ];
         $countData->countByFlagId = [
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 2,
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 2,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 5,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 3,
         ];
         $countData->countByParameterIdAndValueId = [
             $this->getReference(ParameterDataFixture::PARAM_COLOR_PRINTING, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 7,
+                $this->getParameterValueIdForFirstDomain('Yes') => 10,
             ],
             $this->getReference(ParameterDataFixture::PARAM_DIMENSIONS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 5,
+                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 8,
                 $this->getParameterValueIdForFirstDomain('426x306x145 mm') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_LCD, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 4,
-                $this->getParameterValueIdForFirstDomain('No') => 3,
+                $this->getParameterValueIdForFirstDomain('Yes') => 5,
+                $this->getParameterValueIdForFirstDomain('No') => 5,
             ],
             $this->getReference(ParameterDataFixture::PARAM_MAXIMUM_SIZE, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('A3') => 5,
-                $this->getParameterValueIdForFirstDomain('A4') => 2,
+                $this->getParameterValueIdForFirstDomain('A3') => 7,
+                $this->getParameterValueIdForFirstDomain('A4') => 3,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_RESOLUTION, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('4800x1200') => 2,
-                $this->getParameterValueIdForFirstDomain('2400x600') => 5,
+                $this->getParameterValueIdForFirstDomain('4800x1200') => 3,
+                $this->getParameterValueIdForFirstDomain('2400x600') => 7,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_TECHNOLOGY, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('inkjet') => 7,
+                $this->getParameterValueIdForFirstDomain('inkjet') => 10,
             ],
             $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 7,
+                $this->getParameterValueIdForFirstDomain('Yes') => 10,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('5.4 kg') => 1,
-                $this->getParameterValueIdForFirstDomain('3.5 kg') => 6,
+                $this->getParameterValueIdForFirstDomain('3.5 kg') => 9,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 5,
+                $this->getParameterValueIdForFirstDomain('Yes') => 8,
                 $this->getParameterValueIdForFirstDomain('No') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WARRANTY_IN_YEARS, Parameter::class)->getId() => [
@@ -205,39 +205,43 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
 
         $countData->countInStock = 2;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 2,
         ];
         $countData->countByFlagId = [
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 2,
         ];
         $countData->countByParameterIdAndValueId = [
             $this->getReference(ParameterDataFixture::PARAM_COLOR_PRINTING, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 2,
+                $this->getParameterValueIdForFirstDomain('Yes') => 3,
             ],
             $this->getReference(ParameterDataFixture::PARAM_DIMENSIONS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 1,
+                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 2,
                 $this->getParameterValueIdForFirstDomain('426x306x145 mm') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_LCD, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 2,
+                $this->getParameterValueIdForFirstDomain('No') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_MAXIMUM_SIZE, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('A3') => 2,
+                $this->getParameterValueIdForFirstDomain('A4') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_RESOLUTION, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('4800x1200') => 2,
+                $this->getParameterValueIdForFirstDomain('2400x600') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_TECHNOLOGY, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('inkjet') => 2,
+                $this->getParameterValueIdForFirstDomain('inkjet') => 3,
             ],
             $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 2,
+                $this->getParameterValueIdForFirstDomain('Yes') => 3,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('5.4 kg') => 1,
-                $this->getParameterValueIdForFirstDomain('3.5 kg') => 1,
+                $this->getParameterValueIdForFirstDomain('3.5 kg') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 1,
+                $this->getParameterValueIdForFirstDomain('Yes') => 2,
                 $this->getParameterValueIdForFirstDomain('No') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WARRANTY_IN_YEARS, Parameter::class)->getId() => [
@@ -276,45 +280,45 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
 
         $countData->countInStock = 6;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 3,
-            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 4,
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 2,
         ];
         $countData->countByFlagId = [
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 2,
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 2,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 4,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 3,
         ];
         $countData->countByParameterIdAndValueId = [
             $this->getReference(ParameterDataFixture::PARAM_COLOR_PRINTING, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 6,
+                $this->getParameterValueIdForFirstDomain('Yes') => 8,
             ],
             $this->getReference(ParameterDataFixture::PARAM_DIMENSIONS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 4,
+                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 6,
                 $this->getParameterValueIdForFirstDomain('426x306x145 mm') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_LCD, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('Yes') => 4,
-                $this->getParameterValueIdForFirstDomain('No') => 2,
+                $this->getParameterValueIdForFirstDomain('No') => 4,
             ],
             $this->getReference(ParameterDataFixture::PARAM_MAXIMUM_SIZE, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('A3') => 5,
-                $this->getParameterValueIdForFirstDomain('A4') => 1,
+                $this->getParameterValueIdForFirstDomain('A3') => 6,
+                $this->getParameterValueIdForFirstDomain('A4') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_RESOLUTION, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('4800x1200') => 2,
-                $this->getParameterValueIdForFirstDomain('2400x600') => 4,
+                $this->getParameterValueIdForFirstDomain('2400x600') => 6,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_TECHNOLOGY, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('inkjet') => 6,
+                $this->getParameterValueIdForFirstDomain('inkjet') => 8,
             ],
             $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 6,
+                $this->getParameterValueIdForFirstDomain('Yes') => 8,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('3.5 kg') => 5,
+                $this->getParameterValueIdForFirstDomain('3.5 kg') => 7,
                 $this->getParameterValueIdForFirstDomain('5.4 kg') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 4,
+                $this->getParameterValueIdForFirstDomain('Yes') => 6,
                 $this->getParameterValueIdForFirstDomain('No') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WARRANTY_IN_YEARS, Parameter::class)->getId() => [
@@ -360,11 +364,41 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
         $countData = new ProductFilterCountData();
 
         $countData->countInStock = 0;
-        $countData->countByBrandId = [];
+        $countData->countByBrandId = [
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
+        ];
         $countData->countByFlagId = [];
         $countData->countByParameterIdAndValueId = [
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
                 $this->getParameterValueIdForFirstDomain('5.4 kg') => 1,
+                $this->getParameterValueIdForFirstDomain('3.5 kg') => 2,
+            ],
+            4 => [
+                $this->getParameterValueIdForFirstDomain('Yes') => 2,
+            ],
+            11 => [
+                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 2,
+            ],
+            29 => [
+                $this->getParameterValueIdForFirstDomain('inkjet') => 2,
+            ],
+            30 => [
+                $this->getParameterValueIdForFirstDomain('A3') => 1,
+                $this->getParameterValueIdForFirstDomain('A4') => 1,
+            ],
+            31 => [
+                $this->getParameterValueIdForFirstDomain('Yes') => 1,
+                $this->getParameterValueIdForFirstDomain('No') => 1,
+            ],
+            32 => [
+                $this->getParameterValueIdForFirstDomain('4800x1200') => 1,
+                $this->getParameterValueIdForFirstDomain('2400x600') => 1,
+            ],
+            33 => [
+                $this->getParameterValueIdForFirstDomain('Yes') => 2,
+            ],
+            34 => [
+                $this->getParameterValueIdForFirstDomain('Yes') => 2,
             ],
         ];
 
@@ -405,41 +439,45 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
 
         $countData->countInStock = 4;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 3,
-            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 5,
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 2,
         ];
-        $countData->countByFlagId = [];
+        $countData->countByFlagId = [
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 3,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 1,
+        ];
         $countData->countByParameterIdAndValueId = [
             $this->getReference(ParameterDataFixture::PARAM_COLOR_PRINTING, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 4,
+                $this->getParameterValueIdForFirstDomain('Yes') => 7,
             ],
             $this->getReference(ParameterDataFixture::PARAM_DIMENSIONS, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 4,
+                $this->getParameterValueIdForFirstDomain('449x304x152 mm') => 7,
                 $this->getParameterValueIdForFirstDomain('426x306x145 mm') => 2,
             ],
             $this->getReference(ParameterDataFixture::PARAM_LCD, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 2,
-                $this->getParameterValueIdForFirstDomain('No') => 2,
+                $this->getParameterValueIdForFirstDomain('Yes') => 3,
+                $this->getParameterValueIdForFirstDomain('No') => 4,
             ],
             $this->getReference(ParameterDataFixture::PARAM_MAXIMUM_SIZE, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('A3') => 2,
-                $this->getParameterValueIdForFirstDomain('A4') => 2,
+                $this->getParameterValueIdForFirstDomain('A3') => 4,
+                $this->getParameterValueIdForFirstDomain('A4') => 3,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_RESOLUTION, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('2400x600') => 4,
+                $this->getParameterValueIdForFirstDomain('2400x600') => 6,
+                $this->getParameterValueIdForFirstDomain('4800x1200') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_PRINT_TECHNOLOGY, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('inkjet') => 4,
+                $this->getParameterValueIdForFirstDomain('inkjet') => 7,
             ],
             $this->getReference(ParameterDataFixture::PARAM_USB, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 4,
+                $this->getParameterValueIdForFirstDomain('Yes') => 7,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('3.5 kg') => 4,
+                $this->getParameterValueIdForFirstDomain('3.5 kg') => 7,
                 $this->getParameterValueIdForFirstDomain('5.4 kg') => 1,
             ],
             $this->getReference(ParameterDataFixture::PARAM_WIFI, Parameter::class)->getId() => [
-                $this->getParameterValueIdForFirstDomain('Yes') => 4,
+                $this->getParameterValueIdForFirstDomain('Yes') => 7,
             ],
         ];
 
@@ -497,12 +535,13 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
         $countData = new ProductFilterCountData();
         $countData->countInStock = 5;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 4,
-            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 6,
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 2,
+            $this->getReference(BrandDataFixture::BRAND_DLINK, Brand::class)->getId() => 1,
         ];
         $countData->countByFlagId = [
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 1,
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 1,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 2,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 4,
         ];
 
         return [
@@ -522,7 +561,8 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
         $countData = new ProductFilterCountData();
         $countData->countInStock = 1;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_CANON, Brand::class)->getId() => 3,
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
         ];
         $countData->countByFlagId = [];
 
@@ -544,11 +584,12 @@ class ProductOnCurrentDomainElasticFacadeCountDataTest extends ParameterTransact
 
         $countData->countInStock = 4;
         $countData->countByBrandId = [
-            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 1,
+            $this->getReference(BrandDataFixture::BRAND_HP, Brand::class)->getId() => 2,
+            $this->getReference(BrandDataFixture::BRAND_DLINK, Brand::class)->getId() => 1,
         ];
         $countData->countByFlagId = [
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 1,
-            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 1,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_ACTION, Flag::class)->getId() => 2,
+            $this->getReference(FlagDataFixture::FLAG_PRODUCT_NEW, Flag::class)->getId() => 3,
         ];
 
         return [

--- a/project-base/app/tests/App/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductSellingDeniedRecalculatorTest.php
@@ -128,11 +128,7 @@ class ProductSellingDeniedRecalculatorTest extends TransactionFunctionalTestCase
 
         /** @var \App\Model\Product\ProductData $variant1ProductData */
         $variant1ProductData = $this->productDataFactory->createFromProduct($variant1);
-        $variant1ProductData->sellingDenied = false;
-
-        foreach ($variant1ProductData->productStockData as $productStockData) {
-            $productStockData->productQuantity = 0;
-        }
+        $variant1ProductData->sellingDenied = true;
 
         $this->productFacade->edit($variant1->getId(), $variant1ProductData);
 

--- a/project-base/app/tests/App/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Search/FilterQueryTest.php
@@ -59,7 +59,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByFlags([3])
             ->applyDefaultOrdering();
 
-        $this->assertIdWithFilter($filter, [25, 27, 29, 9, 13, 14, 19, 31, 35, 44]);
+        $this->assertIdWithFilter($filter, [25, 27, 29, 9, 144, 10, 13, 14, 50, 19, 21, 22, 31, 35, 42, 44]);
     }
 
     public function testFlagBrand(): void
@@ -138,19 +138,19 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByCategory([9])
             ->applyDefaultOrdering();
 
-        $this->assertIdWithFilter($filter, [72, 25, 27, 29, 28, 26, 33, 39, 40], 'top');
+        $this->assertIdWithFilter($filter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40], 'top');
 
         $nameAscFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_NAME_ASC, $pricingGroup);
-        $this->assertIdWithFilter($nameAscFilter, [72, 25, 27, 29, 28, 26, 33, 39, 40], 'name asc');
+        $this->assertIdWithFilter($nameAscFilter, [72, 25, 27, 29, 28, 26, 33, 39, 40, 50], 'name asc');
 
         $nameDescFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_NAME_DESC, $pricingGroup);
-        $this->assertIdWithFilter($nameDescFilter, [40, 39, 33, 26, 28, 29, 27, 25, 72], 'name desc');
+        $this->assertIdWithFilter($nameDescFilter, [40, 39, 33, 26, 28, 29, 27, 25, 72, 50], 'name desc');
 
         $priceAscFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRICE_ASC, $pricingGroup);
-        $this->assertIdWithFilter($priceAscFilter, [40, 33, 39, 29, 25, 26, 27, 28, 72], 'price asc');
+        $this->assertIdWithFilter($priceAscFilter, [40, 33, 39, 29, 25, 26, 27, 28, 72, 50], 'price asc');
 
         $priceDescFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRICE_DESC, $pricingGroup);
-        $this->assertIdWithFilter($priceDescFilter, [72, 28, 27, 25, 26, 29, 39, 33, 40], 'price desc');
+        $this->assertIdWithFilter($priceDescFilter, [72, 28, 27, 25, 26, 29, 39, 33, 40, 50], 'price desc');
     }
 
     public function testMatchQuery(): void
@@ -174,7 +174,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByCategory([9])
             ->applyDefaultOrdering();
 
-        $this->assertIdWithFilter($filter, [72, 25, 27, 29, 28, 26, 33, 39, 40]);
+        $this->assertIdWithFilter($filter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40]);
 
         $limit5Filter = $filter->setLimit(5);
         $this->assertIdWithFilter($limit5Filter, [72, 25, 27, 29, 28]);
@@ -184,11 +184,11 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
 
         $limit4Page2Filter = $filter->setLimit(4)
             ->setPage(2);
-        $this->assertIdWithFilter($limit4Page2Filter, [28, 26, 33, 39]);
+        $this->assertIdWithFilter($limit4Page2Filter, [28, 26, 50, 33]);
 
         $limit4Page3Filter = $filter->setLimit(4)
             ->setPage(3);
-        $this->assertIdWithFilter($limit4Page3Filter, [40]);
+        $this->assertIdWithFilter($limit4Page3Filter, [39, 40]);
 
         $limit4Page4Filter = $filter->setLimit(4)
             ->setPage(4);

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/AnonymousAddOrderItemsToCartTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/AnonymousAddOrderItemsToCartTest.php
@@ -219,7 +219,7 @@ class AnonymousAddOrderItemsToCartTest extends GraphQlTestCase
 
         $expectedNotAddedProducts = [
             [
-                'name' => t('D-Link', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
+                'name' => t('MIO Cyclo 100, bicycle computer, 1,8"', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale),
             ],
         ];
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Cart/RetrieveCartTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Cart/RetrieveCartTest.php
@@ -414,6 +414,9 @@ class RetrieveCartTest extends GraphQlTestCase
                 [
                     'name' => t('24" Philips 32PFL4308', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
                 ],
+                [
+                    'name' => t('Canon PIXMA MG2450', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
+                ],
             ],
             'isSellingDenied' => false,
             'description' => t(

--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
@@ -66,7 +66,7 @@ class GetOrderAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
     public function testGetOrderByUuidReturnsError(): void
     {
         $order = $this->getOrderOfNotCurrentlyLoggedCustomerUser();
-        $expectedErrorMessage = "Order with UUID '84f95773-6d06-59d9-8680-fb35abfe99ac' not found.";
+        $expectedErrorMessage = "Order with UUID 'fa2603a2-afc3-57c7-8b76-6c809a3957c2' not found.";
 
         $response = $this->getResponseContentForGql(__DIR__ . '/graphql/GetOrderQuery.graphql', [
             'uuid' => $order->getUuid(),

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/Flag/FlagTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/Flag/FlagTest.php
@@ -168,13 +168,13 @@ class FlagTest extends GraphQlTestCase
                             'name' => t('TV, audio', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
                         ],
                         [
-                            'name' => t('Electronics', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
-                        ],
-                        [
                             'name' => t('Printers', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
                         ],
                         [
                             'name' => t('Books', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
+                        ],
+                        [
+                            'name' => t('Electronics', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),
                         ],
                         [
                             'name' => t('Mobile Phones', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $this->getFirstDomainLocale()),

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductTest.php
@@ -258,6 +258,9 @@ class ProductTest extends GraphQlTestCase
                         [
                             'name' => t('24" Philips 32PFL4308', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
                         ],
+                        [
+                            'name' => t('Canon PIXMA MG2450', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale),
+                        ],
                     ],
                     'isSellingDenied' => false,
                     'description' => t(

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsFilteringTest.php
@@ -113,7 +113,7 @@ class ProductsFilteringTest extends ProductsGraphQlTestCase
 
         $productsExpected = [
             ['name' => t(
-                'ZN-8009 steam iron Ferrato stainless steel 2200 Watt Blue',
+                'ROCCAT Kone Pure Optical Gaming Mouse',
                 [],
                 Translator::DATA_FIXTURES_TRANSLATION_DOMAIN,
                 $this->firstDomainLocale,

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/ProductsTest.php
@@ -263,7 +263,7 @@ class ProductsTest extends ProductsGraphQlTestCase
     {
         $firstDomainLocale = $this->getLocaleForFirstDomain();
         $productName = t(
-            'ZN-8009 steam iron Ferrato stainless steel 2200 Watt Blue',
+            'Samsung Galaxy Core Plus (SM-G350) - white',
             [],
             Translator::DATA_FIXTURES_TRANSLATION_DOMAIN,
             $firstDomainLocale,

--- a/project-base/app/tests/FrontendApiBundle/Functional/Product/PromotedProductsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Product/PromotedProductsTest.php
@@ -30,6 +30,7 @@ class PromotedProductsTest extends GraphQlTestCase
             ['name' => t('Canon EH-22L', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
             ['name' => t('Canon EOS 700D', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
             ['name' => t('Canon MG3550', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
+            ['name' => t('Canon PIXMA MG2450', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
             ['name' => t('Genius repro SP-M120 black', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
             ['name' => t('24" Philips 32PFL4308', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $firstDomainLocale)],
         ];

--- a/project-base/storefront/components/Blocks/Product/AddToCart.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCart.tsx
@@ -59,25 +59,27 @@ export const AddToCart: FC<AddToCartProps> = ({
 
     return (
         <div className={twMergeCustom('flex items-stretch justify-between gap-2', className)}>
-            <Spinbox
-                defaultValue={1}
-                id={productUuid}
-                max={maxQuantity}
-                min={minQuantity}
-                ref={spinboxRef}
-                size="small"
-                step={1}
-            />
+            {maxQuantity !== 0 && (
+                <Spinbox
+                    defaultValue={1}
+                    id={productUuid}
+                    max={maxQuantity}
+                    min={minQuantity}
+                    ref={spinboxRef}
+                    size="small"
+                    step={1}
+                />
+            )}
             <Button
-                className="py-2"
-                isDisabled={fetching}
+                className={`py-2 ${maxQuantity === 0 ? 'w-full' : ''}`}
+                isDisabled={fetching || maxQuantity === 0}
                 name="add-to-cart"
                 size="small"
                 tid={TIDs.blocks_product_addtocart}
                 onClick={onAddToCartHandler}
             >
                 {fetching ? <Loader className="w-4 text-white" /> : <CartIcon className="w-4 text-white" />}
-                <span>{t('Add to cart')}</span>
+                <span>{maxQuantity === 0 ? t('Currently unavailable') : t('Add to cart')}</span>
             </Button>
         </div>
     );

--- a/project-base/storefront/components/Blocks/Product/AddToCart.tsx
+++ b/project-base/storefront/components/Blocks/Product/AddToCart.tsx
@@ -59,7 +59,7 @@ export const AddToCart: FC<AddToCartProps> = ({
 
     return (
         <div className={twMergeCustom('flex items-stretch justify-between gap-2', className)}>
-            {maxQuantity !== 0 && (
+            {maxQuantity > 0 && (
                 <Spinbox
                     defaultValue={1}
                     id={productUuid}
@@ -71,15 +71,15 @@ export const AddToCart: FC<AddToCartProps> = ({
                 />
             )}
             <Button
-                className={`py-2 ${maxQuantity === 0 ? 'w-full' : ''}`}
-                isDisabled={fetching || maxQuantity === 0}
+                className={`py-2 ${maxQuantity <= 0 ? 'w-full' : ''}`}
+                isDisabled={fetching || maxQuantity <= 0}
                 name="add-to-cart"
                 size="small"
                 tid={TIDs.blocks_product_addtocart}
                 onClick={onAddToCartHandler}
             >
                 {fetching ? <Loader className="w-4 text-white" /> : <CartIcon className="w-4 text-white" />}
-                <span>{maxQuantity === 0 ? t('Currently unavailable') : t('Add to cart')}</span>
+                <span>{maxQuantity <= 0 ? t('Currently unavailable') : t('Add to cart')}</span>
             </Button>
         </div>
     );

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart/ProductDetailAddToCart.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart/ProductDetailAddToCart.tsx
@@ -55,24 +55,26 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
             ) : (
                 <div className="text-sm vl:text-base">
                     <div className="flex items-center justify-between">
-                        <Spinbox
-                            defaultValue={1}
-                            id={product.uuid}
-                            max={product.stockQuantity}
-                            min={1}
-                            ref={spinboxRef}
-                            step={1}
-                        />
-                        <div className="ml-2 flex-1">
+                        {product.stockQuantity !== 0 && (
+                            <Spinbox
+                                defaultValue={1}
+                                id={product.uuid}
+                                max={product.stockQuantity}
+                                min={1}
+                                ref={spinboxRef}
+                                step={1}
+                            />
+                        )}
+                        <div className={`flex-1 ${product.stockQuantity !== 0 ? 'ml-2' : ''}`}>
                             <Button
                                 className="whitespace-nowrap px-4 sm:px-8 w-fit h-12"
-                                isDisabled={fetching}
+                                isDisabled={fetching || product.stockQuantity === 0}
                                 tid={TIDs.pages_productdetail_addtocart_button}
                                 onClick={onAddToCartHandler}
                             >
                                 {fetching ? <Loader className="w-[18px]" /> : <CartIcon className="w-[18px]" />}
 
-                                {t('Add to cart')}
+                                {product.stockQuantity === 0 ? t('Currently unavailable') : t('Add to cart')}
                             </Button>
                         </div>
                     </div>

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart/ProductDetailAddToCart.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailAddToCart/ProductDetailAddToCart.tsx
@@ -55,7 +55,7 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
             ) : (
                 <div className="text-sm vl:text-base">
                     <div className="flex items-center justify-between">
-                        {product.stockQuantity !== 0 && (
+                        {product.stockQuantity > 0 && (
                             <Spinbox
                                 defaultValue={1}
                                 id={product.uuid}
@@ -65,16 +65,16 @@ export const ProductDetailAddToCart: FC<ProductDetailAddToCartProps> = ({ produc
                                 step={1}
                             />
                         )}
-                        <div className={`flex-1 ${product.stockQuantity !== 0 ? 'ml-2' : ''}`}>
+                        <div className={`flex-1 ${product.stockQuantity <= 0 ? 'ml-2' : ''}`}>
                             <Button
                                 className="whitespace-nowrap px-4 sm:px-8 w-fit h-12"
-                                isDisabled={fetching || product.stockQuantity === 0}
+                                isDisabled={fetching || product.stockQuantity <= 0}
                                 tid={TIDs.pages_productdetail_addtocart_button}
                                 onClick={onAddToCartHandler}
                             >
                                 {fetching ? <Loader className="w-[18px]" /> : <CartIcon className="w-[18px]" />}
 
-                                {product.stockQuantity === 0 ? t('Currently unavailable') : t('Add to cart')}
+                                {product.stockQuantity <= 0 ? t('Currently unavailable') : t('Add to cart')}
                             </Button>
                         </div>
                     </div>

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -85,6 +85,7 @@
     "Current password": "Současné heslo",
     "Currently close": "Právě zavřeno",
     "Currently open": "Právě otevřeno",
+    "Currently unavailable": "Momentálně nedostupné",
     "Customer": "Zákazník",
     "Customer Centre": "Zákaznické centrum",
     "Customer information": "Informace o zákazníkovi",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -85,6 +85,7 @@
     "Current password": "Current password",
     "Currently close": "Currently close",
     "Currently open": "Currently open",
+    "Currently unavailable": "Currently unavailable",
     "Customer": "Customer",
     "Customer Centre": "Customer Centre",
     "Customer information": "Customer information",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -85,6 +85,7 @@
     "Current password": "Súčasné heslo",
     "Currently close": "Práve otvorené",
     "Currently open": "Práve zatvorené",
+    "Currently unavailable": "Momentálne nedostupné",
     "Customer": "Zákazník",
     "Customer Centre": "Zákaznícke centrum",
     "Customer information": "Informácie o zákazníkovi",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Product stock is not included in calculated sale exclusion anymore. It is desired behaviour to have sold out products included in listings. Also in stock filter and availability feeds would be obsolete otherwise. Sold out product has disabled add to cart button to prevent buying of such product.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes







































































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-tweak-automatic-product-hiding.odin.shopsys.cloud
  - https://cz.ab-tweak-automatic-product-hiding.odin.shopsys.cloud
<!-- Replace -->
