### PR TITLE
fix price filtering for products with special prices

### DIFF
--- a/packages/framework/src/Form/Admin/PriceList/PriceListFormType.php
+++ b/packages/framework/src/Form/Admin/PriceList/PriceListFormType.php
@@ -45,6 +45,7 @@ final class PriceListFormType extends AbstractType
             $builder
                 ->add('id', DisplayOnlyType::class, [
                     'label' => t('ID'),
+                    'data' => $priceList->getId(),
                 ])
                 ->add('lastUpdate', DisplayOnlyType::class, [
                     'label' => t('Last update'),

--- a/packages/framework/src/Form/Transformers/CategoriesIdsToCategoriesTransformer.php
+++ b/packages/framework/src/Form/Transformers/CategoriesIdsToCategoriesTransformer.php
@@ -36,7 +36,7 @@ class CategoriesIdsToCategoriesTransformer implements DataTransformerInterface
     }
 
     /**
-     * @param int[] $categoriesIds
+     * @param string[] $categoriesIds
      * @return \Shopsys\FrameworkBundle\Model\Category\Category[]
      */
     public function reverseTransform($categoriesIds): array
@@ -46,7 +46,7 @@ class CategoriesIdsToCategoriesTransformer implements DataTransformerInterface
         if (is_array($categoriesIds)) {
             foreach ($categoriesIds as $categoryId) {
                 try {
-                    $categories[] = $this->categoryRepository->getById($categoryId);
+                    $categories[] = $this->categoryRepository->getById((int)$categoryId);
                 } catch (CategoryNotFoundException $e) {
                     throw new TransformationFailedException('Category not found', 0, $e);
                 }

--- a/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/packages/framework/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use InvalidArgumentException;
 use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
-use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Paginator\QueryPaginator;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFacade;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlRepository;
@@ -395,8 +394,6 @@ class ProductExportRepository
                 'price_without_vat' => (float)$price->getPriceWithoutVat()->getAmount(),
                 'vat' => (float)$price->getVatAmount()->getAmount(),
                 'price_from' => $productPrice->isPriceFrom(),
-                'filtering_minimal_price' => (float)$this->getMaximalVariantPriceForFilteringMinimalPrice($product, $pricingGroup, $domainId)->getAmount(),
-                'filtering_maximal_price' => (float)$this->getMinimalVariantPriceForFilteringMaximalPrice($product, $pricingGroup, $domainId)->getAmount(),
                 'variant_prices' => $this->getVariantPrices($product, $pricingGroup, $domainId),
             ];
         }
@@ -576,90 +573,6 @@ class ProductExportRepository
         }
 
         return $result;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
