### PR TITLE
[project-base][SSP-2259] added wheel click condition for safari navigation loading

### DIFF
--- a/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
+++ b/project-base/storefront/components/Basic/ExtendedNextLink/ExtendedNextLink.tsx
@@ -31,7 +31,8 @@ export const ExtendedNextLink: FC<ExtendedNextLinkProps> = ({
     const isDynamic = type && FriendlyPagesTypesKeys.includes(type as any);
 
     const handleOnClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
-        const isWithoutOpeningInNewTab = !e.ctrlKey && !e.metaKey;
+        const mouseWheelClick = e.button === 1;
+        const isWithoutOpeningInNewTab = !e.ctrlKey && !e.metaKey && !mouseWheelClick;
 
         if (isWithoutOpeningInNewTab) {
             onClick?.(e);

--- a/upgrade-notes/storefront_20240710_101718.md
+++ b/upgrade-notes/storefront_20240710_101718.md
@@ -1,0 +1,3 @@
+#### Safari wheel click freez ([#3260](https://github.com/shopsys/shopsys/pull/3260))
+
+-   safari needs a wheel click condition for opening links in a new tab without a loading skeleton in the current tab


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Safari needs a wheel click condition for opening links in a new tab without a loading skeleton in the current tab.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2259-safari-navigation-loading.odin.shopsys.cloud
  - https://cz.tc-ssp-2259-safari-navigation-loading.odin.shopsys.cloud
<!-- Replace -->
