### PR TITLE
[framework] Annotations fixer access of nullable does not break fixer

### DIFF
--- a/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
+++ b/packages/framework/src/Component/ClassExtension/MethodAnnotationsFactory.php
@@ -129,7 +129,7 @@ class MethodAnnotationsFactory
         try {
             $reflectionMethod = $reflectionClass->getMethod($methodName);
 
-            return $reflectionMethod->getDeclaringClass()->getName() === $reflectionClass->getName();
+            return $reflectionMethod?->getDeclaringClass()->getName() === $reflectionClass->getName();
         } catch (OutOfBoundsException $ex) {
             return false;
         }


### PR DESCRIPTION
Fix anntoations fixer access to nullable variable