### PR TITLE
Generate empty migration file

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -415,6 +415,14 @@
     <target name="db-performance" depends="production-protection,db-wipe-public-schema,clean,clean-redis,db-import-basic-structure,db-migrations,domains-data-create,db-fixtures-demo,plugin-demo-data-load,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,db-fixtures-performance" description="Drops all data in main database and creates a new one with performance data."/>
 
     <target name="db-rebuild" depends="production-protection,db-wipe-public-schema,db-import-basic-structure,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace" description="Drops all data in database and creates a new one with base data only."/>
+    <target name="db-migrations-generate-empty" description="Generates new empty migration file.">
+        <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:migrations:generate"/>
+            <arg value="--empty"/>
+            <arg value="--verbose"/>
+        </exec>
+    </target>
 
     <target name="db-wipe-public-schema" depends="production-protection" description="Drops and creates public database schema." hidden="true">
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">

--- a/packages/migrations/src/Command/GenerateMigrationCommand.php
+++ b/packages/migrations/src/Command/GenerateMigrationCommand.php
@@ -44,6 +44,13 @@ class GenerateMigrationCommand extends Command
         parent::__construct();
     }
 
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Generate a new migration if need it')
+            ->addOption('empty', null, null, 'Generate an empty migration');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -53,7 +60,7 @@ class GenerateMigrationCommand extends Command
 
         $filteredSchemaDiffSqlCommands = $this->databaseSchemaFacade->getFilteredSchemaDiffSqlCommands();
 
-        if (count($filteredSchemaDiffSqlCommands) === 0) {
+        if (count($filteredSchemaDiffSqlCommands) === 0 && $input->getOption('empty') === false) {
             $output->writeln('<info>Database schema is satisfying ORM, no migrations were generated.</info>');
 
             return static::RETURN_CODE_OK;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| As a programmer, I have the option to create a new migration that will be empty. We often use this when I want to create a migration, for example, to modify data.


|New feature| Yes
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes
