### PR TITLE
[project-base] added cookies store to error page to avoid undefined userIdentifier

### DIFF
--- a/project-base/storefront/pages/_error.tsx
+++ b/project-base/storefront/pages/_error.tsx
@@ -2,6 +2,7 @@ import { Error404Content } from 'components/Pages/ErrorPage/Error404Content';
 import { Error500Content } from 'components/Pages/ErrorPage/Error500Content';
 import { NextPage } from 'next';
 import { ReactElement } from 'react';
+import { CookiesStoreState, getCookiesStoreState } from 'utils/cookies/cookiesStore';
 import { isWithErrorDebugging, isWithToastAndConsoleErrorDebugging } from 'utils/errors/isWithErrorDebugging';
 import { logException } from 'utils/errors/logException';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
@@ -16,6 +17,7 @@ type ErrorPageProps = {
     statusCode: number;
     props: Partial<ServerSidePropsType> | Promise<Partial<ServerSidePropsType>>;
     err: string;
+    cookiesStore: CookiesStoreState;
 };
 
 const ErrorPage: NextPage<ErrorPageProps> = ({ hasGetInitialPropsRun, err, statusCode }): ReactElement => {
@@ -29,6 +31,7 @@ const ErrorPage: NextPage<ErrorPageProps> = ({ hasGetInitialPropsRun, err, statu
 ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConfig, t }) => async (context: any) => {
     const middlewareStatusCode = Number.parseInt(context.res.getHeader(MIDDLEWARE_STATUS_CODE_KEY) || '');
     const middlewareStatusMessage = context.res.getHeader(MIDDLEWARE_STATUS_MESSAGE_KEY);
+    const cookiesStoreState = getCookiesStoreState(context);
 
     const serverSideProps = await initServerSideProps({ context, redisClient, domainConfig, t });
     const statusCode = middlewareStatusCode || context.res.statusCode || 500;
@@ -60,6 +63,7 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
         statusCode,
         err,
         hasGetInitialPropsRun: true,
+        cookiesStore: cookiesStoreState,
     } as ErrorPageProps;
 });
 

--- a/upgrade-notes/storefront_20241202_094542.md
+++ b/upgrade-notes/storefront_20241202_094542.md
@@ -1,0 +1,4 @@
+#### unknow error after visit error page ([#3631](https://github.com/shopsys/shopsys/pull/3631))
+
+- added cookiesStore to error page props to avoid undefined userIdentifier
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Added cookies store to error page to avoid undefined userIdentifier

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### Check the appropriate checkboxes below, please

- [ ] [BC breaks](https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/) <!-- Do not forget to update UPGRADE.md -->
- [ ] New feature <!-- Do not forget to update docs -->
- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2981-unknow-error-after-404.odin.shopsys.cloud
  - https://cz.tc-ssp-2981-unknow-error-after-404.odin.shopsys.cloud
<!-- Replace -->
