### PR TITLE
Wrong annotation on fulltext search method

### DIFF
--- a/packages/framework/src/Component/String/DatabaseSearching.php
+++ b/packages/framework/src/Component/String/DatabaseSearching.php
@@ -24,7 +24,7 @@ class DatabaseSearching
     }
 
     /**
-     * @param string|null $string
+     * @param string $string
      * @return string
      */
     public static function getFullTextLikeSearchString($string)


### PR DESCRIPTION
#### Description, the reason for the PR
The method cannot accept null because `rtrim` then throws an error. 

> Fatal error: Uncaught TypeError: rtrim(): Argument #1 ($string) must be of type string, null given

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://lk-db-search.odin.shopsys.cloud
  - https://cz.lk-db-search.odin.shopsys.cloud
<!-- Replace -->