-     * @param int $domainId
-     * @return \Shopsys\FrameworkBundle\Component\Money\Money
-     */
-    protected function getMaximalVariantPriceForFilteringMinimalPrice(
-        Product $product,
-        PricingGroup $pricingGroup,
-        int $domainId,
-    ): Money {
-        $price = null;
-
-        if (!$product->isMainVariant()) {
-            return $this->productPriceCalculation->calculatePrice(
-                $product,
-                $pricingGroup->getDomainId(),
-                $pricingGroup,
-            )->getPrice()->getPriceWithVat();
-        }
-
-        $variants = $this->productRepository->getAllSellableVariantsByMainVariant($product, $domainId, $pricingGroup);
-
-        foreach ($variants as $variant) {
-            $variantPrice = $this->productPriceCalculation->calculatePrice(
-                $variant,
-                $pricingGroup->getDomainId(),
-                $pricingGroup,
-            )->getPrice()->getPriceWithVat();
-
-            if ($price === null || $variantPrice->isGreaterThan($price)) {
-                $price = $variantPrice;
-            }
-        }
-
-        if ($price === null) {
-            $price = Money::zero();
-        }
-
-        return $price;
-    }
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Model\Product\Product $product
-     * @param \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup
-     * @param int $domainId
-     * @return \Shopsys\FrameworkBundle\Component\Money\Money
-     */
-    protected function getMinimalVariantPriceForFilteringMaximalPrice(
-        Product $product,
-        PricingGroup $pricingGroup,
-        int $domainId,
-    ): Money {
-        $price = null;
-
-        if (!$product->isMainVariant()) {
-            return $this->productPriceCalculation->calculatePrice(
-                $product,
-                $pricingGroup->getDomainId(),
-                $pricingGroup,
-            )->getPrice()->getPriceWithVat();
-        }
-
-        $variants = $this->productRepository->getAllSellableVariantsByMainVariant($product, $domainId, $pricingGroup);
-
-        foreach ($variants as $variant) {
-            $variantPrice = $this->productPriceCalculation->calculatePrice(
-                $variant,
-                $pricingGroup->getDomainId(),
-                $pricingGroup,
-            )->getPrice()->getPriceWithVat();
-
-            if ($price === null || $variantPrice->isLessThan($price)) {
-                $price = $variantPrice;
-            }
-        }
-
-        if ($price === null) {
-            $price = Money::zero();
-        }
-
-        return $price;
     }
 
     /**

--- a/packages/framework/src/Model/Product/Search/FilterQuery.php
+++ b/packages/framework/src/Model/Product/Search/FilterQuery.php
@@ -135,7 +135,12 @@ class FilterQuery
             if (!params['_source']['prices'].isEmpty()) {
                 for (def price : params['_source']['prices']) {
                     if (price['pricing_group_id'] === params['pricing_group_id']) {
-                        finalPrice = Math.min(finalPrice, price['filtering_maximal_price']);
+                        finalPrice = Math.min(finalPrice, price['price_with_vat']);
+                        for (def variantPrice : price['variant_prices']) {
+                            if (variantPrice['price_with_vat'] < finalPrice) {
+                                finalPrice = variantPrice['price_with_vat'];
+                            }
+                        }
                         break;
                     }
                 }
@@ -158,7 +163,7 @@ class FilterQuery
                             }
 
                             finalPrice = Math.min(finalPrice, price['price_with_vat']);
-                            usedProductIds.add(price['product_id'])
+                            usedProductIds.add(price['product_id']);
                         }
                     }
                 }
@@ -189,11 +194,18 @@ class FilterQuery
         $scriptMaxValue = "
             double finalPrice = 0;
             DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm:ss').withZone(java.time.ZoneOffset.UTC);
+            int productId = params['_source']['id'];
 
             if (!params['_source']['prices'].isEmpty()) {
                 for (def price : params['_source']['prices']) {
                     if (price['pricing_group_id'] === params['pricing_group_id']) {
-                        finalPrice = Math.max(finalPrice, price['filtering_minimal_price']);
+                        finalPrice = Math.max(finalPrice, price['price_with_vat']);
+                        for (def variantPrice : price['variant_prices']) {
+                            if (variantPrice['price_with_vat'] > finalPrice) {
+                                finalPrice = variantPrice['price_with_vat'];
+                                productId = variantPrice['variant_id'];                            
+                            }
+                        }
                         break;
                     }
                 }
@@ -215,8 +227,12 @@ class FilterQuery
                                 continue;
                             }
 
-                            finalPrice = Math.max(finalPrice, price['price_with_vat']);
-                            usedProductIds.add(price['product_id'])
+                            if (productId != price['product_id']) {
+                                continue;
+                            }
+
+                            finalPrice = Math.min(finalPrice, price['price_with_vat']);
+                            usedProductIds.add(price['product_id']);
                         }
                     }
                 }

--- a/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
+++ b/project-base/app/src/Model/Product/Elasticsearch/ProductExportRepository.php
@@ -50,8 +50,6 @@ use Shopsys\FrameworkBundle\Model\Seo\HreflangLinksFacade;
  * @method array extractStoreAvailabilitiesInformation(\App\Model\Product\Product $product, int $domainId)
  * @method array extractSpecialPrices(int $domainId, \App\Model\Product\Product $product)
  * @method array extractPrices(int $domainId, \App\Model\Product\Product $product)
- * @method \Shopsys\FrameworkBundle\Component\Money\Money getMaximalVariantPriceForFilteringMinimalPrice(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, int $domainId)
- * @method \Shopsys\FrameworkBundle\Component\Money\Money getMinimalVariantPriceForFilteringMaximalPrice(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, int $domainId)
  * @method array getVariantPrices(\App\Model\Product\Product $product, \Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroup $pricingGroup, int $domainId)
  */
 class ProductExportRepository extends BaseProductExportRepository

