### PR TITLE
add register form to payment confirmation page

### DIFF
--- a/packages/framework/src/Model/GoPay/GoPayOrderMapper.php
+++ b/packages/framework/src/Model/GoPay/GoPayOrderMapper.php
@@ -53,6 +53,8 @@ class GoPayOrderMapper
                     [
                         'orderIdentifier' => $order->getUuid(),
                         'orderPaymentStatusPageValidityHash' => $order->getOrderPaymentStatusPageValidityHash(),
+                        'orderEmail' => $order->getEmail(),
+                        'orderUrlHash' => $order->getUrlHash(),
                     ],
                     UrlGeneratorInterface::ABSOLUTE_URL,
                 ),

--- a/project-base/storefront/components/Pages/OrderConfirmation/RegistrationAfterOrder.tsx
+++ b/project-base/storefront/components/Pages/OrderConfirmation/RegistrationAfterOrder.tsx
@@ -10,7 +10,6 @@ import { useCouldBeCustomerRegisteredQuery } from 'graphql/requests/customer/que
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import Trans from 'next-translate/Trans';
 import useTranslation from 'next-translate/useTranslation';
-import { useRouter } from 'next/router';
 import { OrderConfirmationUrlQuery } from 'pages/order-confirmation';
 import { useRef } from 'react';
 import { FormProvider } from 'react-hook-form';
@@ -22,14 +21,17 @@ import { blurInput } from 'utils/forms/blurInput';
 import { useErrorPopup } from 'utils/forms/useErrorPopup';
 import { showErrorMessage } from 'utils/toasts/showErrorMessage';
 
-export const RegistrationAfterOrder: FC = () => {
+export const RegistrationAfterOrder: FC<Partial<OrderConfirmationUrlQuery>> = ({
+    orderUuid,
+    companyNumber,
+    orderEmail,
+    orderUrlHash,
+}) => {
     const { t } = useTranslation();
     const [formProviderMethods] = useRegistrationAfterOrderForm();
     const formMeta = useRegistrationAfterOrderFormMeta(formProviderMethods);
     const { registerByOrder } = useRegistration();
     const isInvalidRegistrationRef = useRef(false);
-    const { query } = useRouter();
-    const { orderUuid, companyNumber, orderEmail, orderUrlHash } = query as OrderConfirmationUrlQuery;
     const isUserLoggedIn = useIsUserLoggedIn();
 
     useErrorPopup(formProviderMethods, formMeta.fields, undefined, GtmMessageOriginType.order_confirmation_page);

--- a/project-base/storefront/pages/order-confirmation.tsx
+++ b/project-base/storefront/pages/order-confirmation.tsx
@@ -35,7 +35,7 @@ const OrderConfirmationPage: FC<ServerSidePropsType> = () => {
     const { t } = useTranslation();
     const { query } = useRouter();
     const { fetchCart } = useCurrentCart(false);
-    const { orderUuid, orderPaymentType } = query as OrderConfirmationUrlQuery;
+    const { orderUuid, orderPaymentType, companyNumber, orderEmail, orderUrlHash } = query as OrderConfirmationUrlQuery;
 
     const gtmStaticPageViewEvent = useGtmStaticPageViewEvent(GtmPageType.order_confirmation);
     useGtmPageViewEvent(gtmStaticPageViewEvent);
@@ -68,7 +68,12 @@ const OrderConfirmationPage: FC<ServerSidePropsType> = () => {
                             <GoPayGateway orderUuid={orderUuid!} />
                         ) : undefined}
                     </ConfirmationPageContent>
-                    <RegistrationAfterOrder />
+                    <RegistrationAfterOrder
+                        companyNumber={companyNumber}
+                        orderEmail={orderEmail}
+                        orderUrlHash={orderUrlHash}
+                        orderUuid={orderUuid}
+                    />
                 </Webline>
             </CommonLayout>
         </>

--- a/project-base/storefront/pages/order-payment-confirmation.tsx
+++ b/project-base/storefront/pages/order-payment-confirmation.tsx
@@ -71,11 +71,13 @@ const OrderPaymentConfirmationPage: FC<ServerSidePropsType> = () => {
                         paymentStatusData={paymentStatusData}
                         successContentData={successContentData}
                     />
-                    <RegistrationAfterOrder
-                        orderEmail={orderEmail as string | undefined}
-                        orderUrlHash={orderUrlHash as string | undefined}
-                        orderUuid={orderUuid}
-                    />
+                    {paymentStatusData?.UpdatePaymentStatus.isPaid && successContentData && (
+                        <RegistrationAfterOrder
+                            orderEmail={orderEmail as string | undefined}
+                            orderUrlHash={orderUrlHash as string | undefined}
+                            orderUuid={orderUuid}
+                        />
+                    )}
                 </Webline>
             </CommonLayout>
         </>

--- a/project-base/storefront/pages/order-payment-confirmation.tsx
+++ b/project-base/storefront/pages/order-payment-confirmation.tsx
@@ -7,6 +7,7 @@ import {
     getPaymentSessionExpiredErrorMessage,
     useUpdatePaymentStatus,
 } from 'components/Pages/Order/PaymentConfirmation/paymentConfirmationUtils';
+import { RegistrationAfterOrder } from 'components/Pages/OrderConfirmation/RegistrationAfterOrder';
 import { useOrderPaymentFailedContentQuery } from 'graphql/requests/orders/queries/OrderPaymentFailedContentQuery.generated';
 import { useOrderPaymentSuccessfulContentQuery } from 'graphql/requests/orders/queries/OrderPaymentSuccessfulContentQuery.generated';
 import useTranslation from 'next-translate/useTranslation';
@@ -18,7 +19,7 @@ import { initServerSideProps, ServerSidePropsType } from 'utils/serverSide/initS
 const OrderPaymentConfirmationPage: FC<ServerSidePropsType> = () => {
     const { t } = useTranslation();
 
-    const { orderIdentifier, orderPaymentStatusPageValidityHash } = useRouter().query;
+    const { orderIdentifier, orderPaymentStatusPageValidityHash, orderEmail, orderUrlHash } = useRouter().query;
     const orderUuid = getStringFromUrlQuery(orderIdentifier);
     const orderPaymentStatusPageValidityHashParam = getStringFromUrlQuery(orderPaymentStatusPageValidityHash);
     const paymentStatusData = useUpdatePaymentStatus(orderUuid, orderPaymentStatusPageValidityHashParam);
@@ -69,6 +70,11 @@ const OrderPaymentConfirmationPage: FC<ServerSidePropsType> = () => {
                         orderUuid={orderUuid}
                         paymentStatusData={paymentStatusData}
                         successContentData={successContentData}
+                    />
+                    <RegistrationAfterOrder
+                        orderEmail={orderEmail as string | undefined}
+                        orderUrlHash={orderUrlHash as string | undefined}
+                        orderUuid={orderUuid}
                     />
                 </Webline>
             </CommonLayout>

--- a/upgrade-notes/storefront_20250114_122253.md
+++ b/upgrade-notes/storefront_20250114_122253.md
@@ -1,0 +1,4 @@
+#### {taskName} ([#3670](https://github.com/shopsys/shopsys/pull/3670))
+
+- `RegistrationAfterOrder` component is now shown also on `order-payment-confirmation` page if payment was successful
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
To fix UX, the register form is now displayed on the `order-payment-confirmation` also. This allows customers using  external payments to register after successful order creation and payment.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-2928-register-after-payment-fix.odin.shopsys.cloud
  - https://cz.jm-ssp-2928-register-after-payment-fix.odin.shopsys.cloud
<!-- Replace -->
