### PR TITLE
[luigis-box] added additional information to LuigisBoxClient failed requests

### DIFF
--- a/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
+++ b/packages/luigis-box/src/Component/LuigisBox/LuigisBoxClient.php
@@ -102,6 +102,8 @@ class LuigisBoxClient
                 [
                     'exception' => $e,
                     'luigisBoxBatchLoadData' => $luigisBoxBatchLoadData,
+                    'options' => $options,
+                    'response' => isset($response) ? $response->toArray(false) : null,
                 ],
             );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| There were some mandatory information missing in logs.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-luigis-box-additional-fail-data.odin.shopsys.cloud
  - https://cz.tl-luigis-box-additional-fail-data.odin.shopsys.cloud
<!-- Replace -->
