### PR TITLE
[framework] EntityLogEventListener now handles PersistentCollection directly instead of catching Exception

### DIFF
--- a/packages/framework/src/Component/EntityLog/EventListener/EntityLogEventListener.php
+++ b/packages/framework/src/Component/EntityLog/EventListener/EntityLogEventListener.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PostPersistEventArgs;
 use Doctrine\ORM\Event\PostUpdateEventArgs;
 use Doctrine\ORM\Event\PreRemoveEventArgs;
+use Doctrine\ORM\PersistentCollection;
 use Psr\Log\LoggerInterface;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfig;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfigFactory;
@@ -155,6 +156,12 @@ class EntityLogEventListener implements ResetInterface
         }
 
         $changeSet = $unitOfWork->getEntityChangeSet($entity);
+
+        foreach ($changeSet as $key => $value) {
+            if ($value instanceof PersistentCollection) {
+                unset($changeSet[$key]); //collection is logged in resolveChangesOnCollectionForEntity method
+            }
+        }
 
         if (count($changeSet) > 0) {
             $resolvedChangeSet = array_merge($resolvedChangeSet, $this->changeSetResolver->resolveChangeSetForEntity($changeSet, $entity));


### PR DESCRIPTION
Problem: I enabled logging on the Product entity, then made a change through the administration, for example in CATNUM, but I didn't see any changes in the entity log.

Solution: The issue was that the method ChangeSetResolver::getResolvedChanges received a PersistentCollection object instead of an array, which is what this method expects when the collection is modified.

I'm not sure if it's the correct solution, but catching Throwable doesn't seem like the right approach to me.