### PR TITLE
[project-base] fix build on split package

### DIFF
--- a/project-base/.github/workflows/run-checks-tests.yaml
+++ b/project-base/.github/workflows/run-checks-tests.yaml
@@ -23,8 +23,6 @@ jobs:
                 run: docker-compose exec -T php-fpm php phing db-create test-db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate
             -   name: Check standards
                 run: docker-compose exec -T php-fpm php phing standards
-            -   name: Run PHPStan level 5
-                run: php ./app/vendor/bin/phpstan analyze -c ./app/phpstan.neon ./app/src --level=5
             -   name: Run tests
                 run: docker-compose exec -T php-fpm php phing tests
             -   name: Run acceptance tests
@@ -120,8 +118,6 @@ jobs:
                 run: docker-compose exec -T php-fpm php phing db-create test-db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate
             -   name: Check standards
                 run: docker-compose exec -T php-fpm php phing standards
-            -   name: Run PHPStan level 5
-                run: php ./app/vendor/bin/phpstan analyze -c ./app/phpstan.neon ./app/src --level=5
             -   name: Run tests
                 run: docker-compose exec -T php-fpm php phing tests
             -   name: Run acceptance tests

--- a/project-base/app/tests/App/Performance/Page/AllPagesTest.php
+++ b/project-base/app/tests/App/Performance/Page/AllPagesTest.php
@@ -6,6 +6,7 @@ namespace Tests\App\Performance\Page;
 
 use Doctrine\DBAL\Logging\LoggerChain;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Environment\EnvironmentType;
 use Shopsys\HttpSmokeTesting\RequestDataSet;
@@ -37,9 +38,7 @@ class AllPagesTest extends KernelTestCase
             ->switchDomainById(Domain::FIRST_DOMAIN_ID);
     }
 
-    /**
-     * @group warmup
-     */
+    #[Group('warmup')]
     public function testAdminPagesWarmup()
     {
         $this->doWarmupPagesWithProgress(
@@ -47,9 +46,7 @@ class AllPagesTest extends KernelTestCase
         );
     }
 
-    /**
-     * @group warmup
-     */
+    #[Group('warmup')]
     public function testFrontPagesWarmup()
     {
         $this->doWarmupPagesWithProgress(

--- a/project-base/app/tests/FrontendApiBundle/Functional/Hreflang/HreflangLinksTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Hreflang/HreflangLinksTest.php
@@ -12,6 +12,7 @@ use App\DataFixtures\Demo\FlagDataFixture;
 use App\DataFixtures\Demo\ProductDataFixture;
 use App\DataFixtures\Demo\SeoPageDataFixture;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Tests\FrontendApiBundle\Test\GraphQlTestCase;
 
@@ -139,13 +140,13 @@ class HreflangLinksTest extends GraphQlTestCase
     }
 
     /**
-     * @group multidomain
      * @param string $entityReference
      * @param string $routeName
      * @param string $graphQlFileName
      * @param string $graphQlType
      */
     #[DataProvider('getHreflangEntitiesDataProvider')]
+    #[Group('multidomain')]
     public function testAlternateDomainLanguages(
         string $entityReference,
         string $routeName,

--- a/project-base/app/tests/FrontendApiBundle/Functional/Payment/OrderPaymentsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Payment/OrderPaymentsTest.php
@@ -9,6 +9,7 @@ use App\DataFixtures\Demo\PaymentDataFixture;
 use App\Model\Order\Order;
 use App\Model\Payment\Payment;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
@@ -43,12 +44,12 @@ class OrderPaymentsTest extends GraphQlTestCase
     }
 
     /**
-     * @group multidomain
      * @param string $orderReferenceName
      * @param string $expectedCurrentPaymentReferenceName
      * @param array $expectedAvailablePaymentReferenceNames
      */
     #[DataProvider('getOrderPaymentsMultidomainDataProvider')]
+    #[Group('multidomain')]
     public function testGetOrderPaymentsMultidomain(
         string $orderReferenceName,
         string $expectedCurrentPaymentReferenceName,
@@ -58,12 +59,12 @@ class OrderPaymentsTest extends GraphQlTestCase
     }
 
     /**
-     * @group singledomain
      * @param string $orderReferenceName
      * @param string $expectedCurrentPaymentReferenceName
      * @param array $expectedAvailablePaymentReferenceNames
      */
     #[DataProvider('getOrderPaymentsSingledomainDataProvider')]
+    #[Group('singledomain')]
     public function testGetOrderPaymentsSingledomain(
         string $orderReferenceName,
         string $expectedCurrentPaymentReferenceName,

--- a/upgrade-notes/backend_20240710_121329.md
+++ b/upgrade-notes/backend_20240710_121329.md
@@ -1,0 +1,3 @@
+#### fix singledomain/multidomain tests ([#3256](https://github.com/shopsys/shopsys/pull/3256))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| The split project-base package build was failing because of an unmatching PHP version. However, the job was unnecessary because PHPStan is checked within "standards" job. It was also necessary to fix tests that started to fail with singledomain configuration after PHPUnit was upgraded in https://github.com/shopsys/shopsys/pull/3213
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-stan.odin.shopsys.cloud
  - https://cz.rv-fix-stan.odin.shopsys.cloud
<!-- Replace -->
