### PR TITLE
[shopsys] moved two attributes of ProductFormType from project-base to framework

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -1,4 +1,4 @@
-# UPGRADING FROM 13.x to 14.0
+# UPGRADING FROM 13.x to 14.0.1
 
 The releases of Shopsys Platform adhere to the [Backward Compatibility Promise](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) to make the upgrades to new versions easier and help long-term maintainability.
 
@@ -60,7 +60,11 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
     - see #project-base-diff to update your project
 -->
 
-## [Upgrade from v14.0.0 to v14.0.1-dev](https://github.com/shopsys/shopsys/compare/v14.0.0...14.0)
+## [Upgrade from v14.0.0 to v14.0.1-dev](https://github.com/shopsys/shopsys/compare/v14.0.0...14.0.1)
+
+#### moved two attributes of ProductFormType from project-base to the framework ([#3320](https://github.com/shopsys/shopsys/pull/3320))
+
+-   see #project-base-diff to update your project
 
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 

--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -10,6 +10,7 @@ use Shopsys\FormTypesBundle\YesNoType;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade;
 use Shopsys\FrameworkBundle\Form\Admin\Product\Parameter\ProductParameterValueFormType;
+use Shopsys\FrameworkBundle\Form\Admin\Stock\ProductStockFormType;
 use Shopsys\FrameworkBundle\Form\CategoriesType;
 use Shopsys\FrameworkBundle\Form\Constraints\NotNegativeMoneyAmount;
 use Shopsys\FrameworkBundle\Form\Constraints\UniqueProductParameters;
@@ -41,6 +42,7 @@ use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
@@ -127,6 +129,7 @@ class ProductFormType extends AbstractType
         $builder->add($this->createBasicInformationGroup($builder, $product, $disabledItemInMainVariantAttr));
         $builder->add($this->createDisplayAvailabilityGroup($builder, $product, $disabledItemInMainVariantAttr));
         $builder->add($this->createPricesGroup($builder, $product));
+        $builder->add($this->createStocksGroup($builder));
         $builder->add($this->createDescriptionsGroup($builder, $product));
         $builder->add($this->createShortDescriptionsGroup($builder, $product));
         $builder->add($this->createShortDescriptionsUspGroup($builder));
@@ -387,6 +390,12 @@ class ProductFormType extends AbstractType
                 'label' => t('Hide product'),
             ]);
 
+        $builderDisplayAvailabilityGroup->add('domainHidden', MultidomainType::class, [
+            'label' => t('Hide on domain'),
+            'required' => false,
+            'entry_type' => YesNoType::class,
+        ]);
+
         $builderDisplayAvailabilityGroup
             ->add('sellingFrom', DatePickerType::class, [
                 'required' => false,
@@ -563,6 +572,25 @@ class ProductFormType extends AbstractType
             ]);
 
         return $builderDisplayAvailabilityGroup;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @return \Symfony\Component\Form\FormBuilderInterface
+     */
+    private function createStocksGroup(FormBuilderInterface $builder)
+    {
+        $stockGroupBuilder = $builder->create('stocksGroup', GroupType::class, [
+            'label' => t('Warehouses'),
+        ]);
+
+        $stockGroupBuilder->add('productStockData', CollectionType::class, [
+            'required' => false,
+            'entry_type' => ProductStockFormType::class,
+            'render_form_row' => false,
+        ]);
+
+        return $stockGroupBuilder;
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -122,6 +122,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
             $productData->variantAlias[$locale] = null;
         }
         $productData->availability = $this->availabilityFacade->getDefaultInStockAvailability();
