### PR TITLE
[framework] replaced unsupported currency SLL with new SLE

### DIFF
--- a/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
+++ b/packages/framework/src/Model/Localization/IntlCurrencyRepository.php
@@ -137,7 +137,7 @@ class IntlCurrencyRepository extends BaseCurrencyRepository
         'SEK',
         'SGD',
         'SHP',
-        'SLL',
+        'SLE',
         'SOS',
         'SRD',
         'SSP',


### PR DESCRIPTION

| Q             | A
| ------------- | ---
|Description, reason for the PR| Leone is a currency of Sierra Leone, First Leone (SLL) is replaced with the Second Leone (SLE) The new leone was introduced in July 2022. Old leones were legal tender until 31 December 2023 and redeemable for current legal tender in commercial banks until 31 March 2024.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| Possibly, if you're using SLL currency. <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-sll-currency.odin.shopsys.cloud
  - https://cz.mg-sll-currency.odin.shopsys.cloud
<!-- Replace -->
