### PR TITLE
makefile: fix using unknown dir base-project inside base-project

### DIFF
--- a/project-base/Makefile
+++ b/project-base/Makefile
@@ -3,14 +3,14 @@ generate-schema:
 	docker cp shopsys-framework-php-fpm:/var/www/html/schema.graphql /tmp/schema.graphql
 	docker cp /tmp/schema.graphql shopsys-framework-storefront:/home/node/app/schema.graphql
 	docker compose exec -u root storefront chown node:node schema.graphql
-	find project-base/storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;
+	docker compose exec storefront sh -c 'rm -rf /home/node/app/requests/*.generated.tsx'
 	docker compose exec storefront npm run gql
 	docker compose exec storefront rm -rf /home/node/app/schema.graphql
 
 generate-schema-native:
 	cd app; php phing frontend-api-generate-graphql-schema
 	cp app/schema.graphql storefront/schema.graphql
-	find project-base/storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;
+	find storefront/graphql/requests -type f -name "*.generated.tsx" -exec rm {} \;
 	cd storefront; npm run gql
 	rm -rf storefront/schema.graphql
 

--- a/upgrade-notes/backend_20250109_091240.md
+++ b/upgrade-notes/backend_20250109_091240.md
@@ -1,0 +1,4 @@
+#### Fix cleanup of generated GraphQL requests in Makefile ([#3725](https://github.com/shopsys/shopsys/pull/3725))
+- The Makefile in project-base removed *.generated.tsx files inside the storefront wrong way (by specifying dir project-base, which does not exist in project-base), fixed by using storefront Docker container instead of using host commands.
+- Update your project-base/Makefile to align with these changes.
+- See #project-base-diff for details.


### PR DESCRIPTION
#### Fix cleanup of generated GraphQL requests in Makefile
- The Makefile in project-base removed *.generated.tsx files inside the storefront wrong way (by specifying dir project-base, which does not exist in project-base), fixed by using storefront Docker container instead of using host commands.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
