### PR TITLE
Fix feed info to correctly handle only for current time option

### DIFF
--- a/packages/framework/src/Model/Feed/FeedFacade.php
+++ b/packages/framework/src/Model/Feed/FeedFacade.php
@@ -42,7 +42,7 @@ class FeedFacade
      */
     public function getFeedsInfo(bool $onlyForCurrentTime = false): array
     {
-        $feedConfigs = $onlyForCurrentTime ? $this->feedRegistry->getAllFeedConfigs() : $this->feedRegistry->getFeedConfigsForCurrentTime();
+        $feedConfigs = $onlyForCurrentTime ? $this->feedRegistry->getFeedConfigsForCurrentTime() : $this->feedRegistry->getAllFeedConfigs();
 
         $feedsInfo = [];
 


### PR DESCRIPTION
#### Description, the reason for the PR
...

There appears to be bug when checking the `$onlyForCurrentTime` condition to load config for current time instead of config for all feeds... 

Please take a look on this... 

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
