### PR TITLE
[project-base] add nominal promo code to demo data

### DIFF
--- a/UPGRADE-15.0.md
+++ b/UPGRADE-15.0.md
@@ -1033,6 +1033,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   update `shopsys/deployment` package to a new major version
 -   see #project-base-diff to update your project
 
+#### add nominal promo code to demo data ([#3197](https://github.com/shopsys/shopsys/pull/3197))
+
+-   see #project-base-diff to update your project
+
 ### Storefront
 
 #### added query/mutation name to URL and headers ([#3041](https://github.com/shopsys/shopsys/pull/3041))

--- a/project-base/app/src/DataFixtures/Demo/PromoCodeDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/PromoCodeDataFixture.php
@@ -130,6 +130,13 @@ class PromoCodeDataFixture extends AbstractReferenceFixture implements Dependent
         $this->setDefaultLimit($promoCode);
         $this->addReferenceForDomain(self::PROMO_CODE_FOR_NEW_PRODUCT, $promoCode, Domain::FIRST_DOMAIN_ID);
 
+        $promoCodeData = $this->promoCodeDataFactory->create();
+        $promoCodeData->code = 'test100';
+        $promoCodeData->discountType = PromoCode::DISCOUNT_TYPE_NOMINAL;
+        $promoCodeData->domainId = Domain::FIRST_DOMAIN_ID;
+        $promoCode = $this->promoCodeFacade->create($promoCodeData);
+        $this->setDefaultNominalLimit($promoCode);
+
         $this->loadForOtherDomains();
     }
 
@@ -144,6 +151,13 @@ class PromoCodeDataFixture extends AbstractReferenceFixture implements Dependent
             $promoCodeData->domainId = $domainId;
             $promoCode = $this->promoCodeFacade->create($promoCodeData);
             $this->setDefaultLimit($promoCode);
+
+            $promoCodeData = $this->promoCodeDataFactory->create();
+            $promoCodeData->code = 'test100';
+            $promoCodeData->discountType = PromoCode::DISCOUNT_TYPE_NOMINAL;
+            $promoCodeData->domainId = $domainId;
+            $promoCode = $this->promoCodeFacade->create($promoCodeData);
+            $this->setDefaultNominalLimit($promoCode);
         }
     }
 
@@ -165,6 +179,17 @@ class PromoCodeDataFixture extends AbstractReferenceFixture implements Dependent
     private function setDefaultLimit(PromoCode $promoCode): void
     {
         $promoCodeLimit = $this->promoCodeLimitFactory->create('1.0', '10');
+        $promoCodeLimit->setPromoCode($promoCode);
+        $this->em->persist($promoCodeLimit);
+        $this->em->flush();
+    }
+
+    /**
+     * @param \App\Model\Order\PromoCode\PromoCode $promoCode
+     */
+    private function setDefaultNominalLimit(PromoCode $promoCode): void
+    {
+        $promoCodeLimit = $this->promoCodeLimitFactory->create('101', '100');
         $promoCodeLimit->setPromoCode($promoCode);
         $this->em->persist($promoCodeLimit);
         $this->em->flush();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There was no nominal promo code in demo data and now there is one for each domain.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-promo-code-data-fixtures.odin.shopsys.cloud
  - https://cz.ab-promo-code-data-fixtures.odin.shopsys.cloud
<!-- Replace -->
