### PR TITLE
Add gtm payment event with storing in localStorage

### DIFF
--- a/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
+++ b/project-base/storefront/components/Pages/Order/ContactInformation/contactInformationUtils.ts
@@ -18,9 +18,12 @@ import {
 } from 'graphql/requests/orders/mutations/CreateOrderMutation.generated';
 import { GtmMessageOriginType } from 'gtm/enums/GtmMessageOriginType';
 import { getGtmCreateOrderEventOrderPart, getGtmCreateOrderEventUserPart } from 'gtm/factories/getGtmCreateOrderEvent';
+import { getGtmPaymentEvent } from 'gtm/factories/getGtmPaymentEvent';
 import { onGtmCreateOrderEventHandler } from 'gtm/handlers/onGtmCreateOrderEventHandler';
+import { onGtmPaymentTryEventHandler } from 'gtm/handlers/onGtmPaymentEventHandler';
 import { getGtmReviewConsents } from 'gtm/utils/getGtmReviewConsents';
 import { saveGtmCreateOrderEventInLocalStorage } from 'gtm/utils/gtmCreateOrderEventLocalStorage';
+import { saveGtmPaymentEventInLocalStorage } from 'gtm/utils/gtmPaymentEventLocalStorage';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 import { OrderConfirmationUrlQuery } from 'pages/order-confirmation';
@@ -225,12 +228,8 @@ const useHandleEventsAfterOrderCreation = () => {
                 domainConfig,
             );
             const gtmCreateOrderEventUserPart = getGtmCreateOrderEventUserPart(user, userContactInformation);
-
+            const gtmPaymentEvent = getGtmPaymentEvent(orderNumber, payment.name, false, -1);
             const isPaymentWithPaymentGate = getIsPaymentWithPaymentGate(payment.type);
-            if (isPaymentWithPaymentGate) {
-                saveGtmCreateOrderEventInLocalStorage(gtmCreateOrderEventOrderPart, gtmCreateOrderEventUserPart);
-            }
-
             const isPaymentSuccessful = isPaymentWithPaymentGate ? undefined : true;
 
             onGtmCreateOrderEventHandler(
@@ -239,6 +238,13 @@ const useHandleEventsAfterOrderCreation = () => {
                 !canSeePrices,
                 isPaymentSuccessful,
             );
+
+            if (isPaymentWithPaymentGate) {
+                saveGtmCreateOrderEventInLocalStorage(gtmCreateOrderEventOrderPart, gtmCreateOrderEventUserPart);
+                saveGtmPaymentEventInLocalStorage(gtmPaymentEvent);
+            } else {
+                onGtmPaymentTryEventHandler(orderNumber, payment.name, true);
+            }
         }
 
         if (cartUuid) {

--- a/project-base/storefront/components/Pages/Order/PaymentConfirmation/paymentConfirmationUtils.ts
+++ b/project-base/storefront/components/Pages/Order/PaymentConfirmation/paymentConfirmationUtils.ts
@@ -1,8 +1,15 @@
 import { useUpdatePaymentStatusMutation } from 'graphql/requests/orders/mutations/UpdatePaymentStatusMutation.generated';
+import { getGtmPaymentEvent } from 'gtm/factories/getGtmPaymentEvent';
 import {
     getGtmCreateOrderEventFromLocalStorage,
     removeGtmCreateOrderEventFromLocalStorage,
 } from 'gtm/utils/gtmCreateOrderEventLocalStorage';
+import {
+    getGtmPaymentEventFromLocalStorage,
+    removeGtmPaymentEventFromLocalStorage,
+    saveGtmPaymentEventInLocalStorage,
+} from 'gtm/utils/gtmPaymentEventLocalStorage';
+import { gtmSafePushEvent } from 'gtm/utils/gtmSafePushEvent';
 import { Translate } from 'next-translate';
 import { useEffect, useRef } from 'react';
 import { CombinedError } from 'urql';
@@ -48,6 +55,24 @@ export const useUpdatePaymentStatus = (orderUuid: string, orderPaymentStatusPage
             wasPaymentStatusUpdatedRef.current = true;
         }
     }, []);
