### PR TITLE
[framework] Activation of CSRF protection for the deleteConfirm actions in admin

### DIFF
--- a/packages/framework/src/Controller/Admin/ArticleController.php
+++ b/packages/framework/src/Controller/Admin/ArticleController.php
@@ -179,6 +179,7 @@ class ArticleController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      * @return \Symfony\Component\HttpFoundation\Response
      */

--- a/packages/framework/src/Controller/Admin/BlogArticleController.php
+++ b/packages/framework/src/Controller/Admin/BlogArticleController.php
@@ -175,6 +175,7 @@ class BlogArticleController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      * @return \Symfony\Component\HttpFoundation\Response
      */

--- a/packages/framework/src/Controller/Admin/ComplaintStatusController.php
+++ b/packages/framework/src/Controller/Admin/ComplaintStatusController.php
@@ -89,6 +89,7 @@ class ComplaintStatusController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      * @throws \Shopsys\FrameworkBundle\Component\ConfirmDelete\Exception\InvalidEntityPassedException
      * @return \Symfony\Component\HttpFoundation\Response

--- a/packages/framework/src/Controller/Admin/CurrencyController.php
+++ b/packages/framework/src/Controller/Admin/CurrencyController.php
@@ -43,6 +43,7 @@ class CurrencyController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      */
     #[Route(path: '/currency/delete-confirm/{id}', requirements: ['id' => '\d+'])]

--- a/packages/framework/src/Controller/Admin/OrderStatusController.php
+++ b/packages/framework/src/Controller/Admin/OrderStatusController.php
@@ -84,6 +84,7 @@ class OrderStatusController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      */
     #[Route(path: '/order-status/delete-confirm/{id}', requirements: ['id' => '\d+'])]

--- a/packages/framework/src/Controller/Admin/PricingGroupController.php
+++ b/packages/framework/src/Controller/Admin/PricingGroupController.php
@@ -85,6 +85,7 @@ class PricingGroupController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      */
     #[Route(path: '/pricing/group/delete-confirm/{id}', requirements: ['id' => '\d+'])]

--- a/packages/framework/src/Controller/Admin/SalesRepresentativeController.php
+++ b/packages/framework/src/Controller/Admin/SalesRepresentativeController.php
@@ -161,6 +161,7 @@ class SalesRepresentativeController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      * @return \Symfony\Component\HttpFoundation\Response
      */

--- a/packages/framework/src/Controller/Admin/SeoPageController.php
+++ b/packages/framework/src/Controller/Admin/SeoPageController.php
@@ -155,6 +155,7 @@ class SeoPageController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      * @return \Symfony\Component\HttpFoundation\Response
      */

--- a/packages/framework/src/Controller/Admin/UnitController.php
+++ b/packages/framework/src/Controller/Admin/UnitController.php
@@ -41,9 +41,10 @@ class UnitController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      */
-    #[Route(path: '/unit/delete-confirm/{id}', requirements: ['id' => '\d+'])]
+    #[Route(path: '/product/unit/delete-confirm/{id}', requirements: ['id' => '\d+'])]
     public function deleteConfirmAction($id)
     {
         try {

--- a/packages/framework/src/Controller/Admin/VatController.php
+++ b/packages/framework/src/Controller/Admin/VatController.php
@@ -42,6 +42,7 @@ class VatController extends AdminBaseController
     }
 
     /**
+     * @CsrfProtection
      * @param int $id
      */
     #[Route(path: '/vat/delete-confirm/{id}', requirements: ['id' => '\d+'])]

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -130,7 +130,7 @@ class RouteConfigCustomization
                 }
             })
             ->customize(function (RouteConfig $config, RouteInfo $info) {
-                if (preg_match('~(_delete$)|(_delete_all$)|(^admin_mail_deletetemplate$)|(^admin_(stock|store)_setdefault$)|(^admin_customer_send_reset_password$)~', $info->getRouteName())) {
+                if (preg_match('~(_delete$)|(_delete_all$)|(^admin_mail_deletetemplate$)|(^admin_(stock|store)_setdefault$)|(^admin_customer_send_reset_password$)|(^admin_.*_deleteconfirm$)~', $info->getRouteName())) {
                     $debugNote = 'Add CSRF token for any delete action during test execution. '
                         . '(Routes are protected by RouteCsrfProtector.)';
                     $config->changeDefaultRequestDataSet($debugNote)
@@ -149,8 +149,14 @@ class RouteConfigCustomization
                                 $requestDataSet->setParameter($parameterName, $token->getValue());
                             },
                         );
-                    $config->changeDefaultRequestDataSet('Expect redirect by 302 for any delete action.')
-                        ->setExpectedStatusCode(302);
+
+                    if (preg_match('~(^admin_.*_deleteconfirm$)~', $info->getRouteName())) {
+                        $config->changeDefaultRequestDataSet('Expect redirect by 200 for any delete confirm action.')
+                            ->setExpectedStatusCode(200);
+                    } else {
+                        $config->changeDefaultRequestDataSet('Expect redirect by 302 for any delete action.')
+                            ->setExpectedStatusCode(302);
+                    }
                 }
             });
     }


### PR DESCRIPTION
#### Description, the reason for the PR
Fixes a bug when in the admin section, when calling the deleteConfirm action, the protection of the CSRF token was not checked.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mvn-ssp-2702-fix-csrf-protection-by-delete-confirm.odin.shopsys.cloud
  - https://cz.mvn-ssp-2702-fix-csrf-protection-by-delete-confirm.odin.shopsys.cloud
<!-- Replace -->