--- a/project-base/app/src/Resources/definition/product/1.json
+++ b/project-base/app/src/Resources/definition/product/1.json
@@ -187,12 +187,6 @@
                     "price_from": {
                         "type": "boolean"
                     },
-                    "filtering_minimal_price": {
-                        "type": "float"
-                    },
-                    "filtering_maximal_price": {
-                        "type": "float"
-                    },
                     "variant_prices": {
                         "type": "nested",
                         "properties": {

--- a/project-base/app/src/Resources/definition/product/2.json
+++ b/project-base/app/src/Resources/definition/product/2.json
@@ -187,12 +187,6 @@
                     "price_from": {
                         "type": "boolean"
                     },
-                    "filtering_minimal_price": {
-                        "type": "float"
-                    },
-                    "filtering_maximal_price": {
-                        "type": "float"
-                    },
                     "variant_prices": {
                         "type": "nested",
                         "properties": {

--- a/project-base/app/tests/App/Functional/Model/Product/Search/FilterQueryTest.php
+++ b/project-base/app/tests/App/Functional/Model/Product/Search/FilterQueryTest.php
@@ -59,7 +59,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
         $filter = $this->createFilter()
             ->filterByBrands([$brandApple->getId()]);
 
-        $this->assertIdWithFilter($filter, [5]);
+        $this->assertIdsWithFilter($filter, [5]);
     }
 
     public function testFlag(): void
@@ -72,7 +72,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByFlags([$flagNew->getId()])
             ->applyOrderingByIdAscending();
 
-        $this->assertIdWithFilter($filter, [9, 10, 13, 14, 19, 21, 22, 25, 27, 29, 31, 35, 42, 44, 50, 144]);
+        $this->assertIdsWithFilter($filter, [9, 10, 13, 14, 19, 21, 22, 25, 27, 29, 31, 35, 42, 44, 50, 144]);
     }
 
     public function testFlagBrand(): void
@@ -87,7 +87,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByFlags([$flagSale->getId()])
             ->applyOrderingByIdAscending();
 
-        $this->assertIdWithFilter($filter, []);
+        $this->assertIdsWithFilter($filter, []);
     }
 
     public function testMultiFilter(): void
@@ -118,7 +118,44 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
                 ),
             );
 
-        $this->assertIdWithFilter($filter, [33]);
+        $this->assertIdsWithFilter($filter, [33]);
+    }
+
+    public function testFilterByPriceProductWithSpecialPrice(): void
+    {
+        $testedProductId = 28; // the product has active special price 61 CZK with original price 65 CZK
+        $currencyCzk = $this->getReference(CurrencyDataFixture::CURRENCY_CZK, Currency::class);
+        $pricingGroup = $this->getReferenceForDomain(
+            PricingGroupDataFixture::PRICING_GROUP_ORDINARY,
+            Domain::FIRST_DOMAIN_ID,
+            PricingGroup::class,
+        );
+        $categoryBooks = $this->getReference(CategoryDataFixture::CATEGORY_BOOKS, Category::class);
+        $filter = $this->createFilter()
+            ->filterByCategory($categoryBooks->getId())
+            ->filterByPrices(
+                $pricingGroup,
+                $this->priceConverter->convertPriceWithVatToDomainDefaultCurrencyPrice(
+                    Money::create(64),
+                    $currencyCzk,
+                    Domain::FIRST_DOMAIN_ID,
+                ),
+            )
+            ->applyOrderingByIdAscending();
+        $this->assertIdNotInResult($filter, $testedProductId, 'product with special price lower than filter price from should not be in result');
+
+        $filter = $this->createFilter()
+            ->filterByCategory($categoryBooks->getId())
+            ->filterByPrices(
+                $pricingGroup,
+                $this->priceConverter->convertPriceWithVatToDomainDefaultCurrencyPrice(
+                    Money::create(60),
+                    $currencyCzk,
+                    Domain::FIRST_DOMAIN_ID,
+                ),
+            )
+            ->applyOrderingByIdAscending();
+        $this->assertIdInResult($filter, $testedProductId, 'product with special price higher than filter price from should be in result');
     }
 
     public function testParameters(): void
