### PR TITLE
Returns only static content from vshosting CDN

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -117,6 +117,17 @@ server {
         }
     }
 
+    # cdn headers
+    location ~ /$ {
+        if ($http_cdn_vshosting_real_ip != '') {
+             return 410;
+        }
+        if ($http_cdn_vshosting_real_ip_img != '') {
+            return 410;
+        }
+        try_files @storefront @storefront;
+    }
+
     location ~ / {
         try_files @storefront @storefront;
     }

--- a/project-base/docker/nginx/nginx.conf
+++ b/project-base/docker/nginx/nginx.conf
@@ -112,6 +112,17 @@ server {
         }
     }
 
+    # cdn headers
+    location ~ /$ {
+        if ($http_cdn_vshosting_real_ip != '') {
+             return 410;
+        }
+        if ($http_cdn_vshosting_real_ip_img != '') {
+            return 410;
+        }
+        try_files @storefront @storefront;
+    }
+
     location ~ / {
         try_files @storefront @storefront;
     }

--- a/upgrade-notes/backend_20240909_120530.md
+++ b/upgrade-notes/backend_20240909_120530.md
@@ -1,0 +1,4 @@
+#### returns only static content from vshosting CDN ([#3419](https://github.com/shopsys/shopsys/pull/3419))
+
+-   upgrade shopsys/deployment library to last version
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed situation where CDN returns pages too and crawlers index bad pages

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced server response handling for CDN-related requests at the root URL.
	- Introduced upgrade notes for the Shopsys project, detailing the upgrade of the `shopsys/deployment` library to improve content delivery and performance.

- **Documentation**
	- Added structured upgrade notes to assist developers with the transition to the new library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://pt-ssp-2294-cdn.odin.shopsys.cloud
  - https://cz.pt-ssp-2294-cdn.odin.shopsys.cloud
<!-- Replace -->
