### PR TITLE
[project-base] closed day data fixture now works for domains without store

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/ClosedDayDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ClosedDayDataFixture.php
@@ -38,12 +38,16 @@ class ClosedDayDataFixture extends AbstractReferenceFixture implements Dependent
     {
         foreach ($this->domain->getAll() as $domainConfig) {
             $domainId = $domainConfig->getId();
-            $store = $this->storeFacade->getStoresByDomainId($domainId)[0];
+            $stores = $this->storeFacade->getStoresByDomainId($domainId);
+
+            if (!array_key_exists(0, $stores)) {
+                continue;
+            }
 
             foreach ($this->getClosedDays($domainConfig) as [$date, $name]) {
                 $closedDayData = $this->closedDayDataFactory->create();
                 $closedDayData->domainId = $domainId;
-                $closedDayData->excludedStores = [$store];
+                $closedDayData->excludedStores = [$stores[0]];
                 $closedDayData->date = $date;
                 $closedDayData->name = $name;
                 $this->closedDayFacade->create($closedDayData);

--- a/upgrade-notes/backend_20240724_143006.md
+++ b/upgrade-notes/backend_20240724_143006.md
@@ -1,0 +1,3 @@
+#### fix closed day data fixture for domains without any store created ([#3283](https://github.com/shopsys/shopsys/pull/3283))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| If some domain do not have stores in data fixtures, closed day datafixture now silently skip creating such related closed days instead of fail on error.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-closed-day-datafixture-fix.odin.shopsys.cloud
  - https://cz.mg-closed-day-datafixture-fix.odin.shopsys.cloud
<!-- Replace -->
