### PR TITLE
[projcet-base] Fix preselecting packetery with empty pickup point

### DIFF
--- a/upgrade-notes/storefront_20241213_151348.md
+++ b/upgrade-notes/storefront_20241213_151348.md
@@ -1,0 +1,6 @@
+#### Fix preselecting packetery with empty pickup point ([#3663](https://github.com/shopsys/shopsys/pull/3663))
+
+- when we unselect transport or clear a persist store, we lose the previously selected pickup point of packetery transport
+- now we check the correctness of data before preselecting packetery transport with corrupted pickup point
+- in case of incomplete info, the error is thrown and then caught in `loadTransportAndPaymentFromLastOrder` just to skip the `changeTransportInCart` and the rest of preselecting of transport and payment from last order
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
To fix bug with selecting packetery transport with incomplete data for pickup point, the pickup point is checked and, in case of missing info, the preselect is skipped.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-2980-packeta-without-selected-place-fix.odin.shopsys.cloud
  - https://cz.jm-ssp-2980-packeta-without-selected-place-fix.odin.shopsys.cloud
<!-- Replace -->
