### PR TITLE
[shopsys] Change blog categories for real root category

### DIFF
--- a/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
+++ b/packages/framework/assets/js/admin/components/CategoryTreeSorting.js
@@ -34,6 +34,7 @@ export default class CategoryTreeSorting {
             helper: 'clone',
             opacity: 0.6,
             revert: 100,
+            protectRoot: this.$rootTree.hasClass('js-protect-root'),
             change: () => _this.onChange()
         });
 

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -135,7 +135,7 @@ class BlogCategoryFormType extends AbstractType
                 'required' => true,
                 'choices' => $parentChoices,
                 'choice_label' => function (BlogCategory $blogCategory) {
-                    $padding = str_repeat("\u{00a0}", ($blogCategory->getLevel() - 1) * 2);
+                    $padding = str_repeat("\u{00a0}", $blogCategory->getLevel() * 2);
 
                     return $padding . $blogCategory->getName();
                 },

--- a/packages/framework/src/Migrations/Version20241112100245.php
+++ b/packages/framework/src/Migrations/Version20241112100245.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Exception;
+use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+class Version20241112100245 extends AbstractMigration implements ContainerAwareInterface
+{
+    use MultidomainMigrationTrait;
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $rootBlogCategories = $this->sql('SELECT id FROM blog_categories WHERE parent_id IS NULL AND level = 0')->fetchAllAssociative();
+
+        if (count($rootBlogCategories) === 1) {
+            $blogCategoryId = reset($rootBlogCategories)['id'];
+            $translation = $this->sql('SELECT 1 FROM blog_category_translations WHERE translatable_id = ?', [$blogCategoryId])->fetchOne();
+
+            if ($translation === false) {
+                $this->sql('UPDATE blog_categories SET parent_id = NULL WHERE parent_id = ?', [$blogCategoryId]);
+                $this->sql('DELETE FROM blog_category_domains WHERE blog_category_id = ?', [$blogCategoryId]);
+                $this->sql('DELETE FROM blog_categories WHERE id = ?', [$blogCategoryId]);
+                $this->sql('UPDATE blog_categories SET level = level -1');
+            }
+
+            $entityManager = $this->container->get('doctrine.orm.default_entity_manager');
+            $repository = $entityManager->getRepository(BlogCategory::class);
+
+            if ($repository instanceof NestedTreeRepository) {
+                $repository->recover();
+            }
+        } elseif (count($rootBlogCategories) > 1) {
+            throw new Exception('There is more than one root blog category. Please see upgrade notes.');
+        }
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Blog/Category/BlogCategory.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategory.php
@@ -20,8 +20,6 @@ use Shopsys\FrameworkBundle\Model\Localization\AbstractTranslatableEntity;
  */
 class BlogCategory extends AbstractTranslatableEntity
 {
-    public const BLOG_MAIN_PAGE_CATEGORY_ID = 2;
-
     /**
      * @var int
      * @ORM\Column(type="integer")
@@ -336,7 +334,7 @@ class BlogCategory extends AbstractTranslatableEntity
      */
     public function isMainPage()
     {
-        return $this->id === self::BLOG_MAIN_PAGE_CATEGORY_ID;
+        return $this->parent === null;
     }
 
     /**

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -45,7 +45,6 @@ class BlogCategoryRepository extends NestedTreeRepository
     {
         return $this->getBlogCategoryRepository()
             ->createQueryBuilder('bc')
-            ->where('bc.parent IS NOT NULL')
             ->orderBy('bc.lft');
     }
 
@@ -111,10 +110,6 @@ class BlogCategoryRepository extends NestedTreeRepository
         /** @var \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory $blogCategory */
         $blogCategory = $this->getBlogCategoryRepository()->find($blogCategoryId);
 
-        if ($blogCategory !== null && $blogCategory->getParent() === null) {
-            return null;
-        }
-
         return $blogCategory;
     }
 
@@ -173,7 +168,6 @@ class BlogCategoryRepository extends NestedTreeRepository
         $this->addTranslation($queryBuilder, $locale);
 
         $queryBuilder
-            ->andWhere('bc.level >= 1')
             ->orderBy('bc.lft');
 
         return $queryBuilder;
@@ -205,6 +199,21 @@ class BlogCategoryRepository extends NestedTreeRepository
         $queryBuilder->setParameter('domainId', $domainId);
 
         return $queryBuilder;
+    }
+
+    /**
+     * @param int $domainId
+     * @return \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategory[]
+     */
+    public function getAllVisibleChildrenWithRootByDomainId(int $domainId): array
+    {
+        $queryBuilder = $this->getAllVisibleByDomainIdQueryBuilder($domainId)
+            ->andWhere('bc.parent IS NULL');
+
+        $locale = $this->domain->getDomainConfigById($domainId)->getLocale();
+        $this->addTranslation($queryBuilder, $locale);
+
+        return $queryBuilder->getQuery()->execute();
     }
 
     /**

--- a/packages/framework/src/Model/Blog/Category/BlogCategoryWithPreloadedChildrenFactory.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryWithPreloadedChildrenFactory.php
@@ -55,7 +55,7 @@ class BlogCategoryWithPreloadedChildrenFactory
         $firstLevelBlogCategories = [];
 
         foreach ($blogCategories as $blogCategory) {
-            if ($blogCategory->getLevel() === 1) {
+            if ($blogCategory->getLevel() === 0) {
                 $firstLevelBlogCategories[] = $blogCategory;
             }
         }

--- a/packages/framework/src/Model/Blog/Category/Exception/RootLevelBlogCategoryAlreadyExistsException.php
+++ b/packages/framework/src/Model/Blog/Category/Exception/RootLevelBlogCategoryAlreadyExistsException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Blog\Category\Exception;
+
+use Exception;
+
+class RootLevelBlogCategoryAlreadyExistsException extends Exception
+{
+    /**
+     * @param int $blogCategoryId
+     * @param \Exception|null $previous
+     */
+    public function __construct(int $blogCategoryId, ?Exception $previous = null)
+    {
+        $message = sprintf('There can be only one blog category with root level. The current root level blog category ID is "%d".', $blogCategoryId);
+
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/packages/framework/src/Resources/views/Admin/Content/Blog/Category/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Blog/Category/list.html.twig
@@ -32,7 +32,7 @@
                                 id: blogCategoryWithPreloadedChildren.blogCategory.id,
                                 (constant('Shopsys\\FrameworkBundle\\Component\\Router\\Security\\RouteCsrfProtector::CSRF_TOKEN_REQUEST_PARAMETER')): csrf_token(csrfTokenId)
                             }) %}
