### PR TITLE
[shopsys] SF security check now runs only for supported versions

### DIFF
--- a/.github/workflows/storefront-security-check.yaml
+++ b/.github/workflows/storefront-security-check.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                branches: ['13.0', '14.0', '15.0', '16.0']
+                branches: ['15.0', '16.0']
             fail-fast: false
         steps:
             -   name: GIT checkout branch - ${{ matrix.branches }}


### PR DESCRIPTION
#### Description, the reason for the PR
It is not necessary to run the checks for the versions that are not supported

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-github-actions-branches.odin.shopsys.cloud
  - https://cz.rv-github-actions-branches.odin.shopsys.cloud
<!-- Replace -->
