### PR TITLE
[framework] limited user can't use free transport and gateway payments

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -136,6 +136,8 @@ return ECSConfig::configure()
                 __DIR__ . '/packages/framework/tests/Unit/Component/Domain/DomainDataCreatorTest.php',
                 __DIR__ . '/packages/framework/tests/Unit/Model/Category/CategoryNestedSetCalculatorTest.php',
                 __DIR__ . '/packages/framework/tests/Unit/Model/Mail/EnvelopeListenerTest.php',
+                __DIR__ . '/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php',
+                __DIR__ . '/packages/framework/tests/Unit/Model/Payment/IndependentPaymentVisibilityCalculationTest.php',
                 __DIR__ . '/packages/migrations/tests/Unit/Component/Doctrine/Migrations/MigrationsLockComparatorTest.php',
                 __DIR__ . '/packages/product-feed-zbozi/src/DataFixtures/ZboziPluginDataFixture.php',
                 __DIR__ . '/utils/releaser/src/ReleaseWorker/Release/CreateAndPushGitTagsExceptProjectBaseReleaseWorker.php',

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleProvider.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleProvider.php
@@ -29,11 +29,15 @@ class CustomerUserRoleProvider
     }
 
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser $customerUser
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser|null $customerUser
      * @return bool
      */
-    public function canSeePrices(CustomerUser $customerUser): bool
+    public function canCustomerUserSeePrices(?CustomerUser $customerUser): bool
     {
+        if ($customerUser === null) {
+            return true;
+        }
+
         $roles = $this->getRolesForCustomerUser($customerUser);
 
         return in_array(CustomerUserRole::ROLE_API_CUSTOMER_SEES_PRICES, $roles, true);

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleProvider.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleProvider.php
@@ -6,14 +6,17 @@ namespace Shopsys\FrameworkBundle\Model\Customer\User\Role;
 
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Component\Security\Core\Security;
 
 class CustomerUserRoleProvider
 {
     /**
      * @param \Symfony\Component\Security\Core\Role\RoleHierarchyInterface $roleHierarchy
+     * @param \Symfony\Component\Security\Core\Security $security
      */
     public function __construct(
         protected readonly RoleHierarchyInterface $roleHierarchy,
+        protected readonly Security $security,
     ) {
     }
 
@@ -41,5 +44,17 @@ class CustomerUserRoleProvider
         $roles = $this->getRolesForCustomerUser($customerUser);
 
         return in_array(CustomerUserRole::ROLE_API_CUSTOMER_SEES_PRICES, $roles, true);
+    }
+
+    /**
+     * @return bool
+     */
+    public function canCurrentCustomerUserSeePrices(): bool
+    {
+        if ($this->security->getUser() === null) {
+            return true;
+        }
+
+        return $this->security->isGranted(CustomerUserRole::ROLE_API_CUSTOMER_SEES_PRICES);
     }
 }

--- a/packages/framework/src/Model/Payment/IndependentPaymentVisibilityCalculation.php
+++ b/packages/framework/src/Model/Payment/IndependentPaymentVisibilityCalculation.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
 
 class IndependentPaymentVisibilityCalculation
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider $customerUserRoleProvider
      */
-    public function __construct(protected readonly Domain $domain)
-    {
+    public function __construct(
+        protected readonly Domain $domain,
+        protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
+    ) {
     }
 
     /**
@@ -35,6 +39,14 @@ class IndependentPaymentVisibilityCalculation
             return false;
         }
 
-        return $payment->isEnabled($domainId);
+        if (!$payment->isEnabled($domainId)) {
+            return false;
+        }
+
+        if (!$this->customerUserRoleProvider->canCurrentCustomerUserSeePrices()) {
+            return !$payment->isGatewayPayment();
+        }
+
+        return true;
     }
 }

--- a/packages/framework/src/Model/Payment/Payment.php
+++ b/packages/framework/src/Model/Payment/Payment.php
@@ -488,4 +488,22 @@ class Payment extends AbstractTranslatableEntity implements OrderableEntityInter
     {
         return $this->uuid;
     }
+
+    /**
+     * @return string[]
+     */
+    protected function getGatewayPayments(): array
+    {
+        return [
+            self::TYPE_GOPAY,
+        ];
+    }
+
+    /**
+     * @return bool
+     */
+    public function isGatewayPayment(): bool
+    {
+        return in_array($this->type, $this->getGatewayPayments(), true);
+    }
 }

