### PR TITLE
[framework] fix calculation of transport price

### DIFF
--- a/packages/framework/src/Model/Cart/CartPriceProvider.php
+++ b/packages/framework/src/Model/Cart/CartPriceProvider.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor;
+use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\PersonalPickupPointMiddleware;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
@@ -58,6 +59,10 @@ class CartPriceProvider
     {
         $orderInput = $this->orderInputFactory->createFromCart($cart, $domainConfig);
         $orderInput->setTransport($transport);
+
+        if (!$transport->isPacketery()) {
+            $orderInput->cleanAdditionalData(PersonalPickupPointMiddleware::ADDITIONAL_DATA_PICKUP_PLACE_IDENTIFIER);
+        }
 
         $orderData = $this->orderDataFactory->create();
 

--- a/packages/framework/src/Model/Cart/Payment/CartPaymentDataFactory.php
+++ b/packages/framework/src/Model/Cart/Payment/CartPaymentDataFactory.php
@@ -7,21 +7,21 @@ namespace Shopsys\FrameworkBundle\Model\Cart\Payment;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
-use Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider;
 
 class CartPaymentDataFactory
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentFacade $paymentFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider $paymentPriceProvider
      */
     public function __construct(
         protected readonly PaymentFacade $paymentFacade,
         protected readonly Domain $domain,
-        protected readonly CartPriceProvider $cartPriceProvider,
+        protected readonly PaymentPriceProvider $paymentPriceProvider,
     ) {
     }
 
@@ -53,7 +53,7 @@ class CartPaymentDataFactory
      */
     protected function getPaymentWatchedPriceWithVat(int $domainId, Cart $cart, Payment $payment): Money
     {
-        return $this->cartPriceProvider->getPaymentPrice(
+        return $this->paymentPriceProvider->getPaymentPrice(
             $cart,
             $payment,
             $this->domain->getDomainConfigById($domainId),

--- a/packages/framework/src/Model/Cart/Transport/CartTransportDataFactory.php
+++ b/packages/framework/src/Model/Cart/Transport/CartTransportDataFactory.php
@@ -7,21 +7,21 @@ namespace Shopsys\FrameworkBundle\Model\Cart\Transport;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
-use Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
+use Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider;
 
 class CartTransportDataFactory
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Transport\TransportFacade $transportFacade
-     * @param \Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider $transportPriceProvider
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly TransportFacade $transportFacade,
-        protected readonly CartPriceProvider $cartPriceProvider,
+        protected readonly TransportPriceProvider $transportPriceProvider,
     ) {
     }
 
@@ -56,7 +56,7 @@ class CartTransportDataFactory
      */
     protected function getTransportWatchedPriceWithVat(int $domainId, Cart $cart, Transport $transport): Money
     {
-        return $this->cartPriceProvider->getTransportPrice(
+        return $this->transportPriceProvider->getTransportPrice(
             $cart,
             $transport,
             $this->domain->getDomainConfigById($domainId),

--- a/packages/framework/src/Model/Order/Processing/OrderInput.php
+++ b/packages/framework/src/Model/Order/Processing/OrderInput.php
@@ -119,6 +119,14 @@ class OrderInput
     }
 
     /**
+     * @param string $key
+     */
+    public function cleanAdditionalData(string $key): void
+    {
+        unset($this->additionalData[$key]);
+    }
+
+    /**
      * @return \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCode[]
      */
     public function getPromoCodes(): array

--- a/packages/framework/src/Model/Payment/PaymentPriceProvider.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceProvider.php
@@ -2,19 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Shopsys\FrameworkBundle\Model\Cart;
+namespace Shopsys\FrameworkBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Model\Cart\Cart;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory;
 use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor;
-use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\PersonalPickupPointMiddleware;
-use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
-use Shopsys\FrameworkBundle\Model\Transport\Transport;
 
-class CartPriceProvider
+class PaymentPriceProvider
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory $orderInputFactory
@@ -47,30 +45,5 @@ class CartPriceProvider
         );
 
         return $orderData->totalPricesByItemType[OrderItemTypeEnum::TYPE_PAYMENT];
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Cart\Cart $cart
-     * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
-     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
-     */
-    public function getTransportPrice(Cart $cart, Transport $transport, DomainConfig $domainConfig): Price
-    {
-        $orderInput = $this->orderInputFactory->createFromCart($cart, $domainConfig);
-        $orderInput->setTransport($transport);
-
-        if (!$transport->isPacketery()) {
-            $orderInput->cleanAdditionalData(PersonalPickupPointMiddleware::ADDITIONAL_DATA_PICKUP_PLACE_IDENTIFIER);
-        }
-
-        $orderData = $this->orderDataFactory->create();
-
-        $orderData = $this->orderProcessor->process(
-            $orderInput,
-            $orderData,
-        );
-
-        return $orderData->totalPricesByItemType[OrderItemTypeEnum::TYPE_TRANSPORT];
     }
 }

--- a/packages/framework/src/Model/Transport/TransportPriceProvider.php
+++ b/packages/framework/src/Model/Transport/TransportPriceProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Transport;
+
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Model\Cart\Cart;
+use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemTypeEnum;
+use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory;
+use Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory;
+use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor;
+use Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessorMiddleware\PersonalPickupPointMiddleware;
+use Shopsys\FrameworkBundle\Model\Pricing\Price;
+
+class TransportPriceProvider
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory $orderInputFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\OrderDataFactory $orderDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor $orderProcessor
+     */
+    public function __construct(
+        protected readonly OrderInputFactory $orderInputFactory,
+        protected readonly OrderDataFactory $orderDataFactory,
+        protected readonly OrderProcessor $orderProcessor,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Cart\Cart $cart
+     * @param \Shopsys\FrameworkBundle\Model\Transport\Transport $transport
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price
+     */
+    public function getTransportPrice(Cart $cart, Transport $transport, DomainConfig $domainConfig): Price
+    {
+        $orderInput = $this->orderInputFactory->createFromCart($cart, $domainConfig);
+        $orderInput->setTransport($transport);
+
+        if (!$transport->isPacketery()) {
+            $orderInput->cleanAdditionalData(PersonalPickupPointMiddleware::ADDITIONAL_DATA_PICKUP_PLACE_IDENTIFIER);
+        }
+
+        $orderData = $this->orderDataFactory->create();
+
+        $orderData = $this->orderProcessor->process(
+            $orderInput,
+            $orderData,
+        );
+
+        return $orderData->totalPricesByItemType[OrderItemTypeEnum::TYPE_TRANSPORT];
+    }
+}

--- a/packages/frontend-api/src/Model/Payment/PaymentValidationFacade.php
+++ b/packages/frontend-api/src/Model/Payment/PaymentValidationFacade.php
@@ -6,9 +6,9 @@ namespace Shopsys\FrontendApiBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
-use Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
 use Shopsys\FrontendApiBundle\Model\Payment\Exception\InvalidPaymentTransportCombinationException;
 use Shopsys\FrontendApiBundle\Model\Payment\Exception\PaymentPriceChangedException;
@@ -19,13 +19,13 @@ class PaymentValidationFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade
-     * @param \Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider $paymentPriceProvider
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly CurrentCustomerUser $currentCustomerUser,
         protected readonly CartApiFacade $cartApiFacade,
-        protected readonly CartPriceProvider $cartPriceProvider,
+        protected readonly PaymentPriceProvider $paymentPriceProvider,
     ) {
     }
 
@@ -35,7 +35,7 @@ class PaymentValidationFacade
      */
     public function checkPaymentPrice(Payment $payment, Cart $cart): void
     {
-        $calculatedPaymentPrice = $this->cartPriceProvider->getPaymentPrice(
+        $calculatedPaymentPrice = $this->paymentPriceProvider->getPaymentPrice(
             $cart,
             $payment,
             $this->domain->getCurrentDomainConfig(),

--- a/packages/frontend-api/src/Model/Resolver/Price/PriceQuery.php
+++ b/packages/frontend-api/src/Model/Resolver/Price/PriceQuery.php
@@ -6,10 +6,10 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Price;
 
 use ArrayObject;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation;
+use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPrice;
@@ -17,6 +17,7 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 use Shopsys\FrameworkBundle\Model\Product\ProductCachedAttributesFacade;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
 use Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation;
+use Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider;
 use Shopsys\FrontendApiBundle\Component\GqlContext\GqlContextHelper;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
 use Shopsys\FrontendApiBundle\Model\Order\OrderApiFacade;
@@ -36,7 +37,8 @@ class PriceQuery extends AbstractQuery
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade
      * @param \Shopsys\FrontendApiBundle\Model\Order\OrderApiFacade $orderApiFacade
-     * @param \Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider $transportPriceProvider
+     * @param \Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider $paymentPriceProvider
      */
     public function __construct(
         protected readonly ProductCachedAttributesFacade $productCachedAttributesFacade,
@@ -48,7 +50,8 @@ class PriceQuery extends AbstractQuery
         protected readonly CurrentCustomerUser $currentCustomerUser,
         protected readonly CartApiFacade $cartApiFacade,
         protected readonly OrderApiFacade $orderApiFacade,
-        protected readonly CartPriceProvider $cartPriceProvider,
+        protected readonly TransportPriceProvider $transportPriceProvider,
+        protected readonly PaymentPriceProvider $paymentPriceProvider,
     ) {
     }
 
@@ -108,7 +111,7 @@ class PriceQuery extends AbstractQuery
             return $this->calculateIndependentPaymentPrice($payment);
         }
 
-        return $this->cartPriceProvider->getPaymentPrice($cart, $payment, $this->domain->getCurrentDomainConfig());
+        return $this->paymentPriceProvider->getPaymentPrice($cart, $payment, $this->domain->getCurrentDomainConfig());
     }
 
     /**
@@ -149,7 +152,7 @@ class PriceQuery extends AbstractQuery
             return $this->calculateIndependentTransportPrice($transport);
         }
 
-        return $this->cartPriceProvider->getTransportPrice($cart, $transport, $this->domain->getCurrentDomainConfig());
+        return $this->transportPriceProvider->getTransportPrice($cart, $transport, $this->domain->getCurrentDomainConfig());
     }
 
     /**

--- a/packages/frontend-api/src/Model/Transport/TransportValidationFacade.php
+++ b/packages/frontend-api/src/Model/Transport/TransportValidationFacade.php
@@ -6,10 +6,10 @@ namespace Shopsys\FrontendApiBundle\Model\Transport;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Cart\Cart;
-use Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider;
 use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
 use Shopsys\FrameworkBundle\Model\Store\StoreFacade;
 use Shopsys\FrameworkBundle\Model\Transport\Transport;
+use Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider;
 use Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade;
 use Shopsys\FrontendApiBundle\Model\Transport\Exception\InvalidTransportPaymentCombinationException;
 use Shopsys\FrontendApiBundle\Model\Transport\Exception\MissingPickupPlaceIdentifierException;
@@ -23,14 +23,14 @@ class TransportValidationFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
      * @param \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade
-     * @param \Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider
+     * @param \Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider $transportPriceProvider
      */
     public function __construct(
         protected readonly StoreFacade $storeFacade,
         protected readonly Domain $domain,
         protected readonly CurrentCustomerUser $currentCustomerUser,
         protected readonly CartApiFacade $cartApiFacade,
-        protected readonly CartPriceProvider $cartPriceProvider,
+        protected readonly TransportPriceProvider $transportPriceProvider,
     ) {
     }
 
@@ -67,7 +67,7 @@ class TransportValidationFacade
      */
     public function checkTransportPrice(Transport $transport, Cart $cart): void
     {
-        $calculatedTransportPrice = $this->cartPriceProvider->getTransportPrice(
+        $calculatedTransportPrice = $this->transportPriceProvider->getTransportPrice(
             $cart,
             $transport,
             $this->domain->getCurrentDomainConfig(),

--- a/upgrade-order-processing.md
+++ b/upgrade-order-processing.md
@@ -236,7 +236,7 @@ For more information about the order processing system, you may see the [Order P
 -    protected readonly Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade,
 -    protected readonly Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory,
 -    protected readonly Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation $paymentPriceCalculation,
-+    protected readonly Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider,
++    protected readonly Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider $paymentPriceProvider,
  )
 ```
 
@@ -250,7 +250,7 @@ For more information about the order processing system, you may see the [Order P
 -    protected readonly Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade,
 -    protected readonly Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory,
 -    protected readonly Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation $transportPriceCalculation,
-+    protected readonly Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider,
++    protected readonly Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider $transportPriceProvider,
  )
 ```
 
@@ -289,7 +289,7 @@ For more information about the order processing system, you may see the [Order P
 -    protected readonly Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory,
      protected readonly Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser,
      protected readonly Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade,
-+    protected readonly Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider,
++    protected readonly Shopsys\FrameworkBundle\Model\Payment\PaymentPriceProvider $paymentPriceProvider,
  )
 ```
 
@@ -303,7 +303,7 @@ For more information about the order processing system, you may see the [Order P
 -    protected readonly Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory $orderPreviewFactory,
      protected readonly Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser,
      protected readonly Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade,
-+    protected readonly Shopsys\FrameworkBundle\Model\Cart\CartPriceProvider $cartPriceProvider,
++    protected readonly Shopsys\FrameworkBundle\Model\Transport\TransportPriceProvider $transportPriceProvider,
  )
 ```
 
@@ -348,7 +348,8 @@ For more information about the order processing system, you may see the [Order P
     -    protected readonly OrderPreviewFactory $orderPreviewFactory,
          protected readonly CartApiFacade $cartApiFacade,
          protected readonly OrderApiFacade $orderApiFacade,
-    +    protected readonly CartPriceProvider $cartPriceProvider,
+    +    protected readonly TransportPriceProvider $transportPriceProvider,
+    +    protected readonly PaymentPriceProvider $paymentPriceProvider,
      )
     ```
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When there was already selected Packeta transport in the cart, the price calculation failed for another transport type (personal pickup at a store) because of mistaking the selected Packeta pickup place ID for the personal pickup store UUID. Moreover, slight refactoring was performed  - `CartPriceProvider` was split into `TransportPriceProvider` and `PaymentPriceProvider` - the original naming was confusing as the logic is used to get prices of transport/payments which are not need to be necessarily set in cart
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-transport-price-query.odin.shopsys.cloud
  - https://cz.rv-fix-transport-price-query.odin.shopsys.cloud
<!-- Replace -->
