### PR TITLE
[project-base] fix product count in autocomplete

### DIFF
--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearchProductsResult.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearchProductsResult.tsx
@@ -46,7 +46,7 @@ export const AutocompleteSearchProductsResult: FC<AutocompleteSearchProductsResu
         <div tid={TIDs.layout_header_search_autocomplete_popup_products}>
             <SearchResultSectionTitle>
                 {t('Products')}
-                {` (${productsSearch.totalCount})`}
+                {productsSearch.totalCount !== -1 && ` (${productsSearch.totalCount})`}
             </SearchResultSectionTitle>
 
             <ProductsSlider

--- a/upgrade-notes/storefront_20240826_134856.md
+++ b/upgrade-notes/storefront_20240826_134856.md
@@ -1,0 +1,3 @@
+#### fix product count in autocomplete ([#3370](https://github.com/shopsys/shopsys/pull/3370))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
-1 is a special value sent from API that means the total count is not available (it is not provided by Luigis Box)
- see https://github.com/shopsys/shopsys/blob/HEAD/project-base/app/config/graphql/types/ModelType/Product/ProductConnection.types.yaml#L8
#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-search-results-count.odin.shopsys.cloud
  - https://cz.rv-fix-search-results-count.odin.shopsys.cloud
<!-- Replace -->
