### PR TITLE
[framework] annotation fixer now works for all Shopsys packages

### DIFF
--- a/.github/monorepo/monorepo_functions.sh
+++ b/.github/monorepo/monorepo_functions.sh
@@ -13,6 +13,7 @@ NC="\e[0m"
 #   \Shopsys\Releaser\ReleaseWorker\AbstractShopsysReleaseWorker
 #   /docs/introduction/monorepo.md
 #   /CHANGELOG.md
+#   /packages/framework/src/Resources/config/packages_registry.yaml
 #   "replace" section in monorepo's composer.json
 get_all_packages() {
     echo "administration \

--- a/docs/introduction/console-commands-for-application-management-phing-targets.md
+++ b/docs/introduction/console-commands-for-application-management-phing-targets.md
@@ -227,8 +227,10 @@ Exports only changed data for index to Elasticsearch.
 
 #### annotations-check
 
-Checks whether annotations of extended classes in the project match the actual types according to [`ClassExtensionRegistry`](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php).
+Checks whether annotations of extended classes in the project match the actual types according to [`ClassExtensionRegistry`](https://github.com/shopsys/shopsys/blob/15.0/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php).
 Reported problems can be fixed using [`annotations-fix` phing target](#annotations-fix).
+Annotations fixing tool uses [`packages_registry.yaml`](https://github.com/shopsys/shopsys/blob/15.0/packages/framework/src/Resources/config/packages_registry.yaml) configuration file to determine namespace of the extended classes in the project.
+If you want to change this namespace, you need to extend this configuration in your project.
 
 #### annotations-fix
 

--- a/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
+++ b/packages/framework/src/Command/ExtendedClassesAnnotationsCommand.php
@@ -40,7 +40,7 @@ class ExtendedClassesAnnotationsCommand extends Command
                 'By default, the command fixes and adds all the relevant annotations for extended classes. When using this option, it just reports files that need to be fixed.',
             )
             ->setHelp('What does the command do exactly?
-- Replaces the framework with the project annotations in all project files when there exists a project extension of a given framework class.
+- Replaces the shopsys with the project annotations in all project files when there exists a project extension of a given shopsys class.
 - Adds @property annotations to project classes when there exists a property in parent class that is extended in the project.
 - Adds @method annotations to project classes when there exists a method in parent class that accepts as a parameter or returns an instance of a class that is extended in the project.');
     }
@@ -73,7 +73,7 @@ class ExtendedClassesAnnotationsCommand extends Command
     {
         $symfonyStyle = new SymfonyStyle($input, $output);
         $isDryRun = (bool)$input->getOption(static::DRY_RUN);
-        $filesForReplacingAnnotations = $this->replaceFrameworkWithProjectAnnotations($isDryRun);
+        $filesForReplacingAnnotations = $this->replaceShopsysWithProjectAnnotations($isDryRun);
 
         if (count($filesForReplacingAnnotations) > 0) {
             if ($isDryRun) {
@@ -123,7 +123,7 @@ class ExtendedClassesAnnotationsCommand extends Command
      * @param bool $isDryRun
      * @return string[]
      */
-    protected function replaceFrameworkWithProjectAnnotations(bool $isDryRun): array
+    protected function replaceShopsysWithProjectAnnotations(bool $isDryRun): array
     {
         $finder = $this->getFinderForReplacingAnnotations();
         $filesForReplacingAnnotations = [];
@@ -168,8 +168,8 @@ class ExtendedClassesAnnotationsCommand extends Command
         $classExtensionMap = $this->classExtensionRegistry->getClassExtensionMap();
         $filesForAddingPropertyOrMethodAnnotations = [];
 
-        foreach ($classExtensionMap as $frameworkClass => $projectClass) {
-            $frameworkClassBetterReflection = ReflectionObject::createFromName($frameworkClass);
+        foreach ($classExtensionMap as $shopsysClass => $projectClass) {
+            $shopsysClassBetterReflection = ReflectionObject::createFromName($shopsysClass);
             $projectClassBetterReflection = ReflectionObject::createFromName($projectClass);
 
             if (str_starts_with($projectClass, 'App') === false) {
@@ -177,11 +177,11 @@ class ExtendedClassesAnnotationsCommand extends Command
             }
 
             $projectClassNecessaryPropertyAnnotationsLines = $this->propertyAnnotationsFactory->getProjectClassNecessaryPropertyAnnotationsLines(
-                $frameworkClassBetterReflection,
+                $shopsysClassBetterReflection,
                 $projectClassBetterReflection,
             );
             $projectClassNecessaryMethodAnnotationsLines = $this->methodAnnotationsAdder->getProjectClassNecessaryMethodAnnotationsLines(
-                $frameworkClassBetterReflection,
+                $shopsysClassBetterReflection,
                 $projectClassBetterReflection,
             );
 

--- a/packages/framework/src/Component/ClassExtension/AnnotationsReplacementsMap.php
+++ b/packages/framework/src/Component/ClassExtension/AnnotationsReplacementsMap.php
@@ -40,20 +40,4 @@ class AnnotationsReplacementsMap
 
         return $replacements;
     }
-
-    /**
-     * This method assumes that {@see AnnotationsReplacementsMap::getPatterns()} doesn't use modifiers after delimiter
-     *
-     * @return string
-     */
-    public function getPatternForAny(): string
-    {
-        $patternsWithoutDelimiters = [];
-
-        foreach ($this->getPatterns() as $pattern) {
-            $patternsWithoutDelimiters[] = substr($pattern, 1, -1);
-        }
-
-        return '/' . implode('|', $patternsWithoutDelimiters) . '/';
-    }
 }

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -23,12 +23,10 @@ class ClassExtensionRegistry
     protected array $otherClassesExtensionMap = [];
 
     /**
-     * @param string $frameworkRootDir
      * @param string[] $entityExtensionMap
      * @param array<int, array{name: string, path: string, namespace: string, app_namespace: string}> $packagesRegistry
      */
     public function __construct(
-        protected readonly string $frameworkRootDir,
         protected readonly array $entityExtensionMap,
         protected readonly array $packagesRegistry,
     ) {
@@ -57,6 +55,10 @@ class ClassExtensionRegistry
         $otherClassesMap = [];
 
         foreach ($this->packagesRegistry as $package) {
+            if (!is_dir($package['path'] . '/src')) {
+                continue;
+            }
+
             $finder = Finder::create()
                 ->files()
                 ->ignoreUnreadableDirs()

--- a/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
+++ b/packages/framework/src/Component/ClassExtension/ClassExtensionRegistry.php
@@ -61,8 +61,7 @@ class ClassExtensionRegistry
                 ->files()
                 ->ignoreUnreadableDirs()
                 ->in($package['path'] . '/src')
-                ->name('/.*\.php/');
-
+                ->name('/.*\.php$/');
 
             /** @var \Symfony\Component\Finder\SplFileInfo $file */
             foreach ($finder as $file) {

--- a/packages/framework/src/DependencyInjection/Compiler/RegisterProjectShopsysClassExtensionsCompilerPass.php
+++ b/packages/framework/src/DependencyInjection/Compiler/RegisterProjectShopsysClassExtensionsCompilerPass.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
-class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPassInterface
+class RegisterProjectShopsysClassExtensionsCompilerPass implements CompilerPassInterface
 {
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
@@ -49,14 +49,14 @@ class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPas
                 continue;
             }
 
-            $frameworkClassBetterReflection = ReflectionObject::createFromName($serviceId);
+            $shopsysClassBetterReflection = ReflectionObject::createFromName($serviceId);
 
-            if ($frameworkClassBetterReflection->isInterface() && !$this->isProjectClass($aliasId)) {
+            if ($shopsysClassBetterReflection->isInterface() && !$this->isProjectClass($aliasId)) {
                 continue;
             }
 
             $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$serviceId, $aliasId]);
-            $this->addAllVariantsOfServiceToClassExtension($frameworkClassBetterReflection, $classExtensionRegistryDefinition, $aliasId);
+            $this->addAllVariantsOfServiceToClassExtension($shopsysClassBetterReflection, $classExtensionRegistryDefinition, $aliasId);
         }
     }
 
@@ -118,25 +118,25 @@ class RegisterProjectFrameworkClassExtensionsCompilerPass implements CompilerPas
     }
 
     /**
-     * @param \Roave\BetterReflection\Reflection\ReflectionClass $frameworkClassBetterReflection
+     * @param \Roave\BetterReflection\Reflection\ReflectionClass $shopsysClassBetterReflection
      * @param \Symfony\Component\DependencyInjection\Definition $classExtensionRegistryDefinition
      * @param string $aliasId
      */
     private function addAllVariantsOfServiceToClassExtension(
-        ReflectionClass $frameworkClassBetterReflection,
+        ReflectionClass $shopsysClassBetterReflection,
         Definition $classExtensionRegistryDefinition,
         string $aliasId,
     ): void {
-        if ($frameworkClassBetterReflection->isInterface()) {
-            $className = preg_replace('/Interface$/', '', $frameworkClassBetterReflection->getName());
+        if ($shopsysClassBetterReflection->isInterface()) {
+            $className = preg_replace('/Interface$/', '', $shopsysClassBetterReflection->getName());
 
             if ($className !== $aliasId && class_exists($className)) {
                 $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$className, $aliasId]);
             }
         } else {
-            $interfaceName = $frameworkClassBetterReflection->getName() . 'Interface';
+            $interfaceName = $shopsysClassBetterReflection->getName() . 'Interface';
 
-            if ($interfaceName !== $aliasId && interface_exists($interfaceName) && in_array($interfaceName, $frameworkClassBetterReflection->getInterfaceNames(), true)) {
+            if ($interfaceName !== $aliasId && interface_exists($interfaceName) && in_array($interfaceName, $shopsysClassBetterReflection->getInterfaceNames(), true)) {
                 $classExtensionRegistryDefinition->addMethodCall('addExtendedService', [$interfaceName, $aliasId]);
             }
         }

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -32,6 +32,7 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
         $loader->load('parameters_common.yaml');
         $loader->load('services.yaml');
         $loader->load('paths.yaml');
+        $loader->load('packages_registry.yaml');
 
         if ($container->getParameter('kernel.environment') === EnvironmentType::DEVELOPMENT) {
             $loader->load('services_dev.yaml');

--- a/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
+++ b/packages/framework/src/DependencyInjection/ShopsysFrameworkExtension.php
@@ -32,7 +32,6 @@ class ShopsysFrameworkExtension extends Extension implements PrependExtensionInt
         $loader->load('parameters_common.yaml');
         $loader->load('services.yaml');
         $loader->load('paths.yaml');
-        $loader->load('packages_registry.yaml');
 
         if ($container->getParameter('kernel.environment') === EnvironmentType::DEVELOPMENT) {
             $loader->load('services_dev.yaml');

--- a/packages/framework/src/Resources/config/packages_registry.yaml
+++ b/packages/framework/src/Resources/config/packages_registry.yaml
@@ -1,0 +1,4 @@
+parameters:
+    shopsys.packages.registry:
+        - { name: 'framework', path: '%shopsys.framework.root_dir%', namespace: 'Shopsys\FrameworkBundle', app_namespace: 'App' }
+        - { name: 'frontend-api', path: '%shopsys.framework.root_dir%/../frontend-api', namespace: 'Shopsys\FrontendApiBundle', app_namespace: 'App\FrontendApi' }

--- a/packages/framework/src/Resources/config/packages_registry.yaml
+++ b/packages/framework/src/Resources/config/packages_registry.yaml
@@ -1,4 +1,20 @@
 parameters:
     shopsys.packages.registry:
-        - { name: 'framework', path: '%shopsys.framework.root_dir%', namespace: 'Shopsys\FrameworkBundle', app_namespace: 'App' }
-        - { name: 'frontend-api', path: '%shopsys.framework.root_dir%/../frontend-api', namespace: 'Shopsys\FrontendApiBundle', app_namespace: 'App\FrontendApi' }
+        article-feed-luigis-box': { path: '%shopsys.framework.root_dir%/../article-feed-luigis-box', namespace: 'Shopsys\ArticleFeed\LuigisBoxBundle', app_namespace: 'App\ArticleFeed\LuigisBox' }
+        brand-feed-luigis-box: { path: '%shopsys.framework.root_dir%/../brand-feed-luigis-box', namespace: 'Shopsys\BrandFeed\LuigisBoxBundle', app_namespace: 'App\BrandFeed\LuigisBox' }
+        category-feed-luigis-box: { path: '%shopsys.framework.root_dir%/../category-feed-luigis-box', namespace: 'Shopsys\CategoryFeed\LuigisBoxBundle', app_namespace: 'App\CategoryFeed\LuigisBox' }
+        coding-standards: { path: '%shopsys.framework.root_dir%/../coding-standards', namespace: 'Shopsys\CodingStandards', app_namespace: 'App\CodingStandards' }
+        form-types-bundle: { path: '%shopsys.framework.root_dir%/../form-types-bundle', namespace: 'Shopsys\FormTypesBundle', app_namespace: 'App\FormTypes' }
+        framework: { path: '%shopsys.framework.root_dir%', namespace: 'Shopsys\FrameworkBundle', app_namespace: 'App' }
+        frontend-api: { path: '%shopsys.framework.root_dir%/../frontend-api', namespace: 'Shopsys\FrontendApiBundle', app_namespace: 'App\FrontendApi' }
+        google-cloud-bundle: { path: '%shopsys.framework.root_dir%/../google-cloud-bundle', namespace: 'Shopsys\GoogleCloudBundle', app_namespace: 'App\GoogleCloud' }
+        http-smoke-testing: { path: '%shopsys.framework.root_dir%/../http-smoke-testing', namespace: 'Shopsys\HttpSmokeTesting', app_namespace: 'App\HttpSmokeTesting' }
+        luigis-box: { path: '%shopsys.framework.root_dir%/../luigis-box', namespace: 'Shopsys\LuigisBoxBundle', app_namespace: 'App\LuigisBox' }
+        migrations: { path: '%shopsys.framework.root_dir%/../migrations', namespace: 'Shopsys\MigrationBundle', app_namespace: 'App\Migration' }
+        plugin-interface: { path: '%shopsys.framework.root_dir%/../plugin-interface', namespace: 'Shopsys\Plugin', app_namespace: 'App\Plugin' }
+        product-feed-google: { path: '%shopsys.framework.root_dir%/../product-feed-google', namespace: 'Shopsys\ProductFeed\GoogleBundle', app_namespace: 'App\ProductFeed\Google' }
+        product-feed-heureka: { path: '%shopsys.framework.root_dir%/../product-feed-heureka', namespace: 'Shopsys\ProductFeed\HeurekaBundle', app_namespace: 'App\ProductFeed\Heureka' }
+        product-feed-heureka-delivery: { path: '%shopsys.framework.root_dir%/../product-feed-heureka-delivery', namespace: 'Shopsys\ProductFeed\HeurekaDeliveryBundle', app_namespace: 'App\ProductFeed\HeurekaDelivery' }
+        product-feed-luigis-box: {path: '%shopsys.framework.root_dir%/../product-feed-heureka-delivery', namespace: 'Shopsys\ProductFeed\LuigisBoxBundle', app_namespace: 'App\ProductFeed\LuigisBox' }
+        product-feed-zbozi: { path: '%shopsys.framework.root_dir%/../product-feed-zbozi', namespace: 'Shopsys\ProductFeed\ZboziBundle', app_namespace: 'App\ProductFeed\Zbozi' }
+        s3-bridge: { path: '%shopsys.framework.root_dir%/../s3-bridge', namespace: 'Shopsys\S3Bridge', app_namespace: 'App\S3Bridge' }

--- a/packages/framework/src/Resources/config/services_dev.yaml
+++ b/packages/framework/src/Resources/config/services_dev.yaml
@@ -13,6 +13,7 @@ services:
         arguments:
             $frameworkRootDir: '%shopsys.framework.root_dir%'
             $entityExtensionMap: '%shopsys.entity_extension.map%'
+            $packagesRegistry: '%shopsys.packages.registry%'
 
     Shopsys\FrameworkBundle\Component\Elasticsearch\Debug\ElasticsearchCollector:
         tags:

--- a/packages/framework/src/Resources/config/services_dev.yaml
+++ b/packages/framework/src/Resources/config/services_dev.yaml
@@ -1,5 +1,7 @@
-services:
+imports:
+    - { resource: packages_registry.yaml }
 
+services:
     _defaults:
         autoconfigure: true
         autowire: true
@@ -11,7 +13,6 @@ services:
 
     Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry:
         arguments:
-            $frameworkRootDir: '%shopsys.framework.root_dir%'
             $entityExtensionMap: '%shopsys.entity_extension.map%'
             $packagesRegistry: '%shopsys.packages.registry%'
 

--- a/packages/framework/src/ShopsysFrameworkBundle.php
+++ b/packages/framework/src/ShopsysFrameworkBundle.php
@@ -13,7 +13,7 @@ use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterMultiDesignFile
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginCrudExtensionsCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterPluginDataFixturesCompilerPass;
 use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProductFeedConfigsCompilerPass;
-use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProjectFrameworkClassExtensionsCompilerPass;
+use Shopsys\FrameworkBundle\DependencyInjection\Compiler\RegisterProjectShopsysClassExtensionsCompilerPass;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -48,7 +48,7 @@ class ShopsysFrameworkBundle extends Bundle
             return;
         }
 
-        $container->addCompilerPass(new RegisterProjectFrameworkClassExtensionsCompilerPass());
+        $container->addCompilerPass(new RegisterProjectShopsysClassExtensionsCompilerPass());
 
         $container->addResource(new DirectoryResource($container->getParameter('kernel.project_dir') . '/src/Component'));
         $container->addResource(new DirectoryResource($container->getParameter('kernel.project_dir') . '/src/Model'));

--- a/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/AnnotationsReplacerTest.php
@@ -25,6 +25,7 @@ class AnnotationsReplacerTest extends TestCase
             'Shopsys\FrameworkBundle\Model\Category\CategoryFacade' => 'App\Model\Category\CategoryFacade',
             'Shopsys\FrameworkBundle\Model\Product\ProductDataFactory' => 'App\Model\MyProduct\ProductDataFactory',
             'Shopsys\FrameworkBundle\Model\Article\ArticleData' => 'App\Model\Article\ArticleData',
+            'Shopsys\FrontendApiBundle\Model\Product\ProductRepository' => 'App\FrontendApi\Model\Product\ProductRepository',
         ]);
 
         $this->annotationsReplacer = new AnnotationsReplacer($replacementMap, new DocBlockParser());
@@ -57,8 +58,16 @@ class AnnotationsReplacerTest extends TestCase
                 'output' => '@var \Shopsys\FrameworkBundle\Model\Article\ArticleDataInterface',
             ],
             [
+                'input' => '@var \Shopsys\FrontendApiBundle\Model\Product\ProductRepository',
+                'output' => '@var \App\FrontendApi\Model\Product\ProductRepository',
+            ],
+            [
                 'input' => '@param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade',
                 'output' => '@param \App\Model\Category\CategoryFacade',
+            ],
+            [
+                'input' => '@param \Shopsys\FrontendApiBundle\Model\Product\ProductRepository',
+                'output' => '@param \App\FrontendApi\Model\Product\ProductRepository',
             ],
             [
                 'input' => '@return \Shopsys\FrameworkBundle\Model\Category\CategoryFacade',
@@ -103,6 +112,7 @@ class AnnotationsReplacerTest extends TestCase
             ), '\App\Model\Category\CategoryFacade|null'],
             [$reflectionClass->getMethod('returnsFrameworkArticleDataArray'), '\App\Model\Article\ArticleData[]'],
             [$reflectionClass->getMethod('returnsInt'), 'int'],
+            [$reflectionClass->getMethod('returnsFrontendApiProductRepository'), '\App\FrontendApi\Model\Product\ProductRepository'],
         ];
     }
 
@@ -152,6 +162,7 @@ class AnnotationsReplacerTest extends TestCase
             [$reflectionMethod->getParameter('categoryFacade'), '\App\Model\Category\CategoryFacade'],
             [$reflectionMethod->getParameter('categoryFacadeOrNull'), '\App\Model\Category\CategoryFacade|null'],
             [$reflectionMethod->getParameter('array'), '\App\Model\Article\ArticleData[]'],
+            [$reflectionMethod->getParameter('frontendApiproductRepository'), '\App\FrontendApi\Model\Product\ProductRepository'],
             [$reflectionMethod->getParameter('integer'), 'int'],
         ];
     }

