### PR TITLE
[project-base][SSP-2465] Add search parameters to queries

### DIFF
--- a/project-base/storefront/components/Pages/Search/searchUtils.ts
+++ b/project-base/storefront/components/Pages/Search/searchUtils.ts
@@ -34,6 +34,7 @@ export const useSearchProductsData = (totalProductCount?: number) => {
     const currentSearchString = useCurrentSearchStringQuery();
     const currentLoadMore = useCurrentLoadMoreQuery();
     const mappedFilter = mapParametersFilter(currentFilter);
+    const parameters = mappedFilter?.parameters?.map((parameter) => parameter.parameter);
 
     const previousLoadMoreRef = useRef(currentLoadMore);
     const previousPageRef = useRef(currentPage);
@@ -99,6 +100,7 @@ export const useSearchProductsData = (totalProductCount?: number) => {
             currentPage,
             currentLoadMore,
             userIdentifier,
+            parameters,
         );
 
         if (
@@ -125,6 +127,7 @@ export const useSearchProductsData = (totalProductCount?: number) => {
                 pageSize,
                 isAutocomplete: false,
                 userIdentifier,
+                parameters,
             },
             previousProductsFromCache,
         );
@@ -145,6 +148,7 @@ const readProductsSearchFromCache = (
     endCursor: string,
     pageSize: number,
     userIdentifier: string,
+    parameters?: string[] | null,
 ): TypeListedProductConnectionFragment | undefined => {
     const dataFromCache = client.readQuery<TypeSearchProductsQuery, TypeSearchProductsQueryVariables>(
         SearchProductsQueryDocument,
@@ -156,6 +160,7 @@ const readProductsSearchFromCache = (
             pageSize,
             isAutocomplete: false,
             userIdentifier,
+            parameters,
         },
     )?.data?.productsSearch;
 
@@ -171,6 +176,7 @@ const getPreviousProductsFromCache = (
     currentPage: number,
     currentLoadMore: number,
     userIdentifier: string,
+    parameters?: string[] | null,
 ) => {
     let cachedPartOfProducts: TypeListedProductConnectionFragment['edges'] | undefined;
     let iterationsCounter = currentLoadMore;
@@ -185,6 +191,7 @@ const getPreviousProductsFromCache = (
             offsetEndCursor,
             pageSize,
             userIdentifier,
+            parameters,
         );
 
         if (productsSearchFromCache) {
@@ -210,6 +217,7 @@ export const useSearchQuery = (searchString: string | undefined) => {
     const currentSort = useCurrentSortQuery();
     const currentLoadMore = useCurrentLoadMoreQuery();
     const mappedFilter = mapParametersFilter(currentFilter);
+    const parameters = mappedFilter?.parameters?.map((parameter) => parameter.parameter) ?? [];
     const { pageSize, isMoreThanOnePage } = getPageSizeInfo(false, currentLoadMore);
     const endCursor = getEndCursor(currentPage, isMoreThanOnePage ? undefined : currentLoadMore);
     const client = useClient();
@@ -228,6 +236,7 @@ export const useSearchQuery = (searchString: string | undefined) => {
                     filter: mappedFilter,
                     orderingMode: currentSort,
                     pageSize,
+                    parameters,
                 })
                 .then((searchResponse) => {
                     setSearchData(searchResponse.data);

--- a/project-base/storefront/graphql/requests/search/queries/AutocompleteSearchQuery.generated.tsx
+++ b/project-base/storefront/graphql/requests/search/queries/AutocompleteSearchQuery.generated.tsx
@@ -14,6 +14,7 @@ export type TypeAutocompleteSearchQueryVariables = Types.Exact<{
   maxCategoryCount: Types.InputMaybe<Types.Scalars['Int']['input']>;
   isAutocomplete: Types.Scalars['Boolean']['input'];
   userIdentifier: Types.Scalars['Uuid']['input'];
+  parameters?: Types.InputMaybe<Array<Types.Scalars['Uuid']['input']> | Types.Scalars['Uuid']['input']>;
 }>;
 
 
@@ -98,25 +99,25 @@ export type TypeAutocompleteSearchQuery = { __typename?: 'Query', articlesSearch
     
 
 export const AutocompleteSearchQueryDocument = gql`
-    query AutocompleteSearchQuery($search: String!, $maxProductCount: Int, $maxCategoryCount: Int, $isAutocomplete: Boolean!, $userIdentifier: Uuid!) {
+    query AutocompleteSearchQuery($search: String!, $maxProductCount: Int, $maxCategoryCount: Int, $isAutocomplete: Boolean!, $userIdentifier: Uuid!, $parameters: [Uuid!] = []) {
   articlesSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     ...SimpleArticleInterfaceFragment
   }
   brandSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     ...SimpleBrandFragment
   }
   categoriesSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
     first: $maxCategoryCount
   ) {
     ...SimpleCategoryConnectionFragment
   }
   productsSearch: productsSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
     first: $maxProductCount
   ) {
     orderingMode

--- a/project-base/storefront/graphql/requests/search/queries/SearchProductsQuery.generated.tsx
+++ b/project-base/storefront/graphql/requests/search/queries/SearchProductsQuery.generated.tsx
@@ -13,6 +13,7 @@ export type TypeSearchProductsQueryVariables = Types.Exact<{
   pageSize: Types.InputMaybe<Types.Scalars['Int']['input']>;
   isAutocomplete: Types.Scalars['Boolean']['input'];
   userIdentifier: Types.Scalars['Uuid']['input'];
+  parameters?: Types.InputMaybe<Array<Types.Scalars['Uuid']['input']> | Types.Scalars['Uuid']['input']>;
 }>;
 
 
@@ -97,13 +98,13 @@ export type TypeSearchProductsQuery = { __typename?: 'Query', productsSearch: { 
     
 
 export const SearchProductsQueryDocument = gql`
-    query SearchProductsQuery($endCursor: String!, $orderingMode: ProductOrderingModeEnum, $filter: ProductFilter, $search: String!, $pageSize: Int, $isAutocomplete: Boolean!, $userIdentifier: Uuid!) {
+    query SearchProductsQuery($endCursor: String!, $orderingMode: ProductOrderingModeEnum, $filter: ProductFilter, $search: String!, $pageSize: Int, $isAutocomplete: Boolean!, $userIdentifier: Uuid!, $parameters: [Uuid!] = []) {
   productsSearch(
     after: $endCursor
     orderingMode: $orderingMode
     filter: $filter
     first: $pageSize
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     orderingMode
     defaultOrderingMode

--- a/project-base/storefront/graphql/requests/search/queries/SearchProductsQuery.graphql
+++ b/project-base/storefront/graphql/requests/search/queries/SearchProductsQuery.graphql
@@ -6,13 +6,19 @@ query SearchProductsQuery(
     $pageSize: Int
     $isAutocomplete: Boolean!
     $userIdentifier: Uuid!
+    $parameters: [Uuid!] = []
 ) {
     productsSearch(
         after: $endCursor
         orderingMode: $orderingMode
         filter: $filter
         first: $pageSize
-        searchInput: { search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier }
+        searchInput: {
+            search: $search
+            isAutocomplete: $isAutocomplete
+            userIdentifier: $userIdentifier
+            parameters: $parameters
+        }
     ) {
         orderingMode
         defaultOrderingMode

--- a/project-base/storefront/graphql/requests/search/queries/SearchQuery.generated.tsx
+++ b/project-base/storefront/graphql/requests/search/queries/SearchQuery.generated.tsx
@@ -16,6 +16,7 @@ export type TypeSearchQueryVariables = Types.Exact<{
   orderingMode: Types.InputMaybe<Types.TypeProductOrderingModeEnum>;
   filter: Types.InputMaybe<Types.TypeProductFilter>;
   pageSize: Types.InputMaybe<Types.Scalars['Int']['input']>;
+  parameters?: Types.InputMaybe<Array<Types.Scalars['Uuid']['input']> | Types.Scalars['Uuid']['input']>;
 }>;
 
 
@@ -100,19 +101,19 @@ export type TypeSearchQuery = { __typename?: 'Query', articlesSearch: Array<{ __
     
 
 export const SearchQueryDocument = gql`
-    query SearchQuery($search: String!, $isAutocomplete: Boolean!, $userIdentifier: Uuid!, $endCursor: String!, $orderingMode: ProductOrderingModeEnum, $filter: ProductFilter, $pageSize: Int) {
+    query SearchQuery($search: String!, $isAutocomplete: Boolean!, $userIdentifier: Uuid!, $endCursor: String!, $orderingMode: ProductOrderingModeEnum, $filter: ProductFilter, $pageSize: Int, $parameters: [Uuid!] = []) {
   articlesSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     ...SimpleArticleInterfaceFragment
   }
   brandSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     ...ListedBrandFragment
   }
   categoriesSearch(
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     ...ListedCategoryConnectionFragment
   }
@@ -121,7 +122,7 @@ export const SearchQueryDocument = gql`
     orderingMode: $orderingMode
     filter: $filter
     first: $pageSize
-    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier}
+    searchInput: {search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier, parameters: $parameters}
   ) {
     orderingMode
     defaultOrderingMode

--- a/project-base/storefront/graphql/requests/search/queries/SearchQuery.graphql
+++ b/project-base/storefront/graphql/requests/search/queries/SearchQuery.graphql
@@ -6,15 +6,35 @@ query SearchQuery(
     $orderingMode: ProductOrderingModeEnum
     $filter: ProductFilter
     $pageSize: Int
+    $parameters: [Uuid!] = []
 ) {
-    articlesSearch(searchInput: { search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier }) {
+    articlesSearch(
+        searchInput: {
+            search: $search
+            isAutocomplete: $isAutocomplete
+            userIdentifier: $userIdentifier
+            parameters: $parameters
+        }
+    ) {
         ...SimpleArticleInterfaceFragment
     }
-    brandSearch(searchInput: { search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier }) {
+    brandSearch(
+        searchInput: {
+            search: $search
+            isAutocomplete: $isAutocomplete
+            userIdentifier: $userIdentifier
+            parameters: $parameters
+        }
+    ) {
         ...ListedBrandFragment
     }
     categoriesSearch(
-        searchInput: { search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier }
+        searchInput: {
+            search: $search
+            isAutocomplete: $isAutocomplete
+            userIdentifier: $userIdentifier
+            parameters: $parameters
+        }
     ) {
         ...ListedCategoryConnectionFragment
     }
@@ -27,7 +47,12 @@ query SearchQuery(
         orderingMode: $orderingMode
         filter: $filter
         first: $pageSize
-        searchInput: { search: $search, isAutocomplete: $isAutocomplete, userIdentifier: $userIdentifier }
+        searchInput: {
+            search: $search
+            isAutocomplete: $isAutocomplete
+            userIdentifier: $userIdentifier
+            parameters: $parameters
+        }
     ) {
         orderingMode
         defaultOrderingMode

--- a/upgrade-notes/storefront_20240801_162202.md
+++ b/upgrade-notes/storefront_20240801_162202.md
@@ -1,0 +1,5 @@
+#### Add search parameters to search queries ([#3298](https://github.com/shopsys/shopsys/pull/3298))
+
+-   added search parameters to `SearchQuery` and `SearchProductsQuery`
+-   now you should provide `parameters` of the previous search (for example from `mappedFilter.parameters` in `searchUtils.ts`) whenever they are available
+-   see #project-base-diff to update your project


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| To match the order of parametric filters from luigis box, FE now includes order of previous search result in SearchQuery and SearchProductsQuery
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-2465-search-parameters.odin.shopsys.cloud
  - https://cz.jm-ssp-2465-search-parameters.odin.shopsys.cloud
<!-- Replace -->
