### PR TITLE
[project-base] fixed asset loading in helios-ag/fm-elfinder-bundle 12.6

### DIFF
--- a/project-base/app/config/packages/fm_elfinder.yaml
+++ b/project-base/app/config/packages/fm_elfinder.yaml
@@ -1,5 +1,5 @@
 fm_elfinder:
-    assets_path: /components
+    assets_path: false
     instances:
         default:
             editor: ckeditor

--- a/upgrade-notes/backend_20241029_105727.md
+++ b/upgrade-notes/backend_20241029_105727.md
@@ -1,0 +1,3 @@
+#### fix loading of elfinder with the version 12.6 of helios-ag/fm-elfinder-bundle ([#3540](https://github.com/shopsys/shopsys/pull/3540))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

 helios-ag/fm-elfinder-bundle version 12.6 changed the asset_path behavior (see https://github.com/helios-ag/FMElfinderBundle/issues/497), causing the elfinder to fail to load. 
This PR fixes the elfinder loading

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-elfinder.odin.shopsys.cloud
  - https://cz.mg-fix-elfinder.odin.shopsys.cloud
<!-- Replace -->
