### PR TITLE
 Move Friendly URL creation for flag from project-base to framework package

### DIFF
--- a/packages/framework/src/Model/Product/Filter/FlagFilterChoiceRepository.php
+++ b/packages/framework/src/Model/Product/Filter/FlagFilterChoiceRepository.php
@@ -104,7 +104,7 @@ class FlagFilterChoiceRepository
 
         $clonedProductsQueryBuilder
             ->select('1')
-            ->join('p.flags', 'pf')
+            ->join('pd.flags', 'pf')
             ->andWhere('pf.id = f.id')
             ->andWhere('f.visible = true')
             ->resetDQLPart('orderBy');


### PR DESCRIPTION
Description:

After upgrading to SSFW version 14.0.0, the product query returns an error: "friendly URL not found." This error occurs because the Friendly URL for the flag does not exist. The Friendly URL is currently created in the project-base using the FlagFacade.

Solution:

Move the logic for creating the Friendly URL for the flag from the project-base package to the framework package. This change ensures that the creation of Friendly URLs for flags is available regardless of the specific project, thus resolving the mentioned error.