### PR TITLE
[shopsys] ensure graphql schema is always rendered same

### DIFF
--- a/project-base/app/package.json
+++ b/project-base/app/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-node": "^8.0.1",
         "eslint-plugin-promise": "^4.3.1",
         "eslint-plugin-standard": "^4.1.0",
-        "format-graphql": "^1.4.0",
+        "format-graphql": "^1.5.0",
         "glob": "^7.1.6",
         "jest": "^27.0.1",
         "js-yaml": "^3.14.1",

--- a/upgrade-notes/backend_20241218_101900.md
+++ b/upgrade-notes/backend_20241218_101900.md
@@ -1,0 +1,3 @@
+#### ensure graphql schema is always rendered same ([#3678](https://github.com/shopsys/shopsys/pull/3678))
+
+- see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20241218_101900.md
+++ b/upgrade-notes/storefront_20241218_101900.md
@@ -1,0 +1,3 @@
+#### ensure graphql schema is always rendered same ([#3678](https://github.com/shopsys/shopsys/pull/3678))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
New version of `format-graphql` `1.5.0` has been released but some colleagues still used older one, which cause wrong ordering for them.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `format-graphql` dependency to enhance compatibility.
- **Documentation**
	- Added notes on the consistency of GraphQL schema rendering in upgrade notes for both backend and storefront, with references for users on project updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-graphql-schema-ordering.odin.shopsys.cloud
  - https://cz.tl-fix-graphql-schema-ordering.odin.shopsys.cloud
<!-- Replace -->
