### PR TITLE
[framework] FileUpload: set position for the new images only

### DIFF
--- a/packages/framework/src/Component/FileUpload/EntityFileUploadInterface.php
+++ b/packages/framework/src/Component/FileUpload/EntityFileUploadInterface.php
@@ -23,7 +23,7 @@ interface EntityFileUploadInterface
     public function setFileKeyAsUploaded(string $key): void;
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId();
 }

--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -177,7 +177,7 @@ class FileUpload implements ResetInterface
             $entity->setFileAsUploaded($key, $originalFilename);
         }
 
-        if ($entity instanceof Image && $entity->getPosition() === Image::DEFAULT_IMAGE_POSITION) {
+        if ($entity instanceof Image && $entity->getId() === null) {
             $entity->setPosition($this->getPositionForNewEntity($entity));
         }
     }

--- a/packages/framework/src/Component/Image/Image.php
+++ b/packages/framework/src/Component/Image/Image.php
@@ -26,7 +26,7 @@ class Image extends AbstractTranslatableEntity implements EntityFileUploadInterf
     public const int DEFAULT_IMAGE_POSITION = 0;
 
     /**
-     * @var int
+     * @var int|null
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
@@ -226,7 +226,7 @@ class Image extends AbstractTranslatableEntity implements EntityFileUploadInterf
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId()
     {

--- a/packages/framework/src/Component/UploadedFile/UploadedFile.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFile.php
@@ -147,7 +147,7 @@ class UploadedFile extends AbstractTranslatableEntity implements EntityFileUploa
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getId()
     {


### PR DESCRIPTION
#### Description, the reason for the PR
In https://github.com/shopsys/shopsys/pull/3343, the condition for setting the position for a new entity was implemented wrong - even the existing entities might have position `0`, and these should not be changed in `preFlushEntity`, we actually need to do that for the images that have not been persisted yet.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-images.odin.shopsys.cloud
  - https://cz.rv-images.odin.shopsys.cloud
<!-- Replace -->
