### PR TITLE
fix storefront standards

### DIFF
--- a/project-base/storefront/components/Blocks/Banners/BannersDot.tsx
+++ b/project-base/storefront/components/Blocks/Banners/BannersDot.tsx
@@ -36,7 +36,7 @@ export const BannersDot: FC<BannersDotProps> = ({ index, isActive, sliderItem, m
             className={twMergeCustom(
                 'group relative block size-4 cursor-pointer rounded-full bg-labelLinkBackground transition',
                 'vl:flex vl:h-auto vl:w-full vl:rounded-none vl:bg-backgroundMore vl:px-5 vl:py-2 vl:text-left vl:text-text',
-                'vl:after:absolute vl:after:inset-0 vl:after:border-b-[1px] vl:after:border-l-[1px] vl:after:border-t-[1px] vl:after:border-borderAccentLess  vl:after:content-[""] vl:after:first-of-type:rounded-bl-md vl:after:last-of-type:rounded-br-md vl:after:last-of-type:border-r-[1px]',
+                'vl:after:absolute vl:after:inset-0 vl:after:border-b-[1px] vl:after:border-l-[1px] vl:after:border-t-[1px] vl:after:border-borderAccentLess vl:after:content-[""] vl:after:first-of-type:rounded-bl-md vl:after:last-of-type:rounded-br-md vl:after:last-of-type:border-r-[1px]',
                 isActive && 'bg-textAccent vl:bg-background vl:text-textAccent',
             )}
             onClick={() => moveToSlide(index)}

--- a/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpost.tsx
+++ b/project-base/storefront/components/Blocks/BlogSignpost/BlogSignpost.tsx
@@ -31,7 +31,7 @@ export const BlogSignpost: FC<BlogSingpostProps> = ({ blogCategoryItems, activeI
                         variant="secondary"
                         className={twJoin(
                             'relative w-full justify-between !text-base',
-                            'xl:pointer-events-none  xl:bg-transparent xl:p-0 xl:font-semibold xl:text-text xl:outline-none',
+                            'xl:pointer-events-none xl:bg-transparent xl:p-0 xl:font-semibold xl:text-text xl:outline-none',
                             'max-xl:z-aboveOverlay max-xl:py-2.5 max-xl:font-default',
                         )}
                         onClick={() => setIsBlogSignpostOpen(!isBlogSignpostOpen)}

--- a/project-base/storefront/components/Blocks/Categories/PromotedCategoriesContent.tsx
+++ b/project-base/storefront/components/Blocks/Categories/PromotedCategoriesContent.tsx
@@ -37,7 +37,7 @@ export const PromotedCategoriesContent: FC<PromotedCategoriesContentProps> = ({ 
                             href={href}
                             type={linkType}
                             className={twMergeCustom(
-                                'flex cursor-pointer flex-col items-center gap-5 rounded-xl text-center no-underline transition ',
+                                'flex cursor-pointer flex-col items-center gap-5 rounded-xl text-center no-underline transition',
                                 'border border-backgroundMore bg-backgroundMore text-text',
                                 'hover:border-borderAccentLess hover:bg-background hover:text-text hover:no-underline',
                                 'px-6 py-2.5 md:py-4 vl:px-10',
@@ -50,7 +50,7 @@ export const PromotedCategoriesContent: FC<PromotedCategoriesContentProps> = ({ 
                                     tid={TIDs.simple_navigation_image}
                                     className={twJoin(
                                         'relative flex items-center justify-center',
-                                        'size-[60px] lg:size-[100px] vl:size-full ',
+                                        'size-[60px] lg:size-[100px] vl:size-full',
                                         isFirstItemLarge
                                             ? 'vl:max-h-[500px] vl:max-w-[500px]'
                                             : 'lg:max-h-[180px] lg:max-w-[180px]',

--- a/project-base/storefront/components/Blocks/OrderAction/OrderAction.tsx
+++ b/project-base/storefront/components/Blocks/OrderAction/OrderAction.tsx
@@ -29,7 +29,7 @@ export const OrderAction: FC<OrderActionProps> = ({
     return (
         <div
             className={twJoin(
-                'flex flex-col flex-wrap items-center lg:w-full lg:flex-row lg:justify-between ',
+                'flex flex-col flex-wrap items-center lg:w-full lg:flex-row lg:justify-between',
                 withGapBottom && 'mb-12 lg:mb-24',
                 withGapTop && 'mt-8',
             )}

--- a/project-base/storefront/components/Blocks/OrderSummary/OrderSummary.tsx
+++ b/project-base/storefront/components/Blocks/OrderSummary/OrderSummary.tsx
@@ -33,7 +33,7 @@ export const OrderSummary: FC<OrderSummaryProps> = ({ isTransportOrPaymentLoadin
                 <div className="h4 mb-3 font-bold">{t('Your order')}</div>
 
                 <div className="rounded bg-backgroundMore vl:m-0">
-                    <div className="relative flex flex-col px-5 py-3 ">
+                    <div className="relative flex flex-col px-5 py-3">
                         <div className="mb-5">
                             <ul>
                                 {cart.items.map((item) => (

--- a/project-base/storefront/components/Blocks/Popup/CreateComplaintPopup.tsx
+++ b/project-base/storefront/components/Blocks/Popup/CreateComplaintPopup.tsx
@@ -186,7 +186,7 @@ export const CreateComplaintPopup: FC<CreateComplaintPopupProps> = ({ orderUuid,
                         </FormBlockWrapper>
                         <FormBlockWrapper>
                             <FormHeading>{t('Delivery address')}</FormHeading>
-                            <div className="flex w-full flex-col space-y-5 ">
+                            <div className="flex w-full flex-col space-y-5">
                                 <RadiobuttonGroup
                                     control={formProviderMethods.control}
                                     formName={formMeta.formName}

--- a/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductCompareButton.tsx
+++ b/project-base/storefront/components/Blocks/Product/ButtonsAction/ProductCompareButton.tsx
@@ -27,7 +27,7 @@ export const ProductCompareButton: FC<ProductCompareButtonProps> = ({
             onClick={toggleProductInComparison}
         >
             {isProductInComparison ? (
-                <CompareFilledIcon className="size-6  text-activeIconFull" />
+                <CompareFilledIcon className="size-6 text-activeIconFull" />
             ) : (
                 <CompareIcon className="size-6" />
             )}

--- a/project-base/storefront/components/Blocks/Product/ProductsSliderPlaceholder.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsSliderPlaceholder.tsx
@@ -28,7 +28,7 @@ export const ProductsSliderPlaceholder: FC<ProductsSliderPlaceholderProps> = ({
             <ul
                 className={twJoin(
                     "grid snap-x snap-mandatory grid-flow-col overflow-x-auto overscroll-x-contain [-ms-overflow-style:'none'] [scrollbar-width:'none'] [&::-webkit-scrollbar]:hidden",
-                    'auto-cols-[225px] sm:auto-cols-[60%]  md:auto-cols-[45%] lg:auto-cols-[30%] vl:auto-cols-[25%] xl:auto-cols-[20%]',
+                    'auto-cols-[225px] sm:auto-cols-[60%] md:auto-cols-[45%] lg:auto-cols-[30%] vl:auto-cols-[25%] xl:auto-cols-[20%]',
                 )}
             >
                 {products.map((product, index) =>

--- a/project-base/storefront/components/Blocks/PromoCode/PromoCodeInfo.tsx
+++ b/project-base/storefront/components/Blocks/PromoCode/PromoCodeInfo.tsx
@@ -18,10 +18,10 @@ export const PromoCodeInfo: FC<PromoCodeInfoProps> = ({ onRemovePromoCodeCallbac
             <div className="flex items-center font-bold" tid={TIDs.blocks_promocode_promocodeinfo_code}>
                 <LabelLink className="gap-3" onClick={onRemovePromoCodeCallback}>
                     {promoCode.code}
-                    <RemoveIcon className=" w-3" />
+                    <RemoveIcon className="w-3" />
                 </LabelLink>
             </div>
-            <p className="text-textDisabled ">
+            <p className="text-textDisabled">
                 {promoCode.type === TypePromoCodeTypeEnum.FreeTransportPayment
                     ? t('The discount was applied to the order transport and payment.')
                     : t(

--- a/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
+++ b/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
@@ -70,7 +70,7 @@ export const SortingBar: FC<SortingBarProps> = ({ sorting, totalCount, customSor
             </Button>
             <div
                 className={twJoin(
-                    'flex-col rounded-xl bg-background vl:flex vl:flex-row vl:gap-2.5 ',
+                    'flex-col rounded-xl bg-background vl:flex vl:flex-row vl:gap-2.5',
                     isSortMenuOpen
                         ? 'absolute right-0 top-full z-aboveOverlay mt-1 flex w-[60%] divide-y divide-borderAccentLess px-5 py-2.5'
                         : 'hidden',

--- a/project-base/storefront/components/Blocks/SortingBar/SortingBarItem.tsx
+++ b/project-base/storefront/components/Blocks/SortingBar/SortingBarItem.tsx
@@ -13,7 +13,7 @@ export const SortingBarItem: FC<SortingBarItemProps> = ({ children, isActive, hr
         <a
             href={href}
             className={twMergeCustom(
-                'py-4 text-right font-secondary text-xs font-bold uppercase text-link underline hover:text-linkHovered vl:relative vl:rounded-t-xl vl:bg-backgroundMore vl:px-5  vl:py-2.5 vl:text-center ',
+                'py-4 text-right font-secondary text-xs font-bold uppercase text-link underline hover:text-linkHovered vl:relative vl:rounded-t-xl vl:bg-backgroundMore vl:px-5 vl:py-2.5 vl:text-center',
                 isActive &&
                     'font-semibold text-text no-underline vl:border vl:border-borderAccentLess vl:bg-background vl:after:absolute vl:after:bottom-[-2px] vl:after:left-0 vl:after:h-[2px] vl:after:w-full vl:after:bg-background',
             )}

--- a/project-base/storefront/components/Blocks/UpsList/UpsList.tsx
+++ b/project-base/storefront/components/Blocks/UpsList/UpsList.tsx
@@ -16,7 +16,7 @@ export const UpsList: FC = () => {
             <div
                 className={twMergeCustom([
                     'vl:flex vl:justify-around',
-                    'grid snap-x snap-mandatory auto-cols-[60%] grid-flow-col gap-5 overflow-x-auto sm:auto-cols-[37%] md:auto-cols-[26%] lg:auto-cols-[20%] ',
+                    'grid snap-x snap-mandatory auto-cols-[60%] grid-flow-col gap-5 overflow-x-auto sm:auto-cols-[37%] md:auto-cols-[26%] lg:auto-cols-[20%]',
                     "overscroll-x-contain [-ms-overflow-style:'none'] [scrollbar-width:'none'] [&::-webkit-scrollbar]:hidden",
                 ])}
             >

--- a/project-base/storefront/components/Forms/Lib/LabelWrapper.tsx
+++ b/project-base/storefront/components/Forms/Lib/LabelWrapper.tsx
@@ -66,11 +66,11 @@ export const LabelWrapper: FC<LabelWrapperProps> = ({
                 {(inputType === 'checkbox' || inputType === 'radio') && (
                     <div
                         className={twMergeCustom(
-                            'flex size-5 min-w-5 border border-inputBorder bg-inputBackground p-[3px] transition group-hover:bg-inputBackgroundHovered ',
+                            'flex size-5 min-w-5 border border-inputBorder bg-inputBackground p-[3px] transition group-hover:bg-inputBackgroundHovered',
                             inputType === 'checkbox' ? 'rounded' : 'rounded-full p-[5px]',
                             'active:scale-90',
                             checked
-                                ? 'border-inputBorderActive bg-inputBackgroundActive group-hover:bg-inputBackgroundActive '
+                                ? 'border-inputBorderActive bg-inputBackgroundActive group-hover:bg-inputBackgroundActive'
                                 : 'border-2 group-hover:border-inputBorderHovered group-active:border-inputBorderHovered',
                             disabled &&
                                 'border-inputBorderDisabled group-hover:border-inputBorderDisabled group-hover:bg-inputBackgroundDisabled group-active:border-inputBorderDisabled',

--- a/project-base/storefront/components/Forms/Select/Select.tsx
+++ b/project-base/storefront/components/Forms/Select/Select.tsx
@@ -79,7 +79,7 @@ export const Select = <T extends string | number | undefined | Record<any, any> 
 
     return (
         <>
-            <div className={twMergeCustom('relative w-full ', className)} ref={wrapperRef}>
+            <div className={twMergeCustom('relative w-full', className)} ref={wrapperRef}>
                 <div
                     className={twMergeCustom(
                         'group flex h-14 rounded-md border-2 border-inputBorder bg-inputBackground text-inputText hover:border-inputBorderHovered',

--- a/project-base/storefront/components/Layout/Popup/Popup.tsx
+++ b/project-base/storefront/components/Layout/Popup/Popup.tsx
@@ -68,7 +68,7 @@ export const Popup: FC<PopupProps> = ({ children, hideCloseButton, className, co
                         }}
                     >
                         {!hideCloseButton && (
-                            <div className="flex h-9 items-center justify-end ">
+                            <div className="flex h-9 items-center justify-end">
                                 <button
                                     className="flex size-9 cursor-pointer items-center justify-center rounded-full border-0 text-xs text-textAccent no-underline outline-none"
                                     onClick={() => updatePortalContent(null)}

--- a/project-base/storefront/components/Pages/Customer/ComplaintDetail/ComplaintDetailBasicInfo.tsx
+++ b/project-base/storefront/components/Pages/Customer/ComplaintDetail/ComplaintDetailBasicInfo.tsx
@@ -17,7 +17,7 @@ export const ComplaintDetailBasicInfo: FC<ComplaintDetailBasicInfoProps> = ({ co
     return (
         <div className="my-6 flex flex-col gap-4 bg-background vl:mb-8">
             <div className="flex items-center justify-between gap-4 rounded-md bg-backgroundMore px-4 py-3 vl:px-6 vl:py-4">
-                <div className="flex  flex-wrap gap-6 gap-y-2 vl:gap-8">
+                <div className="flex flex-wrap gap-6 gap-y-2 vl:gap-8">
                     <ComplaintItemColumnInfo
                         tid={TIDs.complaint_detail_number}
                         title={t('Complaint number')}

--- a/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelectItemLabel.tsx
+++ b/project-base/storefront/components/Pages/Order/TransportAndPayment/TransportAndPaymentSelect/TransportAndPaymentSelectItemLabel.tsx
@@ -34,7 +34,7 @@ export const TransportAndPaymentSelectItemLabel: FC<TransportAndPaymentSelectIte
     return (
         <div className="flex w-full flex-row items-center gap-5">
             <div
-                className={twJoin('flex h-12  w-12 items-center', !image && 'hidden')}
+                className={twJoin('flex h-12 w-12 items-center', !image && 'hidden')}
                 tid={TIDs.transport_and_payment_list_item_image}
             >
                 <Image alt={image?.name ?? name} className="max-h-12 w-auto" height={48} src={image?.url} width={48} />
@@ -72,7 +72,7 @@ export const TransportAndPaymentSelectItemLabel: FC<TransportAndPaymentSelectIte
                 )}
 
                 {price && isPriceVisible(price.priceWithVat) && (
-                    <div className="block shrink-0 text-sm font-bold lg:hidden ">{formatPrice(price.priceWithVat)}</div>
+                    <div className="block shrink-0 text-sm font-bold lg:hidden">{formatPrice(price.priceWithVat)}</div>
                 )}
             </div>
 

--- a/project-base/storefront/components/Pages/PersonalData/Overview/PersonalDataOverviewContent.tsx
+++ b/project-base/storefront/components/Pages/PersonalData/Overview/PersonalDataOverviewContent.tsx
@@ -52,7 +52,7 @@ export const PersonalDataOverviewContent: FC<PersonalDataOverviewContentProps> =
         <Webline className="flex flex-col items-center">
             <h1 className="w-full max-w-3xl">{t('Personal data overview')}</h1>
             {contentSiteText && (
-                <div className="max-w-3xl [&_section]:mb-5 [&_section]:block [&_section]:text-justify ">
+                <div className="max-w-3xl [&_section]:mb-5 [&_section]:block [&_section]:text-justify">
                     <UserText htmlContent={contentSiteText} />
                 </div>
             )}

--- a/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
+++ b/project-base/storefront/components/Pages/ProductDetail/ProductDetailVariantsTable.tsx
@@ -40,7 +40,7 @@ export const ProductVariantsTable: FC<ProductVariantsTableProps> = ({ variants }
             {variants.map((variant, index) => (
                 <li
                     key={variant.uuid}
-                    className="mx-auto flex w-full max-w-sm flex-col items-center justify-between gap-2 border border-borderAccent p-2 md:max-w-none lg:flex-row lg:border-0 "
+                    className="mx-auto flex w-full max-w-sm flex-col items-center justify-between gap-2 border border-borderAccent p-2 md:max-w-none lg:flex-row lg:border-0"
                     tid={TIDs.pages_productdetail_variant_ + variant.catalogNumber}
                 >
                     <div className="relative h-48 w-full lg:h-16 lg:w-16" tid={TIDs.product_detail_main_image}>


### PR DESCRIPTION
#### Description, the reason for the PR
Because of tailwind lint now also checks for spaces in classnames, this PR fixes these.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://fix-storefront-standards.odin.shopsys.cloud
  - https://cz.fix-storefront-standards.odin.shopsys.cloud
<!-- Replace -->
