### PR TITLE
[project-base] make tests resistant against admin locale change

### DIFF
--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLog;
 use Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogFacade;
 use Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogRepository;
 use Shopsys\FrameworkBundle\Model\Country\Country;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFacade;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
@@ -85,6 +86,11 @@ class EntityLogTest extends TransactionFunctionalTestCase
      */
     private OrderItemFacade $orderItemFacade;
 
+    /**
+     * @inject
+     */
+    private Localization $localization;
+
     public function testCreateEntity(): void
     {
         $order = $this->getNewOrder();
@@ -153,7 +159,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $entityName = EntityLogFacade::getEntityNameByEntity($orderFromDb);
 
         $expectedOldCity = $orderFromDb->getCity();
-        $expectedOldStatusName = $orderFromDb->getStatus()->getName();
+        $expectedOldStatusName = $orderFromDb->getStatus()->getName($this->localization->getAdminLocale());
         $expectedOldStatusId = $orderFromDb->getStatus()->getId();
 
         $orderData = $this->orderDataFactory->createFromOrder($orderFromDb);
@@ -179,7 +185,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $this->assertSame($expectedOldStatusId, $log->getChangeSet()['status']['oldValue']);
         $this->assertSame($expectedOldStatusName, $log->getChangeSet()['status']['oldReadableValue']);
         $this->assertSame($newStatus->getId(), $log->getChangeSet()['status']['newValue']);
-        $this->assertSame($newStatus->getName(), $log->getChangeSet()['status']['newReadableValue']);
+        $this->assertSame($newStatus->getName($this->localization->getAdminLocale()), $log->getChangeSet()['status']['newReadableValue']);
     }
 
     public function testEditCollectionEntity(): void

--- a/project-base/app/tests/App/Functional/Model/Order/Status/OrderStatusFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Order/Status/OrderStatusFacadeTest.php
@@ -8,6 +8,7 @@ use App\DataFixtures\Demo\OrderDataFixture;
 use App\DataFixtures\Demo\OrderStatusDataFixture;
 use App\Model\Order\Order;
 use App\Model\Order\Status\OrderStatus;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Order\OrderDataFactory;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
 use Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusData;
@@ -31,10 +32,20 @@ class OrderStatusFacadeTest extends TransactionFunctionalTestCase
      */
     private OrderDataFactory $orderDataFactory;
 
+    /**
+     * @inject
+     */
+    private Localization $localization;
+
     public function testDeleteByIdAndReplace()
     {
         $orderStatusData = new OrderStatusData();
-        $orderStatusData->name = ['en' => 'name'];
+        $namesByLocale = [];
+
+        foreach ($this->localization->getLocalesOfAllDomains() as $locale) {
+            $namesByLocale[$locale] = 'name';
+        }
+        $orderStatusData->name = $namesByLocale;
         $orderStatusToDelete = $this->orderStatusFacade->create($orderStatusData);
         $orderStatusToReplaceWith = $this->getReference(OrderStatusDataFixture::ORDER_STATUS_NEW, OrderStatus::class);
         $order = $this->getReference(OrderDataFixture::ORDER_PREFIX . '1', Order::class);

--- a/upgrade-notes/backend_20240912_064125.md
+++ b/upgrade-notes/backend_20240912_064125.md
@@ -1,0 +1,3 @@
+#### make tests resistant against admin locale change ([#3430](https://github.com/shopsys/shopsys/pull/3430))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
There is evaluation of order status name in EntityLogTest which fails if admin locale differs from first domain locale. This happens because $orderFromDb->getStatus()->getName() returns value for first domain locale if no specific value is provided. Now the value of admin locale is passed into function call and problem should be solved. 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy of entity log tests to reflect application behavior regarding localization.
	- Enhanced reliability of the logging system by addressing issues that could lead to incorrect logging behavior.
	- Increased flexibility of order status tests to accommodate multiple locales.

- **Documentation**
	- Updated upgrade notes to inform users about necessary project updates for improved testing framework and entity logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ab-fix-entity-log-test.odin.shopsys.cloud
  - https://cz.ab-fix-entity-log-test.odin.shopsys.cloud
<!-- Replace -->
