### PR TITLE
[framework] fix blog category visibility calculation

### DIFF
--- a/packages/framework/src/Migrations/Version20241014125411.php
+++ b/packages/framework/src/Migrations/Version20241014125411.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+class Version20241014125411 extends AbstractMigration implements ContainerAwareInterface
+{
+    use MultidomainMigrationTrait;
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        foreach ($this->getAllDomainIds() as $domainId) {
+            $this->sql('INSERT INTO blog_category_domains (blog_category_id, domain_id, enabled, visible) VALUES (1, :domain_id, true, true) ON CONFLICT DO NOTHING', [
+                'domain_id' => $domainId,
+            ]);
+        }
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
@@ -264,6 +264,16 @@ class BlogCategoryFacade
     }
 
     /**
+     * @param int $domainId
+     * @param int[] $blogCategoryIds
+     * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
+     */
+    public function getVisibleByIds(int $domainId, array $blogCategoryIds): array
+    {
+        return $this->blogCategoryRepository->getVisibleByIds($domainId, $blogCategoryIds);
+    }
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory $blogCategory
      */
     protected function scheduleArticlesToExportByCategory(BlogCategory $blogCategory): void

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -326,6 +326,20 @@ class BlogCategoryRepository extends NestedTreeRepository
 
     /**
      * @param int $domainId
+     * @param int[] $blogCategoryIds
+     * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
+     */
+    public function getVisibleByIds(int $domainId, array $blogCategoryIds): array
+    {
+        return $this->getAllVisibleByDomainIdQueryBuilder($domainId)
+            ->andWhere('bc.id IN (:blogCategoryIds)')
+            ->setParameter('blogCategoryIds', $blogCategoryIds)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @param int $domainId
      * @return int|null
      */
     public function findVisibleMainBlogCategoryIdOnDomain(int $domainId): ?int

--- a/packages/frontend-api/src/Model/Blog/Article/BlogArticleResolverMap.php
+++ b/packages/frontend-api/src/Model/Blog/Article/BlogArticleResolverMap.php
@@ -6,15 +6,18 @@ namespace Shopsys\FrontendApiBundle\Model\Blog\Article;
 
 use DateTime;
 use Overblog\GraphQLBundle\Resolver\ResolverMap;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade;
 
 class BlogArticleResolverMap extends ResolverMap
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade $blogCategoryFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
         protected readonly BlogCategoryFacade $blogCategoryFacade,
+        protected readonly Domain $domain,
     ) {
     }
 
@@ -26,7 +29,7 @@ class BlogArticleResolverMap extends ResolverMap
         return [
             'BlogArticle' => [
                 'blogCategories' => function (array $blogArticleData) {
-                    return $this->blogCategoryFacade->getByIds($blogArticleData['categories']);
+                    return $this->blogCategoryFacade->getVisibleByIds($this->domain->getId(), $blogArticleData['categories']);
                 },
                 'publishDate' => static function (array $blogArticleData) {
                     return new DateTime($blogArticleData['publishDate']);

--- a/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Blog/Article/BlogArticleDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Blog/Article/BlogArticleDecorator.types.yaml
@@ -43,7 +43,7 @@ BlogArticleDecorator:
                 description: "The blog article SEO H1 heading"
             blogCategories:
                 type: "[BlogCategory!]!"
-                description: "The list of the blog article blog categories"
+                description: "The list of the blog article visible categories"
             mainBlogCategoryUuid:
                 type: "Uuid!"
                 description: "The UUID of the main blog category of the blog article"

--- a/project-base/app/schema.graphql
+++ b/project-base/app/schema.graphql
@@ -205,7 +205,7 @@ enum AvailabilityStatusEnum {
 }
 
 type BlogArticle implements Breadcrumb & Slug & ArticleInterface & Hreflang {
-  "The list of the blog article blog categories"
+  "The list of the blog article visible categories"
   blogCategories: [BlogCategory!]!
   "Hierarchy of the current element in relation to the structure"
   breadcrumb: [Link!]!

--- a/project-base/storefront/graphql/docs/schema.md
+++ b/project-base/storefront/graphql/docs/schema.md
@@ -2373,7 +2373,7 @@ Availability status in a format suitable for usage in the code
 <td valign="top">[<a href="#blogcategory">BlogCategory</a>!]!</td>
 <td>
 
-The list of the blog article blog categories
+The list of the blog article visible categories
 
 </td>
 </tr>

--- a/project-base/storefront/graphql/types.ts
+++ b/project-base/storefront/graphql/types.ts
@@ -251,7 +251,7 @@ export enum TypeAvailabilityStatusEnum {
 
 export type TypeBlogArticle = TypeArticleInterface & TypeBreadcrumb & TypeHreflang & TypeSlug & {
   __typename?: 'BlogArticle';
-  /** The list of the blog article blog categories */
+  /** The list of the blog article visible categories */
   blogCategories: Array<TypeBlogCategory>;
   /** Hierarchy of the current element in relation to the structure */
   breadcrumb: Array<TypeLink>;


### PR DESCRIPTION
#### Description, the reason for the PR
With the missing entry in `blog_category_domains` for the root blog category, the blog category visibility calculation was broken:
1) [setRootBlogCategoryVisibleOnDomain](https://github.com/shopsys/shopsys/blob/16.0/packages/framework/src/Model/Blog/Category/BlogCategoryVisibilityRepository.php#L61) was called in vain (there was no `blog_category_domains` entry that passed the condition

2) what was worse, the blog category visibility was never updated for categories of level 1 because of the missing entry for their parent category ([the condition](https://github.com/shopsys/shopsys/blob/16.0/packages/framework/src/Model/Blog/Category/BlogCategoryVisibilityRepository.php#L116) was never met hence the whole UPDATE did not do anything)

As a result, you could remove the blog category name and it would still be visible which was breaking the application further (e.g. assigning such a category to a blog article would cause the blog article edit page to crash on exporting it's breadcrumb, etc.)

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-blog.odin.shopsys.cloud
  - https://cz.rv-fix-blog.odin.shopsys.cloud
<!-- Replace -->
