### PR TITLE
fixed url param value with slash

### DIFF
--- a/project-base/storefront/pages/articles/[articleSlug].tsx
+++ b/project-base/storefront/pages/articles/[articleSlug].tsx
@@ -61,7 +61,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
             const articleResponse: OperationResult<TypeArticleDetailQuery, TypeArticleDetailQueryVariables> =
                 await client!
                     .query(ArticleDetailQueryDocument, {
-                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers),
                     })
                     .toPromise();
 

--- a/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
+++ b/project-base/storefront/pages/blogArticles/[blogArticleSlug].tsx
@@ -69,7 +69,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
                 TypeBlogArticleDetailQueryVariables
             > = await client!
                 .query(BlogArticleDetailQueryDocument, {
-                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers),
                 })
                 .toPromise();
 

--- a/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
+++ b/project-base/storefront/pages/blogCategories/[blogCategorySlug].tsx
@@ -73,7 +73,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
             const blogCategoryResponse: OperationResult<TypeBlogCategoryQuery, TypeBlogCategoryQueryVariables> =
                 await client!
                     .query(BlogCategoryQueryDocument, {
-                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers),
                     })
                     .toPromise();
 

--- a/project-base/storefront/pages/brands/[brandSlug].tsx
+++ b/project-base/storefront/pages/brands/[brandSlug].tsx
@@ -93,7 +93,7 @@ const BrandDetailPage: NextPage = () => {
 export const getServerSideProps = getServerSidePropsWrapper(
     ({ redisClient, domainConfig, ssrExchange, t }) =>
         async (context) => {
-            const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '');
+            const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers);
             const page = getNumberFromUrlQuery(context.query[PAGE_QUERY_PARAMETER_NAME], 1);
             const loadMore = getNumberFromUrlQuery(context.query[LOAD_MORE_QUERY_PARAMETER_NAME], 0);
             const redirect = getRedirectWithOffsetPage(page, loadMore, urlSlug, context.query);

--- a/project-base/storefront/pages/categories/[categorySlug].tsx
+++ b/project-base/storefront/pages/categories/[categorySlug].tsx
@@ -81,7 +81,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
         async (context) => {
             const page = getNumberFromUrlQuery(context.query[PAGE_QUERY_PARAMETER_NAME], 1);
             const loadMore = getNumberFromUrlQuery(context.query[LOAD_MORE_QUERY_PARAMETER_NAME], 0);
-            const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '');
+            const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers);
             const redirect = getRedirectWithOffsetPage(page, loadMore, urlSlug, context.query);
 
             if (redirect) {

--- a/project-base/storefront/pages/flags/[flagSlug].tsx
+++ b/project-base/storefront/pages/flags/[flagSlug].tsx
@@ -83,7 +83,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
         async (context) => {
             const page = getNumberFromUrlQuery(context.query[PAGE_QUERY_PARAMETER_NAME], 1);
             const loadMore = getNumberFromUrlQuery(context.query[LOAD_MORE_QUERY_PARAMETER_NAME], 0);
-            const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '');
+            const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers);
             const redirect = getRedirectWithOffsetPage(page, loadMore, urlSlug, context.query);
 
             if (redirect) {

--- a/project-base/storefront/pages/products/[productSlug].tsx
+++ b/project-base/storefront/pages/products/[productSlug].tsx
@@ -98,7 +98,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
             const productResponse: OperationResult<TypeProductDetailQuery, TypeProductDetailQueryVariables> =
                 await client!
                     .query(ProductDetailQueryDocument, {
-                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                        urlSlug: getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers),
                     })
                     .toPromise();
 

--- a/project-base/storefront/pages/search.tsx
+++ b/project-base/storefront/pages/search.tsx
@@ -43,7 +43,7 @@ const SearchPage: FC<ServerSidePropsType> = () => {
 export const getServerSideProps = getServerSidePropsWrapper(({ redisClient, domainConfig, t }) => async (context) => {
     const page = getNumberFromUrlQuery(context.query[PAGE_QUERY_PARAMETER_NAME], 1);
     const loadMore = getNumberFromUrlQuery(context.query[LOAD_MORE_QUERY_PARAMETER_NAME], 0);
-    const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '');
+    const urlSlug = getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers);
     const redirect = getRedirectWithOffsetPage(page, loadMore, urlSlug, context.query);
 
     if (redirect) {

--- a/project-base/storefront/pages/stores/[storeSlug].tsx
+++ b/project-base/storefront/pages/stores/[storeSlug].tsx
@@ -61,7 +61,7 @@ export const getServerSideProps = getServerSidePropsWrapper(
 
             const storeResponse: OperationResult<TypeStoreDetailQuery, TypeStoreDetailQueryVariables> = await client!
                 .query(StoreDetailQueryDocument, {
-                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? ''),
+                    urlSlug: getSlugFromServerSideUrl(context.req.url ?? '', context.req.headers),
                 })
                 .toPromise();
 

--- a/project-base/storefront/utils/parsing/getSlugFromServerSideUrl.ts
+++ b/project-base/storefront/utils/parsing/getSlugFromServerSideUrl.ts
@@ -1,4 +1,16 @@
-export const getSlugFromServerSideUrl = (originalUrl: string): string => {
+import { getUrlWithoutGetParameters } from './getUrlWithoutGetParameters';
+import { getStringWithoutLeadingSlash } from './stringWIthoutSlash';
+import { NextIncomingMessage } from 'next/dist/server/request-meta';
+import { getIsRedirectedFromSsr } from 'utils/getIsRedirectedFromSsr';
+
+export const getSlugFromServerSideUrl = (
+    originalUrl: string,
+    requestHeaders: NextIncomingMessage['headers'],
+): string => {
+    if (getIsRedirectedFromSsr(requestHeaders)) {
+        return getStringWithoutLeadingSlash(getUrlWithoutGetParameters(originalUrl));
+    }
+
     const lastUrlSegment = originalUrl.split('/').pop()!;
     const beforeExtensionSegment = lastUrlSegment.split('.')[0];
     const strippedSlug = beforeExtensionSegment.split('?')[0];

--- a/upgrade-notes/storefront_20250210_072816.md
+++ b/upgrade-notes/storefront_20250210_072816.md
@@ -1,0 +1,4 @@
+#### fix param value with slash ([#3786](https://github.com/shopsys/shopsys/pull/3786))
+
+- param value with slash is parsed correctly now
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Param value with slash is now fixed.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3156-fix-url-param-value-with-slash.odin.shopsys.cloud
  - https://cz.tc-ssp-3156-fix-url-param-value-with-slash.odin.shopsys.cloud
<!-- Replace -->
