### PR TITLE
framework: add missing symfony/validator dependency

### DIFF
--- a/packages/framework/composer.json
+++ b/packages/framework/composer.json
@@ -111,6 +111,7 @@
         "symfony/serializer": "^6.4",
         "symfony/service-contracts": "^2.5.2",
         "symfony/ux-icons": "^2.22",
+        "symfony/validator": "^6.4",
         "symfony-cmf/routing": "^3.0.3",
         "symfony-cmf/routing-bundle": "^3.0.3",
         "symfony/polyfill-php80": "^1.24.0",


### PR DESCRIPTION
#### Description, the reason for the PR
We are extending `Symfony\Component\Validator\Test\ConstraintValidatorTestCase` in `Tests\FrameworkBundle\Unit\Component\Constraints\FileExtensionMaxLengthValidatorTest` and the dependency was not declared explicitly in the framework package
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-fix-framework.odin.shopsys.cloud
  - https://cz.rv-fix-framework.odin.shopsys.cloud
<!-- Replace -->
