### PR TITLE
navigation edit now respects the admin available locales

### DIFF
--- a/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
+++ b/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Form\Admin\Navigation;
 
 use Shopsys\FormTypesBundle\ActionBarType;
-use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Component\Locale\LocaleHelper;
 use Shopsys\FrameworkBundle\Form\DomainType;
 use Shopsys\FrameworkBundle\Form\SortableValuesType;
 use Shopsys\FrameworkBundle\Form\Transformers\CategoriesIdsToCategoriesTransformer;
 use Shopsys\FrameworkBundle\Form\Transformers\RemoveDuplicatesFromArrayTransformer;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Navigation\NavigationItem;
 use Shopsys\FrameworkBundle\Model\Navigation\NavigationItemData;
 use Symfony\Component\Form\AbstractType;
@@ -20,24 +19,20 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
-class NavigationItemFormType extends AbstractType
+final class NavigationItemFormType extends AbstractType
 {
-    /**
-     * @var string[]
-     */
-    private array $categoryPaths;
-
     /**
      * @param \Shopsys\FrameworkBundle\Form\Transformers\RemoveDuplicatesFromArrayTransformer $removeDuplicatesTransformer
      * @param \Shopsys\FrameworkBundle\Form\Transformers\CategoriesIdsToCategoriesTransformer $categoriesIdsToCategoriesTransformer
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         private readonly RemoveDuplicatesFromArrayTransformer $removeDuplicatesTransformer,
         private readonly CategoriesIdsToCategoriesTransformer $categoriesIdsToCategoriesTransformer,
-        CategoryFacade $categoryFacade,
+        private readonly CategoryFacade $categoryFacade,
+        private readonly Localization $localization,
     ) {
-        $this->categoryPaths = $categoryFacade->getFullPathsIndexedByIdsForDomain(Domain::FIRST_DOMAIN_ID, LocaleHelper::LOCALE_CS);
     }
 
     /**
@@ -49,7 +44,6 @@ class NavigationItemFormType extends AbstractType
     }
 
     /**
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
      * @param array $options
      */
@@ -99,6 +93,7 @@ class NavigationItemFormType extends AbstractType
      * @param string $fieldName
      * @param string $label
      * @param int $index
+     * @param array $categoryPaths
      * @param \Symfony\Component\Form\FormBuilderInterface $builder
      * @return \Symfony\Component\Form\FormBuilderInterface
      */
@@ -106,13 +101,14 @@ class NavigationItemFormType extends AbstractType
         string $fieldName,
         string $label,
         int $index,
+        array $categoryPaths,
         FormBuilderInterface $builder,
     ): FormBuilderInterface {
         return $builder
             ->create($fieldName, SortableValuesType::class, [
                 'label' => $label,
                 'property_path' => sprintf('categoriesByColumnNumber[%d]', $index),
-                'labels_by_value' => $this->categoryPaths,
+                'labels_by_value' => $categoryPaths,
                 'required' => false,
             ])
             ->addViewTransformer($this->removeDuplicatesTransformer)
@@ -124,37 +120,46 @@ class NavigationItemFormType extends AbstractType
      */
     private function addColumnFields(FormBuilderInterface $builder): void
     {
-        $builder->add(
-            $this->createCategoryColumnBuilder(
-                'categoriesInFirstColumn',
-                'Kategorie prvního sloupce',
-                1,
-                $builder,
-            ),
-        )
-        ->add(
-            $this->createCategoryColumnBuilder(
-                'categoriesInSecondColumn',
-                'Kategorie druhého sloupce',
-                2,
-                $builder,
-            ),
-        )
-        ->add(
-            $this->createCategoryColumnBuilder(
-                'categoriesInThirdColumn',
-                'Kategorie třetího sloupce',
-                3,
-                $builder,
-            ),
-        )
-        ->add(
-            $this->createCategoryColumnBuilder(
-                'categoriesInFourthColumn',
-                'Kategorie čtvrtého sloupce',
-                4,
-                $builder,
-            ),
+        $categoryPaths = $this->categoryFacade->getFullPathsIndexedByIds(
+            $this->localization->getAdminLocale(),
         );
+
+        $builder
+            ->add(
+                $this->createCategoryColumnBuilder(
+                    'categoriesInFirstColumn',
+                    t('First column categories'),
+                    1,
+                    $categoryPaths,
+                    $builder,
+                ),
+            )
+            ->add(
+                $this->createCategoryColumnBuilder(
+                    'categoriesInSecondColumn',
+                    t('Second column categories'),
+                    2,
+                    $categoryPaths,
+                    $builder,
+                ),
+            )
+            ->add(
+                $this->createCategoryColumnBuilder(
+                    'categoriesInThirdColumn',
+                    t('Third column categories'),
+                    3,
+                    $categoryPaths,
+                    $builder,
+                ),
+            )
+            ->add(
+                $this->createCategoryColumnBuilder(
+                    'categoriesInFourthColumn',
+                    t('Fourth column categories'),
+                    4,
+                    $categoryPaths,
+                    $builder,
+                ),
+            );
     }
 }

--- a/packages/framework/src/Model/Category/CategoryFacade.php
+++ b/packages/framework/src/Model/Category/CategoryFacade.php
@@ -538,4 +538,13 @@ class CategoryFacade
 
         return $sortedCategories;
     }
