### PR TITLE
github actions: review containers now has limited memory

### DIFF
--- a/docker/conf/docker-compose.github-actions.review.simplified.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.simplified.yml.dist
@@ -18,6 +18,10 @@ services:
         networks:
             - default
             - github-runner_traefik-network
+        deploy:
+            resources:
+                limits:
+                    memory: 200M
 
     php-fpm:
         restart: always
@@ -83,6 +87,10 @@ services:
             - chadburn.job-exec.${BRANCH_NAME_ESCAPED}-cron-watchdog.no-overlap=true
             - chadburn.job-exec.${BRANCH_NAME_ESCAPED}-cron-watchdog.user=www-data
             - chadburn.job-exec.${BRANCH_NAME_ESCAPED}-cron-watchdog.tty=true
+        deploy:
+            resources:
+                limits:
+                    memory: 700M
 
     php-consumer:
         restart: always
@@ -114,6 +122,10 @@ services:
             - sleep 5 && project-base/app/docker/php-fpm/consumer-entrypoint.sh 600
         labels:
             - traefik.enable=false
+        deploy:
+            resources:
+                limits:
+                    memory: 400M
 
     storefront:
         restart: always
@@ -128,6 +140,10 @@ services:
             - services-network
         labels:
             - traefik.enable=false
+        deploy:
+            resources:
+                limits:
+                    memory: 500M
 
     img-proxy:
         image: ghcr.io/imgproxy/imgproxy:latest

--- a/docker/conf/docker-compose.github-actions.review.yml.dist
+++ b/docker/conf/docker-compose.github-actions.review.yml.dist
@@ -42,6 +42,10 @@ services:
         networks:
             - default
             - github-runner_traefik-network
+        deploy:
+            resources:
+                limits:
+                    memory: 200M
 
     php-fpm:
         restart: always
@@ -104,6 +108,10 @@ services:
             - chadburn.job-exec.${BRANCH_NAME_ESCAPED}-cron-watchdog.no-overlap=true
             - chadburn.job-exec.${BRANCH_NAME_ESCAPED}-cron-watchdog.user=www-data
             - chadburn.job-exec.${BRANCH_NAME_ESCAPED}-cron-watchdog.tty=true
+        deploy:
+            resources:
+                limits:
+                    memory: 700M
 
     php-consumer:
         restart: always
@@ -133,6 +141,10 @@ services:
             - sleep 5 && project-base/app/docker/php-fpm/consumer-entrypoint.sh 600
         labels:
             - traefik.enable=false
+        deploy:
+            resources:
+                limits:
+                    memory: 400M
 
     rabbitmq:
         image: rabbitmq:3.12-management-alpine
@@ -142,14 +154,18 @@ services:
     storefront:
         restart: always
         image: storefront-image
-        networks:
-            - default
-        labels:
-            - traefik.enable=false
         environment:
             PACKETERY_API_KEY: "${PACKETERY_API_KEY_VALUE}"
             GOOGLE_MAP_API_KEY: "${GOOGLE_MAP_API_KEY_VALUE}"
             GTM_ID: "${GTM_ID_VALUE}"
+        networks:
+            - default
+        labels:
+            - traefik.enable=false
+        deploy:
+            resources:
+                limits:
+                    memory: 500M
 
     redis:
         image: redis:7.4-alpine


### PR DESCRIPTION
#### Description, the reason for the PR

Containers on the review server shouldn't be able to use all the available resources to prevent resource draining

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-odin-limits.odin.shopsys.cloud
  - https://cz.mg-odin-limits.odin.shopsys.cloud
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added memory resource limits for multiple Docker services:
		- Webserver: 200M memory limit
		- PHP-FPM: 700M memory limit
		- PHP Consumer: 400M memory limit
		- Storefront: 500M memory limit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->