### PR TITLE
[frontend-api] JwtConfiguration is now created on demand

### DIFF
--- a/packages/frontend-api/src/Model/Token/JwtConfigurationProvider.php
+++ b/packages/frontend-api/src/Model/Token/JwtConfigurationProvider.php
@@ -10,9 +10,11 @@ use Lcobucci\JWT\Signer\Key;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
-class JwtConfigurationFactory
+class JwtConfigurationProvider
 {
-    protected const FRONTEND_API_KEYS_FILEPATH_PARAMETER = 'shopsys.frontend_api.keys_filepath';
+    protected const string FRONTEND_API_KEYS_FILEPATH_PARAMETER = 'shopsys.frontend_api.keys_filepath';
+
+    protected ?Configuration $configuration = null;
 
     /**
      * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
@@ -27,17 +29,19 @@ class JwtConfigurationFactory
     /**
      * @return \Lcobucci\JWT\Configuration
      */
-    public function create(): Configuration
+    public function getConfiguration(): Configuration
     {
-        if (!$this->parameterBag->has(static::FRONTEND_API_KEYS_FILEPATH_PARAMETER)) {
-            return Configuration::forUnsecuredSigner();
+        if ($this->configuration !== null) {
+            return $this->configuration;
         }
 
-        return Configuration::forAsymmetricSigner(
+        $this->configuration = Configuration::forAsymmetricSigner(
             $this->getSigner(),
             $this->getPrivateKey(),
             $this->getPublicKey(),
         );
+
+        return $this->configuration;
     }
 
     /**

--- a/packages/frontend-api/src/Resources/config/services.yaml
+++ b/packages/frontend-api/src/Resources/config/services.yaml
@@ -13,9 +13,6 @@ services:
         tags:
             - { name: overblog_graphql.resolver_map, schema: default }
 
-    Lcobucci\JWT\Configuration:
-        factory: [ '@Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationFactory', create ]
-
     Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserLoginInformationProvider:
         alias: Shopsys\FrontendApiBundle\Model\Customer\User\CustomerUserLoginInformationProvider
 

--- a/packages/frontend-api/tests/Unit/Model/Token/TokenFacadeTest.php
+++ b/packages/frontend-api/tests/Unit/Model/Token/TokenFacadeTest.php
@@ -22,7 +22,7 @@ use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\ExpiredTokenUserMessageException;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\InvalidTokenUserMessageException;
 use Shopsys\FrontendApiBundle\Model\Token\Exception\NotVerifiedTokenUserMessageException;
-use Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationFactory;
+use Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationProvider;
 use Shopsys\FrontendApiBundle\Model\Token\TokenFacade;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -125,13 +125,16 @@ class TokenFacadeTest extends TestCase
         $domain = $this->createDomain();
 
         $customerUserFacade = $this->createMock(CustomerUserFacade::class);
-
-        $jwtConfiguration = $this->createJwtConfiguration();
+        $jwtConfigurationProvider = $this->getMockBuilder(JwtConfigurationProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $jwtConfigurationProvider->method('getConfiguration')
+            ->willReturn($this->createJwtConfiguration());
 
         return new TokenFacade(
             $domain,
             $customerUserFacade,
-            $jwtConfiguration,
+            $jwtConfigurationProvider,
         );
     }
 
@@ -143,7 +146,7 @@ class TokenFacadeTest extends TestCase
         $domain = $this->createDomain();
         $parameterBag = new ParameterBag(['shopsys.frontend_api.keys_filepath' => __DIR__ . '/testKeys']);
 
-        return (new JwtConfigurationFactory($parameterBag, $domain))->create();
+        return (new JwtConfigurationProvider($parameterBag, $domain))->getConfiguration();
     }
 
     /**

--- a/project-base/app/src/FrontendApi/Model/Token/TokenFacade.php
+++ b/project-base/app/src/FrontendApi/Model/Token/TokenFacade.php
@@ -8,7 +8,7 @@ use Shopsys\FrontendApiBundle\Model\Token\TokenFacade as BaseTokenFacade;
 
 /**
  * @property \App\Model\Customer\User\CustomerUserFacade $customerUserFacade
- * @method __construct(\Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Model\Customer\User\CustomerUserFacade $customerUserFacade, \Lcobucci\JWT\Configuration $jwtConfiguration)
+ * @method __construct(\Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Model\Customer\User\CustomerUserFacade $customerUserFacade, \Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationProvider $jwtConfigurationProvider)
  * @method string createAccessTokenAsString(\App\Model\Customer\User\CustomerUser $customerUser, string $deviceId, \App\Model\Administrator\Administrator|null $administrator = null)
  * @method \Lcobucci\JWT\UnencryptedToken generateRefreshTokenByCustomerUserAndSecretChainAndDeviceId(\App\Model\Customer\User\CustomerUser $customerUser, string $secretChain, string $deviceId)
  * @method string createRefreshTokenAsString(\App\Model\Customer\User\CustomerUser $customerUser, string $deviceId, \App\Model\Administrator\Administrator|null $administrator = null)

--- a/upgrade-notes/backend_20241126_124621.md
+++ b/upgrade-notes/backend_20241126_124621.md
@@ -1,0 +1,5 @@
+#### create JwtConfiguration on demand ([#3616](https://github.com/shopsys/shopsys/pull/3616))
+
+- `Lcobucci\JWT\Configuration` is not a service anymore, use `Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationProvider::getConfiguration()` instead
+- `Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationFacade` has been renamed to `Shopsys\FrontendApiBundle\Model\Token\JwtConfigurationProvider` and its method `create` has been renamed to `getConfiguration`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
During run of simple tasks like checking standards there is no need to have frontend-api keys generated, but current situation required it so this PR changes such behavior and \Lcobucci\JWT\Configuration is not created until it is needed.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-jwt-configuration-fix.odin.shopsys.cloud
  - https://cz.tl-jwt-configuration-fix.odin.shopsys.cloud
<!-- Replace -->
