### PR TITLE
[framework] Heureka: send order number instead of order id

### DIFF
--- a/packages/framework/src/Model/Heureka/HeurekaShopCertificationFactory.php
+++ b/packages/framework/src/Model/Heureka/HeurekaShopCertificationFactory.php
@@ -35,7 +35,7 @@ class HeurekaShopCertificationFactory
         $options = ['service' => $languageId];
 
         $heurekaShopCertification = new ShopCertification($heurekaApiKey, $options);
-        $heurekaShopCertification->setOrderId($order->getId());
+        $heurekaShopCertification->setOrderId($order->getNumber());
         $heurekaShopCertification->setEmail($order->getEmail());
 
         foreach ($order->getProductItems() as $item) {


### PR DESCRIPTION
#### Description, the reason for the PR
... Send order number instead of order id to Heureka for easier finding order

#### Fixes issues
... 

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated order processing logic to send order numbers instead of order IDs to the Heureka platform for improved integration and tracking.
- **Documentation**
	- Added upgrade notes detailing the changes in order handling and their purpose for better clarity on system enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pt-ssp-2681-heureka.odin.shopsys.cloud
  - https://cz.pt-ssp-2681-heureka.odin.shopsys.cloud
<!-- Replace -->
