### PR TITLE
elasticsearch on local now has limited resources to prevent excessive memory usage

### DIFF
--- a/docker/conf/docker-compose-mac.yml.dist
+++ b/docker/conf/docker-compose-mac.yml.dist
@@ -185,6 +185,12 @@ services:
             - elasticsearch-data:/usr/share/elasticsearch/data
         environment:
             - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+        deploy:
+            resources:
+                limits:
+                    memory: 2G
 
     kibana:
         image: docker.elastic.co/kibana/kibana:7.16.1

--- a/docker/conf/docker-compose.yml.dist
+++ b/docker/conf/docker-compose.yml.dist
@@ -189,6 +189,12 @@ services:
             - elasticsearch-data:/usr/share/elasticsearch/data
         environment:
             - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+        deploy:
+            resources:
+                limits:
+                    memory: 2G
 
     kibana:
         image: docker.elastic.co/kibana/kibana:7.16.1

--- a/project-base/docker/conf/docker-compose-mac.yml.dist
+++ b/project-base/docker/conf/docker-compose-mac.yml.dist
@@ -183,6 +183,12 @@ services:
             - elasticsearch-data:/usr/share/elasticsearch/data
         environment:
             - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+        deploy:
+            resources:
+                limits:
+                    memory: 2G
 
     kibana:
         image: docker.elastic.co/kibana/kibana:7.16.1

--- a/project-base/docker/conf/docker-compose.yml.dist
+++ b/project-base/docker/conf/docker-compose.yml.dist
@@ -187,6 +187,12 @@ services:
             - elasticsearch-data:/usr/share/elasticsearch/data
         environment:
             - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+        deploy:
+            resources:
+                limits:
+                    memory: 2G
 
     kibana:
         image: docker.elastic.co/kibana/kibana:7.16.1

--- a/upgrade-notes/backend_20250129_154324.md
+++ b/upgrade-notes/backend_20250129_154324.md
@@ -1,0 +1,4 @@
+#### limit resources for Elasticsearch on local ([#3763](https://github.com/shopsys/shopsys/pull/3763))
+
+- see #project-base-diff to update your project
+- make the same changes in your uncommitted `docker-compose.yml` file and recreate the `elasticsearch` container


### PR DESCRIPTION
#### Description, the reason for the PR

Recently updated Elasticsearch version may cause excessive memory usage on some local setups. 
This PR limits resource usage to prevent memory draining.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-local-elastic-config.odin.shopsys.cloud
  - https://cz.mg-local-elastic-config.odin.shopsys.cloud
<!-- Replace -->
