### PR TITLE
[framework] Remove deprecated title, caption, geo_location, license + lastmod from image sitemap

### DIFF
--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapDumper.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapDumper.php
@@ -17,4 +17,23 @@ class ImageSitemapDumper extends SitemapDumper
 
         $this->dispatcher->dispatch($event);
     }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapIndex
+     */
+    protected function getRoot(): ImageSitemapIndex
+    {
+        if ($this->root === null) {
+            $this->root = new ImageSitemapIndex();
+
+            foreach ($this->urlsets as $urlset) {
+                $this->root->addSitemap($urlset);
+            }
+        }
+
+        /** @var \Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapIndex $root */
+        $root = $this->root;
+
+        return $root;
+    }
 }

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapFacade.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapFacade.php
@@ -72,12 +72,6 @@ class ImageSitemapFacade
             $products = $this->productRepository->getAllOfferedProductsPaginated($domainId, $pricingGroup, $offset, self::PRODUCTS_BATCH_SIZE);
 
             foreach ($products as $product) {
-                $productName = $product->getName($domainConfig->getLocale());
-
-                if ($productName === null) {
-                    continue;
-                }
-
                 try {
                     $imageUrl = $this->imageFacade->getImageUrl($domainConfig, $product);
                     $imageSitemapItem = new ImageSitemapItem();
@@ -85,7 +79,6 @@ class ImageSitemapFacade
 
                     $sitemapImage = new ImageSitemapItemImage();
                     $sitemapImage->loc = $imageUrl;
-                    $sitemapImage->title = $productName;
                     $imageSitemapItem->images[] = $sitemapImage;
 
                     $imageSitemapItems[] = $imageSitemapItem;

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapIndex.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapIndex.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
+
+use Presta\SitemapBundle\Sitemap\Sitemapindex as BaseSitemapIndex;
+use Presta\SitemapBundle\Sitemap\Urlset;
+
+class ImageSitemapIndex extends BaseSitemapIndex
+{
+    /**
+     * @param \Presta\SitemapBundle\Sitemap\Urlset $urlset
+     * @return string
+     */
+    protected function getSitemapXml(Urlset $urlset): string
+    {
+        return '<sitemap><loc>' . $urlset->getLoc() . '</loc></sitemap>';
+    }
+}

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapItemImage.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapItemImage.php
@@ -7,12 +7,4 @@ namespace Shopsys\FrameworkBundle\Model\ImageSitemap;
 class ImageSitemapItemImage
 {
     public string $loc;
-
-    public ?string $caption = null;
-
-    public ?string $geoLocation = null;
-
-    public string $title;
-
-    public ?string $license = null;
 }

--- a/packages/framework/src/Model/ImageSitemap/ImageSitemapListener.php
+++ b/packages/framework/src/Model/ImageSitemap/ImageSitemapListener.php
@@ -69,13 +69,7 @@ class ImageSitemapListener implements EventSubscriberInterface
             $decoratedUrl = new GoogleImageUrlDecorator($urlConcrete);
 
             foreach ($imageSitemapItem->images as $imageSitemapItemImage) {
-                $googleImage = new GoogleImage(
-                    $imageSitemapItemImage->loc,
-                    $imageSitemapItemImage->caption,
-                    $imageSitemapItemImage->geoLocation,
-                    $imageSitemapItemImage->title,
-                    $imageSitemapItemImage->license,
-                );
+                $googleImage = new GoogleImage($imageSitemapItemImage->loc);
                 $decoratedUrl->addImage($googleImage);
             }
 

--- a/project-base/app/tests/App/Functional/Model/ImageSitemap/ImageSitemapTest.php
+++ b/project-base/app/tests/App/Functional/Model/ImageSitemap/ImageSitemapTest.php
@@ -53,7 +53,7 @@ class ImageSitemapTest extends ApplicationTestCase
         $television = TransformString::stringToFriendlyUrlSlug(t('Television', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainConfig->getLocale()));
         $plasma = TransformString::stringToFriendlyUrlSlug(t('plasma', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainConfig->getLocale()));
 
-        return '~<url><loc>' . $urlPattern . '/' . $television . '-22-sencor-sle-22f46dm4-hello-kitty-' . $plasma . '</loc><image\:image><image\:loc>' . $urlPattern . '/content-test/images/product/22-sencor-sle-22f46dm4-hello-kitty_1\.jpg</image\:loc><image\:title><!\[CDATA\[22" Sencor SLE 22F46DM4 HELLO KITTY\]\]></image\:title></image\:image></url>~';
+        return '~<url><loc>' . $urlPattern . '/' . $television . '-22-sencor-sle-22f46dm4-hello-kitty-' . $plasma . '</loc><image\:image><image\:loc>' . $urlPattern . '/content-test/images/product/22-sencor-sle-22f46dm4-hello-kitty_1\.jpg</image\:loc></image\:image></url>~';
     }
 
     /**
@@ -64,7 +64,7 @@ class ImageSitemapTest extends ApplicationTestCase
     {
         $url = $domainConfig->getUrl();
 
-        return '<url><loc>' . $url . '/televize-22-sencor-sle-22f46dm4-hello-kitty-plazmova</loc><image:image><image:loc>' . $url . '/content/images/product/22-sencor-sle-22f46dm4-hello-kitty_64.jpg</image:loc><image:title><![CDATA[22" Sencor SLE 22F46DM4 HELLO KITTY]]></image:title></image:image></url>';
+        return '<url><loc>' . $url . '/televize-22-sencor-sle-22f46dm4-hello-kitty-plazmova</loc><image:image><image:loc>' . $url . '/content/images/product/22-sencor-sle-22f46dm4-hello-kitty_64.jpg</image:loc></image:image></url>';
     }
 
     /**

--- a/upgrade-notes/backend_20240902_060604.md
+++ b/upgrade-notes/backend_20240902_060604.md
@@ -1,0 +1,8 @@
+#### Remove deprecated title, caption, geo_location, license + lastmod from image sitemap ([#3400](https://github.com/shopsys/shopsys/pull/3400))
+
+-   `Shopsys\FrameworkBundle\Model\ImageSitemap\ImageSitemapItemImage` class was changed:
+    -   `$caption` property was removed
+    -   `$geoLocation` property was removed
+    -   `$title` property was removed
+    -   `$license` property was removed
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
This task removes the deprecaed title, caption, geo_location, license + lastmod tags from the image sitemap in compliance with Google's documentation https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `ImageSitemapIndex` class for better XML sitemap generation.
	- Added a method to retrieve the root sitemap index, enhancing sitemap management.

- **Bug Fixes**
	- Removed the `<image:title>` element from the sitemap, streamlining XML output.

- **Documentation**
	- Updated upgrade notes to reflect changes in sitemap structure and provide guidance for developers. 

- **Chores**
	- Adjusted title property to be nullable for improved flexibility in image sitemap items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->










<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mb-remove-title-and-lastmod-from-image-sitemap.odin.shopsys.cloud
  - https://cz.mb-remove-title-and-lastmod-from-image-sitemap.odin.shopsys.cloud
<!-- Replace -->
