### PR TITLE
[framework] fixed wrong columns used in migration Version20240102112523

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -131,6 +131,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 -   method `\Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade::removeFriendlyUrlsForAllDomains()` has been removed without a replacement
 -   see #project-base-diff to update your project
 
+#### fixed wrong columns used in migration Version20240102112523 ([#3402](https://github.com/shopsys/shopsys/pull/3402))
+
+-   WARNING! This migration can take up to several hours to run, depending on the size of your database. We recommend running it in a staging environment first to estimate the time it will take to run on production. You can run this migration before deploying the new version to production so your project is not locked during deployment and then once again after deployment only for entries created in the meantime.
+
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 
 #### add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Migrations/Version20240102112523.php
+++ b/packages/framework/src/Migrations/Version20240102112523.php
@@ -19,7 +19,7 @@ class Version20240102112523 extends AbstractMigration
         $this->sql('COMMENT ON COLUMN orders.total_product_price_without_vat IS \'(DC2Type:money)\'');
         $this->sql('UPDATE orders
             SET total_product_price_without_vat = (
-                SELECT COALESCE(SUM(order_items.price_with_vat * order_items.quantity), 0)
+                SELECT COALESCE(SUM(order_items.price_without_vat * order_items.quantity), 0)
                 FROM order_items
                 WHERE order_items.order_id = orders.id
                   AND order_items.type = \'product\'


### PR DESCRIPTION
This migration (version 20240102112523) adds a new column total_product_price_without_vat to the orders table. It also includes an SQL script to update existing records in this table. The script calculates the value of total_product_price_without_vat based on the price_with_vat column from the order_items associated with each order.