### PR TITLE
[shopsys] add missing upgrade note for google maps

### DIFF
--- a/upgrade-notes/storefront_20240722_104600.md
+++ b/upgrade-notes/storefront_20240722_104600.md
@@ -5,3 +5,4 @@
 -   `use-supercluster` was added to handle the merging of neighbouring stores into clusters
 -   For production don't forget to set up the `GOOGLE_MAP_API_KEY` in the`.env` file. For development you can leave it blank.
 -   see #project-base-diff to update your project
+-   see also [this commit](https://github.com/shopsys/project-base/commit/0c3cf068e26260cf3186664e9878f6c0e6853e1f) that fixes selecting store by clicking on the map


### PR DESCRIPTION
| Q                                                                                                              | A
|----------------------------------------------------------------------------------------------------------------| ---
| Description, the reason for the PR                                                                             | fix of Google Maps was [pushed directly](https://github.com/shopsys/shopsys/commit/f28efcd662afa0f3645f9bbf96b9dd327e7cd204) to `15.0` branch by mistake, the upgrade note was missing
| New feature                                                                                                    | No <!-- Do not forget to update docs/ -->
| [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/)                   | No <!-- Do not forget to update UPGRADE.md -->
| Fixes issues                                                                                                   | ... <!-- Write "closes #123" for the issue to be closed automatically during merge -->
| Have you read and signed our [License Agreement for contributions](https://www.shopsys.com/license-agreement)? | Yes





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-missing-upgrade.odin.shopsys.cloud
  - https://cz.rv-missing-upgrade.odin.shopsys.cloud
<!-- Replace -->
