### PR TITLE
removed double slash in link after failed payment

### DIFF
--- a/project-base/storefront/components/PaymentsInOrderSelect/paymentInOrderSelectUtils.ts
+++ b/project-base/storefront/components/PaymentsInOrderSelect/paymentInOrderSelectUtils.ts
@@ -48,7 +48,7 @@ export const useChangePaymentInOrder = () => {
                 query: { orderNumber: editedOrder.number },
             });
         } else {
-            router.push(`${orderByHashUrl}/${editedOrder.urlHash}`);
+            router.push(orderByHashUrl + editedOrder.urlHash);
         }
 
         return changePaymentInOrderData;

--- a/upgrade-notes/storefront_20241219_085149.md
+++ b/upgrade-notes/storefront_20241219_085149.md
@@ -1,0 +1,4 @@
+#### console error after failed payment redirect ([#3685](https://github.com/shopsys/shopsys/pull/3685))
+
+- removed double slash in redirect url after failed payment
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Removed double slash in the link after failed payment. Now I have a clear console without errors.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2835-remove-double-slash-in-link.odin.shopsys.cloud
  - https://cz.tc-ssp-2835-remove-double-slash-in-link.odin.shopsys.cloud
<!-- Replace -->
