### PR TITLE
fill delivery address data from existing entity

### DIFF
--- a/packages/framework/src/Model/Country/CountryFacade.php
+++ b/packages/framework/src/Model/Country/CountryFacade.php
@@ -116,4 +116,13 @@ class CountryFacade
     {
         return $this->countryRepository->getCount();
     }
+
+    /**
+     * @param string $countryCode
+     * @return \Shopsys\FrameworkBundle\Model\Country\Country
+     */
+    public function getByCode(string $countryCode): Country
+    {
+        return $this->countryRepository->getByCode($countryCode);
+    }
 }

--- a/packages/framework/src/Model/Country/CountryRepository.php
+++ b/packages/framework/src/Model/Country/CountryRepository.php
@@ -128,4 +128,19 @@ class CountryRepository
             ->getQuery()
             ->getSingleScalarResult();
     }
+
+    /**
+     * @param string $countryCode
+     * @return \Shopsys\FrameworkBundle\Model\Country\Country
+     */
+    public function getByCode(string $countryCode): Country
+    {
+        $country = $this->findByCode($countryCode);
+
+        if ($country === null) {
+            throw new CountryNotFoundException('Country with code ' . $countryCode . ' not found.');
+        }
+
+        return $country;
+    }
 }

--- a/packages/frontend-api/src/Model/Country/Exception/CountryNotFoundUserError.php
+++ b/packages/frontend-api/src/Model/Country/Exception/CountryNotFoundUserError.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrontendApiBundle\Model\Country\Exception;
+
+use Shopsys\FrontendApiBundle\Model\Error\EntityNotFoundUserError;
+use Shopsys\FrontendApiBundle\Model\Error\UserErrorWithCodeInterface;
+
+class CountryNotFoundUserError extends EntityNotFoundUserError implements UserErrorWithCodeInterface
+{
+    protected const string CODE = 'country-not-found';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserErrorCode(): string
+    {
+        return static::CODE;
+    }
+}

--- a/packages/frontend-api/src/Model/Mutation/Customer/DeliveryAddress/DeliveryAddressDataApiFactory.php
+++ b/packages/frontend-api/src/Model/Mutation/Customer/DeliveryAddress/DeliveryAddressDataApiFactory.php
@@ -10,16 +10,19 @@ use Shopsys\FrameworkBundle\Model\Country\CountryFacade;
 use Shopsys\FrameworkBundle\Model\Customer\Customer;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressData;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactory;
+use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFacade;
 
 class DeliveryAddressDataApiFactory
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Country\CountryFacade $countryFacade
      * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressDataFactory $deliveryAddressDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFacade $deliveryAddressFacade
      */
     public function __construct(
         protected readonly CountryFacade $countryFacade,
         protected readonly DeliveryAddressDataFactory $deliveryAddressDataFactory,
+        protected readonly DeliveryAddressFacade $deliveryAddressFacade,
     ) {
     }
 
@@ -49,7 +52,21 @@ class DeliveryAddressDataApiFactory
 
         $country = $this->countryFacade->getByCode($input['country']);
 
-        $deliveryAddressData = $this->deliveryAddressDataFactory->create();
+        $deliveryAddressUuid = $input['uuid'];
+        $deliveryAddressData = null;
+
+        if ($deliveryAddressUuid !== null) {
+            $deliveryAddress = $this->deliveryAddressFacade->findByUuidAndCustomer($deliveryAddressUuid, $customer);
+
+            if ($deliveryAddress !== null) {
+                $deliveryAddressData = $this->deliveryAddressDataFactory->createFromDeliveryAddress($deliveryAddress);
+            }
+        }
+
+        if ($deliveryAddressData === null) {
+            $deliveryAddressData = $this->deliveryAddressDataFactory->create();
+        }
+
         $deliveryAddressData->uuid = $input['uuid'];
         $deliveryAddressData->firstName = $input['firstName'];
         $deliveryAddressData->lastName = $input['lastName'];

