### PR TITLE
[shopsys] remove delete button from banner slider image when editing

### DIFF
--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -113,6 +113,7 @@ class SliderItemFormType extends AbstractType
                 'entity' => $options['slider_item'],
                 'info_text' => t('You can upload following formats: PNG, JPG'),
                 'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],
+                'hide_delete_button' => $options['scenario'] === self::SCENARIO_EDIT,
             ]);
 
         $builder

--- a/packages/framework/src/Form/ImageUploadType.php
+++ b/packages/framework/src/Form/ImageUploadType.php
@@ -49,6 +49,7 @@ class ImageUploadType extends AbstractType
             'multiple' => null,
             'image_entity_class' => null,
             'extensions' => ImageProcessor::SUPPORTED_EXTENSIONS,
+            'hide_delete_button' => false,
         ]);
 
         $resolver->setNormalizer(
@@ -79,6 +80,7 @@ class ImageUploadType extends AbstractType
         $view->vars['images_by_id'] = $this->getImagesIndexedById($options);
         $view->vars['image_type'] = $options['image_type'];
         $view->vars['multiple'] = $this->isMultiple($options);
+        $view->vars['hide_delete_button'] = $options['hide_delete_button'];
     }
 
     /**

--- a/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/imageuploadFields.html.twig
@@ -22,7 +22,7 @@
                                         {{ icon('move') }}
                                     </span>
                                 {% endif %}
-                                {% if not isRemoved %}
+                                {% if not isRemoved and not hide_delete_button %}
                                     <button class="js-file-upload-delete-button btn-no-style list-files__item__remove" type="button" title="{{ 'Delete'|trans }}">
                                         {{ icon('delete') }}
                                     </button>

--- a/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/SliderItemFormTypeExtension.php
@@ -62,6 +62,7 @@ class SliderItemFormTypeExtension extends AbstractTypeExtension
                 'entity' => $options['slider_item'],
                 'info_text' => t('You can upload following formats: PNG, JPG'),
                 'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],
+                'hide_delete_button' => $options['scenario'] === SliderItemFormType::SCENARIO_EDIT,
             ]);
 
         $builderImageGroup
@@ -83,6 +84,7 @@ class SliderItemFormTypeExtension extends AbstractTypeExtension
                 'entity' => $options['slider_item'],
                 'info_text' => t('You can upload following formats: PNG, JPG'),
                 'extensions' => [ImageProcessor::EXTENSION_JPG, ImageProcessor::EXTENSION_JPEG, ImageProcessor::EXTENSION_PNG],
+                'hide_delete_button' => $options['scenario'] === SliderItemFormType::SCENARIO_EDIT,
             ]);
     }
 

--- a/upgrade-notes/backend_20240704_065627.md
+++ b/upgrade-notes/backend_20240704_065627.md
@@ -1,0 +1,4 @@
+#### remove delete button from banner slider image when editing ([#3247](https://github.com/shopsys/shopsys/pull/3247))
+
+-   scenario where banner slider image is already deleted is not fixed by these changes and to fix error state image need to be uploaded again, please check all your banner sliders
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Image is mandatory when creating new homepage slider banner, but it is not while editing. This resulted in scenario where admin could remove image and save banner. Which was fine for backend, but on frontend where image was expected this created error state. As a simple solution we removed delete button from images when editing banner slider and thus image cannot be removed, but only replaced by uploading new one.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-mandatory-banner-slider-image.odin.shopsys.cloud
  - https://cz.ab-mandatory-banner-slider-image.odin.shopsys.cloud
<!-- Replace -->
