### PR TITLE
github-actions: fixed artifact uploading for parallelized cypress tests

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -464,19 +464,19 @@ jobs:
                 if: ${{ failure() }}
                 uses: actions/upload-artifact@v4
                 with:
-                    name: cypress-videos
+                    name: cypress-videos-${{ matrix.group }}
                     path: ./videos
             -   name: Upload Cypress screenshots to artifacts
                 if: ${{ failure() }}
                 uses: actions/upload-artifact@v4
                 with:
-                    name: cypress-screenshots
+                    name: cypress-screenshots-${{ matrix.group }}
                     path: ./screenshots
             -   name: Upload Cypress snapshot diffs to artifacts
                 if: ${{ failure() }}
                 uses: actions/upload-artifact@v4
                 with:
-                    name: cypress-snapshot-diffs
+                    name: cypress-snapshot-diffs-${{ matrix.group }}
                     path: ./snapshotDiffs
             -   name: PHP-FPM container logs
                 if: ${{ failure() }}


### PR DESCRIPTION
#### Description, the reason for the PR

Fixes issue with artifact uploading after parallel execution of cypress tests

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-upload-artifact.odin.shopsys.cloud
  - https://cz.mg-fix-upload-artifact.odin.shopsys.cloud
<!-- Replace -->
