### PR TITLE
[framework] multidomain migration trait now returns only unique locales

### DIFF
--- a/packages/framework/src/Migrations/MultidomainMigrationTrait.php
+++ b/packages/framework/src/Migrations/MultidomainMigrationTrait.php
@@ -62,7 +62,7 @@ trait MultidomainMigrationTrait
             $domainLocales[] = $domainConfig->getLocale();
         }
 
-        return $domainLocales;
+        return array_unique($domainLocales);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If multiple domains have the same locale, the multidomain migration trait should return the array of unique locales. Otherwise, errors with a unique index violation may occur during running database migrations.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-multidomain-trait.odin.shopsys.cloud
  - https://cz.mg-multidomain-trait.odin.shopsys.cloud
<!-- Replace -->
