### PR TITLE
[project-base][SSP-2537] forbidden grapesjs image resize

### DIFF
--- a/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-custom-image-plugin.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-custom-image-plugin.js
@@ -32,6 +32,7 @@ export default grapesjs.plugins.add('custom-image', (editor) => {
             },
 
             defaults: {
+                resizable: false,
                 attributes: {
                     [imagePositionDataAttribute]: 'left',
                     class: ['image-position-left']

--- a/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-text-with-image-plugin.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-text-with-image-plugin.js
@@ -64,6 +64,7 @@ export default grapesjs.plugins.add('text-with-image', editor => {
                 draggable: false,
                 copyable: false,
                 droppable: false,
+                resizable: false,
                 propagate: ['removable', 'draggable', 'copyable', 'droppable'],
                 attributes: {
                     [IMAGE_POSITION_DATA_ATTRIBUTE]: IMAGE_POSITION_LEFT,

--- a/upgrade-notes/storefront_20240816_104132.md
+++ b/upgrade-notes/storefront_20240816_104132.md
@@ -1,0 +1,3 @@
+#### disable grapejs image resize ([#3351](https://github.com/shopsys/shopsys/pull/3351))
+
+-   in the GrapesJS editor, image resizing is now disabled


### PR DESCRIPTION
#### Description, the reason for the PR
In the GrapesJS editor, image resizing is now disabled.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2537-forbid-grapejs-image-resiza.odin.shopsys.cloud
  - https://cz.tc-ssp-2537-forbid-grapejs-image-resiza.odin.shopsys.cloud
<!-- Replace -->
