### PR TITLE
[framework] fixed query wrongly loading flags from Product instead of ProductDomain

### DIFF
--- a/packages/framework/src/Model/Product/Filter/FlagFilterChoiceRepository.php
+++ b/packages/framework/src/Model/Product/Filter/FlagFilterChoiceRepository.php
@@ -104,7 +104,7 @@ class FlagFilterChoiceRepository
 
         $clonedProductsQueryBuilder
             ->select('1')
-            ->join('p.flags', 'pf')
+            ->join('pd.flags', 'pf')
             ->andWhere('pf.id = f.id')
             ->andWhere('f.visible = true')
             ->resetDQLPart('orderBy');


### PR DESCRIPTION
Description, the reason for the PR
This pull request fixes the usage of flags in the repository. Previously, the repository used flags from the product entity, which no longer exists. Now, the repository correctly uses flags from the productDomain entity.