### PR TITLE
[Framework] Preselected country in the delivery address creating by billing address

### DIFF
--- a/packages/framework/src/Model/Customer/DeliveryAddressDataFactory.php
+++ b/packages/framework/src/Model/Customer/DeliveryAddressDataFactory.php
@@ -42,6 +42,7 @@ class DeliveryAddressDataFactory implements DeliveryAddressDataFactoryInterface
     {
         $deliveryAddressData = $this->createInstance();
         $deliveryAddressData->customer = $customer;
+        $deliveryAddressData->country = $customer->getBillingAddress()->getCountry();
 
         return $deliveryAddressData;
     }


### PR DESCRIPTION
#### Description, the reason for the PR
Even though the client was from Slovakia, when creating the delivery address, the first country from the values was preset for him. Now, the country will be preset according to the billing address.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mvn-ssp-2810-default-country-for-new-delivery-address.odin.shopsys.cloud
  - https://cz.mvn-ssp-2810-default-country-for-new-delivery-address.odin.shopsys.cloud
<!-- Replace -->