+        $this->fillProductStockByStocks($productData);
     }
 
     /**
@@ -209,6 +210,7 @@ class ProductDataFactory implements ProductDataFactoryInterface
         $productData->images = $this->imageUploadDataFactory->createFromEntityAndType($product);
         $productData->variants = $product->getVariants();
         $productData->pluginData = $this->pluginDataFormExtensionFacade->getAllData('product', $product->getId());
+        $this->fillProductStockByProduct($productData, $product);
     }
 
     /**

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1405,6 +1405,9 @@ msgstr "Skrýt"
 msgid "Hide advertisement"
 msgstr "Skrýt reklamu"
 
+msgid "Hide on domain"
+msgstr "Skrýt na doméně"
+
 msgid "Hide product"
 msgstr "Skrýt zboží"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1405,6 +1405,9 @@ msgstr ""
 msgid "Hide advertisement"
 msgstr ""
 
+msgid "Hide on domain"
+msgstr ""
+
 msgid "Hide product"
 msgstr ""
 

--- a/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
@@ -10,7 +10,6 @@ use App\Model\Product\Product;
 use Shopsys\FormTypesBundle\MultidomainType;
 use Shopsys\FormTypesBundle\YesNoType;
 use Shopsys\FrameworkBundle\Form\Admin\Product\ProductFormType;
-use Shopsys\FrameworkBundle\Form\Admin\Stock\ProductStockFormType;
 use Shopsys\FrameworkBundle\Form\GroupType;
 use Shopsys\FrameworkBundle\Form\LocalizedFullWidthType;
 use Shopsys\FrameworkBundle\Form\ProductsType;
@@ -91,7 +90,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
 
         $this->setBasicInformationGroup($builder);
         $this->setSeoGroup($builder);
-        $this->setStocksGroup($builder);
         $this->setDisplayAvailabilityGroup($builder, $product);
         $this->setPricesGroup($builder, $product);
         $this->setRelatedProductsGroup($builder, $product);
@@ -148,12 +146,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
                 'required' => false,
                 'disabled' => true,
                 'label' => t('Use stocks'),
-            ])
-            ->add('domainHidden', MultidomainType::class, [
-                'label' => t('Hide on domain'),
-                'required' => false,
-                'entry_type' => YesNoType::class,
-                'position' => ['after' => 'hidden'],
             ]);
     }
 
@@ -178,24 +170,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
         $builderSeoGroup = $builder->get('seoGroup');
 
         $builderSeoGroup->remove('seoH1s');
-    }
-
-    /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     */
-    private function setStocksGroup(FormBuilderInterface $builder): void
-    {
-        $stockGroupBuilder = $builder->create('stocksGroup', GroupType::class, [
-            'label' => t('Warehouses'),
-        ]);
-
-        $stockGroupBuilder->add('productStockData', CollectionType::class, [
-            'required' => false,
-            'entry_type' => ProductStockFormType::class,
-            'render_form_row' => false,
-        ]);
-
-        $builder->add($stockGroupBuilder);
     }
 
     /**

--- a/project-base/app/src/Model/Product/ProductDataFactory.php
+++ b/project-base/app/src/Model/Product/ProductDataFactory.php
@@ -36,6 +36,7 @@ use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
  * @property \App\Component\Router\FriendlyUrl\FriendlyUrlFacade $friendlyUrlFacade
  * @method fillProductStockByProduct(\App\Model\Product\ProductData $productData, \App\Model\Product\Product $product)
  * @method fillProductStockByStocks(\App\Model\Product\ProductData $productData)
+ * @method \App\Model\Product\ProductData create()
  */
 class ProductDataFactory extends BaseProductDataFactory
 {
@@ -110,26 +111,13 @@ class ProductDataFactory extends BaseProductDataFactory
     }
 
     /**
-     * @return \App\Model\Product\ProductData
-     */
-    public function create(): BaseProductData
-    {
-        $productData = $this->createInstance();
-        $this->fillNew($productData);
-        $this->fillProductStockByStocks($productData);
-
-        return $productData;
-    }
-
-    /**
      * @param \App\Model\Product\Product $product
      * @return \App\Model\Product\ProductData
      */
     public function createFromProduct(BaseProduct $product): BaseProductData
     {
-        $productData = $this->createInstance();
-        $this->fillFromProduct($productData, $product);
-        $this->fillProductStockByProduct($productData, $product);
+        /** @var \App\Model\Product\ProductData $productData */
+        $productData = parent::createFromProduct($product);
         $this->fillProductVideosByProductId($productData, $product);
 
         return $productData;
@@ -225,6 +213,7 @@ class ProductDataFactory extends BaseProductDataFactory
         $productData->pluginData = $this->pluginDataFormExtensionFacade->getAllData('product', $product->getId());
         $productData->weight = $product->getWeight();
         $productData->relatedProducts = $product->getRelatedProducts();
+        $this->fillProductStockByProduct($productData, $product);
     }
 
     /**

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -769,9 +769,6 @@ msgstr "Heureka nastavení - zobrazení"
 msgid "Hide"
 msgstr "Skrýt"
 
-msgid "Hide on domain"
-msgstr "Skrýt na doméně"
-
 msgid "Holiday / internal day detail"
 msgstr "Detail svátku / interního dne"
 

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -769,9 +769,6 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-msgid "Hide on domain"
-msgstr ""
-
 msgid "Holiday / internal day detail"
 msgstr ""
 


### PR DESCRIPTION
After upgrading to platform 14.0, the product form type in the administration does not display the new attributes: "Hidden on domain" and "Warehouse". This pull request fixes this issue by ensuring these attributes are correctly displayed.