### PR TITLE
[project-base] added redis timeouts

### DIFF
--- a/project-base/app/config/packages/snc_redis.yaml
+++ b/project-base/app/config/packages/snc_redis.yaml
@@ -6,6 +6,8 @@ snc_redis:
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
                 prefix: '%env(REDIS_PREFIX)%:%build-version%:cache:bestselling_products:'
+                connection_timeout: 2
+                read_write_timeout: 5
         blog_article_export_queue:
             type: 'phpredis'
             alias: 'blog_article_export_queue'
@@ -13,12 +15,16 @@ snc_redis:
             options:
                 serialization: 'json'
                 prefix: '%env(REDIS_PREFIX)%:queue:blog_article_export:'
+                connection_timeout: 2
+                read_write_timeout: 5
         doctrine_query:
             type: 'phpredis'
             alias: 'doctrine_query'
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
                 prefix: '%env(REDIS_PREFIX)%:%build-version%:cache:doctrine:query:'
+                connection_timeout: 2
+                read_write_timeout: 5
         # client is used exclusively for cleaning old versions of redis caches and should not be used for anything else
         global:
             type: 'phpredis'
@@ -26,21 +32,29 @@ snc_redis:
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
                 prefix: '%env(REDIS_PREFIX)%:'
+                connection_timeout: 2
+                read_write_timeout: 5
         image:
             type: 'phpredis'
             alias: 'image'
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
                 prefix: '%env(REDIS_PREFIX)%:%build-version%:cache:image:'
+                connection_timeout: 2
+                read_write_timeout: 5
         main_friendly_url_slugs:
             type: 'phpredis'
             alias: 'main_friendly_url_slugs'
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
                 prefix: '%env(REDIS_PREFIX)%:%build-version%:cache:main_friendly_url_slugs:'
+                connection_timeout: 2
+                read_write_timeout: 5
         storefront_graphql_query:
             type: 'phpredis'
             alias: 'storefront_graphql_query'
             dsn: 'redis://%env(REDIS_HOST)%'
             options:
                 prefix: '%env(REDIS_PREFIX)%:fe:'
+                connection_timeout: 2
+                read_write_timeout: 5

--- a/upgrade-notes/backend_20240920_062952.md
+++ b/upgrade-notes/backend_20240920_062952.md
@@ -1,0 +1,3 @@
+#### add timeouts to snc_redis clients ([#3226](https://github.com/shopsys/shopsys/pull/3226))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR adds connection_timeout and read_write_timeout to the snc_redis clients to improve reliability and performance by ensuring that Redis operations do not hang indefinitely.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-redis-timeouts.odin.shopsys.cloud
  - https://cz.mg-redis-timeouts.odin.shopsys.cloud
<!-- Replace -->
