### PR TITLE
[monorepo] Fix cancel old reviews script

### DIFF
--- a/.github/cancel-old-reviews.sh
+++ b/.github/cancel-old-reviews.sh
@@ -1,41 +1,23 @@
 #!/bin/bash
 
-DEFAULT_BRANCH=$1
-ACTIONS_TOKEN=$2
+# Get the timestamp for 7 days ago
+cutoff_date=$(date -d '7 days ago' +%s)
 
-current_date=$(date +%Y-%m-%d)
-fourteen_days_ago=$(date -d "14 days ago" +%Y-%m-%d)
-seven_days_ago=$(date -d "7 days ago" +%Y-%m-%d)
+# List php-fpm containers that contains at least one non numeric character in branch name
+docker ps -a --format "{{.Names}} {{.CreatedAt}}" | \
+grep -E '^[^-]*[^0-9].*-php-fpm-1' | \
+while read name created_at; do
+  # Remove the timezone from the creation date (we don't need it)
+  created_at_clean=$(echo "$created_at" | sed 's/ +.*//')
 
-api_url_between_fourteen_and_seven_days_ago="https://api.github.com/repos/shopsys/shopsys/actions/runs?created=$fourteen_days_ago..$seven_days_ago"
-response_between_fourteen_and_seven_days_ago=$(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $ACTIONS_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "$api_url_between_fourteen_and_seven_days_ago")
-branches_between_fourteen_and_seven_days_ago=$(echo "$response_between_fourteen_and_seven_days_ago" | jq -r '.workflow_runs[].head_branch' | sort -u)
+  # Convert the cleaned-up creation date to a timestamp
+  container_timestamp=$(date -d "$created_at_clean" +%s)
 
-api_url_last_seven_days="https://api.github.com/repos/shopsys/shopsys/actions/runs?created=$seven_days_ago..$current_date"
-response_last_seven_days=$(curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $ACTIONS_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" "$api_url_last_seven_days")
-branches_last_seven_days=$(echo "$response_last_seven_days" | jq -r '.workflow_runs[].head_branch' | sort -u)
+  # Check if the container is older than 7 days
+  if [ "$container_timestamp" -lt "$cutoff_date" ]; then
+    # Remove the '-php-fpm-1' suffix and print the name
+    branch_name=$(echo "$name" | sed 's/-php-fpm-1$//')
 
-# convert strings to arrays
-SAVEIFS=$IFS
-IFS=$'\n'
-
-branches_last_seven_days=($branches_last_seven_days)
-branches_between_fourteen_and_seven_days_ago=($branches_between_fourteen_and_seven_days_ago)
-
-IFS=$SAVEIFS
-
-# add main branch to branches between 14 and 7 days ago in order to prevent its cancellation
-branches_between_fourteen_and_seven_days_ago+=($DEFAULT_BRANCH)
-
-filtered_branches=()
-
-# check if branch from 14-7 days ago has not been built in the last 7 days
-for (( i=0; i<${#branches_between_fourteen_and_seven_days_ago[@]}; i++ )) do
-    if [[ ! " ${branches_last_seven_days[*]} " =~ " ${branches_between_fourteen_and_seven_days_ago[$i]} " ]]; then
-        filtered_branches+=("${branches_between_fourteen_and_seven_days_ago[$i]}")
-    fi
-done
-
-for BRANCH_NAME in "${filtered_branches[@]}"; do
-    /bin/bash ./.github/cancel-review.sh "$BRANCH_NAME"
+    /bin/bash ./.github/cancel-review.sh "$branch_name"
+  fi
 done

--- a/.github/workflows/cancel-old-reviews.yaml
+++ b/.github/workflows/cancel-old-reviews.yaml
@@ -16,4 +16,4 @@ jobs:
             -   name: Cancel reviews older than seven days
                 working-directory: cancel-old-reviews
                 run: |
-                    /bin/bash ./.github/cancel-old-reviews.sh ${{ github.event.repository.default_branch }} ${{ secrets.ACTIONS_TOKEN }}
+                    /bin/bash ./.github/cancel-old-reviews.sh


### PR DESCRIPTION
#### Description, the reason for the PR
This PR refactors script for canceling old reviews to correctly cancel only reviews older than 7 days. 

#### How to test

1. connect to internal review server
2. create this script that will show branches that should be removed and run it. (Its just copy of script in this PR, but without calling `cancel-review.sh`)
```bash
#!/bin/bash

# Get the timestamp for 7 days ago
cutoff_date=$(date -d '7 days ago' +%s)

# List php-fpm containers that contains at least one non numeric character in branch name
docker ps -a --format "{{.Names}} {{.CreatedAt}}" | \
grep -E '^[^-]*[^0-9].*-php-fpm-1' | \
while read name created_at; do
  # Remove the timezone from the creation date (we don't need it)
  created_at_clean=$(echo "$created_at" | sed 's/ +.*//')

  # Convert the cleaned-up creation date to a timestamp
  container_timestamp=$(date -d "$created_at_clean" +%s)

  # Check if the container is older than 7 days
  if [ "$container_timestamp" -lt "$cutoff_date" ]; then
    # Remove the '-php-fpm-1' suffix and print the name
    branch_name=$(echo "$name" | sed 's/-php-fpm-1$//')

    echo "$branch_name (created on $created_at)"
  fi
done
```
3. Run command bellow that will list php-fpm containers and compare with results of script: `docker ps -a --format "table {{.Names}}\t{{.RunningFor}}" | grep 'php-fpm-1'`

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the cancellation process for outdated reviews by transitioning from a GitHub Actions focus to managing PHP-FPM Docker containers.

- **Bug Fixes**
	- Simplified the command in the GitHub Actions workflow for cancelling reviews, which may improve reliability by reducing dependencies on parameters.

- **Chores**
	- Updated scripts to better manage and clean up old Docker containers, streamlining the review cancellation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-fix-stop-old-reviews.odin.shopsys.cloud
  - https://cz.jg-fix-stop-old-reviews.odin.shopsys.cloud
<!-- Replace -->
