### PR TITLE
[project-base][SSP-2551] updated contact info merge logic to handle empty object

### DIFF
--- a/project-base/storefront/utils/user/useCurrentUserContactInformation.ts
+++ b/project-base/storefront/utils/user/useCurrentUserContactInformation.ts
@@ -43,7 +43,9 @@ const mergeContactInformation = (
         const filteredProperty = filteredContactInformationFromStore[key as keyof ContactInformation];
 
         const isEmptyString = typeof filteredProperty === 'string' && filteredProperty.length === 0;
-        if ((isEmptyString || filteredProperty === undefined) && key in contactInformationFromApi) {
+        const isEmptyObject = typeof filteredProperty === 'object' && filteredProperty.value === '';
+
+        if ((isEmptyString || filteredProperty === undefined || isEmptyObject) && key in contactInformationFromApi) {
             delete filteredContactInformationFromStore[key as keyof ContactInformation];
         }
     }

--- a/upgrade-notes/storefront_20240805_105651.md
+++ b/upgrade-notes/storefront_20240805_105651.md
@@ -1,0 +1,4 @@
+#### default address does not match in cart and edit profile ([#3307](https://github.com/shopsys/shopsys/pull/3307))
+
+-   this update improves the useCurrentUserContactInformation hook, making data merging more reliable and ensuring consistent handling of user contact information from both the API and the store
+-   customer default billing address in cart now matches the one in edit profile page


### PR DESCRIPTION
#### Description, the reason for the PR
This update improves the useCurrentUserContactInformation hook, making data merging more reliable and ensuring consistent handling of user contact information from both the API and the store.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-ssp-2551-default-country-in-billing-address-in-cart.odin.shopsys.cloud
  - https://cz.tc-ssp-ssp-2551-default-country-in-billing-address-in-cart.odin.shopsys.cloud
<!-- Replace -->
