### PR TITLE
repository-clean.sh pipeline id for deployments

### DIFF
--- a/project-base/gitlab/scripts/repository-clean.sh
+++ b/project-base/gitlab/scripts/repository-clean.sh
@@ -61,7 +61,7 @@ for REGISTRY_REPOSITORY in $(echo "${REGISTRY_REPOSITORIES}" | jq -rc '.[]'); do
 
     if [ ! -z "${REPOSITORY_NAME_MAP_TO_ENVIRONMENT[${REPOSITORY_NAME%%-*}]}" ]; then
       ENVIRONMENT=${REPOSITORY_NAME_MAP_TO_ENVIRONMENT[${REPOSITORY_NAME%%-*}]}
-      DEPLOYED_TAG=$(curl -L --silent --header "PRIVATE-TOKEN: ${API_TOKEN}" "${API_URL}/deployments?environment=${ENVIRONMENT}&status=success&sort=desc" | jq -r '.[0].sha')
+      DEPLOYED_TAG=$(curl -L --silent --header "PRIVATE-TOKEN: ${API_TOKEN}" "${API_URL}/deployments?environment=${ENVIRONMENT}&status=success&sort=desc" | jq -r '.[0] | "\(.sha)-\(.deployable.pipeline.id)"')
       DEPLOYED_TAG_CREATED_DATE=$(curl -L --silent --header "PRIVATE-TOKEN: ${API_TOKEN}" "${API_URL}/registry/repositories/${REPOSITORY_ID}/tags/${DEPLOYED_TAG}" | jq -r '.created_at')
 
       if [ ! -z "${DEPLOYED_TAG}" ] && [ "${DEPLOYED_TAG_CREATED_DATE}" != "null" ]; then


### PR DESCRIPTION
#### Description, the reason for the PR
PR #3061 updated container tagging in GitLab CI to include a pipeline ID suffix. This caused registry cleanup to remove deployed containers if newer, non-deployed ones were available. This PR fixes the cleanup logic to preserve deployed containers.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://hn-repository-clean-fix.odin.shopsys.cloud
  - https://cz.hn-repository-clean-fix.odin.shopsys.cloud
<!-- Replace -->
