### PR TITLE
[project-base][SSP-2611] - Reset cache of all queries after turning off maintenance…

### DIFF
--- a/project-base/storefront/components/Pages/ErrorPage/Error503Content.tsx
+++ b/project-base/storefront/components/Pages/ErrorPage/Error503Content.tsx
@@ -2,10 +2,22 @@ import { ErrorPage, ErrorPageTextHeading, ErrorPageTextMain } from './ErrorPageE
 import { ErrorLayout } from 'components/Layout/ErrorLayout';
 import { Webline } from 'components/Layout/Webline/Webline';
 import useTranslation from 'next-translate/useTranslation';
-import React from 'react';
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
 
 export const Error503Content: FC = () => {
     const { t } = useTranslation();
+    const router = useRouter();
+
+    useEffect(() => {
+        const onRouteChangeComplete = () => router.reload();
+
+        router.events.on('routeChangeComplete', onRouteChangeComplete);
+
+        return () => {
+            router.events.off('routeChangeComplete', onRouteChangeComplete);
+        };
+    }, []);
 
     return (
         <ErrorLayout>

--- a/upgrade-notes/storefront_20240827_192848.md
+++ b/upgrade-notes/storefront_20240827_192848.md
@@ -1,0 +1,3 @@
+#### Reset cache of all queries after turning off maintenance ([#3383](https://github.com/shopsys/shopsys/pull/3383))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
… page

#### Description, the reason for the PR
Reset cache of all queries after turning off maintenance page.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error handling for 503 errors with automatic page refresh when navigating back to the error page.

- **Documentation**
	- Added upgrade notes regarding cache reset procedures after deactivating maintenance mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tg-ssp-2611-after-maintenance.odin.shopsys.cloud
  - https://cz.tg-ssp-2611-after-maintenance.odin.shopsys.cloud
<!-- Replace -->
