### PR TITLE
[project-base][SSP-2513] Fixed skeleton loaders while navigating through main navigation

### DIFF
--- a/project-base/storefront/components/Layout/Header/Navigation/DeferredNavigation.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/DeferredNavigation.tsx
@@ -3,6 +3,8 @@ import { useNavigationQuery } from 'graphql/requests/navigation/queries/Navigati
 import dynamic from 'next/dynamic';
 import { useDeferredRender } from 'utils/useDeferredRender';
 
+const DEFAULT_SKELETON_TYPE = 'category';
+
 const NavigationPlaceholder = dynamic(() =>
     import('./NavigationPlaceholder').then((component) => component.NavigationPlaceholder),
 );
@@ -16,8 +18,8 @@ export const DeferredNavigation: FC = () => {
     }
 
     return shouldRender ? (
-        <Navigation navigation={navigationData.navigation} />
+        <Navigation navigation={navigationData.navigation} skeletonType={DEFAULT_SKELETON_TYPE} />
     ) : (
-        <NavigationPlaceholder navigation={navigationData.navigation} />
+        <NavigationPlaceholder navigation={navigationData.navigation} skeletonType={DEFAULT_SKELETON_TYPE} />
     );
 };

--- a/project-base/storefront/components/Layout/Header/Navigation/Navigation.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/Navigation.tsx
@@ -1,15 +1,17 @@
 import { NavigationItem } from './NavigationItem';
 import { TypeCategoriesByColumnFragment } from 'graphql/requests/navigation/fragments/CategoriesByColumnsFragment.generated';
+import { PageType } from 'store/slices/createPageLoadingStateSlice';
 
 export type NavigationProps = {
     navigation: TypeCategoriesByColumnFragment[];
+    skeletonType?: PageType;
 };
 
