### PR TITLE
[framework] fix FormDetailExtension

### DIFF
--- a/packages/framework/src/Twig/FormDetailExtension.php
+++ b/packages/framework/src/Twig/FormDetailExtension.php
@@ -35,7 +35,7 @@ class FormDetailExtension extends AbstractExtension
      */
     public function formId($object)
     {
-        if ($object === null) {
+        if ($object === null || method_exists($object, 'getId') === false) {
             return '';
         }
 


### PR DESCRIPTION
#### Description, the reason for the PR
 added safety net when there is no getId() method for the object

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-form-id.odin.shopsys.cloud
  - https://cz.rv-fix-form-id.odin.shopsys.cloud
<!-- Replace -->
