### PR TITLE
[php-image] pin postgresql-client version for compatibility with the v12.1 server

### DIFF
--- a/packages/php-image/Dockerfile
+++ b/packages/php-image/Dockerfile
@@ -87,7 +87,7 @@ RUN apk add --no-cache --virtual .build-deps \
         musl-locales \
         nano \
         openssl \
-        postgresql-client \
+        postgresql15-client \
         rabbitmq-c \
         vim
 


### PR DESCRIPTION
#### Description, the reason for the PR

In the Alpine Linux base image, PostgreSQL client libraries were installed in the newest version, but the pg_dump utility from v17 generates an incompatible dump with our server v12.1. 

This PR pin the client version to the 15, which works properly.
In the near future, we want to upgrade the PostgreSQL itself to the newest version.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
