### PR TITLE
[project-base] storefront cypress is now removed after cypress tests finish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ define run_acceptance_tests
 	docker compose stop storefront
 	docker compose up -d --wait storefront-cypress --force-recreate
 	-docker compose run --rm -e TYPE=$(1) -e COMMAND=run cypress;
-	docker compose stop storefront-cypress
+	docker rm -f shopsys-framework-storefront-cypress
 	docker compose up -d storefront
 	docker compose exec php-fpm php phing -D change.environment=dev environment-change
 endef
@@ -64,7 +64,7 @@ define open_acceptance_tests
 		xhost + $(get_ip); \
 	fi
 	-docker compose run --rm -e TYPE=$(1) -e DISPLAY=$(get_ip):0 -e COMMAND=open cypress;
-	docker compose stop storefront-cypress
+	docker rm -f shopsys-framework-storefront-cypress
 	docker compose up -d storefront
 	docker compose exec php-fpm php phing -D change.environment=dev environment-change
 endef

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -28,7 +28,7 @@ define run_acceptance_tests
 	docker compose stop storefront
 	docker compose up -d --wait storefront-cypress --force-recreate
 	-docker compose run --rm -e TYPE=$(1) -e COMMAND=run cypress;
-	docker compose stop storefront-cypress
+	docker rm -f shopsys-framework-storefront-cypress
 	docker compose up -d storefront
 	docker compose exec php-fpm php phing -D change.environment=dev environment-change
 endef
@@ -57,7 +57,7 @@ define open_acceptance_tests
 		xhost + $(get_ip); \
 	fi
 	-docker compose run --rm -e TYPE=$(1) -e DISPLAY=$(get_ip):0 -e COMMAND=open cypress;
-	docker compose stop storefront-cypress
+	docker rm -f shopsys-framework-storefront-cypress
 	docker compose up -d storefront
 	docker compose exec php-fpm php phing -D change.environment=dev environment-change
 endef


### PR DESCRIPTION
#### Description, the reason for the PR
In some environments, stopping the storefront-cypress container after cypress tests had finished did not work properly, which left the app in an invalid state. This PR takes a different approach and fixes this issue.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
