### PR TITLE
[shopsys] SSP-2670 - Fix ordering in FE internal search

### DIFF
--- a/packages/frontend-api/src/Model/Resolver/Products/ProductOrderingModeProvider.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/ProductOrderingModeProvider.php
@@ -46,7 +46,7 @@ class ProductOrderingModeProvider
      */
     public function getDefaultOrderingMode(Argument $argument): string
     {
-        if (isset($argument['search'])) {
+        if (isset($argument['searchInput']['search'])) {
             return $this->getDefaultOrderingModeForSearch();
         }
 

--- a/packages/frontend-api/src/Model/Resolver/Products/Search/ProductSearchResultsProvider.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/Search/ProductSearchResultsProvider.php
@@ -6,7 +6,6 @@ namespace Shopsys\FrontendApiBundle\Model\Resolver\Products\Search;
 
 use Overblog\GraphQLBundle\Definition\Argument;
 use Shopsys\FrameworkBundle\Model\Product\Filter\ProductFilterDataFactory;
-use Shopsys\FrameworkBundle\Model\Product\Listing\ProductListOrderingConfig;
 use Shopsys\FrontendApiBundle\Model\Product\Connection\ProductConnection;
 use Shopsys\FrontendApiBundle\Model\Product\Connection\ProductConnectionFactory;
 use Shopsys\FrontendApiBundle\Model\Product\Filter\ProductFilterFacade;
@@ -45,11 +44,11 @@ class ProductSearchResultsProvider implements ProductSearchResultsProviderInterf
         );
 
         return $this->productConnectionFactory->createConnectionForAll(
-            function ($offset, $limit) use ($search, $productFilterData) {
+            function ($offset, $limit) use ($search, $productFilterData, $argument) {
                 return $this->productFacade->getFilteredProductsOnCurrentDomain(
                     $limit,
                     $offset,
-                    ProductListOrderingConfig::ORDER_BY_RELEVANCE,
+                    $this->productOrderingModeProvider->getOrderingModeFromArgument($argument),
                     $productFilterData,
                     $search,
                 );

--- a/project-base/app/src/FrontendApi/Mutation/Order/CreateOrderMutation.php
+++ b/project-base/app/src/FrontendApi/Mutation/Order/CreateOrderMutation.php
@@ -12,6 +12,7 @@ use Shopsys\FrontendApiBundle\Model\Mutation\Order\CreateOrderMutation as BaseCr
  * @property \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
  * @property \App\Model\Order\PlaceOrderFacade $placeOrderFacade
  * @method __construct(\App\FrontendApi\Model\Order\OrderDataFactory $orderDataFactory, \App\Model\Customer\User\CurrentCustomerUser $currentCustomerUser, \Shopsys\FrontendApiBundle\Model\Cart\CartApiFacade $cartApiFacade, \Shopsys\FrontendApiBundle\Model\Order\CreateOrderResultFactory $createOrderResultFactory, \Shopsys\FrontendApiBundle\Model\Cart\CartWatcherFacade $cartWatcherFacade, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \Shopsys\FrameworkBundle\Model\Order\Processing\OrderProcessor $orderProcessor, \App\Model\Order\PlaceOrderFacade $placeOrderFacade, \Shopsys\FrameworkBundle\Model\Order\Processing\OrderInputFactory $orderInputFactory)
+ * @method string[] computeValidationGroups(\Overblog\GraphQLBundle\Definition\Argument $argument, \App\Model\Customer\User\CustomerUser|null $currentCustomerUser)
  */
 class CreateOrderMutation extends BaseCreateOrderMutation
 {

--- a/project-base/storefront/components/Pages/Search/SearchProducts.tsx
+++ b/project-base/storefront/components/Pages/Search/SearchProducts.tsx
@@ -81,7 +81,7 @@ export const SearchProducts: FC = () => {
                             sorting={searchProductsData.orderingMode}
                             totalCount={searchProductsData.totalCount}
                             customSortOptions={[
-                                TypeProductOrderingModeEnum.Priority,
+                                TypeProductOrderingModeEnum.Relevance,
                                 TypeProductOrderingModeEnum.PriceAsc,
                                 TypeProductOrderingModeEnum.PriceDesc,
                             ]}

--- a/upgrade-notes/storefront_20241009_094528.md
+++ b/upgrade-notes/storefront_20241009_094528.md
@@ -1,5 +1,3 @@
-#### {taskName} ([#{pullRequestId}](https://github.com/shopsys/shopsys/pull/{pullRequestId}))
+#### fix product sorting by relevance and prices ([#3488](https://github.com/shopsys/shopsys/pull/3488))
 
--   Adjusted default sorting in internal search according to relevance
--   The functionality of sorting by price in ascending and descending order has been fixed
 -   see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20241009_094528.md
+++ b/upgrade-notes/storefront_20241009_094528.md
@@ -1,0 +1,5 @@
+#### {taskName} ([#{pullRequestId}](https://github.com/shopsys/shopsys/pull/{pullRequestId}))
+
+-   Adjusted default sorting in internal search according to relevance
+-   The functionality of sorting by price in ascending and descending order has been fixed
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Correction of sorting in the frontend's internal search and set as default sorting according to relevance

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mvn-ssp-2670-bad-ordering-in-search-results.odin.shopsys.cloud
  - https://cz.mvn-ssp-2670-bad-ordering-in-search-results.odin.shopsys.cloud
<!-- Replace -->