--- a/packages/framework/tests/Unit/Component/ClassExtension/DocBlockParserTest.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/DocBlockParserTest.php
@@ -87,6 +87,10 @@ class DocBlockParserTest extends TestCase
                 [new Array_(new Object_(new Fqsen('\Shopsys\FrameworkBundle\Model\Article\ArticleData')))],
             ],
             [
+                $reflectionClass->getMethod('returnsFrontendApiProductRepository')->getDocComment(),
+                [new Object_(new Fqsen('\Shopsys\FrontendApiBundle\Model\Product\ProductRepository'))],
+            ],
+            [
                 $reflectionClass->getMethod('returnsInt')->getDocComment(),
                 [new Integer()],
             ],

--- a/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacer.php
+++ b/packages/framework/tests/Unit/Component/ClassExtension/Source/DummyClassForAnnotationsReplacer.php
@@ -43,6 +43,13 @@ class DummyClassForAnnotationsReplacer
     }
 
     /**
+     * @return \Shopsys\FrontendApiBundle\Model\Product\ProductRepository
+     */
+    public function returnsFrontendApiProductRepository()
+    {
+    }
+
+    /**
      * @return int
      */
     public function returnsInt()
@@ -67,9 +74,15 @@ class DummyClassForAnnotationsReplacer
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade|null $categoryFacadeOrNull
      * @param \Shopsys\FrameworkBundle\Model\Article\ArticleData[] $array
