### PR TITLE
[luigis-box] parameter filters are now ordered by theirs ordering priority

### DIFF
--- a/packages/luigis-box/src/Model/Product/Filter/LuigisBoxFacetsToProductFilterOptionsMapper.php
+++ b/packages/luigis-box/src/Model/Product/Filter/LuigisBoxFacetsToProductFilterOptionsMapper.php
@@ -93,6 +93,8 @@ class LuigisBoxFacetsToProductFilterOptionsMapper
             }
         }
 
+        $this->sortParameterChoicesByParameterOrderingPriority($parameterFilterChoices);
+
         $productFilterConfig = $this->productFilterConfigFactory->create($parameterFilterChoices, $flags, $brands, $priceRange);
 
         return $this->productFilterOptionsFactory->createFullProductFilterOptions(
@@ -215,5 +217,22 @@ class LuigisBoxFacetsToProductFilterOptionsMapper
         }
 
         return new ParameterFilterChoice($parameter, $parameterValues);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Filter\ParameterFilterChoice[] $parameterFilterChoices
+     */
+    protected function sortParameterChoicesByParameterOrderingPriority(array &$parameterFilterChoices): void
+    {
+        usort($parameterFilterChoices, static function (ParameterFilterChoice $a, ParameterFilterChoice $b) {
+            $parameterA = $a->getParameter();
+            $parameterB = $b->getParameter();
+
+            if ($parameterA->getOrderingPriority() === $parameterB->getOrderingPriority()) {
+                return strcmp($parameterA->getName(), $parameterB->getName());
+            }
+
+            return $parameterB->getOrderingPriority() - $parameterA->getOrderingPriority();
+        });
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, the reason for the PR| Ordering priority of parameters is now in framework package so this functionality has been introduced to the Luigi's Box as wel..
|New feature| Yes/No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-luigis-box-parameters-ordering.odin.shopsys.cloud
  - https://cz.tl-luigis-box-parameters-ordering.odin.shopsys.cloud
<!-- Replace -->
