### PR TITLE
Improve cron logging/debugging

### DIFF
--- a/packages/framework/src/Command/CronCommand.php
+++ b/packages/framework/src/Command/CronCommand.php
@@ -6,7 +6,8 @@ namespace Shopsys\FrameworkBundle\Command;
 
 use DateTimeZone;
 use NinjaMutex\Lock\LockInterface;
-use Shopsys\FrameworkBundle\Command\Exception\CronCommandException;
+use Shopsys\FrameworkBundle\Command\Exception\CommandException;
+use Shopsys\FrameworkBundle\Command\Exception\CronIsLockedException;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
 use Shopsys\FrameworkBundle\Component\Cron\CronFacade;
 use Shopsys\FrameworkBundle\Component\Cron\MutexFactory;
@@ -82,7 +83,7 @@ class CronCommand extends Command
         if ($this->lock->isLocked(CronLockCommand::CRON_MUTEX_LOCK_NAME)) {
             $output->writeln('Crons are locked with `deploy:cron:lock` command. Nothing to do.');
 
-            return Command::FAILURE;
+            return Command::SUCCESS;
         }
 
         if ($optionRunAllSerially === true) {
@@ -94,7 +95,18 @@ class CronCommand extends Command
         }
 
         $instanceName = $optionInstanceName ?? $this->chooseInstance($input, $output);
-        $this->runCron($input, $this->cronFacade, $this->mutexFactory, $instanceName);
+
+        try {
+            $this->runCron($input, $this->cronFacade, $this->mutexFactory, $instanceName);
+        } catch (CronIsLockedException $e) {
+            $output->writeln($e->getMessage());
+
+            return Command::SUCCESS;
+        } catch (CommandException $e) {
+            $output->writeln($e->getMessage());
+
+            return Command::FAILURE;
+        }
 
         return Command::SUCCESS;
     }
@@ -189,7 +201,7 @@ class CronCommand extends Command
         $mutex = $mutexFactory->getPrefixedCronMutex($instanceName);
 
         if (!$mutex->acquireLock(0)) {
-            throw new CronCommandException(
+            throw new CronIsLockedException(
                 'Cron is locked. Another cron module is already running.',
             );
         }

--- a/packages/framework/src/Command/Exception/CronIsLockedException.php
+++ b/packages/framework/src/Command/Exception/CronIsLockedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command\Exception;
+
+class CronIsLockedException extends CronCommandException
+{
+}

--- a/packages/framework/src/Component/Bytes/BytesHelper.php
+++ b/packages/framework/src/Component/Bytes/BytesHelper.php
@@ -55,4 +55,17 @@ class BytesHelper
 
         return $max;
     }
+
+    /**
+     * @param int $bytes
+     * @return string
+     */
+    public static function convertBytesToReadableString(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        $power = $bytes > 0 ? intval(log($bytes, 1024)) : 0;
+        $power = min($power, count($units) - 1);
+
+        return number_format($bytes / (1024 ** $power), 2) . ' ' . $units[$power];
+    }
 }

--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use Monolog\Logger;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronConfig;
 use Shopsys\FrameworkBundle\Component\Cron\Config\CronModuleConfig;
+use Shopsys\FrameworkBundle\Component\Reflection\ReflectionHelper;
 use Throwable;
 
 class CronFacade
@@ -52,7 +53,16 @@ class CronFacade
      */
     protected function runModules(array $cronModuleConfigs, string $instanceName): void
     {
-        $this->logger->info(sprintf('====== Start of cron instance %s ======', $instanceName));
+        $unique = uniqid();
+
+        $this->logger->pushProcessor(function ($record) use ($instanceName, $unique) {
+            $record->extra['instance'] = $instanceName;
+            $record->extra['runId'] = $unique;
+
+            return $record;
+        });
+
+        $this->logger->info('Start of cron instance');
 
         foreach ($cronModuleConfigs as $cronModuleConfig) {
             $this->runSingleModule($cronModuleConfig);
@@ -62,7 +72,9 @@ class CronFacade
             }
         }
 
