### PR TITLE
administrator now can upload files without ROLE_FILES_FULL that is used for separate administration section

### DIFF
--- a/project-base/app/config/packages/security.yaml
+++ b/project-base/app/config/packages/security.yaml
@@ -484,7 +484,8 @@ security:
         - { path: ^/%admin_url%/uploaded-file/new, roles: ROLE_FILES_FULL }
         - { path: ^/%admin_url%/uploaded-file/edit, roles: ROLE_FILES_FULL, methods: [POST] }
         - { path: ^/%admin_url%/uploaded-file/delete, roles: ROLE_FILES_FULL }
-        - { path: ^/%admin_url%/uploaded-file/, roles: ROLE_FILES_VIEW }
+        - { path: ^/%admin_url%/file-upload/, roles: ROLE_ADMIN }
+        - { path: ^/%admin_url%/uploaded-file/, roles: ROLE_ADMIN }
         # special paths for file manager in wysiwyg, file picker, product picker, grid, domain selector, login as user.
         - { path: ^/%admin_url%/product-picker/, roles: ROLE_ADMIN }
         - { path: ^/%admin_url%/file-picker/, roles: ROLE_ADMIN }

--- a/upgrade-notes/backend_20250204_132803.md
+++ b/upgrade-notes/backend_20250204_132803.md
@@ -1,0 +1,3 @@
+#### fix file upload roles ([#3777](https://github.com/shopsys/shopsys/pull/3777))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Current role settings were false as administrator with full product role could not upload files for products.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-upload-rights.odin.shopsys.cloud
  - https://cz.tl-fix-upload-rights.odin.shopsys.cloud
<!-- Replace -->
