### PR TITLE
[framework] address, name and some other user data is now nullable

### DIFF
--- a/packages/framework/src/Migrations/Version20240724062626.php
+++ b/packages/framework/src/Migrations/Version20240724062626.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20240724062626 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE delivery_addresses ALTER country_id DROP NOT NULL');
+        $this->sql('ALTER TABLE delivery_addresses ALTER street DROP NOT NULL');
+        $this->sql('ALTER TABLE delivery_addresses ALTER city DROP NOT NULL');
+        $this->sql('ALTER TABLE delivery_addresses ALTER postcode DROP NOT NULL');
+        $this->sql('ALTER TABLE delivery_addresses ALTER first_name DROP NOT NULL');
+        $this->sql('ALTER TABLE delivery_addresses ALTER last_name DROP NOT NULL');
+        $this->sql('ALTER TABLE customer_users ALTER first_name DROP NOT NULL');
+        $this->sql('ALTER TABLE customer_users ALTER last_name DROP NOT NULL');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20240729072354.php
+++ b/packages/framework/src/Migrations/Version20240729072354.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20240729072354 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('UPDATE delivery_addresses SET street = NULL WHERE street = \'\'');
+        $this->sql('UPDATE delivery_addresses SET city = NULL WHERE city = \'\'');
+        $this->sql('UPDATE delivery_addresses SET postcode = NULL WHERE postcode = \'\'');
+        $this->sql('UPDATE delivery_addresses SET first_name = NULL WHERE first_name = \'\'');
+        $this->sql('UPDATE delivery_addresses SET last_name = NULL WHERE last_name = \'\'');
+        $this->sql('UPDATE customer_users SET first_name = NULL WHERE first_name = \'\'');
+        $this->sql('UPDATE customer_users SET last_name = NULL WHERE last_name = \'\'');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Migrations/Version20240730070101.php
+++ b/packages/framework/src/Migrations/Version20240730070101.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20240730070101 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE billing_addresses ALTER country_id DROP NOT NULL');
+        $this->sql('ALTER TABLE billing_addresses ALTER street DROP NOT NULL');
+        $this->sql('ALTER TABLE billing_addresses ALTER city DROP NOT NULL');
+        $this->sql('ALTER TABLE billing_addresses ALTER postcode DROP NOT NULL');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Customer/BillingAddress.php
+++ b/packages/framework/src/Model/Customer/BillingAddress.php
@@ -53,26 +53,26 @@ class BillingAddress
 
     /**
      * @var string|null
-     * @ORM\Column(type="string", length=100, nullable=false)
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $street;
 
     /**
      * @var string|null
-     * @ORM\Column(type="string", length=100, nullable=false)
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $city;
 
     /**
      * @var string|null
-     * @ORM\Column(type="string", length=30, nullable=false)
+     * @ORM\Column(type="string", length=30, nullable=true)
      */
     protected $postcode;
 
     /**
      * @var \Shopsys\FrameworkBundle\Model\Country\Country|null
      * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Country\Country")
-     * @ORM\JoinColumn(name="country_id", referencedColumnName="id", nullable=false)
+     * @ORM\JoinColumn(name="country_id", referencedColumnName="id", nullable=true)
      */
     protected $country;
 

--- a/packages/framework/src/Model/Customer/DeliveryAddress.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddress.php
@@ -35,32 +35,32 @@ class DeliveryAddress
     protected $companyName;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=100)
+     * @var string|null
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $firstName;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=100)
+     * @var string|null
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $lastName;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=100)
+     * @var string|null
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $street;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=100)
+     * @var string|null
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $city;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=30)
+     * @var string|null
+     * @ORM\Column(type="string", length=30, nullable=true)
      */
     protected $postcode;
 
@@ -71,9 +71,9 @@ class DeliveryAddress
     protected $telephone;
 
     /**
-     * @var \Shopsys\FrameworkBundle\Model\Country\Country
+     * @var \Shopsys\FrameworkBundle\Model\Country\Country|null
      * @ORM\ManyToOne(targetEntity="Shopsys\FrameworkBundle\Model\Country\Country")
-     * @ORM\JoinColumn(name="country_id", referencedColumnName="id", nullable=false)
+     * @ORM\JoinColumn(name="country_id", referencedColumnName="id", nullable=true)
      */
     protected $country;
 
