### PR TITLE
controllers are now typed

### DIFF
--- a/packages/framework/src/Controller/Admin/ArticleController.php
+++ b/packages/framework/src/Controller/Admin/ArticleController.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Component\ConfirmDelete\ConfirmDeleteResponseFactory;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Grid\GridFactory;
 use Shopsys\FrameworkBundle\Component\Grid\QueryBuilderDataSource;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
@@ -224,7 +225,7 @@ class ArticleController extends AdminBaseController
      * @param string $articlePlacement
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    protected function getGrid($articlePlacement)
+    protected function getGrid(string $articlePlacement): Grid
     {
         $queryBuilder = $this->articleFacade->getOrderedArticlesByDomainIdAndPlacementQueryBuilder(
             $this->adminDomainTabsFacade->getSelectedDomainId(),

--- a/packages/framework/src/Controller/Admin/BestsellingProductController.php
+++ b/packages/framework/src/Controller/Admin/BestsellingProductController.php
@@ -10,6 +10,7 @@ use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class BestsellingProductController extends AdminBaseController
@@ -30,9 +31,10 @@ class BestsellingProductController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/bestselling-product/list/')]
-    public function listAction(Request $request)
+    public function listAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
 
@@ -54,10 +56,10 @@ class BestsellingProductController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/bestselling-product/detail/')]
-    public function detailAction(Request $request)
+    public function detailAction(Request $request): Response
     {
         $categoryId = (int)$request->query->get('categoryId');
         $category = $this->categoryFacade->getById($categoryId);

--- a/packages/framework/src/Controller/Admin/BlogCategoryController.php
+++ b/packages/framework/src/Controller/Admin/BlogCategoryController.php
@@ -150,7 +150,7 @@ class BlogCategoryController extends AdminBaseController
     public function applySortingAction(Request $request): Response
     {
         $categoriesOrderingDataJson = $request->request->get('categoriesOrderingData');
-        $categoriesOrderingData = Json::decode($categoriesOrderingDataJson, Json::FORCE_ARRAY);
+        $categoriesOrderingData = Json::decode($categoriesOrderingDataJson, true);
 
         $this->blogCategoryFacade->reorderByNestedSetValues($categoriesOrderingData);
 

--- a/packages/framework/src/Controller/Admin/BreadcrumbController.php
+++ b/packages/framework/src/Controller/Admin/BreadcrumbController.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
+use Symfony\Component\HttpFoundation\Response;
 
 class BreadcrumbController extends AdminBaseController
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider
      */
-    public function __construct(protected readonly BreadcrumbOverrider $breadcrumbOverrider)
-    {
+    public function __construct(
+        protected readonly BreadcrumbOverrider $breadcrumbOverrider,
+    ) {
     }
 
-    public function indexAction()
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function indexAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Inline/Breadcrumb/breadcrumb.html.twig', [
             'breadcrumbOverrider' => $this->breadcrumbOverrider,

--- a/packages/framework/src/Controller/Admin/CategoryController.php
+++ b/packages/framework/src/Controller/Admin/CategoryController.php
@@ -163,7 +163,7 @@ class CategoryController extends AdminBaseController
     public function applySortingAction(Request $request): Response
     {
         $categoriesOrderingDataJson = $request->request->get('categoriesOrderingData');
-        $categoriesOrderingData = Json::decode($categoriesOrderingDataJson, Json::FORCE_ARRAY);
+        $categoriesOrderingData = Json::decode($categoriesOrderingDataJson, true);
 
         $this->categoryFacade->reorderByNestedSetValues($categoriesOrderingData);
 

--- a/packages/framework/src/Controller/Admin/ContactFormSettingsController.php
+++ b/packages/framework/src/Controller/Admin/ContactFormSettingsController.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Form\Admin\ContactForm\ContactFormSettingsFormType;
 use Shopsys\FrameworkBundle\Model\ContactForm\ContactFormSettingsDataFactory;
 use Shopsys\FrameworkBundle\Model\ContactForm\ContactFormSettingsFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class ContactFormSettingsController extends AdminBaseController
@@ -27,9 +28,10 @@ class ContactFormSettingsController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/contact-form/')]
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $contactFormSettingsData = $this->contactFormSettingsDataFactory->createFromSettingsByDomainId($domainId);

--- a/packages/framework/src/Controller/Admin/CspHeaderController.php
+++ b/packages/framework/src/Controller/Admin/CspHeaderController.php
@@ -15,8 +15,9 @@ class CspHeaderController extends AdminBaseController
     /**
      * @param \Shopsys\FrameworkBundle\Component\Setting\Setting $setting
      */
-    public function __construct(protected readonly Setting $setting)
-    {
+    public function __construct(
+        protected readonly Setting $setting,
+    ) {
     }
 
     /**

--- a/packages/framework/src/Controller/Admin/CurrencyController.php
+++ b/packages/framework/src/Controller/Admin/CurrencyController.php
@@ -32,8 +32,11 @@ class CurrencyController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/currency/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $grid = $this->currencyInlineEdit->getGrid();
 
@@ -45,9 +48,10 @@ class CurrencyController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/currency/delete-confirm/{id}', requirements: ['id' => '\d+'])]
-    public function deleteConfirmAction($id)
+    public function deleteConfirmAction(int $id): Response
     {
         try {
             $currency = $this->currencyFacade->getById($id);
@@ -65,9 +69,10 @@ class CurrencyController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/currency/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction($id)
+    public function deleteAction(int $id): Response
     {
         try {
             $fullName = $this->currencyFacade->getById($id)->getName();
@@ -92,8 +97,9 @@ class CurrencyController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function settingsAction(Request $request)
+    public function settingsAction(Request $request): Response
     {
         $domainNames = [];
 

--- a/packages/framework/src/Controller/Admin/CustomerController.php
+++ b/packages/framework/src/Controller/Admin/CustomerController.php
@@ -71,9 +71,10 @@ class CustomerController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/customer/edit/{id}', requirements: ['id' => '\d+'])]
-    public function editAction(Request $request, int $id)
+    public function editAction(Request $request, int $id): Response
     {
         $customerUser = $this->customerUserFacade->getCustomerUserById($id);
         $customer = $customerUser->getCustomer();
@@ -177,9 +178,10 @@ class CustomerController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/customer/list/')]
-    public function listAction(Request $request)
+    public function listAction(Request $request): Response
     {
         $quickSearchForm = $this->createForm(QuickSearchFormType::class, new QuickSearchFormData());
         $quickSearchForm->handleRequest($request);
@@ -232,9 +234,10 @@ class CustomerController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/customer/new/')]
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         $customerUserUpdateData = $this->customerUserUpdateDataFactory->create();
         $selectedDomainId = $this->adminDomainTabsFacade->getSelectedDomainId();
@@ -324,9 +327,10 @@ class CustomerController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/customer/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction(int $id)
+    public function deleteAction(int $id): Response
     {
         $customerUser = $this->customerUserFacade->getCustomerUserById($id);
         $customer = $customerUser->getCustomer();

--- a/packages/framework/src/Controller/Admin/DomainController.php
+++ b/packages/framework/src/Controller/Admin/DomainController.php
@@ -36,7 +36,10 @@ class DomainController extends AdminBaseController
     ) {
     }
 
-    public function domainTabsAction()
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function domainTabsAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Inline/Domain/tabs.html.twig', [
             'domainConfigs' => $this->domain->getAdminEnabledDomains(),
@@ -46,13 +49,12 @@ class DomainController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @param mixed $id
+     * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/multidomain/select-domain/{id}', requirements: ['id' => '\d+'])]
-    public function selectDomainAction(Request $request, $id)
+    public function selectDomainAction(Request $request, int $id): Response
     {
-        $id = (int)$id;
-
         $this->adminDomainTabsFacade->setSelectedDomainId($id);
 
         $referer = $request->server->get('HTTP_REFERER');
@@ -64,8 +66,11 @@ class DomainController extends AdminBaseController
         return $this->redirect($referer);
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/domain/list')]
-    public function listAction()
+    public function listAction(): Response
     {
         $dataSource = new ArrayDataSource($this->loadData(), 'id');
 
@@ -85,11 +90,11 @@ class DomainController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/domain/edit/{id}', requirements: ['id' => '\d+'], condition: 'request.isXmlHttpRequest()')]
-    public function editAction(Request $request, $id)
+    public function editAction(Request $request, int $id): Response
     {
-        $id = (int)$id;
         $domain = $this->domain->getDomainConfigById($id);
 
         $form = $this->createForm(DomainFormType::class, null, [
@@ -154,7 +159,10 @@ class DomainController extends AdminBaseController
         ]);
     }
 
-    protected function loadData()
+    /**
+     * @return array<int ,array{id: int, name: string, locale: string, icon: string|null}>
+     */
+    protected function loadData(): array
     {
         $data = [];
 

--- a/packages/framework/src/Controller/Admin/FeedController.php
+++ b/packages/framework/src/Controller/Admin/FeedController.php
@@ -14,6 +14,7 @@ use Shopsys\FrameworkBundle\Model\Feed\FeedModuleRepository;
 use Shopsys\FrameworkBundle\Model\Feed\FeedRegistry;
 use Shopsys\FrameworkBundle\Model\Security\Roles;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class FeedController extends AdminBaseController
@@ -37,9 +38,10 @@ class FeedController extends AdminBaseController
     /**
      * @param string $feedName
      * @param int $domainId
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/feed/generate/{feedName}/{domainId}', requirements: ['domainId' => '\d+'])]
-    public function generateAction($feedName, $domainId)
+    public function generateAction(string $feedName, int $domainId): Response
     {
         $domainConfig = $this->domain->getDomainConfigById((int)$domainId);
 
@@ -95,8 +97,11 @@ class FeedController extends AdminBaseController
         return $this->redirectToRoute('admin_feed_list');
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/feed/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $feedsData = [];
         $feedConfigs = $this->feedRegistry->getAllFeedConfigs();

--- a/packages/framework/src/Controller/Admin/FileUploadController.php
+++ b/packages/framework/src/Controller/Admin/FileUploadController.php
@@ -29,7 +29,7 @@ class FileUploadController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/file-upload/')]
-    public function uploadAction(Request $request)
+    public function uploadAction(Request $request): JsonResponse
     {
         $actionResult = [
             'status' => 'error',
@@ -67,7 +67,7 @@ class FileUploadController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/file-upload/delete-temporary-file/')]
-    public function deleteTemporaryFileAction(Request $request)
+    public function deleteTemporaryFileAction(Request $request): JsonResponse
     {
         $filename = $request->get('filename');
 

--- a/packages/framework/src/Controller/Admin/FlagController.php
+++ b/packages/framework/src/Controller/Admin/FlagController.php
@@ -37,8 +37,11 @@ class FlagController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/product/flag/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $grid = $this->flagGridFactory->create();
 
@@ -170,7 +173,7 @@ class FlagController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/flag/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction($id): Response
+    public function deleteAction(int $id): Response
     {
         try {
             $flag = $this->flagFacade->getById($id);

--- a/packages/framework/src/Controller/Admin/FlashMessageController.php
+++ b/packages/framework/src/Controller/Admin/FlashMessageController.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class FlashMessageController extends AdminBaseController
 {
-    public function indexAction()
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function indexAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Inline/FlashMessage/index.html.twig', [
             'errorMessages' => $this->getErrorMessages(),

--- a/packages/framework/src/Controller/Admin/GridController.php
+++ b/packages/framework/src/Controller/Admin/GridController.php
@@ -25,9 +25,10 @@ class GridController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/_grid/get-form/')]
-    public function getFormAction(Request $request)
+    public function getFormAction(Request $request): JsonResponse
     {
         $rowId = $request->get('rowId') !== null ? json_decode($request->get('rowId')) : null;
 
@@ -41,9 +42,10 @@ class GridController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/_grid/save-form/')]
-    public function saveFormAction(Request $request)
+    public function saveFormAction(Request $request): JsonResponse
     {
         $responseData = [];
         $rowId = $request->get('rowId') !== null ? json_decode($request->get('rowId')) : null;
@@ -67,9 +69,10 @@ class GridController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     #[Route(path: '/_grid/save-ordering/')]
-    public function saveOrderingAction(Request $request)
+    public function saveOrderingAction(Request $request): JsonResponse
     {
         $this->gridOrderingFacade->saveOrdering(
             $request->get('entityClass'),

--- a/packages/framework/src/Controller/Admin/HeurekaController.php
+++ b/packages/framework/src/Controller/Admin/HeurekaController.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Form\Admin\Heureka\HeurekaShopCertificationFormType;
 use Shopsys\FrameworkBundle\Model\Heureka\HeurekaFacade;
 use Shopsys\FrameworkBundle\Model\Heureka\HeurekaSetting;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class HeurekaController extends AdminBaseController
@@ -27,9 +28,10 @@ class HeurekaController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/heureka/setting/')]
-    public function settingAction(Request $request)
+    public function settingAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $domainConfig = $this->adminDomainTabsFacade->getSelectedDomainConfig();

--- a/packages/framework/src/Controller/Admin/NewsletterController.php
+++ b/packages/framework/src/Controller/Admin/NewsletterController.php
@@ -34,9 +34,10 @@ class NewsletterController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/newsletter/list/')]
-    public function listAction(Request $request)
+    public function listAction(Request $request): Response
     {
         $quickSearchForm = $this->createForm(QuickSearchFormType::class, new QuickSearchFormData());
         $quickSearchForm->handleRequest($request);
@@ -93,8 +94,11 @@ class NewsletterController extends AdminBaseController
         return $this->redirectToRoute('admin_newsletter_list');
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     */
     #[Route(path: '/newsletter/export-csv/')]
-    public function exportAction()
+    public function exportAction(): StreamedResponse
     {
         $response = new StreamedResponse();
         $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
@@ -109,7 +113,7 @@ class NewsletterController extends AdminBaseController
     /**
      * @param int $domainId
      */
-    protected function streamCsvExport($domainId)
+    protected function streamCsvExport(int $domainId): void
     {
         $output = new SplFileObject('php://output', 'w+');
 

--- a/packages/framework/src/Controller/Admin/OrderStatusController.php
+++ b/packages/framework/src/Controller/Admin/OrderStatusController.php
@@ -28,8 +28,11 @@ class OrderStatusController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/order-status/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $grid = $this->orderStatusInlineEdit->getGrid();
 
@@ -42,9 +45,10 @@ class OrderStatusController extends AdminBaseController
      * @CsrfProtection
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/order-status/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction(Request $request, $id)
+    public function deleteAction(Request $request, int $id): Response
     {
         $newId = $request->get('newId');
 
@@ -86,9 +90,10 @@ class OrderStatusController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/order-status/delete-confirm/{id}', requirements: ['id' => '\d+'])]
-    public function deleteConfirmAction($id)
+    public function deleteConfirmAction(int $id): Response
     {
         try {
             $orderStatus = $this->orderStatusFacade->getById($id);

--- a/packages/framework/src/Controller/Admin/ParameterValueController.php
+++ b/packages/framework/src/Controller/Admin/ParameterValueController.php
@@ -70,7 +70,7 @@ class ParameterValueController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/parameter-value/edit/{id}', name: 'admin_parametervalue_edit', requirements: ['id' => '\d+'])]
     public function editAction(Request $request, int $id): Response

--- a/packages/framework/src/Controller/Admin/PaymentController.php
+++ b/packages/framework/src/Controller/Admin/PaymentController.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory;
 use Shopsys\FrameworkBundle\Model\Payment\PaymentFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class PaymentController extends AdminBaseController
@@ -35,9 +36,10 @@ class PaymentController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/payment/new/')]
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         $paymentData = $this->paymentDataFactory->create();
 
@@ -73,9 +75,10 @@ class PaymentController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/payment/edit/{id}', requirements: ['id' => '\d+'])]
-    public function editAction(Request $request, $id)
+    public function editAction(Request $request, int $id): Response
     {
         $payment = $this->paymentFacade->getById($id);
         $paymentData = $this->paymentDataFactory->createFromPayment($payment);
@@ -115,9 +118,10 @@ class PaymentController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/payment/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction($id)
+    public function deleteAction(int $id): Response
     {
         try {
             $paymentName = $this->paymentFacade->getById($id)->getName();
@@ -137,7 +141,10 @@ class PaymentController extends AdminBaseController
         return $this->redirectToRoute('admin_transportandpayment_list');
     }
 
-    public function listAction()
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function listAction(): Response
     {
         $grid = $this->paymentGridFactory->create();
 

--- a/packages/framework/src/Controller/Admin/PersonalDataController.php
+++ b/packages/framework/src/Controller/Admin/PersonalDataController.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Form\Admin\PersonalData\PersonalDataFormType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class PersonalDataController extends AdminBaseController
@@ -24,9 +25,10 @@ class PersonalDataController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/personal-data/setting/')]
-    public function settingAction(Request $request)
+    public function settingAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $personalDataDisplaySiteContent = $this->setting->getForDomain(

--- a/packages/framework/src/Controller/Admin/PricingGroupController.php
+++ b/packages/framework/src/Controller/Admin/PricingGroupController.php
@@ -34,8 +34,11 @@ class PricingGroupController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/pricing/group/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $grid = $this->pricingGroupInlineEdit->getGrid();
 
@@ -48,9 +51,10 @@ class PricingGroupController extends AdminBaseController
      * @CsrfProtection
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/pricing/group/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction(Request $request, int $id)
+    public function deleteAction(Request $request, int $id): Response
     {
         $newId = $request->get('newId');
         $newId = $newId !== null ? (int)$newId : null;
@@ -87,9 +91,10 @@ class PricingGroupController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/pricing/group/delete-confirm/{id}', requirements: ['id' => '\d+'])]
-    public function deleteConfirmAction($id)
+    public function deleteConfirmAction(int $id): Response
     {
         try {
             $pricingGroup = $this->pricingGroupFacade->getById($id);
@@ -135,8 +140,9 @@ class PricingGroupController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function settingsAction(Request $request)
+    public function settingsAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $pricingGroupSettingsFormData = [

--- a/packages/framework/src/Controller/Admin/ProductController.php
+++ b/packages/framework/src/Controller/Admin/ProductController.php
@@ -6,6 +6,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Doctrine\ORM\QueryBuilder;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\Grid\Grid;
 use Shopsys\FrameworkBundle\Component\Router\Security\Annotation\CsrfProtection;
 use Shopsys\FrameworkBundle\Component\Setting\Setting;
 use Shopsys\FrameworkBundle\Form\Admin\Product\ProductFormType;
@@ -160,9 +161,10 @@ class ProductController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/list/')]
-    public function listAction(Request $request)
+    public function listAction(Request $request): Response
     {
         $advancedSearchForm = $this->advancedSearchProductFacade->createAdvancedSearchForm($request);
         $advancedSearchData = $advancedSearchForm->getData();
@@ -248,9 +250,10 @@ class ProductController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/get-advanced-search-rule-form/', methods: ['post'])]
-    public function getRuleFormAction(Request $request)
+    public function getRuleFormAction(Request $request): Response
     {
         $ruleForm = $this->advancedSearchProductFacade->createRuleForm(
             $request->get('filterName'),
@@ -264,9 +267,10 @@ class ProductController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/create-variant/')]
-    public function createVariantAction(Request $request)
+    public function createVariantAction(Request $request): Response
     {
         $form = $this->createForm(VariantFormType::class);
         $form->handleRequest($request);
@@ -306,16 +310,17 @@ class ProductController extends AdminBaseController
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
      * @return \Shopsys\FrameworkBundle\Component\Grid\Grid
      */
-    protected function getGrid(QueryBuilder $queryBuilder)
+    protected function getGrid(QueryBuilder $queryBuilder): Grid
     {
         return $this->productGridFactory->getProductControllerGrid($queryBuilder);
     }
 
     /**
      * @param int $productId
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/visibility/{productId}')]
-    public function visibilityAction($productId)
+    public function visibilityAction(int $productId): Response
     {
         $product = $this->productFacade->getById($productId);
 
@@ -368,7 +373,7 @@ class ProductController extends AdminBaseController
     /**
      * @return bool
      */
-    protected function productCanBeCreated()
+    protected function productCanBeCreated(): bool
     {
         return $this->unitFacade->isAtLeastOneUnitCreated()
             && $this->setting->get(Setting::DEFAULT_UNIT) !== 0;
@@ -379,8 +384,6 @@ class ProductController extends AdminBaseController
      */
     protected function setSellingToUntilEndOfDay(?ProductData $productData): void
     {
-        if ($productData->sellingTo !== null) {
-            $productData->sellingTo->modify('+1 day -1 second');
-        }
+        $productData?->sellingTo?->modify('+1 day -1 second');
     }
 }

--- a/packages/framework/src/Controller/Admin/ProductPickerController.php
+++ b/packages/framework/src/Controller/Admin/ProductPickerController.php
@@ -50,12 +50,12 @@ class ProductPickerController extends AdminBaseController
     #[Route(path: '/product-picker/pick-multiple/{jsInstanceId}/{allowMainVariants}/{allowVariants}/{withPrice}/{domainId}')]
     public function pickMultipleAction(
         Request $request,
-        $jsInstanceId,
+        string $jsInstanceId,
         bool $allowMainVariants = true,
         bool $allowVariants = true,
         bool $withPrice = false,
         int $domainId = Domain::FIRST_DOMAIN_ID,
-    ) {
+    ): Response {
         return $this->getPickerResponse(
             $request,
             [
@@ -75,9 +75,10 @@ class ProductPickerController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param string $parentInstanceId
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product-picker/pick-single/{parentInstanceId}/', defaults: ['parentInstanceId' => '__instance_id__'])]
-    public function pickSingleAction(Request $request, $parentInstanceId)
+    public function pickSingleAction(Request $request, string $parentInstanceId): Response
     {
         return $this->getPickerResponse(
             $request,
@@ -97,8 +98,9 @@ class ProductPickerController extends AdminBaseController
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param array $viewParameters
      * @param array $gridViewParameters
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function getPickerResponse(Request $request, array $viewParameters, array $gridViewParameters)
+    protected function getPickerResponse(Request $request, array $viewParameters, array $gridViewParameters): Response
     {
         $advancedSearchForm = $this->advancedSearchProductFacade->createAdvancedSearchForm($request);
         $advancedSearchData = $advancedSearchForm->getData();

--- a/packages/framework/src/Controller/Admin/PromoCodeController.php
+++ b/packages/framework/src/Controller/Admin/PromoCodeController.php
@@ -179,7 +179,7 @@ class PromoCodeController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/promo-code/new-mass-generate')]
     public function newMassGenerateAction(Request $request): Response
@@ -225,7 +225,7 @@ class PromoCodeController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/promo-code/list-mass-generate-batch')]
     public function listMassGenerateBatchAction(Request $request): Response
@@ -243,13 +243,13 @@ class PromoCodeController extends AdminBaseController
 
     /**
      * @param int $batchId
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/promo-code/download-mass-generate-batch/{batchId}')]
     public function downloadMassGenerateBatchAction(int $batchId): Response
     {
         $tempFileName = tempnam(sys_get_temp_dir(), 'promoCodesCsv');
-        file_put_contents($tempFileName, $this->generateCsvFromPromoCodeFromBatchId((int)$batchId));
+        file_put_contents($tempFileName, $this->generateCsvFromPromoCodeFromBatchId($batchId));
 
         $fileName = 'promoCodesBatch-' . $batchId;
 

--- a/packages/framework/src/Controller/Admin/SeoController.php
+++ b/packages/framework/src/Controller/Admin/SeoController.php
@@ -30,7 +30,7 @@ class SeoController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/seo/')]
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $seoSettingData = [

--- a/packages/framework/src/Controller/Admin/SliderController.php
+++ b/packages/framework/src/Controller/Admin/SliderController.php
@@ -16,6 +16,7 @@ use Shopsys\FrameworkBundle\Model\Slider\SliderItem;
 use Shopsys\FrameworkBundle\Model\Slider\SliderItemDataFactory;
 use Shopsys\FrameworkBundle\Model\Slider\SliderItemFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class SliderController extends AdminBaseController
@@ -38,8 +39,11 @@ class SliderController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/slider/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('s')
@@ -68,9 +72,10 @@ class SliderController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/slider/item/new/')]
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         $sliderItemData = $this->sliderItemDataFactory->create();
         $sliderItemData->domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
@@ -108,9 +113,10 @@ class SliderController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/slider/item/edit/{id}', requirements: ['id' => '\d+'])]
-    public function editAction(Request $request, $id)
+    public function editAction(Request $request, int $id): Response
     {
         $sliderItem = $this->sliderItemFacade->getById($id);
         $sliderItemData = $this->sliderItemDataFactory->createFromSliderItem($sliderItem);
@@ -152,9 +158,10 @@ class SliderController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/slider/item/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction($id)
+    public function deleteAction(int $id): Response
     {
         try {
             $name = $this->sliderItemFacade->getById($id)->getName();

--- a/packages/framework/src/Controller/Admin/SuperadminController.php
+++ b/packages/framework/src/Controller/Admin/SuperadminController.php
@@ -47,7 +47,7 @@ class SuperadminController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/superadmin/errors/')]
-    public function errorsAction()
+    public function errorsAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Content/Superadmin/errors.html.twig');
     }
@@ -57,7 +57,7 @@ class SuperadminController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/superadmin/pricing/')]
-    public function pricingAction(Request $request)
+    public function pricingAction(Request $request): Response
     {
         $pricingSettingData = [
             'type' => $this->pricingSetting->getInputPriceType(),
@@ -85,7 +85,7 @@ class SuperadminController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/superadmin/urls/')]
-    public function urlsAction()
+    public function urlsAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Content/Superadmin/urlsListGrid.html.twig');
     }
@@ -95,7 +95,7 @@ class SuperadminController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/superadmin/modules/')]
-    public function modulesAction(Request $request)
+    public function modulesAction(Request $request): Response
     {
         $formData = [];
 
@@ -127,7 +127,7 @@ class SuperadminController extends AdminBaseController
      * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/superadmin/css-documentation/')]
-    public function cssDocumentationAction()
+    public function cssDocumentationAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Content/Superadmin/cssDocumentation.html.twig');
     }

--- a/packages/framework/src/Controller/Admin/TopCategoryController.php
+++ b/packages/framework/src/Controller/Admin/TopCategoryController.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Form\Admin\Category\TopCategory\TopCategoriesFormType;
 use Shopsys\FrameworkBundle\Model\Category\TopCategory\TopCategoryFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class TopCategoryController extends AdminBaseController
@@ -24,9 +25,10 @@ class TopCategoryController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/category/top-category/list/')]
-    public function listAction(Request $request)
+    public function listAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $formData = [

--- a/packages/framework/src/Controller/Admin/TopProductController.php
+++ b/packages/framework/src/Controller/Admin/TopProductController.php
@@ -9,6 +9,7 @@ use Shopsys\FrameworkBundle\Form\Admin\Product\TopProduct\TopProductsFormType;
 use Shopsys\FrameworkBundle\Model\Product\ProductFrontendLimitProvider;
 use Shopsys\FrameworkBundle\Model\Product\TopProduct\TopProductFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class TopProductController extends AdminBaseController
@@ -27,9 +28,10 @@ class TopProductController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/top-product/list/')]
-    public function listAction(Request $request)
+    public function listAction(Request $request): Response
     {
         $domainId = $this->adminDomainTabsFacade->getSelectedDomainId();
         $formData = [
@@ -57,7 +59,7 @@ class TopProductController extends AdminBaseController
      * @param int $domainId
      * @return \Shopsys\FrameworkBundle\Model\Product\Product[]
      */
-    protected function getProductsForDomain($domainId)
+    protected function getProductsForDomain(int $domainId): array
     {
         $topProducts = $this->topProductFacade->getAll($domainId);
         $products = [];

--- a/packages/framework/src/Controller/Admin/TransferIssueController.php
+++ b/packages/framework/src/Controller/Admin/TransferIssueController.php
@@ -87,7 +87,7 @@ class TransferIssueController extends AdminBaseController
     public function deleteAction(int $id): RedirectResponse
     {
         try {
-            $this->transferIssueFacade->deleteById((int)$id);
+            $this->transferIssueFacade->deleteById($id);
 
             $this->addSuccessFlashTwig(
                 t('Transfer problem has been marked as resolved'),

--- a/packages/framework/src/Controller/Admin/TransportAndPaymentController.php
+++ b/packages/framework/src/Controller/Admin/TransportAndPaymentController.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Form\Admin\TransportAndPayment\FreeTransportAndPaymentPriceLimitsFormType;
 use Shopsys\FrameworkBundle\Model\Pricing\PricingSetting;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class TransportAndPaymentController extends AdminBaseController
@@ -22,17 +23,21 @@ class TransportAndPaymentController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/transport-and-payment/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         return $this->render('@ShopsysFramework/Admin/Content/TransportAndPayment/list.html.twig');
     }
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/transport-and-payment/free-transport-and-payment-limit/')]
-    public function freeTransportAndPaymentLimitAction(Request $request)
+    public function freeTransportAndPaymentLimitAction(Request $request): Response
     {
         $formData = [];
 

--- a/packages/framework/src/Controller/Admin/TransportController.php
+++ b/packages/framework/src/Controller/Admin/TransportController.php
@@ -13,6 +13,7 @@ use Shopsys\FrameworkBundle\Model\Transport\Grid\TransportGridFactory;
 use Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory;
 use Shopsys\FrameworkBundle\Model\Transport\TransportFacade;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class TransportController extends AdminBaseController
@@ -35,9 +36,10 @@ class TransportController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/transport/new/')]
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         $transportData = $this->transportDataFactory->create();
 
@@ -73,9 +75,10 @@ class TransportController extends AdminBaseController
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/transport/edit/{id}', requirements: ['id' => '\d+'])]
-    public function editAction(Request $request, $id)
+    public function editAction(Request $request, int $id): Response
     {
         $transport = $this->transportFacade->getById($id);
         $transportData = $this->transportDataFactory->createFromTransport($transport);
@@ -117,9 +120,10 @@ class TransportController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/transport/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction($id)
+    public function deleteAction(int $id): Response
     {
         try {
             $transportName = $this->transportFacade->getById($id)->getName();
@@ -139,7 +143,10 @@ class TransportController extends AdminBaseController
         return $this->redirectToRoute('admin_transportandpayment_list');
     }
 
-    public function listAction()
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function listAction(): Response
     {
         $grid = $this->transportGridFactory->create();
 

--- a/packages/framework/src/Controller/Admin/UnitController.php
+++ b/packages/framework/src/Controller/Admin/UnitController.php
@@ -28,8 +28,11 @@ class UnitController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/product/unit/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $unitInlineEdit = $this->unitInlineEdit;
 
@@ -43,9 +46,10 @@ class UnitController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/unit/delete-confirm/{id}', requirements: ['id' => '\d+'])]
-    public function deleteConfirmAction($id)
+    public function deleteConfirmAction(int $id): Response
     {
         try {
             $unit = $this->unitFacade->getById($id);
@@ -88,9 +92,10 @@ class UnitController extends AdminBaseController
      * @CsrfProtection
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/unit/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction(Request $request, $id)
+    public function deleteAction(Request $request, int $id): Response
     {
         $newId = $request->get('newId');
 
@@ -125,9 +130,10 @@ class UnitController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/product/unit/setting/')]
-    public function settingAction(Request $request)
+    public function settingAction(Request $request): Response
     {
         try {
             $defaultUnit = $this->unitFacade->getDefaultUnit();

--- a/packages/framework/src/Controller/Admin/VatController.php
+++ b/packages/framework/src/Controller/Admin/VatController.php
@@ -31,8 +31,11 @@ class VatController extends AdminBaseController
     ) {
     }
 
+    /**
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     #[Route(path: '/vat/list/')]
-    public function listAction()
+    public function listAction(): Response
     {
         $grid = $this->vatInlineEdit->getGrid();
 
@@ -44,9 +47,10 @@ class VatController extends AdminBaseController
     /**
      * @CsrfProtection
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/vat/delete-confirm/{id}', requirements: ['id' => '\d+'])]
-    public function deleteConfirmAction(int $id)
+    public function deleteConfirmAction(int $id): Response
     {
         try {
             $vat = $this->vatFacade->getById($id);
@@ -81,9 +85,10 @@ class VatController extends AdminBaseController
      * @CsrfProtection
      * @param \Symfony\Component\HttpFoundation\Request $request
      * @param int $id
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     #[Route(path: '/vat/delete/{id}', requirements: ['id' => '\d+'])]
-    public function deleteAction(Request $request, $id)
+    public function deleteAction(Request $request, int $id): Response
     {
         $newId = $request->get('newId');
 
@@ -118,8 +123,9 @@ class VatController extends AdminBaseController
 
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function settingsAction(Request $request)
+    public function settingsAction(Request $request): Response
     {
         $vatSettingsFormData = [
             'defaultVat' => $this->vatFacade->getDefaultVatForDomain(


### PR DESCRIPTION
#### Description, the reason for the PR

Controllers are now typed to prevent accidental errors when the type is added lower in the application layer (facade/repository) and then the error occurs.
For example, before this change, deleting a flag caused an error.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-typed-controllers.odin.shopsys.cloud
  - https://cz.mg-typed-controllers.odin.shopsys.cloud
<!-- Replace -->
