### PR TITLE
added deduplication for product messages in the queue, including scopes

### DIFF
--- a/docs/asynchronous-processing/product-recalculations.md
+++ b/docs/asynchronous-processing/product-recalculations.md
@@ -38,7 +38,19 @@ When you need to recalculate visibility of all products, you should use the `Sho
 This method dispatches the special message "dispatch all" to the message broker, and this message is then handled by the async handler, which takes care of dispatching all product IDs to recalculation.
 That way, we may dispatch all products to recalculation during request without worrying about the size of the catalog – it's not necessary to load all products (nor their IDs) from the database, and the user interface is not blocked by this operation.
 
-## Dispatch recalculation message when indirect change is made
+## Product Deduplication and Batch Dispatching
+
+To optimize performance and avoid redundant processing, the recalculation dispatch mechanism incorporates product deduplication and batch dispatching strategies.
+Export scopes ([mentioned later in this article](#recalculation-scope)) are stored in Redis, allowing products to remain in the queue only once while still supporting the addition of new scopes dynamically.
+This ensures that if a product ID is already present in Redis, it will not be dispatched again, preventing unnecessary recalculations and improving efficiency.
+Additionally, if a product ID is not yet present in Redis, Shopsys Platform ensures that all scopes are exported, guaranteeing that all relevant data is properly processed.
+
+When a large number of product IDs, typically more than 2000, are dispatched at once due to i.e., [affected changes](#dispatch-recalculation-message-when-an-indirect-change-is-made), Shopsys Platform takes an optimized approach.
+Instead of dispatching all product IDs individually in a currently running request, a few messages are sent to trigger the dispatch, significantly enhancing performance in large-scale recalculations.
+
+These refinements effectively minimize redundant messages, making recalculations more efficient and well-suited for handling large product catalogs with frequent changes.
+
+## Dispatch recalculation message when an indirect change is made
 
 Sometimes it is necessary to trigger recalculation for product when some indirect change is made.
 For example, when a category is deleted, when the parameter translation of a product is changed, etc.

--- a/docs/asynchronous-processing/product-recalculations.md
+++ b/docs/asynchronous-processing/product-recalculations.md
@@ -52,7 +52,7 @@ These refinements effectively minimize redundant messages, making recalculations
 
 ## Dispatch recalculation message when an indirect change is made
 
-Sometimes it is necessary to trigger recalculation for product when some indirect change is made.
+Sometimes it is necessary to trigger recalculation for a product when some indirect change is made.
 For example, when a category is deleted, when the parameter translation of a product is changed, etc.
 
 For this situation, the `\Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAffectedProductsSubscriber` subscriber is used.
@@ -88,7 +88,7 @@ You may disable this cron module if it doesn't suit your needs.
 
 ## Handle recalculations in tests
 
-In functional tests, you sometime need to trigger recalculations to be able to test some use-case.
+In functional tests, you sometimes need to trigger recalculations to be able to test some use-case.
 For example, when you need to test the change of a product visibility, you need to recalculate it after the change is made, so the data returned from GraphQL are accurate.
 
 You should use the `Tests\App\Test\WebTestCase::handleDispatchedRecalculationMessages()` method to process all dispatched recalculation messages.
@@ -129,10 +129,10 @@ That way we are sure the code works – the message is truly dispatched, thus th
 
 ## Recalculation scope
 
-In many occasions, to optimize the application, you might need to restrict the scope of a product recalculation and elastic export.
+On many occasions, to optimize the application, you might need to restrict the scope of a product recalculation and elastic export.
 Sometimes you do not need to recalculate visibility or selling denied, or you need to export just particular fields into Elasticsearch.
-For example, when launching a new domain, you need to export just the product URLs into Elasticsearch which takes significantly less time than the full recalculation and export.
-On the other hand, it might be hard to keep in mind all the dependencies (e.g. you need to know you need to recalculate visibility after you change `Product::$sellingFrom`,
+For example, when launching a new domain, you need to export just the product URLs into Elasticsearch, which takes significantly less time than the full recalculation and export.
+On the other hand, it might be hard to keep in mind all the dependencies (e.g., you need to know you need to recalculate visibility after you change `Product::$sellingFrom`,
 or you need to keep in mind that with a change of product URL, you always need to export `hreflang_links` into Elasticsearch as well, etc.).
 
 For this purpose, recalculation scopes are defined as an associative array in the `Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfigFacade` class.
@@ -141,7 +141,7 @@ Each scope rule defines which fields should be exported to Elasticsearch togethe
 
 You can use `./bin/console shopsys:list:export-scopes` command to list and examine all the available scopes.
 
-The scope usage can be seen in action e.g. in `Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAffectedProductsSubscriber` class:
+The scope usage can be seen in action e.g., in `Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAffectedProductsSubscriber` class:
 
 ```php
 public function dispatchAffectedByBrand(BrandEvent $brandEvent): void
@@ -158,7 +158,7 @@ public function dispatchAffectedByBrand(BrandEvent $brandEvent): void
 
 Thanks to the usage of `SCOPE_BRAND` here, no visibility or selling denied recalculations are done after a brand is updated, only the brand-related fields (brand ID, name, and URL) are exported to Elasticsearch for the affected products.
 
-There are several methods that allow you to modify the scopes configuration further to suit your project needs.
+There are several methods that allow you to modify the scope configuration further to suit your project needs.
 
 - `addExportFieldsToExistingScopeRule()`
 - `addNewExportScopeRule()`

--- a/docs/model/navigation.yml
+++ b/docs/model/navigation.yml
@@ -10,6 +10,5 @@ arrange:
     - custom-entities.md
     - elasticsearch.md
     - front-end-product-searching.md
-    - front-end-product-filtering.md
     - log-entity-changes.md
     - domain-limiting.md

--- a/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
+++ b/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
@@ -145,9 +145,10 @@ class DispatchRecalculationMessageCommand extends Command
             return Command::FAILURE;
         }
 
-        $dispatchedProductIds = $this->productRecalculationDispatcher->dispatchProductIds($productIds, $priority, $scopes);
+        $this->productRecalculationDispatcher->dispatchProductIds($productIds, $priority, $scopes);
+
         $symfonyStyle->success([
-            'Dispatched message for IDs', implode(', ', $dispatchedProductIds),
+            'Dispatched message for IDs', implode(', ', $productIds),
             sprintf('Priority: %s', $priority),
             sprintf('Scopes: %s', count($scopes) > 0 ? implode(', ', $scopes) : '-'),
         ]);

