### PR TITLE
Mystery of disappearing RGB color value

### DIFF
--- a/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
+++ b/project-base/app/src/Model/Product/Parameter/ParameterRepository.php
@@ -44,7 +44,7 @@ class ParameterRepository extends BaseParameterRepository
             $this->em->flush();
         }
 
-        if ($parameterValue->getRgbHex() !== $parameterValueData->rgbHex) {
+        if ($parameterValueData->rgbHex !== null && $parameterValue->getRgbHex() !== $parameterValueData->rgbHex) {
             $parameterValue->edit($parameterValueData);
             $this->em->flush();
         }


### PR DESCRIPTION
#### Description, the reason for the PR

This PR solves the mystery of the disappearing RGB color value. When a product with a color parameter is saved, the RGB value disappears from the assigned parameter values. I strongly believe this PR is only a HOTFIX and that it deserves more digging to solve the issue once and for all.

How to reproduce with demo data:
1. Go to Administration.
2. Check parameter values (Settings > Lists and Nomenclatures > Parameter Values of Type: Color) – all have an RGB set.
3. Edit the product "100 Czech crowns ticket".
4. Set any color parameter and choose the value "red".
5. Save the product.
6. Check parameter values again (Settings > Lists and Nomenclatures > Parameter Values of Type: Color) – all still have an RGB set, except for "red," which is now missing its RGB.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
