### PR TITLE
[framework] the price filter now takes into account the pricing group

### DIFF
--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -229,15 +229,15 @@ class FilterQuery
         ?Money $maximalPrice = null,
     ): self {
         $clone = clone $this;
-
-        $prices = [];
+        $priceGte = null;
+        $priceLte = null;
 
         if ($minimalPrice !== null) {
-            $prices['gte'] = (float)$minimalPrice->getAmount();
+            $priceGte = (float)$minimalPrice->getAmount();
         }
 
         if ($maximalPrice !== null) {
-            $prices['lte'] = (float)$maximalPrice->getAmount();
+            $priceLte = (float)$maximalPrice->getAmount();
         }
 
         $clone->filters[] = [
@@ -249,14 +249,27 @@ class FilterQuery
                             'match_all' => new stdClass(),
                         ],
                         'filter' => [
-                            [
-                                'term' => [
-                                    'prices.pricing_group_id' => $pricingGroup->getId(),
-                                ],
-                            ],
-                            [
-                                'range' => [
-                                    'prices.price_with_vat' => $prices,
+                            'bool' => [
+                                'must' => [
+                                    [
+                                        'range' => [
+                                            'prices.filtering_minimal_price' => [
+                                                'gte' => $priceGte,
+                                            ],
+                                        ],
+                                    ],
+                                    [
+                                        'range' => [
+                                            'prices.filtering_maximal_price' => [
+                                                'lte' => $priceLte,
+                                            ],
+                                        ],
+                                    ],
+                                    [
+                                        'term' => [
+                                            'prices.pricing_group_id' => $pricingGroup->getId(),
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],

--- a/upgrade-notes/backend_20240820_124554.md
+++ b/upgrade-notes/backend_20240820_124554.md
@@ -1,0 +1,3 @@
+#### the price filter now takes into account the pricing group ([#3361](https://github.com/shopsys/shopsys/pull/3361))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Pricing filter did not include pricing group.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-price-filter.odin.shopsys.cloud
  - https://cz.tl-fix-price-filter.odin.shopsys.cloud
<!-- Replace -->
