### PR TITLE
[framework] getting position for new image is now more robust

### DIFF
--- a/packages/framework/src/Component/FileUpload/FileUpload.php
+++ b/packages/framework/src/Component/FileUpload/FileUpload.php
@@ -273,7 +273,7 @@ class FileUpload
         }
 
         $position = match ($uploadEntityType) {
-            'image' => $this->imageRepository->getImagesCountByEntityIndexedById(
+            'image' => $this->imageRepository->getNewImagePosition(
                 $entityName,
                 $entityId,
                 $type,

--- a/packages/framework/src/Component/Image/ImageRepository.php
+++ b/packages/framework/src/Component/Image/ImageRepository.php
@@ -148,11 +148,11 @@ class ImageRepository
      * @param string|null $type
      * @return int
      */
-    public function getImagesCountByEntityIndexedById(string $entityName, int $entityId, ?string $type = null): int
+    public function getNewImagePosition(string $entityName, int $entityId, ?string $type = null): int
     {
-        $queryBuilder = $this->em->createQueryBuilder()
-            ->select('COUNT(i)')
-            ->from(Image::class, 'i', 'i.id')
+        $queryBuilder = $this->getImageRepository()
+            ->createQueryBuilder('i', 'i.id')
+            ->select('MAX(i.position)')
             ->andWhere('i.entityName = :entityName')->setParameter('entityName', $entityName)
             ->andWhere('i.entityId = :entityId')->setParameter('entityId', $entityId);
 
@@ -162,6 +162,8 @@ class ImageRepository
             $queryBuilder->andWhere('i.type = :type')->setParameter('type', $type);
         }
 
-        return $queryBuilder->getQuery()->getSingleScalarResult();
+        $position = $queryBuilder->getQuery()->getSingleScalarResult();
+
+        return $position === null ? 0 : ++$position;
     }
 }

--- a/upgrade-notes/backend_20240909_132416.md
+++ b/upgrade-notes/backend_20240909_132416.md
@@ -1,0 +1,4 @@
+#### improve getting position for new image ([#3421](https://github.com/shopsys/shopsys/pull/3421))
+
+-   `Shopsys\FrameworkBundle\Component\Image\ImageRepository` class was changed:
+    -   `getImagesCountByEntityIndexedById()` method was renamed to `getNewImagePosition()`


### PR DESCRIPTION
#### Description, the reason for the PR
The image count might not always be the highest position, e.g. when an image is removed, and positions are not recalculated.


#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [x] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced image upload functionality to determine the position of new images more effectively.
	- Introduced a method to retrieve the latest image position associated with entities.

- **Documentation**
	- Added upgrade notes to inform developers about the renaming of the image position retrieval method. 

- **Bug Fixes**
	- Improved logic for determining image positions, ensuring more accurate results when uploading new images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-images-position.odin.shopsys.cloud
  - https://cz.rv-images-position.odin.shopsys.cloud
<!-- Replace -->
