### PR TITLE
fix tests

### DIFF
--- a/project-base/app/tests/App/Functional/Model/Product/ProductVisibilityFacadeTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/ProductVisibilityFacadeTest.php
@@ -61,6 +61,6 @@ class ProductVisibilityFacadeTest extends TransactionFunctionalTestCase
         $visibilityIndexedByProductId = $this->productVisibilityFacade->areProductsVisibleForDefaultPricingGroupOnSomeDomainIndexedByProductId(
             [$productId],
         );
-        $this->assertTrue($visibilityIndexedByProductId[$productId]);
+        $this->assertSame($visibilityIndexedByProductId[$productId], $this->domain->isMultidomain());
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
@@ -227,19 +227,19 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
 
         $firstDomainLocale = $this->getLocaleForFirstDomain();
         $expectedViolationMessages = [
-            0 => t(
+            'input.firstName' => t(
                 'First name cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 100],
                 'validators',
                 $firstDomainLocale,
             ),
-            1 => t(
+            'input.lastName' => t(
                 'Last name cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 100],
                 'validators',
                 $firstDomainLocale,
             ),
-            2 => t(
+            'input.telephone' => t(
                 'Telephone number cannot be longer than {{ limit }} characters',
                 ['{{ limit }}' => 30],
                 'validators',
@@ -250,13 +250,12 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
         $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
         $responseData = $this->getErrorsExtensionValidationFromResponse($response);
 
-        $i = 0;
+        $this->assertCount(count($expectedViolationMessages), $responseData);
 
-        foreach ($responseData as $responseRow) {
+        foreach ($responseData as $key => $responseRow) {
             foreach ($responseRow as $validationError) {
                 $this->assertArrayHasKey('message', $validationError);
-                $this->assertEquals($expectedViolationMessages[$i], $validationError['message']);
-                $i++;
+                $this->assertEquals($expectedViolationMessages[$key], $validationError['message']);
             }
         }
     }

--- a/upgrade-notes/backend_20241205_151830.md
+++ b/upgrade-notes/backend_20241205_151830.md
@@ -8,3 +8,4 @@
     - localhost and CI is covered by `db-create` target.
     - check your code for usages of the `NORMALIZED(columnName) LIKE NORMALIZED(:text)` and create the indexes for corresponding columns the same way they are created in the migration `Version20241205144230`
 - see #project-base-diff to update your project
+- see also #project-base-diff of [#3737](https://github.com/shopsys/shopsys/pull/3737) with additional fix


### PR DESCRIPTION
#### Description, the reason for the PR
- `testAreProductsVisibleForDefaultPricingGroupOnEachDomainIndexedByProductId` was [failing with a single domain setup](https://github.com/shopsys/project-base/actions/runs/12783836114/job/35635674490) as it was counting on the fact the application has two domains.

- `testChangePersonalDataWithWrongData` was sometimes failing as it was counting on the order of the validation messages
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-builds.odin.shopsys.cloud
  - https://cz.rv-fix-builds.odin.shopsys.cloud
<!-- Replace -->
