### PR TITLE
[docs] lost documentation from Commerce Cloud has returned

### DIFF
--- a/docs/administration/admin-rights.md
+++ b/docs/administration/admin-rights.md
@@ -1,0 +1,35 @@
+# Admin rights
+
+-   Administrator rights are implemented using Symfony roles in `config/packages/security.yaml` (for detailed information, see the [Symfony security documentation](https://symfony.com/doc/5.4/security.html)). The most important settings are:
+
+    -   `role_hierarchy`
+        -   defines the roles' inheritance
+        -   e.g. entry `ROLE_ORDER_FULL: [ROLE_ORDER_VIEW]` means that by granting the `ROLE_ORDER_FULL` role, the `ROLE_ORDER_VIEW` is granted automatically as well.
+    -   `access_control`
+
+        -   defines which role has access to which path pattern
+        -   the access is evaluated from the top to the bottom, so it is important to define the most nested paths the first, see the example below:
+
+        ```yaml
+        # CORRECT: full rights are required to access the page for creating a new article:
+        - { path: ^/%admin_url%/article/new, roles: ROLE_ARTICLE_FULL }
+        - { path: ^/%admin_url%/article/, roles: ROLE_ARTICLE_VIEW }
+
+        # INCORRECT: the second line is not reachable, so the admin with "view" rights would be able to access the article creation page:
+        - { path: ^/%admin_url%/article/, roles: ROLE_ARTICLE_VIEW }
+        - { path: ^/%admin_url%/article/new, roles: ROLE_ARTICLE_FULL }
+        ```
+
+-   All the available roles are defined along with their human-readable labels in `src/Model/Security/Roles.php`
+-   If a particular page or section is restricted for the given admin, it is removed from the menu
+    -   see `src/Controller/Admin/SideMenuConfigurationSubscriber.php`
+    -   see `src/Model/Security/MenuItemsGrantedRolesSetting.php`
+    -   we use the default [access decision strategy (i.e. `affirmative`)](https://symfony.com/doc/5.4/security/voters.html#changing-the-access-decision-strategy), i.e., an admin will be granted access if he has at least one of the required roles, see the example below:
+    ```php
+    // returns true if the admin has at least one of the roles ROLE_FEED_VIEW, ROLE_HEUREKA_VIEW, or ROLE_SCRIPT_VIEW
+    $this->security->isGranted([
+        Roles::ROLE_FEED_VIEW,
+        Roles::ROLE_HEUREKA_VIEW,
+        Roles::ROLE_SCRIPT_VIEW,
+    ]);
+    ```

--- a/docs/administration/disabling-form-fields.md
+++ b/docs/administration/disabling-form-fields.md
@@ -1,0 +1,13 @@
+# Disabling form fields
+
+During project implementation, there is usually necessary to have imported some fields from other systems.
+Those imported fields do not need (or even must not) be changeable in administration.
+For this purpose, there is implemented the way how to define fields which should be disabled.
+
+## Enable form disabling
+
+To enable disabling defined fields there, need to be set ENV variable `DISABLE_FORM_FIELDS_FROM_TRANSFER` to true.
+
+## Define disabled fields
+
+Disabled fields are defined by constant `DISABLED_FIELDS` for example in: `App\Form\Admin\CategoryFormTypeExtension`

--- a/docs/administration/index.md
+++ b/docs/administration/index.md
@@ -4,3 +4,5 @@
 -   [Grid](./grid.md)
     -   [Grid Rendering Customization](./grid-rendering-customization.md)
     -   [Grid Data Sources](./grid-data-sources.md)
+-   [Admin rights](./admin-rights.md)
+-   [Disabling form fields](./disabling-form-fields.md)

--- a/docs/administration/navigation.yml
+++ b/docs/administration/navigation.yml
@@ -4,3 +4,5 @@ arrange:
     - grid.md
     - grid-rendering-customization.md
     - grid-data-sources.md
+    - admin-rights.md
+    - disabling-form-fields.md

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -21,3 +21,5 @@
 -   [Front-end Breadcrumb Navigation](./front-end-breadcrumb-navigation.md)
 -   [Autocompletion for Phing Targets](./autocompletion-for-phing-targets.md)
 -   [Blackfire profiling](./blackfire-profiling.md)
+-   [PHPStorm settings](./phpstorm-settings.md)
+-   [Postman Settings](./postman-settings.md)

--- a/docs/introduction/navigation.yml
+++ b/docs/introduction/navigation.yml
@@ -26,3 +26,5 @@ arrange:
     - blackfire-profiling.md
     - monorepo.md
     - faq-and-common-issues.md
+    - phpstorm-settings.md
+    - postman-settings.md

--- a/docs/introduction/phpstorm-settings.md
+++ b/docs/introduction/phpstorm-settings.md
@@ -1,0 +1,16 @@
+# PHPStorm Settings
+
+If you are using PHPStorm, we have prepared the code scheme for you to work easily with Shopsys Platform and its Frontend API.
+
+## Importing the scheme in PHPStorm
+
+_Note: This guide will import new scheme in your PHPStorm, your previous schemes and other PHPStorm settings will not be changed._
+
+-   To configure your IDE, select `PhpStorm -> Preferences` for macOS or `File -> Settings` for Windows and Linux.
+-   From menu select `Editor -> Code Style`
+-   Right of `Scheme` select box is cogwheel, click it and select `Import Scheme...`
+-   Import file `app/config/phpstorm/phpstorm.xml`
+-   Now you will see the new scheme in Scheme select box
+-   Make sure that you have selected this scheme for PHP, JavaScript, and Typescript
+
+_Note: In some cases it is necessary to invalidate cache (`File -> Invalidate Caches ...`) and restart PHPStorm for changes to take effect._

--- a/docs/introduction/postman-settings.md
+++ b/docs/introduction/postman-settings.md
@@ -1,0 +1,46 @@
+# Postman Settings
+
+Postman is a strong tool for working with different APIs.
+This article describes how to easily import `schema.graphql` to your Postman to help you with queries and mutations.
+
+## How to retrieve schema.graphql
+
+There are two ways of retrieving `schema.graphql`.
+
+### Generate schema.graphql in your locally running project
+
+Run this command inside `php-fpm` container:
+
+```
+php phing frontend-api-generate-graphql-schema
+```
+
+`graphql.schema` file will be generated in root folder of the project.
+
+### Download schema.graphql from CI server on Gitlab
+
+Open this project in `Gitlab` and go to `CI / CD` -> `Pipelines` section.
+Find the last build of the desired branch and open it.
+Then click on `Review` stage.
+In right menu in `Job artifacts` select `Browse` and then find and download `schema.graphql` file.
+
+## Importing schema.graphql into Postman
+
+Open `Postman` application.
+Select your desired workspace (default is `My Workspace`).
+In left menu click on `APIs` and then click on `+` button.
+Enter desired API name like `Shopsys Platform Frontend API`.
+The version number is up to you as we are not versioning the Frontend API.
+Select `GraphQL` option from `Schema type` and `GraphQL SDL` option from `Schema format`.
+Your API will be created.
+
+On API page click on `Define` tab and copy and paste `schema.graphql` content here.
+Click on `Save` button and then on `Generate collection` button.
+Enter desired collection name like `Shopsys Platform Frontend API`.
+Select `Test the API` from `What do you want to do with this collection?` selection and click on `Generate collection` button.
+In left menu click on `Collections` and you should see your new collection there.
+Click on the new collection and under `Variables` tab enter new variable `url` and as current value set URL address of GraphQL endpoint like `http://127.0.0.1:8000/graphql/`.
+
+You are now able to easily run `queries` and `mutations` from this collection.
+
+For more info about how to create requests in Postman see [Postman docs](https://learning.postman.com/docs/sending-requests/requests/).


### PR DESCRIPTION
#### Description, the reason for the PR
We had few docs articles in Commerce Cloud that have not been moved with Commerce Cloud functionality. This PR brings them back.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-update-docs.odin.shopsys.cloud
  - https://cz.tl-update-docs.odin.shopsys.cloud
<!-- Replace -->
