### PR TITLE
ROLE_API_CUSTOMER_SELF_MANAGE tweaks

### DIFF
--- a/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Customer/DeliveryAddress/DeliveryAddressMutationDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Customer/DeliveryAddress/DeliveryAddressMutationDecorator.types.yaml
@@ -10,6 +10,7 @@ DeliveryAddressMutationDecorator:
                     deliveryAddressUuid:
                         type: Uuid!
                 resolve: "@=mutation('deleteDeliveryAddressMutation', args)"
+                access: "@=isGranted('ROLE_API_CUSTOMER_SELF_MANAGE')"
             EditDeliveryAddress:
                 type: "[DeliveryAddress!]!"
                 description: "Edit delivery address by Uuid"
@@ -18,6 +19,7 @@ DeliveryAddressMutationDecorator:
                         type: DeliveryAddressInput!
                         validation: cascade
                 resolve: "@=mutation('editDeliveryAddressMutation', args)"
+                access: "@=isGranted('ROLE_API_CUSTOMER_SELF_MANAGE')"
             SetDefaultDeliveryAddress:
                 type: "CurrentCustomerUser!"
                 description: "Set default delivery address by Uuid"
@@ -25,6 +27,7 @@ DeliveryAddressMutationDecorator:
                     deliveryAddressUuid:
                         type: Uuid!
                 resolve: "@=mutation('setDefaultDeliveryAddressMutation', args['deliveryAddressUuid'])"
+                access: "@=isGranted('ROLE_API_CUSTOMER_SELF_MANAGE')"
             CreateDeliveryAddress:
                 type: "[DeliveryAddress!]!"
                 description: "Create a new delivery address"
@@ -33,3 +36,4 @@ DeliveryAddressMutationDecorator:
                         type: DeliveryAddressInput!
                         validation: cascade
                 resolve: "@=mutation('createDeliveryAddressMutation', args)"
+                access: "@=isGranted('ROLE_API_CUSTOMER_SELF_MANAGE')"

--- a/packages/frontend-api/src/Resources/config/graphql-types/Mutation/MutationDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/Mutation/MutationDecorator.types.yaml
@@ -46,6 +46,7 @@ MutationDecorator:
                         type: ChangePersonalDataInput!
                         validation: cascade
                 resolve: "@=mutation('changePersonalDataMutation', args, validator)"
+                access: "@=isGranted('ROLE_API_CUSTOMER_SELF_MANAGE')"
             ChangeCompanyData:
                 type: 'CurrentCustomerUser!'
                 description: "Changes customer user company data"

--- a/packages/frontend-api/src/Voter/CustomerUserVoter.php
+++ b/packages/frontend-api/src/Voter/CustomerUserVoter.php
@@ -61,10 +61,6 @@ class CustomerUserVoter extends AbstractB2bVoter
             return $this->isRoleApiAllGranted($inputData, $token);
         }
 
-        if ($this->security->isGranted('ROLE_API_CUSTOMER_SELF_MANAGE')) {
-            return $this->isRoleApiCustomerSelfManageGranted($inputData, $token);
-        }
-
         return false;
     }
 
@@ -96,20 +92,5 @@ class CustomerUserVoter extends AbstractB2bVoter
         }
 
         return $loggedCustomerUser->getCustomer()->getId() === $editedCustomerUser->getCustomer()->getId();
-    }
-
-    /**
-     * @param array $inputData
-     * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
-     * @return bool
-     */
-    protected function isRoleApiCustomerSelfManageGranted(array $inputData, TokenInterface $token): bool
-    {
-        /** @var \Shopsys\FrontendApiBundle\Model\User\FrontendApiUser $loggedUser */
-        $loggedUser = $token->getUser();
-        $loggedUserUuid = $loggedUser->getUuid();
-        $editedUserUuid = $inputData['customerUserUuid'];
-
-        return $loggedUserUuid === $editedUserUuid;
     }
 }

--- a/project-base/app/src/DataFixtures/Demo/CustomerUserRoleGroupDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/CustomerUserRoleGroupDataFixture.php
@@ -94,9 +94,7 @@ class CustomerUserRoleGroupDataFixture extends AbstractReferenceFixture
         foreach ($this->domainsForDataFixtureProvider->getAllowedDemoDataLocales() as $locale) {
             $customerUserRoleGroupData->names[$locale] = t('Catalog user', [], Translator::DATA_FIXTURES_TRANSLATION_DOMAIN, $locale);
         }
-        $customerUserRoleGroupData->roles = [
-            CustomerUserRole::ROLE_API_CUSTOMER_SELF_MANAGE,
-        ];
+        $customerUserRoleGroupData->roles = [];
 
         $customerUserRoleGroup = $this->customerUserRoleGroupFacade->create($customerUserRoleGroupData);
         $this->addReference(self::ROLE_GROUP_CATALOG_USER, $customerUserRoleGroup);

--- a/project-base/app/tests/FrontendApiBundle/Functional/Customer/DeleteDeliveryAddressTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Customer/DeleteDeliveryAddressTest.php
@@ -15,20 +15,13 @@ class DeleteDeliveryAddressTest extends GraphQlWithLoginTestCase
         $customer = $this->getReference(CustomerUserDataFixture::USER_WITH_RESET_PASSWORD_HASH, CustomerUser::class);
         $deliveryAddressUuid = $customer->getDefaultDeliveryAddress()->getUuid();
 
-        $query = '
-mutation {
-    DeleteDeliveryAddress(deliveryAddressUuid: "' . $deliveryAddressUuid . '") {
-        uuid
-    }
-}';
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../_graphql/mutation/DeleteDeliveryAddressMutation.graphql',
+            [
+                'uuid' => $deliveryAddressUuid,
+            ],
+        );
 
-        $jsonExpected = '
-{
-    "data": {
-        "DeleteDeliveryAddress":[]
-    }
-}';
-
-        $this->assertQueryWithExpectedJson($query, $jsonExpected);
+        $this->assertSame([], $this->getResponseDataForGraphQlType($response, 'DeleteDeliveryAddress'));
     }
 }

--- a/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/CurrentCustomerUserTest.php
@@ -126,7 +126,7 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
     public function testChangePersonalData(): void
     {
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             $this->getJohnDoeBaseData(),
         );
         $data = [
@@ -140,7 +140,7 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
     public function testEditCustomerCompany(): void
     {
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             [
                 ...$this->getJohnDoeBaseData(),
                 'companyCustomer' => true,
@@ -181,7 +181,7 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
         $companyNumber = $existingBillingAddress->getCompanyNumber();
 
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             [
                 ...$this->getJohnDoeBaseData(),
                 'companyCustomer' => true,
@@ -212,7 +212,7 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
     public function testChangePersonalDataWithWrongData(): void
     {
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             [
                 'telephone' => '1234567890123456789012345678901',
                 'firstName' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent suscipit ultrices molestie. Donec s',
@@ -263,7 +263,7 @@ class CurrentCustomerUserTest extends GraphQlWithLoginTestCase
     public function testChangePersonalDataWithWrongCompanyData(): void
     {
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             [
                 ...$this->getJohnDoeBaseData(),
                 'companyCustomer' => true,

--- a/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/graphql/ChangePersonalAndCompanyDataMutation.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Customer/User/graphql/ChangePersonalAndCompanyDataMutation.graphql
@@ -1,0 +1,50 @@
+mutation ChangePersonalAndCompanyDataMutation(
+    $firstName: String!
+    $lastName: String!
+    $telephone: String!
+    $newsletterSubscription: Boolean!
+    $street: String!
+    $city: String!
+    $country: String!
+    $postcode: String!
+    $companyCustomer: Boolean! = false
+    $companyName: String
+    $companyNumber: String
+    $companyTaxNumber: String
+) {
+    ChangePersonalData(input: {
+        telephone: $telephone
+        firstName: $firstName
+        lastName: $lastName
+        newsletterSubscription: $newsletterSubscription
+    }) {
+        firstName
+        lastName,
+        telephone,
+        email
+        newsletterSubscription
+    }
+
+    ChangeCompanyData(input: {
+        street: $street
+        city: $city
+        country: $country
+        postcode: $postcode
+        companyCustomer: $companyCustomer
+        companyName: $companyName
+        companyNumber: $companyNumber
+        companyTaxNumber: $companyTaxNumber
+    }) {
+        street
+        city
+        country {
+            code
+        }
+        postcode
+        ...on CurrentCompanyCustomerUser {
+            companyName
+            companyNumber
+            companyTaxNumber
+        }
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/Functional/_graphql/mutation/DeleteDeliveryAddressMutation.graphql
+++ b/project-base/app/tests/FrontendApiBundle/Functional/_graphql/mutation/DeleteDeliveryAddressMutation.graphql
@@ -1,0 +1,5 @@
+mutation DeleteDeliveryAddress($uuid: Uuid!) {
+    DeleteDeliveryAddress(deliveryAddressUuid: $uuid) {
+        uuid
+    }
+}

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserCatalogUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserCatalogUserTest.php
@@ -307,4 +307,67 @@ class CustomerUserCatalogUserTest extends GraphQlB2bDomainWithLoginTestCase
 
         $this->assertAccessDeniedError($response);
     }
+
+    public function testDeleteDeliveryAddressMutationIsNotAllowed(): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../../Functional/_graphql/mutation/DeleteDeliveryAddressMutation.graphql',
+            [
+                'uuid' => self::FAKE_UUID,
+            ],
+        );
+
+        $this->assertAccessDeniedError($response);
+    }
+
+    public function testEditDeliveryAddressMutationIsNotAllowed(): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../../Functional/_graphql/mutation/EditDeliveryAddressMutation.graphql',
+            [
+                'uuid' => self::FAKE_UUID,
+                'firstName' => 'firstName',
+                'lastName' => 'lastName',
+                'street' => 'street',
+                'city' => 'city',
+                'postcode' => '12345',
+                'country' => 'CZ',
+                'companyName' => 'Shopsys',
+                'telephone' => '777777777',
+            ],
+        );
+
+        $this->assertAccessDeniedError($response);
+    }
+
+    public function testSetDefaultDeliveryAddressMutationIsNotAllowed(): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../../Functional/_graphql/mutation/SetDefaultDeliveryAddressMutation.graphql',
+            [
+                'deliveryAddressUuid' => self::FAKE_UUID,
+            ],
+        );
+
+        $this->assertAccessDeniedError($response);
+    }
+
+    public function testCreateDeliveryAddressMutationIsNotAllowed(): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../../Functional/_graphql/mutation/CreateDeliveryAddressMutation.graphql',
+            [
+                'firstName' => 'firstName',
+                'lastName' => 'lastName',
+                'street' => 'street',
+                'city' => 'city',
+                'postcode' => '12345',
+                'country' => 'CZ',
+                'companyName' => 'Shopsys',
+                'telephone' => '777777777',
+            ],
+        );
+
+        $this->assertAccessDeniedError($response);
+    }
 }

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserCatalogUserTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserCatalogUserTest.php
@@ -7,6 +7,7 @@ namespace Tests\FrontendApiBundle\FunctionalB2b\CustomerUser;
 use App\DataFixtures\Demo\CompanyDataFixture;
 use Shopsys\FrameworkBundle\Model\Complaint\ComplaintResolutionEnum;
 use Tests\FrontendApiBundle\Functional\Order\MinimalOrderAsAuthenticatedCustomerUserTest;
