### PR TITLE
[framework] fixed owner of complaint sequences

### DIFF
--- a/docs/cookbook/adding-a-new-order-item-type.md
+++ b/docs/cookbook/adding-a-new-order-item-type.md
@@ -30,7 +30,7 @@ class Service
 {
     /**
      * @ORM\Id
-     * @ORM\GeneratedValue
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
     protected int $id;

--- a/packages/framework/src/Migrations/Version20241008072724.php
+++ b/packages/framework/src/Migrations/Version20241008072724.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20241008072724 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('DROP SEQUENCE IF EXISTS complaints_id_seq');
+        $this->sql('DROP SEQUENCE IF EXISTS complaint_items_id_seq');
+
+        $this->sql('CREATE SEQUENCE complaints_id_seq');
+        $this->sql('SELECT setval(\'complaints_id_seq\', (SELECT MAX(id) FROM complaints))');
+        $this->sql('ALTER TABLE complaints ALTER id SET DEFAULT nextval(\'complaints_id_seq\')');
+        $this->sql('CREATE SEQUENCE complaint_items_id_seq');
+        $this->sql('SELECT setval(\'complaint_items_id_seq\', (SELECT MAX(id) FROM complaint_items))');
+        $this->sql('ALTER TABLE complaint_items ALTER id SET DEFAULT nextval(\'complaint_items_id_seq\')');
+
+        $this->sql('ALTER SEQUENCE complaint_items_id_seq OWNED BY complaint_items.id');
+        $this->sql('ALTER SEQUENCE complaints_id_seq OWNED BY complaints.id');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Complaint/Complaint.php
+++ b/packages/framework/src/Model/Complaint/Complaint.php
@@ -18,7 +18,7 @@ class Complaint
     /**
      * @var int
      * @ORM\Id
-     * @ORM\GeneratedValue
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
     protected $id;

--- a/packages/framework/src/Model/Complaint/ComplaintItem.php
+++ b/packages/framework/src/Model/Complaint/ComplaintItem.php
@@ -15,7 +15,7 @@ class ComplaintItem
     /**
      * @var int
      * @ORM\Id
-     * @ORM\GeneratedValue
+     * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\Column(type="integer")
      */
     protected $id;


### PR DESCRIPTION
#### Description, the reason for the PR

Complaint item sequences did not have the owner set properly, which caused problems during repeated first deployments. 
This PR fixes that.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-sequence.odin.shopsys.cloud
  - https://cz.mg-fix-sequence.odin.shopsys.cloud
<!-- Replace -->
