### PR TITLE
[luigis-box] facets are now ordered by storefront and also include applied parameter filters

### DIFF
--- a/packages/frontend-api/src/Resources/config/graphql-types/SearchInputDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/SearchInputDecorator.types.yaml
@@ -12,3 +12,7 @@ SearchInputDecorator:
             isAutocomplete:
                 type: "Boolean!"
                 defaultValue: false
+            parameters:
+                type: "[Uuid!]"
+                defaultValue: []
+                description: "Ordered list of parameters used in Luigi's Box to ensure same order of parameters in search results"

--- a/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
+++ b/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
@@ -437,9 +437,12 @@ class LuigisBoxClient
         LuigisBoxSearchBatchLoadData $luigisBoxBatchLoadData,
     ): int {
         if ($luigisBoxBatchLoadData->getType() === TypeInLuigisBoxEnum::PRODUCT) {
-            return static::COUNT_OF_DYNAMIC_PARAMETER_FILTERS - (
-                count($luigisBoxBatchLoadData->getFacetNames()) -
-                count(LuigisBoxFacetsToProductFilterOptionsMapper::PRODUCT_FACET_NAMES)
+            return max(
+                0,
+                static::COUNT_OF_DYNAMIC_PARAMETER_FILTERS - (
+                    count($luigisBoxBatchLoadData->getFacetNames()) -
+                    count(LuigisBoxFacetsToProductFilterOptionsMapper::PRODUCT_FACET_NAMES)
+                ),
             );
         }
 

--- a/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
+++ b/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
@@ -14,6 +14,7 @@ use Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxBatchLoadData;
 use Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxRecommendationBatchLoadData;
 use Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxSearchBatchLoadData;
 use Shopsys\LuigisBoxBundle\Model\Endpoint\LuigisBoxEndpointEnum;
+use Shopsys\LuigisBoxBundle\Model\Product\Filter\LuigisBoxFacetsToProductFilterOptionsMapper;
 use Shopsys\LuigisBoxBundle\Model\Type\TypeInLuigisBoxEnum;
 use Shopsys\ProductFeed\LuigisBoxBundle\Model\FeedItem\LuigisBoxProductFeedItem;
 use Symfony\Bridge\Monolog\Logger;
@@ -22,7 +23,7 @@ use Throwable;
 
 class LuigisBoxClient
 {
-    protected const int COUNT_OF_DYNAMIC_PARAMETER_FILTERS = 5;
+    protected const int COUNT_OF_DYNAMIC_PARAMETER_FILTERS = 15;
 
     /**
      * @param string $luigisBoxApiUrl
@@ -201,7 +202,7 @@ class LuigisBoxClient
                 '&q=' . urlencode($luigisBoxBatchLoadData->getQuery()) .
                 '&remove_fields=nested' .
                 '&size=' . $this->getMainTypeLimit($limitsByType) .
-                '&dynamic_facets_size=' . static::COUNT_OF_DYNAMIC_PARAMETER_FILTERS;
+                '&dynamic_facets_size=' . $this->getNumberOfDynamicalFacetsWithoutAppliedFilterFacets($luigisBoxBatchLoadData);
 
             if ($luigisBoxBatchLoadData->getPage() > 0) {
                 $url .= '&from=' . $luigisBoxBatchLoadData->getPage();
@@ -426,5 +427,22 @@ class LuigisBoxClient
         }
 
         return implode(',', $luigisBoxLimits);
+    }
+
+    /**
+     * @param \Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxSearchBatchLoadData $luigisBoxBatchLoadData
+     * @return int
+     */
+    protected function getNumberOfDynamicalFacetsWithoutAppliedFilterFacets(
+        LuigisBoxSearchBatchLoadData $luigisBoxBatchLoadData,
+    ): int {
+        if ($luigisBoxBatchLoadData->getType() === TypeInLuigisBoxEnum::PRODUCT) {
+            return static::COUNT_OF_DYNAMIC_PARAMETER_FILTERS - (
+                count($luigisBoxBatchLoadData->getFacetNames()) -
+                count(LuigisBoxFacetsToProductFilterOptionsMapper::PRODUCT_FACET_NAMES)
+            );
+        }
+
+        return static::COUNT_OF_DYNAMIC_PARAMETER_FILTERS;
     }
 }

--- a/packages/luigis-box/src/Model/Batch/LuigisBoxBatchLoadDataFactory.php
+++ b/packages/luigis-box/src/Model/Batch/LuigisBoxBatchLoadDataFactory.php
@@ -33,7 +33,7 @@ class LuigisBoxBatchLoadDataFactory
      * @param int $page
      * @param \Overblog\GraphQLBundle\Definition\Argument $argument
      * @param array $luigisBoxFilter
-     * @param string[] $facets
+     * @param string[] $facetNames
      * @return \Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxBatchLoadData
      */
     public function createForSearch(
@@ -42,7 +42,7 @@ class LuigisBoxBatchLoadDataFactory
         int $page,
         Argument $argument,
         array $luigisBoxFilter = [],
-        array $facets = [],
+        array $facetNames = [],
     ): LuigisBoxBatchLoadData {
         $this->typeInLuigisBoxEnum->validateCase($type);
 
@@ -55,8 +55,6 @@ class LuigisBoxBatchLoadDataFactory
         $endpoint = $argument['searchInput']['isAutocomplete'] === true ? LuigisBoxEndpointEnum::AUTOCOMPLETE : LuigisBoxEndpointEnum::SEARCH;
         $userIdentifier = $argument['searchInput']['userIdentifier'];
 
-        $facets = array_unique([...$facets, ...$this->facetFactory->getDefaultFacetNamesByType($type)], SORT_REGULAR);
-
         return new LuigisBoxSearchBatchLoadData(
             $type,
             $endpoint,
@@ -66,7 +64,7 @@ class LuigisBoxBatchLoadDataFactory
             $page,
             $luigisBoxFilter,
             $orderingMode,
-            $facets,
+            array_unique([...$this->facetFactory->getDefaultFacetNamesByType($type), ...$facetNames], SORT_REGULAR),
         );
     }
 

--- a/packages/luigis-box/src/Model/Batch/LuigisBoxBatchLoadDataFactory.php
+++ b/packages/luigis-box/src/Model/Batch/LuigisBoxBatchLoadDataFactory.php
@@ -7,7 +7,7 @@ namespace Shopsys\LuigisBoxBundle\Model\Batch;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Shopsys\LuigisBoxBundle\Component\LuigisBox\Filter\ProductFilterToLuigisBoxFilterMapper;
 use Shopsys\LuigisBoxBundle\Model\Endpoint\LuigisBoxEndpointEnum;
-use Shopsys\LuigisBoxBundle\Model\Product\Filter\LuigisBoxFacetsToProductFilterOptionsMapper;
+use Shopsys\LuigisBoxBundle\Model\Facet\FacetFactory;
 use Shopsys\LuigisBoxBundle\Model\Type\RecommendationTypeEnum;
 use Shopsys\LuigisBoxBundle\Model\Type\TypeInLuigisBoxEnum;
 
@@ -17,11 +17,13 @@ class LuigisBoxBatchLoadDataFactory
      * @param \Shopsys\LuigisBoxBundle\Component\LuigisBox\Filter\ProductFilterToLuigisBoxFilterMapper $productFilterToLuigisBoxFilterMapper
      * @param \Shopsys\LuigisBoxBundle\Model\Type\TypeInLuigisBoxEnum $typeInLuigisBoxEnum
      * @param \Shopsys\LuigisBoxBundle\Model\Type\RecommendationTypeEnum $recommendationTypeEnum
+     * @param \Shopsys\LuigisBoxBundle\Model\Facet\FacetFactory $facetFactory
      */
     public function __construct(
         protected readonly ProductFilterToLuigisBoxFilterMapper $productFilterToLuigisBoxFilterMapper,
         protected readonly TypeInLuigisBoxEnum $typeInLuigisBoxEnum,
         protected readonly RecommendationTypeEnum $recommendationTypeEnum,
+        protected readonly FacetFactory $facetFactory,
     ) {
     }
 
@@ -31,6 +33,7 @@ class LuigisBoxBatchLoadDataFactory
      * @param int $page
      * @param \Overblog\GraphQLBundle\Definition\Argument $argument
      * @param array $luigisBoxFilter
+     * @param string[] $facets
      * @return \Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxBatchLoadData
      */
     public function createForSearch(
@@ -39,6 +42,7 @@ class LuigisBoxBatchLoadDataFactory
         int $page,
         Argument $argument,
         array $luigisBoxFilter = [],
+        array $facets = [],
     ): LuigisBoxBatchLoadData {
         $this->typeInLuigisBoxEnum->validateCase($type);
 
@@ -51,6 +55,8 @@ class LuigisBoxBatchLoadDataFactory
         $endpoint = $argument['searchInput']['isAutocomplete'] === true ? LuigisBoxEndpointEnum::AUTOCOMPLETE : LuigisBoxEndpointEnum::SEARCH;
         $userIdentifier = $argument['searchInput']['userIdentifier'];
 
+        $facets = array_unique([...$facets, ...$this->facetFactory->getDefaultFacetNamesByType($type)], SORT_REGULAR);
+
         return new LuigisBoxSearchBatchLoadData(
             $type,
             $endpoint,
@@ -60,20 +66,8 @@ class LuigisBoxBatchLoadDataFactory
             $page,
             $luigisBoxFilter,
             $orderingMode,
-            $this->getFacetNamesByType($type),
+            $facets,
         );
-    }
-
-    /**
-     * @param string $type
-     * @return string[]
-     */
-    protected function getFacetNamesByType(string $type): array
-    {
-        return match ($type) {
-            TypeInLuigisBoxEnum::PRODUCT => LuigisBoxFacetsToProductFilterOptionsMapper::PRODUCT_FACET_NAMES,
-            default => [],
-        };
     }
 
     /**

--- a/packages/luigis-box/src/Model/Facet/FacetFactory.php
+++ b/packages/luigis-box/src/Model/Facet/FacetFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\LuigisBoxBundle\Model\Facet;
+
+use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData;
+use Shopsys\LuigisBoxBundle\Model\Product\Filter\LuigisBoxFacetsToProductFilterOptionsMapper;
+use Shopsys\LuigisBoxBundle\Model\Type\TypeInLuigisBoxEnum;
+
+class FacetFactory
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterData $productFilterData
+     * @return string[]
+     */
+    public function mapFacetsFromProductFilterData(ProductFilterData $productFilterData): array
+    {
+        $facets = [];
+
+        foreach ($productFilterData->parameters as $parameterFilterData) {
+            $facets[] = $parameterFilterData->parameter->getName();
+        }
+
+        return $facets;
+    }
+
+    /**
+     * @param string $type
+     * @return string[]
+     */
+    public function getDefaultFacetNamesByType(string $type): array
+    {
+        return match ($type) {
+            TypeInLuigisBoxEnum::PRODUCT => LuigisBoxFacetsToProductFilterOptionsMapper::PRODUCT_FACET_NAMES,
+            default => [],
+        };
+    }
+}

--- a/project-base/app/schema.graphql
+++ b/project-base/app/schema.graphql
@@ -1919,6 +1919,8 @@ input RemovePromoCodeFromCartInput {
 "Represents search input object"
 input SearchInput {
   isAutocomplete: Boolean! = false
+  "Ordered list of parameters used in Luigi's Box to ensure same order of parameters in search results"
+  parameters: [Uuid!] = []
   search: String!
   "Unique identifier of the user who initiated the search in format UUID version 4 (^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[1-8][0-9A-Fa-f]{3}-[ABab89][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/)"
   userIdentifier: Uuid!

--- a/project-base/storefront/graphql/docs/schema.md
+++ b/project-base/storefront/graphql/docs/schema.md
@@ -9726,6 +9726,15 @@ Represents search input object
 <td></td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>parameters</strong></td>
+<td valign="top">[<a href="#uuid">Uuid</a>!]</td>
+<td>
+
+Ordered list of parameters used in Luigi's Box to ensure same order of parameters in search results
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>search</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td></td>

--- a/project-base/storefront/graphql/types.ts
+++ b/project-base/storefront/graphql/types.ts
@@ -2536,6 +2536,8 @@ export type TypeRemovePromoCodeFromCartInput = {
 /** Represents search input object */
 export type TypeSearchInput = {
   isAutocomplete: Scalars['Boolean']['input'];
+  /** Ordered list of parameters used in Luigi's Box to ensure same order of parameters in search results */
+  parameters: InputMaybe<Array<Scalars['Uuid']['input']>>;
   search: Scalars['String']['input'];
   /** Unique identifier of the user who initiated the search in format UUID version 4 (^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[1-8][0-9A-Fa-f]{3}-[ABab89][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$/) */
   userIdentifier: Scalars['Uuid']['input'];

--- a/upgrade-notes/backend_20240529_084428.md
+++ b/upgrade-notes/backend_20240529_084428.md
@@ -1006,6 +1006,48 @@
 
 -   see #project-base-diff to update your project
 
+#### fix Luigi's Box filters might miss already selected parameters ([#3220](https://github.com/shopsys/shopsys/pull/3220))
+
+-   `\Shopsys\LuigisBoxBundle\Model\Batch\LuigisBoxBatchLoadDataFactory` class was changed:
+    -   `__construct()` method changed its interface:
+        ```diff
+            public function __construct(
+                protected readonly ProductFilterToLuigisBoxFilterMapper $productFilterToLuigisBoxFilterMapper,
+                protected readonly TypeInLuigisBoxEnum $typeInLuigisBoxEnum,
+                protected readonly RecommendationTypeEnum $recommendationTypeEnum,
+        +       protected readonly FacetFactory $facetFactory,
+            ) {
+        ```
+    -   `createForSearch()` method changed its interface:
+        ```diff
+            public function createForSearch(
+                string $type,
+                int $limit,
+                int $page,
+                Argument $argument,
+                array $luigisBoxFilter = [],
+        +       array $facets = [],
+            ): LuigisBoxBatchLoadData {
+        ```
+    -   `getFacetNamesByType()` method has been replaced by `\Shopsys\LuigisBoxBundle\Model\Facet\FacetFactory::getDefaultFacetNamesByType()`
+-   `\Shopsys\LuigisBoxBundle\Model\Product\ProductSearchResultsProvider` class was changed:
+    -   `__construct()` method changed its interface:
+        ```diff
+            public function __construct(
+                string $enabledDomainIds,
+                protected readonly ProductConnectionFactory $productConnectionFactory,
+                protected readonly LuigisBoxClient $client,
+                protected readonly Domain $domain,
+                protected readonly ProductFilterToLuigisBoxFilterMapper $productFilterToLuigisBoxFilterMapper,
+                protected readonly DataLoaderInterface $luigisBoxBatchLoader,
+                protected readonly LuigisBoxBatchLoadDataFactory $luigisBoxBatchLoadDataFactory,
+                protected readonly ProductFilterDataMapper $productFilterDataMapper,
+        +       protected readonly FacetFactory $facetFactory,
+            ) {
+        ```
+
+-   see #project-base-diff to update your project
+
 #### removed ReadyCategorySeoMixDataForForm ([#3214](https://github.com/shopsys/shopsys/pull/3214))
 -   see #project-base-diff to update your project
 

--- a/upgrade-notes/backend_20240529_084428.md
+++ b/upgrade-notes/backend_20240529_084428.md
@@ -1016,6 +1016,7 @@
                 protected readonly TypeInLuigisBoxEnum $typeInLuigisBoxEnum,
                 protected readonly RecommendationTypeEnum $recommendationTypeEnum,
         +       protected readonly FacetFactory $facetFactory,
+        +       protected readonly ParameterFacade $parameterFacade,
             ) {
         ```
     -   `createForSearch()` method changed its interface:
@@ -1026,7 +1027,7 @@
                 int $page,
                 Argument $argument,
                 array $luigisBoxFilter = [],
-        +       array $facets = [],
+        +       array $facetNames = [],
             ): LuigisBoxBatchLoadData {
         ```
     -   `getFacetNamesByType()` method has been replaced by `\Shopsys\LuigisBoxBundle\Model\Facet\FacetFactory::getDefaultFacetNamesByType()`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| As parameter facets are dynamically returned from Luigi's Box, a situation where already picked filters have been removed might occur. This PR ensures that selected filters will not be removed.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-generate-luigis-box-facets-from-filter.odin.shopsys.cloud
  - https://cz.tl-generate-luigis-box-facets-from-filter.odin.shopsys.cloud
<!-- Replace -->