+use Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\Helper\ChangePersonalAndCompanyDataInputProvider;
 use Tests\FrontendApiBundle\Test\GraphQlB2bDomainWithLoginTestCase;
 
 class CustomerUserCatalogUserTest extends GraphQlB2bDomainWithLoginTestCase
@@ -292,6 +293,16 @@ class CustomerUserCatalogUserTest extends GraphQlB2bDomainWithLoginTestCase
                     ],
                 ],
             ],
+        );
+
+        $this->assertAccessDeniedError($response);
+    }
+
+    public function testChangePersonalDataMutationIsNotAllowed(): void
+    {
+        $response = $this->getResponseContentForGql(
+            __DIR__ . '/../_graphql/ChangePersonalDataMutation.graphql',
+            ChangePersonalAndCompanyDataInputProvider::PERSONAL_DATA_INPUT_ARRAY,
         );
 
         $this->assertAccessDeniedError($response);

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserOwnerTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserOwnerTest.php
@@ -18,7 +18,7 @@ use Shopsys\FrameworkBundle\Model\Customer\Customer;
 use Shopsys\FrameworkBundle\Model\Customer\Exception\CustomerUserNotFoundException;
 use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroup;
 use Shopsys\FrontendApiBundle\Component\Constraints\UniqueBillingAddressApi;
-use Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\Helper\ChangePersonalDataInputProvider;
+use Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\Helper\ChangePersonalAndCompanyDataInputProvider;
 use Tests\FrontendApiBundle\Test\GraphQlB2bDomainWithLoginTestCase;
 
 class CustomerUserOwnerTest extends GraphQlB2bDomainWithLoginTestCase
@@ -37,11 +37,11 @@ class CustomerUserOwnerTest extends GraphQlB2bDomainWithLoginTestCase
     {
         $existingBillingAddress = $this->getReferenceForDomain(CompanyDataFixture::SHOPSYS_COMPANY, $this->domain->getId(), Customer::class)->getBillingAddress();
 
-        $input = ChangePersonalDataInputProvider::INPUT_ARRAY;
+        $input = ChangePersonalAndCompanyDataInputProvider::INPUT_ARRAY;
         $input['companyNumber'] = $existingBillingAddress->getCompanyNumber();
 
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/../../Functional/Customer/User/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/../../Functional/Customer/User/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             $input,
         );
         $this->assertResponseContainsArrayOfExtensionValidationErrors($response);
@@ -51,13 +51,13 @@ class CustomerUserOwnerTest extends GraphQlB2bDomainWithLoginTestCase
     }
 
     /**
-     * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserSelfManageTest::testChangePersonalDataMutationIsNotAllowed()
+     * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserSelfManageTest::testChangeCompanyDataMutationIsNotAllowed()
      */