+     * @param \Shopsys\FrontendApiBundle\Model\Product\ProductRepository $frontendApiproductRepository
      * @param int $integer
      */
-    public function acceptsVariousParameters($categoryFacade, $categoryFacadeOrNull, $array, $integer)
-    {
+    public function acceptsVariousParameters(
+        $categoryFacade,
+        $categoryFacadeOrNull,
+        $array,
+        $frontendApiproductRepository,
+        $integer,
+    ) {
     }
 }

--- a/project-base/app/src/Controller/Admin/MailController.php
+++ b/project-base/app/src/Controller/Admin/MailController.php
@@ -16,9 +16,10 @@ use Symfony\Component\Routing\Annotation\Route;
  * @property \App\Model\Mail\MailTemplateFacade $mailTemplateFacade
  * @property \App\Model\Mail\Grid\MailTemplateGridFactory $mailTemplateGridFactory
  * @property \App\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory
- * @method __construct(\Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade, \App\Model\Mail\MailTemplateFacade $mailTemplateFacade, \App\Model\Mail\Setting\MailSettingFacade $mailSettingFacade, \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider, \App\Model\Mail\Grid\MailTemplateGridFactory $mailTemplateGridFactory, \Shopsys\FrameworkBundle\Model\Mail\MailTemplateConfiguration $mailTemplateConfiguration, \App\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory)
+ * @method __construct(\Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade, \App\Model\Mail\MailTemplateFacade $mailTemplateFacade, \App\Model\Mail\Setting\MailSettingFacade $mailSettingFacade, \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider, \App\Model\Mail\Grid\MailTemplateGridFactory $mailTemplateGridFactory, \App\Model\Mail\MailTemplateConfiguration $mailTemplateConfiguration, \App\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory)
  * @property \App\Model\Mail\Setting\MailSettingFacade $mailSettingFacade
  * @method \App\Model\Administrator\Administrator getCurrentAdministrator()
