### PR TITLE
[framework] functional tests are now run per folder to prevent memory limits

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -35,12 +35,17 @@
     <property name="path.stylelint.executable" value="${path.node_modules.bin}/stylelint"/>
     <property name="path.test.database.dump" value="${path.var}/cache/test-db-dump.sql"/>
     <property name="path.tests" value="${path.root}/tests"/>
+    <property name="path.tests.failed" value="${path.var}/PHING_TESTS_FAILED"/>
+    <property name="path.tests.functional" value="${path.tests}/App/Functional/"/>
+    <property name="path.tests.frontend_api.functional" value="${path.tests}/FrontendApiBundle/Functional/"/>
+    <property name="path.tests.frontend_api.functional.b2b" value="${path.tests}/FrontendApiBundle/FunctionalB2b/"/>
     <property name="path.var" value="${path.root}/var"/>
     <property name="path.vendor" value="${path.root}/vendor"/>
     <property name="path.web" value="${path.root}/web"/>
     <property name="path.yaml-standards.executable" value="${path.bin}/yaml-standards"/>
     <property name="phpstan.level" value="5"/>
     <property name="phpstan.memory-limit" value="2048M"/>
+    <property name="tests.stop-on-failed-group" value="false"/>
     <property name="translations.dump.flags" value="--keep"/>
     <property name="yaml-standards.indent-count" value="4"/>
     <property name="yaml-standards.args" value=""/>
@@ -141,7 +146,7 @@
 
     <target name="build-dev" depends="build-version-generate,clean,composer-dev,timezones-check,dirs-create,test-dirs-create,assets,npm,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,elasticsearch-index-recreate,elasticsearch-export,error-pages-generate,tests-acceptance-build,clean-redis-old,checks" description="Builds application for development preserving your DB and runs checks on changed files."/>
 
-    <target name="build-dev-quick" depends="build-version-generate,clean,composer-dev,dirs-create,test-dirs-create,assets,npm,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,elasticsearch-index-migrate,clean-redis-old" description="Builds application for development preserving your DB while skipping nonessential steps."/>    <target name="build-dev-quick" depends="build-version-generate,clean,composer-dev,dirs-create,test-dirs-create,assets,npm,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,elasticsearch-index-migrate,clean-redis-old" description="Builds application for development preserving your DB while skipping nonessential ."/>
+    <target name="build-dev-quick" depends="build-version-generate,clean,composer-dev,dirs-create,test-dirs-create,assets,npm,db-migrations,domains-data-create,friendly-urls-generate,friendly-url-entity-mapping-check,domains-urls-replace,elasticsearch-index-migrate,clean-redis-old" description="Builds application for development preserving your DB while skipping nonessential steps."/>
 
     <target name="build-new" depends="production-protection,wipe,build-version-generate,composer-prod,redis-check,dirs-create,assets,npm,db-rebuild,elasticsearch-index-recreate,error-pages-generate,warmup,clean-redis-old" description="Builds application for production with clean DB (with base data only)."/>
 
@@ -1414,42 +1419,117 @@
         </trycatch>
     </target>
 
+    <target name="tests-check-failed">
+        <available file="${path.tests.failed}" type="file" property="tests.failed"/>
+        <if>
+            <isset property="tests.failed"/>
+            <then>
+                <phingcall target="tests-reset-failed"/>
+                <fail message="Tests failed"/>
+            </then>
+        </if>
+    </target>
+
     <target name="tests-functional" depends="tests-functional-application,tests-functional-frontend-api,tests-functional-frontend-api-b2b" description="Runs functional tests."/>
 
     <target name="tests-functional-application" depends="production-protection,clean,test-clean-redis,domains-info-load" description="Runs application functional tests." hidden="true">
-        <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="true">
+        <phingcall target="tests-reset-failed"/>
+        <foreach param="testsDirname" target="tests-functional-application-run">
+            <dirSet dir="${path.tests.functional}">
+                <include name="*/"/>
+                <exclude name="/"/>
+                <exclude name="*_*"/>
+                <exclude name="*/**/"/>
+            </dirSet>
+        </foreach>
+        <phingcall target="tests-check-failed"/>
+    </target>
+
+    <target name="tests-functional-application-run" description="Runs application functional tests in provided folder" hidden="true">
+        <echo message="Running tests from: ${path.tests.functional}${testsDirname}"/>
+        <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="${tests.stop-on-failed-group}" returnProperty="tests.exit-code">
             <arg value="--colors=always"/>
-            <arg value="--testsuite"/>
-            <arg value="Functional"/>
             <arg value="--exclude-group"/>
             <arg value="${phpunit-exclude-group}"/>
             <arg value="--configuration"/>
             <arg value="${path.root}/phpunit.xml"/>
+            <arg value="${path.tests.functional}${testsDirname}"/>
         </exec>