-    public function testChangePersonalDataMutation(): void
+    public function testChangePersonalAndCompanyDataMutation(): void
     {
-        $personalData = ChangePersonalDataInputProvider::INPUT_ARRAY;
+        $personalData = ChangePersonalAndCompanyDataInputProvider::INPUT_ARRAY;
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/../../Functional/Customer/User/graphql/ChangePersonalDataMutation.graphql',
+            __DIR__ . '/../../Functional/Customer/User/graphql/ChangePersonalAndCompanyDataMutation.graphql',
             $personalData,
         );
         $responseData = [

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserSelfManageTest.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/CustomerUserSelfManageTest.php
@@ -7,13 +7,11 @@ namespace Tests\FrontendApiBundle\FunctionalB2b\CustomerUser;
 use App\DataFixtures\Demo\CompanyComplaintDataFixture;
 use App\DataFixtures\Demo\CompanyDataFixture;
 use App\DataFixtures\Demo\CompanyOrderDataFixture;
-use App\DataFixtures\Demo\CustomerUserRoleGroupDataFixture;
 use App\Model\Customer\User\CustomerUser;
 use App\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Complaint\Complaint;
 use Shopsys\FrameworkBundle\Model\Complaint\ComplaintResolutionEnum;
-use Shopsys\FrameworkBundle\Model\Customer\User\Role\CustomerUserRoleGroup;
-use Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\Helper\ChangePersonalDataInputProvider;
+use Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\Helper\ChangePersonalAndCompanyDataInputProvider;
 use Tests\FrontendApiBundle\Test\GraphQlB2bDomainWithLoginTestCase;
 
 class CustomerUserSelfManageTest extends GraphQlB2bDomainWithLoginTestCase
@@ -22,13 +20,13 @@ class CustomerUserSelfManageTest extends GraphQlB2bDomainWithLoginTestCase
     protected const string COMPLAINT_EMAIL = 'no-reply@shopsys.com';
 
     /**
-     * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserOwnerTest::testChangePersonalDataMutation()
+     * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserOwnerTest::testChangePersonalAndCompanyDataMutation()
      */
-    public function testChangePersonalDataMutationIsNotAllowed(): void
+    public function testChangeCompanyDataMutationIsNotAllowed(): void
     {
         $response = $this->getResponseContentForGql(
-            __DIR__ . '/../../Functional/Customer/User/graphql/ChangePersonalDataMutation.graphql',
-            ChangePersonalDataInputProvider::INPUT_ARRAY,
+            __DIR__ . '/../_graphql/ChangeCompanyDataMutation.graphql',
+            ChangePersonalAndCompanyDataInputProvider::COMPANY_DATA_INPUT_ARRAY,
         );
 
         $this->assertAccessDeniedError($response);
@@ -59,7 +57,7 @@ class CustomerUserSelfManageTest extends GraphQlB2bDomainWithLoginTestCase
 
     /**
      * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserOwnerTest::testEditAnotherCustomerUserPersonalData()
-     * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserSelfManageTest::testEditSelfCustomerUserPersonalData()
+     * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserSelfManageTest::testEditSelfCustomerUserPersonalDataIsNotAllowed()
      */
     public function testEditAnotherCustomerUserPersonalDataIsNotAllowed(): void
     {
@@ -76,36 +74,15 @@ class CustomerUserSelfManageTest extends GraphQlB2bDomainWithLoginTestCase
      * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserSelfManageTest::testEditAnotherCustomerUserPersonalDataIsNotAllowed()
      * @see \Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\CustomerUserOwnerTest::testEditAnotherCustomerUserPersonalData()
      */
-    public function testEditSelfCustomerUserPersonalData(): void
+    public function testEditSelfCustomerUserPersonalDataIsNotAllowed(): void
     {
         $currentCustomerUser = $this->getCustomerUserByDefaultCredentials();
-        $newRoleGroup = $this->getReference(CustomerUserRoleGroupDataFixture::ROLE_GROUP_USER, CustomerUserRoleGroup::class);
-
-        $editedFirstName = 'Edited first name';
-        $editedLastName = 'Edited last name';
-        $editedTelephone = '001122456';
-        $editedRoleGroupUuid = $newRoleGroup->getUuid();
 
         $response = $this->getResponseContentForGql(__DIR__ . '/../_graphql/EditCustomerUserPersonalDataMutation.graphql', [
             'customerUserUuid' => $currentCustomerUser->getUuid(),
-            'firstName' => $editedFirstName,
-            'lastName' => $editedLastName,
-            'telephone' => $editedTelephone,
-            'roleGroupUuid' => $editedRoleGroupUuid,
         ]);
 
-        $responseData = $this->getResponseDataForGraphQlType($response, 'EditCustomerUserPersonalData');
-
-        $this->assertSame($editedFirstName, $responseData['firstName']);
-        $this->assertSame($editedLastName, $responseData['lastName']);
-        $this->assertSame($editedTelephone, $responseData['telephone']);
-        $this->assertSame($editedRoleGroupUuid, $responseData['roleGroup']['uuid']);
-
-        $refreshedCurrentCustomerUser = $this->customerUserFacade->getCustomerUserById($currentCustomerUser->getId());
-        $this->assertSame($editedFirstName, $refreshedCurrentCustomerUser->getFirstName());
-        $this->assertSame($editedLastName, $refreshedCurrentCustomerUser->getLastName());
-        $this->assertSame($editedTelephone, $refreshedCurrentCustomerUser->getTelephone());
-        $this->assertSame($newRoleGroup->getUuid(), $refreshedCurrentCustomerUser->getRoleGroup()->getUuid());
+        $this->assertAccessDeniedError($response);
     }
 
     /**

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/Helper/ChangePersonalAndCompanyDataInputProvider.php
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/CustomerUser/Helper/ChangePersonalAndCompanyDataInputProvider.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\FrontendApiBundle\FunctionalB2b\CustomerUser\Helper;
 
-class ChangePersonalDataInputProvider
+class ChangePersonalAndCompanyDataInputProvider
 {
     public const array INPUT_ARRAY = [
+        ...self::PERSONAL_DATA_INPUT_ARRAY,
+        ...self::COMPANY_DATA_INPUT_ARRAY,
+    ];
+
+    public const array PERSONAL_DATA_INPUT_ARRAY = [
         'telephone' => '123456321',
         'firstName' => 'John',
         'lastName' => 'Doe',
         'newsletterSubscription' => false,
+    ];
+
+    public const array COMPANY_DATA_INPUT_ARRAY = [
         'street' => '123 Fake street',
         'city' => 'Springfield',
         'country' => 'CZ',

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/_graphql/ChangeCompanyDataMutation.graphql
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/_graphql/ChangeCompanyDataMutation.graphql
@@ -1,8 +1,4 @@
-mutation ChangePersonalDataMutation(
-    $firstName: String!
-    $lastName: String!
-    $telephone: String!
-    $newsletterSubscription: Boolean!
+mutation ChangeCompanyData(
     $street: String!
     $city: String!
     $country: String!
@@ -12,19 +8,6 @@ mutation ChangePersonalDataMutation(
     $companyNumber: String
     $companyTaxNumber: String
 ) {
-    ChangePersonalData(input: {
-        telephone: $telephone
-        firstName: $firstName
-        lastName: $lastName
-        newsletterSubscription: $newsletterSubscription
-    }) {
-        firstName
-        lastName,
-        telephone,
-        email
-        newsletterSubscription
-    }
-
     ChangeCompanyData(input: {
         street: $street
         city: $city

--- a/project-base/app/tests/FrontendApiBundle/FunctionalB2b/_graphql/ChangePersonalDataMutation.graphql
+++ b/project-base/app/tests/FrontendApiBundle/FunctionalB2b/_graphql/ChangePersonalDataMutation.graphql
@@ -1,0 +1,19 @@
+mutation ChangePersonalData(
+    $firstName: String!
+    $lastName: String!
+    $telephone: String!
+    $newsletterSubscription: Boolean!
+) {
+    ChangePersonalData(input: {
+        telephone: $telephone
+        firstName: $firstName
+        lastName: $lastName
+        newsletterSubscription: $newsletterSubscription
+    }) {
+        firstName
+        lastName,
+        telephone,
+        email
+        newsletterSubscription
+    }
+}

--- a/project-base/storefront/components/Blocks/Popup/ManageCustomerUserPopup.tsx
+++ b/project-base/storefront/components/Blocks/Popup/ManageCustomerUserPopup.tsx
@@ -172,7 +172,8 @@ export const ManageCustomerUserPopup: FC<ManageCustomerUserPopupProps> = ({ cust
                                                 (option) => option.value === field.value.value,
                                             )}
                                             isDisabled={
-                                                !canManageCompanyData || (mode === 'edit' && customerUser?.uuid === uuid)
+                                                !canManageCompanyData ||
+                                                (mode === 'edit' && customerUser?.uuid === uuid)
                                             }
                                             onSelectOption={field.onChange}
                                         />

--- a/project-base/storefront/components/Blocks/Popup/ManageCustomerUserPopup.tsx
+++ b/project-base/storefront/components/Blocks/Popup/ManageCustomerUserPopup.tsx
@@ -33,7 +33,7 @@ export const ManageCustomerUserPopup: FC<ManageCustomerUserPopupProps> = ({ cust
     const [, customerEditUser] = useEditCustomerUserPersonalDataMutation();
     const [, customerAddUser] = useAddNewCustomerUserMutation();
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
-    const { canManageProfile, currentCustomerUserUuid: uuid } = useAuthorization();
+    const { canManageCompanyData, currentCustomerUserUuid: uuid } = useAuthorization();
     const customerUserRoleGroupsAsSelectOptions = useCustomerUserGroupsAsSelectOptions();
     const customerUserData = getCustomerUser(customerUser);
 
@@ -172,7 +172,7 @@ export const ManageCustomerUserPopup: FC<ManageCustomerUserPopupProps> = ({ cust
                                                 (option) => option.value === field.value.value,
                                             )}
                                             isDisabled={
-                                                !canManageProfile || (mode === 'edit' && customerUser?.uuid === uuid)
+                                                !canManageCompanyData || (mode === 'edit' && customerUser?.uuid === uuid)
                                             }
                                             onSelectOption={field.onChange}
                                         />

--- a/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsList/ProductListItem.tsx
@@ -6,8 +6,8 @@ import { ProductWishlistButton } from 'components/Blocks/Product/ButtonsAction/P
 import { ProductAction } from 'components/Blocks/Product/ProductAction';
 import { ProductAvailability } from 'components/Blocks/Product/ProductAvailability';
 import { ProductPrice } from 'components/Blocks/Product/ProductPrice';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TIDs } from 'cypress/tids';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
@@ -68,7 +68,7 @@ export const ProductListItem = forwardRef<HTMLLIElement, ProductItemProps>(
     ) => {
         const { url } = useDomainConfig();
         const { t } = useTranslation();
-        const currentCustomerData = useCurrentCustomerData();
+        const { canSeePrices } = useAuthorization();
 
         return (
             <li
@@ -88,13 +88,7 @@ export const ProductListItem = forwardRef<HTMLLIElement, ProductItemProps>(
                     type={product.isMainVariant ? 'productMainVariant' : 'product'}
                     onClickExtended={disableClickWhenTextSelected}
                     onMouseUp={() => {
-                        onGtmProductClickEventHandler(
-                            product,
-                            gtmProductListName,
-                            listIndex,
-                            url,
-                            !!currentCustomerData?.arePricesHidden,
-                        );
+                        onGtmProductClickEventHandler(product, gtmProductListName, listIndex, url, !canSeePrices);
                         onClick?.(product, listIndex);
                     }}
                 >

--- a/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
+++ b/project-base/storefront/components/Blocks/SortingBar/SortingBar.tsx
@@ -2,8 +2,8 @@ import { SortingBarItem } from './SortingBarItem';
 import { SortIcon } from 'components/Basic/Icon/SortIcon';
 import { Overlay } from 'components/Basic/Overlay/Overlay';
 import { Button } from 'components/Forms/Button/Button';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { DEFAULT_SORT } from 'config/constants';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TypeProductOrderingModeEnum } from 'graphql/types';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
@@ -31,8 +31,8 @@ export const SortingBar: FC<SortingBarProps> = ({ sorting, totalCount, customSor
     const asPathWithoutQueryParams = router.asPath.split('?')[0];
     const currentSort = useCurrentSortQuery();
     const updateSort = useUpdateSortQuery();
-    const currentCustomerUser = useCurrentCustomerData();
     const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
+    const { canSeePrices } = useAuthorization();
 
     const sortOptionsLabels = {
         [TypeProductOrderingModeEnum.Priority]: t('Priority'),
@@ -44,7 +44,7 @@ export const SortingBar: FC<SortingBarProps> = ({ sorting, totalCount, customSor
     };
 
     const sortOptions = (customSortOptions || DEFAULT_SORT_OPTIONS).filter((sortOption) =>
-        currentCustomerUser?.arePricesHidden ? !getIsPriceRelatedSortOption(sortOption) : true,
+        !canSeePrices ? !getIsPriceRelatedSortOption(sortOption) : true,
     );
     const selectedSortOption = currentSort || sorting || DEFAULT_SORT;
 

--- a/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserAuthenticatedContent.tsx
+++ b/project-base/storefront/components/Layout/Header/MenuIconic/MenuIconicItemUserAuthenticatedContent.tsx
@@ -14,6 +14,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { twJoin } from 'tailwind-merge';
 import { useLogout } from 'utils/auth/useLogout';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
+import { useUserProfileSectionLabel } from 'utils/user/useUserProfileSectionLabel';
 
 export const MenuIconicItemUserAuthenticatedContent: FC = () => {
     const { t } = useTranslation();
@@ -38,6 +39,7 @@ export const MenuIconicItemUserAuthenticatedContent: FC = () => {
         ],
         url,
     );
+    const userProfileSectionLabel = useUserProfileSectionLabel();
 
     return (
         <>
@@ -98,7 +100,7 @@ export const MenuIconicItemUserAuthenticatedContent: FC = () => {
                         type="editProfile"
                     >
                         <EditIcon className="size-6" />
-                        {t('Edit profile')}
+                        {userProfileSectionLabel}
                     </MenuIconicSubItemLink>
                 </MenuIconicItemUserAuthenticatedContentListItem>
 

--- a/project-base/storefront/components/Pages/Cart/CartPreview.tsx
+++ b/project-base/storefront/components/Pages/Cart/CartPreview.tsx
@@ -21,8 +21,25 @@ export const CartPreview: FC = () => {
         error: t('There was an error while removing the promo code from the order.'),
     });
 
-    if (!cart?.items.length || !isPriceVisible(cart.totalItemsPrice.priceWithVat)) {
+    const buttonContinue = (
+        <Button
+            className="mt-4"
+            size="xlarge"
+            tid={TIDs.blocks_orderaction_next}
+            variant="primary"
+            onClick={goToNextStepFromCartPage}
+        >
+            {t('Continue with order')}
+            <ArrowSecondaryIcon className="size-4 -rotate-90" />
+        </Button>
+    );
+
+    if (!cart?.items.length) {
         return null;
+    }
+
+    if (!isPriceVisible(cart.totalItemsPrice.priceWithVat)) {
+        return buttonContinue;
     }
 
     return (
@@ -73,16 +90,7 @@ export const CartPreview: FC = () => {
                 </span>
             </div>
 
-            <Button
-                className="mt-4"
-                size="xlarge"
-                tid={TIDs.blocks_orderaction_next}
-                variant="primary"
-                onClick={goToNextStepFromCartPage}
-            >
-                {t('Continue with order')}
-                <ArrowSecondaryIcon className="size-4 -rotate-90" />
-            </Button>
+            {buttonContinue}
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/CategoryDetail/CategoryBestsellers/CategoryBestsellersListItem.tsx
+++ b/project-base/storefront/components/Pages/CategoryDetail/CategoryBestsellers/CategoryBestsellersListItem.tsx
@@ -3,8 +3,8 @@ import { ProductAvailability } from 'components/Blocks/Product/ProductAvailabili
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
 import { ProductPrice } from 'components/Blocks/Product/ProductPrice';
 import { ProductListItemImage } from 'components/Blocks/Product/ProductsList/ProductListItemImage';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TIDs } from 'cypress/tids';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
@@ -23,7 +23,7 @@ export const CategoryBestsellersListItem: FC<CategoryBestsellersListItemProps> =
     listIndex,
 }) => {
     const { url } = useDomainConfig();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     const productUrl = (product.__typename === 'Variant' && product.mainVariant?.slug) || product.slug;
 
@@ -33,16 +33,8 @@ export const CategoryBestsellersListItem: FC<CategoryBestsellersListItemProps> =
             draggable={false}
             href={productUrl}
             type={product.__typename === 'RegularProduct' ? 'product' : 'productMainVariant'}
+            onClick={() => onGtmProductClickEventHandler(product, gtmProductListName, listIndex, url, !canSeePrices)}
             onClickExtended={disableClickWhenTextSelected}
-            onClick={() =>
-                onGtmProductClickEventHandler(
-                    product,
-                    gtmProductListName,
-                    listIndex,
-                    url,
-                    !!currentCustomerData?.arePricesHidden,
-                )
-            }
         >
             <div className="flex w-20 shrink-0">
                 <ProductListItemImage

--- a/project-base/storefront/components/Pages/Customer/CustomerContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/CustomerContent.tsx
@@ -13,6 +13,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { twJoin } from 'tailwind-merge';
 import { useLogout } from 'utils/auth/useLogout';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
+import { useUserProfileSectionLabel } from 'utils/user/useUserProfileSectionLabel';
 
 export const CustomerContent: FC = () => {
     const { t } = useTranslation();
@@ -35,6 +36,7 @@ export const CustomerContent: FC = () => {
         ],
         url,
     );
+    const userProfileSectionLabel = useUserProfileSectionLabel();
 
     return (
         <>
@@ -72,7 +74,7 @@ export const CustomerContent: FC = () => {
                     <CustomerListItem>
                         <ExtendedNextLink href={customerEditProfileUrl} type="editProfile">
                             <EditIcon className="mr-5 size-6" />
-                            {t('Edit profile')}
+                            {userProfileSectionLabel}
                         </ExtendedNextLink>
                     </CustomerListItem>
 

--- a/project-base/storefront/components/Pages/Customer/EditProfile/AddressList.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/AddressList.tsx
@@ -3,6 +3,7 @@ import { PhoneIcon } from 'components/Basic/Icon/PhoneIcon';
 import { RemoveIcon } from 'components/Basic/Icon/RemoveIcon';
 import { DeliveryAddressPopup } from 'components/Blocks/Popup/DeliveryAddressPopup';
 import { Button } from 'components/Forms/Button/Button';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDeleteDeliveryAddressMutation } from 'graphql/requests/customer/mutations/DeleteDeliveryAddressMutation.generated';
 import { useSetDefaultDeliveryAddressMutation } from 'graphql/requests/customer/mutations/SetDefaultDeliveryAddressMutation.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
@@ -35,6 +36,7 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
     const [, deleteDeliveryAddress] = useDeleteDeliveryAddressMutation();
     const [, setDefaultDeliveryAddress] = useSetDefaultDeliveryAddressMutation();
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
+    const { canManagePersonalData } = useAuthorization();
 
     const deleteItemHandler = async (deliveryAddressUuid: string | undefined) => {
         if (deliveryAddressUuid === undefined) {
@@ -65,6 +67,9 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
     };
 
     const setDefaultItemHandler = async (deliveryAddressUuid: string) => {
+        if (!canManagePersonalData) {
+            return;
+        }
         if (defaultDeliveryAddress?.uuid === deliveryAddressUuid) {
             return;
         }
@@ -105,7 +110,9 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
                         'relative flex w-full justify-between rounded-md border-2 border-borderAccentLess bg-background p-4',
                         defaultDeliveryAddress?.uuid === address.uuid
                             ? 'border-borderAccent bg-backgroundAccentLess'
-                            : 'cursor-pointer',
+                            : canManagePersonalData
+                              ? 'cursor-pointer'
+                              : '',
                     )}
                     onClick={() => setDefaultItemHandler(address.uuid)}
                 >
@@ -124,24 +131,26 @@ export const AddressList: FC<AddressListProps> = ({ defaultDeliveryAddress, deli
                                 <PhoneIcon className="w-4" />
                             </div>
                         )}
-                        <div className="space-between mt-auto flex gap-2 pt-2">
-                            <Button
-                                className="flex-1"
-                                size="small"
-                                variant="inverted"
-                                onClick={(e) => openDeleteAddressPopup(e, address.uuid)}
-                            >
-                                <RemoveIcon className="size-4" /> {t('Delete')}
-                            </Button>
-                            <Button
-                                className="flex-1"
-                                size="small"
-                                variant="inverted"
-                                onClick={(e) => openDeliveryAddressPopup(e, address)}
-                            >
-                                <EditIcon className="size-4" /> {t('Edit')}
-                            </Button>
-                        </div>
+                        {canManagePersonalData && (
+                            <div className="space-between mt-auto flex gap-2 pt-2">
+                                <Button
+                                    className="flex-1"
+                                    size="small"
+                                    variant="inverted"
+                                    onClick={(e) => openDeleteAddressPopup(e, address.uuid)}
+                                >
+                                    <RemoveIcon className="size-4" /> {t('Delete')}
+                                </Button>
+                                <Button
+                                    className="flex-1"
+                                    size="small"
+                                    variant="inverted"
+                                    onClick={(e) => openDeliveryAddressPopup(e, address)}
+                                >
+                                    <EditIcon className="size-4" /> {t('Edit')}
+                                </Button>
+                            </div>
+                        )}
                     </div>
                 </div>
             ))}

--- a/project-base/storefront/components/Pages/Customer/EditProfile/BillingAddress.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/BillingAddress.tsx
@@ -14,7 +14,7 @@ import { useCountriesAsSelectOptions } from 'utils/countries/useCountriesAsSelec
 
 export const BillingAddress: FC = () => {
     const { t } = useTranslation();
-    const { canManageProfile } = useAuthorization();
+    const { canManageCompanyData } = useAuthorization();
 
     const formProviderMethods = useFormContext<CustomerChangeProfileFormType>();
     const formMeta = useCustomerChangeProfileFormMeta(formProviderMethods);
@@ -47,7 +47,7 @@ export const BillingAddress: FC = () => {
                     required: true,
                     type: 'text',
                     autoComplete: 'street-address',
-                    disabled: !canManageProfile,
+                    disabled: !canManageCompanyData,
                 }}
             />
             <FormColumn>
@@ -61,7 +61,7 @@ export const BillingAddress: FC = () => {
                         required: true,
                         type: 'text',
                         autoComplete: 'address-level2',
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                     }}
                 />
                 <TextInputControlled
@@ -78,7 +78,7 @@ export const BillingAddress: FC = () => {
                         required: true,
                         type: 'text',
                         autoComplete: 'postal-code',
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                     }}
                 />
             </FormColumn>
@@ -89,7 +89,7 @@ export const BillingAddress: FC = () => {
                         <>
                             <Select
                                 isRequired
-                                isDisabled={!canManageProfile}
+                                isDisabled={!canManageCompanyData}
                                 label={formMeta.fields.country.label}
                                 options={countriesAsSelectOptions}
                                 tid={formMeta.formName + '-' + formMeta.fields.country.name}

--- a/project-base/storefront/components/Pages/Customer/EditProfile/CompanyCustomer.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/CompanyCustomer.tsx
@@ -11,7 +11,7 @@ export const CompanyCustomer: FC = () => {
     const { t } = useTranslation();
     const formProviderMethods = useFormContext<CustomerChangeProfileFormType>();
     const formMeta = useCustomerChangeProfileFormMeta(formProviderMethods);
-    const { canManageProfile } = useAuthorization();
+    const { canManageCompanyData } = useAuthorization();
 
     return (
         <FormBlockWrapper>
@@ -27,7 +27,7 @@ export const CompanyCustomer: FC = () => {
                         required: true,
                         type: 'text',
                         autoComplete: 'organization',
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                     }}
                 />
                 <TextInputControlled
@@ -39,7 +39,7 @@ export const CompanyCustomer: FC = () => {
                         label: formMeta.fields.companyNumber.label,
                         required: true,
                         type: 'text',
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                     }}
                 />
                 <TextInputControlled
@@ -51,7 +51,7 @@ export const CompanyCustomer: FC = () => {
                         label: formMeta.fields.companyTaxNumber.label,
                         required: false,
                         type: 'text',
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                     }}
                 />
             </>

--- a/project-base/storefront/components/Pages/Customer/EditProfile/DeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/DeliveryAddress.tsx
@@ -2,6 +2,7 @@ import { AddressList } from './AddressList';
 import { Button } from 'components/Forms/Button/Button';
 import { FormBlockWrapper, FormHeading } from 'components/Forms/Form/Form';
 import { FormLine } from 'components/Forms/Lib/FormLine';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import useTranslation from 'next-translate/useTranslation';
 import dynamic from 'next/dynamic';
 import { useSessionStore } from 'store/useSessionStore';
@@ -21,6 +22,7 @@ type DeliveryAddressProps = {
 
 export const DeliveryAddress: FC<DeliveryAddressProps> = ({ defaultDeliveryAddress, deliveryAddresses }) => {
     const { t } = useTranslation();
+    const { canManagePersonalData } = useAuthorization();
     const updatePortalContent = useSessionStore((s) => s.updatePortalContent);
 
     const openDeliveryAddressPopup = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -32,9 +34,11 @@ export const DeliveryAddress: FC<DeliveryAddressProps> = ({ defaultDeliveryAddre
         <FormBlockWrapper className="border-b-0">
             <FormHeading className="flex justify-between">
                 {t('Delivery addresses')}
-                <Button size="small" variant="inverted" onClick={(e) => openDeliveryAddressPopup(e)}>
-                    {t('Add new address')}
-                </Button>
+                {canManagePersonalData && (
+                    <Button size="small" variant="inverted" onClick={(e) => openDeliveryAddressPopup(e)}>
+                        {t('Add new address')}
+                    </Button>
+                )}
             </FormHeading>
             <FormLine>
                 <AddressList defaultDeliveryAddress={defaultDeliveryAddress} deliveryAddresses={deliveryAddresses} />

--- a/project-base/storefront/components/Pages/Customer/EditProfile/EditProfileContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/EditProfileContent.tsx
@@ -28,7 +28,7 @@ export const EditProfileContent: FC<EditProfileContentProps> = ({ currentCustome
     const { t } = useTranslation();
     const [, customerEditProfile] = useChangePersonalDataMutation();
     const [, companyEditProfile] = useChangeCompanyDataMutation();
-    const { canManageProfile } = useAuthorization();
+    const { canManageCompanyData } = useAuthorization();
 
     const [formProviderMethods] = useCustomerChangeProfileForm({
         ...currentCustomerUser,
@@ -61,7 +61,7 @@ export const EditProfileContent: FC<EditProfileContentProps> = ({ currentCustome
 
         let isCompanyDataChanged = true;
 
-        if (canManageProfile) {
+        if (canManageCompanyData) {
             const changeCompanyDataResult = await companyEditProfile({
                 input: {
                     billingAddressUuid: currentCustomerUser.billingAddressUuid,

--- a/project-base/storefront/components/Pages/Customer/EditProfile/EditProfileContent.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/EditProfileContent.tsx
@@ -28,7 +28,7 @@ export const EditProfileContent: FC<EditProfileContentProps> = ({ currentCustome
     const { t } = useTranslation();
     const [, customerEditProfile] = useChangePersonalDataMutation();
     const [, companyEditProfile] = useChangeCompanyDataMutation();
-    const { canManageCompanyData } = useAuthorization();
+    const { canManageCompanyData, canManagePersonalData } = useAuthorization();
 
     const [formProviderMethods] = useCustomerChangeProfileForm({
         ...currentCustomerUser,
@@ -105,9 +105,11 @@ export const EditProfileContent: FC<EditProfileContentProps> = ({ currentCustome
                         deliveryAddresses={currentCustomerUser.deliveryAddresses}
                     />
 
-                    <FormButtonWrapper className="mt-0 pb-6">
-                        <SubmitButton isDisabled={isSubmitting}>{t('Save profile')}</SubmitButton>
-                    </FormButtonWrapper>
+                    {canManagePersonalData && (
+                        <FormButtonWrapper className="mt-0 pb-6">
+                            <SubmitButton isDisabled={isSubmitting}>{t('Save profile')}</SubmitButton>
+                        </FormButtonWrapper>
+                    )}
                 </FormContentWrapper>
             </Form>
         </FormProvider>

--- a/project-base/storefront/components/Pages/Customer/EditProfile/PersonalData.tsx
+++ b/project-base/storefront/components/Pages/Customer/EditProfile/PersonalData.tsx
@@ -4,6 +4,7 @@ import { FormColumn } from 'components/Forms/Lib/FormColumn';
 import { FormLine } from 'components/Forms/Lib/FormLine';
 import { TextInputControlled } from 'components/Forms/TextInput/TextInputControlled';
 import { useCustomerChangeProfileFormMeta } from 'components/Pages/Customer/EditProfile/customerChangeProfileFormMeta';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import useTranslation from 'next-translate/useTranslation';
 import { useFormContext } from 'react-hook-form';
 import { CustomerChangeProfileFormType } from 'types/form';
@@ -12,6 +13,7 @@ export const PersonalData: FC = () => {
     const { t } = useTranslation();
     const formProviderMethods = useFormContext<CustomerChangeProfileFormType>();
     const formMeta = useCustomerChangeProfileFormMeta(formProviderMethods);
+    const { canManagePersonalData } = useAuthorization();
 
     return (
         <FormBlockWrapper>
@@ -45,6 +47,7 @@ export const PersonalData: FC = () => {
                     textInputProps={{
                         label: formMeta.fields.firstName.label,
                         required: true,
+                        disabled: !canManagePersonalData,
                         type: 'text',
                         autoComplete: 'given-name',
                     }}
@@ -57,6 +60,7 @@ export const PersonalData: FC = () => {
                     textInputProps={{
                         label: formMeta.fields.lastName.label,
                         required: true,
+                        disabled: !canManagePersonalData,
                         type: 'text',
                         autoComplete: 'family-name',
                     }}
@@ -70,6 +74,7 @@ export const PersonalData: FC = () => {
                 textInputProps={{
                     label: formMeta.fields.telephone.label,
                     required: true,
+                    disabled: !canManagePersonalData,
                     type: 'tel',
                     autoComplete: 'tel',
                 }}
@@ -81,6 +86,7 @@ export const PersonalData: FC = () => {
                 render={(checkbox) => <FormLine>{checkbox}</FormLine>}
                 checkboxProps={{
                     label: formMeta.fields.newsletterSubscription.label,
+                    disabled: !canManagePersonalData,
                 }}
             />
         </FormBlockWrapper>

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationAddress.tsx
@@ -19,7 +19,7 @@ export const ContactInformationAddress: FC = () => {
     const formProviderMethods = useFormContext<ContactInformation>();
     const formMeta = useContactInformationFormMeta(formProviderMethods);
     const countriesAsSelectOptions = useCountriesAsSelectOptions();
-    const { canManageProfile } = useAuthorization();
+    const { canManageCompanyData } = useAuthorization();
 
     return (
         <FormBlockWrapper>
@@ -31,7 +31,7 @@ export const ContactInformationAddress: FC = () => {
                     name={formMeta.fields.street.name}
                     render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
                     textInputProps={{
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                         label: formMeta.fields.street.label,
                         required: true,
                         type: 'text',
@@ -47,7 +47,7 @@ export const ContactInformationAddress: FC = () => {
                     name={formMeta.fields.city.name}
                     render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
                     textInputProps={{
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                         label: formMeta.fields.city.label,
                         required: true,
                         type: 'text',
@@ -65,7 +65,7 @@ export const ContactInformationAddress: FC = () => {
                         </FormLine>
                     )}
                     textInputProps={{
-                        disabled: !canManageProfile,
+                        disabled: !canManageCompanyData,
                         label: formMeta.fields.postcode.label,
                         required: true,
                         type: 'text',

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
@@ -36,7 +36,7 @@ export const ContactInformationDeliveryAddress: FC = () => {
     const { canManagePersonalData } = useAuthorization();
 
     const deliveryAddressesRadiobuttons = [
-        ...(user?.deliveryAddresses.map((deliveryAddress) => ({
+        ...(user?.deliveryAddresses.map((deliveryAddress, index) => ({
             label: (
                 <p className="flex flex-col">
                     <strong className="mr-1">
@@ -51,7 +51,7 @@ export const ContactInformationDeliveryAddress: FC = () => {
                 </p>
             ),
             value: deliveryAddress.uuid,
-            id: deliveryAddress.uuid,
+            id: index.toString(),
             labelWrapperClassName: 'flex-row-reverse',
         })) ?? []),
     ];

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationDeliveryAddress.tsx
@@ -8,6 +8,7 @@ import { RadiobuttonGroup } from 'components/Forms/Radiobutton/RadiobuttonGroup'
 import { Select } from 'components/Forms/Select/Select';
 import { TextInputControlled } from 'components/Forms/TextInput/TextInputControlled';
 import { useContactInformationFormMeta } from 'components/Pages/Order/ContactInformation/contactInformationFormMeta';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { AnimatePresence } from 'framer-motion';
 import useTranslation from 'next-translate/useTranslation';
@@ -32,6 +33,41 @@ export const ContactInformationDeliveryAddress: FC = () => {
     const showAddressSelection = !!user?.deliveryAddresses.length && !pickupPlace;
     const countriesAsSelectOptions = useCountriesAsSelectOptions();
     const isNewDeliveryAddressSelected = deliveryAddressUuid === 'new-delivery-address';
+    const { canManagePersonalData } = useAuthorization();
+
+    const deliveryAddressesRadiobuttons = [
+        ...(user?.deliveryAddresses.map((deliveryAddress) => ({
+            label: (
+                <p className="flex flex-col">
+                    <strong className="mr-1">
+                        {deliveryAddress.firstName} {deliveryAddress.lastName}
+                    </strong>
+                    <span>{deliveryAddress.companyName}</span>
+                    <span>{deliveryAddress.telephone}</span>
+                    <span>
+                        {deliveryAddress.street}, {deliveryAddress.city}, {deliveryAddress.postcode}
+                    </span>
+                    <span>{deliveryAddress.country.name}</span>
+                </p>
+            ),
+            value: deliveryAddress.uuid,
+            id: deliveryAddress.uuid,
+            labelWrapperClassName: 'flex-row-reverse',
+        })) ?? []),
+    ];
+
+    if (canManagePersonalData) {
+        deliveryAddressesRadiobuttons.push({
+            label: (
+                <p>
+                    <span className="font-bold">{t('Different delivery address')}</span>
+                </p>
+            ),
+            value: 'new-delivery-address',
+            id: '-new-delivery-address',
+            labelWrapperClassName: 'flex-row-reverse',
+        });
+    }
 
     return (
         <FormBlockWrapper>
@@ -59,36 +95,7 @@ export const ContactInformationDeliveryAddress: FC = () => {
                                     control={formProviderMethods.control}
                                     formName={formMeta.formName}
                                     name={formMeta.fields.deliveryAddressUuid.name}
-                                    radiobuttons={[
-                                        ...user.deliveryAddresses.map((deliveryAddress) => ({
-                                            label: (
-                                                <p className="flex flex-col">
-                                                    <strong className="mr-1">
-                                                        {deliveryAddress.firstName} {deliveryAddress.lastName}
-                                                    </strong>
-                                                    <span>{deliveryAddress.companyName}</span>
-                                                    <span>{deliveryAddress.telephone}</span>
-                                                    <span>
-                                                        {deliveryAddress.street}, {deliveryAddress.city},{' '}
-                                                        {deliveryAddress.postcode}
-                                                    </span>
-                                                    <span>{deliveryAddress.country.name}</span>
-                                                </p>
-                                            ),
-                                            value: deliveryAddress.uuid,
-                                            labelWrapperClassName: 'flex-row-reverse',
-                                        })),
-                                        {
-                                            label: (
-                                                <p>
-                                                    <span className="font-bold">{t('Different delivery address')}</span>
-                                                </p>
-                                            ),
-                                            value: 'new-delivery-address',
-                                            id: '-new-delivery-address',
-                                            labelWrapperClassName: 'flex-row-reverse',
-                                        },
-                                    ]}
+                                    radiobuttons={deliveryAddressesRadiobuttons}
                                     render={(radiobutton, key) => (
                                         <div
                                             key={key}
@@ -105,176 +112,179 @@ export const ContactInformationDeliveryAddress: FC = () => {
                         )}
 
                         <AnimatePresence initial={false}>
-                            {(!user?.deliveryAddresses.length || isNewDeliveryAddressSelected || !!pickupPlace) && (
-                                <AnimateCollapseDiv className="!block" keyName="different-address">
-                                    <FormColumn className="mt-4">
-                                        <TextInputControlled
-                                            control={formProviderMethods.control}
-                                            formName={formMeta.formName}
-                                            name={formMeta.fields.deliveryFirstName.name}
-                                            render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
-                                            textInputProps={{
-                                                label: formMeta.fields.deliveryFirstName.label,
-                                                required: true,
-                                                type: 'text',
-                                                autoComplete: 'given-name',
-                                                onChange: (event) => {
-                                                    updateContactInformation({
-                                                        deliveryFirstName: event.currentTarget.value,
-                                                    });
-                                                },
-                                            }}
-                                        />
-
-                                        <TextInputControlled
-                                            control={formProviderMethods.control}
-                                            formName={formMeta.formName}
-                                            name={formMeta.fields.deliveryLastName.name}
-                                            render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
-                                            textInputProps={{
-                                                label: formMeta.fields.deliveryLastName.label,
-                                                required: true,
-                                                type: 'text',
-                                                autoComplete: 'family-name',
-                                                onChange: (event) =>
-                                                    updateContactInformation({
-                                                        deliveryLastName: event.currentTarget.value,
-                                                    }),
-                                            }}
-                                        />
-                                    </FormColumn>
-
-                                    {!pickupPlace && (
-                                        <TextInputControlled
-                                            control={formProviderMethods.control}
-                                            formName={formMeta.formName}
-                                            name={formMeta.fields.deliveryCompanyName.name}
-                                            render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
-                                            textInputProps={{
-                                                label: formMeta.fields.deliveryCompanyName.label,
-                                                type: 'text',
-                                                autoComplete: 'organization',
-                                                onChange: (event) =>
-                                                    updateContactInformation({
-                                                        deliveryCompanyName: event.currentTarget.value,
-                                                    }),
-                                            }}
-                                        />
-                                    )}
-
-                                    <TextInputControlled
-                                        control={formProviderMethods.control}
-                                        formName={formMeta.formName}
-                                        name={formMeta.fields.deliveryTelephone.name}
-                                        render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
-                                        textInputProps={{
-                                            label: formMeta.fields.deliveryTelephone.label,
-                                            required: true,
-                                            type: 'tel',
-                                            autoComplete: 'tel',
-                                            onChange: (event) =>
-                                                updateContactInformation({
-                                                    deliveryTelephone: event.currentTarget.value,
-                                                }),
-                                        }}
-                                    />
-
-                                    {!pickupPlace && (
-                                        <>
+                            {canManagePersonalData &&
+                                (!user?.deliveryAddresses.length || isNewDeliveryAddressSelected || !!pickupPlace) && (
+                                    <AnimateCollapseDiv className="!block" keyName="different-address">
+                                        <FormColumn className="mt-4">
                                             <TextInputControlled
                                                 control={formProviderMethods.control}
                                                 formName={formMeta.formName}
-                                                name={formMeta.fields.deliveryStreet.name}
+                                                name={formMeta.fields.deliveryFirstName.name}
                                                 render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
                                                 textInputProps={{
-                                                    label: formMeta.fields.deliveryStreet.label,
+                                                    label: formMeta.fields.deliveryFirstName.label,
                                                     required: true,
                                                     type: 'text',
-                                                    autoComplete: 'street-address',
-                                                    onChange: (event) =>
+                                                    autoComplete: 'given-name',
+                                                    onChange: (event) => {
                                                         updateContactInformation({
-                                                            deliveryStreet: event.currentTarget.value,
-                                                        }),
+                                                            deliveryFirstName: event.currentTarget.value,
+                                                        });
+                                                    },
                                                 }}
                                             />
 
-                                            <FormColumn>
+                                            <TextInputControlled
+                                                control={formProviderMethods.control}
+                                                formName={formMeta.formName}
+                                                name={formMeta.fields.deliveryLastName.name}
+                                                render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
+                                                textInputProps={{
+                                                    label: formMeta.fields.deliveryLastName.label,
+                                                    required: true,
+                                                    type: 'text',
+                                                    autoComplete: 'family-name',
+                                                    onChange: (event) =>
+                                                        updateContactInformation({
+                                                            deliveryLastName: event.currentTarget.value,
+                                                        }),
+                                                }}
+                                            />
+                                        </FormColumn>
+
+                                        {!pickupPlace && (
+                                            <TextInputControlled
+                                                control={formProviderMethods.control}
+                                                formName={formMeta.formName}
+                                                name={formMeta.fields.deliveryCompanyName.name}
+                                                render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
+                                                textInputProps={{
+                                                    label: formMeta.fields.deliveryCompanyName.label,
+                                                    type: 'text',
+                                                    autoComplete: 'organization',
+                                                    onChange: (event) =>
+                                                        updateContactInformation({
+                                                            deliveryCompanyName: event.currentTarget.value,
+                                                        }),
+                                                }}
+                                            />
+                                        )}
+
+                                        <TextInputControlled
+                                            control={formProviderMethods.control}
+                                            formName={formMeta.formName}
+                                            name={formMeta.fields.deliveryTelephone.name}
+                                            render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
+                                            textInputProps={{
+                                                label: formMeta.fields.deliveryTelephone.label,
+                                                required: true,
+                                                type: 'tel',
+                                                autoComplete: 'tel',
+                                                onChange: (event) =>
+                                                    updateContactInformation({
+                                                        deliveryTelephone: event.currentTarget.value,
+                                                    }),
+                                            }}
+                                        />
+
+                                        {!pickupPlace && (
+                                            <>
                                                 <TextInputControlled
                                                     control={formProviderMethods.control}
                                                     formName={formMeta.formName}
-                                                    name={formMeta.fields.deliveryCity.name}
+                                                    name={formMeta.fields.deliveryStreet.name}
                                                     render={(textInput) => <FormLine bottomGap>{textInput}</FormLine>}
                                                     textInputProps={{
-                                                        label: formMeta.fields.deliveryCity.label,
+                                                        label: formMeta.fields.deliveryStreet.label,
                                                         required: true,
                                                         type: 'text',
-                                                        autoComplete: 'address-level2',
+                                                        autoComplete: 'street-address',
                                                         onChange: (event) =>
                                                             updateContactInformation({
-                                                                deliveryCity: event.currentTarget.value,
+                                                                deliveryStreet: event.currentTarget.value,
                                                             }),
                                                     }}
                                                 />
 
-                                                <TextInputControlled
-                                                    control={formProviderMethods.control}
-                                                    formName={formMeta.formName}
-                                                    name={formMeta.fields.deliveryPostcode.name}
-                                                    render={(textInput) => (
-                                                        <FormLine bottomGap isSmallInput>
-                                                            {textInput}
-                                                        </FormLine>
-                                                    )}
-                                                    textInputProps={{
-                                                        label: formMeta.fields.deliveryPostcode.label,
-                                                        required: true,
-                                                        type: 'text',
-                                                        autoComplete: 'postal-code',
-                                                        onChange: (event) =>
-                                                            updateContactInformation({
-                                                                deliveryPostcode: event.currentTarget.value,
-                                                            }),
-                                                    }}
-                                                />
-                                            </FormColumn>
+                                                <FormColumn>
+                                                    <TextInputControlled
+                                                        control={formProviderMethods.control}
+                                                        formName={formMeta.formName}
+                                                        name={formMeta.fields.deliveryCity.name}
+                                                        render={(textInput) => (
+                                                            <FormLine bottomGap>{textInput}</FormLine>
+                                                        )}
+                                                        textInputProps={{
+                                                            label: formMeta.fields.deliveryCity.label,
+                                                            required: true,
+                                                            type: 'text',
+                                                            autoComplete: 'address-level2',
+                                                            onChange: (event) =>
+                                                                updateContactInformation({
+                                                                    deliveryCity: event.currentTarget.value,
+                                                                }),
+                                                        }}
+                                                    />
 
-                                            <FormLine>
-                                                <Controller
-                                                    name={formMeta.fields.deliveryCountry.name}
-                                                    render={({ fieldState: { error }, field }) => (
-                                                        <>
-                                                            <Select
-                                                                isRequired
-                                                                label={formMeta.fields.deliveryCountry.label}
-                                                                activeOption={countriesAsSelectOptions.find(
-                                                                    (option) => option.value === field.value.value,
-                                                                )}
-                                                                options={countriesAsSelectOptions.map((option) => ({
-                                                                    ...option,
-                                                                    id: option.value + '-my-id',
-                                                                }))}
-                                                                tid={
-                                                                    formMeta.formName +
-                                                                    '-' +
-                                                                    formMeta.fields.deliveryCountry.name
-                                                                }
-                                                                onSelectOption={(...selectOnChangeEventData) => {
-                                                                    field.onChange(...selectOnChangeEventData);
-                                                                    updateContactInformation({
-                                                                        deliveryCountry:
-                                                                            selectOnChangeEventData[0] as SelectOptionType,
-                                                                    });
-                                                                }}
-                                                            />
-                                                            <FormLineError error={error} inputType="select" />
-                                                        </>
-                                                    )}
-                                                />
-                                            </FormLine>
-                                        </>
-                                    )}
-                                </AnimateCollapseDiv>
-                            )}
+                                                    <TextInputControlled
+                                                        control={formProviderMethods.control}
+                                                        formName={formMeta.formName}
+                                                        name={formMeta.fields.deliveryPostcode.name}
+                                                        render={(textInput) => (
+                                                            <FormLine bottomGap isSmallInput>
+                                                                {textInput}
+                                                            </FormLine>
+                                                        )}
+                                                        textInputProps={{
+                                                            label: formMeta.fields.deliveryPostcode.label,
+                                                            required: true,
+                                                            type: 'text',
+                                                            autoComplete: 'postal-code',
+                                                            onChange: (event) =>
+                                                                updateContactInformation({
+                                                                    deliveryPostcode: event.currentTarget.value,
+                                                                }),
+                                                        }}
+                                                    />
+                                                </FormColumn>
+
+                                                <FormLine>
+                                                    <Controller
+                                                        name={formMeta.fields.deliveryCountry.name}
+                                                        render={({ fieldState: { error }, field }) => (
+                                                            <>
+                                                                <Select
+                                                                    isRequired
+                                                                    label={formMeta.fields.deliveryCountry.label}
+                                                                    activeOption={countriesAsSelectOptions.find(
+                                                                        (option) => option.value === field.value.value,
+                                                                    )}
+                                                                    options={countriesAsSelectOptions.map((option) => ({
+                                                                        ...option,
+                                                                        id: option.value + '-my-id',
+                                                                    }))}
+                                                                    tid={
+                                                                        formMeta.formName +
+                                                                        '-' +
+                                                                        formMeta.fields.deliveryCountry.name
+                                                                    }
+                                                                    onSelectOption={(...selectOnChangeEventData) => {
+                                                                        field.onChange(...selectOnChangeEventData);
+                                                                        updateContactInformation({
+                                                                            deliveryCountry:
+                                                                                selectOnChangeEventData[0] as SelectOptionType,
+                                                                        });
+                                                                    }}
+                                                                />
+                                                                <FormLineError error={error} inputType="select" />
+                                                            </>
+                                                        )}
+                                                    />
+                                                </FormLine>
+                                            </>
+                                        )}
+                                    </AnimateCollapseDiv>
+                                )}
                         </AnimatePresence>
                     </AnimateCollapseDiv>
                 )}

--- a/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationSendOrderButton.tsx
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/FormBlocks/ContactInformationSendOrderButton.tsx
@@ -2,6 +2,7 @@ import { Link, linkPlaceholderTwClass } from 'components/Basic/Link/Link';
 import { CheckboxControlled } from 'components/Forms/Checkbox/CheckboxControlled';
 import { ChoiceFormLine } from 'components/Forms/Lib/ChoiceFormLine';
 import { useContactInformationFormMeta } from 'components/Pages/Order/ContactInformation/contactInformationFormMeta';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useSettingsQuery } from 'graphql/requests/settings/queries/SettingsQuery.generated';
 import Trans from 'next-translate/Trans';
 import { useFormContext, useWatch } from 'react-hook-form';
@@ -12,6 +13,7 @@ import { twJoin } from 'tailwind-merge';
 export const ContactInformationSendOrderButton: FC = () => {
     const formProviderMethods = useFormContext<ContactInformation>();
     const updateContactInformation = usePersistStore((store) => store.updateContactInformation);
+    const { canManagePersonalData } = useAuthorization();
 
     const { formState } = formProviderMethods;
 
@@ -55,18 +57,20 @@ export const ContactInformationSendOrderButton: FC = () => {
                     }}
                 />
             )}
-            <CheckboxControlled
-                control={formProviderMethods.control}
-                formName={formMeta.formName}
-                name={formMeta.fields.newsletterSubscription.name}
-                render={(checkbox) => <ChoiceFormLine>{checkbox}</ChoiceFormLine>}
-                checkboxProps={{
-                    label: formMeta.fields.newsletterSubscription.label,
-                }}
-                onChange={(event) =>
-                    updateContactInformation({ newsletterSubscription: Boolean(event.currentTarget.value) })
-                }
-            />
+            {canManagePersonalData && (
+                <CheckboxControlled
+                    control={formProviderMethods.control}
+                    formName={formMeta.formName}
+                    name={formMeta.fields.newsletterSubscription.name}
+                    render={(checkbox) => <ChoiceFormLine>{checkbox}</ChoiceFormLine>}
+                    checkboxProps={{
+                        label: formMeta.fields.newsletterSubscription.label,
+                    }}
+                    onChange={(event) =>
+                        updateContactInformation({ newsletterSubscription: Boolean(event.currentTarget.value) })
+                    }
+                />
+            )}
         </div>
     );
 };

--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
@@ -7,6 +7,7 @@ import {
     getFormValuesWithoutDeliveryInfo,
     getSelectedDeliveryAddressForLoggedInUser,
 } from './deliveryAddressUtils';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { handleCartModifications } from 'connectors/cart/Cart';
 import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
@@ -211,6 +212,7 @@ const useHandleEventsAfterOrderCreation = () => {
     const { cart, payment, promoCode } = useCurrentCart();
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
     const resetContactInformation = usePersistStore((store) => store.resetContactInformation);
+    const { canSeePrices } = useAuthorization();
 
     const handleEventsAfterOrderCreation = (orderNumber: string) => {
         if (cart && payment) {
@@ -234,7 +236,7 @@ const useHandleEventsAfterOrderCreation = () => {
             onGtmCreateOrderEventHandler(
                 gtmCreateOrderEventOrderPart,
                 gtmCreateOrderEventUserPart,
-                !!user?.arePricesHidden,
+                !canSeePrices,
                 isPaymentSuccessful,
             );
         }

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadItem.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadItem.tsx
@@ -4,8 +4,8 @@ import { Image } from 'components/Basic/Image/Image';
 import { ProductAction } from 'components/Blocks/Product/ProductAction';
 import { ProductFlags } from 'components/Blocks/Product/ProductFlags';
 import { Button } from 'components/Forms/Button/Button';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TypeProductInProductListFragment } from 'graphql/requests/productLists/fragments/ProductInProductListFragment.generated';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
@@ -31,11 +31,11 @@ export const ProductComparisonHeadItem: FC<ProductComparisonItemProps> = ({
     const { t } = useTranslation();
     const { url } = useDomainConfig();
     const { calcMaxMarginLeft } = useComparisonTable(productsCompareCount);
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     const onProductDetailRedirectHandler = useCallback(
         (product: TypeListedProductFragment, listName: GtmProductListNameType, index: number) => {
-            onGtmProductClickEventHandler(product, listName, index, url, !!currentCustomerData?.arePricesHidden);
+            onGtmProductClickEventHandler(product, listName, index, url, !canSeePrices);
         },
         [url],
     );

--- a/project-base/storefront/components/providers/AuthorizationProvider.tsx
+++ b/project-base/storefront/components/providers/AuthorizationProvider.tsx
@@ -23,7 +23,7 @@ export const useAuthorization = () => {
     const isCompanyUser = isB2B && currentCustomerUser?.companyCustomer;
 
     const canManageUsers = isCompanyUser && customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
-    const canManageProfile = !isCompanyUser || customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
+    const canManageCompanyData = !isCompanyUser || customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
 
     const canCreateOrder = isCompanyUser
         ? customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation)
@@ -47,7 +47,7 @@ export const useAuthorization = () => {
         isB2B,
         isCompanyUser,
         canManageUsers,
-        canManageProfile,
+        canManageCompanyData,
         canCreateOrder,
         canViewCompanyOrders,
         canCreateComplaint,

--- a/project-base/storefront/components/providers/AuthorizationProvider.tsx
+++ b/project-base/storefront/components/providers/AuthorizationProvider.tsx
@@ -22,6 +22,7 @@ export const useAuthorization = () => {
     const isB2B = type === CustomerUserAreaEnum.B2B;
     const isCompanyUser = isB2B && currentCustomerUser?.companyCustomer;
 
+    const canSeePrices = customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiCustomerSeesPrices);
     const canManageUsers = isCompanyUser && customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
     const canManageCompanyData = !isCompanyUser || customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
     const canManagePersonalData = customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage);
@@ -54,5 +55,6 @@ export const useAuthorization = () => {
         canViewCompanyOrders,
         canCreateComplaint,
         canViewCompanyComplaints,
+        canSeePrices,
     };
 };

--- a/project-base/storefront/components/providers/AuthorizationProvider.tsx
+++ b/project-base/storefront/components/providers/AuthorizationProvider.tsx
@@ -4,7 +4,7 @@ import { TypeCustomerUserRoleEnum } from 'graphql/types';
 import { createContext, useContext } from 'react';
 import { CustomerUserAreaEnum } from 'types/customer';
 
-export const CustomerUserRolesContext = createContext<TypeCustomerUserRoleEnum[]>([]);
+export const CustomerUserRolesContext = createContext<TypeCustomerUserRoleEnum[] | null>(null);
 
 type AuthorizationProviderProps = {
     customerUserRoles: TypeCustomerUserRoleEnum[];
@@ -17,6 +17,11 @@ export const AuthorizationProvider: FC<AuthorizationProviderProps> = ({ customer
 export const useAuthorization = () => {
     const { type } = useDomainConfig();
     const customerUserRoles = useContext(CustomerUserRolesContext);
+
+    if (!customerUserRoles) {
+        throw new Error(`useAuthorization must be use within AuthorizationProvider`);
+    }
+
     const currentCustomerUser = useCurrentCustomerData();
 
     const isB2B = type === CustomerUserAreaEnum.B2B;

--- a/project-base/storefront/components/providers/AuthorizationProvider.tsx
+++ b/project-base/storefront/components/providers/AuthorizationProvider.tsx
@@ -24,6 +24,7 @@ export const useAuthorization = () => {
 
     const canManageUsers = isCompanyUser && customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
     const canManageCompanyData = !isCompanyUser || customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiAll);
+    const canManagePersonalData = customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiCustomerSelfManage);
 
     const canCreateOrder = isCompanyUser
         ? customerUserRoles.includes(TypeCustomerUserRoleEnum.RoleApiCartAndOrderCreation)
@@ -48,6 +49,7 @@ export const useAuthorization = () => {
         isCompanyUser,
         canManageUsers,
         canManageCompanyData,
+        canManagePersonalData,
         canCreateOrder,
         canViewCompanyOrders,
         canCreateComplaint,

--- a/project-base/storefront/connectors/customer/CurrentCustomer.ts
+++ b/project-base/storefront/connectors/customer/CurrentCustomer.ts
@@ -1,5 +1,5 @@
 import { useCurrentCustomerUserQuery } from 'graphql/requests/customer/queries/CurrentCustomerUserQuery.generated';
-import { TypeCustomerUserRoleEnum, TypeDeliveryAddress } from 'graphql/types';
+import { TypeDeliveryAddress } from 'graphql/types';
 import { CurrentCustomerType, DeliveryAddressType } from 'types/customer';
 
 export const useCurrentCustomerData = (): CurrentCustomerType | undefined => {
@@ -36,7 +36,6 @@ export const useCurrentCustomerData = (): CurrentCustomerType | undefined => {
         oldPassword: '',
         newPassword: '',
         newPasswordConfirm: '',
-        arePricesHidden: !currentCustomerUser.roles.includes(TypeCustomerUserRoleEnum.RoleApiCustomerSeesPrices),
         country: currentCustomerUser.country ?? {
             __typename: 'Country',
             name: '',

--- a/project-base/storefront/gtm/utils/pageViewEvents/productList/useGtmPaginatedProductListViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/productList/useGtmPaginatedProductListViewEvent.ts
@@ -1,6 +1,6 @@
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { DEFAULT_PAGE_SIZE } from 'config/constants';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { useGtmContext } from 'gtm/context/GtmProvider';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
@@ -21,7 +21,7 @@ export const useGtmPaginatedProductListViewEvent = (
     const { url } = useDomainConfig();
     const stringifiedProducts = JSON.stringify(paginatedProducts);
     const { didPageViewRun, isScriptLoaded } = useGtmContext();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     useEffect(() => {
         if (
@@ -45,7 +45,7 @@ export const useGtmPaginatedProductListViewEvent = (
                     currentPage + currentLoadMore,
                     DEFAULT_PAGE_SIZE,
                     url,
-                    !!currentCustomerData?.arePricesHidden,
+                    !canSeePrices,
                 ),
             );
         }

--- a/project-base/storefront/gtm/utils/pageViewEvents/productList/useGtmSliderProductListViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/productList/useGtmSliderProductListViewEvent.ts
@@ -1,5 +1,5 @@
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { useGtmContext } from 'gtm/context/GtmProvider';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
@@ -14,21 +14,12 @@ export const useGtmSliderProductListViewEvent = (
     const wasViewedRef = useRef(false);
     const { url } = useDomainConfig();
     const { didPageViewRun, isScriptLoaded } = useGtmContext();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     useEffect(() => {
         if (isScriptLoaded && didPageViewRun && products?.length && !wasViewedRef.current) {
             wasViewedRef.current = true;
-            gtmSafePushEvent(
-                getGtmProductListViewEvent(
-                    products,
-                    gtmProuctListName,
-                    1,
-                    0,
-                    url,
-                    !!currentCustomerData?.arePricesHidden,
-                ),
-            );
+            gtmSafePushEvent(getGtmProductListViewEvent(products, gtmProuctListName, 1, 0, url, !canSeePrices));
         }
     }, [gtmProuctListName, products, url, didPageViewRun]);
 };

--- a/project-base/storefront/gtm/utils/pageViewEvents/useGtmCartViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/useGtmCartViewEvent.ts
@@ -1,4 +1,4 @@
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useGtmContext } from 'gtm/context/GtmProvider';
 import { getGtmCartViewEvent } from 'gtm/factories/getGtmCartViewEvent';
 import { GtmPageViewEventType } from 'gtm/types/events';
@@ -9,7 +9,7 @@ export const useGtmCartViewEvent = (gtmPageViewEvent: GtmPageViewEventType): voi
     const wasViewedRef = useRef(false);
     const previousPromoCodes = useRef(JSON.stringify(gtmPageViewEvent.cart?.promoCodes));
     const { didPageViewRun, isScriptLoaded } = useGtmContext();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     useEffect(() => {
         if (
@@ -28,7 +28,7 @@ export const useGtmCartViewEvent = (gtmPageViewEvent: GtmPageViewEventType): voi
                     gtmPageViewEvent.cart.valueWithoutVat,
                     gtmPageViewEvent.cart.valueWithVat,
                     gtmPageViewEvent.cart.products,
-                    !!currentCustomerData?.arePricesHidden,
+                    !canSeePrices,
                 ),
             );
         }

--- a/project-base/storefront/gtm/utils/pageViewEvents/useGtmContactInformationPageViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/useGtmContactInformationPageViewEvent.ts
@@ -1,4 +1,4 @@
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useGtmContext } from 'gtm/context/GtmProvider';
 import { getGtmContactInformationPageViewEvent } from 'gtm/factories/getGtmContactInformationPageViewEvent';
 import { GtmPageViewEventType } from 'gtm/types/events';
@@ -8,7 +8,7 @@ import { useEffect, useRef } from 'react';
 export const useGtmContactInformationPageViewEvent = (gtmPageViewEvent: GtmPageViewEventType): void => {
     const wasViewedRef = useRef(false);
     const { didPageViewRun, isScriptLoaded } = useGtmContext();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     useEffect(() => {
         if (
@@ -19,9 +19,7 @@ export const useGtmContactInformationPageViewEvent = (gtmPageViewEvent: GtmPageV
             !wasViewedRef.current
         ) {
             wasViewedRef.current = true;
-            gtmSafePushEvent(
-                getGtmContactInformationPageViewEvent(gtmPageViewEvent.cart, !!currentCustomerData?.arePricesHidden),
-            );
+            gtmSafePushEvent(getGtmContactInformationPageViewEvent(gtmPageViewEvent.cart, !canSeePrices));
         }
     }, [gtmPageViewEvent._isLoaded, gtmPageViewEvent.cart, didPageViewRun]);
 };

--- a/project-base/storefront/gtm/utils/pageViewEvents/useGtmPaymentAndTransportPageViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/useGtmPaymentAndTransportPageViewEvent.ts
@@ -1,4 +1,4 @@
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useGtmContext } from 'gtm/context/GtmProvider';
 import { getGtmTransportAndPaymentPageViewEvent } from 'gtm/factories/getGtmTransportAndPaymentPageViewEvent';
 import { GtmPageViewEventType } from 'gtm/types/events';
@@ -8,7 +8,7 @@ import { useEffect, useRef } from 'react';
 export const useGtmPaymentAndTransportPageViewEvent = (gtmPageViewEvent: GtmPageViewEventType): void => {
     const wasViewedRef = useRef(false);
     const { didPageViewRun, isScriptLoaded } = useGtmContext();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     useEffect(() => {
         if (
@@ -24,7 +24,7 @@ export const useGtmPaymentAndTransportPageViewEvent = (gtmPageViewEvent: GtmPage
                 getGtmTransportAndPaymentPageViewEvent(
                     gtmPageViewEvent.cart.currencyCode,
                     gtmPageViewEvent.cart,
-                    !!currentCustomerData?.arePricesHidden,
+                    !canSeePrices,
                 ),
             );
         }

--- a/project-base/storefront/gtm/utils/pageViewEvents/useGtmProductDetailViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/useGtmProductDetailViewEvent.ts
@@ -1,5 +1,5 @@
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TypeMainVariantDetailFragment } from 'graphql/requests/products/fragments/MainVariantDetailFragment.generated';
 import { TypeProductDetailFragment } from 'graphql/requests/products/fragments/ProductDetailFragment.generated';
 import { useGtmContext } from 'gtm/context/GtmProvider';
@@ -15,19 +15,12 @@ export const useGtmProductDetailViewEvent = (
     const lastViewedProductDetailSlug = useRef<string | undefined>(undefined);
     const { url, currencyCode } = useDomainConfig();
     const { didPageViewRun, isScriptLoaded } = useGtmContext();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     useEffect(() => {
         if (isScriptLoaded && didPageViewRun && lastViewedProductDetailSlug.current !== slug && !isProductFetching) {
             lastViewedProductDetailSlug.current = slug;
-            gtmSafePushEvent(
-                getGtmProductDetailViewEvent(
-                    productDetailData,
-                    currencyCode,
-                    url,
-                    !!currentCustomerData?.arePricesHidden,
-                ),
-            );
+            gtmSafePushEvent(getGtmProductDetailViewEvent(productDetailData, currencyCode, url, !canSeePrices));
         }
     }, [productDetailData, currencyCode, slug, url, isProductFetching, didPageViewRun]);
 };

--- a/project-base/storefront/pages/customer/edit-profile.tsx
+++ b/project-base/storefront/pages/customer/edit-profile.tsx
@@ -7,18 +7,18 @@ import { TypeBreadcrumbFragment } from 'graphql/requests/breadcrumbs/fragments/B
 import { GtmPageType } from 'gtm/enums/GtmPageType';
 import { useGtmStaticPageViewEvent } from 'gtm/factories/useGtmStaticPageViewEvent';
 import { useGtmPageViewEvent } from 'gtm/utils/pageViewEvents/useGtmPageViewEvent';
-import useTranslation from 'next-translate/useTranslation';
 import { getServerSidePropsWrapper } from 'utils/serverSide/getServerSidePropsWrapper';
 import { initServerSideProps } from 'utils/serverSide/initServerSideProps';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
+import { useUserProfileSectionLabel } from 'utils/user/useUserProfileSectionLabel';
 
 const EditProfilePage: FC = () => {
-    const { t } = useTranslation();
     const { url } = useDomainConfig();
     const [customerEditProfileUrl] = getInternationalizedStaticUrls(['/customer', '/customer/edit-profile'], url);
     const currentCustomerUserData = useCurrentCustomerData();
+    const userProfileSectionLabel = useUserProfileSectionLabel();
     const breadcrumbs: TypeBreadcrumbFragment[] = [
-        { __typename: 'Link', name: t('Edit profile'), slug: customerEditProfileUrl },
+        { __typename: 'Link', name: userProfileSectionLabel, slug: customerEditProfileUrl },
     ];
 
     const gtmStaticPageViewEvent = useGtmStaticPageViewEvent(GtmPageType.other, breadcrumbs);
@@ -30,8 +30,8 @@ const EditProfilePage: FC = () => {
             <CustomerLayout
                 breadcrumbs={breadcrumbs}
                 breadcrumbsType="account"
-                pageHeading={t('Edit profile')}
-                title={t('Edit profile')}
+                pageHeading={userProfileSectionLabel}
+                title={userProfileSectionLabel}
             >
                 {currentCustomerUserData !== undefined && (
                     <EditProfileContent currentCustomerUser={currentCustomerUserData} />

--- a/project-base/storefront/public/locales/cs/common.json
+++ b/project-base/storefront/public/locales/cs/common.json
@@ -234,6 +234,7 @@
     "My account": "Můj účet",
     "My complaints": "Moje reklamace",
     "My orders": "Moje objednávky",
+    "My profile": "Moje osobní údaje",
     "Name ascending": "Název A-Z",
     "Name descending": "Název Z-A",
     "Need advice?": "Potřebujete poradit?",

--- a/project-base/storefront/public/locales/en/common.json
+++ b/project-base/storefront/public/locales/en/common.json
@@ -222,6 +222,7 @@
     "My account": "My account",
     "My complaints": "My complaints",
     "My orders": "My orders",
+    "My profile": "My profile",
     "Name ascending": "Name A-Z",
     "Name descending": "Name Z-A",
     "Need advice?": "Need advice?",

--- a/project-base/storefront/public/locales/sk/common.json
+++ b/project-base/storefront/public/locales/sk/common.json
@@ -234,6 +234,7 @@
     "My account": "Môj účet",
     "My complaints": "Moje reklamácie",
     "My orders": "Moje objednávky",
+    "My profile": "",
     "Name ascending": "Názov A-Z",
     "Name descending": "Názov Z-A",
     "Need advice?": "Potrebujete poradiť?",

--- a/project-base/storefront/types/customer.ts
+++ b/project-base/storefront/types/customer.ts
@@ -54,7 +54,6 @@ export type CurrentCustomerType = {
     pricingGroup: string;
     hasPasswordSet: boolean;
     loginInfo: TypeLoginInfo;
-    arePricesHidden: boolean;
     roles: string[];
     roleGroup: TypeCustomerUserRoleGroup;
     salesRepresentative?: TypeSalesRepresentative | null;

--- a/project-base/storefront/utils/cart/useAddToCart.ts
+++ b/project-base/storefront/utils/cart/useAddToCart.ts
@@ -1,5 +1,5 @@
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import {
     TypeAddToCartMutation,
     useAddToCartMutation,
@@ -28,7 +28,7 @@ export const useAddToCart = (gtmMessageOrigin: GtmMessageOriginType, gtmProductL
     const domainConfig = useDomainConfig();
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     const addToCart: AddToCart = async (productUuid, quantity, listIndex, isAbsoluteQuantity = false) => {
         const itemToBeAdded = cart?.items.find((item) => item.product.uuid === productUuid);
@@ -69,7 +69,7 @@ export const useAddToCart = (gtmMessageOrigin: GtmMessageOriginType, gtmProductL
                 listIndex,
                 gtmProductListName,
                 isUserLoggedIn,
-                !!currentCustomerData?.arePricesHidden,
+                !canSeePrices,
             );
         });
 

--- a/project-base/storefront/utils/cart/useChangePaymentInCart.ts
+++ b/project-base/storefront/utils/cart/useChangePaymentInCart.ts
@@ -1,4 +1,4 @@
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { TypeCartFragment } from 'graphql/requests/cart/fragments/CartFragment.generated';
 import { useChangePaymentInCartMutation } from 'graphql/requests/cart/mutations/ChangePaymentInCartMutation.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
@@ -20,7 +20,7 @@ export const useChangePaymentInCart = () => {
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const { t } = useTranslation();
     const { gtmCartInfo } = useGtmCartInfo();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     const gtmCart = useLatest(gtmCartInfo);
 
@@ -57,7 +57,7 @@ export const useChangePaymentInCart = () => {
                 onGtmPaymentChangeEventHandler(
                     gtmCart.current,
                     changePaymentResult.data?.ChangePaymentInCart.payment ?? null,
-                    !!currentCustomerData?.arePricesHidden,
+                    !canSeePrices,
                 );
             });
 

--- a/project-base/storefront/utils/cart/useChangeTransportInCart.ts
+++ b/project-base/storefront/utils/cart/useChangeTransportInCart.ts
@@ -1,4 +1,4 @@
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { TypeCartFragment } from 'graphql/requests/cart/fragments/CartFragment.generated';
 import { useChangeTransportInCartMutation } from 'graphql/requests/cart/mutations/ChangeTransportInCartMutation.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
@@ -20,7 +20,7 @@ export const useChangeTransportInCart = () => {
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const { t } = useTranslation();
     const { gtmCartInfo } = useGtmCartInfo();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     const gtmCart = useLatest(gtmCartInfo);
 
@@ -62,7 +62,7 @@ export const useChangeTransportInCart = () => {
                 changeTransportResult.data?.ChangeTransportInCart.transport ?? null,
                 newPickupPlace,
                 changeTransportResult.data?.ChangeTransportInCart.payment?.name,
-                !!currentCustomerData?.arePricesHidden,
+                !canSeePrices,
             );
         });
 

--- a/project-base/storefront/utils/cart/useRemoveFromCart.ts
+++ b/project-base/storefront/utils/cart/useRemoveFromCart.ts
@@ -1,5 +1,5 @@
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
-import { useCurrentCustomerData } from 'connectors/customer/CurrentCustomer';
 import { TypeCartFragment } from 'graphql/requests/cart/fragments/CartFragment.generated';
 import { TypeCartItemFragment } from 'graphql/requests/cart/fragments/CartItemFragment.generated';
 import { useRemoveFromCartMutation } from 'graphql/requests/cart/mutations/RemoveFromCartMutation.generated';
@@ -18,7 +18,7 @@ export const useRemoveFromCart = (gtmProductListName: GtmProductListNameType) =>
     const { url, currencyCode } = useDomainConfig();
     const cartUuid = usePersistStore((store) => store.cartUuid);
     const { fetchCart } = useCurrentCart();
-    const currentCustomerData = useCurrentCustomerData();
+    const { canSeePrices } = useAuthorization();
 
     const updateCartUuid = usePersistStore((store) => store.updateCartUuid);
 
@@ -41,7 +41,7 @@ export const useRemoveFromCart = (gtmProductListName: GtmProductListNameType) =>
                     listIndex,
                     gtmProductListName,
                     url,
-                    !!currentCustomerData?.arePricesHidden,
+                    !canSeePrices,
                 );
             });
 

--- a/project-base/storefront/utils/user/useUserMenuItems.ts
+++ b/project-base/storefront/utils/user/useUserMenuItems.ts
@@ -12,6 +12,7 @@ import { PageType } from 'store/slices/createPageLoadingStateSlice';
 import { useComparison } from 'utils/productLists/comparison/useComparison';
 import { useWishlist } from 'utils/productLists/wishlist/useWishlist';
 import { getInternationalizedStaticUrls } from 'utils/staticUrls/getInternationalizedStaticUrls';
+import { useUserProfileSectionLabel } from 'utils/user/useUserProfileSectionLabel';
 
 type UserMenuItemType = {
     link: string;
@@ -48,6 +49,7 @@ export const useUserMenuItems = (): UserMenuItemType[] => {
         ],
         url,
     );
+    const userProfileSectionLabel = useUserProfileSectionLabel();
 
     const userMenuItems: UserMenuItemType[] = [];
 
@@ -79,7 +81,7 @@ export const useUserMenuItems = (): UserMenuItemType[] => {
     }
 
     userMenuItems.push({
-        text: t('Edit profile'),
+        text: userProfileSectionLabel,
         link: customerEditProfileUrl,
         type: 'editProfile',
         iconComponent: EditIcon,

--- a/project-base/storefront/utils/user/useUserProfileSectionLabel.ts
+++ b/project-base/storefront/utils/user/useUserProfileSectionLabel.ts
@@ -1,0 +1,9 @@
+import { useAuthorization } from 'components/providers/AuthorizationProvider';
+import useTranslation from 'next-translate/useTranslation';
+
+export const useUserProfileSectionLabel = (): string => {
+    const { t } = useTranslation();
+    const { canManagePersonalData } = useAuthorization();
+
+    return canManagePersonalData ? t('Edit profile') : t('My profile');
+};

--- a/upgrade-notes/backend_20250214_171357.md
+++ b/upgrade-notes/backend_20250214_171357.md
@@ -1,0 +1,4 @@
+#### ROLE_API_CUSTOMER_SELF_MANAGE tweaks ([#3788](https://github.com/shopsys/shopsys/pull/3788))
+
+- `Shopsys\FrontendApiBundle\Voter\CustomerUserVoter::isRoleApiCustomerSelfManageGranted()` was removed
+- see #project-base-diff to update your project

--- a/upgrade-notes/storefront_20250214_171357.md
+++ b/upgrade-notes/storefront_20250214_171357.md
@@ -1,0 +1,8 @@
+#### ROLE_API_CUSTOMER_SELF_MANAGE tweaks ([#3788](https://github.com/shopsys/shopsys/pull/3788))
+
+- `useAuthorization()` now provides new properties `canSeePrices`, `canManageCompanyData`, and `canManagePersonalData` to determine the corresponding permissions
+    - `canManageCompanyData` replaced the former `canManageProfile` property
+    - `canSeePrices` replaced the former `CurrentCustomer.arePricesHidden` type property provided by `useCurrentCustomerData()` hook (beware the reverted value)
+- introduced new `useUserProfileSectionLabel()` hook to provide a label for the user profile section
+    - the label depends on the customer user permissions
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
The role was not restricting users from editing their personal data, that is fixed now:

- `ChangePersonalDataMutation` now requires `ROLE_API_CUSTOMER_SELF_MANAGE`
- delivery address mutations now require `ROLE_API_CUSTOMER_SELF_MANAGE`
- `EditCustomerUserPersonalDataMutation` now always requires `ROLE_API_ALL`
- SF refactoring: use `AuthorizationProvider` to determine whether a customer can see prices
- SF: fix missing "continue" button in cart for users without ROLE_API_CUSTOMER_SEES_PRICES role

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)



































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-self-manage-fix.odin.shopsys.cloud
  - https://cz.rv-self-manage-fix.odin.shopsys.cloud
<!-- Replace -->
