### PR TITLE
[project-base] category without image is now rendered correctly

### DIFF
--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryDetailContent.tsx
@@ -44,8 +44,8 @@ export const CategoryDetailContent: FC<CategoryDetailContentProps> = ({ category
             <CollapsibleDescriptionWithImage
                 currentPage={currentPage}
                 description={category.description}
-                imageName={category.images[0].name || category.name}
-                imageUrl={category.images[0].url}
+                imageName={category.images[0]?.name || category.name}
+                imageUrl={category.images[0]?.url}
                 scrollTargetRef={scrollTargetRef}
             />
 

--- a/upgrade-notes/storefront_20241114_101951.md
+++ b/upgrade-notes/storefront_20241114_101951.md
@@ -1,0 +1,3 @@
+#### fix not rendering category without image ([#3600](https://github.com/shopsys/shopsys/pull/3600))
+
+-   see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Missing image caused error so category detail was not rendered.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-category-without-image.odin.shopsys.cloud
  - https://cz.tl-fix-category-without-image.odin.shopsys.cloud
<!-- Replace -->
