### PR TITLE
[shopsys] easier mail template extending

### DIFF
--- a/docs/cookbook/adding-a-new-email-template.md
+++ b/docs/cookbook/adding-a-new-email-template.md
@@ -197,6 +197,21 @@ and corresponding methods can look like this
     Replacements (real values) for the variables are, most of the time, some user-entered values.<br>
     It's crucial to escape these values properly!
 
+## How to add custom variables to an existing mail template
+
+You can append them by calling parent method like this
+
+```php
+/**
+ * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+ */
+protected function createOrderStatusMailTemplateVariables(): MailTemplateVariables
+{
+    return parent::createOrderStatusMailTemplateVariables()
+        ->addVariable(OrderMail::VARIABLE_TRACKING_INSTRUCTIONS, t('Tracking instructions'), MailTemplateVariables::CONTEXT_BODY);
+}
+```
+
 ## Sending email
 
 Now, when the template is stored in the database, and we are properly replacing variables, we are ready to send this email when the user enters a new password after the reset password process.

--- a/packages/framework/src/Model/Mail/MailTemplateConfiguration.php
+++ b/packages/framework/src/Model/Mail/MailTemplateConfiguration.php
@@ -74,11 +74,14 @@ class MailTemplateConfiguration
         $this->mailTemplateVariables[$mailTemplateSlug] = $mailTemplateVariables;
     }
 
-    protected function registerOrderStatusMailTemplates(): void
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    protected function createOrderStatusMailTemplateVariables(): MailTemplateVariables
     {
-        $orderStatusMailTemplate = new MailTemplateVariables('', self::TYPE_ORDER_STATUS);
+        $mailTemplateVariables = new MailTemplateVariables('', self::TYPE_ORDER_STATUS);
 
-        $orderStatusMailTemplate
+        return $mailTemplateVariables
             ->addVariable(OrderMail::VARIABLE_NUMBER, t('Order number'))
             ->addVariable(OrderMail::VARIABLE_DATE, t('Date and time of order creation'))
             ->addVariable(OrderMail::VARIABLE_URL, t('E-shop URL address'), MailTemplateVariables::CONTEXT_BODY)
@@ -124,22 +127,30 @@ class MailTemplateConfiguration
                 t('Payment instructions'),
                 MailTemplateVariables::CONTEXT_BODY,
             );
+    }
+
+    protected function registerOrderStatusMailTemplates(): void
+    {
+        $mailTemplateVariables = $this->createOrderStatusMailTemplateVariables();
 
         $allOrderStatuses = $this->orderStatusFacade->getAll();
 
         foreach ($allOrderStatuses as $orderStatus) {
             $this->addMailTemplateVariables(
                 OrderMail::getMailTemplateNameByStatus($orderStatus),
-                $orderStatusMailTemplate->withNewName($orderStatus->getName()),
+                $mailTemplateVariables->withNewName($orderStatus->getName()),
             );
         }
     }
 
-    protected function registerStaticMailTemplates(): void
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    protected function createRegistrationConfirmationMailTemplateVariables(): MailTemplateVariables
     {
-        // registration mail template
-        $mailTemplate = new MailTemplateVariables(t('Registration confirmation'));
-        $mailTemplate
+        $mailTemplateVariables = new MailTemplateVariables(t('Registration confirmation'));
+
+        return $mailTemplateVariables
             ->addVariable(RegistrationMail::VARIABLE_FIRST_NAME, t('First name'), MailTemplateVariables::CONTEXT_BODY)
             ->addVariable(RegistrationMail::VARIABLE_LAST_NAME, t('Last name'), MailTemplateVariables::CONTEXT_BODY)
             ->addVariable(RegistrationMail::VARIABLE_EMAIL, t('Email'), MailTemplateVariables::CONTEXT_BODY)
@@ -149,11 +160,16 @@ class MailTemplateConfiguration
                 t('Link to the log in page'),
                 MailTemplateVariables::CONTEXT_BODY,
             );
