### PR TITLE
[shopsys] fixed image resolving for transport in FrontendAPI

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1,4 +1,4 @@
-# UPGRADING FROM 13.x to 14.0
+# UPGRADING FROM 13.x to 14.0.1
 
 The releases of Shopsys Platform adhere to the [Backward Compatibility Promise](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) to make the upgrades to new versions easier and help long-term maintainability.
 
@@ -60,7 +60,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     - see #project-base-diff to update your project
 -->
 
-## [Upgrade from v14.0.0 to v14.0.1-dev](https://github.com/shopsys/shopsys/compare/v14.0.0...14.0)
+## [Upgrade from v14.0.0 to v14.0.1-dev](https://github.com/shopsys/shopsys/compare/v14.0.0...14.0.1)
+
+#### fixed image resolving for transport in FrontendAPI ([#3316](https://github.com/shopsys/shopsys/pull/3316))
+
+-   see #project-base-diff to update your project
 
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 

--- a/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/TransportDecorator.types.yaml
@@ -30,7 +30,7 @@ TransportDecorator:
             images:
                 type: "[Image!]!"
                 description: "Transport images"
-                resolve: '@=query("imagesByEntityQuery", value, args["type"])'
+                resolve: '@=query("imagesByEntityPromiseQuery", value, args["type"])'
                 args:
                     type:
                         type: "String"

--- a/project-base/app/config/graphql/types/ModelType/Transport/Transport.types.yaml
+++ b/project-base/app/config/graphql/types/ModelType/Transport/Transport.types.yaml
@@ -14,14 +14,6 @@ Transport:
                 type: "StoreConnection"
                 description: "Stores available for personal pickup"
                 resolve: "@=query('storesByTransportQuery', value, args)"
-            images:
-                type: "[Image!]!"
-                description: "Transport images"
-                resolve: '@=query("imagesByEntityPromiseQuery", value, args["type"])'
-                args:
-                    type:
-                        type: "String"
-                        defaultValue: null
             mainImage:
                 type: "Image"
                 description: "Transport image by params"


### PR DESCRIPTION
This pull request fixes an issue where the Transport decorator was using a non-existing method imagesByEntityQuery. The decorator now uses the correct method for resolving images.