### PR TITLE
[shopsys] fix app class used outside of project base

### DIFF
--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product;
 
-use App\Component\Doctrine\QueryBuilderExtender;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender;
 use Shopsys\FrameworkBundle\Model\Category\Category;
 use Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup;
 use Shopsys\FrameworkBundle\Model\Product\Brand\Brand;
@@ -19,7 +19,7 @@ class ProductRepository
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Product\Search\ProductElasticsearchRepository $productElasticsearchRepository
-     * @param \App\Component\Doctrine\QueryBuilderExtender $queryBuilderExtender
+     * @param \Shopsys\FrameworkBundle\Component\Doctrine\QueryBuilderExtender $queryBuilderExtender
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
@@ -465,7 +465,7 @@ class ProductRepository
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
      * @param int $offset
      * @param int $limit
-     * @return \App\Model\Product\Product[]
+     * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
     public function getAllOfferedProductsPaginated(
         int $domainId,

--- a/project-base/app/src/Model/Product/ProductRepository.php
+++ b/project-base/app/src/Model/Product/ProductRepository.php
@@ -33,6 +33,8 @@ use Shopsys\FrameworkBundle\Model\Stock\ProductStock;
  * @method \App\Model\Product\Product getOneByCatnumExcludeMainVariants(string $productCatnum)
  * @method \App\Model\Product\Product getOneByUuid(string $uuid)
  * @method \App\Model\Product\Product[] getAllSellableVariantsByMainVariant(\App\Model\Product\Product $mainVariant, int $domainId, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup)
+ * @method \App\Model\Product\Product[] getAllOfferedProductsPaginated(int $domainId, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, int $offset, int $limit)
+ * @property \App\Component\Doctrine\QueryBuilderExtender $queryBuilderExtender
  */
 class ProductRepository extends BaseProductRepository
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was /App class used in framework package which is not allowed outside of project base, causing package tests to fail after monorepo split. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-fix-iterative-image-sitemap.odin.shopsys.cloud
  - https://cz.ab-fix-iterative-image-sitemap.odin.shopsys.cloud
<!-- Replace -->
