### PR TITLE
[project-base][SSP-2167] removed invalid cache invalidation when adding to product list

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -1045,3 +1045,5 @@ We want to implement more usable UI design which will be better base for upcomin
 
 -   simple navgation images are now blacked-out during cypress tests
 -   make sure you add the blackout everywhere where your snapshots contain simple navigation with images
+
+#### removed invalid cache invalidation when adding to product list ([#3172](https://github.com/shopsys/shopsys/pull/3172))

--- a/project-base/storefront/urql/cache/updates.ts
+++ b/project-base/storefront/urql/cache/updates.ts
@@ -137,7 +137,6 @@ export const cacheUpdates: UpdatesConfig = {
             manuallyUpdateCartQuery(cache, result.RemovePromoCodeFromCart, result.RemovePromoCodeFromCart.uuid);
         },
         AddProductToList(result: TypeAddProductToListMutation, args: TypeAddProductToListMutationVariables, cache) {
-            cache.invalidate('Query');
             manuallyUpdateProductListQuery(args.input.productListInput, result.AddProductToList, cache);
         },
         RemoveProductFromList(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Removed invalid cache invalidation when adding to product list.
|New feature| No
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)|  No
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2167-product-list-cache-fix.odin.shopsys.cloud
  - https://cz.sh-ssp-2167-product-list-cache-fix.odin.shopsys.cloud
<!-- Replace -->
