### PR TITLE
[framework] domains in admin now have colors up to 40 domains

### DIFF
--- a/packages/framework/assets/styles/admin/components/in/image.less
+++ b/packages/framework/assets/styles/admin/components/in/image.less
@@ -84,5 +84,98 @@
         &--9 {
             background-color: #c38f57;
         }
+        &--10 {
+            background-color: #190b3d;
+        }
+        &--11 {
+            background-color: #1f352b;
+        }
+        &--12 {
+            background-color: #59111d;
+        }
+        &--13 {
+            background-color: #398c70;
+        }
+        &--14 {
+            background-color: #a58851;
+        }
+        &--15 {
+            background-color: #717769;
+        }
+        &--16 {
+            background-color: #d4bae0;
+        }
+        &--17 {
+            background-color: #627a39;
+        }
+        &--18 {
+            background-color: #739e99;
+        }
+        &--19 {
+            background-color: #a50876;
+        }
+        &--20 {
+            background-color: #93854e;
+        }
+        &--21 {
+            background-color: #6e0bc4;
+        }
+        &--22 {
+            background-color: #59697c;
+        }
+        &--23 {
+            background-color: #859616;
+        }
+        &--24 {
+            background-color: #0c3b7a;
+        }
+        &--25 {
+            background-color: #443e47;
+        }
+        &--26 {
+            background-color: #23594a;
+        }
+        &--27 {
+            background-color: #a9c5f2;
+        }
+        &--28 {
+            background-color: #a56403;
+        }
+        &--29 {
+            background-color: #1939b7;
+        }
+        &--30 {
+            background-color: #a0715e;
+        }
+        &--31 {
+            background-color: #b70c65;
+        }
+        &--32 {
+            background-color: #233f2c;
+        }
+        &--33 {
+            background-color: #110308;
+        }
+        &--34 {
+            background-color: #7f2d07;
+        }
+        &--35 {
+            background-color: #b3e53d;
+        }
+        &--36 {
+            background-color: #fc5dd7;
+        }
+        &--37 {
+            background-color: #a38d35;
+        }
+        &--38 {
+            background-color: #230823;
+        }
+        &--39 {
+            background-color: #9abff4;
+        }
+        &--40 {
+            background-color: #c0392b;
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| This PR enhances the admin panel by extending the color-coding support for domains from 10 to 40. This change allows for better visual differentiation and management of more domains within the admin interface. 
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-domain-colors.odin.shopsys.cloud
  - https://cz.mg-domain-colors.odin.shopsys.cloud
<!-- Replace -->
