### PR TITLE
NoDomainSelectedException is no longer throwed during maintenance page + additional Sentry context

### DIFF
--- a/packages/framework/src/Command/MaintenanceModeCommand.php
+++ b/packages/framework/src/Command/MaintenanceModeCommand.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Command;
 
-use Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeSubscriber;
-use Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade;
+use Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -22,13 +21,13 @@ class MaintenanceModeCommand extends Command
     /**
      * @var string
      */
-    private const ACTION_ARGUMENT = 'action';
+    private const string ACTION_ARGUMENT = 'action';
 
     /**
-     * @param \Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade $redisClientFacade
+     * @param \Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade $maintenanceModeFacade
      */
     public function __construct(
-        protected readonly RedisClientFacade $redisClientFacade,
+        protected readonly MaintenanceModeFacade $maintenanceModeFacade,
     ) {
         parent::__construct();
     }
@@ -73,7 +72,7 @@ class MaintenanceModeCommand extends Command
      */
     public function enableMaintenanceMode(SymfonyStyle $symfonyStyleIo): void
     {
-        $this->redisClientFacade->save(MaintenanceModeSubscriber::MAINTENANCE_KEY, true);
+        $this->maintenanceModeFacade->enable();
         $symfonyStyleIo->note('Maintenance mode was enabled');
     }
 
@@ -82,8 +81,8 @@ class MaintenanceModeCommand extends Command
      */
     public function disableMaintenanceMode(SymfonyStyle $symfonyStyleIo): void
     {
-        if ($this->redisClientFacade->contains(MaintenanceModeSubscriber::MAINTENANCE_KEY)) {
-            $this->redisClientFacade->delete(MaintenanceModeSubscriber::MAINTENANCE_KEY);
+        if ($this->maintenanceModeFacade->isEnabled()) {
+            $this->maintenanceModeFacade->disable();
             $symfonyStyleIo->note('Maintenance mode was disabled');
         }
     }

--- a/packages/framework/src/Component/AddSentryContextSubscriber.php
+++ b/packages/framework/src/Component/AddSentryContextSubscriber.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component;
+
+use App\Environment;
+use RedisException;
+use Sentry\State\Scope;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
+use Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface;
+use Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade;
+use Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser;
+use Shopsys\FrameworkBundle\ShopsysFrameworkBundle;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use function Sentry\configureScope;
+
+class AddSentryContextSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade $maintenanceModeFacade
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
+     * @param \Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface $displayTimeZoneProvider
+     * @param \Shopsys\FrameworkBundle\Model\Customer\User\CurrentCustomerUser $currentCustomerUser
+     */
+    public function __construct(
+        protected readonly MaintenanceModeFacade $maintenanceModeFacade,
+        protected readonly Domain $domain,
+        protected readonly DisplayTimeZoneProviderInterface $displayTimeZoneProvider,
+        protected readonly CurrentCustomerUser $currentCustomerUser,
+    ) {
+    }
+
+    public function setSentryContext(): void
+    {
+        $context = [
+            'environment' => class_exists('App\Environment') ? Environment::getEnvironment() : '',
+            'version' => ShopsysFrameworkBundle::VERSION,
+            'systemTimeZone' => date_default_timezone_get(),
+            'userId' => $this->currentCustomerUser->findCurrentCustomerUser()?->getId(),
+        ];
+
+        try {
+            $context['maintenance-page'] = $this->maintenanceModeFacade->isEnabled();
+        } catch (RedisException) {
+        }
+
+        try {
+            $context['currentDomainId'] = $this->domain->getId();
+            $context['currentDomainName'] = $this->domain->getName();
+            $context['currentDomainLocale'] = $this->domain->getLocale();
+            $context['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName();
+        } catch (NoDomainSelectedException | FileNotFoundException) {
+        }
+
+        configureScope(function (Scope $scope) use ($context): void {
+            $scope->setContext('Shopsys', $context);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'setSentryContext',
+            ConsoleEvents::COMMAND => 'setSentryContext',
+        ];
+    }
+}

--- a/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
+++ b/packages/framework/src/Component/Collector/ShopsysFrameworkDataCollector.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Component\Collector;
 
 use PharIo\Version\Version;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Domain\Exception\NoDomainSelectedException;
 use Shopsys\FrameworkBundle\Component\Localization\DisplayTimeZoneProviderInterface;
 use Shopsys\FrameworkBundle\ShopsysFrameworkBundle;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,12 +35,20 @@ class ShopsysFrameworkDataCollector extends DataCollector
             'version' => ShopsysFrameworkBundle::VERSION,
             'docsVersion' => $this->resolveDocsVersion(ShopsysFrameworkBundle::VERSION),
             'domains' => $this->domain->getAll(),
-            'currentDomainId' => $this->domain->getId(),
-            'currentDomainName' => $this->domain->getName(),
-            'currentDomainLocale' => $this->domain->getLocale(),
             'systemTimeZone' => date_default_timezone_get(),
-            'displayTimeZone' => $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName(),
         ];
+
+        try {
+            $this->data['currentDomainId'] = $this->domain->getId();
+            $this->data['currentDomainName'] = $this->domain->getName();
+            $this->data['currentDomainLocale'] = $this->domain->getLocale();
+            $this->data['displayTimeZone'] = $this->displayTimeZoneProvider->getDisplayTimeZoneByDomainId($this->domain->getId())->getName();
+        } catch (NoDomainSelectedException) {
+            $this->data['currentDomainId'] = 0;
+            $this->data['currentDomainName'] = '-';
+            $this->data['currentDomainLocale'] = '-';
+            $this->data['displayTimeZone'] = '-';
+        }
     }
 
     /**

--- a/packages/framework/src/Component/Domain/DomainSubscriber.php
+++ b/packages/framework/src/Component/Domain/DomainSubscriber.php
@@ -39,7 +39,7 @@ class DomainSubscriber implements EventSubscriberInterface
     {
         return [
             // Setting domain by request must be done before loading other services (eg.: routing, localization...)
-            KernelEvents::REQUEST => [['onKernelRequest', 100]],
+            KernelEvents::REQUEST => [['onKernelRequest', 20000]],
         ];
     }
 }

--- a/packages/framework/src/Component/Maintenance/MaintenanceModeFacade.php
+++ b/packages/framework/src/Component/Maintenance/MaintenanceModeFacade.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Maintenance;
+
+use Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade;
+
+class MaintenanceModeFacade
+{
+    public const string MAINTENANCE_KEY = 'maintenance';
+
+    protected ?bool $isMaintenanceModeEnabled = null;
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade $redisClientFacade
+     */
+    public function __construct(
+        protected readonly RedisClientFacade $redisClientFacade,
+    ) {
+    }
+
+    public function disable(): void
+    {
+        $this->redisClientFacade->delete(static::MAINTENANCE_KEY);
+        $this->isMaintenanceModeEnabled = false;
+    }
+
+    public function enable(): void
+    {
+        $this->redisClientFacade->save(static::MAINTENANCE_KEY, true);
+        $this->isMaintenanceModeEnabled = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        if ($this->isMaintenanceModeEnabled === null) {
+            $this->isMaintenanceModeEnabled = $this->redisClientFacade->contains(static::MAINTENANCE_KEY);
+        }
+
+        return $this->isMaintenanceModeEnabled;
+    }
+}