--- a/packages/framework/src/Model/Payment/PaymentFacade.php
+++ b/packages/framework/src/Model/Payment/PaymentFacade.php
@@ -342,11 +342,12 @@ class PaymentFacade
     public function isPaymentVisibleAndEnabledOnCurrentDomain(Payment $payment): bool
     {
         try {
-            $this->getEnabledOnDomainByUuid($payment->getUuid(), $this->domain->getId());
+            $domainId = $this->domain->getId();
+            $payment = $this->getEnabledOnDomainByUuid($payment->getUuid(), $domainId);
+
+            return $this->paymentVisibilityCalculation->isVisible($payment, $domainId);
         } catch (PaymentNotFoundException $exception) {
             return false;
         }
-
-        return true;
     }
 }

--- a/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Payment;
 
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
@@ -14,10 +15,12 @@ class PaymentPriceCalculation
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation $basePriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider $customerUserRoleProvider
      */
     public function __construct(
         protected readonly BasePriceCalculation $basePriceCalculation,
         protected readonly PricingSetting $pricingSetting,
+        protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
     ) {
     }
 
@@ -64,6 +67,10 @@ class PaymentPriceCalculation
      */
     protected function isFree(Price $productsPrice, int $domainId): bool
     {
+        if (!$this->customerUserRoleProvider->canCurrentCustomerUserSeePrices()) {
+            return false;
+        }
+
         $freeTransportAndPaymentPriceLimit = $this->pricingSetting->getFreeTransportAndPaymentPriceLimit($domainId);
 
         if ($freeTransportAndPaymentPriceLimit === null) {

--- a/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentPriceCalculation.php
@@ -79,31 +79,4 @@ class PaymentPriceCalculation
 
         return $productsPrice->getPriceWithVat()->isGreaterThanOrEqualTo($freeTransportAndPaymentPriceLimit);
     }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Payment\Payment[] $payments
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency $currency
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Price $productsPrice
-     * @param int $domainId
-     * @return \Shopsys\FrameworkBundle\Model\Pricing\Price[]
-     */
-    public function getCalculatedPricesIndexedByPaymentId(
-        array $payments,
-        Currency $currency,
-        Price $productsPrice,
-        int $domainId,
-    ): array {
-        $paymentsPricesByPaymentId = [];
-
-        foreach ($payments as $payment) {
-            $paymentsPricesByPaymentId[$payment->getId()] = $this->calculatePrice(
-                $payment,
-                $currency,
-                $productsPrice,
-                $domainId,
-            );
-        }
-
-        return $paymentsPricesByPaymentId;
-    }
 }

--- a/packages/framework/src/Model/Payment/PaymentVisibilityCalculation.php
+++ b/packages/framework/src/Model/Payment/PaymentVisibilityCalculation.php
@@ -41,7 +41,7 @@ class PaymentVisibilityCalculation
      * @param int $domainId
      * @return bool
      */
