### PR TITLE
[project-base] [SSP-2500] fixed margins in adverts on category detail page

### DIFF
--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -77,7 +77,7 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
                 {isPanelOpen && <Overlay isActive={isPanelOpen} onClick={handlePanelOpenerClick} />}
 
                 <div className="flex flex-1 flex-col">
-                    <Adverts className="mt-6" currentCategory={category} positionName="productList" />
+                    <Adverts className="mb-6" currentCategory={category} positionName="productList" />
 
                     <h1>{title}</h1>
 

--- a/upgrade-notes/storefront_20240809_121652.md
+++ b/upgrade-notes/storefront_20240809_121652.md
@@ -1,0 +1,3 @@
+#### fixed margins in adverts on category detail page ([#3327](https://github.com/shopsys/shopsys/pull/3327))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Margins caused the advert to not be correctly aligned. Furthermore, the advert was too close to the category title. This PR fixes it.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://sh-ssp-2500-fix-adverts-margin.odin.shopsys.cloud
  - https://cz.sh-ssp-2500-fix-adverts-margin.odin.shopsys.cloud
<!-- Replace -->