--- a/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
+++ b/packages/framework/src/Command/DispatchRecalculationMessageCommand.php
@@ -137,6 +137,8 @@ class DispatchRecalculationMessageCommand extends Command
         try {
             Assert::allNumeric($productIds, 'All product IDs must be numeric');
             Assert::notEmpty($productIds, 'You must specify at least one product ID');
+
+            $productIds = array_map('intval', $productIds);
         } catch (InvalidArgumentException $e) {
             $symfonyStyle->error($e->getMessage());
 

--- a/packages/framework/src/Model/Product/ProductFacade.php
+++ b/packages/framework/src/Model/Product/ProductFacade.php
@@ -269,9 +269,9 @@ class ProductFacade
     /**
      * @return iterable<array{id: int}>
      */
-    public function iterateAllProductIds(): iterable
+    public function iterateAllProductIdsExceptVariant(): iterable
     {
-        return $this->productRepository->iterateAllProductIds();
+        return $this->productRepository->iterateAllProductIdsExceptVariant();
     }
 
     /**

--- a/packages/framework/src/Model/Product/ProductRepository.php
+++ b/packages/framework/src/Model/Product/ProductRepository.php
@@ -299,10 +299,12 @@ class ProductRepository
     /**
      * @return iterable<array{id: int}>
      */
-    public function iterateAllProductIds(): iterable
+    public function iterateAllProductIdsExceptVariant(): iterable
     {
         return $this->getAllProductsQueryBuilder()
             ->select('p.id')
+            ->where('p.variantType != :variantType')
+            ->setParameter('variantType', Product::VARIANT_TYPE_VARIANT)
             ->getQuery()
             ->toIterable();
     }

--- a/packages/framework/src/Model/Product/Recalculation/AbstractProductRecalculationMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/AbstractProductRecalculationMessage.php
@@ -8,11 +8,9 @@ abstract class AbstractProductRecalculationMessage
 {
     /**
      * @param int $productId
-     * @param string[] $exportScopes
      */
     public function __construct(
         public readonly int $productId,
-        public readonly array $exportScopes = [],
     ) {
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchAllProductsMessageHandler.php
@@ -24,10 +24,14 @@ class DispatchAllProductsMessageHandler implements MessageHandlerInterface
      */
     public function __invoke(DispatchAllProductsMessage $message): void
     {
-        $productIds = $this->productFacade->iterateAllProductIds();
+        $productIds = $this->productFacade->iterateAllProductIdsExceptVariant();
 
         foreach ($productIds as $productId) {
-            $this->productRecalculationDispatcher->dispatchSingleProductId($productId['id'], ProductRecalculationPriorityEnum::REGULAR, $message->exportScopes);
+            $this->productRecalculationDispatcher->dispatchSingleProductId(
+                $productId['id'],
+                ProductRecalculationPriorityEnum::REGULAR,
+                $message->exportScopes,
+            );
         }
     }
 }

--- a/packages/framework/src/Model/Product/Recalculation/DispatchProductIdsBatchMessage.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchProductIdsBatchMessage.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+class DispatchProductIdsBatchMessage
+{
+    /**
+     * @param int[] $productIds
+     * @param string[] $exportScopes
+     * @param string $productRecalculationPriorityEnum
+     */
+    public function __construct(
+        public readonly array $productIds = [],
+        public readonly array $exportScopes = [],
+        public readonly string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+    ) {
+    }
+}

--- a/packages/framework/src/Model/Product/Recalculation/DispatchProductIdsBatchMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/DispatchProductIdsBatchMessageHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+use Nette\Utils\Json;
+use Psr\Log\LoggerInterface;
+use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class DispatchProductIdsBatchMessageHandler implements MessageHandlerInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcherExecutor $productRecalculationDispatcherExecutor
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        protected readonly ProductRepository $productRepository,
+        protected readonly ProductRecalculationDispatcherExecutor $productRecalculationDispatcherExecutor,
+        protected readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchProductIdsBatchMessage $message
+     */
+    public function __invoke(DispatchProductIdsBatchMessage $message): void
+    {
+        $dispatchedProductIds = $this->productRecalculationDispatcherExecutor->dispatchProductIds(
+            $message->productIds,
+            $message->productRecalculationPriorityEnum,
+            $message->exportScopes,
+        );
+
+        if ($dispatchedProductIds === []) {
+            $this->logger->info('No new products were dispatched as they are already in the queue.', [
+                'product_ids' => Json::encode($message->productIds),
+                'export_scopes' => Json::encode($message->exportScopes),
+            ]);
+
+            return;
+        }
+
+        $this->logger->info('Dispatched batch of products for recalculation.', [
+            'product_ids' => Json::encode($dispatchedProductIds),
+            'export_scopes' => Json::encode($message->exportScopes),
+        ]);
+    }
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDeduplicationFacade.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+use Nette\Utils\Json;
+use Redis;
+
+class ProductRecalculationDeduplicationFacade
+{
+    protected const int TTL = 10800;
+
+    /**
+     * @param \Redis $redisClient
+     * @param bool $isDeduplicationActive
+     */
+    public function __construct(
+        protected readonly Redis $redisClient,
+        protected readonly bool $isDeduplicationActive,
+    ) {
+    }
+
+    /**
+     * @param int[] $productIds
+     * @param string $priority
+     */
+    public function delete(
+        array $productIds,
+        string $priority,
+    ): void {
+        if (!$this->isDeduplicationActive) {
+            return;
+        }
+
+        $this->redisClient->hDel($this->getCacheKey($priority), ...array_map('strval', $productIds));
+    }
+
+    /**
+     * @param int[] $productIds
+     * @param string $priority
+     * @return array<int,string[]>
+     */
+    public function getScopesIndexedByProductId(
+        array $productIds,
+        string $priority,
+    ): array {
+        if (!$this->isDeduplicationActive) {
+            return array_fill_keys($productIds, []);
+        }
+
+        $exportScopesIndexedByProductIds = $this->doGetStoredExportScopes($productIds, $priority);
+
+        foreach ($exportScopesIndexedByProductIds as $productId => $exportScopesJson) {
+            if ($exportScopesJson === false) {
+                $exportScopesJson = '[]';
+            }
+
+            $exportScopes = Json::decode($exportScopesJson, true);
+            $exportScopesIndexedByProductIds[$productId] = $exportScopes;
+        }
+
+        return $exportScopesIndexedByProductIds;
+    }
+
+    /**
+     * @param int[] $productIdsWithMainVariants
+     * @param string[] $requestedExportScopes
+     * @param string $priority
+     * @return int[]
+     */
+    public function updateScopesAndReturnProductIdsToDispatch(
+        array $productIdsWithMainVariants,
+        array $requestedExportScopes,
+        string $priority,
+    ): array {
+        if (!$this->isDeduplicationActive) {
+            return $productIdsWithMainVariants;
+        }
+
+        $exportScopesIndexedByProductIds = $this->doGetStoredExportScopes($productIdsWithMainVariants, $priority);
+        $productIdsToDispatch = [];
+
+        foreach ($exportScopesIndexedByProductIds as $productId => $storedScopesJson) {
+            if ($storedScopesJson === false) {
+                $productIdsToDispatch[] = $productId;
+            }
+
+            $updatedScopesJson = $this->updateScopesByRequestedScopes($requestedExportScopes, $storedScopesJson);
+            $exportScopesIndexedByProductIds[$productId] = $updatedScopesJson;
+        }
+
+        $this->redisClient->hMset($this->getCacheKey($priority), $exportScopesIndexedByProductIds);
+        $this->redisClient->rawCommand(
+            'HEXPIRE',
+            $this->redisClient->getOption(Redis::OPT_PREFIX) . $this->getCacheKey($priority),
+            self::TTL,
+            'FIELDS',
+            count($exportScopesIndexedByProductIds),
+            ...array_keys($exportScopesIndexedByProductIds),
+        );
+
+        return $productIdsToDispatch;
+    }
+
+    /**
+     * @param string[] $requestedExportScopes
+     * @param false|string $storedScopesJson
+     * @return string
+     */
+    protected function updateScopesByRequestedScopes(
+        array $requestedExportScopes,
+        false|string $storedScopesJson,
+    ): string {
+        // no scopes stored; store requested scopes
+        if ($storedScopesJson === false) {
+            return Json::encode($requestedExportScopes);
+        }
+
+        $storedScopes = Json::decode($storedScopesJson, true);
+
+        // all scopes are already stored; do not modify stored scopes
+        if ($storedScopes === []) {
+            return $storedScopesJson;
+        }
+
+        // requested all scopes; store all scopes
+        if ($requestedExportScopes === []) {
+            return '[]';
+        }
+
+        // all requested scopes already stored; do not modify stored scopes
+        if (array_diff($requestedExportScopes, $storedScopes) === []) {
+            return $storedScopesJson;
+        }
+
+        // update stored scopes with newly requested scopes
+        $newScopes = array_unique(array_merge($storedScopes, $requestedExportScopes));
+
+        return Json::encode($newScopes);
+    }
+
+    /**
+     * @param int[] $productIds
+     * @param string $priority
+     * @return array<int, string|false>
+     */
+    protected function doGetStoredExportScopes(array $productIds, string $priority): array
+    {
+        $exportScopesIndexedByProductIds = $this->redisClient->hMget(
+            $this->getCacheKey($priority),
+            array_map('strval', $productIds),
+        );
+
+        if ($exportScopesIndexedByProductIds === false) {
+            $exportScopesIndexedByProductIds = array_fill_keys($productIds, false);
+        }
+
+        return $exportScopesIndexedByProductIds;
+    }
+
+    /**
+     * @param string $priority
+     * @return string
+     */
+    protected function getCacheKey(string $priority): string
+    {
+        return 'product_recalculation_ids_' . $priority;
+    }
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcher.php
@@ -11,11 +11,15 @@ use Shopsys\FrameworkBundle\Model\Product\Product;
 
 class ProductRecalculationDispatcher extends AbstractMessageDispatcher
 {
+    protected const int DISPATCH_BATCH_SIZE = 2000;
+
     /**
      * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig $productExportScopeConfig
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDispatcherExecutor $productRecalculationDispatcherExecutor
      */
     public function __construct(
         protected readonly ProductExportScopeConfig $productExportScopeConfig,
+        protected readonly ProductRecalculationDispatcherExecutor $productRecalculationDispatcherExecutor,
     ) {
     }
 
@@ -23,14 +27,13 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
      * @param \Shopsys\FrameworkBundle\Model\Product\Product[] $products
      * @param string $productRecalculationPriorityEnum
      * @param string[] $exportScopes
-     * @return int[]
      */
     public function dispatchProducts(
         array $products,
         string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
         array $exportScopes = [],
-    ): array {
-        return $this->dispatchProductIds(
+    ): void {
+        $this->dispatchProductIds(
             array_map(static fn (Product $product) => $product->getId(), $products),
             $productRecalculationPriorityEnum,
             $exportScopes,
@@ -41,26 +44,38 @@ class ProductRecalculationDispatcher extends AbstractMessageDispatcher
      * @param int[] $productIds
      * @param string $productRecalculationPriorityEnum
      * @param string[] $exportScopes
-     * @return int[]
      */
     public function dispatchProductIds(
         array $productIds,
         string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
         array $exportScopes = [],
-    ): array {
+    ): void {
         $this->verifyExportScopes($exportScopes);
         $productIds = array_unique($productIds);
 
-        foreach ($productIds as $productId) {
-            $message = match ($productRecalculationPriorityEnum) {
-                ProductRecalculationPriorityEnum::HIGH => new ProductRecalculationPriorityHighMessage((int)$productId, $exportScopes),
-                ProductRecalculationPriorityEnum::REGULAR => new ProductRecalculationPriorityRegularMessage((int)$productId, $exportScopes),
-                default => throw new UnknownProductRecalculationPriorityException($productRecalculationPriorityEnum),
-            };
-            $this->messageBus->dispatch($message);
+        $productIdsCount = count($productIds);
+
+        if ($productIdsCount <= static::DISPATCH_BATCH_SIZE) {
+            $this->productRecalculationDispatcherExecutor->dispatchProductIds(
+                $productIds,
+                $productRecalculationPriorityEnum,
+                $exportScopes,
+            );
+
+            return;
         }
 
-        return $productIds;
+        for ($i = 0; $i < $productIdsCount; $i += static::DISPATCH_BATCH_SIZE) {
+            $productIdsBatch = array_slice($productIds, $i, static::DISPATCH_BATCH_SIZE);
+
+            $this->messageBus->dispatch(
+                new DispatchProductIdsBatchMessage(
+                    $productIdsBatch,
+                    $exportScopes,
+                    $productRecalculationPriorityEnum,
+                ),
+            );
+        }
     }
 
     /**

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcherExecutor.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationDispatcherExecutor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
+
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @internal This class is not intended to be used directly from your code. Use ProductRecalculationDispatcher
+ */
+class ProductRecalculationDispatcherExecutor
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationRepository $productRecalculationRepository
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade $productRecalculationDeduplicationFacade
+     * @param \Symfony\Component\Messenger\MessageBusInterface $messageBus
+     */
+    public function __construct(
+        protected readonly ProductRecalculationRepository $productRecalculationRepository,
+        protected readonly ProductRecalculationDeduplicationFacade $productRecalculationDeduplicationFacade,
+        protected readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @param int[] $productIds
+     * @param string $productRecalculationPriorityEnum
+     * @param string[] $exportScopes
+     * @return int[]
+     */
+    public function dispatchProductIds(
+        array $productIds,
+        string $productRecalculationPriorityEnum = ProductRecalculationPriorityEnum::REGULAR,
+        array $exportScopes = [],
+    ): array {
+        $productIdsWithMainVariants = $this->productRecalculationRepository->replaceVariantIdsWithMainVariantIds($productIds);
+
+        $productIdsToDispatch = $this->productRecalculationDeduplicationFacade->updateScopesAndReturnProductIdsToDispatch(
+            $productIdsWithMainVariants,
+            $exportScopes,
+            $productRecalculationPriorityEnum,
+        );
+
+        if ($productIdsToDispatch === []) {
+            return [];
+        }
+
+        foreach ($productIdsToDispatch as $productId) {
+            $message = match ($productRecalculationPriorityEnum) {
+                ProductRecalculationPriorityEnum::HIGH => new ProductRecalculationPriorityHighMessage($productId),
+                ProductRecalculationPriorityEnum::REGULAR => new ProductRecalculationPriorityRegularMessage($productId),
+                default => throw new UnknownProductRecalculationPriorityException($productRecalculationPriorityEnum),
+            };
+
+            $this->messageBus->dispatch($message);
+        }
+
+        return $productIdsToDispatch;
+    }
+}

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationFacade.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationFacade.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Model\Product\Recalculation;
 
+use Nette\Utils\Json;
+use Psr\Log\LoggerInterface;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexDefinitionLoader;
 use Shopsys\FrameworkBundle\Component\Elasticsearch\IndexFacade;
@@ -29,6 +31,7 @@ class ProductRecalculationFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator $productSellingDeniedRecalculator
      * @param \Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfigFacade $productExportScopeConfigFacade
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductElasticsearchProvider $productElasticsearchProvider
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade $productRecalculationDeduplicationFacade
      */
     public function __construct(
         protected readonly IndexFacade $indexFacade,
@@ -40,17 +43,33 @@ class ProductRecalculationFacade
         protected readonly ProductSellingDeniedRecalculator $productSellingDeniedRecalculator,
         protected readonly ProductExportScopeConfigFacade $productExportScopeConfigFacade,
         protected readonly ProductElasticsearchProvider $productElasticsearchProvider,
+        protected readonly ProductRecalculationDeduplicationFacade $productRecalculationDeduplicationFacade,
     ) {
     }
 
     /**
-     * @param array<int, string[]> $exportScopesIndexedByProductId
+     * @param int[] $productIds
+     * @param string $priority
+     * @param \Psr\Log\LoggerInterface|null $logger
      */
-    public function recalculate(array $exportScopesIndexedByProductId): void
+    public function recalculate(array $productIds, string $priority, ?LoggerInterface $logger = null): void
     {
+        $exportScopesIndexedByProductId = $this->productRecalculationDeduplicationFacade->getScopesIndexedByProductId($productIds, $priority);
+
         foreach ($this->groupProductIdsWithSameScopes($exportScopesIndexedByProductId) as $productIdsWithScopes) {
-            $idsToRecalculate = $this->productRecalculationRepository->getIdsToRecalculate($productIdsWithScopes[self::KEY_PRODUCT_IDS]);
+            $idsToRecalculate = $this->productRecalculationRepository->getIdsToRecalculateByMainVariantIds(
+                $productIdsWithScopes[self::KEY_PRODUCT_IDS],
+            );
+
             $this->recalculateWithScope($idsToRecalculate, $productIdsWithScopes[self::KEY_SCOPES]);
+
+            $logger?->info('Products recalculated', [
+                'product_ids' => Json::encode($idsToRecalculate),
+                'export_scopes' => Json::encode($productIdsWithScopes[self::KEY_SCOPES]),
+                'priority' => $priority,
+            ]);
+
+            $this->productRecalculationDeduplicationFacade->delete($idsToRecalculate, $priority);
         }
     }
 

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationMessageHandler.php
@@ -39,32 +39,54 @@ class ProductRecalculationMessageHandler implements BatchHandlerInterface
      */
     protected function process(array $jobs): void
     {
-        $acknowledgers = [];
-        $exportScopesIndexedByProductId = [];
+        $priorities = [];
 
         /**
          * @var \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage $message
          * @var \Symfony\Component\Messenger\Handler\Acknowledger $ack
          */
         foreach ($jobs as [$message, $ack]) {
-            $acknowledgers[] = $ack;
-            $exportScopesIndexedByProductId[$message->productId] = $message->exportScopes;
+            $priority = $this->getPriority($message);
+            $priorities[$priority]['productIds'][] = $message->productId;
+            $priorities[$priority]['acknowledgers'][] = $ack;
+        }
+
+        foreach ($priorities as $priority => $data) {
+            $this->processPriority($data['productIds'], $priority, $data['acknowledgers']);
+        }
+    }
+
+    /**
+     * @param int[] $productIds
+     * @param string $priority
+     * @param \Symfony\Component\Messenger\Handler\Acknowledger[] $acknowledgers
+     */
+    protected function processPriority(array $productIds, string $priority, array $acknowledgers): void
+    {
+        if (count($productIds) === 0) {
+            return;
         }
 
         try {
-            $this->productRecalculationFacade->recalculate($exportScopesIndexedByProductId);
+            $this->productRecalculationFacade->recalculate($productIds, $priority, $this->logger);
             $this->ackAll($acknowledgers);
         } catch (Throwable $e) {
             $this->logger->error($e->getMessage());
             $this->nackAll($acknowledgers, $e);
-
-            return;
         }
+    }
 
-        $this->logger->info('Product recalculated', [
-            'product_ids' => json_encode(array_keys($exportScopesIndexedByProductId), JSON_THROW_ON_ERROR),
-            'export_scopes' => json_encode($exportScopesIndexedByProductId, JSON_THROW_ON_ERROR),
-        ]);
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage $message
+     * @return string
+     */
+    protected function getPriority(AbstractProductRecalculationMessage $message): string
+    {
+        return match (true) {
+            $message instanceof ProductRecalculationPriorityHighMessage => ProductRecalculationPriorityEnum::HIGH,
+            $message instanceof ProductRecalculationPriorityRegularMessage => ProductRecalculationPriorityEnum::REGULAR,
+            default => throw new UnknownProductRecalculationPriorityException($message::class),
+        };
     }
 
     /**

--- a/packages/framework/src/Model/Product/Recalculation/ProductRecalculationRepository.php
+++ b/packages/framework/src/Model/Product/Recalculation/ProductRecalculationRepository.php
@@ -21,57 +21,36 @@ class ProductRecalculationRepository
      * @param int[] $productIds
      * @return int[]
      */
-    public function getIdsToRecalculate(array $productIds): array
+    public function replaceVariantIdsWithMainVariantIds(array $productIds): array
     {
-        $mainVariantsIds = $this->getMainVariantIdsOfVariants($productIds);
-
-        $productIdsWithAddedMainVariantIds = [...$productIds, ...$mainVariantsIds];
-
-        $regularProductOrMainVariantIds = $this->dropVariantIdsFromProductIds($productIdsWithAddedMainVariantIds);
-        $variantIds = $this->getVariantIds($productIdsWithAddedMainVariantIds);
-
-        return [...$variantIds, ...$regularProductOrMainVariantIds];
-    }
-
-    /**
-     * @param int[] $productIds
-     * @return int[]
-     */
-    protected function getMainVariantIdsOfVariants(array $productIds): array
-    {
-        $result = $this->em->createQuery('SELECT IDENTITY(p.mainVariant) as id FROM ' . Product::class . ' p WHERE p.id IN (:productIds) AND p.variantType = :variantTypeVariant')
+        $ids = $this->em
+            ->createQuery(
+                'SELECT DISTINCT 
+                CASE
+                    WHEN p.variantType = :variantTypeVariant THEN IDENTITY(p.mainVariant) 
+                    ELSE p.id
+                END AS resolved_id
+                FROM ' . Product::class . ' p 
+                WHERE p.id IN (:productIds)',
+            )
             ->setParameter('productIds', $productIds)
             ->setParameter('variantTypeVariant', Product::VARIANT_TYPE_VARIANT)
-            ->getResult();
+            ->getArrayResult();
 
-        return array_column($result, 'id');
-    }
-
-    /**
-     * @param int[] $productIds
-     * @return int[]
-     */
-    protected function dropVariantIdsFromProductIds(array $productIds): array
-    {
-        $result = $this->em->createQuery('SELECT p.id FROM ' . Product::class . ' p WHERE p.id IN (:productIds) AND p.variantType != :variantTypeVariant')
-            ->setParameter('productIds', $productIds)
-            ->setParameter('variantTypeVariant', Product::VARIANT_TYPE_VARIANT)
-            ->getResult();
-
-        return array_column($result, 'id');
+        return array_column($ids, 'resolved_id');
     }
 
     /**
      * @param int[] $mainVariantsIds
      * @return int[]
      */
-    protected function getVariantIds(array $mainVariantsIds): array
+    public function getIdsToRecalculateByMainVariantIds(array $mainVariantsIds): array
     {
-        $result = $this->em->createQuery('SELECT p.id FROM ' . Product::class . ' p WHERE p.mainVariant IN (:productIds) AND p.variantType = :variantTypeVariant')
+        $ids = $this->em
+            ->createQuery('SELECT p.id FROM ' . Product::class . ' p WHERE p.mainVariant IN (:productIds) OR p.id IN (:productIds)')
             ->setParameter('productIds', $mainVariantsIds)
-            ->setParameter('variantTypeVariant', Product::VARIANT_TYPE_VARIANT)
-            ->getResult();
+            ->getArrayResult();
 
-        return array_column($result, 'id');
+        return array_column($ids, 'id');
     }
 }

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -17,7 +17,7 @@ services:
 
     Shopsys\FrameworkBundle\:
         exclude: '../../{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
-        resource: '../../**/*{CategoryAutomatedFilter,Calculation,Dispatcher,Enum,Facade,Factory,Formatter,Generator,Handler,Helper,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Sender,Service,Scheduler,Subscriber,Transformer,DataFetcher}.php'
+        resource: '../../**/*{CategoryAutomatedFilter,Calculation,Dispatcher,Enum,Executor,Facade,Factory,Formatter,Generator,Handler,Helper,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Sender,Service,Scheduler,Subscriber,Transformer,DataFetcher}.php'
 
     Shopsys\FrameworkBundle\Controller\:
         resource: '../../Controller/'
@@ -408,6 +408,7 @@ services:
             $persistentClients:
                 - '@snc_redis.global'
                 - '@snc_redis.blog_article_export_queue'
+                - '@snc_redis.product_recalculation_queue'
 
     Shopsys\FrameworkBundle\Component\Redis\RedisVersionsFacade:
         arguments:
@@ -717,12 +718,20 @@ services:
         arguments:
             - '@bestselling_product_cache'
 
-
     Shopsys\FrameworkBundle\Model\Product\Elasticsearch\ProductIndex: ~
 
     Shopsys\FrameworkBundle\Model\Product\Elasticsearch\Scope\ProductExportScopeConfig: ~
 
     Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForCustomerUser: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchProductIdsBatchMessageHandler:
+        arguments:
+            $logger: '@monolog.logger.queue'
+
+    Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade:
+        arguments:
+            $redisClient: '@snc_redis.product_recalculation_queue'
+            $isDeduplicationActive: '@=env("defined:MESSENGER_TRANSPORT_DSN") and not (parameter("kernel.environment") matches "/^(test|acc)$/")'
 
     Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationMessageHandler:
         arguments:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -50,9 +50,6 @@ parameters:
             message: '#^Service "test.service_container" is not registered in the container.$#'
             path: %currentWorkingDirectory%/*/tests/*
         -
-            message: '#^Service "snc_redis.test" is not registered in the container.$#'
-            path: %currentWorkingDirectory%/project-base/app/tests/App/Functional/Component/Redis/Redis*FacadeTest.php
-        -
             message: '#^Service "doctrine.orm.default_metadata_driver" is private.$#'
             path: %currentWorkingDirectory%/packages/framework/src/DependencyInjection/Compiler/RegisterExtendedEntitiesCompilerPass.php
         -

--- a/project-base/app/config/packages/messenger.yaml
+++ b/project-base/app/config/packages/messenger.yaml
@@ -10,7 +10,8 @@ framework:
         routing:
             Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityRegularMessage: product_recalculation_priority_regular
             Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityHighMessage: product_recalculation_priority_high
-            Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAllProductsMessage: product_recalculation_priority_regular
+            Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchAllProductsMessage: product_recalculation_priority_high
+            Shopsys\FrameworkBundle\Model\Product\Recalculation\DispatchProductIdsBatchMessage: product_recalculation_priority_high
             Shopsys\FrameworkBundle\Model\Order\Messenger\PlacedOrderMessage: placed_order_transport
             Symfony\Component\Mailer\Messenger\SendEmailMessage: send_email_transport
         transports:

--- a/project-base/app/config/packages/snc_redis.yaml
+++ b/project-base/app/config/packages/snc_redis.yaml
@@ -50,6 +50,14 @@ snc_redis:
                 prefix: '%env(REDIS_PREFIX)%:%build-version%:cache:main_friendly_url_slugs:'
                 connection_timeout: 2
                 read_write_timeout: 5
+        product_recalculation_queue:
+            type: 'phpredis'
+            alias: 'product_recalculation_queue'
+            dsn: 'redis://%env(REDIS_HOST)%'
+            options:
+                prefix: '%env(REDIS_PREFIX)%:queue:recalculation:'
+                connection_timeout: 2
+                read_write_timeout: 5
         storefront_graphql_query:
             type: 'phpredis'
             alias: 'storefront_graphql_query'

--- a/project-base/app/config/services.yaml
+++ b/project-base/app/config/services.yaml
@@ -16,7 +16,7 @@ services:
         exclude:
             - '../src/{Command,Controller,DependencyInjection,Form,Migrations,Resources,Twig}'
             - '../src/FrontendApi/**/*{Resolver,Mapper}.php'
-        resource: '../src/**/*{Calculation,Collector,Dispatcher,Enum,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,Validator,Transfer,Helper,Converter,DataFetcher}.php'
+        resource: '../src/**/*{Calculation,Collector,Dispatcher,Enum,Executor,Facade,Factory,Generator,Handler,InlineEdit,Listener,Loader,Mapper,Middleware,Parser,Provider,Recalculator,Registry,Repository,Resolver,Service,Scheduler,Subscriber,Transformer,Validator,Transfer,Helper,Converter,DataFetcher}.php'
 
     App\Command\:
         resource: '../src/Command'

--- a/project-base/app/phpstan.neon
+++ b/project-base/app/phpstan.neon
@@ -33,9 +33,6 @@ parameters:
         -
             message: '#^Service "test.service_container" is not registered in the container.$#'
             path: %currentWorkingDirectory%/tests/*
-        -
-            message: '#^Service "snc_redis.test" is not registered in the container.$#'
-            path: %currentWorkingDirectory%/tests/App/Functional/Component/Redis/Redis*FacadeTest.php
     excludePaths:
         - tests/App/Unit/PhpStan/GedmoTestEntity.php
         # Exclude coding standards for generated files

--- a/project-base/app/tests/App/Functional/Component/Redis/RedisFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Component/Redis/RedisFacadeTest.php
@@ -14,6 +14,7 @@ class RedisFacadeTest extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        /** @phpstan-ignore symfonyContainer.serviceNotFound (service is available only in test env) */
         $this->redisClient = self::getContainer()->get('snc_redis.test');
     }
 

--- a/project-base/app/tests/App/Functional/Model/Product/ProductVisibilityFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductVisibilityFacadeTest.php
@@ -44,7 +44,7 @@ class ProductVisibilityFacadeTest extends TransactionFunctionalTestCase
         $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnEachDomainIndexedByProductId(
             [$productId],
         );
-        $this->assertTrue($visibilityIndexedByProductId[$productId]);
+        $this->assertTrue($visibilityIndexedByProductId[$productId], 'Product should be visible on all domains');
 
         $product = $this->getReference(ProductDataFixture::PRODUCT_PREFIX . $productId);
         $productData = $this->productDataFactory->createFromProduct($product);
@@ -56,7 +56,7 @@ class ProductVisibilityFacadeTest extends TransactionFunctionalTestCase
         $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnEachDomainIndexedByProductId(
             [$productId],
         );
-        $this->assertFalse($visibilityIndexedByProductId[$productId]);
+        $this->assertFalse($visibilityIndexedByProductId[$productId], 'Product was hidden on first domain, should not be visible on all domains');
 
         $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnSomeDomainIndexedByProductId(
             [$productId],

--- a/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationDeduplicationFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationDeduplicationFacadeTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\App\Functional\Model\Product\Recalculation;
+
+use Nette\Utils\Json;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Redis;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade;
+use Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationPriorityEnum;
+use Tests\App\Test\TransactionFunctionalTestCase;
+
+class ProductRecalculationDeduplicationFacadeTest extends TransactionFunctionalTestCase
+{
+    // This is a value from Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationDeduplicationFacade::getCacheKey()
+    private const string REDIS_KEY = 'product_recalculation_ids_' . ProductRecalculationPriorityEnum::REGULAR;
+
+    private Redis $redis;
+
+    protected function setUp(): void
+    {
+        /** @phpstan-ignore symfonyContainer.serviceNotFound (service is available only in test env) */
+        $this->redis = self::getContainer()->get('snc_redis.test');
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->redis->del(self::REDIS_KEY);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<int, string[]> $initialData
+     * @param int[] $productIds
+     * @param array<int, string[]> $expectedOutput
+     */
+    #[DataProvider('getScopesIndexedByProductIdProvider')]
+    public function testGetScopesIndexedByProductId(array $initialData, array $productIds, array $expectedOutput): void
+    {
+        $productRecalculationDeduplicationFacade = new ProductRecalculationDeduplicationFacade($this->redis, true);
+
+        $this->preSetRedisData($initialData);
+
+        $result = $productRecalculationDeduplicationFacade->getScopesIndexedByProductId($productIds, ProductRecalculationPriorityEnum::REGULAR);
+
+        $this->assertSame($expectedOutput, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public static function getScopesIndexedByProductIdProvider(): array
+    {
+        return [
+            'empty redis' => [
+                'initialData' => [],
+                'productIds' => [1, 2],
+                'expectedOutput' => [
+                    1 => [],
+                    2 => [],
+                ],
+            ],
+            'requested already stored id' => [
+                'initialData' => [
+                    1 => ['scope1'],
+                    2 => ['scope2'],
+                ],
+                'productIds' => [1, 2],
+                'expectedOutput' => [
+                    1 => ['scope1'],
+                    2 => ['scope2'],
+                ],
+            ],
+            'requested not stored id' => [
+                'initialData' => [
+                    1 => ['scope1'],
+                    2 => ['scope2'],
+                ],
+                'productIds' => [3],
+                'expectedOutput' => [
+                    3 => [],
+                ],
+            ],
+            'requested mixed' => [
+                'initialData' => [
+                    1 => ['scope1'],
+                    2 => ['scope2'],
+                ],
+                'productIds' => [1, 3],
+                'expectedOutput' => [
+                    1 => ['scope1'],
+                    3 => [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, string[]> $initialData
+     * @param int[] $productIds
+     * @param string[] $scopes
+     * @param int[] $expectedOutput
+     * @param array<int, string[]> $expectedStoredData
+     */
+    #[DataProvider('updateScopesAndReturnProductIdsToDispatchProvider')]
+    public function testUpdateScopesAndReturnProductIdsToDispatch(
+        array $initialData,
+        array $productIds,
+        array $scopes,
+        array $expectedOutput,
+        array $expectedStoredData,
+    ): void {
+        $productRecalculationDeduplicationFacade = new ProductRecalculationDeduplicationFacade($this->redis, true);
+        $this->preSetRedisData($initialData);
+
+        $result = $productRecalculationDeduplicationFacade->updateScopesAndReturnProductIdsToDispatch(
+            $productIds,
+            $scopes,
+            ProductRecalculationPriorityEnum::REGULAR,
+        );
+
+        $this->assertSame($expectedOutput, $result, 'Product IDs to dispatch are not as expected');
+
+        $storedData = $this->fetchRedisData();
+        $this->assertEquals($expectedStoredData, $storedData, 'Stored data is not as expected');
+    }
+
+    /**
+     * @return array
+     */
+    public static function updateScopesAndReturnProductIdsToDispatchProvider(): array
+    {
+        return [
+            'empty redis; all passed ids are returned; passed export scopes stored' => [
+                'initialData' => [],
+                'productIds' => [1, 2],
+                'scopes' => ['scope1', 'scope2'],
+                'expectedOutput' => [1, 2],
+                'expectedStoredData' => [1 => ['scope1', 'scope2'], 2 => ['scope1', 'scope2']],
+            ],
+            'passed product id is not in initial data; passed scope is stored, product id returned' => [
+                'initialData' => [1 => ['scope1']],
+                'productIds' => [1, 2],
+                'scopes' => ['scope1'],
+                'expectedOutput' => [2],
+                'expectedStoredData' => [1 => ['scope1'], 2 => ['scope1']],
+            ],
+            'already stored product id with scope [] (all); no id returned, no change in stored data' => [
+                'initialData' => [1 => []],
+                'productIds' => [1],
+                'scopes' => [],
+                'expectedOutput' => [],
+                'expectedStoredData' => [1 => []],
+            ],
+            'initial data has some scope; passing scope []; scope [] is stored; product id is not returned' => [
+                'initialData' => [1 => ['scope1']],
+                'productIds' => [1],
+                'scopes' => [],
+                'expectedOutput' => [],
+                'expectedStoredData' => [1 => []],
+            ],
+            'passing new scope; scope is added to stored data; product id is not returned' => [
+                'initialData' => [1 => ['scope1']],
+                'productIds' => [1],
+                'scopes' => ['scope2'],
+                'expectedOutput' => [],
+                'expectedStoredData' => [1 => ['scope1', 'scope2']],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, string[]> $initialData
+     */
+    public function preSetRedisData(array $initialData): void
+    {
+        $this->redis->del(self::REDIS_KEY);
+
+        foreach ($initialData as $productId => $scopes) {
+            $this->redis->hSet(self::REDIS_KEY, (string)$productId, Json::encode($scopes));
+        }
+    }
+
+    /**
+     * @return array<int, string[]>
+     */
+    private function fetchRedisData(): array
+    {
+        $storedData = $this->redis->hGetAll(self::REDIS_KEY);
+
+        return array_map(
+            static fn ($value) => Json::decode($value, true),
+            $storedData,
+        );
+    }
+}

--- a/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationRepositoryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Recalculation/ProductRecalculationRepositoryTest.php
@@ -22,9 +22,9 @@ class ProductRecalculationRepositoryTest extends TransactionFunctionalTestCase
     #[DataProvider('getProductsForRecalculationProvider')]
     public function testProperIdsAreReturned(array $inputIds, array $expectedIds): void
     {
-        $calculatedIds = $this->productRecalculationRepository->getIdsToRecalculate($inputIds);
+        $calculatedIds = $this->productRecalculationRepository->getIdsToRecalculateByMainVariantIds($inputIds);
 
-        $this->assertSame($expectedIds, $calculatedIds);
+        $this->assertEqualsCanonicalizing($expectedIds, $calculatedIds);
     }
 
     /**
@@ -37,29 +37,62 @@ class ProductRecalculationRepositoryTest extends TransactionFunctionalTestCase
             'expectedIds' => [1, 2, 3],
         ];
 
-        yield 'variant has also other Variants along with MainVariant' => [
-            'inputIds' => [153], // variant
-            'expectedIds' => [74, 75, 152, 153, 82], // variants first, then main variant
-        ];
-
         yield 'mainVariant has also Variants' => [
             'inputIds' => [69], // main variant
-            'expectedIds' => [53, 54, 148, 149, 150, 151, 69], // variants first, then main variant
+            'expectedIds' => [53, 54, 69, 148, 149, 150, 151], // main variant and its variants
         ];
 
-        yield 'variants and MainVariant in input does not duplicate ids' => [
-            'inputIds' => [148, 69, 151], // variant, main variant, variant
-            'expectedIds' => [53, 54, 148, 149, 150, 151, 69], // variants first, then main variant
+        yield 'multiple main variants returns all variants' => [
+            'inputIds' => [82, 69], // main variant, main variant
+            'expectedIds' => [53, 54, 69, 74, 75, 82, 148, 149, 150, 151, 152, 153], // main variants and their variants
         ];
 
-        yield 'ids are properly sorted for variants and main variant' => [
-            'inputIds' => [54, 53, 151, 69, 149, 150, 148], // randomized input order
-            'expectedIds' => [53, 54, 148, 149, 150, 151, 69], // variants first, then main variant
+        yield 'combination of multiple regular products, main variants' => [
+            'inputIds' => [2, 82, 3, 69], // regular product, main variant, regular product, main variant
+            'expectedIds' => [2, 3, 53, 54, 69, 74, 75, 82, 148, 149, 150, 151, 152, 153], // regular products, main variants, and their variants
+        ];
+    }
+
+    /**
+     * @param int[] $inputIds
+     * @param int[] $expectedIds
+     */
+    #[DataProvider('getIdsForVariantReplacementProvider')]
+    public function testVariantIdsAreReplaced(array $inputIds, array $expectedIds): void
+    {
+        $calculatedIds = $this->productRecalculationRepository->replaceVariantIdsWithMainVariantIds($inputIds);
+
+        $this->assertEqualsCanonicalizing($expectedIds, $calculatedIds);
+    }
+
+    /**
+     * @return iterable
+     */
+    public static function getIdsForVariantReplacementProvider(): iterable
+    {
+        yield 'regular products only' => [
+            'inputIds' => [1, 2, 3],
+            'expectedIds' => [1, 2, 3],
         ];
 
-        yield 'combination of multiple regular products, variants and main variant' => [
-            'inputIds' => [2, 75, 3, 69], // regular product, variant, regular product, main variant
-            'expectedIds' => [53, 54, 148, 149, 150, 151, 74, 75, 152, 153, 2, 3, 69, 82], // variants first, then regular products and main variant
+        yield 'variant is replaced' => [
+            'inputIds' => [151], // variant
+            'expectedIds' => [69], // main variant
+        ];
+
+        yield 'multiple variants with different main variant' => [
+            'inputIds' => [74, 150], // variants with different main variant
+            'expectedIds' => [69, 82], // main variant
+        ];
+
+        yield 'multiple variants with same main variant' => [
+            'inputIds' => [150, 151], // variants with the same main variant
+            'expectedIds' => [69], // main variant
+        ];
+
+        yield 'regular product with variant and main variant' => [
+            'inputIds' => [2, 151, 69], // regular product, variant, main variant
+            'expectedIds' => [2, 69], // regular product, main variant
         ];
     }
 }

--- a/project-base/app/tests/App/Test/WebTestCase.php
+++ b/project-base/app/tests/App/Test/WebTestCase.php
@@ -195,7 +195,7 @@ abstract class WebTestCase extends BaseWebTestCase implements ServiceContainerTe
         $productRecalculationMessageHandler = $this->productRecalculationMessageHandler;
         $dispatchAllProductsMessageHandler = $this->dispatchAllProductsMessageHandler;
 
-        $envelopes = $regularPriorityTransport->getSent();
+        $envelopes = $highPriorityTransport->getSent();
 
         foreach ($envelopes as $envelope) {
             $message = $envelope->getMessage();

--- a/upgrade-notes/backend_20250206_212223.md
+++ b/upgrade-notes/backend_20250206_212223.md
@@ -1,0 +1,15 @@
+#### add product recalculation queue deduplication ([#3669](https://github.com/shopsys/shopsys/pull/3669))
+
+- ensure you have Redis on version 7.4 (see [#3673](https://github.com/shopsys/shopsys/pull/3673))
+- method use `\Shopsys\FrameworkBundle\Model\Product\ProductFacade::iterateAllProductIds()` was removed, use `iterateAllProductIdsExceptVariant()`instead
+- method use `\Shopsys\FrameworkBundle\Model\Product\ProductRepository::iterateAllProductIds()` was removed, use `iterateAllProductIdsExceptVariant()`instead
+- `\Shopsys\FrameworkBundle\Model\Product\Recalculation\AbstractProductRecalculationMessage` no longer contain `exportScopes`. Scopes are now stored in Redis.
+    - check also `ProductRecalculationPriorityHighMessage` and `ProductRecalculationPriorityRegularMessage`
+- `Shopsys\FrameworkBundle\Model\Product\Recalculation\ProductRecalculationRepository`
+    - method `getIdsToRecalculate()` was removed
+    - method `getMainVariantIdsOfVariants()` was removed
+    - method `dropVariantIdsFromProductIds()` was removed
+    - method `getVariantIds()` was removed
+    - use `replaceVariantIdsWithMainVariantIds()` or `getIdsToRecalculateByMainVariantIds()` instead
+- check the documentation for more details about [deduplication of product recalculation queue](https://docs.shopsys.com/asynchronous-processing/product-recalculations#product-deduplication-and-batch-dispatching)
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

- export scopes are moved from message to Redis to be able to keep the product in queue only once, while being able to add new scope
- if more than 2000 ids are dispatched at once (usually through affected changes), only the message to dispatch messages is sent to improve performance
- If the product ID is already present in Redis, the message is not dispatched again
- If the product ID is not in Redis, a handler for the message exports all scopes

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

Fixing the problem when multiple consumers are processing product recalculation messages with the same product ID. Messages in the queue are filtered out before another message with the same product ID is dispatched.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)






























































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jj-ssp-rabbitmq-deduplication2.odin.shopsys.cloud
  - https://cz.jj-ssp-rabbitmq-deduplication2.odin.shopsys.cloud
<!-- Replace -->
