### PR TITLE
fix annotations for getTranslations() method in all translatable entities

### DIFF
--- a/packages/framework/src/Component/Image/Image.php
+++ b/packages/framework/src/Component/Image/Image.php
@@ -18,6 +18,7 @@ use Symfony\Component\Clock\DatePoint;
 
 /**
  * @method \Shopsys\FrameworkBundle\Component\Image\ImageTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Component\Image\ImageTranslation> getTranslations()
  */
 #[ORM\Table(name: 'images')]
 #[ORM\Index(columns: ['entity_name', 'entity_id', 'type'])]
@@ -37,7 +38,7 @@ class Image extends AbstractTranslatableEntity implements EntityFileUploadInterf
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Component\Image\ImageTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Component\Image\ImageTranslation>
      */
     #[Prezent\Translations(targetEntity: ImageTranslation::class)]
     #[Override]

--- a/packages/framework/src/Component/UploadedFile/UploadedFile.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFile.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Localization\TranslatableEntityTrait;
 
 /**
  * @method \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Component\UploadedFile\UploadedFileTranslation> getTranslations()
  */
 #[ORM\Table(name: 'uploaded_files')]
 #[ORM\Entity]

--- a/packages/framework/src/Model/Blog/Article/BlogArticle.php
+++ b/packages/framework/src/Model/Blog/Article/BlogArticle.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method translation($locale = null): BlogArticleTranslation
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleTranslation> getTranslations()
  */
 #[ORM\Table(name: 'blog_articles')]
 #[ORM\Entity]
@@ -37,7 +38,7 @@ class BlogArticle extends AbstractTranslatableEntity
     protected $blogArticleBlogCategoryDomains;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleTranslation>
      */
     #[Prezent\Translations(targetEntity: BlogArticleTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Blog/Category/BlogCategory.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategory.php
@@ -16,6 +16,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method translation($locale = null): BlogCategoryTranslation
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryTranslation> getTranslations()
  */
 #[ORM\Table(name: 'blog_categories')]
 #[ORM\Entity]
@@ -33,7 +34,7 @@ class BlogCategory extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryTranslation>
      */
     #[Prezent\Translations(targetEntity: BlogCategoryTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Category/Category.php
+++ b/packages/framework/src/Model/Category/Category.php
@@ -17,6 +17,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Category\CategoryTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Category\CategoryTranslation> getTranslations()
  */
 #[ORM\Table(name: 'categories')]
 #[ORM\Index(columns: ['lft'])]
@@ -42,7 +43,7 @@ class Category extends AbstractTranslatableEntity
     protected $uuid;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Category\CategoryTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Category\CategoryTranslation>
      */
     #[Prezent\Translations(targetEntity: CategoryTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Complaint/Status/ComplaintStatus.php
+++ b/packages/framework/src/Model/Complaint/Status/ComplaintStatus.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusTranslation> getTranslations()
  */
 #[ORM\Table(name: 'complaint_statuses')]
 #[ORM\Entity]
@@ -28,7 +29,7 @@ class ComplaintStatus extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusTranslation>
      */
     #[Prezent\Translations(targetEntity: ComplaintStatusTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Complaint/Status/ComplaintStatusDataFactory.php
