### PR TITLE
[framework] fixed slider on banner edit in czech language

### DIFF
--- a/packages/framework/assets/js/admin/components/NumberSlider.js
+++ b/packages/framework/assets/js/admin/components/NumberSlider.js
@@ -2,9 +2,7 @@ import 'jquery-ui/ui/widgets/slider';
 import Register from '../../common/utils/Register';
 
 export default class NumberSlider {
-
     constructor ($sliderContainer) {
-
         $sliderContainer.children('.js-number-slider__slider').slider({
             min: 0,
             max: 1,
@@ -13,7 +11,10 @@ export default class NumberSlider {
                 $(this).next('.js-number-slider__input').val(ui.value);
             },
             create: function (event, ui) {
-                $(this).slider('value', $(this).next('.js-number-slider__input').val());
+                $(this).slider(
+                    'value',
+                    $(this).next('.js-number-slider__input').val().replace(',', '.')
+                );
             }
         });
     }

--- a/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
+++ b/packages/framework/src/Form/Admin/Slider/SliderItemFormType.php
@@ -101,16 +101,13 @@ class SliderItemFormType extends AbstractType
             ])
             ->add('opacity', NumberSliderType::class, [
                 'required' => true,
+                'scale' => 2,
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please enter description box opacity']),
                     new Constraints\Range([
                         'min' => 0,
                         'max' => 1,
                         'notInRangeMessage' => 'Opacity must be between {{ min }} and {{ max }}',
-                    ]),
-                    new Constraints\Regex([
-                        'pattern' => '/^\d(\.\d{1,2})?$/',
-                        'message' => 'Opacity must be a number with up to two decimal places',
                     ]),
                 ],
                 'label' => t('Description opacity'),

--- a/packages/framework/src/Resources/translations/validators.cs.po
+++ b/packages/framework/src/Resources/translations/validators.cs.po
@@ -133,9 +133,6 @@ msgstr "Odkaz musí být validní URL adresa"
 msgid "Name cannot be longer than {{ limit }} characters"
 msgstr "Název nesmí být delší než {{ limit }} znaků"
 
-msgid "Opacity must be a number with up to two decimal places"
-msgstr "Průhlednost musí být číslo s až dvěma desetinnými místy"
-
 msgid "Opacity must be between {{ min }} and {{ max }}"
 msgstr "Průhlednost musí být mezi {{ min }} a {{ max }}"
 

--- a/packages/framework/src/Resources/translations/validators.en.po
+++ b/packages/framework/src/Resources/translations/validators.en.po
@@ -133,9 +133,6 @@ msgstr ""
 msgid "Name cannot be longer than {{ limit }} characters"
 msgstr ""
 
-msgid "Opacity must be a number with up to two decimal places"
-msgstr ""
-
 msgid "Opacity must be between {{ min }} and {{ max }}"
 msgstr ""
 


### PR DESCRIPTION
#### Description, the reason for the PR

When administration was in the Czech locale, the slider on the banner edit page did not behave properly. This is fixed now.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-slider-slider.odin.shopsys.cloud
  - https://cz.mg-fix-slider-slider.odin.shopsys.cloud
<!-- Replace -->
