### PR TITLE
tweak FilterQueryTest::testParameters() and testFlagBrand()

### DIFF
--- a/project-base/app/tests/App/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Search/FilterQueryTest.php
@@ -80,14 +80,14 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
         $this->skipTestIfFirstDomainIsNotInEnglish();
 
         $brandGenius = $this->getReference(BrandDataFixture::BRAND_GENIUS, Brand::class);
-        $flagSale = $this->getReference(FlagDataFixture::FLAG_PRODUCT_SALE, Flag::class);
+        $flagMadeInCz = $this->getReference(FlagDataFixture::FLAG_PRODUCT_MADEIN_CZ, Flag::class);
 
         $filter = $this->createFilter()
             ->filterByBrands([$brandGenius->getId()])
-            ->filterByFlags([$flagSale->getId()])
+            ->filterByFlags([$flagMadeInCz->getId()])
             ->applyOrderingByIdAscending();
 
-        $this->assertIdsWithFilter($filter, []);
+        $this->assertIdsWithFilter($filter, [16, 19]);
     }
 
     public function testMultiFilter(): void
@@ -164,7 +164,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
 
         $parameterCover = $this->getReference(ParameterDataFixture::PARAM_COVER, Parameter::class);
         $parameterPagesCount = $this->getReference(ParameterDataFixture::PARAM_PAGES_COUNT, Parameter::class);
-        $parameterDimensions = $this->getReference(ParameterDataFixture::PARAM_DIMENSIONS, Parameter::class);
+        $parameterWeight = $this->getReference(ParameterDataFixture::PARAM_WEIGHT, Parameter::class);
 
         $parameters = [
             $parameterCover->getId() => [
@@ -185,7 +185,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
                     true,
                 ),
             ],
-            $parameterDimensions->getId() => [
+            $parameterWeight->getId() => [
                 $this->getParameterValueIdForFirstDomain(
                     '50',
                     true,
@@ -196,7 +196,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
         $filter = $this->createFilter()
             ->filterByParameters($parameters);
 
-        $this->assertIdsWithFilter($filter, []);
+        $this->assertIdsWithFilter($filter, [25, 28]);
     }
 
     public function testOrdering(): void

--- a/upgrade-notes/backend_20260316_102432.md
+++ b/upgrade-notes/backend_20260316_102432.md
@@ -1,0 +1,3 @@
+#### tweak FilterQueryTest::testParameters() and testFlagBrand() ([#3734](https://github.com/shopsys/shopsys/pull/3734))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Tweaked the filter combinations so the tests are now actually testing returned data instead of empty arrays
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





----
:globe_with_meridians: Live Preview:
  - https://rv-tweak-filter-query.odin.shopsys.cloud
  - https://cz.rv-tweak-filter-query.odin.shopsys.cloud
  - https://rv-tweak-filter-query.odin.shopsys.cloud/sk
<!-- SLACK_TIMESTAMP: 1773653318.738899 -->




<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-tweak-filter-query.odin.shopsys.cloud
  - https://cz.rv-tweak-filter-query.odin.shopsys.cloud
  - https://rv-tweak-filter-query.odin.shopsys.cloud/sk
<!-- Replace -->
