### PR TITLE
[framework] admin parameter form now validates parameter name uniqueness within a given locale

### DIFF
--- a/packages/framework/assets/js/admin/validation/form/index.js
+++ b/packages/framework/assets/js/admin/validation/form/index.js
@@ -4,6 +4,7 @@ import './validationFreTransportAndPayment';
 import './validationMailTemplate';
 import './validationAdvert';
 import './validationOrder';
+import './validationParameterName';
 import './validationPromoCode';
 import './validationHreflangSetting';
 import './validationStore';

--- a/packages/framework/assets/js/admin/validation/form/validationParameterName.js
+++ b/packages/framework/assets/js/admin/validation/form/validationParameterName.js
@@ -1,0 +1,13 @@
+import Register from '../../../common/utils/Register';
+
+function validationParameterName ($container) {
+    window.$('form[name="parameter_form"]').jsFormValidator({
+        callbacks: {
+            validateUniqueParameterName: function () {
+                // JS validation is not necessary
+            }
+        }
+    });
+}
+
+(new Register()).registerCallback(validationParameterName);

--- a/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterFacade.php
@@ -109,6 +109,17 @@ class ParameterFacade
     }
 
     /**
+     * @param string $name
+     * @param string $locale
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter|null $excludeParameter
+     * @return bool
+     */
+    public function existsParameterByName(string $name, string $locale, ?Parameter $excludeParameter = null): bool
+    {
+        return $this->parameterRepository->existsParameterByName($name, $locale, $excludeParameter);
+    }
+
+    /**
      * @param int $parameterId
      * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterData $parameterData
      * @return \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -569,4 +569,32 @@ class ParameterRepository
             ->getQuery()
             ->execute();
     }
+
+    /**
+     * @param string $name
+     * @param string $locale
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter|null $excludeParameter
+     * @return bool
+     */
+    public function existsParameterByName(string $name, string $locale, ?Parameter $excludeParameter = null): bool
+    {
+        $queryBuilder = $this->em->createQueryBuilder()
+            ->select('count(p)')
+            ->from(Parameter::class, 'p')
+            ->join('p.translations', 'pt')
+            ->where('pt.name = :name')
+            ->andWhere('pt.locale = :locale')
+            ->setParameter('name', $name)
+            ->setParameter('locale', $locale);
+
+        if ($excludeParameter !== null) {
+            $queryBuilder
+                ->andWhere('p != :excludeParameter')
+                ->setParameter('excludeParameter', $excludeParameter);
+        }
+
+        return $queryBuilder
+            ->getQuery()
+            ->getSingleScalarResult() > 0;
+    }
 }

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -145,6 +145,9 @@ msgstr "Hodnota parametru musí být číselná"
 msgid "Parameter value must be of type {{ type }}"
 msgstr "Hodnota parametru musí být typu {{ type }}"
 
+msgid "Parameter with this name already exists for the locale \"%locale%\"."
+msgstr "Parametr se zadaným názvem už existuje pro jazyk \"%locale%\"."
+
 msgid "Parameter {{ parameterName }} is used more than once"
 msgstr "Parametr {{ parameterName }} je použit více než jednou"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -145,6 +145,9 @@ msgstr ""
 msgid "Parameter value must be of type {{ type }}"
 msgstr ""
 
+msgid "Parameter with this name already exists for the locale \"%locale%\"."
+msgstr ""
+
 msgid "Parameter {{ parameterName }} is used more than once"
 msgstr ""
 

--- a/project-base/app/src/Model/Product/Parameter/ParameterFacade.php
+++ b/project-base/app/src/Model/Product/Parameter/ParameterFacade.php
@@ -33,6 +33,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * @method \App\Model\Product\Parameter\Parameter[] getSliderParametersWithoutTheirsNumericValueFilled()
  * @method int getCountOfParameterValuesWithoutTheirsNumericValueFilledQueryBuilder(\App\Model\Product\Parameter\Parameter $parameter)
  * @method \App\Model\Product\Parameter\Parameter[] getAllWithTranslations(string $locale)
+ * @method bool existsParameterByName(string $name, string $locale, \App\Model\Product\Parameter\Parameter|null $excludeParameter = null)
  */
 class ParameterFacade extends BaseParameterFacade
 {

--- a/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
+++ b/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
@@ -38,6 +38,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
  * @method int getCountOfParameterValuesWithoutTheirsNumericValueFilledQueryBuilder(\App\Model\Product\Parameter\Parameter $parameter)
  * @method \App\Model\Product\Product[] getProductsByParameterValues(\Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterValue[] $parameterValues)
  * @method \App\Model\Product\Parameter\Parameter[] getAllWithTranslations(string $locale)
+ * @method bool existsParameterByName(string $name, string $locale, \App\Model\Product\Parameter\Parameter|null $excludeParameter = null)
  */
 class ParameterRepository extends BaseParameterRepository
 {

--- a/upgrade-notes/backend_20240807_095718.md
+++ b/upgrade-notes/backend_20240807_095718.md
@@ -1,0 +1,3 @@
+#### validate parameter name uniqueness ([#3317](https://github.com/shopsys/shopsys/pull/3317))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Having multiple parameters with the same name is quite confusing and it breaks Luigi's Box functionality as it requires the parameter names to be unique.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [X] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-parameter-unique-name.odin.shopsys.cloud
  - https://cz.rv-parameter-unique-name.odin.shopsys.cloud
<!-- Replace -->
