### PR TITLE
gitlab security check is now dependent on build of storefront

### DIFF
--- a/project-base/.gitlab-ci.yml
+++ b/project-base/.gitlab-ci.yml
@@ -293,6 +293,7 @@ security:check:
         - service
     needs:
         - build
+        - build-storefront
     rules:
         -   if: '$CI_COMMIT_BRANCH == "master" && $CI_PIPELINE_SOURCE != "schedule"'
     script:

--- a/upgrade-notes/backend_20250214_103903.md
+++ b/upgrade-notes/backend_20250214_103903.md
@@ -1,0 +1,3 @@
+#### fix Gitlab security check ([#3800](https://github.com/shopsys/shopsys/pull/3800))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-fix-gitlab-security-check.odin.shopsys.cloud
  - https://cz.tl-fix-gitlab-security-check.odin.shopsys.cloud
<!-- Replace -->
