### PR TITLE
[framework] SSP-2751 - Set default ordering by last/first name in getCustomerUsersQueryBuilder

### DIFF
--- a/packages/framework/src/Model/Customer/CustomerRepository.php
+++ b/packages/framework/src/Model/Customer/CustomerRepository.php
@@ -77,6 +77,7 @@ class CustomerRepository
         return
             $this->getCustomerUsersQueryBuilder($customer)
             ->select('cu')
+            ->addOrderBy('cu.firstName, cu.lastName', 'ASC')
             ->getQuery()
             ->getResult();
     }

--- a/packages/framework/src/Model/Customer/CustomerRepository.php
+++ b/packages/framework/src/Model/Customer/CustomerRepository.php
@@ -77,7 +77,7 @@ class CustomerRepository
         return
             $this->getCustomerUsersQueryBuilder($customer)
             ->select('cu')
-            ->addOrderBy('cu.firstName, cu.lastName', 'ASC')
+            ->addOrderBy('cu.lastName, cu.firstName', 'ASC')
             ->getQuery()
             ->getResult();
     }

--- a/project-base/storefront/components/Pages/Customer/Users/CustomerUsersTable.tsx
+++ b/project-base/storefront/components/Pages/Customer/Users/CustomerUsersTable.tsx
@@ -98,7 +98,7 @@ export const CustomerUsersTable: FC = () => {
             {customerUsers.map((user) => (
                 <Row key={user.uuid} className="border-none bg-tableBackground odd:bg-tableBackgroundContrast">
                     <Cell className="py-2 text-left text-sm font-bold uppercase leading-5">
-                        {user.firstName} {user.lastName} {currentCustomerUserUuid === user.uuid && `(${t('You')})`}
+                        {user.lastName} {user.firstName} {currentCustomerUserUuid === user.uuid && `(${t('You')})`}
                     </Cell>
 
                     <Cell className="hidden py-2 text-left text-sm leading-5 vl:table-cell">{user.email}</Cell>


### PR DESCRIPTION
#### Description, the reason for the PR
The listing of the customer users did not have the sorting set. Now the listing is sorted first by last name and then by first name ASC. Last name is now displayed first in the table, followed by first name.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mvn-ssp-2751-customer-users-ordering.odin.shopsys.cloud
  - https://cz.mvn-ssp-2751-customer-users-ordering.odin.shopsys.cloud
<!-- Replace -->
