### PR TITLE
[framework] fix packages builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -190,7 +190,7 @@
         "codeception/module-db": "^3.1.0",
         "codeception/module-webdriver": "^3.2.1",
         "codeception/phpunit-wrapper": "^9.0.7",
-        "friendsofphp/php-cs-fixer": "^3.3.1",
+        "friendsofphp/php-cs-fixer": "^3.58.1",
         "php-mock/php-mock-phpunit": "^2.7",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpstan/phpstan": "^1.6.8",

--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.3",
         "ext-tokenizer": "*",
-        "friendsofphp/php-cs-fixer": "^3.3.1",
+        "friendsofphp/php-cs-fixer": "^3.58.1",
         "nette/utils": "^3.1.3",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpstan/phpstan": "^1.6.8",

--- a/packages/framework/src/Controller/Front/UploadedFileController.php
+++ b/packages/framework/src/Controller/Front/UploadedFileController.php
@@ -11,7 +11,7 @@ use Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade;
 class UploadedFileController
 {
     /**
-     * @param \App\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
+     * @param \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade
      * @param \League\Flysystem\FilesystemOperator $filesystem
      */
     public function __construct(

--- a/packages/framework/src/Model/Payment/PaymentRepository.php
+++ b/packages/framework/src/Model/Payment/PaymentRepository.php
@@ -149,7 +149,7 @@ class PaymentRepository
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
-     * @return \App\Model\Payment\Payment[]
+     * @return \Shopsys\FrameworkBundle\Model\Payment\Payment[]
      */
     public function getAllWithEagerLoadedDomainsAndTranslations(DomainConfig $domainConfig): array
     {

--- a/project-base/app/src/Model/Payment/PaymentRepository.php
+++ b/project-base/app/src/Model/Payment/PaymentRepository.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentRepository as BasePaymentReposi
  * @method \App\Model\Payment\Payment getOneByUuid(string $uuid)
  * @method \App\Model\Payment\Payment[] getByGoPayPaymentMethod(\Shopsys\FrameworkBundle\Model\GoPay\PaymentMethod\GoPayPaymentMethod $goPayPaymentMethod)
  * @method \App\Model\Payment\Payment getEnabledOnDomainByUuid(string $uuid, int $domainId)
+ * @method \App\Model\Payment\Payment[] getAllWithEagerLoadedDomainsAndTranslations(\Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig)
  */
 class PaymentRepository extends BasePaymentRepository
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| in https://github.com/shopsys/shopsys/pull/3157, some features were moved from project-base to the framework package, however, some App annotations were left in the framework package. The errors were reported by phpstan in the framework package after split. Also, the `shopsys/coding-standards` package tests started to fail when composer dependencies were installed with `--prefer-lowest` flag after CS Fixer conflict was removed from the composer.json file in https://github.com/shopsys/shopsys/commit/f0391638e317293e3cc0043c1f1741d5b680bc74
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-stan.odin.shopsys.cloud
  - https://cz.rv-fix-stan.odin.shopsys.cloud
<!-- Replace -->
