### PR TITLE
[SSP-3141]  - add grapesjs three columns component

### DIFF
--- a/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-custom-blocks-plugin.js
+++ b/project-base/app/assets/js/admin/grapesjs/plugins/grapesjs-custom-blocks-plugin.js
@@ -2,9 +2,8 @@ import grapesjs from 'grapesjs';
 import Translator from 'bazinga-translator';
 
 export default grapesjs.plugins.add('custom-blocks', (editor, options) => {
-
     editor.Components.addType('text-ckeditor', {
-        isComponent: element => element.classList && element.classList.contains('gjs-text-ckeditor'),
+        isComponent: (element) => element.classList && element.classList.contains('gjs-text-ckeditor'),
         extend: 'text',
         model: {
             defaults: {
@@ -33,6 +32,19 @@ export default grapesjs.plugins.add('custom-blocks', (editor, options) => {
         attributes: { class: 'gjs-fonts gjs-f-b2' },
         content: `
             <div class="row" data-gjs-droppable=".column">
+                <div class="column"></div>
+                <div class="column"></div>
+            </div>
+        `
+    });
+
+    editor.Blocks.add('column3', {
+        label: Translator.trans('Column 3'),
+        category: Translator.trans('Basic objects'),
+        attributes: { class: 'gjs-fonts gjs-f-b3' },
+        content: `
+            <div class="row" data-gjs-droppable=".column">
+                <div class="column"></div>
                 <div class="column"></div>
                 <div class="column"></div>
             </div>

--- a/project-base/app/translations/messages.cs.po
+++ b/project-base/app/translations/messages.cs.po
@@ -31,6 +31,9 @@ msgstr "Sloupec 1"
 msgid "Column 2"
 msgstr "Sloupec 2"
 
+msgid "Column 3"
+msgstr "Sloupec 3"
+
 msgid "Columns"
 msgstr "Sloupce"
 

--- a/project-base/app/translations/messages.en.po
+++ b/project-base/app/translations/messages.en.po
@@ -31,6 +31,9 @@ msgstr ""
 msgid "Column 2"
 msgstr ""
 
+msgid "Column 3"
+msgstr ""
+
 msgid "Columns"
 msgstr ""
 

--- a/upgrade-notes/storefront_20250131_133659.md
+++ b/upgrade-notes/storefront_20250131_133659.md
@@ -1,0 +1,3 @@
+#### add grapesjs three columns component ([#3769](https://github.com/shopsys/shopsys/pull/3769))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Add three columns component to grapesjs.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tg-ssp-3141-grapesjs-three-columns.odin.shopsys.cloud
  - https://cz.tg-ssp-3141-grapesjs-three-columns.odin.shopsys.cloud
<!-- Replace -->
