### PR TITLE
remove pagination title from first page

### DIFF
--- a/project-base/storefront/components/Pages/BrandDetail/BrandDetailContent.tsx
+++ b/project-base/storefront/components/Pages/BrandDetail/BrandDetailContent.tsx
@@ -8,6 +8,7 @@ import { Webline } from 'components/Layout/Webline/Webline';
 import { TypeBrandDetailFragment } from 'graphql/requests/brands/fragments/BrandDetailFragment.generated';
 import { useRef } from 'react';
 import { useCurrentPageQuery } from 'utils/queryParams/useCurrentPageQuery';
+import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
 
 type BrandDetailContentProps = {
     brand: TypeBrandDetailFragment;
@@ -18,11 +19,13 @@ export const BrandDetailContent: FC<BrandDetailContentProps> = ({ brand }) => {
     const paginationScrollTargetRef = useRef<HTMLDivElement>(null);
     const currentPage = useCurrentPageQuery();
 
+    const title = useSeoTitleWithPagination(brand.products.totalCount, brand.name, brand.seoH1);
+
     brand.products.productFilterOptions.brands = null;
 
     return (
         <Webline>
-            <h1 ref={scrollTargetRef}>{brand.seoH1 || brand.name}</h1>
+            <h1 ref={scrollTargetRef}>{title}</h1>
 
             <CollapsibleDescriptionWithImage
                 currentPage={currentPage}

--- a/project-base/storefront/components/Pages/FlagDetail/FlagDetailContent.tsx
+++ b/project-base/storefront/components/Pages/FlagDetail/FlagDetailContent.tsx
@@ -6,6 +6,7 @@ import { DeferredFilterAndSortingBar } from 'components/Blocks/SortingBar/Deferr
 import { Webline } from 'components/Layout/Webline/Webline';
 import { TypeFlagDetailFragment } from 'graphql/requests/flags/fragments/FlagDetailFragment.generated';
 import { useRef } from 'react';
+import { useSeoTitleWithPagination } from 'utils/seo/useSeoTitleWithPagination';
 
 type FlagDetailContentProps = {
     flag: TypeFlagDetailFragment;
@@ -14,11 +15,13 @@ type FlagDetailContentProps = {
 export const FlagDetailContent: FC<FlagDetailContentProps> = ({ flag }) => {
     const paginationScrollTargetRef = useRef<HTMLDivElement>(null);
 
+    const title = useSeoTitleWithPagination(flag.products.totalCount, flag.name);
+
     flag.products.productFilterOptions.flags = null;
 
     return (
         <Webline>
-            <h1>{flag.name}</h1>
+            <h1>{title}</h1>
 
             <FilteredProductsWrapper paginationScrollTargetRef={paginationScrollTargetRef}>
                 <DeferredFilterPanel

--- a/project-base/storefront/config/constants.ts
+++ b/project-base/storefront/config/constants.ts
@@ -1,7 +1,7 @@
 import { TypeOrderItemTypeEnum, TypeProductOrderingModeEnum } from 'graphql/types';
 
 export const DEFAULT_PAGE_SIZE = 28;
-export const DEFAULT_BLOG_PAGE_SIZE = 28;
+export const DEFAULT_BLOG_PAGE_SIZE = 6;
 export const DEFAULT_SORT = TypeProductOrderingModeEnum.Priority as const;
 /**
  * For those that are set to "true", we optimistically navigate out from a SEO category when a value of that type is changed

--- a/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
+++ b/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
@@ -2,7 +2,7 @@ import { getEndCursor } from 'components/Blocks/Product/Filter/utils/getEndCurso
 import { LastVisitedProducts } from 'components/Blocks/Product/LastVisitedProducts/LastVisitedProducts';
 import { CommonLayout } from 'components/Layout/CommonLayout';
 import { BlogCategoryContent } from 'components/Pages/BlogCategory/BlogCategoryContent';
-import { DEFAULT_PAGE_SIZE } from 'config/constants';
+import { DEFAULT_BLOG_PAGE_SIZE, DEFAULT_PAGE_SIZE } from 'config/constants';
 import { BlogCategoriesDocument } from 'graphql/requests/blogCategories/queries/BlogCategoriesQuery.generated';
 import { BlogCategoryArticlesDocument } from 'graphql/requests/blogCategories/queries/BlogCategoryArticlesQuery.generated';
 import {
@@ -37,6 +37,7 @@ const BlogCategoryPage: NextPage<ServerSidePropsType> = () => {
         blogCategoryData?.blogCategory?.articlesTotalCount,
         blogCategoryData?.blogCategory?.name,
         blogCategoryData?.blogCategory?.seoTitle,
+        DEFAULT_BLOG_PAGE_SIZE,
     );
 
     const pageViewEvent = useGtmFriendlyPageViewEvent(blogCategoryData?.blogCategory);

--- a/project-base/storefront/utils/seo/useSeoTitleWithPagination.ts
+++ b/project-base/storefront/utils/seo/useSeoTitleWithPagination.ts
@@ -27,8 +27,12 @@ export const useSeoTitleWithPagination = (
         })}`;
     }
 
-    return `${title} ${t('page {{ currentPage }} from {{ totalPages }}', {
-        currentPage,
-        totalPages: Math.ceil(totalCount / pageSize),
-    })}`;
+    if (currentPage > 1) {
+        return `${title} ${t('page {{ currentPage }} from {{ totalPages }}', {
+            currentPage,
+            totalPages: Math.ceil(totalCount / pageSize),
+        })}`;
+    }
+
+    return title;
 };

--- a/upgrade-notes/storefront_20250116_143527.md
+++ b/upgrade-notes/storefront_20250116_143527.md
@@ -1,0 +1,5 @@
+#### remove pagination title from first page ([#3741](https://github.com/shopsys/shopsys/pull/3741))
+
+- removed pagination title from first page
+- changed default number of article blog based on figma design
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Removed pagination title from first page and changed default number of article blog based on figma design.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3086-remove-pagination-title-from-first-page.odin.shopsys.cloud
  - https://cz.tc-ssp-3086-remove-pagination-title-from-first-page.odin.shopsys.cloud
<!-- Replace -->
