### PR TITLE
[project-base] fixed datafixtures for more than two domains

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/OrderDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/OrderDataFixture.php
@@ -790,7 +790,7 @@ class OrderDataFixture extends AbstractReferenceFixture implements DependentFixt
         string $paymentReferenceName,
         ?CustomerUser $customerUser = null,
     ): Order {
-        $uniqueOrderHash = '';
+        $uniqueOrderHash = $orderData->domainId . '-';
 
         $transport = $this->getReference($transportReferenceName, Transport::class);
         $payment = $this->getReference($paymentReferenceName, Payment::class);

--- a/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/ProductDataFixture.php
@@ -21,7 +21,7 @@ use Shopsys\FrameworkBundle\Component\Translation\Translator;
 
 class ProductDataFixture extends AbstractReferenceFixture implements DependentFixtureInterface
 {
-    public const PRODUCT_PREFIX = 'product_';
+    public const string PRODUCT_PREFIX = 'product_';
     private const string UUID_NAMESPACE = '5d92301d-1583-4505-842a-27fe6854f587';
 
     private int $productNo = 1;

--- a/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Order/GetOrderAsAuthenticatedCustomerUserTest.php
@@ -66,7 +66,7 @@ class GetOrderAsAuthenticatedCustomerUserTest extends GraphQlWithLoginTestCase
     public function testGetOrderByUuidReturnsError(): void
     {
         $order = $this->getOrderOfNotCurrentlyLoggedCustomerUser();
-        $expectedErrorMessage = "Order with UUID '84f95773-6d06-59d9-8680-fb35abfe99ac' not found.";
+        $expectedErrorMessage = "Order with UUID '0947eaa8-ec4f-5773-9965-e6dc480d8ebc' not found.";
 
         $response = $this->getResponseContentForGql(__DIR__ . '/graphql/GetOrderQuery.graphql', [
             'uuid' => $order->getUuid(),

--- a/upgrade-notes/backend_20240724_150311.md
+++ b/upgrade-notes/backend_20240724_150311.md
@@ -1,0 +1,3 @@
+#### fix data fixtures for more than two domains ([#3284](https://github.com/shopsys/shopsys/pull/3284))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| When more than two domains are used, some data fixtures may fail on unique index violations. This PR fixes that.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-datafixtures-more-domains.odin.shopsys.cloud
  - https://cz.mg-fix-datafixtures-more-domains.odin.shopsys.cloud
<!-- Replace -->