+
+    /**
+     * @param string $locale
+     * @return string[]
+     */
+    public function getFullPathsIndexedByIds(string $locale): array
+    {
+        return $this->categoryRepository->getFullPathsIndexedByIds($locale);
+    }
 }

--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -108,6 +108,26 @@ class CategoryRepository extends NestedTreeRepository
     {
         $queryBuilder = $this->getPreOrderTreeTraversalForAllCategoriesByDomainQueryBuilder($domainId, $locale);
 
+        return $this->getFullPathsByQueryBuilder($queryBuilder);
+    }
+
+    /**
+     * @param string $locale
+     * @return string[]
+     */
+    public function getFullPathsIndexedByIds(string $locale): array
+    {
+        $queryBuilder = $this->getPreOrderTreeTraversalForAllCategoriesQueryBuilder($locale);
+
+        return $this->getFullPathsByQueryBuilder($queryBuilder);
+    }
+
+    /**
+     * @param \Doctrine\ORM\QueryBuilder $queryBuilder
+     * @return string[]
+     */
+    protected function getFullPathsByQueryBuilder(QueryBuilder $queryBuilder): array
+    {
         $rows = $queryBuilder->select('c.id, IDENTITY(c.parent) AS parentId, ct.name')->getQuery()->getScalarResult();
 
         $fullPathsById = [];
@@ -121,6 +141,22 @@ class CategoryRepository extends NestedTreeRepository
         }
 
         return $fullPathsById;