+        <if>
+            <not>
+                <equals arg1="${tests.exit-code}" arg2="0"/>
+            </not>
+            <then>
+                <phingcall target="tests-set-failed"/>
+            </then>
+        </if>
     </target>
 
     <target name="tests-functional-frontend-api" depends="production-protection,clean,test-clean-redis,domains-info-load" description="Runs Frontend API functional tests." hidden="true">
-        <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="true">
-            <arg value="--colors=always"/>
-            <arg value="--testsuite"/>
-            <arg value="FrontendApiFunctional"/>
-            <arg value="--exclude-group"/>
-            <arg value="${phpunit-exclude-group}"/>
-            <arg value="--configuration"/>
-            <arg value="${path.root}/phpunit.xml"/>
-        </exec>
+        <phingcall target="tests-reset-failed"/>
+        <foreach param="testsDirname" target="tests-functional-frontend-api-run">
+            <dirSet dir="${path.tests.frontend_api.functional}">
+                <include name="*/"/>
+                <exclude name="/"/>
+                <exclude name="*_*"/>
+                <exclude name="*/**/"/>
+            </dirSet>
+        </foreach>
+        <phingcall target="tests-check-failed"/>
     </target>
 
     <target name="tests-functional-frontend-api-b2b" depends="production-protection,clean,test-clean-redis,domains-info-load" description="Runs Frontend API functional tests on B2B domain." hidden="true">
-        <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="true">
+        <phingcall target="tests-reset-failed"/>
+        <foreach param="testsDirname" target="tests-functional-frontend-api-b2b-run">
+            <dirSet dir="${path.tests.frontend_api.functional.b2b}">
+                <include name="*/"/>
+                <exclude name="/"/>
+                <exclude name="*_*"/>
+                <exclude name="*/**/"/>
+            </dirSet>
+        </foreach>
+        <phingcall target="tests-check-failed"/>
+    </target>
+
+    <target name="tests-functional-frontend-api-b2b-run" description="Runs application functional tests in provided folder" hidden="true">
+        <echo message="Running tests from: ${path.tests.frontend_api.functional.b2b}${testsDirname}"/>
+        <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="${tests.stop-on-failed-group}" returnProperty="tests.exit-code">
             <arg value="--colors=always"/>
-            <arg value="--testsuite"/>
-            <arg value="FrontendApiFunctionalB2b"/>
             <arg value="--exclude-group"/>
             <arg value="${phpunit-exclude-group}"/>
             <arg value="--configuration"/>
             <arg value="${path.root}/phpunit.xml"/>
+            <arg value="${path.tests.frontend_api.functional.b2b}${testsDirname}"/>
         </exec>
+
+        <if>
+            <not>
+                <equals arg1="${tests.exit-code}" arg2="0"/>
+            </not>
+            <then>
+                <phingcall target="tests-set-failed"/>
+            </then>
+        </if>
+    </target>
+
+    <target name="tests-functional-frontend-api-run" description="Runs application functional tests in provided folder" hidden="true">
+        <echo message="Running tests from: ${path.tests.frontend_api.functional}${testsDirname}"/>
+        <exec executable="${path.phpunit.executable}" logoutput="true" passthru="true" checkreturn="${tests.stop-on-failed-group}" returnProperty="tests.exit-code">
+            <arg value="--colors=always"/>
+            <arg value="--exclude-group"/>
+            <arg value="${phpunit-exclude-group}"/>
+            <arg value="--configuration"/>
+            <arg value="${path.root}/phpunit.xml"/>
+            <arg value="${path.tests.frontend_api.functional}${testsDirname}"/>
+        </exec>
+        <if>
+            <not>
+                <equals arg1="${tests.exit-code}" arg2="0"/>
+            </not>
+            <then>
+                <phingcall target="tests-set-failed"/>
+            </then>
+        </if>
     </target>
 
     <target name="tests-functional-single" depends="set-functional-test-name,production-protection,clean,test-clean-redis,domains-info-load" description="Runs custom functional test.">
@@ -1495,6 +1575,20 @@
             <arg value="--configuration"/>
             <arg value="${path.root}/phpunit.xml"/>
         </exec>
+    </target>
+
+    <target name="tests-reset-failed">
+        <available file="${path.tests.failed}" type="file" property="tests.failed"/>
+        <if>
+            <isset property="tests.failed"/>
+            <then>
+                <delete file="${path.tests.failed}"/>
+            </then>
+        </if>
+    </target>
+
+    <target name="tests-set-failed">
+        <touch file="${path.tests.failed}"/>
     </target>
 
     <target name="tests-smoke" depends="production-protection,clean,test-clean-redis,domains-info-load" description="Runs smoke tests.">


### PR DESCRIPTION
#### Description, the reason for the PR
There is problem with functional tests, that with growing number of them the memory is increasing and tests are slowing down when run in single phpunit suite. This change introduces running phpunit tests per folder that reduces memory and increases speed of tests by up to 60%. This has been inspired by @RostislavKreisinger 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-run-functional-tests-per-folder.odin.shopsys.cloud
  - https://cz.tl-run-functional-tests-per-folder.odin.shopsys.cloud
<!-- Replace -->
