### PR TITLE
close db and redis connections when worker is in idle state

### DIFF
--- a/packages/framework/src/Component/Messenger/CloseIdleConnectionSubscriber.php
+++ b/packages/framework/src/Component/Messenger/CloseIdleConnectionSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Messenger;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+
+class CloseIdleConnectionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @param \Doctrine\Persistence\ManagerRegistry $managerRegistry
+     * @param \Shopsys\FrameworkBundle\Component\Redis\RedisFacade $redisFacade
+     */
+    public function __construct(
+        protected readonly ManagerRegistry $managerRegistry,
+        protected readonly RedisFacade $redisFacade,
+    ) {
+    }
+
+    /**
+     * @return iterable
+     */
+    public static function getSubscribedEvents(): iterable
+    {
+        yield WorkerRunningEvent::class => 'onWorkerRunning';
+    }
+
+    /**
+     * @param \Symfony\Component\Messenger\Event\WorkerRunningEvent $event
+     */
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        if (!$event->isWorkerIdle()) {
+            return;
+        }
+
+        foreach ($this->managerRegistry->getConnections() as $connection) {
+            $connection->close();
+        }
+
+        foreach ($this->redisFacade->getConnections() as $redis) {
+            $redis->close();
+        }
+    }
+}

--- a/packages/framework/src/Component/Redis/RedisFacade.php
+++ b/packages/framework/src/Component/Redis/RedisFacade.php
@@ -63,6 +63,14 @@ class RedisFacade
         }
     }
 
+    /**
+     * @return iterable<\Redis>
+     */
+    public function getConnections(): iterable
+    {
+        return $this->allClients;
+    }
+
     public function pingAllClients(): void
     {
         foreach ($this->allClients as $redis) {

--- a/packages/framework/tests/Unit/Component/Messenger/CloseIdleConnectionSubscriberTest.php
+++ b/packages/framework/tests/Unit/Component/Messenger/CloseIdleConnectionSubscriberTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FrameworkBundle\Unit\Component\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Redis;
+use Shopsys\FrameworkBundle\Component\Messenger\CloseIdleConnectionSubscriber;
+use Shopsys\FrameworkBundle\Component\Redis\RedisFacade;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Worker;
+
+class CloseIdleConnectionSubscriberTest extends TestCase
+{
+    private ManagerRegistry|MockObject $managerRegistry;
+
+    private RedisFacade|MockObject $redisFacade;
+
+    private CloseIdleConnectionSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->managerRegistry = $this->createMock(ManagerRegistry::class);
+        $this->redisFacade = $this->createMock(RedisFacade::class);
+        $this->subscriber = new CloseIdleConnectionSubscriber($this->managerRegistry, $this->redisFacade);
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        $expected = [
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ];
+
+        $this->assertEquals($expected, iterator_to_array(CloseIdleConnectionSubscriber::getSubscribedEvents()));
+    }
+
+    public function testWhenWorkerIsIdle(): void
+    {
+        $dbConnection1 = $this->createMock(Connection::class);
+        $dbConnection2 = $this->createMock(Connection::class);
+
+        $redisConnection = $this->createMock(Redis::class);
+
+        $this->managerRegistry
+            ->expects($this->once())
+            ->method('getConnections')
+            ->willReturn([$dbConnection1, $dbConnection2]);
+
+        $this->redisFacade
+            ->expects($this->once())
+            ->method('getConnections')
+            ->willReturn([$redisConnection]);
+
+        $redisConnection
+            ->expects($this->once())
+            ->method('close');
+
+        $dbConnection1
+            ->expects($this->once())
+            ->method('close');
+
+        $dbConnection2
+            ->expects($this->once())
+            ->method('close');
+
+        $worker = $this->createMock(Worker::class);
+        $event = new WorkerRunningEvent($worker, true);
+
+        $this->subscriber->onWorkerRunning($event);
+    }
+
+    public function testWhenWorkerIsNotIdle(): void
+    {
+        $this->managerRegistry
+            ->expects($this->never())
+            ->method('getConnections');
+
+        $this->redisFacade
+            ->expects($this->never())
+            ->method('getConnections');
+
+        $worker = $this->createMock(Worker::class);
+        $event = new WorkerRunningEvent($worker, false);
+
+        $this->subscriber->onWorkerRunning($event);
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

If a worker is not working we don't need open connections to the database and Redis.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jg-idle-connection.odin.shopsys.cloud
  - https://cz.jg-idle-connection.odin.shopsys.cloud
<!-- Replace -->
