### PR TITLE
added support for entity with single domain friendly URL

### DIFF
--- a/docs/introduction/using-form-types.md
+++ b/docs/introduction/using-form-types.md
@@ -169,7 +169,11 @@ Displays select box with all domain names or domain URLs.
 Defaults to `false`.  
 If you set this option to `true`, domain url will be shown instead of domain name.
 
-### [FileUploadType](https://github.com/shopsys/shopsys/blob/HEAD/packages/framework/src/Form/FileUploadType.php)
+#### limit_domains_by_ids
+
+Limits list of displayed domains to provided ids.
+
+### [FileUploadType](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Form/FileUploadType.php)
 
 Uses `AbstractFileUploadType` to display a widget for files upload and to work with them (similar as `ImageUploadType`).
 After a file or files are uploaded it shows box for every file and lets you to downloads, order or delete files.
@@ -219,7 +223,11 @@ Extends `BasicFileUploadType` with additional support for translated file names.
 Displays a select box with domain urls and text field that lets you to create friendly url on selected domain with your valid slug.
 Uses `DomainType` to display select box with domain urls.
 
-### [UrlListType](https://github.com/shopsys/shopsys/blob/HEAD/packages/framework/src/Form/UrlListType.php)
+#### limit_domains_by_ids
+
+Limits list of displayed domains to provided ids.
+
+### [UrlListType](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Form/UrlListType.php)
 
 Uses `FriendlyUrlType` to display a list of friendly URLs for each domain that lets you delete and create friendly URLs with unique slugs and select which URL should be the main for the domain.
 
@@ -231,7 +239,11 @@ Defines which route should the URLs go into.
 
 Defines what is the entity ID that the URLs are assigned to.
 
-### [ImageUploadType](https://github.com/shopsys/shopsys/blob/HEAD/packages/framework/src/Form/ImageUploadType.php)
+#### limit_domains_by_ids
+
+Limits list of displayed domains to provided ids.
+
+### [ImageUploadType](https://github.com/shopsys/shopsys/blob/master/packages/framework/src/Form/ImageUploadType.php)
 
 Uses `AbstractFileUploadType` to display a widget for images upload and to work with them (same as `FileUploadType`).
 

--- a/packages/framework/src/Component/Domain/Domain.php
+++ b/packages/framework/src/Component/Domain/Domain.php
@@ -236,23 +236,31 @@ class Domain implements DomainIdsProviderInterface
     }
 
     /**
+     * @param int[] $limitDomainsByIds
      * @return int[]
      */
-    public function getAdminEnabledDomainIds(): array
+    public function getAdminEnabledDomainIds(array $limitDomainsByIds = []): array
     {
         $selectedDomainIds = $this->administratorFacade->getCurrentlyLoggedAdministrator()->getDisplayOnlyDomainIds();
 
-        return count($selectedDomainIds) > 0 ? $selectedDomainIds : $this->getAllIds();
+        $domainIds = count($selectedDomainIds) > 0 ? $selectedDomainIds : $this->getAllIds();
+
+        if (count($limitDomainsByIds) > 0) {
+            return array_intersect($domainIds, $limitDomainsByIds);
+        }
+
+        return $domainIds;
     }
 
     /**
+     * @param int[] $limitDomainsByIds
      * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
      */
