### PR TITLE
[project-base][SSP-2508] updated filter slider apperance

### DIFF
--- a/project-base/storefront/components/Blocks/Product/Filter/FilterSelectedParameters.tsx
+++ b/project-base/storefront/components/Blocks/Product/Filter/FilterSelectedParameters.tsx
@@ -100,32 +100,32 @@ export const FilterSelectedParameters: FC<FilterSelectedParametersProps> = ({ fi
                                   );
                               })
                             : undefined;
-                    if (!selectedParameterOptions || (!selectedParameterValues && !isSliderParameter)) {
+
+                    if (!selectedParameterOptions) {
                         return null;
                     }
 
                     return (
                         <SelectedParametersList key={selectedParameterOptions.uuid}>
                             <SelectedParametersName>{selectedParameterOptions.name}:</SelectedParametersName>
-                            {isSliderParameter ? (
+                            {isSliderParameter && (
                                 <SelectedParametersListItem key={selectedParameterOptions.uuid}>
                                     <span>{t('from')}&nbsp;</span>
                                     {selectedParameter.minimalValue || selectedParameterOptions.minimalValue}
                                     {!!selectedParameterOptions.unit?.name &&
                                         `\xa0${selectedParameterOptions.unit.name}`}
-
                                     <span>&nbsp;{t('to')}&nbsp;</span>
                                     {selectedParameter.maximalValue || selectedParameterOptions.maximalValue}
                                     {selectedParameterOptions.unit?.name && `\xa0${selectedParameterOptions.unit.name}`}
-
                                     <SelectedParametersIcon
                                         onClick={() =>
                                             updateFilterParametersQuery(selectedParameterOptions.uuid, undefined)
                                         }
                                     />
                                 </SelectedParametersListItem>
-                            ) : (
-                                selectedParameterValues?.map((selectedValue) => (
+                            )}
+                            {selectedParameterValues &&
+                                selectedParameterValues.map((selectedValue) => (
                                     <SelectedParametersListItem key={selectedValue.uuid}>
                                         {selectedValue.text}
                                         <SelectedParametersIcon
@@ -137,8 +137,7 @@ export const FilterSelectedParameters: FC<FilterSelectedParametersProps> = ({ fi
                                             }
                                         />
                                     </SelectedParametersListItem>
-                                ))
-                            )}
+                                ))}
                         </SelectedParametersList>
                     );
                 })}

--- a/upgrade-notes/storefront_20240802_100126.md
+++ b/upgrade-notes/storefront_20240802_100126.md
@@ -1,0 +1,3 @@
+#### active filter slider is not showing up ([#3300](https://github.com/shopsys/shopsys/pull/3300))
+
+-   users can now see the active filter slider at the top of the filter panel


### PR DESCRIPTION
| Q             | A
| ------------- | ---
|Description, reason for the PR| Users can now see the active filter slider at the top of the filter panel.
|New feature| No <!-- Do not forget to update docs/ -->
|[BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)| No <!-- Do not forget to update UPGRADE.md -->
|Fixes issues| ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
|Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)?| Yes








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-ssp-2508-filter-slider-apperance.odin.shopsys.cloud
  - https://cz.tc-ssp-ssp-2508-filter-slider-apperance.odin.shopsys.cloud
<!-- Replace -->
