### PR TITLE
[shopsys] fix builds on version branches

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -424,9 +424,11 @@ jobs:
         steps:
             -   name: Check pull request labels
                 run: |
-                    PULL_REQUEST_LABELS=`gh api -H "Accept: application/vnd.github+json" /repos/shopsys/shopsys/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name]'`
-                    if echo "$PULL_REQUEST_LABELS" | jq -e '. | index("regenerate screenshots")' >/dev/null; then
-                        exit 1;
+                    if [ -n "${{ github.event.pull_request.number }}" ]; then
+                        PULL_REQUEST_LABELS=`gh api -H "Accept: application/vnd.github+json" /repos/shopsys/shopsys/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name]'`
+                        if echo "$PULL_REQUEST_LABELS" | jq -e '. | index("regenerate screenshots")' >/dev/null; then
+                            exit 1;
+                        fi
                     fi
             -   name: GIT checkout branch - ${{ github.ref }}
                 uses: actions/checkout@v4


### PR DESCRIPTION
#### Description, the reason for the PR
Github action `tests-storefront-acceptance` was failing for version branches (e.g. `16.0`) because it was not able to find the pull request. The job is triggered for pull requests but also after push to the version branch (see https://github.com/shopsys/shopsys/blob/16.0/.github/workflows/docker-build.yaml#L2) so it must deal with the scenario when there is no pull request.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-build-fix-cypress.odin.shopsys.cloud
  - https://cz.rv-build-fix-cypress.odin.shopsys.cloud
<!-- Replace -->