-    public function getAdminEnabledDomains(): array
+    public function getAdminEnabledDomains(array $limitDomainsByIds = []): array
     {
         $domains = [];
 
-        foreach ($this->getAdminEnabledDomainIds() as $selectedDomainId) {
+        foreach ($this->getAdminEnabledDomainIds($limitDomainsByIds) as $selectedDomainId) {
             $domains[$selectedDomainId] = $this->getDomainConfigById($selectedDomainId);
         }
 

--- a/packages/framework/src/Component/Router/FriendlyUrl/Exception/FriendlyUrlIsNotMultidomainException.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/Exception/FriendlyUrlIsNotMultidomainException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception;
+
+use Exception;
+
+class FriendlyUrlIsNotMultidomainException extends Exception
+{
+    /**
+     * @param string $routeName
+     */
+    public function __construct(string $routeName)
+    {
+        parent::__construct('Route "' . $routeName . '" does not support creating URL for multiple domains.');
+    }
+}

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlFactory.php
@@ -6,7 +6,10 @@ namespace Shopsys\FrameworkBundle\Component\Router\FriendlyUrl;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlIsNotMultidomainException;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class FriendlyUrlFactory
 {
@@ -14,11 +17,13 @@ class FriendlyUrlFactory
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver $entityNameResolver
      * @param \Shopsys\FrameworkBundle\Component\String\TransformStringHelper $transformStringHelper
+     * @param \Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory $domainRouterFactory
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly EntityNameResolver $entityNameResolver,
         protected readonly TransformStringHelper $transformStringHelper,
+        protected readonly DomainRouterFactory $domainRouterFactory,
     ) {
     }
 
@@ -78,6 +83,10 @@ class FriendlyUrlFactory
     ): array {
         $friendlyUrls = [];
 
+        if ($this->isRouteMultidomain($routeName) === false) {
+            throw new FriendlyUrlIsNotMultidomainException($routeName);
+        }
+
         foreach ($this->domain->getAll() as $domainConfig) {
             if (array_key_exists($domainConfig->getLocale(), $namesByLocale)) {
                 $friendlyUrl = $this->createIfValid(
@@ -94,5 +103,22 @@ class FriendlyUrlFactory
         }
 
         return $friendlyUrls;
+    }
+
+    /**
+     * @param string $routeName
+     * @return bool
+     */
+    protected function isRouteMultidomain(string $routeName): bool
+    {
+        $friendlyUrlRouter = $this->domainRouterFactory->getFriendlyUrlRouter($this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID));
+        $routeCollection = $friendlyUrlRouter->getRouteCollection();
+        $route = $routeCollection->get($routeName);
+
+        if ($route === null) {
+            throw new RouteNotFoundException('Route "' . $routeName . '" not found.');
+        }
+
+        return $route->getOption('multidomain') ?? true;
     }
 }

--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGeneratorFacade.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrlGeneratorFacade.php
@@ -28,7 +28,7 @@ class FriendlyUrlGeneratorFacade
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
-    public function generateUrlsForSupportedEntities(OutputInterface $output)
+    public function generateUrlsForSupportedEntities(OutputInterface $output): void
     {
         foreach ($this->domain->getAll() as $domainConfig) {
             $output->writeln(' Start of generating friendly urls for domain ' . $domainConfig->getUrl());
@@ -48,12 +48,18 @@ class FriendlyUrlGeneratorFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return int
      */
-    protected function generateUrlsByDomainConfig(OutputInterface $output, DomainConfig $domainConfig)
+    protected function generateUrlsByDomainConfig(OutputInterface $output, DomainConfig $domainConfig): int
     {
         $totalCountOfCreatedUrls = 0;
         $friendlyUrlRouter = $this->domainRouterFactory->getFriendlyUrlRouter($domainConfig);
 
         foreach ($friendlyUrlRouter->getRouteCollection() as $routeName => $route) {
+            $isMultidomain = $route->getOption('multidomain') ?? true;
+
+            if ($isMultidomain === false) {
+                continue;
+            }
+
             $countOfCreatedUrls = $this->generateUrlsByRoute($domainConfig, $routeName);
             $totalCountOfCreatedUrls += $countOfCreatedUrls;
 
@@ -73,7 +79,7 @@ class FriendlyUrlGeneratorFacade
      * @param string $routeName
      * @return int
      */
-    protected function generateUrlsByRoute(DomainConfig $domainConfig, $routeName)
+    protected function generateUrlsByRoute(DomainConfig $domainConfig, string $routeName): int
     {
         $countOfCreatedUrls = 0;
 

--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -51,13 +51,16 @@ class ArticleFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var \Shopsys\FrameworkBundle\Model\Article\Article|null $article */
+        $article = $options['article'];
+
         $seoMetaDescriptionAttributes = $this->getSeoMetaDescriptionAttributes($options);
 
         $builderArticleData = $builder->create('articleData', GroupType::class, [
             'label' => t('Article data'),
         ]);
 
-        if ($options['article'] === null) {
+        if ($article === null) {
             $builderArticleData
                 ->add('domainId', DomainType::class, [
                     'required' => true,
@@ -76,11 +79,11 @@ class ArticleFormType extends AbstractType
         } else {
             $builderArticleData
                 ->add('id', DisplayOnlyType::class, [
-                    'data' => $options['article']->getId(),
+                    'data' => $article->getId(),
                     'label' => t('ID'),
                 ])
                 ->add('domain', DisplayOnlyType::class, [
-                    'data' => $this->domain->getDomainConfigById($options['article']->getDomainId())->getName(),
+                    'data' => $this->domain->getDomainConfigById($article->getDomainId())->getName(),
                     'label' => t('Domain'),
                 ]);
         }
@@ -176,12 +179,13 @@ class ArticleFormType extends AbstractType
                 'label' => t('Heading (H1)'),
             ]);
 
-        if ($options['article'] !== null) {
+        if ($article !== null) {
             $builderSeoData
                 ->add('urls', UrlListType::class, [
                     'label' => t('URL addresses'),
                     'route_name' => 'front_article_detail',
-                    'entity_id' => $options['article']->getId(),
+                    'entity_id' => $article->getId(),
+                    'limit_domains_by_ids' => [$article->getDomainId()],
                 ]);
         }
 
@@ -190,7 +194,7 @@ class ArticleFormType extends AbstractType
             ->add($builderSeoData)
             ->add('actionBar', ActionBarType::class, [
                 'back_route' => 'admin_article_list',
-                'entity' => $options['article'],
+                'entity' => $article,
             ]);
     }
 

--- a/packages/framework/src/Form/Admin/Store/StoreFormType.php
+++ b/packages/framework/src/Form/Admin/Store/StoreFormType.php
@@ -95,6 +95,7 @@ class StoreFormType extends AbstractType
                     'route_name' => StoreFriendlyUrlProvider::ROUTE_NAME,
                     'entity_id' => $store->getId(),
                     'label' => t('URL settings'),
+                    'limit_domains_by_ids' => [$store->getDomainId()],
                 ]);
         }
 
@@ -112,6 +113,7 @@ class StoreFormType extends AbstractType
             ->add('domainId', DomainType::class, [
                 'required' => true,
                 'label' => t('Display on'),
+                'disabled' => $store !== null,
             ])
             ->add('externalId', TextType::class, [
                 'required' => false,

--- a/packages/framework/src/Form/DomainType.php
+++ b/packages/framework/src/Form/DomainType.php
@@ -29,7 +29,7 @@ class DomainType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        $view->vars['domainConfigs'] = $this->getSortedDomainConfigsByAdminDomainTabs();
+        $view->vars['domainConfigs'] = $this->getSortedDomainConfigsByAdminDomainTabs($options['limit_domains_by_ids']);
         $view->vars['displayUrl'] = $options['displayUrl'];
     }
 
@@ -38,22 +38,26 @@ class DomainType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults([
-            'displayUrl' => false,
-        ]);
+        $resolver
+            ->setDefaults([
+                'displayUrl' => false,
+                'limit_domains_by_ids' => [],
+            ])
+            ->setAllowedTypes('limit_domains_by_ids', 'array');
     }
 
     /**
+     * @param int[] $limitDomainsByIds
      * @return \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig[]
      */
-    private function getSortedDomainConfigsByAdminDomainTabs(): array
+    private function getSortedDomainConfigsByAdminDomainTabs(array $limitDomainsByIds): array
     {
         $selectedDomainId = $this->adminDomainTabsFacade->getSelectedDomainId();
 
         $list = [];
         $list[] = $this->adminDomainTabsFacade->getSelectedDomainConfig();
 
-        foreach ($this->domain->getAdminEnabledDomains() as $domainConfig) {
+        foreach ($this->domain->getAdminEnabledDomains($limitDomainsByIds) as $domainConfig) {
             if ($domainConfig->getId() !== $selectedDomainId) {
                 $list[] = $domainConfig;
             }

--- a/packages/framework/src/Form/FriendlyUrlType.php
+++ b/packages/framework/src/Form/FriendlyUrlType.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\UrlListData;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
 class FriendlyUrlType extends AbstractType
@@ -23,7 +24,9 @@ class FriendlyUrlType extends AbstractType
         $builder->add(UrlListData::FIELD_DOMAIN, DomainType::class, [
             'displayUrl' => true,
             'required' => true,
+            'limit_domains_by_ids' => $options['limit_domains_by_ids'],
         ]);
+
         $builder->add(UrlListData::FIELD_SLUG, TextType::class, [
             'required' => true,
             'constraints' => [
@@ -31,5 +34,17 @@ class FriendlyUrlType extends AbstractType
                 new Constraints\Regex(static::SLUG_REGEX),
             ],
         ]);
+    }
+
+    /**
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'limit_domains_by_ids' => [],
+            ])
+            ->setAllowedTypes('limit_domains_by_ids', 'array');
     }
 }

--- a/packages/framework/src/Form/UrlListType.php
+++ b/packages/framework/src/Form/UrlListType.php
@@ -51,6 +51,9 @@ class UrlListType extends AbstractType
             'required' => false,
             'allow_add' => true,
             'error_bubbling' => false,
+            'entry_options' => [
+                'limit_domains_by_ids' => $this->domain->getAdminEnabledDomainIds($options['limit_domains_by_ids']),
+            ],
             'constraints' => [
                 new UniqueSlugsOnDomains(),
             ],
@@ -59,6 +62,7 @@ class UrlListType extends AbstractType
         $friendlyUrlsByDomain = $this->getFriendlyUrlsIndexedByDomain(
             $options['route_name'],
             (int)$options['entity_id'],
+            $options['limit_domains_by_ids'],
         );
 
         foreach ($friendlyUrlsByDomain as $domainId => $friendlyUrls) {
@@ -97,10 +101,12 @@ class UrlListType extends AbstractType
         $absoluteUrlsByDomainIdAndSlug = $this->getAbsoluteUrlsIndexedByDomainIdAndSlug(
             $options['route_name'],
             (int)$options['entity_id'],
+            $options['limit_domains_by_ids'],
         );
         $mainUrlsSlugsOnDomains = $this->getMainFriendlyUrlSlugsIndexedByDomainId(
             $options['route_name'],
             $options['entity_id'],
+            $options['limit_domains_by_ids'],
         );
 
         $view->vars['absoluteUrlsByDomainIdAndSlug'] = $absoluteUrlsByDomainIdAndSlug;
@@ -114,27 +120,31 @@ class UrlListType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->setDefaults([
-            'data_class' => UrlListData::class,
-            'required' => false,
-            'route_name' => null,
-            'entity_id' => null,
-        ]);
+        $resolver
+            ->setDefaults([
+                'data_class' => UrlListData::class,
+                'required' => false,
+                'route_name' => null,
+                'entity_id' => null,
+                'limit_domains_by_ids' => [],
+            ])
+            ->setAllowedTypes('limit_domains_by_ids', 'array');
     }
 
     /**
      * @param string $routeName
      * @param int $entityId
+     * @param array $limitDomainsByIds
      * @return \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl[][]
      */
-    private function getFriendlyUrlsIndexedByDomain(string $routeName, int $entityId): array
+    private function getFriendlyUrlsIndexedByDomain(string $routeName, int $entityId, array $limitDomainsByIds): array
     {
         $friendlyUrlsByDomain = [];
 
         $friendlyUrls = $this->friendlyUrlFacade->getAllByRouteNameDomainIdsAndEntityIds(
             $routeName,
             $entityId,
-            $this->domain->getAdminEnabledDomainIds(),
+            $this->domain->getAdminEnabledDomainIds($limitDomainsByIds),
         );
 
         foreach ($friendlyUrls as $friendlyUrl) {
@@ -147,11 +157,15 @@ class UrlListType extends AbstractType
     /**
      * @param string $routeName
      * @param int $entityId
+     * @param int[] $limitDomainsByIds
      * @return string[][]
      */
-    private function getAbsoluteUrlsIndexedByDomainIdAndSlug(string $routeName, int $entityId): array
-    {
-        $friendlyUrlsByDomain = $this->getFriendlyUrlsIndexedByDomain($routeName, $entityId);
+    private function getAbsoluteUrlsIndexedByDomainIdAndSlug(
+        string $routeName,
+        int $entityId,
+        array $limitDomainsByIds,
+    ): array {
+        $friendlyUrlsByDomain = $this->getFriendlyUrlsIndexedByDomain($routeName, $entityId, $limitDomainsByIds);
         $absoluteUrlsByDomainIdAndSlug = [];
 
         foreach ($friendlyUrlsByDomain as $domainId => $friendlyUrls) {
@@ -174,13 +188,17 @@ class UrlListType extends AbstractType
     /**
      * @param string $routeName
      * @param int|null $entityId
+     * @param array $limitDomainsByIds
      * @return string[]
      */
-    private function getMainFriendlyUrlSlugsIndexedByDomainId(string $routeName, ?int $entityId): array
-    {
+    private function getMainFriendlyUrlSlugsIndexedByDomainId(
+        string $routeName,
+        ?int $entityId,
+        array $limitDomainsByIds,
+    ): array {
         $mainFriendlyUrlsSlugsByDomainId = [];
 
-        foreach ($this->domain->getAdminEnabledDomainIds() as $domainId) {
+        foreach ($this->domain->getAdminEnabledDomainIds($limitDomainsByIds) as $domainId) {
             if ($entityId === null) {
                 $mainFriendlyUrlsSlugsByDomainId[$domainId] = null;
 

--- a/packages/framework/src/Model/Article/ArticleDataFactory.php
+++ b/packages/framework/src/Model/Article/ArticleDataFactory.php
@@ -70,14 +70,12 @@ class ArticleDataFactory
         $articleData->type = $article->getType();
         $articleData->url = $article->getUrl();
 
-        foreach ($this->domain->getAll() as $domainConfig) {
-            $articleData->urls->mainFriendlyUrlsByDomainId[$domainConfig->getId()] =
-                $this->friendlyUrlFacade->findMainFriendlyUrl(
-                    $domainConfig->getId(),
-                    'front_article_detail',
-                    $article->getId(),
-                );
-        }
+        $articleData->urls->mainFriendlyUrlsByDomainId[$article->getDomainId()] =
+            $this->friendlyUrlFacade->findMainFriendlyUrl(
+                $article->getDomainId(),
+                'front_article_detail',
+                $article->getId(),
+            );
     }
 
     /**

--- a/packages/framework/src/Model/Store/Store.php
+++ b/packages/framework/src/Model/Store/Store.php
@@ -156,6 +156,7 @@ class Store implements OrderableEntityInterface
         $this->position = static::GEDMO_SORTABLE_LAST_POSITION;
         $this->uuid = $storeData->uuid ?: Uuid::uuid4()->toString();
         $this->openingHours = new ArrayCollection();
+        $this->domainId = $storeData->domainId;
         $this->setData($storeData);
     }
 
@@ -192,7 +193,6 @@ class Store implements OrderableEntityInterface
         $this->specialMessage = $storeData->specialMessage;
         $this->latitude = $storeData->latitude;
         $this->longitude = $storeData->longitude;
-        $this->domainId = $storeData->domainId;
         $this->email = $storeData->email;
         $this->phone = $storeData->phone;
         $this->directions = $storeData->directions;

--- a/packages/framework/src/Model/Store/StoreDataFactory.php
+++ b/packages/framework/src/Model/Store/StoreDataFactory.php
@@ -65,14 +65,12 @@ class StoreDataFactory
         $storeData->longitude = $store->getLongitude();
         $storeData->image = $this->imageUploadDataFactory->createFromEntityAndType($store);
 
-        foreach ($this->domain->getAllIds() as $domainId) {
-            $mainFriendlyUrl = $this->friendlyUrlFacade->findMainFriendlyUrl(
-                $domainId,
-                StoreFriendlyUrlProvider::ROUTE_NAME,
-                $store->getId(),
-            );
-            $storeData->urls->mainFriendlyUrlsByDomainId[$domainId] = $mainFriendlyUrl;
-        }
+        $mainFriendlyUrl = $this->friendlyUrlFacade->findMainFriendlyUrl(
+            $store->getDomainId(),
+            StoreFriendlyUrlProvider::ROUTE_NAME,
+            $store->getId(),
+        );
+        $storeData->urls->mainFriendlyUrlsByDomainId[$store->getDomainId()] = $mainFriendlyUrl;
 
         return $storeData;
     }

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlFactoryTest.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Tests\FrameworkBundle\Unit\Component\Router\FriendlyUrl;
 
 use DateTimeZone;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
+use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\Exception\FriendlyUrlIsNotMultidomainException;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactory;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Component\String\TransformStringHelper;
@@ -18,17 +21,6 @@ class FriendlyUrlFactoryTest extends TestCase
 {
     public function testCreateForAllDomains()
     {
-        $defaultTimeZone = new DateTimeZone('Europe/Prague');
-        $domainConfigs = [
-            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.cz', 'example.cz', 'cs', $defaultTimeZone),
-            new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.com', 'example.com', 'en', $defaultTimeZone),
-        ];
-        $settingMock = $this->createMock(Setting::class);
-        $administratorFacadeMock = $this->createMock(AdministratorFacade::class);
-        $domain = new Domain($domainConfigs, $settingMock, $administratorFacadeMock);
-
-        $friendlyUrlFactory = new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper());
-
         $routeName = 'route_name';
         $entityId = 7;
         $namesByLocale = [
@@ -36,7 +28,11 @@ class FriendlyUrlFactoryTest extends TestCase
             'en' => 'en-name',
         ];
 
+        $friendlyUrlFactory = $this->getFriendlyUrlFactory();
+        $friendlyUrlFactory->method('isRouteMultidomain')->willReturn(true);
+
         $friendlyUrls = $friendlyUrlFactory->createForAllDomains($routeName, $entityId, $namesByLocale);
+
         $this->assertCount(2, $friendlyUrls);
 
         foreach ($friendlyUrls as $friendlyUrl) {
@@ -49,5 +45,46 @@ class FriendlyUrlFactoryTest extends TestCase
                 $this->assertSame($namesByLocale['en'], $friendlyUrl->getSlug());
             }
         }
+    }
+
+    public function testCreateForAllDomainsFailsForSingleDomainRoute()
+    {
+        $routeName = 'route_name';
+        $entityId = 7;
+        $namesByLocale = [
+            'cs' => 'cs-name',
+            'en' => 'en-name',
+        ];
+
+        $this->expectException(FriendlyUrlIsNotMultidomainException::class);
+
+        $friendlyUrlFactory = $this->getFriendlyUrlFactory();
+        $friendlyUrlFactory->method('isRouteMultidomain')->willReturn(false);
+
+        $friendlyUrlFactory->createForAllDomains($routeName, $entityId, $namesByLocale);
+    }
+
+    /**
+     * @return \Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactory|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getFriendlyUrlFactory(): FriendlyUrlFactory|MockObject
+    {
+        $defaultTimeZone = new DateTimeZone('Europe/Prague');
+        $domainConfigs = [
+            new DomainConfig(Domain::FIRST_DOMAIN_ID, 'http://example.cz', 'example.cz', 'cs', $defaultTimeZone),
+            new DomainConfig(Domain::SECOND_DOMAIN_ID, 'http://example.com', 'example.com', 'en', $defaultTimeZone),
+        ];
+        $settingMock = $this->createMock(Setting::class);
+        $administratorFacadeMock = $this->createMock(AdministratorFacade::class);
+        $domain = new Domain($domainConfigs, $settingMock, $administratorFacadeMock);
+        $domainRouterFactoryMock = $this->createMock(DomainRouterFactory::class);
+
+        $friendlyUrlFactory = $this->getMockBuilder(FriendlyUrlFactory::class)
+            ->setConstructorArgs([$domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryMock])
+            ->onlyMethods(['isRouteMultidomain'])
+            ->getMock();
+
+
+        return $friendlyUrlFactory;
     }
 }

--- a/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
+++ b/packages/framework/tests/Unit/Component/Router/FriendlyUrl/FriendlyUrlUniqueResultFactoryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\EntityExtension\EntityNameResolver;
+use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrl;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlFactory;
 use Shopsys\FrameworkBundle\Component\Router\FriendlyUrl\FriendlyUrlUniqueResultFactory;
@@ -35,9 +36,10 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $administratorFacadeMock = $this->createMock(AdministratorFacade::class);
         $domain = new Domain($this->getDomainConfigs(), $settingMock, $administratorFacadeMock);
+        $domainRouterFactoryMock = $this->createMock(DomainRouterFactory::class);
 
         $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(
-            new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper()),
+            new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryMock),
         );
 
         $attempt = 1;
@@ -59,9 +61,10 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $administratorFacadeMock = $this->createMock(AdministratorFacade::class);
         $domain = new Domain($this->getDomainConfigs(), $settingMock, $administratorFacadeMock);
+        $domainRouterFactoryMock = $this->createMock(DomainRouterFactory::class);
 
         $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(
-            new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper()),
+            new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryMock),
         );
 
         $attempt = 1;
@@ -86,9 +89,10 @@ class FriendlyUrlUniqueResultFactoryTest extends TestCase
         $settingMock = $this->createMock(Setting::class);
         $administratorFacadeMock = $this->createMock(AdministratorFacade::class);
         $domain = new Domain($this->getDomainConfigs(), $settingMock, $administratorFacadeMock);
+        $domainRouterFactoryMock = $this->createMock(DomainRouterFactory::class);
 
         $friendlyUrlUniqueResultFactory = new FriendlyUrlUniqueResultFactory(
-            new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper()),
+            new FriendlyUrlFactory($domain, new EntityNameResolver([]), new TransformStringHelper(), $domainRouterFactoryMock),
         );
 
         $attempt = 3;

--- a/project-base/app/config/shopsys-routing/routing_friendly_url.yaml
+++ b/project-base/app/config/shopsys-routing/routing_friendly_url.yaml
@@ -24,6 +24,8 @@ front_category_seo:
 
 front_stores_detail:
     path: friendly-url
+    options:
+        multidomain: false
 
 front_flag_detail:
     path: friendly-url

--- a/project-base/app/config/shopsys-routing/routing_friendly_url.yaml
+++ b/project-base/app/config/shopsys-routing/routing_friendly_url.yaml
@@ -3,6 +3,8 @@
 
 front_article_detail:
     path: friendly-url
+    options:
+        multidomain: false
 
 front_product_detail:
     path: friendly-url

--- a/upgrade-notes/backend_20250224_105239.md
+++ b/upgrade-notes/backend_20250224_105239.md
@@ -1,0 +1,4 @@
+#### add support for single domain friendly URLs ([#3809](https://github.com/shopsys/shopsys/pull/3809))
+
+- `Article` and `Store` friendly URL addresses are now restricted to only domain selected at the entity. Remove previously created friendly URLs on other domains to clean your application.
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
These form types now have `limit_domains_by_ids` attribute to use it only with selected domain
- UrlListType
- FriendlyUrlType
- DomainType

Friendly URLs now accept `options: multidomain` to define if friendly URLs should be copied to other domains.

Stores now have saved friendly URLS only for one domain.
<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to filter displayed domains by specific IDs across multiple forms, allowing for a more focused selection.
  - Updated store configuration so that the assigned store domain is set during creation and cannot be changed later.
  - Improved URL generation and routing by ensuring consistent handling of single- versus multi-domain routes.

- **Documentation**
  - Updated guidance to reflect the new domain filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-single-domain-url-list.odin.shopsys.cloud
  - https://cz.tl-single-domain-url-list.odin.shopsys.cloud
<!-- Replace -->