--- a/packages/framework/src/Component/Maintenance/MaintenanceModeSubscriber.php
+++ b/packages/framework/src/Component/Maintenance/MaintenanceModeSubscriber.php
@@ -64,7 +64,7 @@ class MaintenanceModeSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['enableMaintenanceOnRequest', 1000000],
+            KernelEvents::REQUEST => ['enableMaintenanceOnRequest', 10000],
         ];
     }
 }

--- a/packages/framework/src/Component/Maintenance/MaintenanceModeSubscriber.php
+++ b/packages/framework/src/Component/Maintenance/MaintenanceModeSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Component\Maintenance;
 
-use Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -13,16 +12,12 @@ use Twig\Environment;
 
 class MaintenanceModeSubscriber implements EventSubscriberInterface
 {
-    public const MAINTENANCE_KEY = 'maintenance';
-
-    protected ?bool $isMaintenanceMode = null;
-
     /**
-     * @param \Shopsys\FrameworkBundle\Component\Redis\RedisClientFacade $redisClientFacade
+     * @param \Shopsys\FrameworkBundle\Component\Maintenance\MaintenanceModeFacade $maintenanceModeFacade
      * @param \Twig\Environment $twigEnvironment
      */
     public function __construct(
-        protected readonly RedisClientFacade $redisClientFacade,
+        protected readonly MaintenanceModeFacade $maintenanceModeFacade,
         protected readonly Environment $twigEnvironment,
     ) {
     }
@@ -32,11 +27,7 @@ class MaintenanceModeSubscriber implements EventSubscriberInterface
      */
     public function enableMaintenanceOnRequest(RequestEvent $requestEvent): void
     {
-        if ($this->isMaintenanceMode === null) {
-            $this->isMaintenanceMode = $this->redisClientFacade->contains(self::MAINTENANCE_KEY);
-        }
-
-        if ($this->isMaintenanceMode === false
+        if ($this->maintenanceModeFacade->isEnabled() === false
             || in_array(PHP_SAPI, ['cli', 'cli-server', 'phpdbg'], true)
         ) {
             return;


### PR DESCRIPTION
#### Description, the reason for the PR

Additional context is sent to Sentry to help with debugging.

!!! Branch is deployed on alpha to test if context is sent to Sentry correctly.

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-sentry.odin.shopsys.cloud
  - https://cz.tl-sentry.odin.shopsys.cloud
<!-- Replace -->
