### PR TITLE
[framework] moved FlagDetailFriendlyUrlDataProvider from project-base to framework

### DIFF
--- a/packages/framework/src/Model/Product/Flag/FlagDetailFriendlyUrlDataProvider.php
+++ b/packages/framework/src/Model/Product/Flag/FlagDetailFriendlyUrlDataProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Model\Product\Flag;
+namespace Shopsys\FrameworkBundle\Model\Product\Flag;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
@@ -13,15 +13,15 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataProvider
 
 class FlagDetailFriendlyUrlDataProvider implements FriendlyUrlDataProviderInterface
 {
-    private const ROUTE_NAME = 'front_flag_detail';
+    protected const string ROUTE_NAME = 'front_flag_detail';
 
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlDataFactoryInterface $friendlyUrlDataFactory
      */
     public function __construct(
-        private EntityManagerInterface $em,
-        private FriendlyUrlDataFactoryInterface $friendlyUrlDataFactory,
+        protected readonly EntityManagerInterface $em,
+        protected readonly FriendlyUrlDataFactoryInterface $friendlyUrlDataFactory,
     ) {
     }
 

--- a/upgrade-notes/backend_20240909_105040.md
+++ b/upgrade-notes/backend_20240909_105040.md
@@ -1,0 +1,3 @@
+#### moved FlagDetailFriendlyUrlDataProvider from project-base to the framework ([#3416](https://github.com/shopsys/shopsys/pull/3416))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
15.0 version of #3403 

#### Check the appropriate checkboxes below, please

- [x] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced extensibility of the `FlagDetailFriendlyUrlDataProvider` class for better accessibility in subclasses.
  
- **Refactor**
	- Corrected the namespace for the `FlagDetailFriendlyUrlDataProvider` to improve organization.
	- Moved the `FlagDetailFriendlyUrlDataProvider` to the framework for improved modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-move-flag-urld-provider.odin.shopsys.cloud
  - https://cz.tl-move-flag-urld-provider.odin.shopsys.cloud
<!-- Replace -->