+ * @property \App\Model\Mail\MailTemplateConfiguration $mailTemplateConfiguration
  */
 class MailController extends baseMailController
 {

--- a/project-base/app/src/Controller/Admin/ProductController.php
+++ b/project-base/app/src/Controller/Admin/ProductController.php
@@ -16,10 +16,11 @@ use Symfony\Component\Routing\Annotation\Route;
  * @property \App\Component\Setting\Setting $setting
  * @property \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
  * @method setSellingToUntilEndOfDay(\App\Model\Product\ProductData|null $productData)
- * @method __construct(\Shopsys\FrameworkBundle\Model\Product\MassAction\ProductMassActionFacade $productMassActionFacade, \Shopsys\FrameworkBundle\Component\Grid\GridFactory $gridFactory, \App\Model\Product\ProductFacade $productFacade, \App\Model\Product\ProductDataFactory $productDataFactory, \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider, \Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade $administratorGridFacade, \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListAdminFacade $productListAdminFacade, \Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchProductFacade $advancedSearchProductFacade, \Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade $productVariantFacade, \Shopsys\FrameworkBundle\Twig\ProductExtension $productExtension, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Model\Product\Unit\UnitFacade $unitFacade, \App\Component\Setting\Setting $setting)
+ * @method __construct(\Shopsys\FrameworkBundle\Model\Product\MassAction\ProductMassActionFacade $productMassActionFacade, \Shopsys\FrameworkBundle\Component\Grid\GridFactory $gridFactory, \App\Model\Product\ProductFacade $productFacade, \App\Model\Product\ProductDataFactory $productDataFactory, \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider, \Shopsys\FrameworkBundle\Model\Administrator\AdministratorGridFacade $administratorGridFacade, \Shopsys\FrameworkBundle\Model\Product\Listing\ProductListAdminFacade $productListAdminFacade, \Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchProductFacade $advancedSearchProductFacade, \Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade $productVariantFacade, \App\Twig\ProductExtension $productExtension, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Model\Product\Unit\UnitFacade $unitFacade, \App\Component\Setting\Setting $setting)
  * @property \Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade $productVariantFacade
  * @property \App\Model\Product\Unit\UnitFacade $unitFacade
  * @method \App\Model\Administrator\Administrator getCurrentAdministrator()
+ * @property \App\Twig\ProductExtension $productExtension
  */
 class ProductController extends BaseProductController
 {

--- a/project-base/app/src/Form/Constraints/UniqueEmailValidator.php
+++ b/project-base/app/src/Form/Constraints/UniqueEmailValidator.php
@@ -12,6 +12,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * @property \App\Model\Customer\User\CustomerUserFacade $customerUserFacade
+ * @method __construct(\App\Model\Customer\User\CustomerUserFacade $customerUserFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain)
  */
 class UniqueEmailValidator extends BaseUniqueEmailValidator
 {

--- a/project-base/app/src/Model/Cart/AddProductResult.php
+++ b/project-base/app/src/Model/Cart/AddProductResult.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Model\Cart\AddProductResult as BaseAddProductResult;
 /**
  * @property \App\Model\Cart\Item\CartItem $cartItem
  * @method \App\Model\Cart\Item\CartItem getCartItem()
+ * @method __construct(\App\Model\Cart\Item\CartItem $cartItem, bool $isNew, int $addedQuantity, int $notOnStockQuantity)
  */
 class AddProductResult extends BaseAddProductResult
 {

--- a/project-base/app/src/Model/Cart/CartFacade.php
+++ b/project-base/app/src/Model/Cart/CartFacade.php
@@ -18,7 +18,7 @@ use Shopsys\FrameworkBundle\Model\Cart\CartFacade as BaseCartFacade;
  * @method deleteCart(\App\Model\Cart\Cart $cart)
  * @method \App\Model\Cart\Cart|null findCartByCustomerUserIdentifier(\Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifier $customerUserIdentifier)
  * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \Shopsys\FrameworkBundle\Model\Cart\CartFactory $cartFactory, \App\Model\Product\ProductRepository $productRepository, \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserIdentifierFactory $customerUserIdentifierFactory, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser, \App\Model\Order\PromoCode\CurrentPromoCodeFacade $currentPromoCodeFacade, \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser $productPriceCalculation, \Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactoryInterface $cartItemFactory, \Shopsys\FrameworkBundle\Model\Cart\CartRepository $cartRepository, \Shopsys\FrameworkBundle\Model\Product\Availability\ProductAvailabilityFacade $productAvailabilityFacade)
- * @method \Shopsys\FrameworkBundle\Model\Cart\AddProductResult addProductToExistingCart(\App\Model\Product\Product $product, int $quantity, \App\Model\Cart\Cart $cart, bool $isAbsoluteQuantity = false)
+ * @method \App\Model\Cart\AddProductResult addProductToExistingCart(\App\Model\Product\Product $product, int $quantity, \App\Model\Cart\Cart $cart, bool $isAbsoluteQuantity = false)
  * @method \App\Model\Cart\Cart removeItemFromExistingCartByUuid(string $cartItemUuid, \App\Model\Cart\Cart $cart)
  */
 class CartFacade extends BaseCartFacade

--- a/project-base/app/src/Model/Mail/Grid/MailTemplateGridFactory.php
+++ b/project-base/app/src/Model/Mail/Grid/MailTemplateGridFactory.php
@@ -11,7 +11,8 @@ use Shopsys\FrameworkBundle\Model\Mail\Grid\MailTemplateGridFactory as BaseMailT
 
 /**
  * @property \App\Model\Mail\MailTemplateRepository $mailTemplateRepository
- * @method __construct(\App\Model\Mail\MailTemplateRepository $mailTemplateRepository, \Shopsys\FrameworkBundle\Component\Grid\GridFactory $gridFactory, \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade, \Shopsys\FrameworkBundle\Model\Mail\MailTemplateConfiguration $mailTemplateConfiguration)
+ * @method __construct(\App\Model\Mail\MailTemplateRepository $mailTemplateRepository, \Shopsys\FrameworkBundle\Component\Grid\GridFactory $gridFactory, \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade, \App\Model\Mail\MailTemplateConfiguration $mailTemplateConfiguration)
+ * @property \App\Model\Mail\MailTemplateConfiguration $mailTemplateConfiguration
  */
 class MailTemplateGridFactory extends BaseMailTemplateGridFactory
 {

--- a/project-base/app/src/Model/Order/Processing/OrderProcessorMiddleware/AddProductsMiddleware.php
+++ b/project-base/app/src/Model/Order/Processing/OrderProcessorMiddleware/AddProductsMiddleware.php
@@ -10,6 +10,10 @@ use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedItemPrice;
 use Shopsys\FrameworkBundle\Model\Order\Item\QuantifiedProduct;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\AddProductsMiddleware as BaseAddProductsMiddleware;
 
+/**
+ * @property \App\Model\Order\Item\OrderItemDataFactory $orderItemDataFactory
+ * @method __construct(\Shopsys\FrameworkBundle\Model\Product\Pricing\QuantifiedProductPriceCalculation $quantifiedProductPriceCalculation, \App\Model\Order\Item\OrderItemDataFactory $orderItemDataFactory)
+ */
 class AddProductsMiddleware extends BaseAddProductsMiddleware
 {
     /**

--- a/project-base/app/src/Twig/ProductExtension.php
+++ b/project-base/app/src/Twig/ProductExtension.php
@@ -14,6 +14,13 @@ use Twig\TwigFunction;
  * Class ProductExtension
  *
  * @property \Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade $productCachedAttributesFacade
+ * @property \App\Model\Category\CategoryFacade $categoryFacade
+ * @method string getProductDisplayName(\App\Model\Product\Product $product)
+ * @method string getProductListDisplayName(\App\Model\Product\Product $product)
+ * @method \App\Model\Category\Category getProductMainCategory(\App\Model\Product\Product $product, int $domainId)
+ * @method \App\Model\Category\Category|null findProductMainCategory(\App\Model\Product\Product $product, int $domainId)
+ * @method \Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice|null getProductSellingPrice(\App\Model\Product\Product $product)
+ * @method \Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValue[] getProductParameterValues(\App\Model\Product\Product $product)
  */
 class ProductExtension extends BaseProductExtension
 {

--- a/upgrade-notes/backend_20240529_084428.md
+++ b/upgrade-notes/backend_20240529_084428.md
@@ -1020,6 +1020,23 @@
     -   `Phing` is no longer direct dependency, but is downloaded separately via `php project-base/app/app/downloadPhing.php` command. This is done directly in `composer.json` file, so you should follow changes in project-base to update `composer.json`, `phing` and other files accordingly
 -   see #project-base-diff to update your project
 
+#### all Shopsys packages are included in ClassExtensionRegistry so annotation fixer now works for all Shopsys packages ([#3230](https://github.com/shopsys/shopsys/pull/3230))
+
+-   `Shopsys\FrameworkBundle\Command\ExtendedClassesAnnotationsCommand` class was changed:
+    -   method `replaceFrameworkWithProjectAnnotations()` renamed to `replaceShopsysWithProjectAnnotations()`
+-   `Shopsys\FrameworkBundle\Component\ClassExtension\ClassExtensionRegistry` class was changed:
+    -   `__construct()` method changed its interface:
+        ```diff
+            public function __construct(
+        -       protected readonly string $frameworkRootDir,
+        -       protected readonly array $entityExtensionMap = [],
+        +       protected readonly array $entityExtensionMap,
+        +       protected readonly array $packagesRegistry,
+            ) {
+        ```
+    -   run `php phing annotations-fix` to apply changes in your project
+-   see #project-base-diff to update your project
+
 #### move part of the parameter and filters functionality from project-base to framework and frontend-api packages ([#3221](https://github.com/shopsys/shopsys/pull/3221))
 
 -   [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the framework and frontend-api packages:

--- a/utils/releaser/src/ReleaseWorker/AbstractShopsysReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AbstractShopsysReleaseWorker.php
@@ -26,6 +26,7 @@ abstract class AbstractShopsysReleaseWorker implements StageWorkerInterface
      *      /.github/monorepo/monorepo_functions.sh
      *      /docs/introduction/monorepo.md
      *      /CHANGELOG-XX.X.md
+     *      /packages/framework/src/Resources/config/packages_registry.yaml
      *      "replace" section in monorepo's composer.json as well
      *
      * @var string[]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| We have annotation fixer, that updates annotations for project extended classes so IDE has knowledge of extensions made in project and developers do not need to update those annotations manually. This PR extends its functionality now to all Shopsys packages, instead of current limitation to framework and frontend-api bundle.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #2372
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-annotation-fixer-for-all-packages.odin.shopsys.cloud
  - https://cz.tl-annotation-fixer-for-all-packages.odin.shopsys.cloud
<!-- Replace -->