-        $this->addMailTemplateVariables(MailTemplate::REGISTRATION_CONFIRM_NAME, $mailTemplate);
+    }
 
-        // reset password mail template
-        $mailTemplate = new MailTemplateVariables(t('Forgotten password sending'));
-        $mailTemplate
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    protected function createResetPasswordMailTemplateVariables(): MailTemplateVariables
+    {
+        $mailTemplateVariables = new MailTemplateVariables(t('Forgotten password sending'));
+
+        return $mailTemplateVariables
             ->addVariable(ResetPasswordMail::VARIABLE_EMAIL, t('Email'))
             ->addVariable(
                 ResetPasswordMail::VARIABLE_NEW_PASSWORD_URL,
@@ -161,11 +177,16 @@ class MailTemplateConfiguration
                 MailTemplateVariables::CONTEXT_BOTH,
                 MailTemplateVariables::REQUIRED_BODY,
             );
-        $this->addMailTemplateVariables(MailTemplate::RESET_PASSWORD_NAME, $mailTemplate);
+    }
 
-        // personal data export mail template
-        $mailTemplate = new MailTemplateVariables(t('Personal information export'));
-        $mailTemplate
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    protected function createPersonalDataExportMailTemplateVariables(): MailTemplateVariables
+    {
+        $mailTemplateVariables = new MailTemplateVariables(t('Personal information export'));
+
+        return $mailTemplateVariables
             ->addVariable(PersonalDataExportMail::VARIABLE_DOMAIN, t('E-shop name'))
             ->addVariable(PersonalDataExportMail::VARIABLE_EMAIL, t('Email'), MailTemplateVariables::CONTEXT_BODY)
             ->addVariable(
@@ -174,11 +195,16 @@ class MailTemplateConfiguration
                 MailTemplateVariables::CONTEXT_BODY,
                 MailTemplateVariables::REQUIRED_BODY,
             );
-        $this->addMailTemplateVariables(MailTemplate::PERSONAL_DATA_EXPORT_NAME, $mailTemplate);
+    }
 
-        // personal data access mail template
-        $mailTemplate = new MailTemplateVariables(t('Personal information overview'));
-        $mailTemplate
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    protected function createPersonalDataAccessMailTemplateVariables(): MailTemplateVariables
+    {
+        $mailTemplateVariables = new MailTemplateVariables(t('Personal information overview'));
+
+        return $mailTemplateVariables
             ->addVariable(PersonalDataAccessMail::VARIABLE_DOMAIN, t('E-shop name'))
             ->addVariable(PersonalDataAccessMail::VARIABLE_EMAIL, t('Email'), MailTemplateVariables::CONTEXT_BODY)
             ->addVariable(
@@ -187,6 +213,24 @@ class MailTemplateConfiguration
                 MailTemplateVariables::CONTEXT_BODY,
                 MailTemplateVariables::REQUIRED_BODY,
             );
-        $this->addMailTemplateVariables(MailTemplate::PERSONAL_DATA_ACCESS_NAME, $mailTemplate);
+    }
+
+    protected function registerStaticMailTemplates(): void
+    {
+        // registration mail template
+        $mailTemplateVariables = $this->createRegistrationConfirmationMailTemplateVariables();
+        $this->addMailTemplateVariables(MailTemplate::REGISTRATION_CONFIRM_NAME, $mailTemplateVariables);
+
+        // reset password mail template
+        $mailTemplateVariables = $this->createResetPasswordMailTemplateVariables();
+        $this->addMailTemplateVariables(MailTemplate::RESET_PASSWORD_NAME, $mailTemplateVariables);
+
+        // personal data export mail template
+        $mailTemplateVariables = $this->createPersonalDataExportMailTemplateVariables();
+        $this->addMailTemplateVariables(MailTemplate::PERSONAL_DATA_EXPORT_NAME, $mailTemplateVariables);
+
+        // personal data access mail template
+        $mailTemplateVariables = $this->createPersonalDataAccessMailTemplateVariables();
+        $this->addMailTemplateVariables(MailTemplate::PERSONAL_DATA_ACCESS_NAME, $mailTemplateVariables);
     }
 }