+++ b/packages/framework/src/Model/Complaint/Status/ComplaintStatusDataFactory.php
@@ -44,7 +44,6 @@ class ComplaintStatusDataFactory
         ComplaintStatusData $complaintStatusData,
         ComplaintStatus $complaintStatus,
     ): void {
-        /** @var \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatusTranslation[] $translations */
         $translations = $complaintStatus->getTranslations();
         $names = [];
 

--- a/packages/framework/src/Model/Country/Country.php
+++ b/packages/framework/src/Model/Country/Country.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Country\CountryTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Country\CountryTranslation> getTranslations()
  */
 #[ORM\Table(name: 'countries')]
 #[ORM\Entity]
@@ -37,7 +38,7 @@ class Country extends AbstractTranslatableEntity
     protected $code;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Country\CountryTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Country\CountryTranslation>
      */
     #[Prezent\Translations(targetEntity: CountryTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Country/CountryDataFactory.php
+++ b/packages/framework/src/Model/Country/CountryDataFactory.php
@@ -35,7 +35,6 @@ class CountryDataFactory
 
     protected function fillFromCountry(CountryData $countryData, Country $country): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Country\CountryTranslation[] $translations */
         $translations = $country->getTranslations();
 
         foreach ($translations as $translation) {

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroup.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroup.php
@@ -12,7 +12,8 @@ use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
- * @method \Shopsys\FrameworkBundle\Model\Country\CountryTranslation translation(?string $locale = null)
+ * @method \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroupTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroupTranslation> getTranslations()
  */
 #[ORM\Table(name: 'customer_user_role_groups')]
 #[ORM\Entity]
@@ -25,7 +26,7 @@ class CustomerUserRoleGroup extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroupTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroupTranslation>
      */
     #[Prezent\Translations(targetEntity: CustomerUserRoleGroupTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/LanguageConstant/LanguageConstant.php
+++ b/packages/framework/src/Model/LanguageConstant/LanguageConstant.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantTranslation> getTranslations()
  */
 #[ORM\Table(name: 'language_constants')]
 #[ORM\UniqueConstraint(name: 'language_constants_key_namespace', columns: ['key', 'namespace'])]
@@ -42,7 +43,7 @@ class LanguageConstant extends AbstractTranslatableEntity
     protected $namespace;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\LanguageConstant\LanguageConstantTranslation>
      */
     #[Prezent\Translations(targetEntity: LanguageConstantTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Order/Status/OrderStatus.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatus.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Order\Status\Exception\OrderStatusDeletionForb
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTranslation> getTranslations()
  */
 #[ORM\Table(name: 'order_statuses')]
 #[ORM\Entity]
@@ -29,7 +30,7 @@ class OrderStatus extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTranslation>
      */
     #[Prezent\Translations(targetEntity: OrderStatusTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Order/Status/OrderStatusDataFactory.php
+++ b/packages/framework/src/Model/Order/Status/OrderStatusDataFactory.php
@@ -42,7 +42,6 @@ class OrderStatusDataFactory
 
     protected function fillFromOrderStatus(OrderStatusData $orderStatusData, OrderStatus $orderStatus): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusTranslation[] $translations */
         $translations = $orderStatus->getTranslations();
         $names = [];
 

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -22,6 +22,7 @@ use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Payment\PaymentTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Payment\PaymentTranslation> getTranslations()
  */
 #[ORM\Table(name: 'payments')]
 #[ORM\Entity]
@@ -40,7 +41,7 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Payment\PaymentTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Payment\PaymentTranslation>
      */
     #[Prezent\Translations(targetEntity: PaymentTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Payment/PaymentDataFactory.php
+++ b/packages/framework/src/Model/Payment/PaymentDataFactory.php
@@ -67,7 +67,6 @@ class PaymentDataFactory
         $paymentData->czkRounding = $payment->isCzkRounding();
         $paymentData->transports = $payment->getTransports();
 
-        /** @var \Shopsys\FrameworkBundle\Model\Payment\PaymentTranslation[] $translations */
         $translations = $payment->getTranslations();
 
         $names = [];

--- a/packages/framework/src/Model/Product/Brand/Brand.php
+++ b/packages/framework/src/Model/Product/Brand/Brand.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Product\Brand\Exception\BrandDomainNotFoundExc
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Product\Brand\BrandTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Brand\BrandTranslation> getTranslations()
  */
 #[ORM\Table(name: 'brands')]
 #[ORM\Entity]
@@ -43,7 +44,7 @@ class Brand extends AbstractTranslatableEntity
     protected $name;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Brand\BrandTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Brand\BrandTranslation>
      */
     #[Prezent\Translations(targetEntity: BrandTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
+++ b/packages/framework/src/Model/Product/Brand/BrandDataFactory.php
@@ -57,7 +57,6 @@ class BrandDataFactory
     {
         $brandData->name = $brand->getName();
 
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Brand\BrandTranslation[] $translations */
         $translations = $brand->getTranslations();
 
         $brandData->descriptions = [];

--- a/packages/framework/src/Model/Product/Flag/Flag.php
+++ b/packages/framework/src/Model/Product/Flag/Flag.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductPromotionXy;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation> getTranslations()
  */
 #[ORM\Table(name: 'flags')]
 #[ORM\Entity]
@@ -35,7 +36,7 @@ class Flag extends AbstractTranslatableEntity
     protected $uuid;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation>
      */
     #[Prezent\Translations(targetEntity: FlagTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Product/Flag/FlagDataFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagDataFactory.php
@@ -45,7 +45,6 @@ class FlagDataFactory
 
     protected function fillFromFlag(FlagData $flagData, Flag $flag): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Flag\FlagTranslation[] $translations */
         $translations = $flag->getTranslations();
         $names = [];
 

--- a/packages/framework/src/Model/Product/Parameter/Parameter.php
+++ b/packages/framework/src/Model/Product/Parameter/Parameter.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterTranslation> getTranslations()
  */
 #[ORM\Table(name: 'parameters')]
 #[ORM\Entity]
@@ -44,7 +45,7 @@ class Parameter extends AbstractTranslatableEntity
     protected $uuid;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterTranslation>
      */
     #[Prezent\Translations(targetEntity: ParameterTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Product/Parameter/ParameterDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterDataFactory.php
@@ -45,7 +45,6 @@ class ParameterDataFactory
 
     protected function fillFromParameter(ParameterData $parameterData, Parameter $parameter): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterTranslation[] $translations */
         $translations = $parameter->getTranslations();
         $names = [];
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterGroup.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGroup.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupTranslation> getTranslations()
  */
 #[ORM\Table(name: 'parameter_groups')]
 #[ORM\Entity]
@@ -31,7 +32,7 @@ class ParameterGroup extends AbstractTranslatableEntity implements OrderableEnti
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupTranslation>
      */
     #[Prezent\Translations(targetEntity: ParameterGroupTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Product/Parameter/ParameterGroupDataFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGroupDataFactory.php
@@ -36,7 +36,6 @@ class ParameterGroupDataFactory
         ParameterGroupData $parameterGroupData,
         ParameterGroup $parameterGroup,
     ): void {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterGroupTranslation[] $translations */
         $translations = $parameterGroup->getTranslations();
         $names = [];
 

--- a/packages/framework/src/Model/Product/Product.php
+++ b/packages/framework/src/Model/Product/Product.php
@@ -29,6 +29,7 @@ use Shopsys\FrameworkBundle\Model\Transport\Transport;
  * Product
  *
  * @method \Shopsys\FrameworkBundle\Model\Product\ProductTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\ProductTranslation> getTranslations()
  */
 #[ORM\Table(name: 'products')]
 #[ORM\Index(columns: ['variant_type'])]
@@ -50,7 +51,7 @@ class Product extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\ProductTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\ProductTranslation>
      */
     #[Prezent\Translations(targetEntity: ProductTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -107,7 +107,6 @@ class ProductDataFactory
 
     protected function fillFromProduct(ProductData $productData, Product $product): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\ProductTranslation[] $translations */
         $translations = $product->getTranslations();
 
         foreach ($translations as $translation) {

--- a/packages/framework/src/Model/Product/Unit/Unit.php
+++ b/packages/framework/src/Model/Product/Unit/Unit.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Product\Unit\UnitTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Unit\UnitTranslation> getTranslations()
  */
 #[ORM\Table(name: 'units')]
 #[ORM\Entity]
@@ -27,7 +28,7 @@ class Unit extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Product\Unit\UnitTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Product\Unit\UnitTranslation>
      */
     #[Prezent\Translations(targetEntity: UnitTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Product/Unit/UnitDataFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitDataFactory.php
@@ -42,7 +42,6 @@ class UnitDataFactory
 
     protected function fillFromUnit(UnitData $unitData, Unit $unit): void
     {
-        /** @var \Shopsys\FrameworkBundle\Model\Product\Unit\UnitTranslation[] $translations */
         $translations = $unit->getTranslations();
         $names = [];
 

--- a/packages/framework/src/Model/Transport/Transport.php
+++ b/packages/framework/src/Model/Transport/Transport.php
@@ -22,6 +22,7 @@ use Shopsys\FrameworkBundle\Model\Transport\Exception\TransportPriceNotFoundExce
 
 /**
  * @method \Shopsys\FrameworkBundle\Model\Transport\TransportTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Transport\TransportTranslation> getTranslations()
  */
 #[ORM\Table(name: 'transports')]
 #[ORM\Entity]
@@ -40,7 +41,7 @@ class Transport extends AbstractTranslatableEntity implements OrderableEntityInt
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Shopsys\FrameworkBundle\Model\Transport\TransportTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Shopsys\FrameworkBundle\Model\Transport\TransportTranslation>
      */
     #[Prezent\Translations(targetEntity: TransportTranslation::class)]
     #[Override]

--- a/packages/framework/src/Model/Transport/TransportDataFactory.php
+++ b/packages/framework/src/Model/Transport/TransportDataFactory.php
@@ -64,7 +64,6 @@ class TransportDataFactory
         $instructions = [];
         $trackingInstruction = [];
 
-        /** @var \Shopsys\FrameworkBundle\Model\Transport\TransportTranslation[] $translations */
         $translations = $transport->getTranslations();
 
         foreach ($translations as $translate) {

--- a/packages/maker/templates/Entity.tpl.php
+++ b/packages/maker/templates/Entity.tpl.php
@@ -16,7 +16,7 @@ namespace <?= $namespace; ?>;
 <?php if ($entity_config->isTranslatable): ?>
 /**
  * @method \<?= $entity_config->getEntityFullyQualifiedName(EntityTypeEnum::TRANSLATION); ?> translation(?string $locale = null)
- * @method \Doctrine\Common\Collections\Collection<int, \<?= $entity_config->getEntityFullyQualifiedName(EntityTypeEnum::TRANSLATION); ?>> getTranslations()
+ * @method \Doctrine\Common\Collections\Collection<string, \<?= $entity_config->getEntityFullyQualifiedName(EntityTypeEnum::TRANSLATION); ?>> getTranslations()
  */
 <?php endif; ?>
 #[ORM\Table(name: '<?= $entity_config->tableName ?>')]
@@ -43,7 +43,7 @@ class <?= $class_name; ?><?php if ($entity_config->isTranslatable): ?> extends A
 
 <?php if ($entity_config->isTranslatable): ?>
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \<?= $entity_config->getEntityFullyQualifiedName(EntityTypeEnum::TRANSLATION); ?>>
+     * @var \Doctrine\Common\Collections\Collection<string, \<?= $entity_config->getEntityFullyQualifiedName(EntityTypeEnum::TRANSLATION); ?>>
      */
     #[Prezent\Translations(targetEntity: \<?= $entity_config->getEntityFullyQualifiedName(EntityTypeEnum::TRANSLATION); ?>::class)]
     protected $translations;

--- a/project-base/app/src/Model/Product/Product.php
+++ b/project-base/app/src/Model/Product/Product.php
@@ -29,13 +29,14 @@ use Shopsys\FrameworkBundle\Model\Product\ProductData as BaseProductData;
  * @method void addNewVariants(\App\Model\Product\Product[] $currentVariants)
  * @method int[] unsetRemovedVariants(\App\Model\Product\Product[] $currentVariants)
  * @method \App\Model\Product\ProductTranslation translation(?string $locale = null)
- * @property \Doctrine\Common\Collections\Collection<int,\App\Model\Product\ProductTranslation> $translations
+ * @property \Doctrine\Common\Collections\Collection<string,\App\Model\Product\ProductTranslation> $translations
  * @property \Doctrine\Common\Collections\Collection<int,\App\Model\Product\ProductDomain> $domains
  * @method \App\Model\Product\ProductDomain getProductDomain(int $domainId)
  * @property \Shopsys\FrameworkBundle\Model\Product\Unit\Unit $unit
  * @method \Shopsys\FrameworkBundle\Model\Product\Unit\Unit getUnit()
  * @method \App\Model\Product\Flag\Flag[] getFlags(int $domainId)
  * @method void setDomains(\App\Model\Product\ProductData $productData)
+ * @method \Doctrine\Common\Collections\Collection<string, \App\Model\Product\ProductTranslation> getTranslations()
  * @method \App\Model\Product\ProductDomain[] getProductDomains()
  * @property \Doctrine\Common\Collections\Collection<int,\App\Model\Transport\Transport> $excludedTransports
  * @method void setExcludedTransports(\App\Model\Transport\Transport[] $excludedTransports)

--- a/project-base/app/src/Model/Transport/Transport.php
+++ b/project-base/app/src/Model/Transport/Transport.php
@@ -17,7 +17,8 @@ use Shopsys\FrameworkBundle\Model\Transport\Transport as BaseTransport;
  * @method void setPayments(\App\Model\Payment\Payment[] $payments)
  * @method void removePayment(\App\Model\Payment\Payment $payment)
  * @method \App\Model\Transport\TransportTranslation translation(?string $locale = null)
- * @property \Doctrine\Common\Collections\Collection<int,\App\Model\Transport\TransportTranslation> $translations
+ * @property \Doctrine\Common\Collections\Collection<string,\App\Model\Transport\TransportTranslation> $translations
+ * @method \Doctrine\Common\Collections\Collection<string, \App\Model\Transport\TransportTranslation> getTranslations()
  * @method __construct(\App\Model\Transport\TransportData $transportData)
  * @method void edit(\App\Model\Transport\TransportData $transportData)
  * @method void setData(\App\Model\Transport\TransportData $transportData)

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/Category/Category.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/Category/Category.php
@@ -13,6 +13,10 @@ use Prezent\Doctrine\Translatable\Attribute as Prezent;
 use Ramsey\Uuid\Uuid;
 use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
 
+/**
+ * @method \Tests\App\Functional\EntityExtension\Model\Category\CategoryTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Tests\App\Functional\EntityExtension\Model\Category\CategoryTranslation> getTranslations()
+ */
 #[Gedmo\Tree(type: 'nested')]
 #[ORM\Table(name: 'categories')]
 #[ORM\Index(columns: ['lft'])]
@@ -33,7 +37,7 @@ class Category extends AbstractTranslatableEntity
     protected string $uuid;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Tests\App\Functional\EntityExtension\Model\Category\CategoryTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Tests\App\Functional\EntityExtension\Model\Category\CategoryTranslation>
      */
     #[Prezent\Translations(targetEntity: CategoryTranslation::class)]
     #[Override]

--- a/project-base/app/tests/App/Functional/EntityExtension/Model/Product/Product.php
+++ b/project-base/app/tests/App/Functional/EntityExtension/Model/Product/Product.php
@@ -16,6 +16,7 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
  * Product
  *
  * @method \Tests\App\Functional\EntityExtension\Model\Product\ProductTranslation translation(?string $locale = null)
+ * @method \Doctrine\Common\Collections\Collection<string, \Tests\App\Functional\EntityExtension\Model\Product\ProductTranslation> getTranslations()
  */
 #[ORM\Table(name: 'products')]
 #[ORM\Index(columns: ['variant_type'])]
@@ -32,7 +33,7 @@ class Product extends AbstractTranslatableEntity
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<int, \Tests\App\Functional\EntityExtension\Model\Product\ProductTranslation>
+     * @var \Doctrine\Common\Collections\Collection<string, \Tests\App\Functional\EntityExtension\Model\Product\ProductTranslation>
      */
     #[Prezent\Translations(targetEntity: ProductTranslation::class)]
     #[Override]

--- a/upgrade-notes/backend_20260314_160209.md
+++ b/upgrade-notes/backend_20260314_160209.md
@@ -1,0 +1,6 @@
+#### fix annotations for getTranslations() method in all translatable entities ([#3203](https://github.com/shopsys/shopsys/pull/3203))
+
+- in your translatable entities (i.e., entities extending `Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity`), you should use the following annotations:
+    - `@method \Doctrine\Common\Collections\Collection<string, \App\YourNamespace\YourEntityTranslation> getTranslations()` above the entity class
+    - `@var \Doctrine\Common\Collections\Collection<string, \App\YourNamespace\YourEntityTranslation>` above the `protected $translations` property
+- see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| when using `getTranslations()` method of an instance of `AbstractTranslatableEntity`, we had to use inline `@var` annotation to specify the returned type, and moreover, we were defining the type wrong as the method actually returns `Collection`, not an array. This PR adds the correct returned type using `@method` annotations directly in the entities so it is not necessary to use inline `@var` annotations anymore
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





----
:globe_with_meridians: Live Preview:
  - https://rv-fix-translations.odin.shopsys.cloud
  - https://cz.rv-fix-translations.odin.shopsys.cloud
  - https://rv-fix-translations.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773754152.135879 -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-translations.odin.shopsys.cloud
  - https://cz.rv-fix-translations.odin.shopsys.cloud
  - https://rv-fix-translations.odin.shopsys.cloud/sk
<!-- Replace -->
