### PR TITLE
add upgrade notes for cypress copyright blackout

### DIFF
--- a/upgrade-notes/storefront_20250103_140657.md
+++ b/upgrade-notes/storefront_20250103_140657.md
@@ -1,0 +1,5 @@
+#### cypress tests: add blackout for copyright in footer ([#3708](https://github.com/shopsys/shopsys/pull/3708))
+
+- `FooterCopyright.tsx`: wrap the current year in a new span with tid `TIDs.footer_copyright` and rewrite the usage of `t` function into the `<Trans>` component
+- add the blackout for `TIDs.footer_copyright` in all your cypress screenshots that include the footer
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
I forgot to add the upgrade notes in https://github.com/shopsys/shopsys/pull/3708
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-copyright-upgrade.odin.shopsys.cloud
  - https://cz.rv-copyright-upgrade.odin.shopsys.cloud
<!-- Replace -->
