### PR TITLE
[shopsys] fixed duplicate addDomain to query builder

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -74,6 +74,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   see #project-base-diff to update your project
 
+#### fixed duplicate addDomain to query builder ([#3338](https://github.com/shopsys/shopsys/pull/3338))
+
+-   see #project-base-diff to update your project
+
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 
 #### add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -214,7 +214,6 @@ class ProductRepository
         $queryBuilder = $this->getAllListableQueryBuilder($domainId, $pricingGroup);
 
         $this->addTranslation($queryBuilder, $locale);
-        $this->addDomain($queryBuilder, $domainId);
 
         $this->productElasticsearchRepository->filterBySearchText($queryBuilder, $searchText);
 

--- a/project-base/app/src/Model/Product/ProductRepository.php
+++ b/project-base/app/src/Model/Product/ProductRepository.php
@@ -135,28 +135,6 @@ class ProductRepository extends BaseProductRepository
      * @param string|null $searchText
      * @return \Doctrine\ORM\QueryBuilder
      */
-    public function getListableBySearchTextQueryBuilder(
-        $domainId,
-        PricingGroup $pricingGroup,
-        $locale,
-        $searchText,
-    ) {
-        $queryBuilder = $this->getAllListableQueryBuilder($domainId, $pricingGroup);
-
-        $this->addTranslation($queryBuilder, $locale);
-
-        $this->productElasticsearchRepository->filterBySearchText($queryBuilder, $searchText);
-
-        return $queryBuilder;
-    }
-
-    /**
-     * @param int $domainId
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
-     * @param string $locale
-     * @param string|null $searchText
-     * @return \Doctrine\ORM\QueryBuilder
-     */
     public function getSellableBySearchTextQueryBuilder(
         $domainId,
         PricingGroup $pricingGroup,


### PR DESCRIPTION
In the method `getListableBySearchTextQueryBuilder`, the product domain is added to the query builder. However, in the method `getAllListableQueryBuilder`, the product domain is added to the query builder right from the start