### PR TITLE
no log sentry error during maintenance on

### DIFF
--- a/project-base/storefront/pages/_error.tsx
+++ b/project-base/storefront/pages/_error.tsx
@@ -41,7 +41,7 @@ ErrorPage.getInitialProps = getServerSidePropsWrapper(({ redisClient, domainConf
         err = JSON.stringify({ name: err.name, message: err.message, stack: err.stack, cause: err.cause });
     }
 
-    if (statusCode !== 404 || isWithErrorDebugging) {
+    if ((statusCode !== 404 || isWithErrorDebugging) && statusCode !== 503) {
         logException({
             message: err,
             statusCode,

--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -27,6 +27,11 @@ export const getErrorExchange =
                         return;
                     }
 
+                    const isMaintenance = error.response?.status === 503;
+                    if (isMaintenance) {
+                        return;
+                    }
+
                     if (isWithErrorDebugging && operation.kind === 'mutation') {
                         handleErrorMessagesForMutation(error);
 

--- a/project-base/storefront/urql/fetcher.ts
+++ b/project-base/storefront/urql/fetcher.ts
@@ -74,11 +74,24 @@ export const fetcher =
                 body,
             });
 
+            const contentType = result.headers.get('content-type')?.includes('application/json');
+
+            if (!contentType) {
+                return Promise.resolve(
+                    new Response(JSON.stringify({}), {
+                        statusText: result.statusText,
+                        status: result.status,
+                        headers: { 'Content-Type': 'application/json' },
+                    }),
+                );
+            }
+
             const res = await result.json();
 
             if (res.data !== undefined && res.error === undefined) {
                 await redisClient.set(hash, JSON.stringify(res.data), { EX: ttl });
             }
+
             return Promise.resolve(
                 new Response(JSON.stringify(res), {
                     statusText: 'OK',

--- a/project-base/storefront/urql/fetcher.ts
+++ b/project-base/storefront/urql/fetcher.ts
@@ -74,9 +74,9 @@ export const fetcher =
                 body,
             });
 
-            const contentType = result.headers.get('content-type')?.includes('application/json');
+            const isJsonContentType = result.headers.get('content-type')?.includes('application/json');
 
-            if (!contentType) {
+            if (!isJsonContentType) {
                 return Promise.resolve(
                     new Response(JSON.stringify({}), {
                         statusText: result.statusText,

--- a/project-base/storefront/vitest/utils/urql/fetcher.test.ts
+++ b/project-base/storefront/vitest/utils/urql/fetcher.test.ts
@@ -108,6 +108,9 @@ describe('fetcher test', () => {
         vi.stubEnv('REDIS_PREFIX', 'TEST_PREFIX');
         mockFetch.mockImplementation(() =>
             Promise.resolve({
+                headers: new Headers({
+                    'content-type': 'application/json',
+                }),
                 json: () => Promise.resolve({ data: TEST_RESPONSE_BODY }),
             }),
         );
@@ -123,6 +126,24 @@ describe('fetcher test', () => {
             { EX: 3600 },
         );
         vi.unstubAllEnvs();
+    });
+
+    test('should handle non-JSON content-type responses', async () => {
+        (isClientGetter as Mock).mockImplementation(() => false);
+        mockFetch.mockImplementation(() =>
+            Promise.resolve({
+                headers: new Headers({
+                    'content-type': 'text/html',
+                }),
+            }),
+        );
+
+        const testFetcher = fetcher(mockRedisClient);
+        const response = await testFetcher(TEST_URL, REQUEST_WITH_DIRECTIVE);
+        const responseBody = await response.json();
+
+        expect(responseBody).toStrictEqual({});
+        expect(response.headers.get('content-type')).toBe('application/json');
     });
 
     test('using fetcher on an already cached query should get it from Redis', async () => {

--- a/upgrade-notes/storefront_20241217_094417.md
+++ b/upgrade-notes/storefront_20241217_094417.md
@@ -1,0 +1,4 @@
+#### no log sentry error on maintenance page ([#3675](https://github.com/shopsys/shopsys/pull/3675))
+
+- in urql fetcher checking if response is not json then return empty object to avoid sentry error
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Added an exception for logging a sentry error on the maintenance page.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2969-sentry-maintenance-error.odin.shopsys.cloud
  - https://cz.tc-ssp-2969-sentry-maintenance-error.odin.shopsys.cloud
<!-- Replace -->
