### PR TITLE
removed banner text when there is no description

### DIFF
--- a/project-base/storefront/components/Blocks/Banners/Banner.tsx
+++ b/project-base/storefront/components/Blocks/Banners/Banner.tsx
@@ -44,10 +44,10 @@ export const Banner: FC<BannerProps> = ({ banner, bannerSliderState, index, numI
                 mobileAlt={banner.mobileMainImage.name || banner.name}
                 mobileSrc={banner.mobileMainImage.url}
             >
-                <BannerContent banner={banner} className="hidden lg:block" />
+                {banner.description && <BannerContent banner={banner} className="hidden lg:block" />}
             </BannerImage>
 
-            <BannerContent banner={banner} className="block lg:hidden" />
+            {banner.description && <BannerContent banner={banner} className="block lg:hidden" />}
         </div>
     );
 };

--- a/upgrade-notes/storefront_20241231_122219.md
+++ b/upgrade-notes/storefront_20241231_122219.md
@@ -1,0 +1,4 @@
+#### banner without description ([#3707](https://github.com/shopsys/shopsys/pull/3707))
+
+- Removed banner text with background when there is no description
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Removed banner text with background when there is no description

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2952-banner-description.odin.shopsys.cloud
  - https://cz.tc-ssp-2952-banner-description.odin.shopsys.cloud
<!-- Replace -->