+    }
+
+    /**
+     * @param string $locale
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    protected function getPreOrderTreeTraversalForAllCategoriesQueryBuilder(string $locale): QueryBuilder
+    {
+        $queryBuilder = $this->getAllQueryBuilder();
+        $this->addTranslation($queryBuilder, $locale);
+
+        $queryBuilder
+            ->andWhere('c.level >= 1')
+            ->orderBy('c.lft');
+
+        return $queryBuilder;
     }
 
     /**

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2056,6 +2056,9 @@ msgstr "Dokončit přiřazování"
 msgid "Finished at"
 msgstr "Konec"
 
+msgid "First column categories"
+msgstr "Kategorie prvního sloupce"
+
 msgid "First name"
 msgstr "Jméno"
 
@@ -2115,6 +2118,9 @@ msgstr "Zaslání zapomenutého hesla administrátora"
 
 msgid "Forgotten password sending"
 msgstr "Zaslání zapomenutého hesla"
+
+msgid "Fourth column categories"
+msgstr "Kategorie čtvrtého sloupce"
 
 msgid "Free"
 msgstr "Zdarma"
@@ -3865,6 +3871,9 @@ msgstr "Vyhledávání hledá v názvu produktu, katalogovém čísle produktu, 
 msgid "Searching searches in slugs. It is possible to use wildcards * and ?."
 msgstr "Vyhledávání hledá ve sluzích. Je možné používat operátory * a ?."
 
+msgid "Second column categories"
+msgstr "Kategorie druhého sloupce"
+
 msgid "Select new value"
 msgstr "Zvolte novou hodnotu"
 
@@ -4281,6 +4290,9 @@ msgstr "Žádný sklad na této doméně zatím nebyl vytvořen."
 
 msgid "There was an error while saving. The order isn't saved."
 msgstr "Během ukládání došlo k chybě. Pořadí nebylo uloženo."
+
+msgid "Third column categories"
+msgstr "Kategorie třetího sloupce"
 
 msgid "This SEO page cannot be deleted."
 msgstr "Tato SEO stránka nemůže být smazána."

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2056,6 +2056,9 @@ msgstr ""
 msgid "Finished at"
 msgstr ""
 
+msgid "First column categories"
+msgstr ""
+
 msgid "First name"
 msgstr ""
 
@@ -2114,6 +2117,9 @@ msgid "Forgotten administrator password sending"
 msgstr ""
 
 msgid "Forgotten password sending"
+msgstr ""
+
+msgid "Fourth column categories"
 msgstr ""
 
 msgid "Free"
@@ -3865,6 +3871,9 @@ msgstr ""
 msgid "Searching searches in slugs. It is possible to use wildcards * and ?."
 msgstr ""
 
+msgid "Second column categories"
+msgstr ""
+
 msgid "Select new value"
 msgstr ""
 
@@ -4280,6 +4289,9 @@ msgid "There is no warehouse on this domain yet."
 msgstr ""
 
 msgid "There was an error while saving. The order isn't saved."
+msgstr ""
+
+msgid "Third column categories"
 msgstr ""
 
 msgid "This SEO page cannot be deleted."

--- a/project-base/app/src/Model/Category/CategoryFacade.php
+++ b/project-base/app/src/Model/Category/CategoryFacade.php
@@ -166,15 +166,6 @@ class CategoryFacade extends BaseCategoryFacade
     }
 
     /**
-     * @param string $locale
-     * @return string[]
-     */
-    public function getFullPathsIndexedByIds(string $locale): array
-    {
-        return $this->categoryRepository->getFullPathsIndexedByIds($locale);
-    }
-
-    /**
      * @param \App\Model\Category\Category $category
      * @param \Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig $domainConfig
      * @return \App\Model\Category\Category[]

--- a/project-base/app/src/Model/Category/CategoryRepository.php
+++ b/project-base/app/src/Model/Category/CategoryRepository.php
@@ -82,45 +82,6 @@ class CategoryRepository extends BaseCategoryRepository
     }
 
     /**
-     * @param string $locale
-     * @return string[]
-     */
-    public function getFullPathsIndexedByIds(string $locale): array
-    {
-        $queryBuilder = $this->getPreOrderTreeTraversalForAllCategoriesQueryBuilder($locale);
-
-        $rows = $queryBuilder->select('c.id, IDENTITY(c.parent) AS parentId, ct.name')->getQuery()->getScalarResult();
-
-        $fullPathsById = [];
-
-        foreach ($rows as $row) {
-            if (array_key_exists($row['parentId'], $fullPathsById)) {
-                $fullPathsById[$row['id']] = $fullPathsById[$row['parentId']] . ' - ' . $row['name'];
-            } else {
-                $fullPathsById[$row['id']] = $row['name'];
-            }
-        }
-
-        return $fullPathsById;
-    }
-
-    /**
-     * @param string $locale
-     * @return \Doctrine\ORM\QueryBuilder
-     */
-    private function getPreOrderTreeTraversalForAllCategoriesQueryBuilder(string $locale): QueryBuilder
-    {
-        $queryBuilder = $this->getAllQueryBuilder();
-        $this->addTranslation($queryBuilder, $locale);
-
-        $queryBuilder
-            ->andWhere('c.level >= 1')
-            ->orderBy('c.lft');
-
-        return $queryBuilder;
-    }
-
-    /**
      * Thanks to joining "c.domains" instead of "CategoryDomain::class",
      * the category domains can be eager loaded (by adding "cd" to "select" part), but are still excluded from the result array
      *

--- a/upgrade-notes/backend_20250305_064851.md
+++ b/upgrade-notes/backend_20250305_064851.md
@@ -1,0 +1,7 @@
+#### make navigation independent on czech domain presence ([#3837](https://github.com/shopsys/shopsys/pull/3837))
+
+- [features moved](#movement-of-features-from-project-base-to-packages) from project-base to the framework packages:
+    - `CategoryFacade::getFullPathsIndexedByIds()` method
+    - `CategoryRepository::getFullPathsIndexedByIds()` method
+    - `CategoryRepository::getPreOrderTreeTraversalForAllCategoriesQueryBuilder()` method
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

Navigation settings now don't rely on the fact that project uses czech domain.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-navigation.odin.shopsys.cloud
  - https://cz.mg-fix-navigation.odin.shopsys.cloud
<!-- Replace -->
