### PR TITLE
[framework] user is logged out after role change

### DIFF
--- a/packages/framework/src/Model/Customer/User/CustomerUserFacade.php
+++ b/packages/framework/src/Model/Customer/User/CustomerUserFacade.php
@@ -413,9 +413,15 @@ class CustomerUserFacade
     public function editCustomerUser(int $id, CustomerUserData $customerUserData): CustomerUser
     {
         $customerUser = $this->getCustomerUserById($id);
+        $customerUserOriginalRoles = $customerUser->getRoles();
+
         $customerUser->edit($customerUserData);
 
         $this->em->flush();
+
+        if ($this->areRolesChanged($customerUser->getRoles(), $customerUserOriginalRoles)) {
+            $this->customerUserRefreshTokenChainFacade->removeAllCustomerUserRefreshTokenChains($customerUser);
+        }
 
         return $customerUser;
     }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/CustomerUserWithLimitedRoleGroupTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/CustomerUserWithLimitedRoleGroupTest.php
@@ -10,6 +10,7 @@ use App\DataFixtures\Demo\OrderDataFixture;
 use App\DataFixtures\Demo\ProductDataFixture;
 use App\Model\Customer\User\CustomerUser;
 use App\Model\Product\Product;
+use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserDataFactory;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroup;
@@ -39,7 +40,7 @@ class CustomerUserWithLimitedRoleGroupTest extends GraphQlWithLoginTestCase
         $customerUserData = $this->customerUserDataFactory->createFromCustomerUser($customerUser);
         $customerUserData->roleGroup = $this->getReference(CustomerUserRoleGroupDataFixture::ROLE_GROUP_LIMITED_USER, CustomerUserRoleGroup::class);
 
-        $this->customerUserFacade->editCustomerUser($customerUser->getId(), $customerUserData);
+        $this->editCustomerUser($customerUser->getId(), $customerUserData);
 
         $this->login();
     }
@@ -134,5 +135,18 @@ class CustomerUserWithLimitedRoleGroupTest extends GraphQlWithLoginTestCase
         $errors = $this->getErrorsFromResponse($response);
 
         $this->assertSame('Ordering by price is not allowed for current user.', $errors[0]['message']);
+    }
+
+    /**
+     * @param int $id
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserData $customerUserData
+     */
+    private function editCustomerUser(int $id, CustomerUserData $customerUserData): void
+    {
+        $customerUser = $this->customerUserFacade->getCustomerUserById($id);
+
+        $customerUser->edit($customerUserData);
+
+        $this->em->flush();
     }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

user is now logged out, when his role is changed by owner

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-user-reload-role-15.odin.shopsys.cloud
  - https://cz.mg-user-reload-role-15.odin.shopsys.cloud
<!-- Replace -->