--- a/project-base/app/src/Model/Mail/MailTemplateConfiguration.php
+++ b/project-base/app/src/Model/Mail/MailTemplateConfiguration.php
@@ -25,10 +25,14 @@ class MailTemplateConfiguration extends BaseMailTemplateConfiguration
         $this->registerTwoFactorAuthenticationCodeMailTemplate();
     }
 
-    private function registerExtendedOrderStatusMailTemplates(): void
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    private function createExtendedOrderStatusMailTemplatesVariables(): MailTemplateVariables
     {
-        $mailTemplate = new MailTemplateVariables(t('Order status changed'));
-        $mailTemplate
+        $mailTemplateVariables = new MailTemplateVariables(t('Order status changed'));
+
+        return $mailTemplateVariables
             ->addVariable(OrderMail::VARIABLE_NUMBER, t('Order number'))
             ->addVariable(OrderMail::VARIABLE_DATE, t('Date and time of order creation'))
             ->addVariable(OrderMail::VARIABLE_URL, t('E-shop URL address'), MailTemplateVariables::CONTEXT_BODY)
@@ -42,60 +46,62 @@ class MailTemplateConfiguration extends BaseMailTemplateConfiguration
             ->addVariable(OrderMail::VARIABLE_ORDER_DETAIL_URL, t('Order detail URL address'), MailTemplateVariables::CONTEXT_BODY)
             ->addVariable(OrderMail::VARIABLE_TRANSPORT_INSTRUCTIONS, t('Shipping instructions'), MailTemplateVariables::CONTEXT_BODY)
             ->addVariable(OrderMail::VARIABLE_PAYMENT_INSTRUCTIONS, t('Payment instructions'), MailTemplateVariables::CONTEXT_BODY);
+    }
 
