### PR TITLE
[framework] UploadedFileConfig get by class comparison fix

### DIFF
--- a/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfig.php
+++ b/packages/framework/src/Component/UploadedFile/Config/UploadedFileConfig.php
@@ -69,7 +69,7 @@ class UploadedFileConfig implements UploadedFileConfigInterface
     public function getUploadedFileEntityConfigByClass(string $entityClass): UploadedFileEntityConfig
     {
         foreach ($this->uploadedFileEntityConfigsByClass as $className => $entityConfig) {
-            if ($entityClass === $className) {
+            if (is_a($entityClass, $className, true)) {
                 return $entityConfig;
             }
         }


### PR DESCRIPTION
#### Description, the reason for the PR
Fixes class comparison in UploadedFileConfig by replacing strict equality with is_a() to support subclass names from project code

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://hn-uploaded-file-config-by-class-fix.odin.shopsys.cloud
  - https://cz.hn-uploaded-file-config-by-class-fix.odin.shopsys.cloud
<!-- Replace -->
