### PR TITLE
added margin to info message on comparison page

### DIFF
--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparison.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparison.tsx
@@ -25,7 +25,7 @@ export const ProductComparison: FC = () => {
             )}
 
             {!comparison?.products && !isProductListFetching && (
-                <div className="flex items-center">
+                <div className="my-28 flex items-center justify-center">
                     <InfoIcon className="mr-4 w-8" />
                     <div className="h3">{t('Comparison does not contain any products yet.')}</div>
                 </div>

--- a/upgrade-notes/storefront_20250203_141351.md
+++ b/upgrade-notes/storefront_20250203_141351.md
@@ -1,0 +1,3 @@
+#### Add margin to info message on comparison page ([#3775](https://github.com/shopsys/shopsys/pull/3775))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Added margin to info message on comparison page.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3154-empty-comparison-page.odin.shopsys.cloud
  - https://cz.tc-ssp-3154-empty-comparison-page.odin.shopsys.cloud
<!-- Replace -->
