### PR TITLE
[framework] improved rendering information about eshop required settings

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlMatcher.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlMatcher.php
@@ -13,6 +13,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 class FriendlyUrlMatcher
 {
+    protected const string IGNORED_INTERNAL_ROUTE = '_fragment';
+
     /**
      * @param \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository $friendlyUrlRepository
      * @param \Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixRepository $readyCategorySeoMixRepository
@@ -32,6 +34,11 @@ class FriendlyUrlMatcher
     public function match(string $pathinfo, RouteCollection $routeCollection, DomainConfig $domainConfig): array
     {
         $pathWithoutSlash = substr($pathinfo, 1);
+
+        if ($pathWithoutSlash === self::IGNORED_INTERNAL_ROUTE) {
+            throw new ResourceNotFoundException();
+        }
+
         $friendlyUrl = $this->friendlyUrlRepository->findByDomainIdAndSlug($domainConfig->getId(), $pathWithoutSlash);
 
         if ($friendlyUrl === null) {

--- a/packages/framework/src/Model/Country/CountryFacade.php
+++ b/packages/framework/src/Model/Country/CountryFacade.php
@@ -108,4 +108,12 @@ class CountryFacade
     {
         return $this->countryRepository->findByCode($countryCode);
     }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->countryRepository->getCount();
+    }
 }

--- a/packages/framework/src/Model/Country/CountryRepository.php
+++ b/packages/framework/src/Model/Country/CountryRepository.php
@@ -116,4 +116,15 @@ class CountryRepository
     {
         return $this->getCountryRepository()->findOneBy(['code' => $countryCode]);
     }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->getCountryRepository()->createQueryBuilder('c')
+            ->select('COUNT(c.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/packages/framework/src/Model/Product/Unit/UnitFacade.php
+++ b/packages/framework/src/Model/Product/Unit/UnitFacade.php
@@ -168,4 +168,12 @@ class UnitFacade
     {
         $this->eventDispatcher->dispatch(new UnitEvent($unit), $eventType);
     }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->unitRepository->getCount();
+    }
 }

--- a/packages/framework/src/Model/Product/Unit/UnitRepository.php
+++ b/packages/framework/src/Model/Product/Unit/UnitRepository.php
@@ -118,4 +118,15 @@ class UnitRepository
             ->where('p.unit = :oldUnit')->setParameter('oldUnit', $oldUnit)
             ->getQuery()->execute();
     }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->getUnitRepository()->createQueryBuilder('u')
+            ->select('COUNT(u.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/packages/framework/src/Model/Security/MenuItemsGrantedRolesSetting.php
+++ b/packages/framework/src/Model/Security/MenuItemsGrantedRolesSetting.php
@@ -52,6 +52,9 @@ class MenuItemsGrantedRolesSetting
             'products' . static::MENU_ITEM_PATH_SEPARATOR . 'categories' => [
                 Roles::ROLE_CATEGORY_VIEW,
             ],
+            'files' => [
+                Roles::ROLE_FILES_VIEW,
+            ],
             'pricing' . static::MENU_ITEM_PATH_SEPARATOR . 'pricing_groups' => [
                 Roles::ROLE_PRICING_GROUP_VIEW,
             ],

--- a/packages/framework/src/Model/Stock/StockFacade.php
+++ b/packages/framework/src/Model/Stock/StockFacade.php
@@ -139,4 +139,12 @@ class StockFacade
 
         return $stocksById;
     }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->stockRepository->getCount();
+    }
 }

--- a/packages/framework/src/Model/Stock/StockRepository.php
+++ b/packages/framework/src/Model/Stock/StockRepository.php
@@ -120,4 +120,15 @@ class StockRepository
         $stock->setDefault();
         $this->em->flush();
     }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->getQueryBuilder()
+            ->select('count(s.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -52,23 +52,29 @@ msgstr "301 (Trvalé přesměrování)"
 msgid "302 (Temporary redirect)"
 msgstr "302 (Dočasné přesměrování)"
 
-msgid "<a href=\"{{ url }}\">Default unit is not set.</a>"
-msgstr "<a href=\"{{ url }}\">Není nastavena výchozí jednotka.</a>"
+msgid "<a href=\"%url%\">Default unit is not set.</a>"
+msgstr "<a href=\"%url%\">Není nastavena výchozí jednotka.</a>"
 
-msgid "<a href=\"{{ url }}\">Privacy policy article for domain {{ domainName }} is not set.</a>"
-msgstr "<a href=\"{{ url }}\">Není nastaven článek zásady ochrany osobních údajů pro doménu {{ domainName }}.</a>"
+msgid "<a href=\"%url%\">Privacy policy article for domain %domainName% is not set.</a>"
+msgstr "<a href=\"%url%\">Není nastaven článek zásady ochrany osobních údajů pro doménu %domainName%.</a>"
 
-msgid "<a href=\"{{ url }}\">Some required email templates are not fully set.</a>"
-msgstr "<a href=\"{{ url }}\">Některé povinné e-mailové šablony nejsou vyplněny.</a>"
+msgid "<a href=\"%url%\">Some required email templates are not fully set.</a>"
+msgstr "<a href=\"%url%\">Některé povinné e-mailové šablony nejsou vyplněny.</a>"
 
-msgid "<a href=\"{{ url }}\">Terms and conditions article for domain {{ domainName }} is not set.</a>"
-msgstr "<a href=\"{{ url }}\">Není nastaven článek obchodní podmínky pro doménu {{ domainName }}.</a>"
+msgid "<a href=\"%url%\">Term and conditions article for domain %domainName% is not set.</a>"
+msgstr "<a href=\"%url%\">Není nastaven článek obchodní podmínky pro doménu %domainName%.</a>"
 
-msgid "<a href=\"{{ url }}\">There are no units, you need to create some.</a>"
-msgstr "<a href=\"{{ url }}\">Neexistují žádné jednotky, musíte nějakou vytvořit.</a>"
+msgid "<a href=\"%url%\">There are no countries, you need to create some.</a>"
+msgstr "<a href=\"%url%\">Neexistují žádné státy, musíte nějaký vytvořit.</a>"
 
-msgid "<a href=\"{{ url }}\">User consent policy article for domain {{ domainName }} is not set.</a>"
-msgstr "<a href=\"{{ url }}\">Není nastaven článek správa osobních údajů pro doménu {{ domainName }}.</a>"
+msgid "<a href=\"%url%\">There are no units, you need to create some.</a>"
+msgstr "<a href=\"%url%\">Neexistují žádné jednotky, musíte nějakou vytvořit.</a>"
+
+msgid "<a href=\"%url%\">There are no warehouses, you need to create some.</a>"
+msgstr "<a href=\"%url%\">Neexistují žádné sklady, musíte nějaký vytvořit.</a>"
+
+msgid "<a href=\"%url%\">User consent policy article for domain %domainName% is not set.</a>"
+msgstr "<a href=\"%url%\">Není nastaven článek správa osobních údajů pro doménu %domainName%.</a>"
 
 msgid "<strong><a href=\"{{ url }}\">SEO category</a></strong> has been saved"
 msgstr "<strong><a href=\"{{ url }}\">SEO kombinace kategorie</a></strong> byla uložena"
@@ -1903,8 +1909,8 @@ msgstr "Vyplňte také URL pro zvolenou doménu"
 msgid "Fill URL only for selected domain"
 msgstr "Vyplňte pouze URL pro zvolenou doménu"
 
-msgid "Fill missing settings to enable creating products. More information here."
-msgstr "Pro vytvoření produktu doplňte chybějící nastavení. Více informací zde."
+msgid "Fill missing settings to enable creating products."
+msgstr "Pro vytvoření produktu doplňte chybějící nastavení."
 
 msgid "Filter by"
 msgstr "Filtrovat podle"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -52,22 +52,28 @@ msgstr ""
 msgid "302 (Temporary redirect)"
 msgstr ""
 
-msgid "<a href=\"{{ url }}\">Default unit is not set.</a>"
+msgid "<a href=\"%url%\">Default unit is not set.</a>"
 msgstr ""
 
-msgid "<a href=\"{{ url }}\">Privacy policy article for domain {{ domainName }} is not set.</a>"
+msgid "<a href=\"%url%\">Privacy policy article for domain %domainName% is not set.</a>"
 msgstr ""
 
-msgid "<a href=\"{{ url }}\">Some required email templates are not fully set.</a>"
+msgid "<a href=\"%url%\">Some required email templates are not fully set.</a>"
 msgstr ""
 
-msgid "<a href=\"{{ url }}\">Terms and conditions article for domain {{ domainName }} is not set.</a>"
+msgid "<a href=\"%url%\">Term and conditions article for domain %domainName% is not set.</a>"
 msgstr ""
 
-msgid "<a href=\"{{ url }}\">There are no units, you need to create some.</a>"
+msgid "<a href=\"%url%\">There are no countries, you need to create some.</a>"
 msgstr ""
 
-msgid "<a href=\"{{ url }}\">User consent policy article for domain {{ domainName }} is not set.</a>"
+msgid "<a href=\"%url%\">There are no units, you need to create some.</a>"
+msgstr ""
+
+msgid "<a href=\"%url%\">There are no warehouses, you need to create some.</a>"
+msgstr ""
+
+msgid "<a href=\"%url%\">User consent policy article for domain %domainName% is not set.</a>"
 msgstr ""
 
 msgid "<strong><a href=\"{{ url }}\">SEO category</a></strong> has been saved"
@@ -1903,7 +1909,7 @@ msgstr ""
 msgid "Fill URL only for selected domain"
 msgstr ""
 
-msgid "Fill missing settings to enable creating products. More information here."
+msgid "Fill missing settings to enable creating products."
 msgstr ""
 
 msgid "Filter by"

--- a/packages/framework/src/Resources/views/Admin/Content/Product/list.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/list.html.twig
@@ -18,9 +18,9 @@
             <span class="btn btn--primary btn--plus wrap-bar__btn btn--disabled">
                 <i class="btn__icon">+</i>{{ 'Create variant'|trans }}
             </span>
-            <a href="{{ url('admin_default_dashboard') }}" class="btn-link-style wrap-bar__btn">
-                {{ 'Fill missing settings to enable creating products. More information here.'|trans }}
-            </a>
+            <span class="btn-link-style wrap-bar__btn">
+                {{ 'Fill missing settings to enable creating products.'|trans }}
+            </span>
         {% endif %}
     </div>
 {% endblock %}

--- a/packages/framework/src/Resources/views/Admin/Layout/layoutWithPanel.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Layout/layoutWithPanel.html.twig
@@ -19,6 +19,8 @@
                 {{ render(controller('Shopsys\\FrameworkBundle\\Controller\\Admin\\FlashMessageController::indexAction')) }}
             </div>
 
+            {{ render_required_settings() }}
+
             {% if showHeading is not defined or showHeading %}
                 <div class="wrap-bar">
                     <h1 class="wrap-bar__heading">

--- a/packages/framework/src/Resources/views/Components/RequiredSettings/requiredSettings.html.twig
+++ b/packages/framework/src/Resources/views/Components/RequiredSettings/requiredSettings.html.twig
@@ -1,0 +1,11 @@
+{# @var requiredSettingsMessages string[] #}
+<div class="in-message in-message--warning in-message--block">
+    <ul class="in-message__list">
+        {% for message in requiredSettingsMessages %}
+            <li class="in-message__list__item">
+                {{ icon('warning') }}
+                {{ message|raw }}
+            </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/packages/framework/src/Twig/RequiredSettingExtension.php
+++ b/packages/framework/src/Twig/RequiredSettingExtension.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Twig;
+
+use Override;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Setting\Setting;
+use Shopsys\FrameworkBundle\Model\Country\CountryFacade;
+use Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade;
+use Shopsys\FrameworkBundle\Model\Product\Unit\Exception\UnitNotFoundException;
+use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
+use Shopsys\FrameworkBundle\Model\Stock\StockFacade;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class RequiredSettingExtension extends AbstractExtension
+{
+    /**
+     * @var string[]
+     */
+    protected array $requiredSettingsMessages = [];
+
+    /**
+     * @param \Twig\Environment $twig
+     * @param \Symfony\Component\Routing\RouterInterface $router
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
+     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade $mailTemplateFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade $parameterFacade
+     * @param \Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade $unitFacade
+     * @param \Shopsys\FrameworkBundle\Model\Stock\StockFacade $stockFacade
+     * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade
+     */
+    public function __construct(
+        protected readonly Environment $twig,
+        protected readonly RouterInterface $router,
+        protected readonly Domain $domain,
+        protected readonly Setting $setting,
+        protected readonly MailTemplateFacade $mailTemplateFacade,
+        protected readonly ParameterFacade $parameterFacade,
+        protected readonly UnitFacade $unitFacade,
+        protected readonly StockFacade $stockFacade,
+        protected readonly CountryFacade $countryFacade,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('render_required_settings', $this->renderRequiredSettings(...), ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * @return string|null
+     */
+    public function renderRequiredSettings(): ?string
+    {
+        $this->loadRequiredSettingMessages();
+
+        if (count($this->requiredSettingsMessages) === 0) {
+            return null;
+        }
+
+        return $this->twig->render(
+            '@ShopsysFramework/Components/RequiredSettings/requiredSettings.html.twig',
+            [
+                'requiredSettingsMessages' => $this->requiredSettingsMessages,
+            ],
+        );
+    }
+
+    protected function loadRequiredSettingMessages(): void
+    {
+        $this->requiredSettingsMessages = [];
+
+        $this->checkEnabledMailTemplatesHaveTheirBodyAndSubjectFilled();
+        $this->checkAtLeastOneUnitExists();
+        $this->checkDefaultUnitIsSet();
+        $this->checkAtLeastOneStockExists();
+        $this->checkAtLeastOneCountryExists();
+        $this->checkMandatoryArticlesExist();
+        $this->checkAllSliderNumericValuesAreSet();
+    }
+
+    protected function checkEnabledMailTemplatesHaveTheirBodyAndSubjectFilled(): void
+    {
+        if ($this->mailTemplateFacade->existsTemplateWithEnabledSendingHavingEmptyBodyOrSubject()) {
+            $this->requiredSettingsMessages[] = t(
+                '<a href="%url%">Some required email templates are not fully set.</a>',
+                [
+                    '%url%' => $this->router->generate('admin_mail_template'),
+                ],
+            );
+        }
+    }
+
+    protected function checkAtLeastOneUnitExists(): void
+    {
+        if ($this->unitFacade->getCount() === 0) {
+            $this->requiredSettingsMessages[] = t(
+                '<a href="%url%">There are no units, you need to create some.</a>',
+                [
+                    '%url%' => $this->router->generate('admin_unit_list'),
+                ],
+            );
+        }
+    }
+
+    protected function checkDefaultUnitIsSet(): void
+    {
+        try {
+            $this->unitFacade->getDefaultUnit();
+        } catch (UnitNotFoundException) {
+            $this->requiredSettingsMessages[] = t(
+                '<a href="%url%">Default unit is not set.</a>',
+                [
+                    '%url%' => $this->router->generate('admin_unit_list'),
+                ],
+            );
+        }
+    }
+
+    protected function checkAtLeastOneStockExists(): void
+    {
+        if ($this->stockFacade->getCount() === 0) {
+            $this->requiredSettingsMessages[] = t(
+                '<a href="%url%">There are no warehouses, you need to create some.</a>',
+                [
+                    '%url%' => $this->router->generate('admin_stock_list'),
+                ],
+            );
+        }
+    }
+
+    protected function checkAtLeastOneCountryExists(): void
+    {
+        if ($this->countryFacade->getCount() === 0) {
+            $this->requiredSettingsMessages[] = t(
+                '<a href="%url%">There are no countries, you need to create some.</a>',
+                [
+                    '%url%' => $this->router->generate('admin_country_list'),
+                ],
+            );
+        }
+    }
+
+    protected function checkMandatoryArticlesExist(): void
+    {
+        foreach ($this->domain->getAdminEnabledDomainIds() as $domainId) {
+            $domainConfig = $this->domain->getDomainConfigById($domainId);
+
+            if ($this->setting->getForDomain(Setting::TERMS_AND_CONDITIONS_ARTICLE_ID, $domainConfig->getId()) === null) {
+                $this->requiredSettingsMessages[] = t(
+                    '<a href="%url%">Term and conditions article for domain %domainName% is not set.</a>',
+                    [
+                        '%url%' => $this->router->generate('admin_legalconditions_termsandconditions'),
+                        '%domainName%' => $domainConfig->getName(),
+                    ],
+                );
+            }
+
+            if ($this->setting->getForDomain(Setting::PRIVACY_POLICY_ARTICLE_ID, $domainConfig->getId()) === null) {
+                $this->requiredSettingsMessages[] = t(
+                    '<a href="%url%">Privacy policy article for domain %domainName% is not set.</a>',
+                    [
+                        '%url%' => $this->router->generate('admin_legalconditions_privacypolicy'),
+                        '%domainName%' => $domainConfig->getName(),
+                    ],
+                );
+            }
+
+            if ($this->setting->getForDomain(Setting::USER_CONSENT_POLICY_ARTICLE_ID, $domainConfig->getId()) === null) {
+                $this->requiredSettingsMessages[] = t(
+                    '<a href="%url%">User consent policy article for domain %domainName% is not set.</a>',
+                    [
+                        '%url%' => $this->router->generate('admin_userconsentpolicy_setting'),
+                        '%domainName%' => $domainConfig->getName(),
+                    ],
+                );
+            }
+        }
+    }
+
+    protected function checkAllSliderNumericValuesAreSet(): void
+    {
+        $countOfSliderParametersWithoutNumericValueSet = $this->parameterFacade->getCountOfSliderParametersWithoutTheirsNumericValueFilled();
+
+        if ($countOfSliderParametersWithoutNumericValueSet <= 0) {
+            return;
+        }
+
+        $message = t(
+            '{1} There is one parameter slider that does not have its numeric values filled in.|[2,Inf] There are %count% parameter sliders that does not have its numeric values filled in.',
+            [
+                '%count%' => $countOfSliderParametersWithoutNumericValueSet,
+            ],
+        );
+
+        $sliderParametersWithoutTheirsNumericValueFilled = $this->parameterFacade->getSliderParametersWithoutTheirsNumericValueFilled();
+
+        $message .= '<ul>';
+
+        foreach ($sliderParametersWithoutTheirsNumericValueFilled as $parameter) {
+            $message .= sprintf(
+                '<li><a href="%s">%s</a></li>',
+                $this->router->generate('admin_parametervalues_edit', ['id' => $parameter->getId()]),
+                $parameter->getName(),
+            );
+        }
+        $message .= '</ul>';
+
+        $this->requiredSettingsMessages[] = $message;
+    }
+}

--- a/upgrade-notes/backend_20241216_095022.md
+++ b/upgrade-notes/backend_20241216_095022.md
@@ -1,0 +1,12 @@
+#### improve rendering of the eshop required settings ([#3658](https://github.com/shopsys/shopsys/pull/3658))
+
+- `Shopsys\FrameworkBundle\Controller\Admin\DefaultController`
+    - method `addWarningMessagesOnDashboard()` was removed
+    - method `checkEnabledMailTemplatesHaveTheirBodyAndSubjectFilled()` was removed
+    - method `checkAtLeastOneUnitExists()` was removed
+    - method `checkDefaultUnitIsSet()` was removed
+    - method `checkMandatoryArticlesExist()` was removed
+    - method `checkAllSliderNumericValuesAreSet()` was removed
+- use new class `RequiredSettingExtension` instead of removed methods
+- the required settings are now rendered in the `layoutWithPanel.html.twig` template by calling the `render_required_settings()` function instead of inside the flash message
+- translations for the required settings have changed, check if you need to update your custom translations


### PR DESCRIPTION
#### Description, the reason for the PR

The information about the necessity of some settings is now separated from the default flash messages. 
The info about required settings is now rendered on every page on the storefront.
Missing warehouse and country is now reported.

+ Minor fixes and improvements 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-new-build.odin.shopsys.cloud
  - https://cz.mg-new-build.odin.shopsys.cloud
<!-- Replace -->
