### PR TITLE
[framework] admin now can select the administration locale

### DIFF
--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -60,10 +60,9 @@ See how to install Shopsys Platform in production and how to proceed when deploy
 
 ## How to set up the administration with a different locale/language (e.g., Czech)?
 
-Every administrator can switch the administration locale to any of the storefront locales to fit his needs.
-For the newly created administrators, the `en` locale is used by default.
-If you want to switch the defaul value to the another locale, set a parameter `shopsys.admin_default_locale` in your `config/parameters_common.yaml` configuration.
-However, the selected locale has to be one of registered domains locale.
+Every administrator can switch the administration locale to any of the locales defined by the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml` configuration.
+The first locale in the list is the default one.
+However, only locales that are defined in the `domains.yaml` config can be used in the administration.
 This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
 
 ## What are the differences between "listable", "sellable", "offered" and "visible" products?

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -60,8 +60,9 @@ See how to install Shopsys Platform in production and how to proceed when deploy
 
 ## How to set up the administration with a different locale/language (e.g., Czech)?
 
-The administration uses `en` locale by default.
-If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `config/parameters_common.yaml` configuration.
+Every administrator can switch the administration locale to any of the storefront locales to fit his needs.
+For the newly created administrators, the `en` locale is used by default.
+If you want to switch the defaul value to the another locale, set a parameter `shopsys.admin_default_locale` in your `config/parameters_common.yaml` configuration.
 However, the selected locale has to be one of registered domains locale.
 This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
 

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -178,10 +178,11 @@ If you have set a different locale, you can use `translations-dump` that will cr
 #### 3.6 Locale in administration
 
 Administration uses the `en` locale by default for every newly created administrator.
-This means that for example, product list in administration tries to display translations of product names in `en` locale.
-The administrator can then change the locale to any of the storefront locales to fit his needs.
-If you want to switch the default value to the another locale, set a parameter `shopsys.admin_default_locale` in your `config/parameters_common.yaml` configuration to desired locale.
-However, the selected locale has to be one of registered domains locale.
+This means that for example, product list in administration tries to display translations of product names in `en` locale, and all the static texts are in English.
+The administrator can then change the locale to fit his needs to any of the locales defined by the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml`.
+If you want to switch the default value to another locale or restrict the locales an administrator can choose from, set the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml` configuration accordingly.
+The first locale in the list is the default one.
+However, only locales that are defined in the `domains.yaml` config can be used in the administration.
 
 You can change administration translations by adding messages into your `translations/messages.xx.po`.
 

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -177,11 +177,11 @@ If you have set a different locale, you can use `translations-dump` that will cr
 
 #### 3.6 Locale in administration
 
-Administration is by default in `en` locale.
+Administration uses the `en` locale by default for every newly created administrator.
 This means that for example, product list in administration tries to display translations of product names in `en` locale.
-If you want to switch it to the another locale, set a parameter `shopsys.admin_locale` in your `config/parameters_common.yaml` configuration to desired locale.
+The administrator can then change the locale to any of the storefront locales to fit his needs.
+If you want to switch the default value to the another locale, set a parameter `shopsys.admin_default_locale` in your `config/parameters_common.yaml` configuration to desired locale.
 However, the selected locale has to be one of registered domains locale.
-When you change admin locale, you have to update acceptance tests, to have administration use cases tested properly.
 
 You can change administration translations by adding messages into your `translations/messages.xx.po`.
 

--- a/packages/framework/src/Component/Domain/DomainFacade.php
+++ b/packages/framework/src/Component/Domain/DomainFacade.php
@@ -12,7 +12,6 @@ class DomainFacade
 {
     /**
      * @param string $domainImagesDirectory
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\Domain\DomainIconProcessor $domainIconProcessor
      * @param \League\Flysystem\FilesystemOperator $filesystem
      * @param \Shopsys\FrameworkBundle\Component\FileUpload\FileUpload $fileUpload
@@ -20,20 +19,11 @@ class DomainFacade
      */
     public function __construct(
         protected readonly string $domainImagesDirectory,
-        protected readonly Domain $domain,
         protected readonly DomainIconProcessor $domainIconProcessor,
         protected readonly FilesystemOperator $filesystem,
         protected readonly FileUpload $fileUpload,
         protected readonly ImageProcessor $imageProcessor,
     ) {
-    }
-
-    /**
-     * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
-     */
-    public function getAllDomainConfigs(): array
-    {
-        return $this->domain->getAll();
     }
 
     /**

--- a/packages/framework/src/Controller/Admin/LocalizationController.php
+++ b/packages/framework/src/Controller/Admin/LocalizationController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Controller\Admin;
+
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class LocalizationController extends AdminBaseController
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     */
+    public function __construct(
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
+        protected readonly Localization $localization,
+    ) {
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param string $locale
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    #[Route(path: '/administrator/select-locale/{locale}')]
+    public function selectLocaleAction(Request $request, string $locale): Response
+    {
+        $redirectUrl = $request->headers->get('referer', $this->generateUrl('admin_default_dashboard'));
+
+        try {
+            $administrator = $this->getCurrentAdministrator();
+            $this->administratorLocalizationFacade->setSelectedLocale($administrator, $locale);
+            $this->addSuccessFlash(t('Administration localization was changed to "%locale%"', ['%locale%' => $this->localization->getLanguageName($locale, $locale)], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale));
+        } catch (AdminLocaleNotFoundException $exception) {
+            $this->addErrorFlash(t('Locale "%locale%" is not supported. You can choose only from the following locales: "%supportedLocales%".', [
+                '%locale%' => $locale,
+                '%supportedLocales%' => implode('", "', $exception->getPossibleLocales()),
+            ]));
+        }
+
+        return $this->redirect($redirectUrl);
+    }
+}

--- a/packages/framework/src/Controller/Admin/MenuController.php
+++ b/packages/framework/src/Controller/Admin/MenuController.php
@@ -5,21 +5,29 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Symfony\Component\HttpFoundation\Response;
 
 class MenuController extends AdminBaseController
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
-    public function __construct(protected readonly Domain $domain)
-    {
+    public function __construct(
+        protected readonly Domain $domain,
+        protected readonly Localization $localization,
+    ) {
     }
 
-    public function menuAction()
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function menuAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Inline/Menu/menu.html.twig', [
             'domainConfigs' => $this->domain->getAll(),
-            'locales' => $this->domain->getAllLocales(),
+            'allowedLocales' => $this->localization->getAllowedAdminLocales(),
         ]);
     }
 }

--- a/packages/framework/src/Controller/Admin/MenuController.php
+++ b/packages/framework/src/Controller/Admin/MenuController.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
-use Shopsys\FrameworkBundle\Component\Domain\DomainFacade;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 
 class MenuController extends AdminBaseController
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Component\Domain\DomainFacade $domainFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
-    public function __construct(protected readonly DomainFacade $domainFacade)
+    public function __construct(protected readonly Domain $domain)
     {
     }
 
     public function menuAction()
     {
         return $this->render('@ShopsysFramework/Admin/Inline/Menu/menu.html.twig', [
-            'domainConfigs' => $this->domainFacade->getAllDomainConfigs(),
+            'domainConfigs' => $this->domain->getAll(),
+            'locales' => $this->domain->getAllLocales(),
         ]);
     }
 }

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -18,6 +18,7 @@ use Shopsys\FrameworkBundle\Form\UrlListType;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryData;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -34,11 +35,13 @@ class BlogCategoryFormType extends AbstractType
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade $blogCategoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade $seoSettingFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly BlogCategoryFacade $blogCategoryFacade,
         protected readonly Domain $domain,
         protected readonly SeoSettingFacade $seoSettingFacade,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -98,9 +101,9 @@ class BlogCategoryFormType extends AbstractType
     private function createSettingsGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         if ($options['blogCategory'] !== null) {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->domain->getCurrentDomainConfig());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->localization->getAdminLocale());
         } else {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->domain->getLocale());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->localization->getAdminLocale());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Migrations/Version20241106123834.php
+++ b/packages/framework/src/Migrations/Version20241106123834.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Version20241106123834 extends AbstractMigration implements ContainerAwareInterface
+{
+    protected ContainerInterface $container;
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $adminDefaultLocale = $this->container->getParameter('shopsys.admin_default_locale');
+
+        $this->sql(sprintf('ALTER TABLE administrators ADD selected_locale VARCHAR(10) NOT NULL DEFAULT \'%s\'', $adminDefaultLocale));
+        $this->sql('ALTER TABLE administrators ALTER selected_locale DROP DEFAULT');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerInterface|null $container
+     */
+    public function setContainer(?ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+}

--- a/packages/framework/src/Model/Administrator/Administrator.php
+++ b/packages/framework/src/Model/Administrator/Administrator.php
@@ -169,6 +169,12 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     protected $displayOnlyDomainIds;
 
     /**
+     * @var string
+     * @ORM\Column(type="string", length=10)
+     */
+    protected $selectedLocale;
+
+    /**
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorData $administratorData
      */
     public function __construct(AdministratorData $administratorData)
@@ -182,6 +188,7 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
         $this->transferIssuesLastSeenDateTime = $administratorData->transferIssuesLastSeenDateTime;
         $this->uuid = Uuid::uuid4()->toString();
         $this->displayOnlyDomainIds = [];
+        $this->selectedLocale = $administratorData->selectedLocale;
         $this->setData($administratorData);
     }
 
@@ -641,5 +648,21 @@ class Administrator implements UserInterface, UniqueLoginInterface, TimelimitLog
     public function getDisplayOnlyDomainIds()
     {
         return array_map('intval', $this->displayOnlyDomainIds);
+    }
+
+    /**
+     * @param string $selectedLocale
+     */
+    public function setSelectedLocale($selectedLocale)
+    {
+        $this->selectedLocale = $selectedLocale;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSelectedLocale()
+    {
+        return $this->selectedLocale;
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorData.php
+++ b/packages/framework/src/Model/Administrator/AdministratorData.php
@@ -49,6 +49,11 @@ class AdministratorData
      */
     public $displayOnlyDomainIds;
 
+    /**
+     * @var string|null
+     */
+    public $selectedLocale;
+
     public function __construct()
     {
         $this->roles[] = Roles::ROLE_ADMIN;

--- a/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
@@ -10,8 +10,10 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param string $adminDefaultLocale
      */
     public function __construct(
+        protected readonly string $adminDefaultLocale,
         protected readonly Domain $domain,
     ) {
     }
@@ -32,6 +34,7 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
         $administratorData = $this->createInstance();
 
         $administratorData->displayOnlyDomainIds = $this->domain->getAllIds();
+        $administratorData->selectedLocale = $this->adminDefaultLocale;
 
         return $administratorData;
     }

--- a/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 class AdministratorDataFactory implements AdministratorDataFactoryInterface
 {
     /**
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param string $adminDefaultLocale
      */
     public function __construct(
-        protected readonly string $adminDefaultLocale,
+        protected readonly Localization $localization,
         protected readonly Domain $domain,
     ) {
     }
@@ -34,7 +35,7 @@ class AdministratorDataFactory implements AdministratorDataFactoryInterface
         $administratorData = $this->createInstance();
 
         $administratorData->displayOnlyDomainIds = $this->domain->getAllIds();
-        $administratorData->selectedLocale = $this->adminDefaultLocale;
+        $administratorData->selectedLocale = $this->localization->getDefaultAdminLocale();
 
         return $administratorData;
     }

--- a/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Administrator;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+
+class AdministratorLocalizationFacade
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @param \Doctrine\ORM\EntityManagerInterface $em
+     */
+    public function __construct(
+        protected readonly Localization $localization,
+        protected readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Administrator $administrator
+     * @param string $locale
+     */
+    public function setSelectedLocale(Administrator $administrator, string $locale): void
+    {
+        $this->localization->checkLocaleIsSupported($locale);
+        $administrator->setSelectedLocale($locale);
+
+        $this->em->flush();
+    }
+}

--- a/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
@@ -25,7 +25,7 @@ class AdministratorLocalizationFacade
      */
     public function setSelectedLocale(Administrator $administrator, string $locale): void
     {
-        $this->localization->checkLocaleIsSupported($locale);
+        $this->localization->checkAdminLocaleIsSupported($locale);
         $administrator->setSelectedLocale($locale);
 
         $this->em->flush();

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryFacade.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Blog\Category;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Image\ImageFacade;
 use Shopsys\FrameworkBundle\Component\Redis\CleanStorefrontCacheFacade;
@@ -200,12 +199,12 @@ class BlogCategoryFacade
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory $blogCategory
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
      */
-    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategory, DomainConfig $domainConfig): array
+    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategory, string $locale): array
     {
-        return $this->blogCategoryRepository->getTranslatedAllWithoutBranch($blogCategory, $domainConfig);
+        return $this->blogCategoryRepository->getTranslatedAllWithoutBranch($blogCategory, $locale);
     }
 
     /**

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -10,7 +10,6 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
-use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticle;
 use Shopsys\FrameworkBundle\Model\Blog\Article\BlogArticleBlogCategoryDomain;
@@ -88,13 +87,13 @@ class BlogCategoryRepository extends NestedTreeRepository
 
     /**
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory $blogCategoryBranch
-     * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
+     * @param string $locale
      * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
      */
-    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategoryBranch, DomainConfig $domainConfig): array
+    public function getTranslatedAllWithoutBranch(BlogCategory $blogCategoryBranch, string $locale): array
     {
         $queryBuilder = $this->getAllQueryBuilder();
-        $this->addTranslation($queryBuilder, $domainConfig->getLocale());
+        $this->addTranslation($queryBuilder, $locale);
 
         return $queryBuilder->andWhere('bc.lft < :branchLft OR bc.rgt > :branchRgt')
             ->setParameter('branchLft', $blogCategoryBranch->getLft())

--- a/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
+++ b/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
@@ -10,21 +10,25 @@ use RuntimeException;
 class AdminLocaleNotFoundException extends RuntimeException implements LocalizationException
 {
     /**
-     * @param string $adminLocale
+     * @param string|null $adminLocale
      * @param string[] $possibleLocales
      * @param \Exception|null $previous
      */
     public function __construct(
-        string $adminLocale,
-        protected readonly array $possibleLocales,
+        ?string $adminLocale = null,
+        protected readonly array $possibleLocales = [],
         ?Exception $previous = null,
     ) {
-        $message = sprintf(
-            'You tried to use administration in "%1$s" locale, but you have registered only ["%2$s"].'
-            . ' Either register "%1$s" as a locale with some domain or use one of ["%2$s"] as administration locale.',
-            $adminLocale,
-            implode('","', $possibleLocales),
-        );
+        if ($adminLocale === null) {
+            $message = 'There is no locale registered for the administration. Check your "shopsys.allowed_admin_locales" parameter configuration.';
+        } else {
+            $message = sprintf(
+                'You tried to set "%1$s" locale for the administration, but you have registered only ["%2$s"].'
+                . ' Either register "%1$s" as a locale with some domain, set "%1$s" as allowed admin locale, or use one of ["%2$s"] as administration locale.',
+                $adminLocale,
+                implode('","', $possibleLocales),
+            );
+        }
 
         parent::__construct($message, 0, $previous);
     }

--- a/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
+++ b/packages/framework/src/Model/Localization/Exception/AdminLocaleNotFoundException.php
@@ -14,8 +14,11 @@ class AdminLocaleNotFoundException extends RuntimeException implements Localizat
      * @param string[] $possibleLocales
      * @param \Exception|null $previous
      */
-    public function __construct(string $adminLocale, array $possibleLocales, ?Exception $previous = null)
-    {
+    public function __construct(
+        string $adminLocale,
+        protected readonly array $possibleLocales,
+        ?Exception $previous = null,
+    ) {
         $message = sprintf(
             'You tried to use administration in "%1$s" locale, but you have registered only ["%2$s"].'
             . ' Either register "%1$s" as a locale with some domain or use one of ["%2$s"] as administration locale.',
@@ -24,5 +27,13 @@ class AdminLocaleNotFoundException extends RuntimeException implements Localizat
         );
 
         parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPossibleLocales(): array
+    {
+        return $this->possibleLocales;
     }
 }

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -6,6 +6,8 @@ namespace Shopsys\FrameworkBundle\Model\Localization;
 
 use Locale;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\AdministratorIsNotLoggedException;
 use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
 
 class Localization
@@ -17,11 +19,13 @@ class Localization
 
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param string $adminLocale
+     * @param string $adminDefaultLocale
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade
      */
     public function __construct(
         protected readonly Domain $domain,
-        protected readonly string $adminLocale,
+        protected readonly string $adminDefaultLocale,
+        protected readonly AdministratorFrontSecurityFacade $administratorFrontSecurityFacade,
     ) {
     }
 
@@ -38,13 +42,15 @@ class Localization
      */
     public function getAdminLocale(): string
     {
-        $allLocales = $this->getLocalesOfAllDomains();
-
-        if (!in_array($this->adminLocale, $allLocales, true)) {
-            throw new AdminLocaleNotFoundException($this->adminLocale, $allLocales);
+        try {
+            $adminLocale = $this->administratorFrontSecurityFacade->getCurrentAdministrator()->getSelectedLocale();
+        } catch (AdministratorIsNotLoggedException) {
+            $adminLocale = $this->adminDefaultLocale;
         }
 
-        return $this->adminLocale;
+        $this->checkLocaleIsSupported($adminLocale);
+
+        return $adminLocale;
     }
 
     /**
@@ -61,11 +67,12 @@ class Localization
 
     /**
      * @param string $locale
+     * @param string|null $displayLocale
      * @return string
      */
-    public function getLanguageName(string $locale): string
+    public function getLanguageName(string $locale, string $displayLocale = null): string
     {
-        return Locale::getDisplayLanguage($locale);
+        return Locale::getDisplayLanguage($locale, $displayLocale);
     }
 
     /**
@@ -89,5 +96,17 @@ class Localization
         }
 
         return $enabledLocales;
+    }
+
+    /**
+     * @param string $locale
+     */
+    public function checkLocaleIsSupported(string $locale): void
+    {
+        $allLocales = $this->getLocalesOfAllDomains();
+
+        if (!in_array($locale, $allLocales, true)) {
+            throw new AdminLocaleNotFoundException($locale, $allLocales);
+        }
     }
 }

--- a/packages/framework/src/Resources/config/parameters_common.yaml
+++ b/packages/framework/src/Resources/config/parameters_common.yaml
@@ -10,11 +10,11 @@ parameters:
     # Seed for demo data generation
     faker.seed: 1234
 
+    # Administration locale used for newly created administrators. Must be registered in domains.yaml
+    shopsys.admin_default_locale: en
+
     # Time zone that the admin use for entering and viewing dates and times in the datetime pickers
     shopsys.admin_display_timezone: ~
-
-    # Administration locale. Must be registered in domains.yaml
-    shopsys.admin_locale: en
 
     # Hours defined in cron.yaml correspond to this timezone (default is PHP timezone)
     shopsys.cron_timezone: ~

--- a/packages/framework/src/Resources/config/parameters_common.yaml
+++ b/packages/framework/src/Resources/config/parameters_common.yaml
@@ -10,11 +10,11 @@ parameters:
     # Seed for demo data generation
     faker.seed: 1234
 
-    # Administration locale used for newly created administrators. Must be registered in domains.yaml
-    shopsys.admin_default_locale: en
-
     # Time zone that the admin use for entering and viewing dates and times in the datetime pickers
     shopsys.admin_display_timezone: ~
+
+    # Locales to select from in the administration. The first locale is the default one. All locales must be registered in domains.yaml
+    shopsys.allowed_admin_locales: ['en', 'cs']
 
     # Hours defined in cron.yaml correspond to this timezone (default is PHP timezone)
     shopsys.cron_timezone: ~

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -575,6 +575,10 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactory
 
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory:
+        arguments:
+            - '%shopsys.admin_default_locale%'
+
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory
 
@@ -762,7 +766,7 @@ services:
 
     Shopsys\FrameworkBundle\Model\Localization\Localization:
         arguments:
-            $adminLocale: '%shopsys.admin_locale%'
+            $adminDefaultLocale: '%shopsys.admin_default_locale%'
 
     Shopsys\FrameworkBundle\Model\Mail\MailTemplateConfiguration: ~
 

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -575,10 +575,6 @@ services:
     Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFactory
 
-    Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory:
-        arguments:
-            - '%shopsys.admin_default_locale%'
-
     Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactoryInterface:
         alias: Shopsys\FrameworkBundle\Model\Administrator\AdministratorDataFactory
 
@@ -766,7 +762,7 @@ services:
 
     Shopsys\FrameworkBundle\Model\Localization\Localization:
         arguments:
-            $adminDefaultLocale: '%shopsys.admin_default_locale%'
+            $allowedAdminLocales: '%shopsys.allowed_admin_locales%'
 
     Shopsys\FrameworkBundle\Model\Mail\MailTemplateConfiguration: ~
 

--- a/packages/framework/src/Resources/config/services_test.yaml
+++ b/packages/framework/src/Resources/config/services_test.yaml
@@ -24,9 +24,6 @@ services:
     prezent_doctrine_translatable.listener:
         arguments:
             $factory: '@prezent_doctrine_translatable.metadata_factory'
-            $domain: '@Shopsys\FrameworkBundle\Component\Domain\Domain'
-            $administrationFacade: '@Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade'
-            $adminLocale: '%shopsys.admin_default_locale%'
         class: Tests\FrameworkBundle\Test\TestTranslatableListener
         tags:
             - 'doctrine.event_subscriber'

--- a/packages/framework/src/Resources/config/services_test.yaml
+++ b/packages/framework/src/Resources/config/services_test.yaml
@@ -26,7 +26,7 @@ services:
             $factory: '@prezent_doctrine_translatable.metadata_factory'
             $domain: '@Shopsys\FrameworkBundle\Component\Domain\Domain'
             $administrationFacade: '@Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade'
-            $adminLocale: '%shopsys.admin_locale%'
+            $adminLocale: '%shopsys.admin_default_locale%'
         class: Tests\FrameworkBundle\Test\TestTranslatableListener
         tags:
             - 'doctrine.event_subscriber'

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -178,6 +178,9 @@ msgstr "URL detailu poptávky v administraci"
 msgid "Administration"
 msgstr "Administrace"
 
+msgid "Administration localization was changed to \"%locale%\""
+msgstr "Administrace byla přepnuta do jazyka \"%locale%\""
+
 msgid "Administrator"
 msgstr "Administrátor"
 
@@ -2287,6 +2290,9 @@ msgstr "Seznamy a číselníky"
 msgid "Loading"
 msgstr "Načítám"
 
+msgid "Locale \"%locale%\" is not supported. You can choose only from the following locales: \"%supportedLocales%\"."
+msgstr "Lokalizace \"%locale%\" není podporovaná. Můžete si vybrat pouze z následujících lokalizací: \"%supportedLocales%\"."
+
 msgid "Location"
 msgstr "Umístění"
 
@@ -3828,6 +3834,9 @@ msgstr "Superadmin - Nastavení prodeje s/bez DPH"
 
 msgid "Superadmin - URL addresses"
 msgstr "Superadmin - URL adresy"
+
+msgid "Switch locale"
+msgstr "Přepnout jazyk"
 
 msgid "System data"
 msgstr "Systémové údaje"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -178,6 +178,9 @@ msgstr ""
 msgid "Administration"
 msgstr ""
 
+msgid "Administration localization was changed to \"%locale%\""
+msgstr ""
+
 msgid "Administrator"
 msgstr ""
 
@@ -2287,6 +2290,9 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
+msgid "Locale \"%locale%\" is not supported. You can choose only from the following locales: \"%supportedLocales%\"."
+msgstr ""
+
 msgid "Location"
 msgstr ""
 
@@ -3827,6 +3833,9 @@ msgid "Superadmin - Sale including/excluding VAT settings"
 msgstr ""
 
 msgid "Superadmin - URL addresses"
+msgstr ""
+
+msgid "Switch locale"
 msgstr ""
 
 msgid "System data"

--- a/packages/framework/src/Resources/views/Admin/Inline/Domain/locales.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Domain/locales.html.twig
@@ -5,7 +5,7 @@
                 <span class="in-domain__item in-domain__item--active">
                     <span class="in-image in-image--normal">
                         <span class="in-image__in">
-                            {{ localeFlag(domainConfig.locale, true, 32, 22) }}
+                            {{ localeFlag(domainConfig.locale, null, true, 32, 22) }}
                         </span>
                     </span>
                     <span class="in-domain__item__name">
@@ -16,7 +16,7 @@
                 <a class="in-domain__item" href="{{ url('admin_domain_selectdomain', {id: domainConfig.id}) }}">
                     <span class="in-image in-image--normal">
                         <span class="in-image__in">
-                            {{ localeFlag(domainConfig.locale, true, 32, 22) }}
+                            {{ localeFlag(domainConfig.locale, null, true, 32, 22) }}
                         </span>
                     </span>
                     <span class="in-domain__item__name">

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -17,7 +17,7 @@
                     <ul class="js-toggle-menu-submenu box-dropdown__options">
                         {% for locale in allowedLocales %}
                             <li class="box-dropdown__options__item padding-right-10">
-                                <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale) }}">{{ localeFlag(locale) }} {{ languageName(locale) }}</a>
+                                <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale, locale) }}">{{ localeFlag(locale, locale) }} {{ languageName(locale, locale) }}</a>
                             </li>
                         {% endfor %}
                     </ul>

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -1,27 +1,29 @@
 <ul class="js-toggle-menu navig navig--side">
 
     {% if isMultidomain() %}
-        <li class="js-toggle-menu-item navig__item">
-            <div class="box-dropdown">
-                <div
-                        class="box-dropdown__select box-dropdown__select--menu"
-                        title="{{ 'Switch locale'|trans }}"
-                >
-                    <span class="box-dropdown__select__text">
-                        {{ localeFlag(app.user.selectedLocale) }}
-                    </span>
-                    <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
-                    <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
+        {% if allowedLocales|length > 1 %}
+            <li class="js-toggle-menu-item navig__item">
+                <div class="box-dropdown">
+                    <div
+                            class="box-dropdown__select box-dropdown__select--menu"
+                            title="{{ 'Switch locale'|trans }}"
+                    >
+                        <span class="box-dropdown__select__text">
+                            {{ localeFlag(app.user.selectedLocale) }}
+                        </span>
+                        <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
+                        <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
+                    </div>
+                    <ul class="js-toggle-menu-submenu box-dropdown__options">
+                        {% for locale in allowedLocales %}
+                            <li class="box-dropdown__options__item padding-right-10">
+                                <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale) }}">{{ localeFlag(locale) }} {{ languageName(locale) }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
                 </div>
-                <ul class="js-toggle-menu-submenu box-dropdown__options">
-                    {% for locale in locales %}
-                        <li class="box-dropdown__options__item padding-right-10">
-                            <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale) }}">{{ localeFlag(locale) }} {{ languageName(locale) }}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </li>
+            </li>
+        {% endif %}
 
         <li class="js-toggle-menu-item navig__item">
             <div class="box-dropdown">

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -5,6 +5,28 @@
             <div class="box-dropdown">
                 <div
                         class="box-dropdown__select box-dropdown__select--menu"
+                        title="{{ 'Switch locale'|trans }}"
+                >
+                    <span class="box-dropdown__select__text">
+                        {{ localeFlag(app.user.selectedLocale) }}
+                    </span>
+                    <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
+                    <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
+                </div>
+                <ul class="js-toggle-menu-submenu box-dropdown__options">
+                    {% for locale in locales %}
+                        <li class="box-dropdown__options__item padding-right-10">
+                            <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale) }}">{{ localeFlag(locale) }} {{ languageName(locale) }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </li>
+
+        <li class="js-toggle-menu-item navig__item">
+            <div class="box-dropdown">
+                <div
+                        class="box-dropdown__select box-dropdown__select--menu"
                         title="{{ 'Domain filter'|trans }}"
                 >
                     <i class="svg svg-menu"></i>

--- a/packages/framework/src/Twig/LocalizationExtension.php
+++ b/packages/framework/src/Twig/LocalizationExtension.php
@@ -36,6 +36,7 @@ class LocalizationExtension extends AbstractExtension
 
     /**
      * @param string $locale
+     * @param string|null $displayLocale
      * @param bool $showTitle
      * @param int $width
      * @param int $height
@@ -43,6 +44,7 @@ class LocalizationExtension extends AbstractExtension
      */
     public function getLocaleFlagHtml(
         string $locale,
+        string $displayLocale = null,
         bool $showTitle = true,
         int $width = 16,
         int $height = 11,
@@ -60,7 +62,7 @@ class LocalizationExtension extends AbstractExtension
                 '<img src="%s" alt="%s" title="%s" width="%d" height="%d" />',
                 htmlspecialchars($src, ENT_QUOTES),
                 htmlspecialchars($locale, ENT_QUOTES),
-                htmlspecialchars($this->getTitle($locale), ENT_QUOTES),
+                htmlspecialchars($this->getTitle($locale, $displayLocale), ENT_QUOTES),
                 $width,
                 $height,
             );
@@ -77,11 +79,12 @@ class LocalizationExtension extends AbstractExtension
 
     /**
      * @param string $locale
+     * @param string|null $displayLocale
      * @return string
      */
-    public function getTitle($locale)
+    public function getTitle(string $locale, string $displayLocale = null): string
     {
-        return $this->localization->getLanguageName($locale);
+        return $this->localization->getLanguageName($locale, $displayLocale);
     }
 
     /**

--- a/packages/framework/src/Twig/LocalizationExtension.php
+++ b/packages/framework/src/Twig/LocalizationExtension.php
@@ -30,6 +30,7 @@ class LocalizationExtension extends AbstractExtension
     {
         return [
             new TwigFunction('localeFlag', $this->getLocaleFlagHtml(...), ['is_safe' => ['html']]),
+            new TwigFunction('languageName', $this->getTitle(...), ['is_safe' => ['html']]),
         ];
     }
 
@@ -78,7 +79,7 @@ class LocalizationExtension extends AbstractExtension
      * @param string $locale
      * @return string
      */
-    protected function getTitle($locale)
+    public function getTitle($locale)
     {
         return $this->localization->getLanguageName($locale);
     }

--- a/packages/framework/tests/Test/TestTranslatableListener.php
+++ b/packages/framework/tests/Test/TestTranslatableListener.php
@@ -8,6 +8,7 @@ use Metadata\MetadataFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Localization\TranslatableListener;
 
 class TestTranslatableListener extends TranslatableListener
@@ -16,13 +17,13 @@ class TestTranslatableListener extends TranslatableListener
      * @param \Metadata\MetadataFactory $factory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade $administrationFacade
-     * @param string $adminLocale
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         MetadataFactory $factory,
         protected readonly Domain $domain,
         protected readonly AdministrationFacade $administrationFacade,
-        protected readonly string $adminLocale,
+        protected readonly Localization $localization,
     ) {
         parent::__construct($factory);
     }
@@ -33,7 +34,7 @@ class TestTranslatableListener extends TranslatableListener
     public function getCurrentLocale()
     {
         if ($this->administrationFacade->isInAdmin()) {
-            return $this->adminLocale;
+            return $this->localization->getAdminLocale();
         }
 
         try {

--- a/project-base/app/config/packages/security.yaml
+++ b/project-base/app/config/packages/security.yaml
@@ -364,6 +364,7 @@ security:
         - { path: ^/%admin_url%/administrator/my-account/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/administrator/enable-two-factor-authentication/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/administrator/disable-two-factor-authentication/, roles: ROLE_ADMIN }
+        - { path: ^/%admin_url%/administrator/select-locale/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/administrator/groups/list/, roles: ROLE_ADMINISTRATOR_VIEW }
         - { path: ^/%admin_url%/administrator/groups/edit/, roles: ROLE_ADMINISTRATOR_FULL }
         - { path: ^/%admin_url%/administrator/groups/new/, roles: ROLE_ADMINISTRATOR_FULL }

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -8,8 +8,8 @@ parameters:
     # Symfony's FrameworkBundle sets throw_at (error_reporting) to 0 in production by default
     debug.error_handler.throw_at: -1
     locale: en
-    shopsys.admin_default_locale: en
     shopsys.admin_display_timezone: Europe/Prague
+    shopsys.allowed_admin_locales: ['en', 'cs']
     shopsys.cron_timezone: Europe/Prague
 
     # Set to true to log validation errors with log level ERROR instead of INFO

--- a/project-base/app/config/parameters_common.yaml
+++ b/project-base/app/config/parameters_common.yaml
@@ -8,8 +8,8 @@ parameters:
     # Symfony's FrameworkBundle sets throw_at (error_reporting) to 0 in production by default
     debug.error_handler.throw_at: -1
     locale: en
+    shopsys.admin_default_locale: en
     shopsys.admin_display_timezone: Europe/Prague
-    shopsys.admin_locale: en
     shopsys.cron_timezone: Europe/Prague
 
     # Set to true to log validation errors with log level ERROR instead of INFO

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -86,6 +86,10 @@ services:
 
     App\FrontendApi\Model\Token\TokenAuthenticator: ~
 
+    App\Model\Administrator\AdministratorDataFactory:
+        arguments:
+            - '%shopsys.admin_default_locale%'
+
     App\Model\Cart\CartFacade:
         lazy: true
 

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -86,10 +86,6 @@ services:
 
     App\FrontendApi\Model\Token\TokenAuthenticator: ~
 
-    App\Model\Administrator\AdministratorDataFactory:
-        arguments:
-            - '%shopsys.admin_default_locale%'
-
     App\Model\Cart\CartFacade:
         lazy: true
 

--- a/project-base/app/tests/App/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/app/tests/App/Functional/Twig/PriceExtensionTest.php
@@ -207,7 +207,7 @@ class PriceExtensionTest extends FunctionalTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $localization = new Localization($this->domain, 'en', $administratorFrontSecurityFacadeMock);
+        $localization = new Localization($this->domain, ['en'], $administratorFrontSecurityFacadeMock);
 
         return new PriceExtension(
             $currencyFacadeMock,

--- a/project-base/app/tests/App/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/app/tests/App/Functional/Twig/PriceExtensionTest.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade;
 use Shopsys\FrameworkBundle\Model\Localization\IntlCurrencyRepository;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
@@ -202,7 +203,11 @@ class PriceExtensionTest extends FunctionalTestCase
         $currencyFacadeMock
             ->method('getDefaultCurrency')
             ->willReturn($domain1DefaultCurrency);
-        $localization = new Localization($this->domain, 'en');
+        $administratorFrontSecurityFacadeMock = $this->getMockBuilder(AdministratorFrontSecurityFacade::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $localization = new Localization($this->domain, 'en', $administratorFrontSecurityFacadeMock);
 
         return new PriceExtension(
             $currencyFacadeMock,

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -10,7 +10,6 @@ use App\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule;
 use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;

--- a/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
+++ b/project-base/app/tests/App/Smoke/Http/RouteConfigCustomization.php
@@ -10,6 +10,7 @@ use App\Model\Administrator\Administrator;
 use Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\Security\RouteCsrfProtector;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\Vat;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatDeletionCronModule;
 use Shopsys\FrameworkBundle\Model\Product\Unit\Unit;
@@ -402,6 +403,13 @@ class RouteConfigCustomization
                 $config->changeDefaultRequestDataSet('Use catnums instead of ID')
                     ->setParameter('catnums', '9177759,7700768,9146508')
                     ->setExpectedStatusCode(200);
+            })
+            ->customizeByRouteName('admin_localization_selectlocale', function (RouteConfig $config) {
+                /** @var \Shopsys\FrameworkBundle\Component\Domain\Domain $domain */
+                $domain = $this->container->get(Domain::class);
+                $config->changeDefaultRequestDataSet()
+                    ->setParameter('locale', $domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale())
+                    ->setExpectedStatusCode(302);
             });
     }
 

--- a/upgrade-notes/backend_20241106_155311.md
+++ b/upgrade-notes/backend_20241106_155311.md
@@ -1,0 +1,5 @@
+#### allow administrator to select the administration locale ([#3577](https://github.com/shopsys/shopsys/pull/3577))
+
+-   `%shopsys.admin_locale%` container parameter was renamed to `%shopsys.admin_default_locale%`
+-   `Shopsys\FrameworkBundle\Component\Domain\DomainFacade::getAllDomainConfigs()` method was removed, use `Shopsys\FrameworkBundle\Component\Domain\Domain::getAll()` instead
+-   see #project-base-diff to update your project

--- a/upgrade-notes/backend_20241106_155311.md
+++ b/upgrade-notes/backend_20241106_155311.md
@@ -1,5 +1,6 @@
 #### allow administrator to select the administration locale ([#3577](https://github.com/shopsys/shopsys/pull/3577))
 
--   `%shopsys.admin_locale%` container parameter was renamed to `%shopsys.admin_default_locale%`
+-   `%shopsys.admin_locale%` container parameter was removed, use `%shopsys.allowed_admin_locales%` instead
+    -   the parameter is now an array defining the allowed locales for the administration, the first locale in the list is the default one
 -   `Shopsys\FrameworkBundle\Component\Domain\DomainFacade::getAllDomainConfigs()` method was removed, use `Shopsys\FrameworkBundle\Component\Domain\Domain::getAll()` instead
 -   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
We want to allow the administrators to select the administration locale that suits their needs (they can choose from any of the locales that are specified by the new `shopsys.allowed_admin_locales` parameter) so the administration locale change is not dependent on a developer anymore and can be customized per administrator.

![image](https://github.com/user-attachments/assets/7ae0c3fb-fbaa-4ded-82e0-5065b8f374ef)

The language names in the select box are always displayed in their own locale hence e.g. "Czech" is always displayed as "čeština" so the Czechs have no trouble finding it (imagine you are trying to find "チェコ語" to switch to your language from Japanese localization :grin: )

`%shopsys.admin_locale%` container parameter was removed in favor of the new array defined by `%shopsys.allowed_admin_locales%` and the first locale in the list is used as a default value.

Second commit was cherry picked from https://github.com/shopsys/shopsys/pull/3485

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [x] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [x] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-admin-language-switch.odin.shopsys.cloud
  - https://cz.rv-admin-language-switch.odin.shopsys.cloud
<!-- Replace -->
