### PR TITLE
[framework] ensure manually sent mail templates are wrapped with the GrapesJS body

### DIFF
--- a/docs/cookbook/adding-a-new-email-template.md
+++ b/docs/cookbook/adding-a-new-email-template.md
@@ -361,7 +361,51 @@ Shopsys\FrameworkBundle\Model\Mail\MailTemplateConfiguration:
               - '@=service("App\\Component\\Mail\\PasswordChangedMailTemplateVariablesProvider").create()'
 ```
 
+## Bonus: Enable testing the email template in administration on click
+
+This step is unnecessary for the email template to work, but with a little effort, it could add great value for the developers, testers, and e-shop administrators.
+By adding a new implementation of `Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender\MailTemplateSenderInterface`, it will be possible to send the email template to any desired email without the need for performing the action that normally triggers the mail sending.
+
+```php
+class CustomerPasswordChangeMailTemplateSender implements MailTemplateSenderInterface
+{
+    public function __construct(
+        private readonly PasswordChangedMail $passwordChangedMail,
+        private readonly UploadedFileFacade $uploadedFileFacade,
+        private readonly Mailer $mailer,
+        private readonly CustomerUserFacade $customerUserFacade,
+    ) {
+    }
+
+    public function getFormLabelForEntityIdentifier(): ?string
+    {
+        return t('Customer ID');
+    }
+
+    public function supports(MailTemplate $mailTemplate): bool
+    {
+        return $mailTemplate->getName() === PasswordChangedMail::MAIL_TEMPLATE_NAME;
+    }
+
+    public function sendTemplate(MailTemplate $mailTemplate, string $mailTo, ?int $entityId): void
+    {
+        $customerUser = $this->customerUserFacade->getById($entityId);
+        $messageData = $this->passwordChangedMail->createMessage($mailTemplate, $customerUser);
+        $messageData->attachments = $this->uploadedFileFacade->getUploadedFilesByEntity($mailTemplate);
+        $messageData->toEmail = $mailTo;
+        $this->mailer->send($messageData);
+    }
+}
+```
+
+When the implementation is finished, "Send test mail" button will appear on the mail template detail page in the administration.
+The administrator can then choose the email address to which the email should be sent and enter a customer user ID that will be used to fill in the mail variables from.
+
+You might notice that the logic here duplicates the code we added to `CustomerPasswordController::setNewPasswordAction()`.
+This is for the sake of simplicity and readability of this cookbook. In a real-world scenario, you should refactor the code to avoid duplication.
+You can find inspiration in the existing implementations of `Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender\MailTemplateSenderInterface`.
+
 ## Conclusion
 
 Now, in your database is a new email template, and an email from this template is sent to the user whenever he resets his password.
-This template can be easily changed from the administration.
+This template can be easily changed from the administration. For testing purposes, sending the template by clicking from administration to any email address is also possible.

--- a/packages/framework/src/Model/Administrator/Mail/ResetPasswordMailFacade.php
+++ b/packages/framework/src/Model/Administrator/Mail/ResetPasswordMailFacade.php
@@ -32,7 +32,7 @@ class ResetPasswordMailFacade
      */
     public function sendMail(Administrator $administrator)
     {
-        $mailTemplate = $this->mailTemplateFacade->get(
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(
             ResetPasswordMail::MAIL_TEMPLATE_NAME,
             $this->domain->getId(),
         );

--- a/packages/framework/src/Model/Administrator/Mail/TwoFactorAuthenticationMailFacade.php
+++ b/packages/framework/src/Model/Administrator/Mail/TwoFactorAuthenticationMailFacade.php
@@ -32,7 +32,7 @@ class TwoFactorAuthenticationMailFacade implements AuthCodeMailerInterface
      */
     public function sendAuthCode(TwoFactorInterface $administrator): void
     {
-        $mailTemplate = $this->mailTemplateFacade->get(
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(
             TwoFactorAuthenticationMail::TWO_FACTOR_AUTHENTICATION_CODE,
             $this->domain->getId(),
         );

--- a/packages/framework/src/Model/Complaint/Mail/ComplaintMailFacade.php
+++ b/packages/framework/src/Model/Complaint/Mail/ComplaintMailFacade.php
@@ -50,7 +50,7 @@ class ComplaintMailFacade
     {
         $templateName = ComplaintMail::getMailTemplateNameByStatus($complaintStatus);
 
-        return $this->mailTemplateFacade->get($templateName, $domainId);
+        return $this->mailTemplateFacade->getWrappedWithGrapesJsBody($templateName, $domainId);
     }
 
     /**

--- a/packages/framework/src/Model/Customer/Mail/CustomerMailFacade.php
+++ b/packages/framework/src/Model/Customer/Mail/CustomerMailFacade.php
@@ -34,7 +34,7 @@ class CustomerMailFacade
      */
     public function sendRegistrationMail(CustomerUser $customerUser): void
     {
-        $mailTemplate = $this->mailTemplateFacade->get(
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(
             MailTemplate::REGISTRATION_CONFIRM_NAME,
             $customerUser->getDomainId(),
         );
@@ -46,7 +46,7 @@ class CustomerMailFacade
      */
     public function sendActivationMail(CustomerUser $customerUser): void
     {
-        $mailTemplate = $this->mailTemplateFacade->get(CustomerActivationMail::CUSTOMER_ACTIVATION_NAME, $customerUser->getDomainId());
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(CustomerActivationMail::CUSTOMER_ACTIVATION_NAME, $customerUser->getDomainId());
         $this->sendActivationMailTemplate($mailTemplate, $customerUser);
     }
 

--- a/packages/framework/src/Model/Customer/Mail/ResetPasswordMailFacade.php
+++ b/packages/framework/src/Model/Customer/Mail/ResetPasswordMailFacade.php
@@ -32,7 +32,7 @@ class ResetPasswordMailFacade
      */
     public function sendMail(CustomerUser $customerUser)
     {
-        $mailTemplate = $this->mailTemplateFacade->get(
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(
             MailTemplate::RESET_PASSWORD_NAME,
             $customerUser->getDomainId(),
         );

--- a/packages/framework/src/Model/Inquiry/Mail/InquiryMailFacade.php
+++ b/packages/framework/src/Model/Inquiry/Mail/InquiryMailFacade.php
@@ -32,10 +32,10 @@ class InquiryMailFacade
      */
     public function sendMail(Inquiry $inquiry): void
     {
-        $mailTemplate = $this->mailTemplateFacade->get(InquiryMail::ADMIN_MAIL_TEMPLATE_NAME, $inquiry->getDomainId());
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(InquiryMail::ADMIN_MAIL_TEMPLATE_NAME, $inquiry->getDomainId());
         $this->sendMailTemplate($mailTemplate, $inquiry);
 
-        $mailTemplate = $this->mailTemplateFacade->get(InquiryMail::CUSTOMER_MAIL_TEMPLATE_NAME, $inquiry->getDomainId());
+        $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(InquiryMail::CUSTOMER_MAIL_TEMPLATE_NAME, $inquiry->getDomainId());
         $this->sendMailTemplate($mailTemplate, $inquiry);
     }
 

--- a/packages/framework/src/Model/Mail/MailTemplateFacade.php
+++ b/packages/framework/src/Model/Mail/MailTemplateFacade.php
@@ -40,16 +40,11 @@ class MailTemplateFacade
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplate
      */
-    public function get($templateName, $domainId)
+    public function getWrappedWithGrapesJsBody(string $templateName, int $domainId): MailTemplate
     {
         $mailTemplate = $this->mailTemplateRepository->getByNameAndDomainId($templateName, $domainId);
 
-        if ($mailTemplate !== null) {
-            $mailTemplate->setBody($this->mailTemplateBuilder->getMailTemplateWithContent($domainId, $mailTemplate->getBody()));
-            $this->em->detach($mailTemplate);
-        }
-
-        return $mailTemplate;
+        return $this->getTemplateWrappedWithGrapesBody($mailTemplate);
     }
 
     /**
@@ -114,5 +109,17 @@ class MailTemplateFacade
     public function existsTemplateWithEnabledSendingHavingEmptyBodyOrSubject()
     {
         return $this->mailTemplateRepository->existsTemplateWithEnabledSendingHavingEmptyBodyOrSubject();
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplate $mailTemplate
+     * @return \Shopsys\FrameworkBundle\Model\Mail\MailTemplate
+     */
+    public function getTemplateWrappedWithGrapesBody(MailTemplate $mailTemplate): MailTemplate
+    {
+        $mailTemplate->setBody($this->mailTemplateBuilder->getMailTemplateWithContent($mailTemplate->getDomainId(), $mailTemplate->getBody()));
+        $this->em->detach($mailTemplate); // detach from entity manager to avoid accidental persisting the changes to the database
+
+        return $mailTemplate;
     }
 }

--- a/packages/framework/src/Model/Mail/MailTemplateSender/MailTemplateSenderFacade.php
+++ b/packages/framework/src/Model/Mail/MailTemplateSender/MailTemplateSenderFacade.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender;
 
 use Shopsys\FrameworkBundle\Model\Mail\MailTemplate;
+use Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade;
 use Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender\Exception\NoSenderForMailTemplateException;
 use Traversable;
 
@@ -12,9 +13,11 @@ class MailTemplateSenderFacade
 {
     /**
      * @param \Traversable<int, \Shopsys\FrameworkBundle\Model\Mail\MailTemplateSender\MailTemplateSenderInterface> $mailTemplateSenders
+     * @param \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade $mailTemplateFacade
      */
     public function __construct(
         protected readonly Traversable $mailTemplateSenders,
+        protected readonly MailTemplateFacade $mailTemplateFacade,
     ) {
     }
 
@@ -34,7 +37,11 @@ class MailTemplateSenderFacade
      */
     public function sendMail(MailTemplate $mailTemplate, string $mailTo, ?int $entityId): void
     {
-        $this->getTemplateSender($mailTemplate)->sendTemplate($mailTemplate, $mailTo, $entityId);
+        $this->getTemplateSender($mailTemplate)->sendTemplate(
+            $this->mailTemplateFacade->getTemplateWrappedWithGrapesBody($mailTemplate),
+            $mailTo,
+            $entityId,
+        );
     }
 
     /**

--- a/packages/framework/src/Model/Order/Mail/OrderMailFacade.php
+++ b/packages/framework/src/Model/Order/Mail/OrderMailFacade.php
@@ -50,7 +50,7 @@ class OrderMailFacade
     {
         $templateName = OrderMail::getMailTemplateNameByStatus($orderStatus);
 
-        return $this->mailTemplateFacade->get($templateName, $domainId);
+        return $this->mailTemplateFacade->getWrappedWithGrapesJsBody($templateName, $domainId);
     }
 
     /**

--- a/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMailFacade.php
+++ b/packages/framework/src/Model/PersonalData/Mail/PersonalDataAccessMailFacade.php
@@ -35,12 +35,12 @@ class PersonalDataAccessMailFacade
     public function sendMail(PersonalDataAccessRequest $personalDataAccessRequest): void
     {
         if ($personalDataAccessRequest->getType() === PersonalDataAccessRequest::TYPE_DISPLAY) {
-            $mailTemplate = $this->mailTemplateFacade->get(
+            $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(
                 MailTemplate::PERSONAL_DATA_ACCESS_NAME,
                 $personalDataAccessRequest->getDomainId(),
             );
         } else {
-            $mailTemplate = $this->mailTemplateFacade->get(
+            $mailTemplate = $this->mailTemplateFacade->getWrappedWithGrapesJsBody(
                 MailTemplate::PERSONAL_DATA_EXPORT_NAME,
                 $personalDataAccessRequest->getDomainId(),
             );

--- a/project-base/app/src/Model/Mail/MailTemplateFacade.php
+++ b/project-base/app/src/Model/Mail/MailTemplateFacade.php
@@ -15,8 +15,9 @@ use Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade as BaseMailTemplateFac
  * @property \App\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory
  * @property \App\Model\Mail\MailTemplateBuilder $mailTemplateBuilder
  * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Mail\MailTemplateRepository $mailTemplateRepository, \Shopsys\FrameworkBundle\Component\Domain\Domain $domain, \App\Component\UploadedFile\UploadedFileFacade $uploadedFileFacade, \Shopsys\FrameworkBundle\Model\Mail\MailTemplateFactoryInterface $mailTemplateFactory, \App\Model\Mail\MailTemplateDataFactory $mailTemplateDataFactory, \Shopsys\FrameworkBundle\Model\Mail\MailTemplateAttachmentFilepathProvider $mailTemplateAttachmentFilepathProvider, \App\Model\Mail\MailTemplateBuilder $mailTemplateBuilder)
- * @method \App\Model\Mail\MailTemplate get(string $templateName, int $domainId)
+ * @method \App\Model\Mail\MailTemplate getWrappedWithGrapesJsBody(string $templateName, int $domainId)
  * @method createMailTemplateForAllDomains(string $name, \App\Model\Order\Status\OrderStatus|null $orderStatus = null, \Shopsys\FrameworkBundle\Model\Complaint\Status\ComplaintStatus|null $complaintStatus = null)
+ * @method \App\Model\Mail\MailTemplate getTemplateWrappedWithGrapesBody(\App\Model\Mail\MailTemplate $mailTemplate)
  */
 class MailTemplateFacade extends BaseMailTemplateFacade
 {

--- a/upgrade-notes/backend_20241213_153619.md
+++ b/upgrade-notes/backend_20241213_153619.md
@@ -1,0 +1,4 @@
+#### ensure manually sent mail templates are wrapped with the GrapesJS body ([#3664](https://github.com/shopsys/shopsys/pull/{pullRequestId}))
+
+- `Shopsys\FrameworkBundle\Model\Mail\MailTemplateFacade::get()` was renamed to `getWrappedWithGrapesJsBody()`
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
There was a bug in https://github.com/shopsys/shopsys/pull/3639 - mail templates that were manually sent via administration, were missing the GrapeJS wrapper (ensuring nice styling of the mail - header, footer, etc.)

Also, https://docs.shopsys.com/en/16.0/cookbook/adding-a-new-email-template/ was extended with information about the possibility of implementing on-click sender for a mail template.


<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-mails.odin.shopsys.cloud
  - https://cz.rv-fix-mails.odin.shopsys.cloud
<!-- Replace -->
