### PR TITLE
[framework] fixed incorrect usage of frontend-api class in framework package

### DIFF
--- a/packages/framework/src/Component/EntityLog/Detection/DetectionFacade.php
+++ b/packages/framework/src/Component/EntityLog/Detection/DetectionFacade.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\EntityLog\Detection;
 
 use Shopsys\FrameworkBundle\Component\EntityLog\Enum\EntityLogSourceEnum;
-use Shopsys\FrontendApiBundle\Model\User\FrontendApiUser;
 use Symfony\Component\Security\Core\Security;
 
 class DetectionFacade
@@ -29,7 +28,7 @@ class DetectionFacade
 
         $user = $this->security->getUser();
 
-        if ($user instanceof FrontendApiUser) {
+        if ($user !== null) {
             $this->userIdentifier = $user->getUserIdentifier();
         }
     }

--- a/packages/framework/src/Twig/HiddenPriceExtension.php
+++ b/packages/framework/src/Twig/HiddenPriceExtension.php
@@ -6,12 +6,13 @@ namespace Shopsys\FrameworkBundle\Twig;
 
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleResolver;
-use Shopsys\FrontendApiBundle\Component\Price\MoneyFormatterHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 class HiddenPriceExtension extends AbstractExtension
 {
+    protected const string HIDDEN_FORMAT = '***';
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleResolver $customerUserRoleResolver
      */
@@ -41,7 +42,7 @@ class HiddenPriceExtension extends AbstractExtension
     public function hidePriceFilter(string $price, ?CustomerUser $customerUser): string
     {
         if (!$this->customerUserRoleResolver->canCustomerUserSeePrices($customerUser)) {
-            return MoneyFormatterHelper::HIDDEN_FORMAT;
+            return static::HIDDEN_FORMAT;
         }
 
         return $price;


### PR DESCRIPTION
#### Description, the reason for the PR

frontend-api classes should not be used in framework package

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-split.odin.shopsys.cloud
  - https://cz.mg-fix-split.odin.shopsys.cloud
<!-- Replace -->
