### PR TITLE
[SSP-2495] edited required logic for form inputs: deliveryStreet, deliveryCity, deliveryPostcode

### DIFF
--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationFormMeta.ts
@@ -102,6 +102,8 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
                         isDeliveryAddressDifferentFromBilling,
                         deliveryAddressUuid,
                         !!pickupPlace,
+                        false,
+                        true,
                     ),
                 then: () => validateStreet(t),
                 otherwise: (schema) => schema,
@@ -113,6 +115,8 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
                         isDeliveryAddressDifferentFromBilling,
                         deliveryAddressUuid,
                         !!pickupPlace,
+                        false,
+                        true,
                     ),
                 then: () => validateCity(t),
                 otherwise: (schema) => schema,
@@ -124,6 +128,8 @@ export const useContactInformationForm = (): [UseFormReturn<ContactInformation>,
                         isDeliveryAddressDifferentFromBilling,
                         deliveryAddressUuid,
                         !!pickupPlace,
+                        false,
+                        true,
                     ),
                 then: () => validatePostcode(t),
                 otherwise: (schema) => schema,
@@ -159,7 +165,12 @@ const shouldValidateDeliveryAddressField = (
     deliveryAddressUuid: string,
     isPickupPlaceSelected?: boolean,
     isRelevantForPickupPlace?: boolean,
+    isRelevantForDeliveryAddress?: boolean,
 ) => {
+    if (isRelevantForDeliveryAddress && !isPickupPlaceSelected && isDeliveryAddressDifferentFromBilling) {
+        return true;
+    }
+
     if (!isDeliveryAddressDifferentFromBilling || !isRelevantForPickupPlace) {
         return false;
     }


### PR DESCRIPTION
#### Description, the reason for the PR
When the delivery address is displayed, and the user clicks in and then out of any input field (street, city, postal code), the field should be marked in red if it’s required and not filled in.

#### Fixes issues
... 

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://ms-ssp-2495-order-required-inputs.odin.shopsys.cloud
  - https://cz.ms-ssp-2495-order-required-inputs.odin.shopsys.cloud
<!-- Replace -->