-        $this->logger->info(sprintf('======= End of cron instance %s =======', $instanceName));
+        $this->logger->info('End of cron instance');
+
+        $this->logger->popProcessor();
     }
 
     /**
@@ -84,7 +96,14 @@ class CronFacade
             return;
         }
 
-        $this->logger->info('Start of ' . $cronModuleConfig->getServiceId());
+        $shortServiceId = ReflectionHelper::getShortClassName($cronModuleConfig->getServiceId());
+        $this->logger->pushProcessor(function ($record) use ($shortServiceId) {
+            $record->extra['module'] = $shortServiceId;
+
+            return $record;
+        });
+
+        $this->logger->info('Cron module started');
         $cronModuleService = $cronModuleConfig->getService();
         $cronModuleService->setLogger($this->logger);
         $this->cronModuleFacade->markCronAsStarted($cronModuleConfig);
@@ -96,7 +115,7 @@ class CronFacade
             );
         } catch (Throwable $throwable) {
             $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
-            $this->logger->error('End of ' . $cronModuleConfig->getServiceId() . ' because of error', [
+            $this->logger->error('Cron module ended with error', [
                 'exception' => $throwable,
             ]);
 
@@ -107,13 +126,15 @@ class CronFacade
 
         if ($status === CronModuleExecutor::RUN_STATUS_OK) {
             $this->cronModuleFacade->unscheduleModule($cronModuleConfig);
-            $this->logger->info('End of ' . $cronModuleConfig->getServiceId());
         } elseif ($status === CronModuleExecutor::RUN_STATUS_SUSPENDED) {
             $this->cronModuleFacade->suspendModule($cronModuleConfig);
-            $this->logger->info('Suspend ' . $cronModuleConfig->getServiceId());
-        } elseif ($status === CronModuleExecutor::RUN_STATUS_TIMEOUT) {
-            $this->logger->info('Cron reached timeout.');
         }
+
+        $this->logger->info('Cron module ended', [
+            'status' => $status,
+        ]);
+
+        $this->logger->popProcessor();
     }
 
     /**

--- a/packages/framework/src/Component/Cron/CronFacade.php
+++ b/packages/framework/src/Component/Cron/CronFacade.php
@@ -115,11 +115,12 @@ class CronFacade
             );
         } catch (Throwable $throwable) {
             $this->cronModuleFacade->markCronAsFailed($cronModuleConfig);
-            $this->logger->error('Cron module ended with error', [
+            $this->logger->error('Cron module ended', [
+                'status' => 'error',
                 'exception' => $throwable,
             ]);
 
-            throw $throwable;
+            return;
         }
 
         $this->cronModuleFacade->markCronAsEnded($cronModuleConfig);

--- a/packages/framework/src/Component/Cron/CronModuleExecutor.php
+++ b/packages/framework/src/Component/Cron/CronModuleExecutor.php
@@ -88,7 +88,12 @@ class CronModuleExecutor
         $memoryLimit = BytesHelper::getPhpMemoryLimitInBytes();
 
         if ($memoryLimit !== -1 && $memoryUsage >= $memoryLimit * 0.9) {
-            $this->logger->info('Cron was running out of memory, so it was put to sleep to prevent failure.');
+            $this->logger->error('Cron was running out of memory, so it was put to sleep to prevent failure.', [
+                'service_id' => $cronConfig->getServiceId(),
+                'instance_name' => $cronConfig->getInstanceName(),
+                'memory_usage' => BytesHelper::convertBytesToReadableString($memoryUsage),
+                'memory_limit' => BytesHelper::convertBytesToReadableString($memoryLimit),
+            ]);
 
             return false;
         }

--- a/packages/framework/src/Component/Reflection/ReflectionHelper.php
+++ b/packages/framework/src/Component/Reflection/ReflectionHelper.php
@@ -26,4 +26,13 @@ class ReflectionHelper
 
         return self::$constantsIndexedByFqcn[$fqcn];
     }
+
+    /**
+     * @param class-string $fqcn
+     * @return string
+     */
+    public static function getShortClassName(string $fqcn): string
+    {
+        return (new ReflectionClass($fqcn))->getShortName();
+    }
 }


### PR DESCRIPTION
#### Description, the reason for the PR

- cron logger now uses `context` and `extra` to pass some additional info instead of hardcoded values in messages
- cron logger now automatically passes (out of the box) module, instance, and runID (which is unique for every cron module run) as extra attributes that help with searching/debugging
- don't log locked crons into Sentry

Output from console/logs:

```
02:48:06 INFO      [cron] Start of cron instance ["instance" => "service","runId" => "6768cf663004f"]
02:48:06 INFO      [cron] Cron module started ["module" => "VatDeletionCronModule","instance" => "service","runId" => "6768cf663004f"]
02:48:06 INFO      [cron] Deleted 0 vats ["module" => "VatDeletionCronModule","instance" => "service","runId" => "6768cf663004f"]
02:48:06 INFO      [cron] Cron module ended ["status" => "ok"] ["module" => "VatDeletionCronModule","instance" => "service","runId" => "6768cf663004f"]
02:48:06 INFO      [cron] Cron module started ["module" => "DeleteOldCronModuleRunsCronModule","instance" => "service","runId" => "6768cf663004f"]
02:48:06 INFO      [cron] Cron module ended ["status" => "ok"] ["module" => "DeleteOldCronModuleRunsCronModule","instance" => "service","runId" => "6768cf663004f"]
02:48:06 INFO      [cron] End of cron instance ["instance" => "service","runId" => "6768cf663004f"]
```

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
