### PR TITLE
[framework] fixed GoPay no longer failing on missing key of enabledSwifts

### DIFF
--- a/packages/framework/src/Model/GoPay/PaymentMethod/GoPayPaymentMethodFacade.php
+++ b/packages/framework/src/Model/GoPay/PaymentMethod/GoPayPaymentMethodFacade.php
@@ -186,7 +186,7 @@ class GoPayPaymentMethodFacade
     protected function updateSwiftsFromRawData(GoPayPaymentMethod $goPayPaymentMethod, array $goPayMethodRawData): void
     {
         $bankSwiftsBySwift = $this->goPayBankSwiftRepository->getAllIndexedBySwiftByPaymentMethod($goPayPaymentMethod);
-        $goPayBankSwiftsRawData = $goPayMethodRawData['enabledSwifts'];
+        $goPayBankSwiftsRawData = $goPayMethodRawData['enabledSwifts'] ?? null;
 
         if ($goPayBankSwiftsRawData === null) {
             $goPayBankSwiftsRawData = [];


### PR DESCRIPTION
#### Description, the reason for the PR
GoPay stopped sending enabledSwifts key and it cause application to fail.


#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-gopay-empty-swifts.odin.shopsys.cloud
  - https://cz.tl-fix-gopay-empty-swifts.odin.shopsys.cloud
<!-- Replace -->
