### PR TITLE
[framework] don't add manually added order item into repeat order cart

### DIFF
--- a/packages/frontend-api/src/Model/Mutation/Cart/CartMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Cart/CartMutation.php
@@ -120,6 +120,10 @@ class CartMutation extends AbstractMutation
         $addProductResults = [];
 
         foreach ($order->getProductItems() as $orderItem) {
+            if ($orderItem->getProduct() === null) {
+                continue;
+            }
+
             try {
                 $addProductResults[] = $this->cartApiFacade->addProductByUuidToCart($orderItem->getProduct()->getUuid(), $orderItem->getQuantity(), false, $cart);
             } catch (InvalidCartItemUserError) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Repeat order function was crashing If there was manually added order item into cart. Problem was that such item was identified as product but was lacking reference. Now such items are simply ignored while creating new cart.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-manually-added-product-in-repeat-order-cart.odin.shopsys.cloud
  - https://cz.ab-manually-added-product-in-repeat-order-cart.odin.shopsys.cloud
<!-- Replace -->
