### PR TITLE
[coding-standards] fix composer version for coding-standards

### DIFF
--- a/packages/coding-standards/composer.json
+++ b/packages/coding-standards/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.3",
         "ext-tokenizer": "*",
         "friendsofphp/php-cs-fixer": "^3.58.1",
-        "nette/utils": "^3.1.3",
+        "nette/utils": "^4.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpstan/phpstan": "^1.11.7",
         "slevomat/coding-standard": "^8.13.1",


### PR DESCRIPTION
#### Description, the reason for the PR

In #3688 I forgot to upgrade one dependency in the `shopsys/coding-standards` package.

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-fix-composer.odin.shopsys.cloud
  - https://cz.jg-fix-composer.odin.shopsys.cloud
<!-- Replace -->
