### PR TITLE
[project-base] Disable middleware prefetch

### DIFF
--- a/project-base/storefront/next.config.js
+++ b/project-base/storefront/next.config.js
@@ -9,7 +9,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    experimental: { scrollRestoration: true },
+    experimental: { scrollRestoration: true, middlewarePrefetch: 'strict' },
     reactStrictMode: true,
     swcMinify: true,
     assetPrefix: process.env.CDN_DOMAIN ?? undefined,

--- a/upgrade-notes/storefront_20240809_075813.md
+++ b/upgrade-notes/storefront_20240809_075813.md
@@ -1,0 +1,4 @@
+#### disable middleware prefetch ([3325](https://github.com/shopsys/shopsys/pull/3325))
+
+-   Middleware prefetch is disabled now to prevent multiple useless requests to SF
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
On every link on SF NextJS created request to prefetch middleware and returned empty data which is useless for us and this creates DDoS to our SF.

This PR disable this functionality. Look at original issue: https://github.com/vercel/next.js/discussions/44596

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-middleware-prefetch.odin.shopsys.cloud
  - https://cz.jg-middleware-prefetch.odin.shopsys.cloud
<!-- Replace -->
