### PR TITLE
[shopsys] docs: add info about necessary Git long paths settings for Windows installation

### DIFF
--- a/docs/installation/application-requirements.md
+++ b/docs/installation/application-requirements.md
@@ -20,6 +20,10 @@ To be able to install, develop and run Shopsys Platform, the system should have 
 ## Windows
 
 -   [GIT](https://git-scm.com/download/win)
+    -   You will need to enable long paths in your Git configuration:
+        ```bash
+        git config --system core.longpaths true
+        ```
 -   [PostgreSQL 12.1](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows)
 -   [PHP 8.3 or higher](http://php.net/manual/en/install.windows.php) (configure your `php.ini` by [Required PHP Configuration](../introduction/required-php-configuration.md))
 -   [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows)

--- a/docs/installation/installation-using-docker-windows-10.md
+++ b/docs/installation/installation-using-docker-windows-10.md
@@ -64,6 +64,12 @@ In `Debian` application run these commands:
 
 ### 1. Create new project from Shopsys Platform sources
 
+Enable long paths in your Git configuration:
+
+```bash
+git config --system core.longpaths true
+```
+
 Open `Debian` application.
 
 Change your current directory to your home directory (`/home/<your-linux-user-name>/`)

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -194,3 +194,13 @@ Therefore, you can see e.g. `ProductListTypeEnum` which is a class with constant
 Moreover, the class extends `AbstractEnum` that provides `getAllCases()` method.
 The method uses reflection to return all the public constants of the class which simulates the behavior of `cases()` method of the PHP enums.
 The key factor here is that the method is not static, and therefore it would include also the constants of the child class when the "enum" class is extended on a project.
+
+## I am not able to clone the repository because of the error "Filename too long"
+
+If you are using Windows, you can encounter the error "Filename too long" when cloning the repository.
+This is because the repository contains files with long paths (e.g. Cypress tests screenshots).
+To resolve this issue, you can modify your Git configuration to allow long paths by running the following command:
+
+```bash
+git config --system core.longpaths true
+```


### PR DESCRIPTION

#### Description, the reason for the PR
On Windows systems, it is not possible to clone the project repository unless long paths are enabled

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-longpaths.odin.shopsys.cloud
  - https://cz.rv-longpaths.odin.shopsys.cloud
<!-- Replace -->
