### PR TITLE
[shopsys] moved two attributes of ProductFormType from project-base to framework

### DIFF
--- a/packages/framework/src/Form/Admin/Product/ProductFormType.php
+++ b/packages/framework/src/Form/Admin/Product/ProductFormType.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Plugin\PluginCrudExtensionFacade;
 use Shopsys\FrameworkBundle\Form\Admin\Product\Parameter\ProductParameterValueFormType;
 use Shopsys\FrameworkBundle\Form\Admin\Product\Price\ProductPricesWithVatSelectType;
+use Shopsys\FrameworkBundle\Form\Admin\Stock\ProductStockFormType;
 use Shopsys\FrameworkBundle\Form\CategoriesType;
 use Shopsys\FrameworkBundle\Form\Constraints\UniqueProductParameters;
 use Shopsys\FrameworkBundle\Form\DatePickerType;
@@ -38,6 +39,7 @@ use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -115,6 +117,7 @@ class ProductFormType extends AbstractType
         $builder->add($this->createBasicInformationGroup($builder, $product, $disabledItemInMainVariantAttr));
         $builder->add($this->createDisplayAvailabilityGroup($builder, $product));
         $builder->add($this->createPricesGroup($builder, $product));
+        $builder->add($this->createStocksGroup($builder));
         $builder->add($this->createDescriptionsGroup($builder, $product));
         $builder->add($this->createShortDescriptionsGroup($builder, $product));
         $builder->add($this->createShortDescriptionsUspGroup($builder));
@@ -363,6 +366,12 @@ class ProductFormType extends AbstractType
                 'label' => t('Hide product'),
             ]);
 
+        $builderDisplayAvailabilityGroup->add('domainHidden', MultidomainType::class, [
+            'label' => t('Hide on domain'),
+            'required' => false,
+            'entry_type' => YesNoType::class,
+        ]);
+
         $builderDisplayAvailabilityGroup
             ->add('sellingFrom', DatePickerType::class, [
                 'required' => false,
@@ -388,7 +397,6 @@ class ProductFormType extends AbstractType
                 'label' => t('Exclude from sale on domains'),
                 'required' => false,
                 'entry_type' => YesNoType::class,
-                'position' => ['after' => 'sellingDenied'],
             ]);
 
         if (
@@ -463,6 +471,25 @@ class ProductFormType extends AbstractType
             ]);
 
         return $builderDisplayAvailabilityGroup;
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormBuilderInterface $builder
+     * @return \Symfony\Component\Form\FormBuilderInterface
+     */
+    private function createStocksGroup(FormBuilderInterface $builder)
+    {
+        $stockGroupBuilder = $builder->create('stocksGroup', GroupType::class, [
+            'label' => t('Warehouses'),
+        ]);
+
+        $stockGroupBuilder->add('productStockData', CollectionType::class, [
+            'required' => false,
+            'entry_type' => ProductStockFormType::class,
+            'render_form_row' => false,
+        ]);
+
+        return $stockGroupBuilder;
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductDataFactory.php
+++ b/packages/framework/src/Model/Product/ProductDataFactory.php
@@ -109,6 +109,8 @@ class ProductDataFactory
             $productData->name[$locale] = null;
             $productData->variantAlias[$locale] = null;
         }
