### PR TITLE
[shopsys] docs: fix tag name for feeds

### DIFF
--- a/docs/model/product-feeds.md
+++ b/docs/model/product-feeds.md
@@ -22,7 +22,7 @@ For example:
 ```yaml
 Shopsys\ProductFeed\GoogleBundle\GoogleFeed:
     tags:
-        - { name: shopsys.product_feed, hours: '1', minutes: '0' }
+        - { name: shopsys.feed, hours: '1', minutes: '0' }
 ```
 
 Google feed will be generated every day at 1:00 AM.
@@ -32,7 +32,7 @@ You can also set it like this:
 ```yaml
 Shopsys\ProductFeed\GoogleBundle\GoogleFeed:
     tags:
-        - { name: shopsys.product_feed, hours: '*/4', minutes: '0' }
+        - { name: shopsys.feed, hours: '*/4', minutes: '0' }
 ```
 
 In such a case, this feed will be generated every four hours.
@@ -54,7 +54,7 @@ For example, if you want to limit Google Feed to first and third domain, you wil
 ```yaml
 Shopsys\ProductFeed\GoogleBundle\GoogleFeed:
     tags:
-        - { name: shopsys.product_feed, hours: '1', minutes: '0', domain_ids: '1,3' }
+        - { name: shopsys.feed, hours: '1', minutes: '0', domain_ids: '1,3' }
 ```
 
 ## How to implement a custom product feed?


### PR DESCRIPTION
#### Description, the reason for the PR
The tag was renamed in 665f59415b8462c2f149b0435a85821c236d8c2d
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-feed-docs.odin.shopsys.cloud
  - https://cz.rv-feed-docs.odin.shopsys.cloud
<!-- Replace -->
