### PR TITLE
[framework] fixed rendering main blog category in blog article assign to category tree

### DIFF
--- a/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
+++ b/packages/framework/src/Model/Blog/Category/BlogCategoryRepository.php
@@ -70,7 +70,7 @@ class BlogCategoryRepository extends NestedTreeRepository
             ->select('bc, bcd, bct')
             ->join('bc.domains', 'bcd')
             ->join('bc.translations', 'bct')
-            ->where('bc.parent IN (:openedParentIds)')
+            ->where('bc.parent IN (:openedParentIds) OR bc.parent IS NULL')
             ->setParameter('openedParentIds', $openedParentIds)
             ->getQuery()
             ->getResult();


### PR DESCRIPTION
#### Description, the reason for the PR

Blog category tree was not rendering the main blog category on the blog article edit page - it was not possible to assign a blog article to the main blog category. 

This PR fixes that
 
![Snímek obrazovky 2024-12-18 v 17 36 58](https://github.com/user-attachments/assets/8b6545fa-d43c-4980-b875-99137185ef2c)

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-blog-article-category-tree.odin.shopsys.cloud
  - https://cz.mg-fix-blog-article-category-tree.odin.shopsys.cloud
<!-- Replace -->
