### PR TITLE
[project-base][SSP-2475] updated product detail open gallery image size

### DIFF
--- a/project-base/storefront/components/Basic/ModalGallery/ModalGallery.tsx
+++ b/project-base/storefront/components/Basic/ModalGallery/ModalGallery.tsx
@@ -66,7 +66,7 @@ export const ModalGallery: FC<ModalGalleryProps> = ({ initialIndex, items, galle
     });
 
     return (
-        <div className="fixed inset-0 z-aboveOverlay flex select-none flex-col bg-dark p-2" onClick={onCloseModal}>
+        <div className="fixed inset-0 flex select-none flex-col bg-dark p-2 z-maximum" onClick={onCloseModal}>
             <div className="flex w-full flex-1 flex-col justify-center">
                 <div className="relative my-auto flex max-h-[80dvh] flex-1 items-center justify-center" {...handlers}>
                     <SpinnerIcon className="absolute -z-above w-16 text-white opacity-50" />
@@ -74,13 +74,12 @@ export const ModalGallery: FC<ModalGalleryProps> = ({ initialIndex, items, galle
                     {isImage && (
                         <Image
                             key={selectedIndex}
+                            fill
                             alt={selectedGalleryItem.name || `${galleryName}-${selectedIndex}`}
                             className="max-h-full object-contain"
                             draggable={false}
-                            height={1200}
                             sizes="(max-width: 768px) 100vw, 1200px"
                             src={selectedGalleryItem.url}
-                            width={1200}
                             onLoad={() => setIsLoaded(true)}
                         />
                     )}

--- a/upgrade-notes/storefront_20240715_120117.md
+++ b/upgrade-notes/storefront_20240715_120117.md
@@ -1,0 +1,3 @@
+#### image gallery visibility ([#3266](https://github.com/shopsys/shopsys/pull/3266))
+
+-   updated responsive design for image gallery on product detail page


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Open image gallery on the product detail is responsive now.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2475-adjust-product-detail-gallery-image.odin.shopsys.cloud
  - https://cz.tc-ssp-2475-adjust-product-detail-gallery-image.odin.shopsys.cloud
<!-- Replace -->
