### PR TITLE
Flag error for entity mapper

### DIFF
--- a/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
+++ b/packages/frontend-api/src/Model/Resolver/Products/DataMapper/ProductEntityFieldMapper.php
@@ -169,4 +169,13 @@ class ProductEntityFieldMapper
     {
         return $this->hreflangLinksFacade->getForProduct($product, $this->domain->getId());
     }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
+     * @return \Shopsys\FrameworkBundle\Model\Product\Flag[]
+     */
+    public function getFlags(Product $product): array
+    {
+        return $product->getFlags(domainId: $this->domain->getId());
+    }
 }


### PR DESCRIPTION
#### Description, the reason for the PR
The entity field mapper calls the getFlags method on the product without passing the domain.


#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
