### PR TITLE
[project-base][SSP-2326] added option to migrate persist store

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -1183,3 +1183,10 @@ We want to implement more usable UI design which will be better base for upcomin
 #### minor array keys fix ([#3178](https://github.com/shopsys/shopsys/pull/3178))
 
 #### fixed translation on customer's edit profile page ([#3179](https://github.com/shopsys/shopsys/pull/3179))
+
+#### added option to migrate persist store ([#3171](https://github.com/shopsys/shopsys/pull/3171))
+
+-   persist store can now be migrated (read docs in `store-management.md`)
+-   all persist store slices should now expose default state as a constant
+-   docs regarding store management (`store-management.md`) were improved, so make sure that you implement changes to store based on them
+-   remember to update the `DEFAULT_PERSIST_STORE_STATE` constant in your cypress tests to suit the new version of persist store

--- a/docs/storefront/cypress.md
+++ b/docs/storefront/cypress.md
@@ -64,14 +64,12 @@ Each test should be named in a way to describe what the test and the application
 -   Should not be allowed to see transport options if cart is empty
 -   Should login from header and then log out
 
-In the `beforeEach` hook, you can run various preparation logic. There are also other hooks, which you can find in the cypress documentation. One of the specific things you might want to do is to reset the zustand storage by setting `app-store` as visible below. Another thing could be to visit a specific page, such as the cart page if all your tests only focus on that page.
+In the `beforeEach` hook, you can run various preparation logic. There are also other hooks, which you can find in the cypress documentation. One of the specific things you might want to do is to reset the zustand storage as visible below. Another thing could be to visit a specific page, such as the cart page if all your tests only focus on that page.
 
 ```ts
 describe('<Domain Specific Functionality> tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should do something', function () {

--- a/docs/storefront/store-management.md
+++ b/docs/storefront/store-management.md
@@ -6,11 +6,163 @@ Zustand allows us to create multiple stores. Each store consists of `slices`, wh
 
 ## Store structure
 
-Under folder `/project-base/storefront/store`, you can find all possible stores available for storing any kind of values.
+Under folder `/project-base/storefront/store`, you can find all possible stores available for storing any kind of values. Below, all stores are described, together with specific things for them, and when they should be used.
 
-These are stores which we currently use:
+## Persist store
 
--   **Persist Store** - Store which is persisted. That means that information saved in this store will persist after you reload a page or even close the tab/window. Simply, it will remain until it's removed. This is the ideal place to store information (`slices`) like
-    -   **User Consent agreement** (to not ask about the agreement of user consent each time a user opens the page)
-    -   **User CartUuid or ComparisonUuid** (to not lose an unauthenticated user's cart or comparison)
--   **Session Store** - Store for storing temporary information. All values saved in this store will be removed after reloading the page.
+As the name suggests, this store is persisted. That means that information saved in this store will stay in your browser (specifically in your local storage) after you reload the page or even close the tab/window. Simply, it will remain there until it's removed.
+
+### When should it be used?
+
+Persist store should be used if you need something to work across sessions, and not be influenced by user closing the browser. This could be storing the cart UUID, various long-term identifiers, etc. Mind that persist store is not available on the server (due to local storage not being available), so if you need to store something in a persistent manner, but need it on the server as well, you should use [cookie store](#cookie-store). If you do not need to persist the data you are working with, you should look into [session store](#session-store).
+
+### Setting the store name
+
+It is a good practice to rename the store when you start developing your project. You should pick a very specific name, which cannot be confused with another project. This is because if you jump between multiple projects based on this codebase, and develop all of them localy, they are essentially treated as the same application (they all use the same domain). This can result in the persisted store being all messed up in your local storage. This is exactly what causes all those weird errors which simply disappear once you open the application in incognito mode in your browser.
+
+Because of that, we suggest that the first thing you do with your persist store is a change like this:
+
+```diff
+- const PERSIST_STORE_NAME = 'shopsys-platform-persist-store';
++ const PERSIST_STORE_NAME = 'my-amazing-app-persist-store';
+```
+
+### Changes to your persist store's schema, versioning, and migrations
+
+It is possible that you will need to make a breaking change to your schema. These could be, for example, one of the scenarios below:
+
+-   a key is added to the schema
+-   a key is removed from the schema
+-   a key is renamed
+-   a value for a given key changes schematically (e.g. was nullable but is not anymore, could be a number but now can only be a string, etc.)
+
+In such situation, these steps will tell you exactly what to do:
+
+#### 1. Increase the version of your store
+
+```diff
+export const usePersistStore = create<PersistStore>()(
+    persist(
+        ...
+        {
+            ...
+-            version: 1,
++            version: 2,
+```
+
+#### 2. Add migration logic
+
+Here you have to realize that TypeScript trusts whatever you tell it. Because of that, the type you give your `migratedPersistedState` will either help you, or really complicate your development. Some natural options are:
+
+-   `let migratedPersistedState = { ...(persistedState as object) };` (this will enforce property checking for any property you might want to access)
+-   `let migratedPersistedState = { ...(persistedState as Record<string, any>) };` (this will allow you to access any property and not check its type)
+-   `let migratedPersistedState = { ...(persistedState as PersistStoreVersion2Type) };` (if you are sure the type is the store at version 2, e.g. by checking the version or the properties, you can ease your development by assigning this type)
+
+Below you can see a version with `Record<string, any>`:
+
+```ts
+export const usePersistStore = create<PersistStore>()(
+    persist(
+        ...,
+        {
+            ...,
+            migrate: (persistedState, version) => {
+                const migratedPersistedState = { ...(persistedState as Record<string, any>) };
+
+                if (version === 1) {
+                    delete migratedPersistedState.oldKey;
+                    migratedPersistedState.newKey = 'newValue';
+
+                    if (migratedPersistedState.changedKey === null) {
+                        migratedPersistedState.changedKey = 0;
+                    } else {
+                        migratedPersistedState.changedKey = 1;
+                    }
+                }
+
+                return migratedPersistedState as PersistStore;
+            },
+        }
+    ),
+);
+```
+
+#### 3. Add a base version below which the store is just reset (optional)
+
+This can be useful if the newest version is e.g. 100, and you only want to migrate the last 10 versions (which could mean visiting the app and using the store sometimes during the last year). If you want to simply reset all stores with versions lower than 90, as they are too old and migrating them would be too complicated, this is how it can be done
+
+```ts
+export const usePersistStore = create<PersistStore>()(
+    persist(
+        ...,
+        {
+            ...,
+            migrate: (persistedState, version) => {
+                const migratedPersistedState = { ...(persistedState as Record<string, any>) };
+
+                if (version < 90) {
+                    migratedPersistedState = {
+                        ...defaultAuthLoadingState,
+                        ...defaultUserState,
+                        ...defaultContactInformationState,
+                        ...defaultPacketeryState,
+                    };
+                }
+                ...
+
+                return migratedPersistedState as PersistStore;
+            },
+        }
+    ),
+);
+```
+
+#### 4. Fix the `DEFAULT_PERSIST_STORE_STATE` constant in your cypress (optional)
+
+Remember to update the `DEFAULT_PERSIST_STORE_STATE` constant in your cypress so that it mirrors the actual default state set in your persist store.
+
+## Cookie store
+
+As the name suggests, this store works with cookies. That means that information saved in this store will stay in your browser (specifically in your cookies) after you reload the page or even close the tab/window. Simply, it will remain there until it's removed.
+
+### When should it be used?
+
+Cookie store should be used if you need something to work across sessions, and not be influenced by user closing the browser. This could be storing the cart UUID, various long-term identifiers, etc. Mind that cookie store is available on the server, which makes it especially useful if SSR is where you need your data to be accessible. If you do not need the data on the server, you should rather use [persist store](#persist-store). If you do not need to persist the data you are working with, you should look into [session store](#session-store).
+
+### Size limitation
+
+You might ask why even bother with persist store and local storage, when cookies seem to be more powerful. The main answer is the size limitation of cookies. By default, browsers allow cookies to be at most 4kB in size. If you put everything in your cookie store, you may reach this size very quickly, which will result in your app breaking in an unexpected way.
+
+### Working with the state on the server
+
+The whole magic of cookie store on the server is that it is loaded from the cookies as the first thing (inside `getServerSidePropsWrapper.ts`), then passed deeper to the SSR code where it can be worked with, and in the end returned from the `getServerSidePropsWrapper` again.
+
+```ts
+export const getServerSidePropsWrapper =
+    (...) =>
+    async (context: GetServerSidePropsContext) => {
+        const cookiesStoreState = getCookiesStoreState(context);
+
+        ...
+        // You can work with cookiesStoreState here
+        ...
+
+        return {
+            ...
+            props: {
+                ...
+                cookiesStore: cookiesStoreState,
+            },
+        };
+    };
+```
+
+The reason for this is that hooks cannot be used in `getServerSideProps` and the only way to access the state is to work with it as an object. Inside this state you have no access to the mutation functions (setters). You can, however, work directly with the object. This will work because the state on the client will be loaded based on what is returned from `getServerSidePropsWrapper`, and this will also be persisted in the cookie.
+
+## Session store
+
+As the name suggests, this store only works for the duration of the session, which can be ended by refreshing the page, or closing the browser window.
+
+### When should it be used?
+
+Here you should store things which do not benefit from being remembered, such as momentary global state, which can be understood as global `useState`. If you need to store data long-term and persist them, you should look into [persist store](#persist-store) or [cookie store](#cookie-store).

--- a/project-base/storefront/cypress/e2e/authentication/login.cy.ts
+++ b/project-base/storefront/cypress/e2e/authentication/login.cy.ts
@@ -5,15 +5,18 @@ import {
     submitLoginFormOnLoginPage,
     logoutFromCustomerPage,
 } from './authenticationSupport';
-import { customer1, DEFAULT_APP_STORE, password, url } from 'fixtures/demodata';
-import { checkAndHideSuccessToast, checkUrl, takeSnapshotAndCompare } from 'support';
+import { customer1, password, url } from 'fixtures/demodata';
+import {
+    checkAndHideSuccessToast,
+    checkUrl,
+    initializePersistStoreInLocalStorageToDefaultValues,
+    takeSnapshotAndCompare,
+} from 'support';
 import { TIDs } from 'tids';
 
 describe('Login tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should login from login page and then log out', function () {

--- a/project-base/storefront/cypress/e2e/authentication/registration.cy.ts
+++ b/project-base/storefront/cypress/e2e/authentication/registration.cy.ts
@@ -6,7 +6,7 @@ import {
     clearAndFillInRegstrationFormEmail,
     clearAndFillInRegistrationFormPasswords,
 } from './authenticationSupport';
-import { DEFAULT_APP_STORE, password, url } from 'fixtures/demodata';
+import { password, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
 import {
     checkAndHideErrorToast,
@@ -14,6 +14,7 @@ import {
     checkPopupIsVisible,
     checkUrl,
     goToEditProfileFromHeader,
+    initializePersistStoreInLocalStorageToDefaultValues,
     loseFocus,
     takeSnapshotAndCompare,
 } from 'support';
@@ -21,9 +22,7 @@ import { TIDs } from 'tids';
 
 describe('Registration tests (basic)', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
         cy.visitAndWaitForStableAndInteractiveDOM('/');
     });
 
@@ -49,9 +48,7 @@ describe('Registration tests (basic)', () => {
 
 describe('Registration tests (repeated tries)', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
         cy.visitAndWaitForStableAndInteractiveDOM(url.registration);
     });
 

--- a/project-base/storefront/cypress/e2e/cart/cartInHeader.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/cartInHeader.cy.ts
@@ -1,13 +1,11 @@
 import { openHeaderCartByHovering, removeFirstProductFromHeaderCart } from './cartSupport';
-import { DEFAULT_APP_STORE, products } from 'fixtures/demodata';
-import { takeSnapshotAndCompare } from 'support';
+import { products } from 'fixtures/demodata';
+import { initializePersistStoreInLocalStorageToDefaultValues, takeSnapshotAndCompare } from 'support';
 import { TIDs } from 'tids';
 
 describe('Cart in header tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
         cy.addProductToCartForTest(products.helloKitty.uuid, 2).then((cart) =>
             cy.storeCartUuidInLocalStorage(cart.uuid),
         );

--- a/project-base/storefront/cypress/e2e/cart/cartLogin.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/cartLogin.cy.ts
@@ -6,16 +6,19 @@ import {
 } from './cartSupport';
 import { loginFromHeader, logoutFromHeader } from 'e2e/authentication/authenticationSupport';
 import { fillEmailInThirdStep } from 'e2e/order/orderSupport';
-import { DEFAULT_APP_STORE, password, payment, products, transport, url } from 'fixtures/demodata';
+import { password, payment, products, transport, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
-import { checkAndHideInfoToast, checkAndHideSuccessToast, checkPopupIsVisible, takeSnapshotAndCompare } from 'support';
+import {
+    checkAndHideSuccessToast,
+    checkPopupIsVisible,
+    initializePersistStoreInLocalStorageToDefaultValues,
+    takeSnapshotAndCompare,
+} from 'support';
 import { TIDs } from 'tids';
 
 describe('Cart login tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should log in, add product to cart to an already prefilled cart, and empty cart after log out', function () {

--- a/project-base/storefront/cypress/e2e/cart/cartPage.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/cartPage.cy.ts
@@ -14,7 +14,7 @@ import {
 } from './cartSupport';
 import { checkTransportSelectionIsVisible } from 'e2e/order/orderSupport';
 import { changeSelectionOfTransportByName } from 'e2e/transportAndPayment/transportAndPaymentSupport';
-import { DEFAULT_APP_STORE, products, transport, url } from 'fixtures/demodata';
+import { products, transport, url } from 'fixtures/demodata';
 import {
     changeCartItemQuantityWithSpinboxInput,
     checkAndHideInfoToast,
@@ -22,15 +22,14 @@ import {
     checkLoaderOverlayIsNotVisibleAfterTimePeriod,
     checkNumberOfApiRequestsTriggeredByActions,
     checkUrl,
+    initializePersistStoreInLocalStorageToDefaultValues,
     takeSnapshotAndCompare,
 } from 'support';
 import { TIDs } from 'tids';
 
 describe('Cart page tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
         cy.addProductToCartForTest(products.helloKitty.uuid, 2).then((cart) =>
             cy.storeCartUuidInLocalStorage(cart.uuid),
         );

--- a/project-base/storefront/cypress/e2e/cart/cartSupport.ts
+++ b/project-base/storefront/cypress/e2e/cart/cartSupport.ts
@@ -1,6 +1,5 @@
 import { fillInEmailAndPasswordInLoginPopup } from 'e2e/authentication/authenticationSupport';
 import { buttonName } from 'fixtures/demodata';
-import { Blackout, takeSnapshotAndCompare } from 'support';
 import { TIDs } from 'tids';
 
 export const increaseCartItemQuantityWithSpinbox = (catnum: string) => {

--- a/project-base/storefront/cypress/e2e/cart/productAddToCart.cy.ts
+++ b/project-base/storefront/cypress/e2e/cart/productAddToCart.cy.ts
@@ -7,21 +7,20 @@ import {
     increaseProductListQuantityWithSpinbox,
     searchProductByNameWithAutocomplete,
 } from './cartSupport';
-import { DEFAULT_APP_STORE, products, url } from 'fixtures/demodata';
+import { products, url } from 'fixtures/demodata';
 import {
     changeProductListItemQuantityWithSpinboxInput,
     checkPopupIsVisible,
     checkUrl,
     goToPageThroughSimpleNavigation,
+    initializePersistStoreInLocalStorageToDefaultValues,
     takeSnapshotAndCompare,
 } from 'support';
 import { TIDs } from 'tids';
 
 describe('Product add to cart tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should add product to cart from brand page', function () {

--- a/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/contactInformation.cy.ts
@@ -12,16 +12,20 @@ import {
     checkTransportSelectionIsVisible,
     checkContactInformationFormIsNotVisible,
 } from './orderSupport';
-import { DEFAULT_APP_STORE, transport, payment, customer1, orderNote, deliveryAddress, url } from 'fixtures/demodata';
+import { transport, payment, customer1, orderNote, deliveryAddress, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
-import { checkUrl, takeSnapshotAndCompare, loseFocus, clickOnLabel } from 'support';
+import {
+    checkUrl,
+    takeSnapshotAndCompare,
+    loseFocus,
+    clickOnLabel,
+    initializePersistStoreInLocalStorageToDefaultValues,
+} from 'support';
 import { TIDs } from 'tids';
 
 describe('Contact information page tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should redirect to cart page and not display contact information form if cart is empty and user is not logged in', function () {

--- a/project-base/storefront/cypress/e2e/order/createOrder.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/createOrder.cy.ts
@@ -17,6 +17,7 @@ import {
     checkAndHideSuccessToast,
     checkUrl,
     goToEditProfileFromHeader,
+    initializePersistStoreInLocalStorageToDefaultValues,
     loseFocus,
     takeSnapshotAndCompare,
 } from 'support';
@@ -24,6 +25,7 @@ import { TIDs } from 'tids';
 
 describe('Create order tests', () => {
     beforeEach(() => {
+        initializePersistStoreInLocalStorageToDefaultValues();
         cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
     });
 

--- a/project-base/storefront/cypress/e2e/order/createOrderWithDeliveryAddress.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/createOrderWithDeliveryAddress.cy.ts
@@ -8,16 +8,19 @@ import {
     changeOrderConfirmationDynamicPartsToStaticDemodata,
     changeOrderDetailDynamicPartsToStaticDemodata,
 } from './orderSupport';
-import { DEFAULT_APP_STORE, deliveryAddress, payment, transport, url } from 'fixtures/demodata';
+import { deliveryAddress, payment, transport, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
-import { clickOnLabel, loseFocus, takeSnapshotAndCompare } from 'support';
+import {
+    clickOnLabel,
+    initializePersistStoreInLocalStorageToDefaultValues,
+    loseFocus,
+    takeSnapshotAndCompare,
+} from 'support';
 import { TIDs } from 'tids';
 
 describe('Create order with delivery address tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
 
         cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
         cy.preselectTransportForTest(transport.czechPost.uuid);
@@ -92,9 +95,7 @@ describe('Create order with delivery address tests', () => {
 
 describe('Delivery address in order tests (logged-in user)', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should keep filled delivery address for logged-in user after page refresh', function () {
@@ -258,9 +259,7 @@ describe('Delivery address in order tests (logged-in user)', () => {
 
 describe('Delivery address in order tests (with pickup point)', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
 
         cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
         cy.preselectTransportForTest(transport.personalCollection.uuid, transport.personalCollection.storeOstrava.uuid);
@@ -332,9 +331,7 @@ describe('Delivery address in order tests (with pickup point)', () => {
 
 describe('Delivery address in order tests (with pickup point, logged-in user)', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should not prefill delivery contact for logged-in user with saved address and with selected pickup point, and then keep the filled delivery information after refresh', function () {

--- a/project-base/storefront/cypress/e2e/order/orderRepeat.cy.ts
+++ b/project-base/storefront/cypress/e2e/order/orderRepeat.cy.ts
@@ -1,14 +1,12 @@
 import { repeatOrderFromOrderDetail, repeatOrderFromOrderList } from './orderSupport';
-import { DEFAULT_APP_STORE, transport, payment, url, products } from 'fixtures/demodata';
+import { transport, payment, url, products } from 'fixtures/demodata';
 import { generateCustomerRegistrationData, generateCreateOrderInput } from 'fixtures/generators';
-import { checkUrl, takeSnapshotAndCompare } from 'support';
+import { checkUrl, initializePersistStoreInLocalStorageToDefaultValues, takeSnapshotAndCompare } from 'support';
 import { TIDs } from 'tids';
 
 describe('Order repeat tests as logged-in user from order list', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should repeat order (pre-fill cart) for logged-in user with initially empty cart', function () {
@@ -72,9 +70,7 @@ describe('Order repeat tests as logged-in user from order list', () => {
 
 describe('Order repeat tests as unlogged user from order detail', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should repeat order (pre-fill cart) for unlogged user with initially empty cart', function () {

--- a/project-base/storefront/cypress/e2e/order/orderSupport.ts
+++ b/project-base/storefront/cypress/e2e/order/orderSupport.ts
@@ -1,5 +1,6 @@
 import {
-    DEFAULT_APP_STORE,
+    DEFAULT_PERSIST_STORE_STATE,
+    PERSIST_STORE_NAME,
     customer1,
     deliveryAddress,
     link,
@@ -161,14 +162,14 @@ export const fillBillingInfoForDeliveryAddressTests = () => {
 };
 
 export const checkThatContactInformationWasRemovedFromLocalStorage = () => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
     if (!currentAppStoreAsString) {
         throw new Error(
             'Could not load app store from local storage. This is an issue with tests, not with the application.',
         );
     }
 
-    expect(currentAppStoreAsString).to.equal(JSON.stringify(DEFAULT_APP_STORE));
+    expect(currentAppStoreAsString).to.equal(JSON.stringify(DEFAULT_PERSIST_STORE_STATE));
 };
 
 export const checkTransportSelectionIsNotVisible = () => {

--- a/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/lastOrderTransportAndPayment.cy.ts
@@ -1,14 +1,16 @@
 import { changeSelectionOfPaymentByName, changeSelectionOfTransportByName } from './transportAndPaymentSupport';
-import { DEFAULT_APP_STORE, payment, transport, url } from 'fixtures/demodata';
+import { payment, transport, url } from 'fixtures/demodata';
 import { generateCreateOrderInput, generateCustomerRegistrationData } from 'fixtures/generators';
-import { checkLoaderOverlayIsNotVisibleAfterTimePeriod, takeSnapshotAndCompare } from 'support';
+import {
+    checkLoaderOverlayIsNotVisibleAfterTimePeriod,
+    initializePersistStoreInLocalStorageToDefaultValues,
+    takeSnapshotAndCompare,
+} from 'support';
 import { TIDs } from 'tids';
 
 describe('Last order transport and payment select tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
 
         const registrationInput = generateCustomerRegistrationData('commonCustomer');
         cy.registerAsNewUser(registrationInput);

--- a/project-base/storefront/cypress/e2e/transportAndPayment/paymentSelect.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/paymentSelect.cy.ts
@@ -5,20 +5,19 @@ import {
     removeTransportSelectionUsingButton,
 } from './transportAndPaymentSupport';
 import { goToNextOrderStep } from 'e2e/cart/cartSupport';
-import { DEFAULT_APP_STORE, payment, transport, url } from 'fixtures/demodata';
+import { payment, transport, url } from 'fixtures/demodata';
 import {
     checkCanGoToNextOrderStep,
     checkLoaderOverlayIsNotVisibleAfterTimePeriod,
     checkUrl,
+    initializePersistStoreInLocalStorageToDefaultValues,
     takeSnapshotAndCompare,
 } from 'support';
 import { TIDs } from 'tids';
 
 describe('Payment select tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
 
         cy.addProductToCartForTest().then((cart) => cy.storeCartUuidInLocalStorage(cart.uuid));
         cy.preselectTransportForTest(transport.ppl.uuid);

--- a/project-base/storefront/cypress/e2e/transportAndPayment/transportSelect.cy.ts
+++ b/project-base/storefront/cypress/e2e/transportAndPayment/transportSelect.cy.ts
@@ -7,16 +7,19 @@ import {
 } from './transportAndPaymentSupport';
 import { goToNextOrderStep } from 'e2e/cart/cartSupport';
 import { checkEmptyCartTextIsVisible, checkTransportSelectionIsNotVisible } from 'e2e/order/orderSupport';
-import { DEFAULT_APP_STORE, products, transport, url } from 'fixtures/demodata';
+import { products, transport, url } from 'fixtures/demodata';
 import { generateCustomerRegistrationData } from 'fixtures/generators';
-import { checkLoaderOverlayIsNotVisibleAfterTimePeriod, checkUrl, takeSnapshotAndCompare } from 'support';
+import {
+    checkLoaderOverlayIsNotVisibleAfterTimePeriod,
+    checkUrl,
+    initializePersistStoreInLocalStorageToDefaultValues,
+    takeSnapshotAndCompare,
+} from 'support';
 import { TIDs } from 'tids';
 
 describe('Transport select tests', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('should select transport to home', function () {

--- a/project-base/storefront/cypress/e2e/visits/repeatedVisits.cy.ts
+++ b/project-base/storefront/cypress/e2e/visits/repeatedVisits.cy.ts
@@ -1,10 +1,9 @@
-import { DEFAULT_APP_STORE, url } from 'fixtures/demodata';
+import { url } from 'fixtures/demodata';
+import { initializePersistStoreInLocalStorageToDefaultValues } from 'support';
 
 describe('Repeated page visits tests (for defer testing)', () => {
     beforeEach(() => {
-        cy.window().then((win) => {
-            win.localStorage.setItem('app-store', JSON.stringify(DEFAULT_APP_STORE));
-        });
+        initializePersistStoreInLocalStorageToDefaultValues();
     });
 
     it('5 homepage visits with wait', () => {

--- a/project-base/storefront/cypress/fixtures/demodata.ts
+++ b/project-base/storefront/cypress/fixtures/demodata.ts
@@ -150,9 +150,14 @@ export const url = {
 
 export const DEFAULT_APP_STORE = {
     state: {
-        loginLoading: null,
-        cartUuid: null as string | null,
-        comparisonUuid: null,
+        authLoading: null,
+        cartUuid: null,
+        productListUuids: {},
+        userConsent: {
+            statistics: false,
+            marketing: false,
+            preferences: false,
+        },
         contactInformation: {
             email: '',
             telephone: '',
@@ -180,12 +185,6 @@ export const DEFAULT_APP_STORE = {
             isWithoutHeurekaAgreement: false,
         },
         packeteryPickupPoint: null,
-        userConsent: {
-            statistics: false,
-            marketing: false,
-            preferences: false,
-        },
-        wishlistUuid: null,
     },
-    version: 0,
+    version: 1,
 };

--- a/project-base/storefront/cypress/fixtures/demodata.ts
+++ b/project-base/storefront/cypress/fixtures/demodata.ts
@@ -148,10 +148,12 @@ export const url = {
     registration: '/registration',
 } as const;
 
-export const DEFAULT_APP_STORE = {
+export const PERSIST_STORE_NAME = 'shopsys-platform-persist-store';
+
+export const DEFAULT_PERSIST_STORE_STATE = {
     state: {
         authLoading: null,
-        cartUuid: null,
+        cartUuid: null as string | null,
         productListUuids: {},
         userConsent: {
             statistics: false,
@@ -166,6 +168,7 @@ export const DEFAULT_APP_STORE = {
             street: '',
             city: '',
             postcode: '',
+            customer: undefined,
             country: { value: '', label: '' },
             companyName: '',
             companyNumber: '',

--- a/project-base/storefront/cypress/support/api.ts
+++ b/project-base/storefront/cypress/support/api.ts
@@ -1,10 +1,10 @@
 import { TypeCreateOrderMutationVariables } from '../../graphql/requests/orders/mutations/CreateOrderMutation.generated';
 import { TypeRegistrationDataInput } from '../../graphql/types';
 import 'cypress-real-events';
-import { products } from 'fixtures/demodata';
+import { PERSIST_STORE_NAME, products } from 'fixtures/demodata';
 
 Cypress.Commands.add('addProductToCartForTest', (productUuid?: string, quantity?: number) => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
 
     return cy.getCookie('accessToken').then((cookie) => {
         const accessToken = cookie?.value;
@@ -45,7 +45,7 @@ Cypress.Commands.add('addProductToCartForTest', (productUuid?: string, quantity?
 });
 
 Cypress.Commands.add('addPromoCodeToCartForTest', (promoCode: string) => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
 
     return cy.getCookie('accessToken').then((cookie) => {
         const accessToken = cookie?.value;
@@ -88,7 +88,7 @@ Cypress.Commands.add('addPromoCodeToCartForTest', (promoCode: string) => {
 });
 
 Cypress.Commands.add('preselectTransportForTest', (transportUuid: string, pickupPlaceIdentifier?: string) => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
     if (!currentAppStoreAsString) {
         throw new Error(
             'Could not load app store from local storage. This is an issue with tests, not with the application.',
@@ -143,7 +143,7 @@ Cypress.Commands.add('preselectTransportForTest', (transportUuid: string, pickup
 });
 
 Cypress.Commands.add('preselectPaymentForTest', (paymentUuid: string) => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
     if (!currentAppStoreAsString) {
         throw new Error(
             'Could not load app store from local storage. This is an issue with tests, not with the application.',
@@ -230,7 +230,7 @@ Cypress.Commands.add('registerAsNewUser', (registrationInput: TypeRegistrationDa
 });
 
 Cypress.Commands.add('logout', () => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
     if (!currentAppStoreAsString) {
         throw new Error(
             'Could not load app store from local storage. This is an issue with tests, not with the application.',
@@ -265,7 +265,7 @@ Cypress.Commands.add('logout', () => {
 });
 
 Cypress.Commands.add('createOrder', (createOrderVariables: TypeCreateOrderMutationVariables) => {
-    const currentAppStoreAsString = window.localStorage.getItem('app-store');
+    const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
     if (!currentAppStoreAsString) {
         throw new Error(
             'Could not load app store from local storage. This is an issue with tests, not with the application.',

--- a/project-base/storefront/cypress/support/index.ts
+++ b/project-base/storefront/cypress/support/index.ts
@@ -3,7 +3,7 @@ import './api';
 import 'cypress-real-events';
 import compareSnapshotCommand from 'cypress-visual-regression/dist/command';
 import { registerCommand } from 'cypress-wait-for-stable-dom';
-import { DEFAULT_APP_STORE } from 'fixtures/demodata';
+import { DEFAULT_PERSIST_STORE_STATE, PERSIST_STORE_NAME } from 'fixtures/demodata';
 import { TIDs } from 'tids';
 
 registerCommand({ pollInterval: 500, timeout: 5000 });
@@ -32,14 +32,14 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('storeCartUuidInLocalStorage', (cartUuid: string) => {
     return cy.then(() => {
-        const currentAppStoreAsString = window.localStorage.getItem('app-store');
-        let currentAppStore = DEFAULT_APP_STORE;
+        const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
+        let currentAppStore = DEFAULT_PERSIST_STORE_STATE;
         if (currentAppStoreAsString) {
             currentAppStore = JSON.parse(currentAppStoreAsString);
         }
         currentAppStore.state.cartUuid = cartUuid;
 
-        window.localStorage.setItem('app-store', JSON.stringify(currentAppStore));
+        window.localStorage.setItem(PERSIST_STORE_NAME, JSON.stringify(currentAppStore));
     });
 });
 
@@ -69,6 +69,12 @@ Cypress.Commands.add('reloadAndWaitForStableAndInteractiveDOM', () => {
 compareSnapshotCommand({
     capture: 'fullPage',
 });
+
+export const initializePersistStoreInLocalStorageToDefaultValues = () => {
+    cy.window().then((win) => {
+        win.localStorage.setItem(PERSIST_STORE_NAME, JSON.stringify(DEFAULT_PERSIST_STORE_STATE));
+    });
+};
 
 export const checkAndHideSuccessToast = (text?: string) => {
     if (text) {

--- a/project-base/storefront/store/slices/createAuthLoadingSlice.ts
+++ b/project-base/storefront/store/slices/createAuthLoadingSlice.ts
@@ -7,14 +7,20 @@ type AuthLoadingStatus =
     | 'registration-loading'
     | 'registration-loading-with-cart-modifications';
 
-export type AuthLoadingSlice = {
+type AuthLoadingState = {
     authLoading: AuthLoadingStatus | null;
+};
 
+export type AuthLoadingSlice = AuthLoadingState & {
     updateAuthLoadingState: (value: AuthLoadingStatus | null) => void;
 };
 
-export const createAuthLoadingSlice: StateCreator<AuthLoadingSlice> = (set) => ({
+export const defaultAuthLoadingState: AuthLoadingState = {
     authLoading: null,
+};
+
+export const createAuthLoadingSlice: StateCreator<AuthLoadingSlice> = (set) => ({
+    ...defaultAuthLoadingState,
 
     updateAuthLoadingState: (value) => {
         set({ authLoading: value });

--- a/project-base/storefront/store/slices/createContactInformationSlice.ts
+++ b/project-base/storefront/store/slices/createContactInformationSlice.ts
@@ -30,47 +30,52 @@ export type ContactInformation = {
     isWithoutHeurekaAgreement: boolean;
 };
 
-const defaultContactInformation: ContactInformation = {
-    email: '',
-    customer: undefined,
-    telephone: '',
-    firstName: '',
-    lastName: '',
-    street: '',
-    city: '',
-    postcode: '',
-    country: { value: '', label: '' },
-    companyName: '',
-    companyNumber: '',
-    companyTaxNumber: '',
-    isDeliveryAddressDifferentFromBilling: false,
-    deliveryFirstName: '',
-    deliveryLastName: '',
-    deliveryCompanyName: '',
-    deliveryTelephone: '',
-    deliveryStreet: '',
-    deliveryCity: '',
-    deliveryPostcode: '',
-    deliveryCountry: { value: '', label: '' },
-    deliveryAddressUuid: '',
-    newsletterSubscription: false,
-    note: '',
-    isWithoutHeurekaAgreement: false,
+type ContactInformationState = {
+    contactInformation: ContactInformation;
 };
 
-export type ContactInformationSlice = {
-    contactInformation: ContactInformation;
+export type ContactInformationSlice = ContactInformationState & {
     updateContactInformation: (value: Partial<ContactInformation>) => void;
     resetContactInformation: () => void;
 };
 
+export const defaultContactInformationState: ContactInformationState = {
+    contactInformation: {
+        email: '',
+        customer: undefined,
+        telephone: '',
+        firstName: '',
+        lastName: '',
+        street: '',
+        city: '',
+        postcode: '',
+        country: { value: '', label: '' },
+        companyName: '',
+        companyNumber: '',
+        companyTaxNumber: '',
+        isDeliveryAddressDifferentFromBilling: false,
+        deliveryFirstName: '',
+        deliveryLastName: '',
+        deliveryCompanyName: '',
+        deliveryTelephone: '',
+        deliveryStreet: '',
+        deliveryCity: '',
+        deliveryPostcode: '',
+        deliveryCountry: { value: '', label: '' },
+        deliveryAddressUuid: '',
+        newsletterSubscription: false,
+        note: '',
+        isWithoutHeurekaAgreement: false,
+    },
+};
+
 export const createContactInformationSlice: StateCreator<ContactInformationSlice> = (set) => ({
-    contactInformation: defaultContactInformation,
+    ...defaultContactInformationState,
 
     updateContactInformation: (value) => {
         set((store) => ({ ...store, contactInformation: { ...store.contactInformation, ...value } }));
     },
     resetContactInformation: () => {
-        set({ contactInformation: defaultContactInformation });
+        set({ ...defaultContactInformationState });
     },
 });

--- a/project-base/storefront/store/slices/createPacketerySlice.ts
+++ b/project-base/storefront/store/slices/createPacketerySlice.ts
@@ -1,15 +1,21 @@
 import { TypeListedStoreFragment } from 'graphql/requests/stores/fragments/ListedStoreFragment.generated';
 import { StateCreator } from 'zustand';
 
-export type PacketerySlice = {
+type PacketeryState = {
     packeteryPickupPoint: TypeListedStoreFragment | null;
+};
 
+export type PacketerySlice = PacketeryState & {
     setPacketeryPickupPoint: (mappedPacketeryPoint: TypeListedStoreFragment) => void;
     clearPacketeryPickupPoint: () => void;
 };
 
-export const createPacketerySlice: StateCreator<PacketerySlice> = (set) => ({
+export const defaultPacketeryState = {
     packeteryPickupPoint: null,
+};
+
+export const createPacketerySlice: StateCreator<PacketerySlice> = (set) => ({
+    ...defaultPacketeryState,
 
     setPacketeryPickupPoint: (packeteryPickupPoint) => {
         set({ packeteryPickupPoint });

--- a/project-base/storefront/store/slices/createUserSlice.ts
+++ b/project-base/storefront/store/slices/createUserSlice.ts
@@ -6,20 +6,26 @@ type ProductListStoreValue = Partial<{
     [key in TypeProductListTypeEnum]: string;
 }>;
 
-export type UserSlice = {
+type UserState = {
     cartUuid: string | null;
     productListUuids: ProductListStoreValue;
     userConsent: UserConsentFormType | null;
+};
 
+export type UserSlice = UserState & {
     updateCartUuid: (value: string | null) => void;
     updateProductListUuids: (value: ProductListStoreValue) => void;
     updateUserConsent: (userConsent: UserConsentFormType) => void;
 };
 
-export const createUserSlice: StateCreator<UserSlice> = (set) => ({
+export const defaultUserState: UserState = {
     cartUuid: null,
     productListUuids: {},
     userConsent: null,
+};
+
+export const createUserSlice: StateCreator<UserSlice> = (set) => ({
+    ...defaultUserState,
 
     updateCartUuid: (cartUuid) => {
         set({ cartUuid });

--- a/project-base/storefront/store/usePersistStore.ts
+++ b/project-base/storefront/store/usePersistStore.ts
@@ -1,14 +1,18 @@
 import { broadcast } from './broadcast';
-import { AuthLoadingSlice, createAuthLoadingSlice } from './slices/createAuthLoadingSlice';
-import { ContactInformationSlice, createContactInformationSlice } from './slices/createContactInformationSlice';
-import { PacketerySlice, createPacketerySlice } from './slices/createPacketerySlice';
-import { createUserSlice, UserSlice } from './slices/createUserSlice';
+import { AuthLoadingSlice, createAuthLoadingSlice, defaultAuthLoadingState } from './slices/createAuthLoadingSlice';
+import {
+    ContactInformationSlice,
+    createContactInformationSlice,
+    defaultContactInformationState,
+} from './slices/createContactInformationSlice';
+import { PacketerySlice, createPacketerySlice, defaultPacketeryState } from './slices/createPacketerySlice';
+import { createUserSlice, defaultUserState, UserSlice } from './slices/createUserSlice';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 type PersistStore = AuthLoadingSlice & UserSlice & ContactInformationSlice & PacketerySlice;
 
-const STORE_NAME = 'app-store';
+const STORE_NAME = 'shopsys-platform-persist-store';
 
 export const usePersistStore = create<PersistStore>()(
     persist(
@@ -21,6 +25,22 @@ export const usePersistStore = create<PersistStore>()(
             }),
             STORE_NAME,
         ),
-        { name: STORE_NAME },
+        {
+            name: STORE_NAME,
+            version: 1,
+            migrate: (persistedState, version) => {
+                let migratedPersistedState = { ...(persistedState as object) };
+
+                if (version < 1) {
+                    migratedPersistedState = {
+                        ...defaultAuthLoadingState,
+                        ...defaultUserState,
+                        ...defaultContactInformationState,
+                        ...defaultPacketeryState,
+                    };
+                }
+                return migratedPersistedState as PersistStore;
+            },
+        },
     ),
 );

--- a/project-base/storefront/store/usePersistStore.ts
+++ b/project-base/storefront/store/usePersistStore.ts
@@ -10,9 +10,9 @@ import { createUserSlice, defaultUserState, UserSlice } from './slices/createUse
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type PersistStore = AuthLoadingSlice & UserSlice & ContactInformationSlice & PacketerySlice;
+export type PersistStore = AuthLoadingSlice & UserSlice & ContactInformationSlice & PacketerySlice;
 
-const STORE_NAME = 'shopsys-platform-persist-store';
+const PERSIST_STORE_NAME = 'shopsys-platform-persist-store';
 
 export const usePersistStore = create<PersistStore>()(
     persist(
@@ -23,10 +23,10 @@ export const usePersistStore = create<PersistStore>()(
                 ...createContactInformationSlice(...store),
                 ...createPacketerySlice(...store),
             }),
-            STORE_NAME,
+            PERSIST_STORE_NAME,
         ),
         {
-            name: STORE_NAME,
+            name: PERSIST_STORE_NAME,
             version: 1,
             migrate: (persistedState, version) => {
                 let migratedPersistedState = { ...(persistedState as object) };
@@ -39,6 +39,7 @@ export const usePersistStore = create<PersistStore>()(
                         ...defaultPacketeryState,
                     };
                 }
+
                 return migratedPersistedState as PersistStore;
             },
         },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Added option to migrate persist store between versions and added docs regarding how to do it.
|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2326-persist-store-migrations.odin.shopsys.cloud
  - https://cz.sh-ssp-2326-persist-store-migrations.odin.shopsys.cloud
<!-- Replace -->
