### PR TITLE
[framework] flags are no longer all deleted and then recreated but are properly managed

### DIFF
--- a/packages/framework/src/Model/Product/ProductDomain.php
+++ b/packages/framework/src/Model/Product/ProductDomain.php
@@ -339,10 +339,22 @@ class ProductDomain
      */
     public function setFlags($flags): void
     {
-        $this->flags->clear();
+        $existingFlags = [];
+
+        foreach ($this->flags as $flag) {
+            $existingFlags[$flag->getId()] = $flag;
+        }
 
         foreach ($flags as $flag) {
-            $this->flags->add($flag);
+            if (!array_key_exists($flag->getId(), $existingFlags)) {
+                $this->flags->add($flag);
+            } else {
+                unset($existingFlags[$flag->getId()]);
+            }
+        }
+
+        foreach ($existingFlags as $flag) {
+            $this->flags->removeElement($flag);
         }
     }
 


### PR DESCRIPTION
Description:
This PR optimizes the handling of the flags collection in the setFlags method. Previously, the collection was entirely cleared and re-added during each update, which caused unnecessary logging of changes even when the collection itself remained unchanged. This PR ensures that only new flags are added and outdated flags are removed without resetting the entire collection, thus preventing redundant change logs (Entity logs) on each save.

Changes:
Avoids clearing and re-adding the entire flags collection during each update.
Ensures only new flags are added and outdated ones are removed.
Prevents unnecessary logging of entity changes when no actual changes are made to the flags collection.
Issue fixed:
Prevents redundant change logs in the system for unchanged flags collections.