### PR TITLE
[framework] tweak complaint status migration

### DIFF
--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2275,6 +2275,9 @@ msgstr "Byla upravena položka navigace <strong><a href=\"{{ url }}\">{{ name }}
 msgid "Navigation item <strong>{{ name }}</strong> has been removed"
 msgstr "Položka navigace <strong>{{ name }}</strong> byla odebrána"
 
+msgid "New"
+msgstr "Nová"
+
 msgid "New SEO page"
 msgstr "Nová SEO stránka"
 
@@ -3048,6 +3051,9 @@ msgstr "Zrušit filtr"
 
 msgid "Reset password request was sent to <strong>{{ email }}</strong>"
 msgstr "Žádost o resetování hesla byla odeslána na adresu <strong>{{ email }}</strong>"
+
+msgid "Resolved"
+msgstr "Vyřízena"
 
 msgid "Return back"
 msgstr "Vrátit zpět"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2275,6 +2275,9 @@ msgstr ""
 msgid "Navigation item <strong>{{ name }}</strong> has been removed"
 msgstr ""
 
+msgid "New"
+msgstr ""
+
 msgid "New SEO page"
 msgstr ""
 
@@ -3047,6 +3050,9 @@ msgid "Reset filter"
 msgstr ""
 
 msgid "Reset password request was sent to <strong>{{ email }}</strong>"
+msgstr ""
+
+msgid "Resolved"
 msgstr ""
 
 msgid "Return back"


### PR DESCRIPTION
#### Description, the reason for the PR
Instead of creating translations for specific locales, multidomain trait is used to iterate over all locales in the application so projects with non-default setup have no problems with the migrtation

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined creation of complaint statuses and their translations, enhancing maintainability and scalability.
	- Added support for new locales in translation processes.

- **Localization Enhancements**
	- Introduced Czech translations for "New" (Nová) and "Resolved" (Vyřízena).
	- Added entries for "New" and "Resolved" in English translations to improve future localization efforts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-complaint-migration.odin.shopsys.cloud
  - https://cz.rv-fix-complaint-migration.odin.shopsys.cloud
<!-- Replace -->
