### PR TITLE
cleared search input after submit

### DIFF
--- a/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/project-base/storefront/components/Layout/Header/AutocompleteSearch/AutocompleteSearch.tsx
@@ -68,7 +68,7 @@ export const AutocompleteSearch: FC = () => {
                 pathname: searchUrl,
                 query: { q: searchQueryValue },
             });
-            setIsSearchResultsPopupOpen(false);
+            setSearchQueryValue('');
         }
     };
 

--- a/upgrade-notes/storefront_20250227_103530.md
+++ b/upgrade-notes/storefront_20250227_103530.md
@@ -1,0 +1,4 @@
+#### Fix search input popup on search page ([#3828](https://github.com/shopsys/shopsys/pull/3828))
+
+- search input is cleared after submit to be able trigger search popup again
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Search input is cleared after submit to be able trigger search poup again.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-2190-fix-search-popup.odin.shopsys.cloud
  - https://cz.tc-ssp-2190-fix-search-popup.odin.shopsys.cloud
<!-- Replace -->
