### PR TITLE
[project-base] removed stock availability info for products excluded from sale

### DIFF
--- a/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
@@ -138,15 +138,14 @@ export const ProductListItem = forwardRef<HTMLLIElement, ProductItemProps>(
                             />
                         )}
 
-                        {visibleItemsConfig.storeAvailability && (
-                            <ProductAvailability
-                                availability={product.availability}
-                                availableStoresCount={product.availableStoresCount}
-                                className="min-h-10 xs:min-h-[60px] sm:min-h-10"
-                                isInquiryType={product.isInquiryType}
-                            />
-                        )}
-                    </div>
+                    {visibleItemsConfig.storeAvailability && !product.isSellingDenied && (
+                        <ProductAvailability
+                            availability={product.availability}
+                            availableStoresCount={product.availableStoresCount}
+                            className="min-h-10 xs:min-h-[60px] sm:min-h-10"
+                            isInquiryType={product.isInquiryType}
+                        />
+                    )}
                 </ExtendedNextLink>
 
                 <div className="flex w-full items-center justify-between gap-1 px-2.5 py-5 sm:justify-normal sm:gap-2.5 sm:px-5 sm:py-0">

--- a/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
@@ -138,14 +138,15 @@ export const ProductListItem = forwardRef<HTMLLIElement, ProductItemProps>(
                             />
                         )}
 
-                    {visibleItemsConfig.storeAvailability && !product.isSellingDenied && (
-                        <ProductAvailability
-                            availability={product.availability}
-                            availableStoresCount={product.availableStoresCount}
-                            className="min-h-10 xs:min-h-[60px] sm:min-h-10"
-                            isInquiryType={product.isInquiryType}
-                        />
-                    )}
+                        {visibleItemsConfig.storeAvailability && !product.isSellingDenied && (
+                            <ProductAvailability
+                                availability={product.availability}
+                                availableStoresCount={product.availableStoresCount}
+                                className="min-h-10 xs:min-h-[60px] sm:min-h-10"
+                                isInquiryType={product.isInquiryType}
+                            />
+                        )}
+                    </div>
                 </ExtendedNextLink>
 
                 <div className="flex w-full items-center justify-between gap-1 px-2.5 py-5 sm:justify-normal sm:gap-2.5 sm:px-5 sm:py-0">

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonBody.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonBody.tsx
@@ -24,23 +24,26 @@ export const ProductComparisonBody: FC<ProductComparisonBodyProps> = ({ compared
                     </BodyItem>
                 ))}
             </tr>
+
             <tr className="[&>td]:bg-tableBackground [&>td]:odd:bg-tableBackgroundContrast">
                 <BodyItem isSticky>{t('Availability')}</BodyItem>
-                {comparedProducts.map((product) => (
-                    <BodyItem key={`availability-${product.uuid}`}>
-                        <div
-                            className={twJoin(
-                                'break-words text-sm font-bold sm:text-base',
-                                product.availability.status === TypeAvailabilityStatusEnum.InStock &&
-                                    'text-availabilityInStock',
-                                product.availability.status === TypeAvailabilityStatusEnum.OutOfStock &&
-                                    'text-availabilityOutOfStock',
-                            )}
-                        >
-                            {product.availability.name}
-                        </div>
-                    </BodyItem>
-                ))}
+                {comparedProducts
+                    .filter((product) => !product.isSellingDenied)
+                    .map((product) => (
+                        <BodyItem key={`availability-${product.uuid}`}>
+                            <div
+                                className={twJoin(
+                                    'break-words text-sm font-bold sm:text-base',
+                                    product.availability.status === TypeAvailabilityStatusEnum.InStock &&
+                                        'text-availabilityInStock',
+                                    product.availability.status === TypeAvailabilityStatusEnum.OutOfStock &&
+                                        'text-availabilityOutOfStock',
+                                )}
+                            >
+                                {product.availability.name}
+                            </div>
+                        </BodyItem>
+                    ))}
             </tr>
 
             {parametersDataState.map((parameter, parameterIndex) => (

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailContent.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailContent.tsx
@@ -93,26 +93,28 @@ export const ProductDetailContent: FC<ProductDetailContentProps> = ({ product, i
                                 </div>
                             )}
 
-                            <ProductAvailability
-                                availability={product.availability}
-                                availableStoresCount={product.availableStoresCount}
-                                isInquiryType={product.isInquiryType}
-                                className={twJoin(
-                                    'mr-1 flex items-center font-secondary',
-                                    product.availability.status === TypeAvailabilityStatusEnum.InStock &&
-                                        'cursor-pointer',
-                                )}
-                                onClick={() =>
-                                    product.availability.status === TypeAvailabilityStatusEnum.InStock &&
-                                    updatePortalContent(
-                                        <Popup>
-                                            <ProductDetailAvailabilityList
-                                                storeAvailabilities={product.storeAvailabilities}
-                                            />
-                                        </Popup>,
-                                    )
-                                }
-                            />
+                            {!product.isSellingDenied && (
+                                <ProductAvailability
+                                    availability={product.availability}
+                                    availableStoresCount={product.availableStoresCount}
+                                    isInquiryType={product.isInquiryType}
+                                    className={twJoin(
+                                        'mr-1 flex items-center font-secondary',
+                                        product.availability.status === TypeAvailabilityStatusEnum.InStock &&
+                                            'cursor-pointer',
+                                    )}
+                                    onClick={() =>
+                                        product.availability.status === TypeAvailabilityStatusEnum.InStock &&
+                                        updatePortalContent(
+                                            <Popup>
+                                                <ProductDetailAvailabilityList
+                                                    storeAvailabilities={product.storeAvailabilities}
+                                                />
+                                            </Popup>,
+                                        )
+                                    }
+                                />
+                            )}
 
                             <DeferredProductDetailAddToCart product={product} />
 

--- a/upgrade-notes/storefront_20241216_115626.md
+++ b/upgrade-notes/storefront_20241216_115626.md
@@ -1,0 +1,5 @@
+#### remove stock availability from products excluded from sale ([#3667](https://github.com/shopsys/shopsys/pull/3667))
+
+- product availability is no longer displayed for products excluded from sale
+- pages: wishlist, comparison, detail and blog
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Stock availability is now hidden when a product is excluded from sale.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2960-product-box-availability.odin.shopsys.cloud
  - https://cz.tc-ssp-2960-product-box-availability.odin.shopsys.cloud
<!-- Replace -->
