### PR TITLE
[infrastructure] dropped rebuilding Docker images for no longer supported versions of Shopsys Framework

### DIFF
--- a/.github/workflows/rebuild-docker-images.yaml
+++ b/.github/workflows/rebuild-docker-images.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                branches: ['master', '11.0', '12.0', '12.1']
+                branches: ['12.0', '12.1']
             fail-fast: false
         permissions:
             contents: read
@@ -36,7 +36,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                branches: ['master', '11.0', '12.0', '12.1']
+                branches: ['12.0', '12.1']
             fail-fast: false
         permissions:
             contents: read


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Those images were failing and are used in no longer supported versions of Shopsys Framework, so they were dropped.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-drop-rebuilding-images-for-old-versions.odin.shopsys.cloud
  - https://cz.tl-drop-rebuilding-images-for-old-versions.odin.shopsys.cloud
<!-- Replace -->
