### PR TITLE
[framework] EntityLog no longers logs collection without change

### DIFF
--- a/packages/framework/src/Component/EntityLog/ChangeSet/ChangeSetResolver.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/ChangeSetResolver.php
@@ -144,6 +144,10 @@ class ChangeSetResolver
                 ));
             }
 
+            if (count($collectionChanges->deletedItems) === 0 && count($collectionChanges->insertedItems) === 0) {
+                continue;
+            }
+
             $assoc = $scheduledCollection->getMapping();
             $collectionFieldName = $assoc['fieldName'];
             $resolvedChangedCollections[$collectionFieldName] = $collectionChanges;


### PR DESCRIPTION
After enabling logging on the Product entity, I started getting empty values logged for relatedProducts, which is a collection.

Therefore, I added a check to see if anything has changed, and if not, I don't add the change to the logs.

![image](https://github.com/user-attachments/assets/a6c81daa-ca5f-47ef-acde-59f1e5386308)
