### PR TITLE
[project-base] stable feed hash for alpha branch

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -311,6 +311,10 @@ deploy:alpha:
         url: https://${DOMAIN_HOSTNAME_1}
         kubernetes:
             namespace: ${PROJECT_NAME}
+    after_script:
+        -   sleep 20
+        -   RUNNING_WEBSERVER_PHP_FPM_POD=$(kubectl get pods --namespace=${PROJECT_NAME} --field-selector=status.phase=Running -l app=webserver-php-fpm -o=jsonpath='{.items[0].metadata.name}')
+        -   kubectl exec ${RUNNING_WEBSERVER_PHP_FPM_POD} --namespace=${PROJECT_NAME} -- php ./bin/console doctrine:query:sql "UPDATE setting_values SET value='Db4tLxuck2' WHERE name='feedHash'"
 
 test:gatling:
     stage: test


### PR DESCRIPTION
#### Description, the reason for the PR

The alpha branch is deployed with clean demo data. Keeping the feed hash consistent is necessary, so we don't need to change it in other systems after each deployment.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-stable-alpha-feed-prefix.odin.shopsys.cloud
  - https://cz.mg-stable-alpha-feed-prefix.odin.shopsys.cloud
<!-- Replace -->
