### PR TITLE
VACUUM FULL ANALYZE is now run once a week

### DIFF
--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use DateTimeZone;
-use NinjaMutex\Lock\LockInterface;
 use NinjaMutex\Mutex;
 use Override;
 use Shopsys\FrameworkBundle\Command\Exception\CronIsLockedException;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Cron\CronControlFacade;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
 use Shopsys\FrameworkBundle\Component\DateTimeHelper\DateTimeHelper;
@@ -36,9 +36,9 @@ class CronCommand extends Command
 
     public function __construct(
         protected readonly CronFacade $cronFacade,
+        protected readonly CronControlFacade $cronControlFacade,
         protected readonly MutexFactory $mutexFactory,
         protected readonly ParameterBagInterface $parameterBag,
-        protected readonly LockInterface $lock,
         protected readonly DateTimeHelper $dateTimeHelper,
     ) {
         parent::__construct();
@@ -88,7 +88,7 @@ class CronCommand extends Command
             return Command::SUCCESS;
         }
 
-        if ($this->lock->isLocked(CronLockCommand::CRON_MUTEX_LOCK_NAME)) {
+        if ($this->cronControlFacade->isCronLocked()) {
             $output->writeln('Crons are locked with `deploy:cron:lock` command. Nothing to do.');
 
             return Command::SUCCESS;

--- a/packages/framework/src/Command/CronLockCommand.php
+++ b/packages/framework/src/Command/CronLockCommand.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use NinjaMutex\Lock\LockInterface;
 use Override;
+use Shopsys\FrameworkBundle\Component\Cron\CronControlFacade;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,13 +17,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 class CronLockCommand extends Command
 {
-    public const CRON_MUTEX_LOCK_NAME = 'cronLocker';
-
     protected const SLEEP_TIME = 600;
     protected const MAX_LOCK_TIME = 3600;
 
     public function __construct(
-        protected readonly LockInterface $lock,
+        protected readonly CronControlFacade $cronControlFacade,
     ) {
         parent::__construct();
     }
@@ -34,7 +32,7 @@ class CronLockCommand extends Command
     #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (!$this->lock->acquireLock(self::CRON_MUTEX_LOCK_NAME, 0)) {
+        if (!$this->cronControlFacade->lockCron()) {
             return Command::FAILURE;
         }
 
@@ -45,7 +43,7 @@ class CronLockCommand extends Command
             sleep(static::SLEEP_TIME);
         }
 
-        $this->lock->releaseLock(self::CRON_MUTEX_LOCK_NAME);
+        $this->cronControlFacade->unlockCron();
         $output->writeln('Cron lock was released due to timeout.');
 
         return Command::SUCCESS;

--- a/packages/framework/src/Command/CronWatchCommand.php
+++ b/packages/framework/src/Command/CronWatchCommand.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Override;
-use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
-use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
+use Shopsys\FrameworkBundle\Component\Cron\CronControlFacade;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,8 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CronWatchCommand extends Command
 {
     public function __construct(
-        protected readonly CronFacade $cronFacade,
-        protected readonly MutexFactory $mutexFactory,
+        protected readonly CronControlFacade $cronControlFacade,
     ) {
         parent::__construct();
     }
@@ -47,23 +45,7 @@ EOF,
     #[Override]
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $mutexFactory = $this->mutexFactory;
-        $cronInstanceNames = $this->cronFacade->getInstanceNames();
-
-        $mutexLockByCronInstance = array_map(
-            static fn ($cronInstanceName) => $mutexFactory->getPrefixedCronMutex($cronInstanceName),
-            $cronInstanceNames,
-        );
-
-        do {
-            $isAnyCronRunning = false;
-
-            foreach ($mutexLockByCronInstance as $mutexLock) {
-                if ($mutexLock->isLocked() === true) {
-                    $isAnyCronRunning = true;
-                }
-            }
-        } while ($isAnyCronRunning === true);
+        $this->cronControlFacade->waitUntilCronInstancesAreFinished();
 
         return Command::SUCCESS;
     }

--- a/packages/framework/src/Component/Cron/CronControlFacade.php
+++ b/packages/framework/src/Component/Cron/CronControlFacade.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Cron;
+
+use NinjaMutex\Lock\LockInterface;
+use NinjaMutex\Mutex;
+use Symfony\Component\HttpClient\Exception\TimeoutException;
+
+class CronControlFacade
+{
+    protected const string CRON_MUTEX_LOCK_NAME = 'cronLocker';
+
+    public function __construct(
+        protected readonly LockInterface $lock,
+        protected readonly CronFacade $cronFacade,
+        protected readonly MutexFactory $mutexFactory,
+    ) {
+    }
+
+    public function isCronLocked(): bool
+    {
+        return $this->lock->isLocked(static::CRON_MUTEX_LOCK_NAME);
+    }
+
+    public function lockCron(): bool
+    {
+        return $this->lock->acquireLock(static::CRON_MUTEX_LOCK_NAME, 0);
+    }
+
+    public function unlockCron(): void
+    {
+        $this->lock->releaseLock(static::CRON_MUTEX_LOCK_NAME);
+    }
+
+    /**
+     * @param array<string> $excludedCronInstanceNames
+     */
+    public function waitUntilCronInstancesAreFinished(
+        array $excludedCronInstanceNames = [],
+        ?int $timeoutSeconds = null,
+    ): void {
+        $endTime = $timeoutSeconds !== null ? time() + $timeoutSeconds : null;
+        $mutexLocks = $this->getMutexLocksByNonExcludedCronInstance($excludedCronInstanceNames);
+
+        do {
+            $isAnyCronRunning = false;
+
+            foreach ($mutexLocks as $mutexLock) {
+                if ($mutexLock->isLocked() === true) {
+                    $isAnyCronRunning = true;
+
+                    break;
+                }
+            }
+
+            if ($endTime !== null && time() > $endTime) {
+                throw new TimeoutException();
+            }
+        } while ($isAnyCronRunning === true);
+    }
+
+    /**
+     * @param array<string> $excludedCronInstanceNames
+     * @return array<\NinjaMutex\Mutex>
+     */
+    protected function getMutexLocksByNonExcludedCronInstance(array $excludedCronInstanceNames): array
+    {
+        $cronInstanceNames = array_filter(
+            $this->cronFacade->getInstanceNames(),
+            static fn (string $cronInstanceName): bool => !in_array($cronInstanceName, $excludedCronInstanceNames, true),
+        );
+
+        return array_map(
+            fn (string $cronInstanceName): Mutex => $this->mutexFactory->getPrefixedCronMutex($cronInstanceName),
+            $cronInstanceNames,
+        );
+    }
+}

--- a/packages/framework/src/Component/Doctrine/VacuumFullAnalyzeCronModule.php
+++ b/packages/framework/src/Component/Doctrine/VacuumFullAnalyzeCronModule.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Exception;
+use Monolog\Logger;
+use Override;
+use Shopsys\FrameworkBundle\Component\Cron\CronControlFacade;
+use Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade;
+use Shopsys\Plugin\Cron\SimpleCronModuleInterface;
+use Symfony\Component\HttpClient\Exception\TimeoutException;
+
+class VacuumFullAnalyzeCronModule implements SimpleCronModuleInterface
+{
+    protected const int ONE_HOUR_IN_SECONDS = 3600;
+
+    protected const string VACUUM_CRON_INSTANCE_NAME = 'vacuum';
+
+    protected Logger $logger;
+
+    /**
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager
+     * @param \Shopsys\FrameworkBundle\Component\Cron\CronControlFacade $cronControlFacade
+     * @param \Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade $maintenanceModeFacade
+     */
+    public function __construct(
+        protected readonly EntityManagerInterface $entityManager,
+        protected readonly CronControlFacade $cronControlFacade,
+        protected readonly MaintenanceModeFacade $maintenanceModeFacade,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function setLogger(Logger $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function run(): void
+    {
+        if (!$this->cronControlFacade->lockCron()) {
+            $this->logger->error('Cron locking failed.');
+
+            return;
+        }
+
+        $this->logger->info('Cron is now locked.');
+
+        try {
+            $this->logger->info('Waiting till all the cron instances are finished.');
+            $this->cronControlFacade->waitUntilCronInstancesAreFinished(
+                [self::VACUUM_CRON_INSTANCE_NAME],
+                self::ONE_HOUR_IN_SECONDS,
+            );
+            $this->logger->info('Turning on maintenance page');
+            $this->maintenanceModeFacade->enable();
+            $this->makeVacuum();
+        } catch (TimeoutException) {
+            $this->logger->error(sprintf('The vacuum command was not executed because it was not possible to stop all cron modules within the time limit of %d seconds.', static::ONE_HOUR_IN_SECONDS));
+        } catch (Exception $exception) {
+            $this->logger->error($exception->getMessage());
+        } finally {
+            $this->logger->info('Turning off maintenance page');
+            $this->maintenanceModeFacade->disable();
+            $this->cronControlFacade->unlockCron();
+            $this->logger->info('Cron lock was released.');
+        }
+    }
+
+    protected function makeVacuum(): void
+    {
+        $this->logger->info('Start of database vacuum');
+        $this->entityManager->getConnection()->executeQuery('VACUUM FULL ANALYSE');
+        $this->logger->info('End of database vacuum');
+    }
+}

--- a/packages/framework/tests/Unit/Component/Cron/CronControlFacadeTest.php
+++ b/packages/framework/tests/Unit/Component/Cron/CronControlFacadeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Cron;
+
+use NinjaMutex\Lock\LockInterface;
+use NinjaMutex\Mutex;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Cron\CronControlFacade;
+use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
+use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
+
+final class CronControlFacadeTest extends TestCase
+{
+    public function testWaitUntilCronInstancesAreFinishedSkipsExcludedInstances(): void
+    {
+        $cronFacadeStub = $this->createStub(CronFacade::class);
+        $cronFacadeStub->method('getInstanceNames')->willReturn(['default', 'vacuum']);
+
+        $defaultMutexMock = $this->createMutexMock();
+        $defaultMutexMock->expects($this->exactly(2))
+            ->method('isLocked')
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $mutexFactoryMock = $this->createMock(MutexFactory::class);
+        $mutexFactoryMock->expects($this->once())
+            ->method('getPrefixedCronMutex')
+            ->with('default')
+            ->willReturn($defaultMutexMock);
+
+        $cronControlFacade = new CronControlFacade(
+            $this->createStub(LockInterface::class),
+            $cronFacadeStub,
+            $mutexFactoryMock,
+        );
+
+        $cronControlFacade->waitUntilCronInstancesAreFinished(['vacuum']);
+    }
+
+    private function createMutexMock(): Mutex
+    {
+        /** @var \NinjaMutex\Mutex|\PHPUnit\Framework\MockObject\MockObject $mutexMock */
+        $mutexMock = $this->getMockBuilder(Mutex::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isLocked'])
+            ->getMock();
+
+        return $mutexMock;
+    }
+}

--- a/project-base/app/build-cron.xml
+++ b/project-base/app/build-cron.xml
@@ -57,4 +57,12 @@
         </exec>
     </target>
 
+    <target name="cron-vacuum" description="Runs VACUUM background job. Should be executed periodically by system Cron once a week.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}" />
+            <arg value="shopsys:cron" />
+            <arg value="--instance-name=vacuum" />
+        </exec>
+    </target>
+
 </project>

--- a/project-base/app/config/cron.yaml
+++ b/project-base/app/config/cron.yaml
@@ -118,3 +118,9 @@ services:
     Shopsys\FrameworkBundle\Model\Watchdog\WatchdogCronModule:
         tags:
             - { name: shopsys.cron, hours: '*', minutes: '*/10', instanceName: watchdog, readableName: 'Sending watchdog emails' }
+
+    # Vacuum
+
+    Shopsys\FrameworkBundle\Component\Doctrine\VacuumFullAnalyzeCronModule:
+        tags:
+            - { name: shopsys.cron, hours: '3', minutes: '15', instanceName: vacuum, readableName: 'Delete unused temporary data (vacuum) from database.' }

--- a/project-base/app/deploy/deploy-project.sh
+++ b/project-base/app/deploy/deploy-project.sh
@@ -106,6 +106,7 @@ function deploy() {
         ["cron-data-bridge-import"]='*/5 * * * *'
         ["cron-packetery"]='*/5 * * * *'
         ["cron-watchdog"]='*/10 * * * *'
+        ["cron-vacuum"]='15 3 * * 1' # every monday in 3:15 AM
     )
 
     if [ -n "${SENTRY_DSN}" ]; then

--- a/upgrade-notes/backend_20260314_152813.md
+++ b/upgrade-notes/backend_20260314_152813.md
@@ -1,0 +1,4 @@
+#### VACUUM FULL ANALYZE is now run once a week ([#3160](https://github.com/shopsys/shopsys/pull/3160))
+
+- `Shopsys\FrameworkBundle\Command\CronLockCommand::CRON_MUTEX_LOCK_NAME` constant was moved to `Shopsys\FrameworkBundle\Component\Cron\CronControlFacade` and made protected
+- see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| It is a good practice to garbage-collect the Postgres database once in a while in production to avoid performance issues. We added a CRON module that performs `VACUUM FULL ANALYZE` on the database once a week so we don't have to think about it and run it manually anymore.
|New feature| Yes <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-vacuum.odin.shopsys.cloud
  - https://cz.rv-vacuum.odin.shopsys.cloud
  - https://rv-vacuum.odin.shopsys.cloud/sk
<!-- Replace -->
