### PR TITLE
fix localization based on admin language for GrapesJS

### DIFF
--- a/packages/framework/assets/styles/admin/components/in/ckeditor.less
+++ b/packages/framework/assets/styles/admin/components/in/ckeditor.less
@@ -49,3 +49,7 @@
 .cke-textarea {
     display: none;
 }
+
+.cke_combo_text {
+    width: auto !important;
+}

--- a/packages/framework/src/Component/CKEditor/CKEditorRendererDecorator.php
+++ b/packages/framework/src/Component/CKEditor/CKEditorRendererDecorator.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\CKEditor;
 
 use FOS\CKEditorBundle\Renderer\CKEditorRendererInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class CKEditorRendererDecorator implements CKEditorRendererInterface
 {
     /**
      * @param \FOS\CKEditorBundle\Renderer\CKEditorRendererInterface $baseCkEditorRenderer
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      */
-    public function __construct(protected readonly CKEditorRendererInterface $baseCkEditorRenderer)
-    {
+    public function __construct(
+        protected readonly CKEditorRendererInterface $baseCkEditorRenderer,
+        protected readonly RequestStack $requestStack,
+    ) {
     }
 
     /**
@@ -41,6 +45,8 @@ class CKEditorRendererDecorator implements CKEditorRendererInterface
      */
     public function renderWidget(string $id, array $config, array $options = []): string
     {
+        $config['language'] = $this->getRequestLanguage() ?? $config['language'];
+
         return sprintf(
             '$("#%s-preview").click(function() {
                 %s
@@ -103,5 +109,19 @@ class CKEditorRendererDecorator implements CKEditorRendererInterface
     public function renderTemplate(string $name, array $template): string
     {
         return $this->baseCkEditorRenderer->renderTemplate($name, $template);
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getRequestLanguage(): ?string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request !== null && $request->getLocale() !== '') {
+            return $request->getLocale();
+        }
+
+        return null;
     }
 }

--- a/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
+++ b/project-base/app/assets/js/admin/grapesjs/initGrapesJs.js
@@ -17,7 +17,8 @@ import './plugins/grapesjs-table-custom-plugin';
 import './plugins/grapesjs-mail-custom-image-with-variable-plugin';
 import './plugins/grapesjs-mail-custom-image-plugin';
 import 'magnific-popup';
-import { en } from './locales/en';
+import { en } from './locales/en.js';
+import { cs } from './locales/cs.js';
 import Translator from 'bazinga-translator';
 
 import { Buffer } from 'buffer';
@@ -96,12 +97,20 @@ export default class InitGrapesJs {
             forceClass: false,
             nativeDnD: true,
             plugins: plugins,
+            i18n: {
+                locale: Translator.locale,
+                detectLocale: false,
+                messages: {
+                    en, cs
+                }
+            },
             pluginsOpts: {
                 [ckeditorPlugin]: {
                     ckeditor: '',
                     options: {
                         enterMode: 2,
                         versionCheck: false,
+                        language: Translator.locale,
                         allowedContent: true,
                         extraAllowedContent: '*(*)',
                         removePlugins: 'exportpdf',
@@ -173,10 +182,6 @@ export default class InitGrapesJs {
             }
         });
 
-        editor.I18n.setMessages({
-            en
-        });
-
         editor.once('load', () => {
             editor.Panels.getButton('options', 'sw-visibility').set('active', 1);
 
@@ -212,15 +217,24 @@ export default class InitGrapesJs {
             avoidInlineStyle: false,
             forceClass: false,
             plugins: defaultPlugins.concat(customPlugins),
+            i18n: {
+                locale: Translator.locale,
+                detectLocale: false,
+                messages: {
+                    en, cs
+                }
+            },
             pluginsOpts: {
                 [newsletterPlugin]: {
-                    styleManagerSectors: []
+                    styleManagerSectors: [],
+                    useCustomTheme: false
                 },
                 [ckeditorPlugin]: {
                     ckeditor: '',
                     options: {
                         enterMode: 2,
                         versionCheck: false,
+                        language: Translator.locale,
                         toolbar: [
                             { name: 'basicstyles', items: ['Bold', 'Italic', 'Strike', '-', 'RemoveFormat'] },
                             { name: 'format', items: ['Format'] },
@@ -233,14 +247,15 @@ export default class InitGrapesJs {
                         ],
                         extraPlugins: 'strinsert',
                         removePlugins: 'exportpdf',
+                        strinsert_button_label: Translator.trans('Insert variable'),
                         strinsert_strings: [
-                            { 'name': 'Povinné proměnné' },
+                            { 'name': Translator.trans('Mandatory variables') },
                             ...variables
                                 .filter((variable) => variable.isRequired === true)
                                 .map((variable) => {
                                     return { 'name': variable.label, 'value': variable.placeholder };
                                 }),
-                            { 'name': 'Volitelné proměnné' },
+                            { 'name': Translator.trans('Optional variables') },
                             ...variables
                                 .filter((variable) => variable.isRequired === false)
                                 .map((variable) => {
@@ -276,10 +291,6 @@ export default class InitGrapesJs {
                     }
                 }
             }
-        });
-
-        editor.I18n.addMessages({
-            en
         });
 
         editor.Panels.getButton('options', 'sw-visibility').set('active', 1);

--- a/project-base/app/assets/js/admin/grapesjs/locales/cs.js
+++ b/project-base/app/assets/js/admin/grapesjs/locales/cs.js
@@ -10,6 +10,11 @@ export const cs = {
     blockManager: {
         labels: {
             // 'block-id': 'Block Label',
+            image: 'Obrázek',
+            text: 'Text',
+            sect100: '1 sloupec',
+            sect50: '2 sloupce (stejně široké)',
+            'link-block': 'Blok odkazu'
         },
         categories: {
             // 'category-id': 'Category Label',

--- a/project-base/app/assets/js/admin/grapesjs/locales/en.js
+++ b/project-base/app/assets/js/admin/grapesjs/locales/en.js
@@ -10,6 +10,11 @@ export const en = {
     blockManager: {
         labels: {
             // 'block-id': 'Block Label',
+            image: 'Image',
+            text: 'Text',
+            sect100: '1 column',
+            sect50: '2 columns',
+            'link-block': 'Link Block'
         },
         categories: {
             // 'category-id': 'Category Label',

--- a/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-mail-template-plugin.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-mail-template-plugin.js
@@ -53,7 +53,7 @@ export default grapesjs.plugins.add('mail-template', editor => {
     });
 
     editor.Blocks.add('text-ckeditor', {
-        label: 'Text',
+        label: Translator.trans('Text'),
         category: Translator.trans('Basic objects'),
         attributes: { class: 'gjs-fonts gjs-f-text' },
         content: { type: 'text-ckeditor', content: Translator.trans('Insert your text here'), activeOnRender: 1 }

--- a/project-base/app/package.json
+++ b/project-base/app/package.json
@@ -59,6 +59,7 @@
     "dependencies": {
         "@claviska/jquery-minicolors": "^2.3.4",
         "@shopsys/framework": "17.0.0-dev.1",
+        "@yaireo/tagify": "^4.25.1",
         "bazinga-translator": "^2.6.6",
         "buffer": "^6.0.3",
         "chart.js": "^2.9.3",
@@ -66,20 +67,20 @@
         "counterup2": "^1.0.4",
         "grapesjs": "^0.20.3",
         "grapesjs-plugin-ckeditor": "^1.0.1",
-        "grapesjs-preset-newsletter": "^0.2.21",
-        "grapesjs-preset-webpage": "^1.0.2",
+        "grapesjs-preset-newsletter": "^1.0.2",
+        "grapesjs-preset-webpage": "^1.0.3",
         "intersection-observer": "^0.11.0",
         "jquery-hoverintent": "^1.10.1",
         "jquery-ui": "1.12.1",
         "jquery-ui-touch-punch": "^0.2.3",
         "jquery.cookie": "^1.4.1",
+        "juice": "^11.0.0",
         "magnific-popup": "^1.1.0",
         "nestedSortable": "^1.3.4",
         "scrollama": "^2.2.2",
         "select2": "^4.0.12",
         "selectric": "^1.13.0",
-        "slick-carousel": "1.6.0",
-        "@yaireo/tagify": "^4.25.1"
+        "slick-carousel": "1.6.0"
     },
     "jest": {
         "testEnvironment": "jsdom"

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -223,6 +223,9 @@ msgstr "Obrázek"
 msgid "In stock"
 msgstr "Skladem"
 
+msgid "Insert variable"
+msgstr "Vložit proměnnou"
+
 msgid "Insert your text here"
 msgstr "Zde vložte text"
 
@@ -292,6 +295,9 @@ msgstr "Vyrobeno v DE"
 msgid "Made in SK"
 msgstr "Vyrobeno v SK"
 
+msgid "Mandatory variables"
+msgstr "Povinné proměnné"
+
 msgid "Map"
 msgstr "Mapa"
 
@@ -351,6 +357,9 @@ msgstr "Notifikační lišta byla úspěšně smazána"
 
 msgid "Open in new window"
 msgstr "Otevírat v novém okně"
+
+msgid "Optional variables"
+msgstr "Volitelné proměnné"
 
 msgid "Order confirmation page"
 msgstr "Stránka s potvrzením objednávky"

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -223,6 +223,9 @@ msgstr ""
 msgid "In stock"
 msgstr ""
 
+msgid "Insert variable"
+msgstr ""
+
 msgid "Insert your text here"
 msgstr ""
 
@@ -292,6 +295,9 @@ msgstr ""
 msgid "Made in SK"
 msgstr ""
 
+msgid "Mandatory variables"
+msgstr ""
+
 msgid "Map"
 msgstr ""
 
@@ -350,6 +356,9 @@ msgid "Notification bar has been successfuly deleted"
 msgstr ""
 
 msgid "Open in new window"
+msgstr ""
+
+msgid "Optional variables"
 msgstr ""
 
 msgid "Order confirmation page"

--- a/upgrade-notes/backend_20241217_163143.md
+++ b/upgrade-notes/backend_20241217_163143.md
@@ -1,0 +1,3 @@
+#### fix localization based on admin language for GrapesJS ([#3680](https://github.com/shopsys/shopsys/pull/3680))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

This PR upgrades GrapesJS preset packages and fixes localization for Grapes and CKEditor based on admin locale

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)

















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-grapes-fix-localization.odin.shopsys.cloud
  - https://cz.jg-grapes-fix-localization.odin.shopsys.cloud
<!-- Replace -->
