### PR TITLE
Fix autocomplete results GTM event

### DIFF
--- a/project-base/storefront/components/Blocks/Product/DeferredRecommendedProducts.tsx
+++ b/project-base/storefront/components/Blocks/Product/DeferredRecommendedProducts.tsx
@@ -69,6 +69,7 @@ export const DeferredRecommendedProducts: FC<DeferredRecommendedProductsProps> =
             {shouldRender
                 ? render(
                       <ProductsSlider
+                          isLuigisEnabled
                           gtmProductListName={GtmProductListNameType.luigis_box_recommended_products}
                           productItemProps={productItemStyleProps}
                           products={recommendedProductsData.recommendedProducts}

--- a/project-base/storefront/components/Blocks/Product/ProductsSlider.tsx
+++ b/project-base/storefront/components/Blocks/Product/ProductsSlider.tsx
@@ -4,6 +4,7 @@ import { ArrowSecondaryIcon } from 'components/Basic/Icon/ArrowSecondaryIcon';
 import { TypeListedProductFragment } from 'graphql/requests/products/fragments/ListedProductFragment.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { GtmProductListNameType } from 'gtm/enums/GtmProductListNameType';
+import { useGtmSliderProductListViewEvent } from 'gtm/utils/pageViewEvents/productList/useGtmSliderProductListViewEvent';
 import useTranslation from 'next-translate/useTranslation';
 import { RefObject, createRef, useEffect, useRef, useState } from 'react';
 import { useSwipeable } from 'react-swipeable';
@@ -30,6 +31,7 @@ export type ProductsSliderProps = {
     productItemProps?: Partial<ProductItemProps>;
     visibleSliderItems?: number;
     variant?: ProductsSliderVariant;
+    isLuigisEnabled?: boolean;
 };
 
 export const ProductsSlider: FC<ProductsSliderProps> = ({
@@ -42,6 +44,7 @@ export const ProductsSlider: FC<ProductsSliderProps> = ({
     productItemProps,
     visibleSliderItems = VISIBLE_SLIDER_ITEMS,
     variant = 'default',
+    isLuigisEnabled,
 }) => {
     const { t } = useTranslation();
     const sliderRef = useRef<HTMLDivElement>(null);
@@ -131,6 +134,8 @@ export const ProductsSlider: FC<ProductsSliderProps> = ({
                 return '';
         }
     };
+
+    useGtmSliderProductListViewEvent(products, gtmProductListName, isLuigisEnabled);
 
     return (
         <div className="relative" tid={tid}>

--- a/project-base/storefront/gtm/factories/getGtmAutocompleteResultsViewEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmAutocompleteResultsViewEvent.ts
@@ -6,19 +6,21 @@ export const getGtmAutocompleteResultsViewEvent = (
     searchResult: TypeAutocompleteSearchQuery,
     keyword: string,
 ): GtmAutocompleteResultsViewEventType => {
-    const resultsCount =
-        searchResult.categoriesSearch.totalCount +
-        searchResult.productsSearch.totalCount +
-        searchResult.brandSearch.length +
-        searchResult.articlesSearch.length;
+    const category = searchResult.categoriesSearch.edges?.length ?? 0;
+    const product = searchResult.productsSearch.edges?.length ?? 0;
+    const brand = searchResult.brandSearch.length;
+    const article = searchResult.articlesSearch.length;
+
+    const results = category + product + brand + article;
+
     const suggestResult: GtmAutocompleteResultsViewEventType['autocompleteResults'] = {
         keyword,
-        results: resultsCount,
+        results,
         sections: {
-            category: searchResult.categoriesSearch.totalCount,
-            product: searchResult.productsSearch.totalCount,
-            brand: searchResult.brandSearch.length,
-            article: searchResult.articlesSearch.length,
+            category,
+            product,
+            brand,
+            article,
         },
     };
 

--- a/project-base/storefront/gtm/factories/getGtmProductListViewEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmProductListViewEvent.ts
@@ -11,10 +11,12 @@ export const getGtmProductListViewEvent = (
     pageSize: number,
     domainUrl: string,
     arePricesHidden: boolean,
+    isLuigisSlider: boolean = false,
 ): GtmProductListViewEventType => ({
     event: GtmEventType.product_list_view,
     ecommerce: {
         listName: gtmProductListName,
+        LuigiListName: isLuigisSlider ? 'user_click_based' : '',
         products: products.map((product, index) => {
             const listedProductIndex = (currentPageWithLoadMore - 1) * pageSize + index;
 

--- a/project-base/storefront/gtm/types/events.ts
+++ b/project-base/storefront/gtm/types/events.ts
@@ -95,6 +95,7 @@ export type GtmProductListViewEventType = GtmEventInterface<
             listName: GtmProductListNameType;
             products: GtmListedProductType[] | undefined;
             arePricesHidden: boolean;
+            LuigiListName: string;
         };
     }
 >;

--- a/project-base/storefront/gtm/utils/pageViewEvents/productList/useGtmSliderProductListViewEvent.ts
+++ b/project-base/storefront/gtm/utils/pageViewEvents/productList/useGtmSliderProductListViewEvent.ts
@@ -10,6 +10,7 @@ import { useEffect, useRef } from 'react';
 export const useGtmSliderProductListViewEvent = (
     products: TypeListedProductFragment[] | undefined,
     gtmProuctListName: GtmProductListNameType,
+    isLuigisEnabled?: boolean,
 ): void => {
     const wasViewedRef = useRef(false);
     const { url } = useDomainConfig();
@@ -19,7 +20,9 @@ export const useGtmSliderProductListViewEvent = (
     useEffect(() => {
         if (isScriptLoaded && didPageViewRun && products?.length && !wasViewedRef.current) {
             wasViewedRef.current = true;
-            gtmSafePushEvent(getGtmProductListViewEvent(products, gtmProuctListName, 1, 0, url, !canSeePrices));
+            gtmSafePushEvent(
+                getGtmProductListViewEvent(products, gtmProuctListName, 1, 0, url, !canSeePrices, isLuigisEnabled),
+            );
         }
     }, [gtmProuctListName, products, url, didPageViewRun]);
 };

--- a/upgrade-notes/storefront_20250217_090012.md
+++ b/upgrade-notes/storefront_20250217_090012.md
@@ -1,0 +1,5 @@
+#### Fix autocomplete gtm & add list view gtm event ([#3790](https://github.com/shopsys/shopsys/pull/3790))
+
+- autocomplete search result count is now calculated properly
+- all `ProductsSlider` components now send `product_list_view` gtm event, including LB recommended products
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
This PR fixes the sum of all displayed search results in autocomplete. It was moved from using `totalCount` to `length` of the array of edges. Moreover, the GTM event now also contains array of found products as well.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)




















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-gtm-lb-ssp-2983.odin.shopsys.cloud
  - https://cz.jm-gtm-lb-ssp-2983.odin.shopsys.cloud
<!-- Replace -->
