### PR TITLE
[project-base] [SSP-2512] fixed issue with invalid ssrExchange initialization

### DIFF
--- a/project-base/storefront/pages/articles/[articleSlug].tsx
+++ b/project-base/storefront/pages/articles/[articleSlug].tsx
@@ -58,25 +58,25 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 context,
             });
 
-            if (isRedirectedFromSsr(context.req.headers)) {
-                const articleResponse: OperationResult<TypeArticleDetailQuery, TypeArticleDetailQueryVariables> =
-                    await client!
-                        .query(ArticleDetailQueryDocument, {
-                            urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
-                        })
-                        .toPromise();
-
-                const article =
-                    articleResponse.data?.article?.__typename === 'ArticleSite' ? articleResponse.data.article : null;
-
-                const parsedCatnums = parseCatnums(article?.text ?? '');
-
+            const articleResponse: OperationResult<TypeArticleDetailQuery, TypeArticleDetailQueryVariables> =
                 await client!
-                    .query(ProductsByCatnumsDocument, {
-                        catnums: parsedCatnums,
+                    .query(ArticleDetailQueryDocument, {
+                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
                     })
                     .toPromise();
 
+            const article =
+                articleResponse.data?.article?.__typename === 'ArticleSite' ? articleResponse.data.article : null;
+
+            const parsedCatnums = parseCatnums(article?.text ?? '');
+
+            await client!
+                .query(ProductsByCatnumsDocument, {
+                    catnums: parsedCatnums,
+                })
+                .toPromise();
+
+            if (isRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     articleResponse.error?.graphQLErrors,
                     articleResponse.data?.article,

--- a/project-base/storefront/pages/articles/[articleSlug].tsx
+++ b/project-base/storefront/pages/articles/[articleSlug].tsx
@@ -15,7 +15,7 @@ import { OgTypeEnum } from 'types/seo';
 import { OperationResult } from 'urql';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { getSlugFromUrl } from 'utils/parsing/getSlugFromUrl';
 import { parseCatnums } from 'utils/parsing/grapesJsParser';
@@ -76,7 +76,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            if (getIsRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     articleResponse.error?.graphQLErrors,
                     articleResponse.data?.article,

--- a/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
+++ b/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
@@ -17,7 +17,7 @@ import { OgTypeEnum } from 'types/seo';
 import { OperationResult } from 'urql';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { getSlugFromUrl } from 'utils/parsing/getSlugFromUrl';
 import { parseCatnums } from 'utils/parsing/grapesJsParser';
@@ -81,7 +81,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            if (getIsRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     blogArticleResponse.error?.graphQLErrors,
                     blogArticleResponse.data?.blogArticle,

--- a/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
+++ b/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
@@ -64,24 +64,24 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 context,
             });
 
+            const blogArticleResponse: OperationResult<
+                TypeBlogArticleDetailQuery,
+                TypeBlogArticleDetailQueryVariables
+            > = await client!
+                .query(BlogArticleDetailQueryDocument, {
+                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                })
+                .toPromise();
+
+            const parsedCatnums = parseCatnums(blogArticleResponse.data?.blogArticle?.text ?? '');
+
+            await client!
+                .query(ProductsByCatnumsDocument, {
+                    catnums: parsedCatnums,
+                })
+                .toPromise();
+
             if (isRedirectedFromSsr(context.req.headers)) {
-                const blogArticleResponse: OperationResult<
-                    TypeBlogArticleDetailQuery,
-                    TypeBlogArticleDetailQueryVariables
-                > = await client!
-                    .query(BlogArticleDetailQueryDocument, {
-                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
-                    })
-                    .toPromise();
-
-                const parsedCatnums = parseCatnums(blogArticleResponse.data?.blogArticle?.text ?? '');
-
-                await client!
-                    .query(ProductsByCatnumsDocument, {
-                        catnums: parsedCatnums,
-                    })
-                    .toPromise();
-
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     blogArticleResponse.error?.graphQLErrors,
                     blogArticleResponse.data?.blogArticle,

--- a/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
+++ b/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
@@ -69,22 +69,22 @@ export const getServerSideProps = getServerSidePropsWrapper(
             });
             const page = getNumberFromUrlQuery(context.query[PAGE_QUERY_PARAMETER_NAME], 1);
 
-            if (isRedirectedFromSsr(context.req.headers)) {
-                const blogCategoryResponse: OperationResult<TypeBlogCategoryQuery, TypeBlogCategoryQueryVariables> =
-                    await client!
-                        .query(BlogCategoryQueryDocument, {
-                            urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
-                        })
-                        .toPromise();
-
+            const blogCategoryResponse: OperationResult<TypeBlogCategoryQuery, TypeBlogCategoryQueryVariables> =
                 await client!
-                    .query(BlogCategoryArticlesDocument, {
-                        uuid: blogCategoryResponse.data?.blogCategory?.uuid,
-                        endCursor: getEndCursor(page),
-                        pageSize: DEFAULT_PAGE_SIZE,
+                    .query(BlogCategoryQueryDocument, {
+                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
                     })
                     .toPromise();
 
+            await client!
+                .query(BlogCategoryArticlesDocument, {
+                    uuid: blogCategoryResponse.data?.blogCategory?.uuid,
+                    endCursor: getEndCursor(page),
+                    pageSize: DEFAULT_PAGE_SIZE,
+                })
+                .toPromise();
+
+            if (isRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     blogCategoryResponse.error?.graphQLErrors,
                     blogCategoryResponse.data?.blogCategory,

--- a/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
+++ b/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
@@ -18,7 +18,7 @@ import { useRouter } from 'next/router';
 import { OperationResult } from 'urql';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getNumberFromUrlQuery } from 'utils/parsing/getNumberFromUrlQuery';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { getSlugFromUrl } from 'utils/parsing/getSlugFromUrl';
@@ -84,7 +84,8 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            const isRedirectedFromSsr = getIsRedirectedFromSsr(context.req.headers);
+            if (isRedirectedFromSsr) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     blogCategoryResponse.error?.graphQLErrors,
                     blogCategoryResponse.data?.blogCategory,

--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -23,7 +23,7 @@ import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { getMappedProductFilter } from 'utils/filterOptions/getMappedProductFilter';
 import { mapParametersFilter } from 'utils/filterOptions/mapParametersFilter';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getRedirectWithOffsetPage } from 'utils/loadMore/getRedirectWithOffsetPage';
 import { getNumberFromUrlQuery } from 'utils/parsing/getNumberFromUrlQuery';
 import { getProductListSortFromUrlQuery } from 'utils/parsing/getProductListSortFromUrlQuery';
@@ -130,7 +130,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
 
             const [brandDetailResponse] = await Promise.all([brandDetailResponsePromise, brandProductsResponsePromise]);
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            if (getIsRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     brandDetailResponse.error?.graphQLErrors,
                     brandDetailResponse.data?.brand,

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -23,7 +23,7 @@ import { NextPage } from 'next';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { getMappedProductFilter } from 'utils/filterOptions/getMappedProductFilter';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getRedirectWithOffsetPage } from 'utils/loadMore/getRedirectWithOffsetPage';
 import { getNumberFromUrlQuery } from 'utils/parsing/getNumberFromUrlQuery';
 import { getProductListSortFromUrlQuery } from 'utils/parsing/getProductListSortFromUrlQuery';
@@ -125,7 +125,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
 
             categoryUuid = categoryDetailResponse.data?.category?.uuid || null;
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            if (getIsRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     categoryDetailResponse.error?.graphQLErrors,
                     categoryDetailResponse.data?.category,

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -21,7 +21,7 @@ import { useRouter } from 'next/router';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
 import { getMappedProductFilter } from 'utils/filterOptions/getMappedProductFilter';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getRedirectWithOffsetPage } from 'utils/loadMore/getRedirectWithOffsetPage';
 import { getNumberFromUrlQuery } from 'utils/parsing/getNumberFromUrlQuery';
 import { getProductListSortFromUrlQuery } from 'utils/parsing/getProductListSortFromUrlQuery';
@@ -119,7 +119,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
 
             const [flagDetailResponse] = await Promise.all([flagDetailResponsePromise, flagProductsResponsePromise]);
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            if (getIsRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     flagDetailResponse.error?.graphQLErrors,
                     flagDetailResponse.data?.flag,

--- a/project-base/storefront/pages/stores/[storeSlug].tsx
+++ b/project-base/storefront/pages/stores/[storeSlug].tsx
@@ -58,14 +58,13 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 context,
             });
 
-            if (isRedirectedFromSsr(context.req.headers)) {
-                const storeResponse: OperationResult<TypeStoreDetailQuery, TypeStoreDetailQueryVariables> =
-                    await client!
-                        .query(StoreDetailQueryDocument, {
-                            urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
-                        })
-                        .toPromise();
+            const storeResponse: OperationResult<TypeStoreDetailQuery, TypeStoreDetailQueryVariables> = await client!
+                .query(StoreDetailQueryDocument, {
+                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                })
+                .toPromise();
 
+            if (isRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     storeResponse.error?.graphQLErrors,
                     storeResponse.data?.store,

--- a/project-base/storefront/pages/stores/[storeSlug].tsx
+++ b/project-base/storefront/pages/stores/[storeSlug].tsx
@@ -14,7 +14,7 @@ import { useRouter } from 'next/router';
 import { OperationResult } from 'urql';
 import { createClient } from 'urql/createClient';
 import { handleServerSideErrorResponseForFriendlyUrls } from 'utils/errors/handleServerSideErrorResponseForFriendlyUrls';
-import { isRedirectedFromSsr } from 'utils/isRedirectedFromSsr';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { getSlugFromUrl } from 'utils/parsing/getSlugFromUrl';
 import { getPrefixedSeoTitle } from 'utils/seo/getPrefixedSeoTitle';
@@ -64,7 +64,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 })
                 .toPromise();
 
-            if (isRedirectedFromSsr(context.req.headers)) {
+            if (getIsRedirectedFromSsr(context.req.headers)) {
                 const serverSideErrorResponse = handleServerSideErrorResponseForFriendlyUrls(
                     storeResponse.error?.graphQLErrors,
                     storeResponse.data?.store,

--- a/project-base/storefront/utils/getIsRedirectedFromSsr.ts
+++ b/project-base/storefront/utils/getIsRedirectedFromSsr.ts
@@ -1,5 +1,5 @@
 import { NextIncomingMessage } from 'next/dist/server/request-meta';
 
-export const isRedirectedFromSsr = (requestHeader: NextIncomingMessage['headers']): boolean => {
+export const getIsRedirectedFromSsr = (requestHeader: NextIncomingMessage['headers']): boolean => {
     return requestHeader['x-nextjs-data'] !== '1';
 };

--- a/upgrade-notes/storefront_20240807_194942.md
+++ b/upgrade-notes/storefront_20240807_194942.md
@@ -1,0 +1,10 @@
+#### fixed issue with invalid ssrExchange initialization ([#3321](https://github.com/shopsys/shopsys/pull/3321))
+
+-   `isRedirectedFromSsr` was renamed to `getIsRedirectedFromSsr` as it more suits the function character
+-   you should use a single instance of `ssrExchange` on the client, so make sure you make it a singleton (using `useMemo` as visible in `UrqlWrapper.tsx`)
+-   you should call your queries inside `getServerSideProps` the same way both during the first page load and during client-side navigation
+    -   this should be done because of
+        -   consistency (same behavior during both types of page load)
+        -   performance (should be quicker and more optimal to call queries from the server)
+    -   for this, you will most likely have to move the condition using `getIsRedirectedFromSsr` lower in order to call the queries, but still not call `handleServerSideErrorResponseForFriendlyUrls` during client-side navigation, because it could cause some problems if the API query/mutation results in an error (this is a known issue)
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
This PR fixes the invalid initialization of `ssrExchange` on the client by making it a singleton, ensuring SSR-fetched queries during client-side navigation are reused instead of refetched. Additionally, the `isRedirectedFromSsr` flag is now positioned lower in `getServerSideProps` to fetch all necessary data on the server without triggering `handleServerSideErrorResponseForFriendlyUrls`, which could cause issues if a query error occurs on the API.


#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2512-ssr-prefetched-used-on-client.odin.shopsys.cloud
  - https://cz.sh-ssp-2512-ssr-prefetched-used-on-client.odin.shopsys.cloud
<!-- Replace -->
