### PR TITLE
[shopsys] pinned problematic versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "nyholm/psr7": "^1.5",
         "overblog/dataloader-bundle": "^0.6.0",
         "overblog/graphiql-bundle": "^0.3",
-        "overblog/graphql-bundle": "^1.0",
+        "overblog/graphql-bundle": "1.3.2",
         "phing/phing": "3.0.0-rc6",
         "phpdocumentor/reflection-docblock": "^5.3.0",
         "presta/sitemap-bundle": "^3.3",
@@ -180,7 +180,7 @@
         "symfony/workflow": "^5.4",
         "tracy/tracy": "^2.4.13",
         "tuscanicz/enum": "^2.1",
-        "twig/twig": "^3.5.0",
+        "twig/twig": "^3.5.0 <3.10.0",
         "webmozart/assert": "^1.4",
         "webonyx/graphql-php": "^15.6"
     },

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -104,7 +104,7 @@
         "symfony-cmf/routing-bundle": "^2.0.3",
         "symfony/polyfill-php80": "^1.24.0",
         "tracy/tracy": "^2.4.13",
-        "twig/twig": "^3.5.0",
+        "twig/twig": "^3.5.0 <3.10.0",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {

--- a/packages/frontend-api/composer.json
+++ b/packages/frontend-api/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.3",
         "elasticsearch/elasticsearch": "^7.6.1",
         "lcobucci/jwt": "^4.1.5",
-        "overblog/graphql-bundle": "^1.0",
+        "overblog/graphql-bundle": "1.3.2",
         "overblog/graphiql-bundle": "^0.3",
         "overblog/dataloader-bundle": "^0.6.0",
         "shopsys/form-types-bundle": "15.0.x-dev",

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -118,7 +118,7 @@
         "symfony/workflow": "^5.4",
         "tracy/tracy": "^2.4.13",
         "tuscanicz/enum": "^2.1",
-        "twig/twig": "^v3.5.1",
+        "twig/twig": "^3.5.1 <3.10.0",
         "webmozart/assert": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Hotfix for newly released versions. twig/twig 3.10.0 causes memory exhaust on error-pages-generate; overblog/graphql-bundle 1.4.0 do not validate fields that are not passed in graphql query – unexpected behavior (see https://github.com/overblog/GraphQLBundle/pull/1185, and the original PR - https://github.com/overblog/GraphQLBundle/pull/1184)
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-versions-pin.odin.shopsys.cloud
  - https://cz.mg-versions-pin.odin.shopsys.cloud
<!-- Replace -->