-    protected function isVisible(Payment $payment, $domainId)
+    public function isVisible(Payment $payment, $domainId)
     {
         if (!$this->independentPaymentVisibilityCalculation->isIndependentlyVisible($payment, $domainId)) {
             return false;

--- a/packages/framework/src/Model/Transport/TransportPriceCalculation.php
+++ b/packages/framework/src/Model/Transport/TransportPriceCalculation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Transport;
 
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
@@ -14,10 +15,12 @@ class TransportPriceCalculation
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation $basePriceCalculation
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider $customerUserRoleProvider
      */
     public function __construct(
         protected readonly BasePriceCalculation $basePriceCalculation,
         protected readonly PricingSetting $pricingSetting,
+        protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
     ) {
     }
 
@@ -64,6 +67,10 @@ class TransportPriceCalculation
      */
     protected function isFree(Price $productsPrice, int $domainId): bool
     {
+        if (!$this->customerUserRoleProvider->canCurrentCustomerUserSeePrices()) {
+            return false;
+        }
+
         $freeTransportAndPaymentPriceLimit = $this->pricingSetting->getFreeTransportAndPaymentPriceLimit($domainId);
 
         if ($freeTransportAndPaymentPriceLimit === null) {

--- a/packages/framework/src/Model/TransportAndPayment/FreeTransportAndPaymentFacade.php
+++ b/packages/framework/src/Model/TransportAndPayment/FreeTransportAndPaymentFacade.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\TransportAndPayment;
 
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 
 class FreeTransportAndPaymentFacade
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Pricing\PricingSetting $pricingSetting
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider $customerUserRoleProvider
      */
-    public function __construct(protected readonly PricingSetting $pricingSetting)
-    {
+    public function __construct(
+        protected readonly PricingSetting $pricingSetting,
+        protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
+    ) {
     }
 
     /**
@@ -22,6 +26,10 @@ class FreeTransportAndPaymentFacade
      */
     public function isActive($domainId)
     {
+        if (!$this->customerUserRoleProvider->canCurrentCustomerUserSeePrices()) {
+            return false;
+        }
+
         return $this->getFreeTransportAndPaymentPriceLimitOnDomain($domainId) !== null;
     }
 

--- a/packages/framework/src/Model/TransportAndPayment/FreeTransportAndPaymentFacade.php
+++ b/packages/framework/src/Model/TransportAndPayment/FreeTransportAndPaymentFacade.php
@@ -30,7 +30,7 @@ class FreeTransportAndPaymentFacade
      * @param int $domainId
      * @return bool
      */
-    public function isFree(Money $productsPriceWithVat, $domainId)
+    protected function isFree(Money $productsPriceWithVat, $domainId)
     {
         $freeTransportAndPaymentPriceLimit = $this->getFreeTransportAndPaymentPriceLimitOnDomain($domainId);
 

--- a/packages/framework/src/Twig/HiddenPriceExtension.php
+++ b/packages/framework/src/Twig/HiddenPriceExtension.php
@@ -40,7 +40,7 @@ class HiddenPriceExtension extends AbstractExtension
      */
     public function hidePriceFilter(string $price, ?CustomerUser $customerUser): string
     {
-        if ($customerUser !== null && !$this->customerUserRoleProvider->canSeePrices($customerUser)) {
+        if (!$this->customerUserRoleProvider->canCustomerUserSeePrices($customerUser)) {
             return MoneyFormatterHelper::HIDDEN_FORMAT;
         }
 

--- a/packages/framework/tests/Unit/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Payment/IndependentPaymentVisibilityCalculationTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Model\Payment;
+
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
+use Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation;
+use Shopsys\FrameworkBundle\Model\Payment\Payment;
+use Tests\FrameworkBundle\Test\SetTranslatorTrait;
+
+class IndependentPaymentVisibilityCalculationTest extends TestCase
+{
+    use SetTranslatorTrait;
+
+    private Domain|MockObject $domainMock;
+
+    private CustomerUserRoleProvider|MockObject $customerUserRoleProviderMock;
+
+    private IndependentPaymentVisibilityCalculation $paymentVisibilityCalculation;
+
+    protected function setUp(): void
+    {
+        $defaultTimeZone = new DateTimeZone('Europe/Prague');
+        $this->domainMock = $this->createMock(Domain::class);
+        $this->domainMock->method('getDomainConfigById')
+            ->willReturn(
+                new DomainConfig(Domain::FIRST_DOMAIN_ID, '', '', 'cs', $defaultTimeZone),
+            );
+
+        $this->customerUserRoleProviderMock = $this->createMock(CustomerUserRoleProvider::class);
+        $this->paymentVisibilityCalculation = new IndependentPaymentVisibilityCalculation(
+            $this->domainMock,
+            $this->customerUserRoleProviderMock,
+        );
+    }
+
+    /**
+     * @param bool $canSeePrices
+     * @param bool $isGatewayPayment
+     * @param bool $isHidden
+     * @param bool $isDeleted
+     * @param bool $isHiddenByGoPay
+     * @param string $name
+     * @param bool $isEnabled
+     * @param bool $expectedResult
+     */
+    #[DataProvider('paymentVisibilityProvider')]
+    public function testIsIndependentlyVisible(
+        bool $canSeePrices,
+        bool $isGatewayPayment,
+        bool $isHidden,
+        bool $isDeleted,
+        bool $isHiddenByGoPay,
+        string $name,
+        bool $isEnabled,
+        bool $expectedResult,
+    ) {
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('isGatewayPayment')->willReturn($isGatewayPayment);
+        $paymentMock->method('isHidden')->willReturn($isHidden);
+        $paymentMock->method('isDeleted')->willReturn($isDeleted);
+        $paymentMock->method('isHiddenByGoPayByDomainId')->willReturn($isHiddenByGoPay);
+        $paymentMock->method('getName')->willReturn($name);
+        $paymentMock->method('isEnabled')->willReturn($isEnabled);
+
+        $this->customerUserRoleProviderMock->method('canCurrentCustomerUserSeePrices')->willReturn($canSeePrices);
+        $this->domainMock->method('getDomainConfigById')->willReturn((object)['locale' => 'en']);
+
+        $this->assertEquals($expectedResult, $this->paymentVisibilityCalculation->isIndependentlyVisible($paymentMock, 1));
+    }
+
+    /**
+     * @return array
+     */
+    public static function paymentVisibilityProvider(): array
+    {
+        return [
+            'Customer can see prices' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => true,
+            ],
+            'Payment name is empty' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => '',
+                'isEnabled' => true,
+                'expectedResult' => false,
+            ],
+            'Payment is hidden' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => true,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => false,
+            ],
+            'Payment is deleted' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => true,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => false,
+            ],
+            'Payment is hidden by GoPay' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => true,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => false,
+            ],
+            'Payment is enabled' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => true,
+            ],
+            'Payment is not enabled' => [
+                'canSeePrices' => true,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => false,
+                'expectedResult' => false,
+            ],
+            'Customer cannot see prices and payment is a gateway payment' => [
+                'canSeePrices' => false,
+                'isGatewayPayment' => true,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => false,
+            ],
+            'Customer cannot see prices and payment is not a gateway payment' => [
+                'canSeePrices' => false,
+                'isGatewayPayment' => false,
+                'isHidden' => false,
+                'isDeleted' => false,
+                'isHiddenByGoPay' => false,
+                'name' => 'Payment Name',
+                'isEnabled' => true,
+                'expectedResult' => true,
+            ],
+        ];
+    }
+}

--- a/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Payment/PaymentPriceCalculationTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
 use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentData;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation;
@@ -90,13 +91,20 @@ class PaymentPriceCalculationTest extends TestCase
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
                 ->willReturn($inputPriceType);
+        $customerUserRoleProviderMock = $this->getMockBuilder(CustomerUserRoleProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['canCurrentCustomerUserSeePrices'])
+            ->getMock();
+        $customerUserRoleProviderMock
+            ->expects($this->any())->method('canCurrentCustomerUserSeePrices')
+                ->willReturn(true);
 
         $rounding = new Rounding();
 
         $priceCalculation = new PriceCalculation($rounding);
         $basePriceCalculation = new BasePriceCalculation($priceCalculation, $rounding);
 
-        $paymentPriceCalculation = new PaymentPriceCalculation($basePriceCalculation, $pricingSettingMock);
+        $paymentPriceCalculation = new PaymentPriceCalculation($basePriceCalculation, $pricingSettingMock, $customerUserRoleProviderMock);
 
         $vatData = new VatData();
         $vatData->name = 'vat';
@@ -162,13 +170,20 @@ class PaymentPriceCalculationTest extends TestCase
         $pricingSettingMock
             ->expects($this->any())->method('getFreeTransportAndPaymentPriceLimit')
                 ->willReturn($priceLimit);
+        $customerUserRoleProviderMock = $this->getMockBuilder(CustomerUserRoleProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['canCurrentCustomerUserSeePrices'])
+            ->getMock();
+        $customerUserRoleProviderMock
+            ->expects($this->any())->method('canCurrentCustomerUserSeePrices')
+                ->willReturn(true);
 
         $rounding = new Rounding();
 
         $priceCalculation = new PriceCalculation($rounding);
         $basePriceCalculation = new BasePriceCalculation($priceCalculation, $rounding);
 
-        $paymentPriceCalculation = new PaymentPriceCalculation($basePriceCalculation, $pricingSettingMock);
+        $paymentPriceCalculation = new PaymentPriceCalculation($basePriceCalculation, $pricingSettingMock, $customerUserRoleProviderMock);
 
         $vatData = new VatData();
         $vatData->name = 'vat';

--- a/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleProvider;
 use Shopsys\FrameworkBundle\Model\Pricing\BasePriceCalculation;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
@@ -67,12 +68,20 @@ class TransportPriceCalculationTest extends TestCase
         $pricingSettingMock
             ->expects($this->any())->method('getInputPriceType')
                 ->willReturn($inputPriceType);
+        $customerUserRoleProviderMock = $this->getMockBuilder(CustomerUserRoleProvider::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['canCurrentCustomerUserSeePrices'])
+            ->getMock();
+
+        $customerUserRoleProviderMock
+            ->expects($this->any())->method('canCurrentCustomerUserSeePrices')
+                ->willReturn(true);
 
         $rounding = new Rounding();
         $priceCalculation = new PriceCalculation($rounding);
         $basePriceCalculation = new BasePriceCalculation($priceCalculation, $rounding);
 
-        $transportPriceCalculation = new TransportPriceCalculation($basePriceCalculation, $pricingSettingMock);
+        $transportPriceCalculation = new TransportPriceCalculation($basePriceCalculation, $pricingSettingMock, $customerUserRoleProviderMock);
 
         $vatData = new VatData();
         $vatData->name = 'vat';

--- a/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
+++ b/packages/framework/tests/Unit/Model/Transport/TransportPriceCalculationTest.php
@@ -72,7 +72,6 @@ class TransportPriceCalculationTest extends TestCase
             ->disableOriginalConstructor()
             ->onlyMethods(['canCurrentCustomerUserSeePrices'])
             ->getMock();
-
         $customerUserRoleProviderMock
             ->expects($this->any())->method('canCurrentCustomerUserSeePrices')
                 ->willReturn(true);

--- a/project-base/app/tests/FrontendApiBundle/Functional/Price/HiddenPricesTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Price/HiddenPricesTest.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactory;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroup;
 use Shopsys\FrameworkBundle\Model\Order\Order;
+use Shopsys\FrameworkBundle\Model\Payment\Payment;
 use Tests\FrontendApiBundle\Test\GraphQlWithLoginTestCase;
 
 class HiddenPricesTest extends GraphQlWithLoginTestCase
@@ -97,6 +98,32 @@ class HiddenPricesTest extends GraphQlWithLoginTestCase
             $this->assertSame('***', $item['totalPrice']['priceWithoutVat']);
             $this->assertSame('***', $item['unitPrice']['priceWithVat']);
             $this->assertSame('***', $item['unitPrice']['priceWithoutVat']);
+        }
+    }
+
+    public function testCustomerUserCannotSeeGatewayPayments(): void
+    {
+        $query = '
+            query {
+                payments {
+                    uuid
+                    type
+                    price {
+                        priceWithVat
+                        priceWithoutVat
+                    }
+                }
+            }
+        ';
+
+        $response = $this->getResponseContentForQuery($query);
+        $payments = $response['data']['payments'];
+        $this->assertCount(4, $payments);
+
+        foreach ($payments as $payment) {
+            $this->assertSame('***', $payment['price']['priceWithVat']);
+            $this->assertSame('***', $payment['price']['priceWithoutVat']);
+            $this->assertSame(Payment::TYPE_BASIC, $payment['type']);
         }
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Price/HiddenPricesTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Price/HiddenPricesTest.php
@@ -126,4 +126,30 @@ class HiddenPricesTest extends GraphQlWithLoginTestCase
             $this->assertSame(Payment::TYPE_BASIC, $payment['type']);
         }
     }
