### PR TITLE
[Shopsys] Add parallel and regenerate to Gitlab pipelines

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -196,7 +196,7 @@ regenerate-storefront-screenshots:
                 fi
                 git fetch origin "$CI_COMMIT_REF_NAME"
                 git pull --rebase origin "$CI_COMMIT_REF_NAME"
-                git push https://shopsys_bot:$API_TOKEN@gitlab.shopsys.cz/ss6-projects/project-base.git "$CI_COMMIT_REF_NAME" --force -v || (echo "Failed to push changes" && git log -n 5 && exit 1)
+                git push https://shopsys_bot:$API_TOKEN@gitlab.shopsys.cz/ss6-projects/${CI_PROJECT_NAME}.git "$CI_COMMIT_REF_NAME" --force -v || (echo "Failed to push changes" && git log -n 5 && exit 1)
             else
                 echo "No changes in snapshots, skipping commit."
             fi

--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -119,6 +119,15 @@ test:storefront-acceptance:
     <<: *only-default
     tags:
         - tests
+#    parallel:
+#        matrix:
+#            -   GROUP: "authentication"
+#            -   GROUP: "cart"
+#            -   GROUP: "order"
+#            -   GROUP: "transportAndPayment"
+#            -   GROUP: "visits"
+#            -   GROUP: "others"
+
     artifacts:
         paths:
             - ./storefront/cypress/videos/
@@ -134,12 +143,65 @@ test:storefront-acceptance:
         - docker compose up -d
         - docker compose exec -T php-fpm php phing -D production.confirm.action=y composer-prod db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate
         - cd storefront
-        - docker compose run cypress
+        - GROUP=$GROUP docker compose run cypress
     after_script:
         - docker compose logs php-fpm > php-fpm-log.txt
         - docker compose logs webserver > webserver-log.txt
         - docker compose logs storefront > storefront-log.txt
     interruptible: true
+
+regenerate-storefront-screenshots:
+    image: tmaier/docker-compose:latest
+    stage: regenerate
+    <<: *only-default
+    tags:
+        - tests
+    needs:
+        - build
+        - build-storefront
+    #    parallel:
+    #        matrix:
+    #            - GROUP: "authentication"
+    #            - GROUP: "cart"
+    #            - GROUP: "order"
+    #            - GROUP: "transportAndPayment"
+    #            - GROUP: "visits"
+    #            - GROUP: "others"
+    artifacts:
+        paths:
+            - ./storefront/cypress/snapshots/
+            - php-fpm-log.txt
+            - webserver-log.txt
+            - storefront-log.txt
+        when: on_failure
+        expire_in: 1 day
+    script:
+        - apk add --no-cache git
+        - git config --global user.name "Shopsys Bot"
+        - git config --global user.email "bot@shopsys.com"
+        - git clean -fdx
+        - git checkout "$CI_COMMIT_REF_NAME"
+        - cp -f ./gitlab/docker-compose-ci.yml ./docker-compose.yml
+        - docker compose up -d
+        - docker compose exec -T php-fpm php phing -D production.confirm.action=y composer-prod db-create frontend-api-generate-new-keys build-demo-dev-quick error-pages-generate
+        - GROUP=$GROUP docker compose run cypress-regenerate-screenshots
+        - git add ./storefront/cypress/snapshots/e2e
+        - git status
+        - |
+            if ! git diff --staged --quiet; then
+                git commit -m "Regenerated Cypress screenshots for ${GROUP} group"
+                git fetch origin "$CI_COMMIT_REF_NAME"
+                git pull --rebase origin "$CI_COMMIT_REF_NAME"
+                git push https://shopsys_bot:$API_TOKEN@gitlab.shopsys.cz/ss6-projects/project-base.git "$CI_COMMIT_REF_NAME" --force -v || (echo "Failed to push changes" && git log -n 5 && exit 1)
+            else
+                echo "No changes in snapshots, skipping commit."
+            fi
+    after_script:
+        - docker compose logs php-fpm > php-fpm-log.txt
+        - docker compose logs webserver > webserver-log.txt
+        - docker compose logs storefront > storefront-log.txt
+    interruptible: true
+    when: manual
 
 review:
     stage: review

--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -189,7 +189,11 @@ regenerate-storefront-screenshots:
         - git status
         - |
             if ! git diff --staged --quiet; then
-                git commit -m "Regenerated Cypress screenshots for ${GROUP} group"
+                if [ -z "$GROUP" ]; then
+                    git commit -m "Regenerated Cypress screenshots"
+                else
+                    git commit -m "Regenerated Cypress screenshots for ${GROUP} group"
+                fi
                 git fetch origin "$CI_COMMIT_REF_NAME"
                 git pull --rebase origin "$CI_COMMIT_REF_NAME"
                 git push https://shopsys_bot:$API_TOKEN@gitlab.shopsys.cz/ss6-projects/project-base.git "$CI_COMMIT_REF_NAME" --force -v || (echo "Failed to push changes" && git log -n 5 && exit 1)

--- a/project-base/gitlab/docker-compose-ci.yml
+++ b/project-base/gitlab/docker-compose-ci.yml
@@ -52,6 +52,24 @@ services:
         profiles:
             - storefront-acceptance-tests
         network_mode: "host"
+        environment:
+            - GROUP=${GROUP}
+
+    cypress-regenerate-screenshots:
+        build:
+            context: ./storefront/cypress
+            dockerfile: ./docker/Dockerfile
+        container_name: shopsys-framework-cypress-regenerate
+        volumes:
+            - ./storefront/cypress:/app
+            - node_modules:/app/node_modules
+        profiles:
+            - storefront-regenerate-screenshots
+        network_mode: "host"
+        environment:
+            - TYPE=base
+            - COMMAND=run
+            - GROUP=${GROUP}
 
     redis:
         image: redis:5.0-alpine

--- a/upgrade-notes/backend_20241205_071409.md
+++ b/upgrade-notes/backend_20241205_071409.md
@@ -1,0 +1,4 @@
+#### Extend gitlab pipelines for cypress screenshots regeneration ([#3630](https://github.com/shopsys/shopsys/pull/3630))
+
+- see #project-base-diff to update your project
+- see also #project-base-diff of [#3514](https://github.com/shopsys/shopsys/pull/3514) with additional informations about the changes in the cypress.config.ts


### PR DESCRIPTION
#### Description, the reason for the PR
It was not possible to manually run a cypress test regeneration in Gitlab UI. I added a regeneration pipeline that can be run manually in Gitlab UI plus added the ability to set up parallel runs.

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mvn-ssp-2844-gitlab-parallel-cypress-tests-generate.odin.shopsys.cloud
  - https://cz.mvn-ssp-2844-gitlab-parallel-cypress-tests-generate.odin.shopsys.cloud
<!-- Replace -->
