### PR TITLE
[shopsys] Fix zero downtime deployment

### DIFF
--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -382,7 +382,7 @@
     </target>
 
     <target name="db-migrations-count-with-maintenance" hidden="true" description="Get count of database migrations to execute and enable maintenance mode if more than zero.">
-        <exec executable="${path.php.executable}" checkreturn="true" outputProperty="migrationCounts">
+        <exec executable="${path.php.executable}" checkreturn="true" passthru="true" returnProperty="migrationCounts">
             <arg value="${path.bin-console}"/>
             <arg value="shopsys:migrations:count"/>
             <arg value="--simple"/>

--- a/project-base/app/config/packages/monolog.yaml
+++ b/project-base/app/config/packages/monolog.yaml
@@ -1,6 +1,9 @@
 monolog:
-    channels: ["cron", "queue", "slow", "socialNetwork"]
+    channels: ["cron", "queue", "slow", "socialNetwork", "deprecation"]
     handlers:
+        deprecated:
+            type: "null"
+            channels: ["deprecation"]
         sentry:
             type: stream
             path: "%shopsys.log_stream%"

--- a/upgrade-notes/backend_20241222_130921.md
+++ b/upgrade-notes/backend_20241222_130921.md
@@ -1,0 +1,15 @@
+#### Fix zero downtime deployment ([#3689](https://github.com/shopsys/shopsys/pull/3689))
+
+- Phing target `db-migrations-count-with-maintenance` was updated, check your `build.xml` and modify the target appropriately if you have overridden it:
+    ```diff
+    <target name="db-migrations-count-with-maintenance" hidden="true" description="Get count of database migrations to execute and enable maintenance mode if more than zero.">
+    -    <exec executable="${path.php.executable}" checkreturn="true" outputProperty="migrationCounts">
+    +    <exec executable="${path.php.executable}" checkreturn="true" passthru="true" returnProperty="migrationCounts">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:migrations:count"/>
+            <arg value="--simple"/>
+            <arg value="--verbose"/>
+        </exec>
+    ...
+    ```
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Deprecations logging was disabled. This means that the command `db-migrations-count-with-maintenance` started working correctly because there are no deprecations on output anymore. 

Phing command `db-migrations-count-with-maintenance` was also updated to work as `passthru` so logs from Symfony commands will be correctly shown in case of failure. 

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-improve-deployment.odin.shopsys.cloud
  - https://cz.jg-improve-deployment.odin.shopsys.cloud
<!-- Replace -->
