### PR TITLE
graphql schema is now validated on generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 generate-schema:
+	docker compose exec php-fpm php ./bin/console graphql:validate
 	docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
 	docker cp shopsys-framework-php-fpm:/var/www/html/project-base/app/schema.graphql /tmp/schema.graphql
 	docker cp /tmp/schema.graphql shopsys-framework-storefront:/home/node/app/schema.graphql
@@ -8,6 +9,7 @@ generate-schema:
 	docker compose exec storefront rm -rf /home/node/app/schema.graphql
 
 generate-schema-native:
+	php ./bin/console graphql:validate
 	php phing frontend-api-generate-graphql-schema
 	cp project-base/app/schema.graphql project-base/storefront/schema.graphql
 	find project-base/storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;

--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -1,4 +1,5 @@
 generate-schema:
+	docker compose exec php-fpm php ./bin/console graphql:validate
 	docker compose exec php-fpm php phing frontend-api-generate-graphql-schema
 	docker cp shopsys-framework-php-fpm:/var/www/html/schema.graphql /tmp/schema.graphql
 	docker cp /tmp/schema.graphql shopsys-framework-storefront:/home/node/app/schema.graphql
@@ -8,6 +9,7 @@ generate-schema:
 	docker compose exec storefront rm -rf /home/node/app/schema.graphql
 
 generate-schema-native:
+	cd app; php ./bin/console graphql:validate
 	cd app; php phing frontend-api-generate-graphql-schema
 	cp app/schema.graphql storefront/schema.graphql
 	find project-base/storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;

--- a/upgrade-notes/backend_20250108_091649.md
+++ b/upgrade-notes/backend_20250108_091649.md
@@ -1,0 +1,3 @@
+#### add graphql schema validation before schema generating ([#3722](https://github.com/shopsys/shopsys/pull/3722))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

When graphql schema is generated, it's now validated beforehand, so the meaningful error is displayed instead of previous generic error.

For example: 

![Snímek obrazovky 2025-01-08 v 10 24 47](https://github.com/user-attachments/assets/897cc305-88ae-40e2-867d-c6840d3f75e9)


<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-validate-schema-on-generate.odin.shopsys.cloud
  - https://cz.mg-validate-schema-on-generate.odin.shopsys.cloud
<!-- Replace -->
