### PR TITLE
[shopys] moved FlagDetailFriendlyUrlDataProvider from project-base to framework

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -135,6 +135,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
 
 -   WARNING! This migration can take up to several hours to run, depending on the size of your database. We recommend running it in a staging environment first to estimate the time it will take to run on production. You can run this migration before deploying the new version to production so your project is not locked during deployment and then once again after deployment only for entries created in the meantime.
 
+#### moved FlagDetailFriendlyUrlDataProvider from project-base to the framework ([#3403](https://github.com/shopsys/shopsys/pull/3403))
+
+-   see #project-base-diff to update your project
+
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 
 #### add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Model/Product/Flag/FlagDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/Flag/FlagDetailFriendlyUrlDataProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Model\Product\Flag;
+namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
@@ -13,15 +13,15 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataProvider
 
 class FlagDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInterface
 {
-    private const ROUTE_NAME = 'front_flag_detail';
+    protected const string ROUTE_NAME = 'front_flag_detail';
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryInterface $friendlyUrlDataFactory
      */
     public function __construct(
-        private EntityManagerInterface $em,
-        private FriendlyUrlDataFactoryInterface $friendlyUrlDataFactory,
+        protected readonly EntityManagerInterface $em,
+        protected readonly FriendlyUrlDataFactoryInterface $friendlyUrlDataFactory,
     ) {
     }
 


### PR DESCRIPTION
After upgrading our project to version 14.0, querying for products results in an internal server error. This issue occurs because the friendly URL for flags is not found. This Pull Request addresses the problem by fixing the logic responsible for retrieving the friendly URL, preventing the internal server error during product queries.