@@ -144,7 +181,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
         $filter = $this->createFilter()
             ->filterByParameters($parameters);
 
-        $this->assertIdWithFilter($filter, []);
+        $this->assertIdsWithFilter($filter, []);
     }
 
     public function testOrdering(): void
@@ -163,22 +200,22 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByCategory($categoryBooks->getId())
             ->applyOrderingByIdAscending();
 
-        $this->assertIdWithFilter($filter, [25, 26, 27, 28, 29, 33, 39, 40, 50, 72], 'by id asc');
+        $this->assertIdsWithFilter($filter, [25, 26, 27, 28, 29, 33, 39, 40, 50, 72], 'by id asc');
 
         $nameAscFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_NAME_ASC, $pricingGroup);
-        $this->assertIdWithFilter($nameAscFilter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40], 'name asc');
+        $this->assertIdsWithFilter($nameAscFilter, [72, 25, 27, 29, 28, 26, 50, 33, 39, 40], 'name asc');
 
         $nameDescFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_NAME_DESC, $pricingGroup);
-        $this->assertIdWithFilter($nameDescFilter, [40, 39, 33, 50, 26, 28, 29, 27, 25, 72], 'name desc');
+        $this->assertIdsWithFilter($nameDescFilter, [40, 39, 33, 50, 26, 28, 29, 27, 25, 72], 'name desc');
 
         $priceAscFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRICE_ASC, $pricingGroup);
-        $this->assertIdWithFilter($priceAscFilter, [40, 33, 50, 39, 29, 25, 26, 27, 28, 72], 'price asc');
+        $this->assertIdsWithFilter($priceAscFilter, [40, 33, 50, 39, 29, 25, 26, 27, 28, 72], 'price asc');
 
         $priceDescFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRICE_DESC, $pricingGroup);
-        $this->assertIdWithFilter($priceDescFilter, [72, 28, 27, 25, 26, 29, 39, 50, 33, 40], 'price desc');
+        $this->assertIdsWithFilter($priceDescFilter, [72, 28, 27, 25, 26, 29, 39, 50, 33, 40], 'price desc');
 
         $priorityFilter = $filter->applyOrdering(ProductListOrderingConfig::ORDER_BY_PRIORITY, $pricingGroup);
-        $this->assertIdWithFilter($priorityFilter, [72, 25, 27, 29, 28, 26, 33, 39, 40, 50], 'priority');
+        $this->assertIdsWithFilter($priorityFilter, [72, 25, 27, 29, 28, 26, 33, 39, 40, 50], 'priority');
     }
 
     public function testMatchQuery(): void
@@ -188,10 +225,10 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
         $filter = $this->createFilter();
 
         $kittyFilter = $filter->search('kitty');
-        $this->assertIdWithFilter($kittyFilter, [1]);
+        $this->assertIdsWithFilter($kittyFilter, [1]);
 
         $mg3550Filer = $filter->search('mg3550');
-        $this->assertIdWithFilter($mg3550Filer, [9]);
+        $this->assertIdsWithFilter($mg3550Filer, [9]);
     }
 
     public function testPagination(): void
@@ -204,25 +241,25 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterByCategory($categoryBooks->getId())
             ->applyOrderingByIdAscending();
 
-        $this->assertIdWithFilter($filter, [25, 26, 27, 28, 29, 33, 39, 40, 50, 72]);
+        $this->assertIdsWithFilter($filter, [25, 26, 27, 28, 29, 33, 39, 40, 50, 72]);
 
         $limit5Filter = $filter->setLimit(5);
