### PR TITLE
[framework] added missing migration to create admin reset password mail template

### DIFF
--- a/packages/framework/src/Migrations/Version20241212064226.php
+++ b/packages/framework/src/Migrations/Version20241212064226.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
+use Shopsys\FrameworkBundle\Model\Administrator\Mail\ResetPasswordMail;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+class Version20241212064226 extends AbstractMigration implements ContainerAwareInterface
+{
+    use MultidomainMigrationTrait;
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->createMailTemplateIfNotExist(ResetPasswordMail::MAIL_TEMPLATE_NAME);
+
+        foreach ($this->getAllDomainIds() as $domainId) {
+            $domainLocale = $this->getDomainLocale($domainId);
+
+            $this->updateMailTemplate(
+                ResetPasswordMail::MAIL_TEMPLATE_NAME,
+                t('Administrator reset password request', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainLocale),
+                t('Dear administrator.<br /><br />'
+                    . 'You can set a new password following this link: <a href="{new_password_url}">{new_password_url}</a>', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $domainLocale),
+                $domainId,
+            );
+        }
+    }
+
+    /**
+     * @param string $mailTemplateName
+     */
+    private function createMailTemplateIfNotExist(
+        string $mailTemplateName,
+    ): void {
+        foreach ($this->getAllDomainIds() as $domainId) {
+            $mailTemplateCount = $this->sql(
+                'SELECT count(*) FROM mail_templates WHERE name = :mailTemplateName and domain_id = :domainId',
+                [
+                    'mailTemplateName' => $mailTemplateName,
+                    'domainId' => $domainId,
+                ],
+            )->fetchOne();
+
+            if ($mailTemplateCount !== 0) {
+                continue;
+            }
+
+            $this->sql(
+                'INSERT INTO mail_templates (name, domain_id, send_mail) VALUES (:mailTemplateName, :domainId, :sendMail)',
+                [
+                    'mailTemplateName' => $mailTemplateName,
+                    'domainId' => $domainId,
+                    'sendMail' => true,
+                ],
+            );
+        }
+    }
+
+    /**
+     * @param string $mailTemplateName
+     * @param string $subject
+     * @param string $body
+     * @param int $domainId
+     */
+    private function updateMailTemplate(string $mailTemplateName, string $subject, string $body, int $domainId): void
+    {
+        $this->sql(
+            'UPDATE mail_templates SET subject = :subject, body = :body WHERE name = :mailTemplateName AND domain_id = :domainId',
+            [
+                'subject' => $subject,
+                'body' => $body,
+                'mailTemplateName' => $mailTemplateName,
+                'domainId' => $domainId,
+            ],
+        );
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Resources/translations/dataFixtures.cs.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.cs.po
@@ -16,6 +16,12 @@ msgstr "<p> Platba pro objednávku číslo {number} proběhla úspěšně. <br /
 msgid "<p> Payment for order number {number} has failed. <br /><br /> Please contact us to resolve the issue. </p>"
 msgstr "<p> Platba pro objednávku číslo {number} nebyla úspěšná. <br /><br /> Prosím kontaktujte nás pro vyřešení problému. </p>"
 
+msgid "Administrator reset password request"
+msgstr "Požadavek na resetování hesla administrátora"
+
+msgid "Dear administrator.<br /><br />You can set a new password following this link: <a href=\"{new_password_url}\">{new_password_url}</a>"
+msgstr "Vážený administrátore.<br /><br />Můžete nastavit nové heslo následujícím odkazem: <a href=\"{new_password_url}\">{new_password_url}</a>"
+
 msgid "New product inquiry received"
 msgstr "Byla přijata nová poptávka produktu"
 

--- a/packages/framework/src/Resources/translations/dataFixtures.en.po
+++ b/packages/framework/src/Resources/translations/dataFixtures.en.po
@@ -16,6 +16,12 @@ msgstr ""
 msgid "<p> Payment for order number {number} has failed. <br /><br /> Please contact us to resolve the issue. </p>"
 msgstr ""
 
+msgid "Administrator reset password request"
+msgstr ""
+
+msgid "Dear administrator.<br /><br />You can set a new password following this link: <a href=\"{new_password_url}\">{new_password_url}</a>"
+msgstr ""
+
 msgid "New product inquiry received"
 msgstr ""
 

--- a/project-base/app/translations/dataFixtures.cs.po
+++ b/project-base/app/translations/dataFixtures.cs.po
@@ -707,7 +707,7 @@ msgid "DeLonghi ECAM 44.660 B Eletta Plus"
 msgstr "DeLonghi ECAM 44.660 B Eletta Plus"
 
 msgid "Dear administrator.<br /><br />You can set a new password following this link: <a href=\"{new_password_url}\">{new_password_url}</a>"
-msgstr "Vážený administrátore,<br /><br />Můžete nastavit nové heslo následujícím odkazem: <a href=\"{new_password_url}\">{new_password_url}</a>"
+msgstr "Vážený administrátore.<br /><br />Můžete nastavit nové heslo následujícím odkazem: <a href=\"{new_password_url}\">{new_password_url}</a>"
 
 msgid "Dear customer, <br /><br /> based on your email {email}, we are sending you a link to your personal details. By clicking on the link below, you will be taken to a page listing all the<br/> personal details which we have in evidence in our online store {domain}. <br/><br/> To overview your personal information please click here - {url} <br/> The link is valid for next 24 hours.<br/> Best Regards <br/><br/> team of {domain}"
 msgstr "Vážený zákazníku,<br /><br /> na základě vašeho zadaného e-mailu {email}, Vám zasíláme odkaz na zobrazení osobních údajů. Klikem na odkaz níže se dostanete na stránku s <br/> přehledem všech osobních údajů, které k Vašemu e-mailu evidujeme na našem e-shopu {domain}.<br/><br/> Pro zobrazení osobních údajů klikněte zde - {url}<br/> Odkaz je platný 24 hodin.<br/><br/> S pozdravem<br/> tým {domain}"


### PR DESCRIPTION
#### Description, the reason for the PR

In #3606 was introduced a new email template, but the migration for running project was missing. This PR fixes that.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-add-admin-reset-migration.odin.shopsys.cloud
  - https://cz.mg-add-admin-reset-migration.odin.shopsys.cloud
<!-- Replace -->
