### PR TITLE
[framework] trans function now support named arguments

### DIFF
--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -117,14 +117,36 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
         $methodName = $this->getNormalizedMethodName($this->getNodeName($node));
         $domainArgumentIndex = $this->transMethodSpecifications[$methodName]->getDomainArgumentIndex();
 
-        if ($domainArgumentIndex !== null && isset($node->args[$domainArgumentIndex])) {
-            return PhpParserNodeHelper::getConcatenatedStringValue(
-                $node->args[$domainArgumentIndex]->value,
-                $this->file,
-            );
+        if ($domainArgumentIndex === null) {
+            return Translator::DEFAULT_TRANSLATION_DOMAIN;
         }
 
-        return Translator::DEFAULT_TRANSLATION_DOMAIN;
+        $domainArg = null;
+
+        if (isset($node->args[$domainArgumentIndex]) && $node->args[$domainArgumentIndex] instanceof Node\Arg && $node->args[$domainArgumentIndex]->name === null) {
+            $domainArg = $node->args[$domainArgumentIndex];
+        } else {
+            foreach ($node->args as $arg) {
+                if (!$arg instanceof Node\Arg) {
+                    continue;
+                }
+
+                if ($arg->name !== null && $arg->name->name === 'domain') {
+                    $domainArg = $arg;
+
+                    break;
+                }
+            }
+        }
+
+        if ($domainArg === null) {
+            return Translator::DEFAULT_TRANSLATION_DOMAIN;
+        }
+
+        return PhpParserNodeHelper::getConcatenatedStringValue(
+            $domainArg->value,
+            $this->file,
+        );
     }
 
     /**

--- a/packages/framework/src/Component/Translation/PhpFileExtractor.php
+++ b/packages/framework/src/Component/Translation/PhpFileExtractor.php
@@ -143,6 +143,10 @@ class PhpFileExtractor implements FileVisitorInterface, NodeVisitor
             return Translator::DEFAULT_TRANSLATION_DOMAIN;
         }
 
+        if ($domainArg->value instanceof Node\Expr\ConstFetch && (string)$domainArg->value->name === 'null') {
+            return Translator::DEFAULT_TRANSLATION_DOMAIN;
+        }
+
         return PhpParserNodeHelper::getConcatenatedStringValue(
             $domainArg->value,
             $this->file,

--- a/packages/framework/src/Component/Translation/functions.php
+++ b/packages/framework/src/Component/Translation/functions.php
@@ -7,11 +7,11 @@ use Shopsys\FrameworkBundle\Component\Translation\Translator;
 /**
  * @param string $id
  * @param array $parameters
- * @param string|null $translationDomain
+ * @param string|null $domain
  * @param string|null $locale
  * @return string
  */
-function t(string $id, array $parameters = [], ?string $translationDomain = null, ?string $locale = null): string
+function t(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
 {
-    return Translator::staticTrans($id, $parameters, $translationDomain, $locale);
+    return Translator::staticTrans($id, $parameters, $domain, $locale);
 }

--- a/packages/framework/src/Component/Translation/functions.php
+++ b/packages/framework/src/Component/Translation/functions.php
@@ -7,7 +7,7 @@ use Shopsys\FrameworkBundle\Component\Translation\Translator;
 /**
  * @param string $id
  * @param array $parameters
- * @param string|null $domain
+ * @param string|null $domain Translation domain (default is "messages")
  * @param string|null $locale
  * @return string
  */

--- a/packages/framework/tests/Unit/Component/Translation/PhpFileExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/PhpFileExtractorTest.php
@@ -43,6 +43,26 @@ class PhpFileExtractorTest extends TestCase
         $message->addSource(new FileSource($fileName, 27));
         $expected->add($message);
 
+        $message = new Message('my %adjective% string', Translator::DEFAULT_TRANSLATION_DOMAIN);
+        $message->addSource(new FileSource($fileName, 31));
+        $expected->add($message);
+
+        $message = new Message('my string with domain only', 'another-translation-domain');
+        $message->addSource(new FileSource($fileName, 32));
+        $expected->add($message);
+
+        $message = new Message('my %adjective% string with domain', 'another-translation-domain');
+        $message->addSource(new FileSource($fileName, 33));
+        $expected->add($message);
+
+        $message = new Message('my %adjective% string with named locale', 'someDomain');
+        $message->addSource(new FileSource($fileName, 34));
+        $expected->add($message);
+
+        $message = new Message('my %adjective% string with unsorted arguments', 'unsortedDomain');
+        $message->addSource(new FileSource($fileName, 35));
+        $expected->add($message);
+
         $this->assertEquals($expected, $catalogue);
     }
 

--- a/packages/framework/tests/Unit/Component/Translation/PhpFileExtractorTest.php
+++ b/packages/framework/tests/Unit/Component/Translation/PhpFileExtractorTest.php
@@ -63,6 +63,10 @@ class PhpFileExtractorTest extends TestCase
         $message->addSource(new FileSource($fileName, 35));
         $expected->add($message);
 
+        $message = new Message('my %adjective% string with null domain', Translator::DEFAULT_TRANSLATION_DOMAIN);
+        $message->addSource(new FileSource($fileName, 36));
+        $expected->add($message);
+
         $this->assertEquals($expected, $catalogue);
     }
 

--- a/packages/framework/tests/Unit/Component/Translation/Resources/Controller.php
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/Controller.php
@@ -26,6 +26,14 @@ class Controller extends AbstractController
         t('t test');
         t('t test with domain', [], 'testDomain');
 
+        $locale = 'en';
+
+        t('my %adjective% string', ['%adjective%' => 'awesome'], locale: $locale);
+        t('my string with domain only', domain: 'another-translation-domain');
+        t('my %adjective% string with domain', ['%adjective%' => 'awesome'], domain: 'another-translation-domain');
+        t('my %adjective% string with named locale', ['%adjective%' => 'awesome'], 'someDomain', locale: $locale);
+        t('my %adjective% string with unsorted arguments', ['%adjective%' => 'awesome'], locale: $locale, domain: 'unsortedDomain');
+
         /** @Ignore */
         t('ignored');
         /** @Ignore */

--- a/packages/framework/tests/Unit/Component/Translation/Resources/Controller.php
+++ b/packages/framework/tests/Unit/Component/Translation/Resources/Controller.php
@@ -33,6 +33,7 @@ class Controller extends AbstractController
         t('my %adjective% string with domain', ['%adjective%' => 'awesome'], domain: 'another-translation-domain');
         t('my %adjective% string with named locale', ['%adjective%' => 'awesome'], 'someDomain', locale: $locale);
         t('my %adjective% string with unsorted arguments', ['%adjective%' => 'awesome'], locale: $locale, domain: 'unsortedDomain');
+        t('my %adjective% string with null domain', ['%adjective%' => 'awesome'], null, $locale);
 
         /** @Ignore */
         t('ignored');


### PR DESCRIPTION
#### Description, the reason for the PR

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
closes #2574 

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-trans-named-arguments.odin.shopsys.cloud
  - https://cz.jg-trans-named-arguments.odin.shopsys.cloud
<!-- Replace -->
