### PR TITLE
[project-base] showed category image just on first page

### DIFF
--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -61,15 +61,17 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
                 {!!category.description && currentPage === 1 && (
                     <CollapsibleText scrollTargetRef={scrollTargetRef} text={category.description} />
                 )}
-                <div className="h-full flex-shrink-0 sm:h-32">
-                    <Image
-                        alt={category.name}
-                        className="h-full w-auto rounded-lg"
-                        height={500}
-                        src={category.images[0]?.url}
-                        width={500}
-                    />
-                </div>
+                {currentPage === 1 && (
+                    <div className="h-full flex-shrink-0 sm:h-32">
+                        <Image
+                            alt={category.name}
+                            className="h-full w-auto rounded-lg"
+                            height={500}
+                            src={category.images[0]?.url}
+                            width={500}
+                        />
+                    </div>
+                )}
             </div>
 
             <SimpleNavigation

--- a/upgrade-notes/storefront_20241021_115025.md
+++ b/upgrade-notes/storefront_20241021_115025.md
@@ -1,0 +1,3 @@
+#### show category image just on first page ([#3522](https://github.com/shopsys/shopsys/pull/3522))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The category image is displayed only on the first page now.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2760-category-page-image.odin.shopsys.cloud
  - https://cz.tc-ssp-2760-category-page-image.odin.shopsys.cloud
<!-- Replace -->
