### PR TITLE
[project-base] fixed failing MainBlogCategoryDataSettingsTest because of incorrect domain url

### DIFF
--- a/project-base/app/tests/FrontendApiBundle/Functional/Settings/MainBlogCategoryDataSettingsTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Settings/MainBlogCategoryDataSettingsTest.php
@@ -27,7 +27,7 @@ class MainBlogCategoryDataSettingsTest extends GraphQlTestCase
                 'mainBlogCategoryUrl' => $expectedBlogUrl,
                 'mainBlogCategoryMainImage' => [
                     'name' => 'Main blog page - en',
-                    'url' => 'http://127.0.0.1:8000/content-test/images/blogCategory/500.jpg',
+                    'url' => $this->getFullUrlPath('/content-test/images/blogCategory/500.jpg'),
                 ],
             ],
         ];

--- a/upgrade-notes/backend_20241114_094625.md
+++ b/upgrade-notes/backend_20241114_094625.md
@@ -1,0 +1,3 @@
+#### Fixed failing MainBlogCategoryDataSettingsTest because of incorrect domain url ([#3598](https://github.com/shopsys/shopsys/pull/3598))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed failing MainBlogCategoryDataSettingsTest because of incorrect domain url

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-fix-tests.odin.shopsys.cloud
  - https://cz.mt-fix-tests.odin.shopsys.cloud
<!-- Replace -->