@@ -133,7 +133,7 @@ class DeliveryAddress
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFirstName()
     {
@@ -141,7 +141,7 @@ class DeliveryAddress
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastName()
     {
@@ -149,7 +149,7 @@ class DeliveryAddress
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getStreet()
     {
@@ -157,7 +157,7 @@ class DeliveryAddress
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCity()
     {
@@ -165,7 +165,7 @@ class DeliveryAddress
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPostcode()
     {
@@ -181,7 +181,7 @@ class DeliveryAddress
     }
 
     /**
-     * @return \Shopsys\FrameworkBundle\Model\Country\Country
+     * @return \Shopsys\FrameworkBundle\Model\Country\Country|null
      */
     public function getCountry()
     {

--- a/packages/framework/src/Model/Customer/User/CustomerUser.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUser.php
@@ -43,14 +43,14 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     protected $customer;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=100)
+     * @var string|null
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $firstName;
 
     /**
-     * @var string
-     * @ORM\Column(type="string", length=100)
+     * @var string|null
+     * @ORM\Column(type="string", length=100, nullable=true)
      */
     protected $lastName;
 
@@ -214,7 +214,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFirstName()
     {
@@ -267,7 +267,7 @@ class CustomerUser implements UserInterface, TimelimitLoginInterface, PasswordAu
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastName()
     {

--- a/packages/framework/src/Model/Customer/User/CustomerUserUpdateDataFactory.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserUpdateDataFactory.php
@@ -106,6 +106,10 @@ class CustomerUserUpdateDataFactory implements CustomerUserUpdateDataFactoryInte
             $customerUser->getLastName(),
             $order->getLastName(),
         );
+        $customerUserUpdateData->customerUserData->telephone = Utils::ifNull(
+            $customerUser->getTelephone(),
+            $order->getTelephone(),
+        );
         $customerUserUpdateData->billingAddressData = $this->getAmendedBillingAddressDataByOrder(
             $order,
             $billingAddress,

--- a/packages/framework/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php
+++ b/packages/framework/tests/Unit/Model/Customer/CustomerUserUpdateDataFactoryTest.php
@@ -114,6 +114,64 @@ class CustomerUserUpdateDataFactoryTest extends TestCase
         $this->assertSame($order->getCountry(), $customerUserUpdateData->deliveryAddressData->country);
     }
 
+    public function testGetAmendedCustomerUserUpdateDataByOrderForSocialNetworkLogin()
+    {
+        $customerUserUpdateUpdateDataFactory = $this->getCustomerUserUpdateDataFactory();
+
+        $deliveryCountryData = new CountryData();
+        $deliveryCountryData->names = ['cs' => 'Slovenská republika'];
+
+        $customerUserData = TestCustomerProvider::getEmptyTestCustomerUserData();
+        $customerUserData->email = 'social-network-user@shopsys.com';
+        $customerUser = new CustomerUser($customerUserData);
+
+        $deliveryAddress = $customerUser->getDefaultDeliveryAddress();
+
+        $this->assertNull($customerUser->getFirstName());
+        $this->assertNull($customerUser->getLastName());
+        $this->assertNull($customerUser->getTelephone());
+
+        $orderData = TestOrderProvider::getTestOrderData();
+        $order = new Order(
+            $orderData,
+            '123456',
+            '7ebafe9fe',
+        );
+        $order->setCompanyInfo(
+            'companyName',
+            'companyNumber',
+            'companyTaxNumber',
+        );
+        $order->addItem(TestOrderProvider::createOrderTransport($order));
+
+        $customerUserUpdateData = $customerUserUpdateUpdateDataFactory->createAmendedByOrder(
+            $customerUser,
+            $order,
+            $deliveryAddress,
+        );
+
+        $this->assertSame($order->getFirstName(), $customerUserUpdateData->customerUserData->firstName);
+        $this->assertSame($order->getLastName(), $customerUserUpdateData->customerUserData->lastName);
+        $this->assertSame($order->getTelephone(), $customerUserUpdateData->customerUserData->telephone);
+
+        $this->assertSame($order->getCompanyName(), $customerUserUpdateData->billingAddressData->companyName);
+        $this->assertSame($order->getCompanyNumber(), $customerUserUpdateData->billingAddressData->companyNumber);
+        $this->assertSame($order->getCompanyTaxNumber(), $customerUserUpdateData->billingAddressData->companyTaxNumber);
+        $this->assertSame($order->getStreet(), $customerUserUpdateData->billingAddressData->street);
+        $this->assertSame($order->getCity(), $customerUserUpdateData->billingAddressData->city);
+        $this->assertSame($order->getPostcode(), $customerUserUpdateData->billingAddressData->postcode);
+        $this->assertSame($order->getCountry(), $customerUserUpdateData->billingAddressData->country);
+
+        $this->assertSame($order->getDeliveryStreet(), $customerUserUpdateData->deliveryAddressData->street);
+        $this->assertSame($order->getDeliveryCity(), $customerUserUpdateData->deliveryAddressData->city);
+        $this->assertSame($order->getDeliveryPostcode(), $customerUserUpdateData->deliveryAddressData->postcode);
+        $this->assertSame($order->getDeliveryCountry(), $customerUserUpdateData->deliveryAddressData->country);
+        $this->assertSame($order->getDeliveryCompanyName(), $customerUserUpdateData->deliveryAddressData->companyName);
+        $this->assertSame($order->getDeliveryFirstName(), $customerUserUpdateData->deliveryAddressData->firstName);
+        $this->assertSame($order->getDeliveryLastName(), $customerUserUpdateData->deliveryAddressData->lastName);
+        $this->assertSame($order->getDeliveryTelephone(), $customerUserUpdateData->deliveryAddressData->telephone);
+    }
+
     /**
      * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory
      */

--- a/packages/framework/tests/Unit/Model/Customer/TestCustomerProvider.php
+++ b/packages/framework/tests/Unit/Model/Customer/TestCustomerProvider.php
@@ -54,6 +54,7 @@ class TestCustomerProvider
         $customerUserData->firstName = 'Firstname';
         $customerUserData->lastName = 'Lastname';
         $customerUserData->email = 'no-reply@shopsys.com';
+        $customerUserData->telephone = 'telephone';
         $customerUserData->password = 'pa55w0rd';
         $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
         $customerUserData->customer = $customer;
@@ -65,6 +66,36 @@ class TestCustomerProvider
         $customerData->billingAddress = new BillingAddress($billingAddressData);
 
         $deliveryAddressData = self::getDeliveryAddressData($customer);
+        $customerData->deliveryAddresses = [new DeliveryAddress($deliveryAddressData)];
+
+        $customer->edit($customerData);
+
+        return $customerUserData;
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData
+     */
+    public static function getEmptyTestCustomerUserData(): CustomerUserData
+    {
+        $pricingGroupData = new PricingGroupData();
+        $pricingGroupData->name = 'name';
+        $pricingGroup = new PricingGroup($pricingGroupData, Domain::FIRST_DOMAIN_ID);
+
+        $customerData = new CustomerData();
+        $customerData->domainId = Domain::FIRST_DOMAIN_ID;
+        $customer = new Customer($customerData);
+
+        $customerUserData = new CustomerUserData();
+        $customerUserData->domainId = Domain::FIRST_DOMAIN_ID;
+        $customerUserData->customer = $customer;
+        $customerUserData->pricingGroup = $pricingGroup;
+        $customerUserData->createdAt = new DateTime();
+
+        $billingAddressData = self::getEmptyBillingAddressData($customer);
+        $customerData->billingAddress = new BillingAddress($billingAddressData);
+
+        $deliveryAddressData = self::getEmptyDeliveryAddressData($customer);
         $customerData->deliveryAddresses = [new DeliveryAddress($deliveryAddressData)];
 
         $customer->edit($customerData);
@@ -101,6 +132,19 @@ class TestCustomerProvider
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\Customer $customer
+     * @return \Shopsys\FrameworkBundle\Model\Customer\BillingAddressData
+     */
+    public static function getEmptyBillingAddressData(Customer $customer): BillingAddressData
+    {
+        $billingAddressData = new BillingAddressData();
+        $billingAddressData->customer = $customer;
+        $billingAddressData->companyCustomer = true;
+
+        return $billingAddressData;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\Customer $customer
      * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData
      */
     public static function getDeliveryAddressData(Customer $customer): DeliveryAddressData
@@ -120,6 +164,18 @@ class TestCustomerProvider
         $deliveryAddressData->country = $deliveryCountry;
         $deliveryAddressData->customer = $customer;
         $deliveryAddressData->uuid = '1f339571-4066-4c77-99ab-7b5172fbc2e9';
+
+        return $deliveryAddressData;
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Customer\Customer $customer
+     * @return \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData
+     */
+    public static function getEmptyDeliveryAddressData(Customer $customer): DeliveryAddressData
+    {
+        $deliveryAddressData = new DeliveryAddressData();
+        $deliveryAddressData->customer = $customer;
 
         return $deliveryAddressData;
     }

--- a/packages/frontend-api/src/Model/Customer/User/RegistrationDataFactory.php
+++ b/packages/frontend-api/src/Model/Customer/User/RegistrationDataFactory.php
@@ -70,15 +70,10 @@ class RegistrationDataFactory
     public function createFromSocialNetworkProfile(Profile $profile): RegistrationData
     {
         $registrationData = $this->createForDomainId($this->domain->getId());
-        $countries = $this->countryFacade->getAllEnabledOnCurrentDomain();
 
-        $registrationData->firstName = $profile->firstName ?? '';
-        $registrationData->lastName = $profile->lastName ?? '';
+        $registrationData->firstName = $profile->firstName;
+        $registrationData->lastName = $profile->lastName;
         $registrationData->email = $profile->email;
-        $registrationData->street = '';
-        $registrationData->city = '';
-        $registrationData->postcode = '';
-        $registrationData->country = $countries[0];
 
         return $registrationData;
     }

--- a/upgrade-notes/backend_20240725_061952.md
+++ b/upgrade-notes/backend_20240725_061952.md
@@ -1,0 +1,13 @@
+#### address, name and some other user data is now nullable ([#3285](https://github.com/shopsys/shopsys/pull/3285))
+
+-   following fields in `Shopsys\FrameworkBundle\Model\Customer\DeliveryAddress` are now nullable:
+    -   `$firstName`
+    -   `$lastName`
+    -   `$street`
+    -   `$city`
+    -   `$postcode`
+    -   `$country`
+-   following fields in `Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser` are now nullable:
+    -   `$firstName`
+    -   `$lastName`
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Due to social media login it is now possible that user is created without certain data like address and name that are mandatory throughout the application. These data are still mandatory in application and user is required to fill them ich chooses to edit profile or finish order, but they were changed to nullable in database layer so interim state with empty values is also valid
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes


























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-nullable-user-data.odin.shopsys.cloud
  - https://cz.ab-nullable-user-data.odin.shopsys.cloud
<!-- Replace -->