-        $this->assertIdWithFilter($limit5Filter, [25, 26, 27, 28, 29]);
+        $this->assertIdsWithFilter($limit5Filter, [25, 26, 27, 28, 29]);
 
         $limit1Filter = $filter->setLimit(1);
-        $this->assertIdWithFilter($limit1Filter, [25]);
+        $this->assertIdsWithFilter($limit1Filter, [25]);
 
         $limit4Page2Filter = $filter->setLimit(4)
             ->setPage(2);
-        $this->assertIdWithFilter($limit4Page2Filter, [29, 33, 39, 40]);
+        $this->assertIdsWithFilter($limit4Page2Filter, [29, 33, 39, 40]);
 
         $limit4Page3Filter = $filter->setLimit(4)
             ->setPage(3);
-        $this->assertIdWithFilter($limit4Page3Filter, [50, 72]);
+        $this->assertIdsWithFilter($limit4Page3Filter, [50, 72]);
 
         $limit4Page4Filter = $filter->setLimit(4)
             ->setPage(4);
-        $this->assertIdWithFilter($limit4Page4Filter, []);
+        $this->assertIdsWithFilter($limit4Page4Filter, []);
     }
 
     public function testFilterBySellingFrom(): void
@@ -230,7 +267,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
         $filter = $this->createFilter()
             ->filterBySellingFrom(new DateTimeImmutable('-30 days'))
             ->applyOrderingByIdAscending();
-        $this->assertIdWithFilter($filter, [44, 144]);
+        $this->assertIdsWithFilter($filter, [44, 144]);
     }
 
     public function testFilterWithActiveSpecialPriceOnly(): void
@@ -245,7 +282,7 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
             ->filterWithActiveSpecialPriceOnly($pricingGroup)
             ->applyOrderingByIdAscending();
 
-        $this->assertIdWithFilter($filter, [19, 27, 28, 54, 69, 117]);
+        $this->assertIdsWithFilter($filter, [19, 27, 28, 54, 69, 117]);
     }
 
     /**
@@ -253,14 +290,42 @@ class FilterQueryTest extends ParameterTransactionFunctionalTestCase
      * @param int[] $ids
      * @param string $message
      */
-    protected function assertIdWithFilter(FilterQuery $filterQuery, array $ids, string $message = ''): void
+    protected function assertIdsWithFilter(FilterQuery $filterQuery, array $ids, string $message = ''): void
+    {
+        $this->assertSame($ids, $this->getResultIds($filterQuery), $message);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @param int $id
+     * @param string $message
+     */
+    protected function assertIdNotInResult(FilterQuery $filterQuery, int $id, string $message = ''): void
+    {
+        $this->assertNotContains($id, $this->getResultIds($filterQuery), $message);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @param int $id
+     * @param string $message
+     */
+    protected function assertIdInResult(FilterQuery $filterQuery, int $id, string $message = ''): void
+    {
+        $this->assertContains($id, $this->getResultIds($filterQuery), $message);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Search\FilterQuery $filterQuery
+     * @return int[]
+     */
+    protected function getResultIds(FilterQuery $filterQuery): array
     {
         $params = $filterQuery->getQuery();
-
         $params['_source'] = false;
-
         $result = $this->elasticsearchClient->search($params);
-        $this->assertSame($ids, $this->extractIds($result), $message);
+
+        return $this->extractIds($result);
     }
 
     /**

--- a/upgrade-notes/backend_20250207_111605.md
+++ b/upgrade-notes/backend_20250207_111605.md
@@ -1,0 +1,3 @@
+#### fix price filtering for products with special prices ([#3782](https://github.com/shopsys/shopsys/pull/3782))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

- removed `filtering_minimal_price` and `filtering_maximal_price` elasticsearch fields
    - instead, variant prices are iterated directly in `min_current_selling_price_with_vat` and `max_current_selling_price_with_vat` runtime fields
- also fixed display of price list ID in administration and type error on navigation item edit page


<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-special-prices.odin.shopsys.cloud
  - https://cz.rv-fix-special-prices.odin.shopsys.cloud
<!-- Replace -->
