### PR TITLE
[project-base] Remove active filters when switching pages

### DIFF
--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -38,7 +38,7 @@ import {
 import { useCurrentFilterQuery } from 'utils/queryParams/useCurrentFilterQuery';
 import { useCurrentSortQuery } from 'utils/queryParams/useCurrentSortQuery';
 import { getPrefixedSeoTitle } from 'utils/seo/getPrefixedSeoTitle';
-import { useResetOriginalCategorySlug } from 'utils/seo/useResetOriginalCategorySlug';
+import { useResetSessionFilters } from 'utils/seo/useResetOriginalCategorySlug';
 import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps } from 'utils/serverSide/initServerSideProps';
@@ -48,7 +48,7 @@ const BrandDetailPage: NextPage = () => {
     const router = useRouter();
     const currentFilter = useCurrentFilterQuery();
     const currentSort = useCurrentSortQuery();
-    useResetOriginalCategorySlug();
+    useResetSessionFilters();
 
     const [{ data: brandDetailData, fetching: isBrandFetching }] = useBrandDetailQuery({
         variables: {

--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -4,15 +4,15 @@ import { CommonLayout } from 'components/Layout/CommonLayout';
 import { BrandDetailContent } from 'components/Pages/BrandDetail/BrandDetailContent';
 import { DEFAULT_PAGE_SIZE } from 'config/constants';
 import {
-    useBrandDetailQuery,
+    BrandDetailQueryDocument,
     TypeBrandDetailQuery,
     TypeBrandDetailQueryVariables,
-    BrandDetailQueryDocument,
+    useBrandDetailQuery,
 } from 'graphql/requests/brands/queries/BrandDetailQuery.generated';
 import {
+    BrandProductsQueryDocument,
     TypeBrandProductsQuery,
     TypeBrandProductsQueryVariables,
-    BrandProductsQueryDocument,
 } from 'graphql/requests/products/queries/BrandProductsQuery.generated';
 import { useGtmFriendlyPageViewEvent } from 'gtm/factories/useGtmFriendlyPageViewEvent';
 import { useGtmPageViewEvent } from 'gtm/utils/pageViewEvents/useGtmPageViewEvent';
@@ -38,6 +38,7 @@ import {
 import { useCurrentFilterQuery } from 'utils/queryParams/useCurrentFilterQuery';
 import { useCurrentSortQuery } from 'utils/queryParams/useCurrentSortQuery';
 import { getPrefixedSeoTitle } from 'utils/seo/getPrefixedSeoTitle';
+import { useResetOriginalCategorySlug } from 'utils/seo/useResetOriginalCategorySlug';
 import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps } from 'utils/serverSide/initServerSideProps';
@@ -47,6 +48,7 @@ const BrandDetailPage: NextPage = () => {
     const router = useRouter();
     const currentFilter = useCurrentFilterQuery();
     const currentSort = useCurrentSortQuery();
+    useResetOriginalCategorySlug();
 
     const [{ data: brandDetailData, fetching: isBrandFetching }] = useBrandDetailQuery({
         variables: {

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -35,6 +35,7 @@ import {
 } from 'utils/queryParamNames';
 import { useCurrentFilterQuery } from 'utils/queryParams/useCurrentFilterQuery';
 import { useCurrentSortQuery } from 'utils/queryParams/useCurrentSortQuery';
+import { useResetOriginalCategorySlug } from 'utils/seo/useResetOriginalCategorySlug';
 import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps } from 'utils/serverSide/initServerSideProps';
@@ -45,6 +46,7 @@ const FlagDetailPage: NextPage = () => {
     const currentSort = useCurrentSortQuery();
     const orderingMode = getProductListSortFromUrlQuery(router.query[SORT_QUERY_PARAMETER_NAME]);
     const filter = getMappedProductFilter(router.query[FILTER_QUERY_PARAMETER_NAME]);
+    useResetOriginalCategorySlug();
 
     const [{ data: flagDetailData, fetching: isFlagFetching }] = useFlagDetailQuery({
         variables: {

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -35,7 +35,7 @@ import {
 } from 'utils/queryParamNames';
 import { useCurrentFilterQuery } from 'utils/queryParams/useCurrentFilterQuery';
 import { useCurrentSortQuery } from 'utils/queryParams/useCurrentSortQuery';
-import { useResetOriginalCategorySlug } from 'utils/seo/useResetOriginalCategorySlug';
+import { useResetSessionFilters } from 'utils/seo/useResetOriginalCategorySlug';
 import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps } from 'utils/serverSide/initServerSideProps';
@@ -46,7 +46,7 @@ const FlagDetailPage: NextPage = () => {
     const currentSort = useCurrentSortQuery();
     const orderingMode = getProductListSortFromUrlQuery(router.query[SORT_QUERY_PARAMETER_NAME]);
     const filter = getMappedProductFilter(router.query[FILTER_QUERY_PARAMETER_NAME]);
-    useResetOriginalCategorySlug();
+    useResetSessionFilters();
 
     const [{ data: flagDetailData, fetching: isFlagFetching }] = useFlagDetailQuery({
         variables: {

--- a/project-base/storefront/pages/search.tsx
+++ b/project-base/storefront/pages/search.tsx
@@ -12,7 +12,7 @@ import { getNumberFromUrlQuery } from 'utils/parsing/getNumberFromUrlQuery';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { LOAD_MORE_QUERY_PARAMETER_NAME, PAGE_QUERY_PARAMETER_NAME } from 'utils/queryParamNames';
 import { useCurrentSearchStringQuery } from 'utils/queryParams/useCurrentSearchStringQuery';
-import { useResetOriginalCategorySlug } from 'utils/seo/useResetOriginalCategorySlug';
+import { useResetSessionFilters } from 'utils/seo/useResetOriginalCategorySlug';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps, ServerSidePropsType } from 'utils/serverSide/initServerSideProps';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
@@ -21,7 +21,7 @@ const SearchPage: FC<ServerSidePropsType> = () => {
     const { t } = useTranslation();
     const { url } = useDomainConfig();
     const currentSearchString = useCurrentSearchStringQuery();
-    useResetOriginalCategorySlug();
+    useResetSessionFilters();
 
     const [searchUrl] = getInternationalizedStaticUrls(['/search'], url);
     const breadcrumbs: TypeBreadcrumbFragment[] = [{ __typename: 'Link', name: t('Search'), slug: searchUrl }];

--- a/project-base/storefront/pages/search.tsx
+++ b/project-base/storefront/pages/search.tsx
@@ -12,6 +12,7 @@ import { getNumberFromUrlQuery } from 'utils/parsing/getNumberFromUrlQuery';
 import { getSlugFromServerSideUrl } from 'utils/parsing/getSlugFromServerSideUrl';
 import { LOAD_MORE_QUERY_PARAMETER_NAME, PAGE_QUERY_PARAMETER_NAME } from 'utils/queryParamNames';
 import { useCurrentSearchStringQuery } from 'utils/queryParams/useCurrentSearchStringQuery';
+import { useResetOriginalCategorySlug } from 'utils/seo/useResetOriginalCategorySlug';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps, ServerSidePropsType } from 'utils/serverSide/initServerSideProps';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
@@ -20,6 +21,7 @@ const SearchPage: FC<ServerSidePropsType> = () => {
     const { t } = useTranslation();
     const { url } = useDomainConfig();
     const currentSearchString = useCurrentSearchStringQuery();
+    useResetOriginalCategorySlug();
 
     const [searchUrl] = getInternationalizedStaticUrls(['/search'], url);
     const breadcrumbs: TypeBreadcrumbFragment[] = [{ __typename: 'Link', name: t('Search'), slug: searchUrl }];

--- a/project-base/storefront/utils/seo/useResetOriginalCategorySlug.ts
+++ b/project-base/storefront/utils/seo/useResetOriginalCategorySlug.ts
@@ -1,8 +1,19 @@
 import { useSessionStore } from 'store/useSessionStore';
+import { getEmptyDefaultProductFiltersMap } from 'utils/seoCategories/getEmptyDefaultProductFiltersMap';
 
-export const useResetOriginalCategorySlug = () => {
+export const useResetSessionFilters = () => {
     const originalCategorySlug = useSessionStore((s) => s.originalCategorySlug);
     const setOriginalCategorySlug = useSessionStore((s) => s.setOriginalCategorySlug);
+    const defaultProductFiltersMap = useSessionStore((s) => s.defaultProductFiltersMap);
+    const setDefaultProductFiltersMap = useSessionStore((s) => s.setDefaultProductFiltersMap);
+
+    if (
+        defaultProductFiltersMap.brands.size > 0 ||
+        defaultProductFiltersMap.flags.size > 0 ||
+        defaultProductFiltersMap.parameters.size > 0
+    ) {
+        setDefaultProductFiltersMap(getEmptyDefaultProductFiltersMap());
+    }
 
     if (originalCategorySlug) {
         setOriginalCategorySlug(undefined);

--- a/project-base/storefront/utils/seo/useResetOriginalCategorySlug.ts
+++ b/project-base/storefront/utils/seo/useResetOriginalCategorySlug.ts
@@ -1,0 +1,10 @@
+import { useSessionStore } from 'store/useSessionStore';
+
+export const useResetOriginalCategorySlug = () => {
+    const originalCategorySlug = useSessionStore((s) => s.originalCategorySlug);
+    const setOriginalCategorySlug = useSessionStore((s) => s.setOriginalCategorySlug);
+
+    if (originalCategorySlug) {
+        setOriginalCategorySlug(undefined);
+    }
+};

--- a/upgrade-notes/storefront_20241112_155546.md
+++ b/upgrade-notes/storefront_20241112_155546.md
@@ -1,0 +1,5 @@
+#### Remove stale original category slug from session ([#3592](https://github.com/shopsys/shopsys/pull/3592))
+
+-   sorting is now allowed on different pages than category, but the sort was still trying to recover from SEO category by replacing current url with the original category slug and sort/filter queries
+-   flags, brands and search pages are out of scope of SEO, therefore the stale `originalCategorySlug` is removed from session store preventing wrong url rewrites
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
To fix error with sorting on brand page when navigated from SEO category, stale session store value of category slug is removed. 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-2863-product-sort-unknown-error.odin.shopsys.cloud
  - https://cz.jm-ssp-2863-product-sort-unknown-error.odin.shopsys.cloud
<!-- Replace -->