--- a/packages/frontend-api/src/Model/Mutation/Customer/DeliveryAddress/DeliveryAddressDataApiFactory.php
+++ b/packages/frontend-api/src/Model/Mutation/Customer/DeliveryAddress/DeliveryAddressDataApiFactory.php
@@ -47,7 +47,7 @@ class DeliveryAddressDataApiFactory
             throw new InvalidArgumentException('DeliveryAddressInput is not valid.');
         }
 
-        $country = $this->countryFacade->findByCode($input['country']);
+        $country = $this->countryFacade->getByCode($input['country']);
 
         $deliveryAddressData = $this->deliveryAddressDataFactory->create();
         $deliveryAddressData->uuid = $input['uuid'];

--- a/packages/frontend-api/src/Model/Mutation/Customer/DeliveryAddress/DeliveryAddressMutation.php
+++ b/packages/frontend-api/src/Model/Mutation/Customer/DeliveryAddress/DeliveryAddressMutation.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Shopsys\FrontendApiBundle\Model\Mutation\Customer\DeliveryAddress;
 
 use Overblog\GraphQLBundle\Definition\Argument;
+use Shopsys\FrameworkBundle\Model\Country\Exception\CountryNotFoundException;
 use Shopsys\FrameworkBundle\Model\Customer\DeliveryAddressFacade;
 use Shopsys\FrameworkBundle\Model\Customer\Exception\DeliveryAddressNotFoundException;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUser;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserFacade;
 use Shopsys\FrameworkBundle\Model\Customer\User\CustomerUserUpdateDataFactory;
+use Shopsys\FrontendApiBundle\Model\Country\Exception\CountryNotFoundUserError;
 use Shopsys\FrontendApiBundle\Model\Mutation\BaseTokenMutation;
 use Shopsys\FrontendApiBundle\Model\Mutation\Customer\DeliveryAddress\Exception\DeliveryAddressNotFoundUserError;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -57,8 +59,12 @@ class DeliveryAddressMutation extends BaseTokenMutation
         $user = $this->runCheckUserIsLogged();
         $customerUser = $this->customerUserFacade->getByUuid($user->getUuid());
 
-        $deliveryAddress = $this->deliveryAddressDataApiFactory
-            ->createFromDeliveryInputArgumentAndCustomer($argument, $customerUser->getCustomer());
+        try {
+            $deliveryAddress = $this->deliveryAddressDataApiFactory
+                ->createFromDeliveryInputArgumentAndCustomer($argument, $customerUser->getCustomer());
+        } catch (CountryNotFoundException $e) {
+            throw new CountryNotFoundUserError($e->getMessage());
+        }
 
         $this->deliveryAddressFacade->editByCustomer($customerUser->getCustomer(), $deliveryAddress);
 
@@ -97,8 +103,12 @@ class DeliveryAddressMutation extends BaseTokenMutation
         $user = $this->runCheckUserIsLogged();
         $customerUser = $this->customerUserFacade->getByUuid($user->getUuid());
 
-        $deliveryAddressData = $this->deliveryAddressDataApiFactory
-            ->createFromDeliveryInputArgumentAndCustomer($argument, $customerUser->getCustomer());
+        try {
+            $deliveryAddressData = $this->deliveryAddressDataApiFactory
+                ->createFromDeliveryInputArgumentAndCustomer($argument, $customerUser->getCustomer());
+        } catch (CountryNotFoundException $e) {
+            throw new CountryNotFoundUserError($e->getMessage());
+        }
 
         $deliveryAddressData->addressFilled = true;
         $this->deliveryAddressFacade->createIfAddressFilled($deliveryAddressData);


### PR DESCRIPTION
#### Description, the reason for the PR
In FE API delivery address data are not loaded from DeliveryAddress entity, therefore it might lead to clearing stored data. 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mt-delivery-address-api.odin.shopsys.cloud
  - https://cz.mt-delivery-address-api.odin.shopsys.cloud
<!-- Replace -->
