### PR TITLE
[shopsys] add missing symfony/doctrine-messenger dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,7 @@
         "symfony/browser-kit": "^6.4",
         "symfony/css-selector": "^6.4",
         "symfony/debug-bundle": "^6.4",
+        "symfony/doctrine-messenger": "^6.4",
         "symfony/dom-crawler": "^6.4",
         "symfony/dotenv": "^6.4",
         "symfony/error-handler": "^6.4",

--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -93,6 +93,7 @@
         "stof/doctrine-extensions-bundle": "^1.3.0",
         "symfony/amqp-messenger": "^6.4",
         "symfony/css-selector": "^6.4",
+        "symfony/doctrine-messenger": "^6.4",
         "symfony/dom-crawler": "^6.4",
         "symfony/error-handler": "^6.4",
         "symfony/event-dispatcher": "^6.4",

--- a/packages/framework/src/Migrations/Version20241223020558.php
+++ b/packages/framework/src/Migrations/Version20241223020558.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20241223020558 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE messenger_messages ALTER created_at TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->sql('ALTER TABLE messenger_messages ALTER available_at TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->sql('ALTER TABLE messenger_messages ALTER delivered_at TYPE TIMESTAMP(0) WITHOUT TIME ZONE');
+        $this->sql('COMMENT ON COLUMN messenger_messages.created_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->sql('COMMENT ON COLUMN messenger_messages.available_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->sql('COMMENT ON COLUMN messenger_messages.delivered_at IS \'(DC2Type:datetime_immutable)\'');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -89,6 +89,7 @@
         "symfony-cmf/routing": "^3.0.3",
         "symfony-cmf/routing-bundle": "^3.0.3",
         "symfony/debug-bundle": "^6.4",
+        "symfony/doctrine-messenger": "^6.4",
         "symfony/dotenv": "^6.4",
         "symfony/error-handler": "^6.4",
         "symfony/flex": "^1.17",

--- a/upgrade-notes/backend_20241223_145857.md
+++ b/upgrade-notes/backend_20241223_145857.md
@@ -1,0 +1,3 @@
+#### add missing symfony/doctrine-messenger dependency ([#3694](https://github.com/shopsys/shopsys/pull/3694))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

In some version of Symfony, they removed dependency on `doctrine-messenger` package. Since we are using it as a failed queue we need to have it installed. This PR adds this missing dependency.

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-fix-doctrine-messenger.odin.shopsys.cloud
  - https://cz.jg-fix-doctrine-messenger.odin.shopsys.cloud
<!-- Replace -->
