### PR TITLE
[project-base] added dynamic tab index to product detail page

### DIFF
--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailTabs/ProductDetailTabs.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailTabs/ProductDetailTabs.tsx
@@ -53,6 +53,11 @@ export const ProductDetailTabs: FC<ProductDetailTabsProps> = ({ description, par
         groupParameters: groupParameters.sort((a, b) => a.name.localeCompare(b.name)),
     }));
 
+    let tabIndex = 0;
+    const parametersTabIndex = parameters.length ? ++tabIndex : -1;
+    const relatedProductsTabIndex = relatedProducts.length ? ++tabIndex : -1;
+    const filesTabIndex = files.length ? ++tabIndex : -1;
+
     return (
         <Tabs
             className="flex flex-col gap-4 lg:gap-0"
@@ -81,7 +86,7 @@ export const ProductDetailTabs: FC<ProductDetailTabsProps> = ({ description, par
             </TabsContent>
 
             {!!parameters.length && (
-                <TabsContent headingTextMobile={t('Parameters')} isActive={selectedTab === 1}>
+                <TabsContent headingTextMobile={t('Parameters')} isActive={selectedTab === parametersTabIndex}>
                     {sortedIndividualParameters.length > 0 && (
                         <div>
                             <Table className="mx-auto max-w-screen-lg border-0 p-0">
@@ -138,13 +143,16 @@ export const ProductDetailTabs: FC<ProductDetailTabsProps> = ({ description, par
             )}
 
             {!!relatedProducts.length && (
-                <TabsContent headingTextMobile={t('Related Products')} isActive={selectedTab === 2}>
-                    <ProductDetailRelatedProductsTab relatedProducts={relatedProducts} />{' '}
+                <TabsContent
+                    headingTextMobile={t('Related Products')}
+                    isActive={selectedTab === relatedProductsTabIndex}
+                >
+                    <ProductDetailRelatedProductsTab relatedProducts={relatedProducts} />
                 </TabsContent>
             )}
 
             {!!files.length && (
-                <TabsContent headingTextMobile={t('Files')} isActive={selectedTab === 3}>
+                <TabsContent headingTextMobile={t('Files')} isActive={selectedTab === filesTabIndex}>
                     <ul>
                         {files.map((file) => (
                             <li key={file.url}>

--- a/upgrade-notes/storefront_20241209_123845.md
+++ b/upgrade-notes/storefront_20241209_123845.md
@@ -1,0 +1,5 @@
+#### dynamic tab index ([#3644](https://github.com/shopsys/shopsys/pull/3644))
+
+- tab index is now dynamic, so it will be incremented by 1 for each tab, because there can be missing tab in list
+- active tab state is needed for animations to work correctly
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

The tab index is now dynamic so it will be incremented by 1 for each tab. The active tab state is needed for animations to work correctly.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2957-fixed-product-detail-tabs.odin.shopsys.cloud
  - https://cz.tc-ssp-2957-fixed-product-detail-tabs.odin.shopsys.cloud
<!-- Replace -->
