### PR TITLE
Fix cart & missing whishlist/comparison products after external login

### DIFF
--- a/packages/frontend-api/src/Controller/CustomerUserController.php
+++ b/packages/frontend-api/src/Controller/CustomerUserController.php
@@ -31,6 +31,7 @@ class CustomerUserController extends AdminBaseController
             return $this->render('@ShopsysFrontendApi/Admin/Content/Login/loginAsCustomerUser.html.twig', [
                 'tokens' => $this->loginAsUserFacade->loginAdministratorAsCustomerUserAndGetAccessAndRefreshToken($customerUserId),
                 'url' => $this->generateUrl('front_homepage', [], UrlGeneratorInterface::ABSOLUTE_URL),
+                'showCartMergeInfo' => 'false',
             ]);
         } catch (CustomerUserNotFoundException) {
             $this->addErrorFlash(t('Customer not found.'));

--- a/packages/frontend-api/src/Controller/SocialNetworkController.php
+++ b/packages/frontend-api/src/Controller/SocialNetworkController.php
@@ -68,6 +68,7 @@ class SocialNetworkController extends AbstractController
                     $loginResultData->showCartMergeInfo,
                     $loginResultData->isRegistration,
                 ),
+                'showCartMergeInfo' => $loginResultData->showCartMergeInfo ? 'true' : 'false',
             ]);
         } catch (SocialNetworkLoginException $exception) {
             return $this->redirect($this->getRefererUrl($request, $type, true));

--- a/packages/frontend-api/src/Resources/views/Admin/Content/Login/loginAsCustomerUser.html.twig
+++ b/packages/frontend-api/src/Resources/views/Admin/Content/Login/loginAsCustomerUser.html.twig
@@ -4,9 +4,14 @@
 
     date.setTime(date.getTime() + 14 * 24 * 60 * 60 * 1000); // 14 days
 
-    document.cookie = 'accessToken=' + '{{ tokens.accessToken }}' + '; secure; path=/';
     document.cookie =
-        'refreshToken=' + '{{ tokens.refreshToken }}' + '; expires=' + date.toUTCString() + '; secure; path=/';
+        'accessToken=' + '{{ tokens.accessToken }}' + ";{{ app.request.scheme == 'https' ? ' secure;' }} path=/";
+    document.cookie =
+        'refreshToken=' +
+        '{{ tokens.refreshToken }}' +
+        '; expires=' +
+        date.toUTCString() +
+        ";{{ app.request.scheme == 'https' ? ' secure;' }} path=/";
 
     if (window.localStorage) {
         const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);

--- a/packages/frontend-api/src/Resources/views/Admin/Content/Login/loginAsCustomerUser.html.twig
+++ b/packages/frontend-api/src/Resources/views/Admin/Content/Login/loginAsCustomerUser.html.twig
@@ -1,9 +1,28 @@
 <script type="text/javascript">
     var date = new Date();
+    const PERSIST_STORE_NAME = 'shopsys-platform-persist-store';
+
     date.setTime(date.getTime() + 14 * 24 * 60 * 60 * 1000); // 14 days
 
-    document.cookie = "accessToken=" + "{{ tokens.accessToken }}" + "; secure; path=/";
-    document.cookie = "refreshToken=" + "{{ tokens.refreshToken }}"  + "; expires=" + date.toUTCString() + "; secure; path=/";
+    document.cookie = 'accessToken=' + '{{ tokens.accessToken }}' + '; secure; path=/';
+    document.cookie =
+        'refreshToken=' + '{{ tokens.refreshToken }}' + '; expires=' + date.toUTCString() + '; secure; path=/';
+
+    if (window.localStorage) {
+        const currentAppStoreAsString = window.localStorage.getItem(PERSIST_STORE_NAME);
+        if (currentAppStoreAsString) {
+            const currentAppStore = JSON.parse(currentAppStoreAsString);
+            if (currentAppStore.state) {
+                // manually perform `handleActionsAfterLogin` action
+                currentAppStore.state.cartUuid = null;
+                currentAppStore.state.productListUuids = {};
+                currentAppStore.state.userEntry = 'login';
+                currentAppStore.state.authLoading =
+                    '{{ showCartMergeInfo }}' === 'true' ? 'login-loading-with-cart-modifications' : 'login-loading';
+                window.localStorage.setItem(PERSIST_STORE_NAME, JSON.stringify(currentAppStore));
+            }
+        }
+    }
 
     window.location.replace('{{ url|raw }}');
 </script>

--- a/upgrade-notes/backend_20250224_112831.md
+++ b/upgrade-notes/backend_20250224_112831.md
@@ -1,0 +1,4 @@
+#### Fix cart & missing whishlist/comparison products after external login ([#3822](https://github.com/shopsys/shopsys/pull/3822))
+
+- for external logins you need to make sure to properly clear the localStorage entries
+- if you have extended `loginAsCustomerUser.html.twig` template, you need to manually perform `handleActionsAfterLogin`, mainly reset `localStorage` entries for `cartUuid`, `productListUuids`, `authLoading` and `userEntry`


### PR DESCRIPTION
#### Description, the reason for the PR
This PR fixes bug that happens after external login (administration, convertim). The state of persist store after external login was not cleared and it caused storefront to behave unpredictable (cart, wishlist, comparison, etc.). Now, the local storage is reset properly.
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [ ] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://jm-ssp-2889-external-login-bug.odin.shopsys.cloud
  - https://cz.jm-ssp-2889-external-login-bug.odin.shopsys.cloud
<!-- Replace -->