+
+    public function testCustomerUserCannotUseFreeTransport(): void
+    {
+        $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . '1', Product::class);
+        $mutation = 'mutation {
+            AddToCart(
+                input: {
+                    productUuid: "' . $product->getUuid() . '"
+                    quantity: 1
+                }
+            ) {
+                cart {
+                    uuid
+                    remainingAmountWithVatForFreeTransport
+                }
+            }
+        }';
+
+        $response = $this->getResponseContentForQuery($mutation);
+        $newlyCreatedCart = $response['data']['AddToCart']['cart'];
+
+        self::assertNull(
+            $newlyCreatedCart['remainingAmountWithVatForFreeTransport'],
+            'Actual remaining price has to be null for limited user who cannot see prices',
+        );
+    }
 }

--- a/upgrade-notes/backend_20240818_204612.md
+++ b/upgrade-notes/backend_20240818_204612.md
@@ -1,0 +1,37 @@
+#### {limited user can't user free transport and gateway payments ([#3355](https://github.com/shopsys/shopsys/pull/3355))
+
+-   constructor `Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation` changed its interface
+    ```diff
+        public function __construct(
+            protected readonly Domain $domain,
+    +       protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
+        ) {
+    ```
+-   constructor `Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation` changed its interface
+    ```diff
+        public function __construct(
+            protected readonly BasePriceCalculation $basePriceCalculation,
+            protected readonly PricingSetting $pricingSetting,
+    +       protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
+        ) {
+    ```
+-   constructor `Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade` changed its interface
+    ```diff
+        public function __construct(
+            protected readonly PricingSetting $pricingSetting,
+    +       protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
+        ) {
+    ```
+-   constructor `Shopsys\FrameworkBundle\Model\Transport\TransportPriceCalculation` changed its interface
+
+```diff
+    public function __construct(
+          protected readonly BasePriceCalculation $basePriceCalculation,
+          protected readonly PricingSetting $pricingSetting,
+    +     protected readonly CustomerUserRoleProvider $customerUserRoleProvider,
+    ) {
+```
+
+-   method `Shopsys\FrameworkBundle\Model\TransportAndPayment\FreeTransportAndPaymentFacade::isFree` changed visibility to `protected`
+-   method `Shopsys\FrameworkBundle\Model\Payment\PaymentPriceCalculation::getCalculatedPricesIndexedByPaymentId` was removed
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
limited user can't use free transport and can't user gateway payments in order 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [x] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
































<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced payment and transport calculations to respect user roles regarding price visibility.
	- Improved logic for determining payment visibility based on customer roles.
	- Added new tests to validate payment visibility and pricing logic against user roles.

- **Bug Fixes**
	- Improved handling of price visibility in various components across the application.

- **Documentation**
	- Updated translations to support new role and visibility features in multiple languages.

- **Tests**
	- Added functional tests to ensure limited users cannot access sensitive pricing information.
	- Added unit tests to validate new role-based visibility logic for payments and personal data exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-limited-user-orders.odin.shopsys.cloud
  - https://cz.mt-limited-user-orders.odin.shopsys.cloud
<!-- Replace -->
