### PR TITLE
conflicted codeception/codeception 5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -216,6 +216,7 @@
         "zalas/phpunit-injector": "2.5.x-dev as 2.5.1"
     },
     "conflict": {
+        "codeception/codeception": "^5.2.0",
         "symfony/symfony": "*",
         "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0",
         "doctrine/doctrine-migrations-bundle": "3.4.0"

--- a/project-base/app/composer.json
+++ b/project-base/app/composer.json
@@ -139,6 +139,7 @@
         "zalas/phpunit-injector": "2.5.x-dev as 2.5.1"
     },
     "conflict": {
+        "codeception/codeception": "^5.2.0",
         "symfony/symfony": "*",
         "guzzlehttp/psr7": "<=1.8.3 || >=2.0.0 <=2.1.0"
     },

--- a/upgrade-notes/backend_20250217_102248.md
+++ b/upgrade-notes/backend_20250217_102248.md
@@ -1,0 +1,3 @@
+#### conflict codeception/codeception 5.2.0 ([#3806](https://github.com/shopsys/shopsys/pull/3806))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

codeception/codeception 5.2.0 introduced a regression bug with parameter loading. 
A fix is available - https://github.com/Codeception/Codeception/pull/6828, but the version 5.2.0 is broken nevertheless.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-codeception.odin.shopsys.cloud
  - https://cz.mg-fix-codeception.odin.shopsys.cloud
<!-- Replace -->