-export const Navigation: FC<NavigationProps> = ({ navigation }) => {
+export const Navigation: FC<NavigationProps> = ({ navigation, skeletonType }) => {
     return (
         <ul className="relative hidden w-full lg:flex">
             {navigation.map((navigationItem, index) => (
-                <NavigationItem key={index} navigationItem={navigationItem} />
+                <NavigationItem key={index} navigationItem={navigationItem} skeletonType={skeletonType} />
             ))}
         </ul>
     );

--- a/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/NavigationItem.tsx
@@ -3,14 +3,16 @@ import { ArrowIcon } from 'components/Basic/Icon/ArrowIcon';
 import { NavigationItemColumn } from 'components/Layout/Header/Navigation/NavigationItemColumn';
 import { TypeCategoriesByColumnFragment } from 'graphql/requests/navigation/fragments/CategoriesByColumnsFragment.generated';
 import { useState } from 'react';
+import { PageType } from 'store/slices/createPageLoadingStateSlice';
 import { twJoin } from 'tailwind-merge';
 import { useDebounce } from 'utils/useDebounce';
 
 type NavigationItemProps = {
     navigationItem: TypeCategoriesByColumnFragment;
+    skeletonType?: PageType;
 };
 
-export const NavigationItem: FC<NavigationItemProps> = ({ navigationItem }) => {
+export const NavigationItem: FC<NavigationItemProps> = ({ navigationItem, skeletonType }) => {
     const [isMenuOpened, setIsMenuOpened] = useState(false);
     const hasChildren = !!navigationItem.categoriesByColumns.length;
     const isMenuOpenedDelayed = useDebounce(isMenuOpened, 200);
@@ -19,6 +21,7 @@ export const NavigationItem: FC<NavigationItemProps> = ({ navigationItem }) => {
         <li className="group" onMouseEnter={() => setIsMenuOpened(true)} onMouseLeave={() => setIsMenuOpened(false)}>
             <ExtendedNextLink
                 href={navigationItem.link}
+                skeletonType={skeletonType}
                 className={twJoin(
                     'relative m-0 flex items-center px-6 xl:px-5 py-4 group-first-of-type:pl-0 text-sm font-bold uppercase text-white hover:text-white no-underline hover:no-underline vl:text-base transition-colors',
                     (isMenuOpenedDelayed || !hasChildren) &&
@@ -40,6 +43,7 @@ export const NavigationItem: FC<NavigationItemProps> = ({ navigationItem }) => {
                 <div className="absolute left-0 right-0 z-menu grid grid-cols-4 gap-11 bg-white py-12 px-10 shadow-md">
                     <NavigationItemColumn
                         columnCategories={navigationItem.categoriesByColumns}
+                        skeletonType={skeletonType}
                         onLinkClick={() => setIsMenuOpened(false)}
                     />
                 </div>

--- a/project-base/storefront/components/Layout/Header/Navigation/NavigationItemColumn.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/NavigationItemColumn.tsx
@@ -1,13 +1,19 @@
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
 import { Image } from 'components/Basic/Image/Image';
 import { TypeColumnCategoriesFragment } from 'graphql/requests/navigation/fragments/ColumnCategoriesFragment.generated';
+import { PageType } from 'store/slices/createPageLoadingStateSlice';
 
 type NavigationItemColumnProps = {
     columnCategories: TypeColumnCategoriesFragment[];
+    skeletonType?: PageType;
     onLinkClick: () => void;
 };
 
-export const NavigationItemColumn: FC<NavigationItemColumnProps> = ({ columnCategories, onLinkClick }) => (
+export const NavigationItemColumn: FC<NavigationItemColumnProps> = ({
+    columnCategories,
+    skeletonType,
+    onLinkClick,
+}) => (
     <>
         {columnCategories.map((columnCategories, columnIndex) => (
             <ul key={columnIndex} className="flex flex-col gap-9">
@@ -16,6 +22,7 @@ export const NavigationItemColumn: FC<NavigationItemColumnProps> = ({ columnCate
                         <ExtendedNextLink
                             className="mb-4 flex justify-center rounded bg-whiteSnow p-2"
                             href={columnCategory.slug}
+                            skeletonType={skeletonType}
                             onClick={onLinkClick}
                         >
                             <Image
@@ -30,6 +37,7 @@ export const NavigationItemColumn: FC<NavigationItemColumnProps> = ({ columnCate
                         <ExtendedNextLink
                             className="mb-1 block font-bold text-dark no-underline"
                             href={columnCategory.slug}
+                            skeletonType={skeletonType}
                             onClick={onLinkClick}
                         >
                             {columnCategory.name}
@@ -42,6 +50,7 @@ export const NavigationItemColumn: FC<NavigationItemColumnProps> = ({ columnCate
                                         <ExtendedNextLink
                                             className="block text-sm text-dark no-underline"
                                             href={columnCategoryChild.slug}
+                                            skeletonType={skeletonType}
                                             onClick={onLinkClick}
                                         >
                                             {columnCategoryChild.name}

--- a/project-base/storefront/components/Layout/Header/Navigation/NavigationPlaceholder.tsx
+++ b/project-base/storefront/components/Layout/Header/Navigation/NavigationPlaceholder.tsx
@@ -3,7 +3,7 @@ import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNext
 import { ArrowIcon } from 'components/Basic/Icon/ArrowIcon';
 import { twJoin } from 'tailwind-merge';
 
-export const NavigationPlaceholder: FC<NavigationProps> = ({ navigation }) => (
+export const NavigationPlaceholder: FC<NavigationProps> = ({ navigation, skeletonType }) => (
     <ul className="relative hidden w-full lg:flex">
         {navigation.map((navigationItem, index) => {
             const hasChildren = !!navigationItem.categoriesByColumns.length;
@@ -12,6 +12,7 @@ export const NavigationPlaceholder: FC<NavigationProps> = ({ navigation }) => (
                 <li key={index} className="group">
                     <ExtendedNextLink
                         href={navigationItem.link}
+                        skeletonType={skeletonType}
                         className={twJoin(
                             'relative m-0 flex items-center px-6 xl:px-5 py-4 group-first-of-type:pl-0 text-sm font-bold uppercase text-white no-underline hover:text-orangeLight hover:no-underline group-hover:text-orangeLight group-hover:no-underline vl:text-base',
                         )}

--- a/project-base/storefront/vitest/components/ExtendedNextLink/ExtendedNextLink.test.tsx
+++ b/project-base/storefront/vitest/components/ExtendedNextLink/ExtendedNextLink.test.tsx
@@ -1,16 +1,35 @@
 import { render } from '@testing-library/react';
 import { ExtendedNextLink } from 'components/Basic/ExtendedNextLink/ExtendedNextLink';
+import { DomainConfigProvider } from 'components/providers/DomainConfigProvider';
 import { TypeProductOrderingModeEnum } from 'graphql/types';
+import { DomainConfigType } from 'utils/domain/domainConfig';
 import { describe, expect, test } from 'vitest';
+
+const MOCKED_DOMAIN_CONFIG: DomainConfigType = {
+    url: '',
+    currencyCode: '',
+    defaultLocale: '',
+    domainId: 0,
+    fallbackTimezone: '',
+    isLuigisBoxActive: false,
+    mapSetting: {
+        latitude: 0,
+        longitude: 0,
+        zoom: 0,
+    },
+    publicGraphqlEndpoint: '',
+};
 
 describe('ExtendedNextLink snapshot tests', () => {
     test('render ExtendedNextLink with static type', () => {
         const component = render(
-            <ExtendedNextLink href="/test-href">
-                <div>
-                    <span>link text</span>
-                </div>
-            </ExtendedNextLink>,
+            <DomainConfigProvider domainConfig={MOCKED_DOMAIN_CONFIG}>
+                <ExtendedNextLink href="/test-href">
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
         );
 
         expect(component).toMatchFileSnapshot('snap-1.test.tsx.snap');
@@ -18,11 +37,13 @@ describe('ExtendedNextLink snapshot tests', () => {
 
     test('render ExtendedNextLink with static type and `as` prop', () => {
         const component = render(
-            <ExtendedNextLink as="/nice-test-href" href="/test-href">
-                <div>
-                    <span>link text</span>
-                </div>
-            </ExtendedNextLink>,
+            <DomainConfigProvider domainConfig={MOCKED_DOMAIN_CONFIG}>
+                <ExtendedNextLink as="/nice-test-href" href="/test-href">
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
         );
 
         expect(component).toMatchFileSnapshot('snap-2.test.tsx.snap');
@@ -30,11 +51,13 @@ describe('ExtendedNextLink snapshot tests', () => {
 
     test('render ExtendedNextLink with a friendly page type', () => {
         const component = render(
-            <ExtendedNextLink href="/test-category" type="category">
-                <div>
-                    <span>link text</span>
-                </div>
-            </ExtendedNextLink>,
+            <DomainConfigProvider domainConfig={MOCKED_DOMAIN_CONFIG}>
+                <ExtendedNextLink href="/test-category" type="category">
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
         );
 
         expect(component).toMatchFileSnapshot('snap-3.test.tsx.snap');
@@ -42,15 +65,17 @@ describe('ExtendedNextLink snapshot tests', () => {
 
     test('render ExtendedNextLink with a friendly page type and URL query', () => {
         const component = render(
-            <ExtendedNextLink
-                href="/test-category"
-                queryParams={{ sort: TypeProductOrderingModeEnum.PriceAsc }}
-                type="category"
-            >
-                <div>
-                    <span>link text</span>
-                </div>
-            </ExtendedNextLink>,
+            <DomainConfigProvider domainConfig={MOCKED_DOMAIN_CONFIG}>
+                <ExtendedNextLink
+                    href="/test-category"
+                    queryParams={{ sort: TypeProductOrderingModeEnum.PriceAsc }}
+                    type="category"
+                >
+                    <div>
+                        <span>link text</span>
+                    </div>
+                </ExtendedNextLink>
+            </DomainConfigProvider>,
         );
 
         expect(component).toMatchFileSnapshot('snap-4.test.tsx.snap');

--- a/upgrade-notes/storefront_20240805_101042.md
+++ b/upgrade-notes/storefront_20240805_101042.md
@@ -1,0 +1,8 @@
+#### Fix main navigation skeleton loaders ([#3287](https://github.com/shopsys/shopsys/pull/3287))
+
+-   Show skeleton loaders for main navigation
+-   You can choose default skeleton to show by changing `DEFAULT_SKELETON_TYPE` in `DefferedNavigation.tsx` component.
+    Note that this skeleton is applied to ALL navigation links in the main navigation
+-   `isHrefExternal` function was added to check for external links for which we don't want to trigger skeleton loader
+    (this would result into issue with infinite skeleton loader bug)
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| To fix a bug in which the skeleton loaders would not show, I have added a check for an external link, for which we don't switch to the loading state, and for the rest (internal links), if no type provided, we show category skeleton loader by default.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| [SSP-2513](https://shopsys.atlassian.net/browse/SSP-2513?atlOrigin=eyJpIjoiMmFlNjgyZmI2OTZjNGY0Yzk2ZWQyM2QzMDU0NDIyZDAiLCJwIjoiaiJ9) <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-2513-navigation-skeleton-bug.odin.shopsys.cloud
  - https://cz.jm-ssp-2513-navigation-skeleton-bug.odin.shopsys.cloud
<!-- Replace -->