+
+        $this->fillProductStockByStocks($productData);
     }
 
     /**
@@ -181,6 +183,8 @@ class ProductDataFactory
         $productData->pluginData = $this->pluginDataFormExtensionFacade->getAllData('product', $product->getId());
         $productData->weight = $product->getWeight();
         $productData->files = $this->uploadedFileDataFactory->createByEntity($product);
+
+        $this->fillProductStockByProduct($productData, $product);
     }
 
     /**

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -1813,6 +1813,9 @@ msgstr "Skrýt"
 msgid "Hide advertisement"
 msgstr "Skrýt reklamu"
 
+msgid "Hide on domain"
+msgstr "Skrýt na doméně"
+
 msgid "Hide product"
 msgstr "Skrýt zboží"
 
@@ -3759,6 +3762,9 @@ msgstr "Nastavení %domainName% skladů uloženo."
 
 msgid "Warehouse settings"
 msgstr "Nastavení skladů"
+
+msgid "Warehouses"
+msgstr "Sklady"
 
 msgid "Warehouses - full"
 msgstr "Sklady - vše"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -1813,6 +1813,9 @@ msgstr ""
 msgid "Hide advertisement"
 msgstr ""
 
+msgid "Hide on domain"
+msgstr ""
+
 msgid "Hide product"
 msgstr ""
 
@@ -3758,6 +3761,9 @@ msgid "Warehouse setting %domainName% saved."
 msgstr ""
 
 msgid "Warehouse settings"
+msgstr ""
+
+msgid "Warehouses"
 msgstr ""
 
 msgid "Warehouses - full"

--- a/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
+++ b/project-base/app/src/Form/Admin/ProductFormTypeExtension.php
@@ -6,11 +6,8 @@ namespace App\Form\Admin;
 
 use App\Form\Constraints\UniqueProductCatnum;
 use App\Model\Product\Product;
-use Shopsys\FormTypesBundle\MultidomainType;
-use Shopsys\FormTypesBundle\YesNoType;
 use Shopsys\FrameworkBundle\Component\Form\FormBuilderHelper;
 use Shopsys\FrameworkBundle\Form\Admin\Product\ProductFormType;
-use Shopsys\FrameworkBundle\Form\Admin\Stock\ProductStockFormType;
 use Shopsys\FrameworkBundle\Form\GroupType;
 use Shopsys\FrameworkBundle\Form\LocalizedFullWidthType;
 use Shopsys\FrameworkBundle\Form\ProductsType;
@@ -89,7 +86,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
         ]);
 
         $this->setSeoGroup($builder);
-        $this->setStocksGroup($builder);
         $this->setDisplayAvailabilityGroup($builder);
         $this->setPricesGroup($builder, $product);
         $this->setRelatedProductsGroup($builder, $product);
@@ -104,14 +100,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
     private function setDisplayAvailabilityGroup(FormBuilderInterface $builder): void
     {
         $groupBuilder = $builder->get('displayAvailabilityGroup');
-
-        $groupBuilder
-            ->add('domainHidden', MultidomainType::class, [
-                'label' => t('Hide on domain'),
-                'required' => false,
-                'entry_type' => YesNoType::class,
-                'position' => ['after' => 'hidden'],
-            ]);
     }
 
     /**
@@ -135,24 +123,6 @@ class ProductFormTypeExtension extends AbstractTypeExtension
         $builderSeoGroup = $builder->get('seoGroup');
 
         $builderSeoGroup->remove('seoH1s');
-    }
-
-    /**
-     * @param \Symfony\Component\Form\FormBuilderInterface $builder
-     */
-    private function setStocksGroup(FormBuilderInterface $builder): void
-    {
-        $stockGroupBuilder = $builder->create('stocksGroup', GroupType::class, [
-            'label' => t('Warehouses'),
-        ]);
-
-        $stockGroupBuilder->add('productStockData', CollectionType::class, [
-            'required' => false,
-            'entry_type' => ProductStockFormType::class,
-            'render_form_row' => false,
-        ]);
-
-        $builder->add($stockGroupBuilder);
     }
 
     /**

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -325,9 +325,6 @@ msgstr "Heureka"
 msgid "Hide"
 msgstr "Skrýt"
 
-msgid "Hide on domain"
-msgstr "Skrýt na doméně"
-
 msgid "Holiday / internal day detail"
 msgstr "Detail svátku / interního dne"
 

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -325,9 +325,6 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-msgid "Hide on domain"
-msgstr ""
-
 msgid "Holiday / internal day detail"
 msgstr ""
 

--- a/upgrade-notes/backend_20240827_085319.md
+++ b/upgrade-notes/backend_20240827_085319.md
@@ -1,0 +1,3 @@
+#### moved two attributes of ProductFormType from project-base to the framework ([#3376](https://github.com/shopsys/shopsys/pull/3376))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
15.0 version of #3320 

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-move-product-form-type-attributes.odin.shopsys.cloud
  - https://cz.tl-move-product-form-type-attributes.odin.shopsys.cloud
<!-- Replace -->
