### PR TITLE
BlogCategoryFormType works with admin locale

### DIFF
--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -18,6 +18,7 @@ use Shopsys\FrameworkBundle\Form\UrlListType;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryData;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -34,11 +35,13 @@ class BlogCategoryFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade $blogCategoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly BlogCategoryFacade $blogCategoryFacade,
         protected readonly Domain $domain,
         protected readonly SeoSettingFacade $seoSettingFacade,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -98,9 +101,9 @@ class BlogCategoryFormType extends AbstractType
     private function createSettingsGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         if ($options['blogCategory'] !== null) {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->domain->getCurrentDomainConfig());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->localization->getAdminLocale());
         } else {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->domain->getLocale());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->localization->getAdminLocale());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Blog\Category;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Redis\CleanStorefrontCacheFacade;
@@ -200,12 +199,12 @@ class BlogCategoryFacade
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory $blogCategory
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
      */
-    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategory, DomainConfig $domainConfig): array
+    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategory, string $locale): array
     {
-        return $this->blogCategoryRepository->getTranslatedAllWithoutBranch($blogCategory, $domainConfig);
+        return $this->blogCategoryRepository->getTranslatedAllWithoutBranch($blogCategory, $locale);
     }
 
     /**

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticle;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleBlogCategoryDomain;
@@ -88,13 +87,13 @@ class BlogCategoryRepository extends NestedTreeRepository
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory $blogCategoryBranch
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
      */
-    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategoryBranch, DomainConfig $domainConfig): array
+    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategoryBranch, string $locale): array
     {
         $queryBuilder = $this->getAllQueryBuilder();
-        $this->addTranslation($queryBuilder, $domainConfig->getLocale());
+        $this->addTranslation($queryBuilder, $locale);
 
         return $queryBuilder->andWhere('bc.lft < :branchLft OR bc.rgt > :branchRgt')
             ->setParameter('branchLft', $blogCategoryBranch->getLft())


### PR DESCRIPTION
#### Description, the reason for the PR
1. setup first domain to en locale
2. setup admin locale to cs locale
3. got to admin on first domain, edit blog category
4.  parent blog categories select has options, but their names are empty.

This PR solves this problem 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [x] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-blog-categories-locale.odin.shopsys.cloud
  - https://cz.mt-blog-categories-locale.odin.shopsys.cloud
<!-- Replace -->
