### PR TITLE
[administration] Hide warning about not secured CKEditor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -227,7 +227,7 @@
             "php project-base/app/app/downloadPhing.php": "script",
             "php phing clean": "script",
             "shopsys:domains-urls:configure": "symfony-cmd",
-            "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd",
+            "ckeditor:install --clear=skip --release=full --tag=4.22.1": "symfony-cmd",
             "composer security-check": "script"
         }
     },

--- a/project-base/app/assets/extra/bundles/fosckeditor/plugins/strinsert/plugin.js
+++ b/project-base/app/assets/extra/bundles/fosckeditor/plugins/strinsert/plugin.js
@@ -64,7 +64,7 @@ CKEDITOR.plugins.add('strinsert',
                     multiSelect: false,
                     panel:
                         {
-                            css: [ editor.config.contentsCss, CKEDITOR.skin.getPath('editor') ],
+                            css: [CKEDITOR.skin.getPath('editor')].concat(config.contentsCss),
                             voiceLabel: editor.lang.panelVoiceLabel
                         },
 

--- a/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
+++ b/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
@@ -101,6 +101,7 @@ export default class InitGrapesJs {
                         versionCheck: false,
                         allowedContent: true,
                         extraAllowedContent: '*(*)',
+                        removePlugins: 'exportpdf',
                         toolbar: [
                             { name: 'basicstyles', items: ['Bold', 'Italic', 'Strike', '-', 'RemoveFormat'] },
                             { name: 'clipboard', items: ['PasteText', 'PasteFromWord'] },
@@ -220,6 +221,7 @@ export default class InitGrapesJs {
                             { name: 'insert', items: ['SpecialChar', 'strinsert'] }
                         ],
                         extraPlugins: 'strinsert',
+                        removePlugins: 'exportpdf',
                         strinsert_strings: [
                             { 'name': 'Povinné proměnné' },
                             ...variables

--- a/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
+++ b/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
@@ -95,8 +95,10 @@ export default class InitGrapesJs {
             plugins: plugins,
             pluginsOpts: {
                 [ckeditorPlugin]: {
+                    ckeditor: '',
                     options: {
                         enterMode: 2,
+                        versionCheck: false,
                         allowedContent: true,
                         extraAllowedContent: '*(*)',
                         toolbar: [
@@ -203,8 +205,10 @@ export default class InitGrapesJs {
                     styleManagerSectors: []
                 },
                 [ckeditorPlugin]: {
+                    ckeditor: '',
                     options: {
                         enterMode: 2,
+                        versionCheck: false,
                         toolbar: [
                             { name: 'basicstyles', items: ['Bold', 'Italic', 'Strike', '-', 'RemoveFormat'] },
                             { name: 'format', items: ['Format'] },

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -159,7 +159,7 @@
             "php app/downloadPhing.php --phing-version=3.0.0": "script",
             "php phing clean": "script",
             "shopsys:domains-urls:configure": "symfony-cmd",
-            "ckeditor:install --clear=skip --release=full --tag=4.5.11": "symfony-cmd"
+            "ckeditor:install --clear=skip --release=full --tag=4.22.1": "symfony-cmd"
         },
         "security-check": "security-checker security:check"
     },

--- a/project-base/app/config/packages/fos_ck_editor.yaml
+++ b/project-base/app/config/packages/fos_ck_editor.yaml
@@ -2,6 +2,7 @@ fos_ck_editor:
     autoload: false
     configs:
         default:
+            versionCheck: false
             entities_greek: false
             entities_latin: false
             enterMode: 2
@@ -22,6 +23,7 @@ fos_ck_editor:
             extraPlugins: 'layoutmanager'
 
         email:
+            versionCheck: false
             entities_greek: false
             entities_latin: false
             enterMode: 2

--- a/upgrade-notes/backend_20241217_121826.md
+++ b/upgrade-notes/backend_20241217_121826.md
@@ -1,0 +1,3 @@
+#### Hide warning about not secured CKEditor ([#3677](https://github.com/shopsys/shopsys/pull/3677))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Well-known warning from CKEditor `This CKEditor 4 version is not secure. Consider upgrading to the latest one. For more details, please check the browser console.` will not be shown to the administrators anymore.

<img width="316" alt="Shitty warning" src="https://github.com/user-attachments/assets/87d83f50-86d8-4e73-a2fe-bddb184f6a9e" />


<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-remove-ckeditor-warning.odin.shopsys.cloud
  - https://cz.jg-remove-ckeditor-warning.odin.shopsys.cloud
<!-- Replace -->
