### PR TITLE
[shopsys] Moved CSRFExtension from project-base to framework

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1,4 +1,4 @@
-# UPGRADING FROM 13.x to 14.0
+# UPGRADING FROM 13.x to 14.0.1
 
 The releases of Shopsys Platform adhere to the [Backward Compatibility Promise](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) to make the upgrades to new versions easier and help long-term maintainability.
 
@@ -60,7 +60,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     - see #project-base-diff to update your project
 -->
 
-## [Upgrade from v14.0.0 to v14.0.1-dev](https://github.com/shopsys/shopsys/compare/v14.0.0...14.0)
+## [Upgrade from v14.0.0 to v14.0.1-dev](https://github.com/shopsys/shopsys/compare/v14.0.0...14.0.1)
+
+#### moved CSRFExtension from project-base to framework ([#3318](https://github.com/shopsys/shopsys/pull/3318))
+
+-   see #project-base-diff to update your project
 
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 

--- a/packages/framework/src/Twig/CsrfExtension.php
+++ b/packages/framework/src/Twig/CsrfExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Twig;
+namespace Shopsys\FrameworkBundle\Twig;
 
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;


### PR DESCRIPTION
Move class CsrfExtension from project base to framework package because, this [file](https://github.com/shopsys/shopsys/blob/v14.0.0/packages/framework/src/Resources/views/Admin/Content/Stock/detail.html.twig#L10 ) use twig function protectedUrl 