-                            {% if blogCategoryWithPreloadedChildren.blogCategory.level is not same as(1) %}
+                            {% if blogCategoryWithPreloadedChildren.blogCategory.level is not same as(0) %}
                                 <a
                                     data-delete-url="{{ blogCategoryDeleteUrl }}"
                                     class="form-tree__item__control js-category-delete-confirm"

--- a/packages/frontend-api/src/Model/Blog/Category/BlogCategoriesQuery.php
+++ b/packages/frontend-api/src/Model/Blog/Category/BlogCategoriesQuery.php
@@ -25,8 +25,7 @@ class BlogCategoriesQuery extends AbstractQuery
      */
     public function blogCategoriesQuery(): array
     {
-        return $this->blogCategoryFacade->getAllVisibleChildrenByBlogCategoryAndDomainId(
-            $this->blogCategoryFacade->getRootBlogCategory(),
+        return $this->blogCategoryFacade->getAllVisibleChildrenWithRootByDomainId(
             $this->domain->getId(),
         );
     }

--- a/packages/frontend-api/src/Model/Blog/Category/BlogCategoryResolverMap.php
+++ b/packages/frontend-api/src/Model/Blog/Category/BlogCategoryResolverMap.php
@@ -47,9 +47,7 @@ class BlogCategoryResolverMap extends ResolverMap
                     return $blogCategory->getSeoMetaDescription($this->domain->getId());
                 },
                 'parent' => function (BlogCategory $blogCategory) {
-                    $parent = $blogCategory->getParent();
-
-                    return $parent !== null && $parent->getParent() !== null ? $parent : null;
+                    return $blogCategory->getParent();
                 },
                 'slug' => function (BlogCategory $blogCategory) {
                     return '/' . $this->friendlyUrlFacade->getMainFriendlyUrlSlug($this->domain->getId(), 'front_blogcategory_detail', $blogCategory->getId());
@@ -64,8 +62,7 @@ class BlogCategoryResolverMap extends ResolverMap
                     );
                 },
                 'blogCategoriesTree' => function () {
-                    return $this->blogCategoryFacade->getAllVisibleChildrenByBlogCategoryAndDomainId(
-                        $this->blogCategoryFacade->getRootBlogCategory(),
+                    return $this->blogCategoryFacade->getAllVisibleChildrenWithRootByDomainId(
                         $this->domain->getId(),
                     );
                 },

--- a/project-base/app/src/DataFixtures/Demo/BlogArticleDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/BlogArticleDataFixture.php
@@ -54,7 +54,7 @@ class BlogArticleDataFixture extends AbstractReferenceFixture implements Depende
      */
     public function load(ObjectManager $manager): void
     {
-        $mainPageBlogCategory = $this->blogCategoryFacade->getById(BlogCategory::BLOG_MAIN_PAGE_CATEGORY_ID);
+        $mainPageBlogCategory = $this->blogCategoryFacade->getRootBlogCategory();
         $mainPageBlogCategoryData = $this->blogCategoryDataFactory->createFromBlogCategory($mainPageBlogCategory);
         $mainPageBlogCategoryData->uuid = Uuid::uuid5(self::UUID_NAMESPACE, 'Main blog page')->toString();
 

--- a/upgrade-notes/backend_20241113_140226.md
+++ b/upgrade-notes/backend_20241113_140226.md
@@ -1,0 +1,4 @@
+#### replace hidden root blog category by 1st level one ([#3595](https://github.com/shopsys/shopsys/pull/3595))
+
+-   The hidden 0 level root category has been replaced by 1st level category and is visible now. Also there can be only one main category from now. If you had multiple 1st level categories until now, you will need to update your code to reflect this change and also review `packages/framework/src/Migrations/Version20241112100245.php` migration if it wont fail in your use case.
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
For historical reasons, we had a hidden root blog category. It was due to the possibility of the existence of several main blog categories. The new acceptance criteria state that there can only be one root blog category. That's why we redesigned them so that the main category is no longer hidden.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mvn-ssp-2742-disable-zero-level-for-blog-category.odin.shopsys.cloud
  - https://cz.mvn-ssp-2742-disable-zero-level-for-blog-category.odin.shopsys.cloud
<!-- Replace -->
