### PR TITLE
[shopsys] releaser: replace BitWarden mentions with 1Password

### DIFF
--- a/utils/releaser/src/ReleaseWorker/AfterRelease/CheckDocsReleaseWorker.php
+++ b/utils/releaser/src/ReleaseWorker/AfterRelease/CheckDocsReleaseWorker.php
@@ -32,7 +32,7 @@ final class CheckDocsReleaseWorker extends AbstractShopsysReleaseWorker
     ): void {
         $this->symfonyStyle->note('If you are releasing major or minor version, check that this version is present on https://docs.shopsys.com/');
         $this->symfonyStyle->note('Also check that current highest major or minor version is set as default on https://readthedocs.org/dashboard/shopsys-knowledge-base/advanced/');
-        $this->symfonyStyle->note('For login to Read the Docs you can use Shopsys Bot Github account present in BitWarden Vault.');
+        $this->symfonyStyle->note('For login to Read the Docs you can use Shopsys Bot Github account present in 1Password Vault.');
         $this->symfonyStyle->note('Authentication code is also present on page with password.');
 
         $this->symfonyStyle->confirm('Confirm that documentation is set correctly.');

--- a/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ReleaseNewNodeModulePackageVersion.php
+++ b/utils/releaser/src/ReleaseWorker/ReleaseCandidate/ReleaseNewNodeModulePackageVersion.php
@@ -41,7 +41,7 @@ class ReleaseNewNodeModulePackageVersion extends AbstractShopsysReleaseWorker
 # go to packages/framework/assets
 
 npm login
-# pass your credentials (login, password, email) (these credentials are available in BitWarden)
+# pass your credentials (login, password, email) (these credentials are available in 1Password)
 
 npm publish
 


### PR DESCRIPTION
#### Description, the reason for the PR
We no longer use Bitwarden, so the mentions might be confusing :slightly_smiling_face: 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-update-releaser.odin.shopsys.cloud
  - https://cz.rv-update-releaser.odin.shopsys.cloud
<!-- Replace -->
