### PR TITLE
[framework] fixed price range query

### DIFF
--- a/packages/framework/src/Model/Product/Filter/PriceRangeRepository.php
+++ b/packages/framework/src/Model/Product/Filter/PriceRangeRepository.php
@@ -106,7 +106,7 @@ class PriceRangeRepository
             ->setParameter('pricingGroup', $pricingGroup)
             ->resetDQLPart('groupBy')
             ->resetDQLPart('orderBy')
-            ->select('MIN(pmip.priceWithVat) AS minimalPrice, MAX(pmip.priceWithVat) AS maximalPrice');
+            ->select('MIN(pmip.inputPrice) AS minimalPrice, MAX(pmip.inputPrice) AS maximalPrice');
 
         $priceRangeData = $queryBuilder->getQuery()->execute();
         $priceRangeDataRow = reset($priceRangeData);


### PR DESCRIPTION
This pull request fixes an issue in the PriceRangeRepository where the query was searching for the maximum and minimum values on the priceWithVat attribute, which does not exist. The correct attribute to use is inputPrice.