### PR TITLE
[project-base] fixed single banner overflowing

### DIFF
--- a/project-base/storefront/components/Blocks/Banners/Banner.tsx
+++ b/project-base/storefront/components/Blocks/Banners/Banner.tsx
@@ -47,7 +47,7 @@ export const Banner: FC<BannerProps> = ({ banner, bannerSliderState, index, numI
                 <BannerContent banner={banner} className="hidden lg:block" />
             </BannerImage>
 
-            <BannerContent banner={banner} />
+            <BannerContent banner={banner} className="block lg:hidden" />
         </div>
     );
 };

--- a/upgrade-notes/storefront_20241213_085120.md
+++ b/upgrade-notes/storefront_20241213_085120.md
@@ -1,0 +1,4 @@
+#### fix single banner overflow ([#3660](https://github.com/shopsys/shopsys/pull/3660))
+
+- single banner is now showing correctly
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Fixed issue with single banner overflow.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3012-fix-single-banner-overflow.odin.shopsys.cloud
  - https://cz.tc-ssp-3012-fix-single-banner-overflow.odin.shopsys.cloud
<!-- Replace -->
