### PR TITLE
[framework] fixed redundant log for the Money type if the scale of compared object was different

### DIFF
--- a/UPGRADE-14.0.md
+++ b/UPGRADE-14.0.md
@@ -165,6 +165,10 @@ Follow the instructions in relevant sections, e.g. `shopsys/coding-standards` or
              - { name: doctrine.event_listener, event: postFlush, priority: 1 }
     ```
 
+#### fixed redundant log for the Money type if the scale of compared object was different ([#3405](https://github.com/shopsys/shopsys/pull/3405))
+
+-   class `\Shopsys\FrameworkBundle\Component\EntityLog\ChangeSet\ResolvedChanges` now implements `\JsonSerializable` interface to provide output for the `json_encode` function, update your implementation if you need to provide more than default data
+
 ## [Upgrade from v13.0.0 to v14.0.0](https://github.com/shopsys/shopsys/compare/v13.0.0...v14.0.0)
 
 #### add rounded price value to order process ([#2835](https://github.com/shopsys/shopsys/pull/2835))

--- a/packages/framework/src/Component/EntityLog/ChangeSet/DataTypeResolver/MoneyDataTypeResolver.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/DataTypeResolver/MoneyDataTypeResolver.php
@@ -24,15 +24,14 @@ class MoneyDataTypeResolver extends AbstractDataTypeResolver
      */
     public function getResolvedChanges(array $changes): ResolvedChanges
     {
-        $oldMoney = $changes[0];
-        $newMoney = $changes[1];
+        [$oldMoney, $newMoney] = $changes;
 
         return new ResolvedChanges(
             EntityLogFacade::getEntityNameByEntity($oldMoney ?? $newMoney),
             $oldMoney?->getAmount(),
-            $oldMoney?->getAmount(),
+            $oldMoney,
             $newMoney?->getAmount(),
-            $newMoney?->getAmount(),
+            $newMoney,
         );
     }
 

--- a/packages/framework/src/Component/EntityLog/ChangeSet/ResolvedChanges.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/ResolvedChanges.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\EntityLog\ChangeSet;
 
-class ResolvedChanges
+use JsonSerializable;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+
+class ResolvedChanges implements JsonSerializable
 {
     /**
      * @param string $dataType
@@ -27,6 +30,24 @@ class ResolvedChanges
      */
     public function isOldValueSameAsNewValue(): bool
     {
+        if ($this->oldValue instanceof Money && $this->newValue instanceof Money) {
+            return $this->oldValue->equals($this->newValue);
+        }
+
         return $this->oldValue === $this->newValue;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'dataType' => $this->dataType,
+            'oldReadableValue' => $this->oldReadableValue,
+            'oldValue' => $this->oldValue instanceof Money ? $this->oldValue->getAmount() : $this->oldValue,
+            'newReadableValue' => $this->newReadableValue,
+            'newValue' => $this->newValue instanceof Money ? $this->newValue->getAmount() : $this->newValue,
+        ];
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

Update:
The problem is caused by different scales of Money objects. By default, the scale is set to 6, but the default scale of the MoneyType form type is 2. Now ResolvedChanges::isOldValueSameAsNewValue takes into consideration MoneyType and compares it correctly.

Previous:
In our project, changes were being logged on the Product entity for the Money type, even when there was no actual change. This was likely due to rounding and the fact that it was being compared as a string. The system was checking values like 0.000000 and 0.00, which are essentially both 0. This might be an issue specific to our project, but is it correct that Money is compared as a string?

We have the following definition in the entity, for example:

```
/**
 * @var \Shopsys\FrameworkBundle\Component\Money\Money
 * @ORM\Column(type="money", precision=20, scale=6)
 */
private $discountInPercent;
```
And in the form type:


```
$builder->add('discountInPercent', MoneyType::class, [
    'scale' => 6,
    'required' => false,
    'invalid_message' => 'Please enter discount in correct format (positive number with decimal separator)',
    'constraints' => [
        new NotBlank(['message' => 'Please enter discount']),
        new MoneyRange([
            'min' => Money::zero(),
            'minMessage' => 'Discount must be greater or equal to {{ limit }}%',
            'max' => Money::create(100),
            'maxMessage' => 'Discount must be less or equal to {{ limit }}%',
        ]),
    ],
    'attr' => [
        'class' => 'form-line__item--pg',
    ],
    'label' => false,
]);
```
![image](https://github.com/user-attachments/assets/30edb4da-9ed2-4a0d-92bb-a0d524aea69b)

Perhaps the issue lies somewhere in our configuration.
