### PR TITLE
added condition for skipping expected user errors in development

### DIFF
--- a/project-base/storefront/urql/errorExchange.ts
+++ b/project-base/storefront/urql/errorExchange.ts
@@ -66,6 +66,10 @@ export const getErrorExchange =
 const handleErrorMessagesForDevelopment = (error: CombinedError, t: Translate) => {
     const parsedErrors = getUserFriendlyErrors(error, t);
 
+    if (parsedErrors.userError) {
+        return;
+    }
+
     if (!parsedErrors.applicationError || !isNoLogError(parsedErrors.applicationError.type)) {
         logException({
             message: error.message,

--- a/upgrade-notes/storefront_20250304_033049.md
+++ b/upgrade-notes/storefront_20250304_033049.md
@@ -1,0 +1,4 @@
+#### Sentry errors ([#3834](https://github.com/shopsys/shopsys/pull/3834))
+
+- added condition for skipping expected user errors in development
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Added condition for skipping expected user errors in development.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)











<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tc-ssp-3223-handle-errors-for-development.odin.shopsys.cloud
  - https://cz.tc-ssp-3223-handle-errors-for-development.odin.shopsys.cloud
<!-- Replace -->