+
+    useEffect(() => {
+        if (paymentStatusData) {
+            const { isPaid, payment, number } = paymentStatusData.UpdatePaymentStatus;
+            const { gtmPaymentEvent } = getGtmPaymentEventFromLocalStorage();
+
+            const retryCount = gtmPaymentEvent ? gtmPaymentEvent.ecommerce.paymentRetryCount + 1 : 0;
+            const newGtmPaymentEvent = getGtmPaymentEvent(number, payment.name, isPaid, retryCount);
+
+            gtmSafePushEvent(newGtmPaymentEvent);
+
+            if (!isPaid) {
+                saveGtmPaymentEventInLocalStorage(newGtmPaymentEvent);
+            } else {
+                removeGtmPaymentEventFromLocalStorage();
+            }
+        }
+    }, [paymentStatusData]);
 
     return paymentStatusData;
 };

--- a/project-base/storefront/components/PaymentsInOrderSelect/PaymentsInOrderSelect.tsx
+++ b/project-base/storefront/components/PaymentsInOrderSelect/PaymentsInOrderSelect.tsx
@@ -56,6 +56,7 @@ export const PaymentsInOrderSelect: FC<PaymentsInOrderSelectProps> = ({
             const changePaymentInOrderData = await changePaymentInOrderHandler(
                 orderUuid,
                 selectedPaymentForChange.uuid,
+                selectedPaymentForChange.name,
                 selectedPaymentSwiftForChange,
                 selectedPaymentForChange.type !== PaymentTypeEnum.GoPay && withRedirectAfterChanging,
             );

--- a/project-base/storefront/components/PaymentsInOrderSelect/paymentInOrderSelectUtils.ts
+++ b/project-base/storefront/components/PaymentsInOrderSelect/paymentInOrderSelectUtils.ts
@@ -1,5 +1,10 @@
 import { useDomainConfig } from 'components/providers/DomainConfigProvider';
 import { useChangePaymentInOrderMutation } from 'graphql/requests/orders/mutations/ChangePaymentInOrderMutation.generated';
+import { onGtmPaymentTryEventHandler } from 'gtm/handlers/onGtmPaymentEventHandler';
+import {
+    getGtmPaymentEventFromLocalStorage,
+    removeGtmPaymentEventFromLocalStorage,
+} from 'gtm/utils/gtmPaymentEventLocalStorage';
 import useTranslation from 'next-translate/useTranslation';
 import { useRouter } from 'next/router';
 import { useIsUserLoggedIn } from 'utils/auth/useIsUserLoggedIn';
@@ -22,6 +27,7 @@ export const useChangePaymentInOrder = () => {
     const changePaymentInOrderHandler = async (
         orderUuid: string,
         paymentUuid: string,
+        paymentName: string,
         paymentGoPayBankSwift?: string | null,
         withRedirectAfterChanging = true,
     ) => {
@@ -42,14 +48,23 @@ export const useChangePaymentInOrder = () => {
             return changePaymentInOrderData;
         }
 
+        let redirectPromise: Promise<boolean>;
+
         if (isUserLoggedIn) {
-            router.push({
+            redirectPromise = router.push({
                 pathname: customerOrderDetailUrl,
                 query: { orderNumber: editedOrder.number },
             });
         } else {
-            router.push(orderByHashUrl + editedOrder.urlHash);
+            redirectPromise = router.push(orderByHashUrl + editedOrder.urlHash);
         }
+
+        redirectPromise.then(() => {
+            const { gtmPaymentEvent } = getGtmPaymentEventFromLocalStorage();
+            const retryCount = gtmPaymentEvent ? gtmPaymentEvent.ecommerce.paymentRetryCount + 1 : 0;
+            onGtmPaymentTryEventHandler(editedOrder.number, paymentName, true, undefined, retryCount);
+            removeGtmPaymentEventFromLocalStorage();
+        });
 
         return changePaymentInOrderData;
     };

--- a/project-base/storefront/graphql/requests/orders/fragments/ChangePaymentInOrderFragment.generated.tsx
+++ b/project-base/storefront/graphql/requests/orders/fragments/ChangePaymentInOrderFragment.generated.tsx
@@ -1,15 +1,8 @@
 import * as Types from '../../../types';
 
 import gql from 'graphql-tag';
-import { ChangePaymentInOrderFragment } from '../fragments/ChangePaymentInOrderFragment.generated';
-import * as Urql from 'urql';
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type TypeChangePaymentInOrderMutationVariables = Types.Exact<{
-  input: Types.TypeChangePaymentInOrderInput;
-}>;
-
-
-export type TypeChangePaymentInOrderMutation = { __typename?: 'Mutation', ChangePaymentInOrder: { __typename: 'Order', urlHash: string, number: string, paymentTransactionsCount: number, payment: { __typename: 'Payment', uuid: string, name: string, description: string | null, instruction: string | null, type: string, price: { __typename: 'Price', priceWithVat: string, priceWithoutVat: string, vatAmount: string }, mainImage: { __typename: 'Image', name: string | null, url: string } | null, goPayPaymentMethod: { __typename: 'GoPayPaymentMethod', identifier: string, name: string, paymentGroup: string } | null } } };
+import { SimplePaymentFragment } from '../../payments/fragments/SimplePaymentFragment.generated';
+export type TypeChangePaymentInOrderFragment = { __typename: 'Order', urlHash: string, number: string, paymentTransactionsCount: number, payment: { __typename: 'Payment', uuid: string, name: string, description: string | null, instruction: string | null, type: string, price: { __typename: 'Price', priceWithVat: string, priceWithoutVat: string, vatAmount: string }, mainImage: { __typename: 'Image', name: string | null, url: string } | null, goPayPaymentMethod: { __typename: 'GoPayPaymentMethod', identifier: string, name: string, paymentGroup: string } | null } };
 
 
       export interface PossibleTypesResultData {
@@ -94,15 +87,14 @@ export type TypeChangePaymentInOrderMutation = { __typename?: 'Mutation', Change
 };
       export default result;
     
-
-export const ChangePaymentInOrderMutationDocument = gql`
-    mutation ChangePaymentInOrderMutation($input: ChangePaymentInOrderInput!) {
-  ChangePaymentInOrder(input: $input) {
-    ...ChangePaymentInOrderFragment
+export const ChangePaymentInOrderFragment = gql`
+    fragment ChangePaymentInOrderFragment on Order {
+  __typename
+  urlHash
+  number
+  paymentTransactionsCount
+  payment {
+    ...SimplePaymentFragment
   }
 }
-    ${ChangePaymentInOrderFragment}`;
-
-export function useChangePaymentInOrderMutation() {
-  return Urql.useMutation<TypeChangePaymentInOrderMutation, TypeChangePaymentInOrderMutationVariables>(ChangePaymentInOrderMutationDocument);
-};
+    ${SimplePaymentFragment}`;

--- a/project-base/storefront/graphql/requests/orders/fragments/ChangePaymentInOrderFragment.graphql
+++ b/project-base/storefront/graphql/requests/orders/fragments/ChangePaymentInOrderFragment.graphql
@@ -1,0 +1,9 @@
+fragment ChangePaymentInOrderFragment on Order {
+    __typename
+    urlHash
+    number
+    paymentTransactionsCount
+    payment {
+        ...SimplePaymentFragment
+    }
+}

--- a/project-base/storefront/graphql/requests/orders/fragments/UpdatePaymentStatusFragment.generated.tsx
+++ b/project-base/storefront/graphql/requests/orders/fragments/UpdatePaymentStatusFragment.generated.tsx
@@ -1,15 +1,7 @@
 import * as Types from '../../../types';
 
 import gql from 'graphql-tag';
-import { ChangePaymentInOrderFragment } from '../fragments/ChangePaymentInOrderFragment.generated';
-import * as Urql from 'urql';
-export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type TypeChangePaymentInOrderMutationVariables = Types.Exact<{
-  input: Types.TypeChangePaymentInOrderInput;
-}>;
-
-
-export type TypeChangePaymentInOrderMutation = { __typename?: 'Mutation', ChangePaymentInOrder: { __typename: 'Order', urlHash: string, number: string, paymentTransactionsCount: number, payment: { __typename: 'Payment', uuid: string, name: string, description: string | null, instruction: string | null, type: string, price: { __typename: 'Price', priceWithVat: string, priceWithoutVat: string, vatAmount: string }, mainImage: { __typename: 'Image', name: string | null, url: string } | null, goPayPaymentMethod: { __typename: 'GoPayPaymentMethod', identifier: string, name: string, paymentGroup: string } | null } } };
+export type TypeUpdatePaymentStatusFragment = { __typename: 'Order', isPaid: boolean, number: string, paymentTransactionsCount: number, hasPaymentInProcess: boolean, urlHash: string, payment: { __typename?: 'Payment', name: string, type: string } };
 
 
       export interface PossibleTypesResultData {
@@ -94,15 +86,17 @@ export type TypeChangePaymentInOrderMutation = { __typename?: 'Mutation', Change
 };
       export default result;
     
-
-export const ChangePaymentInOrderMutationDocument = gql`
-    mutation ChangePaymentInOrderMutation($input: ChangePaymentInOrderInput!) {
-  ChangePaymentInOrder(input: $input) {
-    ...ChangePaymentInOrderFragment
+export const UpdatePaymentStatusFragment = gql`
+    fragment UpdatePaymentStatusFragment on Order {
+  __typename
+  isPaid
+  number
+  paymentTransactionsCount
+  payment {
+    name
+    type
   }
+  hasPaymentInProcess
+  urlHash
 }
-    ${ChangePaymentInOrderFragment}`;
-
-export function useChangePaymentInOrderMutation() {
-  return Urql.useMutation<TypeChangePaymentInOrderMutation, TypeChangePaymentInOrderMutationVariables>(ChangePaymentInOrderMutationDocument);
-};
+    `;

--- a/project-base/storefront/graphql/requests/orders/fragments/UpdatePaymentStatusFragment.graphql
+++ b/project-base/storefront/graphql/requests/orders/fragments/UpdatePaymentStatusFragment.graphql
@@ -1,0 +1,12 @@
+fragment UpdatePaymentStatusFragment on Order {
+    __typename
+    isPaid
+    number
+    paymentTransactionsCount
+    payment {
+        name
+        type
+    }
+    hasPaymentInProcess
+    urlHash
+}

--- a/project-base/storefront/graphql/requests/orders/mutations/ChangePaymentInOrderMutation.graphql
+++ b/project-base/storefront/graphql/requests/orders/mutations/ChangePaymentInOrderMutation.graphql
@@ -1,9 +1,5 @@
 mutation ChangePaymentInOrderMutation($input: ChangePaymentInOrderInput!) {
     ChangePaymentInOrder(input: $input) {
-        urlHash
-        number
-        payment {
-            ...SimplePaymentFragment
-        }
+        ...ChangePaymentInOrderFragment
     }
 }

--- a/project-base/storefront/graphql/requests/orders/mutations/UpdatePaymentStatusMutation.generated.tsx
+++ b/project-base/storefront/graphql/requests/orders/mutations/UpdatePaymentStatusMutation.generated.tsx
@@ -1,6 +1,7 @@
 import * as Types from '../../../types';
 
 import gql from 'graphql-tag';
+import { UpdatePaymentStatusFragment } from '../fragments/UpdatePaymentStatusFragment.generated';
 import * as Urql from 'urql';
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type TypeUpdatePaymentStatusMutationVariables = Types.Exact<{
@@ -9,7 +10,7 @@ export type TypeUpdatePaymentStatusMutationVariables = Types.Exact<{
 }>;
 
 
-export type TypeUpdatePaymentStatusMutation = { __typename?: 'Mutation', UpdatePaymentStatus: { __typename?: 'Order', isPaid: boolean, paymentTransactionsCount: number, hasPaymentInProcess: boolean, urlHash: string, payment: { __typename?: 'Payment', type: string } } };
+export type TypeUpdatePaymentStatusMutation = { __typename?: 'Mutation', UpdatePaymentStatus: { __typename: 'Order', isPaid: boolean, number: string, paymentTransactionsCount: number, hasPaymentInProcess: boolean, urlHash: string, payment: { __typename?: 'Payment', name: string, type: string } } };
 
 
       export interface PossibleTypesResultData {
@@ -101,16 +102,10 @@ export const UpdatePaymentStatusMutationDocument = gql`
     orderUuid: $orderUuid
     orderPaymentStatusPageValidityHash: $orderPaymentStatusPageValidityHash
   ) {
-    isPaid
-    paymentTransactionsCount
-    payment {
-      type
-    }
-    hasPaymentInProcess
-    urlHash
+    ...UpdatePaymentStatusFragment
   }
 }
-    `;
+    ${UpdatePaymentStatusFragment}`;
 
 export function useUpdatePaymentStatusMutation() {
   return Urql.useMutation<TypeUpdatePaymentStatusMutation, TypeUpdatePaymentStatusMutationVariables>(UpdatePaymentStatusMutationDocument);

--- a/project-base/storefront/graphql/requests/orders/mutations/UpdatePaymentStatusMutation.graphql
+++ b/project-base/storefront/graphql/requests/orders/mutations/UpdatePaymentStatusMutation.graphql
@@ -1,11 +1,5 @@
 mutation UpdatePaymentStatusMutation($orderUuid: Uuid!, $orderPaymentStatusPageValidityHash: String = null) {
     UpdatePaymentStatus(orderUuid: $orderUuid, orderPaymentStatusPageValidityHash: $orderPaymentStatusPageValidityHash) {
-        isPaid
-        paymentTransactionsCount
-        payment {
-            type
-        }
-        hasPaymentInProcess
-        urlHash
+        ...UpdatePaymentStatusFragment
     }
 }

--- a/project-base/storefront/gtm/enums/GtmEventType.ts
+++ b/project-base/storefront/gtm/enums/GtmEventType.ts
@@ -12,6 +12,7 @@ export enum GtmEventType {
     autocomplete_result_click = 'ec.autocomplete_result_click',
     transport_change = 'ec.transport_change',
     contact_information_page_view = 'ec.contact_information_view',
+    payment = 'ec.payment',
     payment_change = 'ec.payment_change',
     payment_fail = 'ec.payment_fail',
     create_order = 'ec.create_order',

--- a/project-base/storefront/gtm/factories/getGtmPaymentEvent.ts
+++ b/project-base/storefront/gtm/factories/getGtmPaymentEvent.ts
@@ -1,0 +1,20 @@
+import { GtmEventType } from 'gtm/enums/GtmEventType';
+import { GtmPaymentEventType } from 'gtm/types/events';
+
+export const getGtmPaymentEvent = (
+    orderNumber: string,
+    paymentName: string,
+    isPaymentSuccessful: boolean,
+    paymentRetryCount: number,
+    paymentFalseReason?: string,
+): GtmPaymentEventType => ({
+    event: GtmEventType.payment,
+    ecommerce: {
+        id: orderNumber,
+        isPaymentSuccessful,
+        paymentRetryCount,
+        PaymentFalseReason: paymentFalseReason,
+        paymentType: paymentName,
+    },
+    _clear: true,
+});

--- a/project-base/storefront/gtm/handlers/onGtmPaymentEventHandler.ts
+++ b/project-base/storefront/gtm/handlers/onGtmPaymentEventHandler.ts
@@ -1,0 +1,20 @@
+import { getGtmPaymentEvent } from 'gtm/factories/getGtmPaymentEvent';
+import { gtmSafePushEvent } from 'gtm/utils/gtmSafePushEvent';
+
+export const onGtmPaymentTryEventHandler = (
+    orderNumber: string,
+    paymentName: string,
+    isPaymentSuccessful?: boolean,
+    paymentFalseReason?: string,
+    paymentRetryCount: number = 0,
+): void => {
+    gtmSafePushEvent(
+        getGtmPaymentEvent(
+            orderNumber,
+            paymentName,
+            isPaymentSuccessful === undefined ? true : isPaymentSuccessful,
+            paymentRetryCount,
+            paymentFalseReason,
+        ),
+    );
+};

--- a/project-base/storefront/gtm/types/events.ts
+++ b/project-base/storefront/gtm/types/events.ts
@@ -193,6 +193,19 @@ export type GtmContactInformationPageViewEventType = GtmEventInterface<
     }
 >;
 
+export type GtmPaymentEventType = GtmEventInterface<
+    GtmEventType.payment,
+    {
+        ecommerce: {
+            id: string;
+            isPaymentSuccessful: boolean;
+            paymentRetryCount: number;
+            PaymentFalseReason?: string | null;
+            paymentType: string;
+        };
+    }
+>;
+
 export type GtmPaymentChangeEventType = GtmEventInterface<
     GtmEventType.payment_change,
     {

--- a/project-base/storefront/gtm/utils/gtmPaymentEventLocalStorage.ts
+++ b/project-base/storefront/gtm/utils/gtmPaymentEventLocalStorage.ts
@@ -1,0 +1,42 @@
+import { compressObjectToString, decompressStringToObject } from './objectCompression';
+import { GtmPaymentEventType } from 'gtm/types/events';
+import { isClient } from 'utils/isClient';
+
+const GTM_PAYMENT_OBJECT_LOCAL_STORAGE_KEY = 'gtmPaymentEvent' as const;
+
+export const saveGtmPaymentEventInLocalStorage = (gtmPaymentEventOrder: GtmPaymentEventType): void => {
+    if (!isClient) {
+        return;
+    }
+    const stringifiedGtmCreateOrderEvent = JSON.stringify(compressObjectToString(gtmPaymentEventOrder));
+
+    localStorage.setItem(GTM_PAYMENT_OBJECT_LOCAL_STORAGE_KEY, stringifiedGtmCreateOrderEvent);
+};
+
+export const getGtmPaymentEventFromLocalStorage = (): {
+    gtmPaymentEvent: GtmPaymentEventType | undefined;
+} => {
+    if (!isClient) {
+        return { gtmPaymentEvent: undefined };
+    }
+
+    const stringifiedGtmPaymentEvent = localStorage.getItem(GTM_PAYMENT_OBJECT_LOCAL_STORAGE_KEY);
+
+    if (stringifiedGtmPaymentEvent === null) {
+        return { gtmPaymentEvent: undefined };
+    }
+
+    const parsedGtmPaymentEvent = JSON.parse(stringifiedGtmPaymentEvent);
+
+    return {
+        gtmPaymentEvent: decompressStringToObject(parsedGtmPaymentEvent),
+    };
+};
+
+export const removeGtmPaymentEventFromLocalStorage = (): void => {
+    if (!isClient) {
+        return;
+    }
+
+    localStorage.removeItem(GTM_PAYMENT_OBJECT_LOCAL_STORAGE_KEY);
+};

--- a/upgrade-notes/storefront_20250220_080503.md
+++ b/upgrade-notes/storefront_20250220_080503.md
@@ -1,0 +1,7 @@
+#### Add gtm payment event & store it in localStorage ([#3814](https://github.com/shopsys/shopsys/pull/3814))
+
+- `payment` event is fired after each payment attempt
+- info about the order payment (namely `orderNumber` and `paymentRetryCount`) is stored to `localStorage` to preserve it for multiple future steps
+- `paymentRetryCount` needs to be manually incremented after each payment try and saved again to `localStorage`
+- be aware that `paymentTransactionsCount` is not valid for this use-case as it only carries info about the retry count for the specific payment type, whereas we need the retry count of payments for the **whole** order (which is not implemented on the BE)
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
To improve the GTM, new `payment` event was added. It is fired with each payment attempt and contains useful information about the payment.

Moreover, the `payment_change` event is now fired even on the `order-payment-confirmation` or `order-detail` page when changing payments after failed payment attempt.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
































<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-gtm-change-payment-ssp-2834.odin.shopsys.cloud
  - https://cz.jm-gtm-change-payment-ssp-2834.odin.shopsys.cloud
<!-- Replace -->