-        $this->addMailTemplateVariables(MailTemplate::ORDER_STATUS_NAME, $mailTemplate);
+    private function registerExtendedOrderStatusMailTemplates(): void
+    {
+        $mailTemplateVariables = $this->createExtendedOrderStatusMailTemplatesVariables();
+
+        $this->addMailTemplateVariables(MailTemplate::ORDER_STATUS_NAME, $mailTemplateVariables);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    private function createCustomerActivationMailTemplateVariables(): MailTemplateVariables
+    {
+        $mailTemplateVariables = new MailTemplateVariables(t('Customer activation'));
+
+        return $mailTemplateVariables
+            ->addVariable(CustomerActivationMail::VARIABLE_EMAIL, t('Email'))
+            ->addVariable(CustomerActivationMail::VARIABLE_ACTIVATION_URL, t('Link to complete the registration'), MailTemplateVariables::CONTEXT_BODY, MailTemplateVariables::REQUIRED_BODY);
     }
 
     private function registerCustomerActivationMailTemplate(): void
     {
-        $mailTemplate = new MailTemplateVariables(t('Customer activation'));
-        $mailTemplate
-            ->addVariable(CustomerActivationMail::VARIABLE_EMAIL, t('Email'))
-            ->addVariable(CustomerActivationMail::VARIABLE_ACTIVATION_URL, t('Link to complete the registration'), MailTemplateVariables::CONTEXT_BODY, MailTemplateVariables::REQUIRED_BODY);
-        $this->addMailTemplateVariables(CustomerActivationMail::CUSTOMER_ACTIVATION_NAME, $mailTemplate);
+        $mailTemplateVariables = $this->createCustomerActivationMailTemplateVariables();
+
+        $this->addMailTemplateVariables(CustomerActivationMail::CUSTOMER_ACTIVATION_NAME, $mailTemplateVariables);
     }
 
-    protected function registerOrderStatusMailTemplates(): void
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    protected function createOrderStatusMailTemplateVariables(): MailTemplateVariables
     {
-        $orderStatusMailTemplate = new MailTemplateVariables('', self::TYPE_ORDER_STATUS);
-
-        $orderStatusMailTemplate
-            ->addVariable(OrderMail::VARIABLE_NUMBER, t('Order number'))
-            ->addVariable(OrderMail::VARIABLE_DATE, t('Date and time of order creation'))
-            ->addVariable(OrderMail::VARIABLE_URL, t('E-shop URL address'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_TRANSPORT, t('Chosen shipping name'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_PAYMENT, t('Chosen payment name'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_TOTAL_PRICE, t('Total order price (including VAT)'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_BILLING_ADDRESS, t('Billing address - name, last name, company, company number, tax number and billing address'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_DELIVERY_ADDRESS, t('Delivery address'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_NOTE, t('Note'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_PRODUCTS, t('List of products in order (name, quantity, price per unit including VAT, total price per item including VAT)'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_ORDER_DETAIL_URL, t('Order detail URL address'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_TRANSPORT_INSTRUCTIONS, t('Shipping instructions'), MailTemplateVariables::CONTEXT_BODY)
-            ->addVariable(OrderMail::VARIABLE_PAYMENT_INSTRUCTIONS, t('Payment instructions'), MailTemplateVariables::CONTEXT_BODY)
+        return parent::createOrderStatusMailTemplateVariables()
             ->addVariable(OrderMail::VARIABLE_TRACKING_INSTRUCTIONS, t('Tracking instructions'), MailTemplateVariables::CONTEXT_BODY);
-
-        /** @var \App\Model\Order\Status\OrderStatus[] $allOrderStatuses */
-        $allOrderStatuses = $this->orderStatusFacade->getAll();
-
-        foreach ($allOrderStatuses as $orderStatus) {
-            $this->addMailTemplateVariables(
-                OrderMail::getMailTemplateNameByStatus($orderStatus),
-                $orderStatusMailTemplate->withNewName($orderStatus->getName()),
-            );
-        }
     }
 
-    private function registerTwoFactorAuthenticationCodeMailTemplate(): void
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplateVariables
+     */
+    private function createTwoFactorAuthenticationCodeMailTemplateVariables(): MailTemplateVariables
     {
-        $mailTemplate = new MailTemplateVariables(t('Two factor authentication code'));
-        $mailTemplate->addVariable(
+        $mailTemplateVariables = new MailTemplateVariables(t('Two factor authentication code'));
+
+        return $mailTemplateVariables->addVariable(
             TwoFactorAuthenticationMail::VARIABLE_AUTHENTICATION_CODE,
             t('Authentication code'),
             MailTemplateVariables::CONTEXT_BODY,
             MailTemplateVariables::REQUIRED_BODY,
         );
+    }
 
-        $this->addMailTemplateVariables(TwoFactorAuthenticationMail::TWO_FACTOR_AUTHENTICATION_CODE, $mailTemplate);
+    private function registerTwoFactorAuthenticationCodeMailTemplate(): void
+    {
+        $mailTemplateVariables = $this->createTwoFactorAuthenticationCodeMailTemplateVariables();
+
+        $this->addMailTemplateVariables(TwoFactorAuthenticationMail::TWO_FACTOR_AUTHENTICATION_CODE, $mailTemplateVariables);
     }
 }

--- a/upgrade-notes/backend_20240628_110358.md
+++ b/upgrade-notes/backend_20240628_110358.md
@@ -1,0 +1,4 @@
+#### easier mail template extending ([#3232](https://github.com/shopsys/shopsys/pull/3232))
+
+-   there is new cookbook example for how to add custom variables to an existing mail template in our docs https://docs.shopsys.com/en/latest/cookbook/adding-a-new-email-template/
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Setting variables for e-mail templates was nested inside of methods where these variables were already propagated for further processing. This resulted into inconvenient extending if something needed tobe changed so we moved variable setting into separate methods.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| closes #1847  <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-easier-mail-template-extending.odin.shopsys.cloud
  - https://cz.ab-easier-mail-template-extending.odin.shopsys.cloud
<!-- Replace -->
