### PR TITLE
customer user role group not found exception fix

### DIFF
--- a/packages/framework/src/Model/Customer/User/Role/Exception/CustomerUserRoleGroupNotFoundException.php
+++ b/packages/framework/src/Model/Customer/User/Role/Exception/CustomerUserRoleGroupNotFoundException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Customer\User\Role\Exception;
 
-use Exception;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class CustomerUserRoleGroupNotFoundException extends Exception implements CustomerUserRoleException
+class CustomerUserRoleGroupNotFoundException extends NotFoundHttpException implements CustomerUserRoleException
 {
 }


### PR DESCRIPTION
#### Description, the reason for the PR
Updated CustomerUserRoleGroupNotFoundException to extend NotFoundHttpException to ensure that requests for customer user roles with non-existent IDs return an HTTP 404 error.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://hn-customer-user-role-group-not-found-fix.odin.shopsys.cloud
  - https://cz.hn-customer-user-role-group-not-found-fix.odin.shopsys.cloud
<!-- Replace -->
