### PR TITLE
[framework] fixed redundant log for the Money type if the scale of compared object was different

### DIFF
--- a/packages/framework/src/Component/EntityLog/ChangeSet/DataTypeResolver/MoneyDataTypeResolver.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/DataTypeResolver/MoneyDataTypeResolver.php
@@ -24,15 +24,14 @@ class MoneyDataTypeResolver extends AbstractDataTypeResolver
      */
     public function getResolvedChanges(array $changes): ResolvedChanges
     {
-        $oldMoney = $changes[0];
-        $newMoney = $changes[1];
+        [$oldMoney, $newMoney] = $changes;
 
         return new ResolvedChanges(
             EntityLogFacade::getEntityNameByEntity($oldMoney ?? $newMoney),
             $oldMoney?->getAmount(),
-            $oldMoney?->getAmount(),
+            $oldMoney,
             $newMoney?->getAmount(),
-            $newMoney?->getAmount(),
+            $newMoney,
         );
     }
 

--- a/packages/framework/src/Component/EntityLog/ChangeSet/ResolvedChanges.php
+++ b/packages/framework/src/Component/EntityLog/ChangeSet/ResolvedChanges.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\EntityLog\ChangeSet;
 
-class ResolvedChanges
+use JsonSerializable;
+use Shopsys\FrameworkBundle\Component\Money\Money;
+
+class ResolvedChanges implements JsonSerializable
 {
     /**
      * @param string $dataType
@@ -27,6 +30,24 @@ class ResolvedChanges
      */
     public function isOldValueSameAsNewValue(): bool
     {
+        if ($this->oldValue instanceof Money && $this->newValue instanceof Money) {
+            return $this->oldValue->equals($this->newValue);
+        }
+
         return $this->oldValue === $this->newValue;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'dataType' => $this->dataType,
+            'oldReadableValue' => $this->oldReadableValue,
+            'oldValue' => $this->oldValue instanceof Money ? $this->oldValue->getAmount() : $this->oldValue,
+            'newReadableValue' => $this->newReadableValue,
+            'newValue' => $this->newValue instanceof Money ? $this->newValue->getAmount() : $this->newValue,
+        ];
     }
 }

--- a/upgrade-notes/backend_20240909_131346.md
+++ b/upgrade-notes/backend_20240909_131346.md
@@ -1,0 +1,3 @@
+#### fixed redundant log for the Money type if the scale of compared object was different ([#3405](https://github.com/shopsys/shopsys/pull/3405))
+
+-   class `\Shopsys\FrameworkBundle\Component\EntityLog\ChangeSet\ResolvedChanges` now implements `\JsonSerializable` interface to provide output for the `json_encode` function, update your implementation if you need to provide more than default data


### PR DESCRIPTION
#### Description, the reason for the PR
15.0 version of #3405 

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JSON serialization for monetary values in the `ResolvedChanges` class.
	- Improved comparison logic for monetary values to ensure accuracy.

- **Bug Fixes**
	- Resolved redundant logging issues related to monetary comparisons.

- **Documentation**
	- Updated upgrade notes to reflect changes in the `ResolvedChanges` class and its serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fixed-red-log.odin.shopsys.cloud
  - https://cz.tl-fixed-red-log.odin.shopsys.cloud
<!-- Replace -->
