### PR TITLE
[project-base] data fixtures: load translations for all locales where required

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/CountryDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/CountryDataFixture.php
@@ -6,6 +6,7 @@ namespace App\DataFixtures\Demo;
 
 use Doctrine\Persistence\ObjectManager;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Country\CountryData;
 use Shopsys\FrameworkBundle\Model\Country\CountryDataFactoryInterface;
@@ -19,10 +20,12 @@ class CountryDataFixture extends AbstractReferenceFixture
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryDataFactory $countryDataFactory
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
         private readonly CountryFacade $countryFacade,
         private readonly CountryDataFactoryInterface $countryDataFactory,
+        private readonly Domain $domain,
     ) {
     }
 
@@ -33,7 +36,7 @@ class CountryDataFixture extends AbstractReferenceFixture
     {
         $countryData = $this->countryDataFactory->create();
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $countryData->names[$locale] = t('Czech republic', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
 
@@ -42,7 +45,7 @@ class CountryDataFixture extends AbstractReferenceFixture
 
         $countryData = $this->countryDataFactory->create();
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $countryData->names[$locale] = t('Slovakia', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
 

--- a/project-base/app/src/DataFixtures/Demo/UnitDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/UnitDataFixture.php
@@ -6,6 +6,7 @@ namespace App\DataFixtures\Demo;
 
 use Doctrine\Persistence\ObjectManager;
 use Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;
@@ -31,11 +32,13 @@ class UnitDataFixture extends AbstractReferenceFixture
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitDataFactory $unitDataFactory
      * @param \App\Component\Setting\Setting $setting
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
         private readonly UnitFacade $unitFacade,
         private readonly UnitDataFactoryInterface $unitDataFactory,
         private readonly Setting $setting,
+        private readonly Domain $domain,
     ) {
     }
 
@@ -46,57 +49,57 @@ class UnitDataFixture extends AbstractReferenceFixture
     {
         $unitData = $this->unitDataFactory->create();
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('m³', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_CUBIC_METERS);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('pcs', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_PIECES);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('g', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_GRAM);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('cm', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_CENTIMETER);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('in', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_INCH);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('t', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_TON);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('kW', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_KILOWATT);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('kg', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_KILOGRAM);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('W', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_WATT);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('V', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_VOLT);
 
-        foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
+        foreach ($this->domain->getAllLocales() as $locale) {
             $unitData->name[$locale] = t('m', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
         $this->createUnit($unitData, self::UNIT_METER);

--- a/upgrade-notes/backend_20240802_220053.md
+++ b/upgrade-notes/backend_20240802_220053.md
@@ -4,3 +4,4 @@
     -   see https://docs.shopsys.com/en/15.0/introduction/basic-and-demo-data-during-application-installation/#loading-demo-data-only-for-certain-domains
 -   class `Shopsys\FrameworkBundle\Component\DataFixture\AbstractReferenceFixture` is now strictly typed
 -   see #project-base-diff to update your project
+-   see also #project-base-diff of [#3391](https://github.com/shopsys/shopsys/pull/3391) with additional fix


### PR DESCRIPTION
#### Description, the reason for the PR
`DomainsForDataFixtureProvider` was introduced in https://github.com/shopsys/shopsys/pull/3293 so a developer can choose for which domains (and hence the locales as well) should be the data fixtures loaded. However, the `name` column in `country_translations` and `unit_translations` tables is not nullable so it must be set for all the locales regardless the `load_demo_data` domain settings.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-data-fixtures.odin.shopsys.cloud
  - https://cz.rv-fix-data-fixtures.odin.shopsys.cloud
<!-- Replace -->
