### PR TITLE
Optional links to social networks for email templates

### DIFF
--- a/packages/framework/src/Controller/Admin/MailController.php
+++ b/packages/framework/src/Controller/Admin/MailController.php
@@ -169,7 +169,7 @@ class MailController extends AdminBaseController
             'youtubeUrl' => $this->mailSettingFacade->getYoutubeUrl($selectedDomainId),
             'linkedinUrl' => $this->mailSettingFacade->getLinkedInUrl($selectedDomainId),
             'tiktokUrl' => $this->mailSettingFacade->getTiktokUrl($selectedDomainId),
-            'footerText' => $this->mailSettingFacade->getFooterTextUrl($selectedDomainId),
+            'footerText' => $this->mailSettingFacade->getFooterText($selectedDomainId),
         ];
 
         $form = $this->createForm(MailSettingFormType::class, $mailSettingData);

--- a/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
+++ b/packages/framework/src/Form/Admin/Mail/MailSettingFormType.php
@@ -50,18 +50,23 @@ class MailSettingFormType extends AbstractType
 
         $footerGroup->add('facebookUrl', TextType::class, [
             'label' => t('Facebook URL'),
+            'required' => false,
         ]);
         $footerGroup->add('instagramUrl', TextType::class, [
             'label' => t('Instagram URL'),
+            'required' => false,
         ]);
         $footerGroup->add('youtubeUrl', TextType::class, [
             'label' => t('Youtube URL'),
+            'required' => false,
         ]);
         $footerGroup->add('linkedinUrl', TextType::class, [
             'label' => t('LinkedIn URL'),
+            'required' => false,
         ]);
         $footerGroup->add('tiktokUrl', TextType::class, [
             'label' => t('TikTok URL'),
+            'required' => false,
         ]);
         $footerGroup->add('footerText', CKEditorType::class, [
             'label' => t('Footer Text'),

--- a/packages/framework/src/Model/Mail/MailTemplateBuilder.php
+++ b/packages/framework/src/Model/Mail/MailTemplateBuilder.php
@@ -36,9 +36,35 @@ class MailTemplateBuilder
      * @param int $domainId
      * @return string
      */
-    protected function getFooterText(int $domainId): string
+    protected function getFooterTextTableRow(int $domainId): string
     {
-        return $this->mailSettingFacade->getFooterTextUrl($domainId);
+        $footerTextTableRow = '';
+        $footerText = $this->getFooterText($domainId);
+
+        if ($footerText !== null) {
+            $footerTextTableRow = <<<EOT
+                <tr>
+                    <td style="padding:10px; text-align:center;">
+                        <div style="max-width:600px; margin:0 auto;">
+                            <span style="font-size:12px; line-height:1.3; mso-line-height-rule:exactly;">
+                                {$footerText}
+                            </span>
+                        </div>
+                    </td>
+                </tr>
+            EOT;
+        }
+
+        return $footerTextTableRow;
+    }
+
+    /**
+     * @param int $domainId
+     * @return string|null
+     */
+    protected function getFooterText(int $domainId): ?string
+    {
+        return $this->mailSettingFacade->getFooterText($domainId);
     }
 
     /**
@@ -241,16 +267,8 @@ class MailTemplateBuilder
                                             &nbsp;
                                         </td>
                                     </tr>
-                                    <tr>
-                                        <td style="padding:10px; text-align:center;">
-                                            <div style="max-width:600px; margin:0 auto;">
-                                                <span style="font-size:12px; line-height:1.3; mso-line-height-rule:exactly;">
-                                                    {$this->getFooterText($domainId)}
-                                                </span>
-                                            </div>
-                                        </td>
-                                    </tr>
                                     {$this->getFooterIconsTableRow($domainId)}
+                                    {$this->getFooterTextTableRow($domainId)}
                                 </table>
                             </div>
 

--- a/packages/framework/src/Model/Mail/MailTemplateBuilder.php
+++ b/packages/framework/src/Model/Mail/MailTemplateBuilder.php
@@ -45,10 +45,31 @@ class MailTemplateBuilder
      * @param int $domainId
      * @return string
      */
+    protected function getFooterIconsTableRow(int $domainId): string
+    {
+        $footerIconsTableRow = '';
+        $footerIconsHtml = $this->getFooterIcons($domainId);
+
+        if ($footerIconsHtml !== '') {
+            $footerIconsTableRow = <<<EOT
+                <tr>
+                    <td style="padding:10px; text-align:center;">
+                        {$footerIconsHtml}
+                    </td>
+                </tr>
+            EOT;
+        }
+
+        return $footerIconsTableRow;
+    }
+
+    /**
+     * @param int $domainId
+     * @return string
+     */
     protected function getFooterIcons(int $domainId): string
     {
         $footerIconsHtml = '';
-        $itemPadding = '';
 
         foreach ($this->mailSettingFacade->getFooterIconUrls($domainId) as $footerIconName => $footerIconUrl) {
             if ($footerIconUrl === null) {
@@ -222,11 +243,6 @@ class MailTemplateBuilder
                                     </tr>
                                     <tr>
                                         <td style="padding:10px; text-align:center;">
-                                            {$this->getFooterIcons($domainId)}
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td style="padding:10px; text-align:center;">
                                             <div style="max-width:600px; margin:0 auto;">
                                                 <span style="font-size:12px; line-height:1.3; mso-line-height-rule:exactly;">
                                                     {$this->getFooterText($domainId)}
@@ -234,6 +250,7 @@ class MailTemplateBuilder
                                             </div>
                                         </td>
                                     </tr>
+                                    {$this->getFooterIconsTableRow($domainId)}
                                 </table>
                             </div>
 

--- a/packages/framework/src/Model/Mail/Setting/MailSetting.php
+++ b/packages/framework/src/Model/Mail/Setting/MailSetting.php
@@ -6,14 +6,14 @@ namespace Shopsys\FrameworkBundle\Model\Mail\Setting;
 
 class MailSetting
 {
-    public const MAIN_ADMIN_MAIL = 'mainAdminMail';
-    public const MAIN_ADMIN_MAIL_NAME = 'mainAdminMailName';
-    public const MAIL_WHITELIST = 'mailWhitelist';
-    public const MAIL_WHITELIST_ENABLED = 'mailWhitelistEnabled';
-    public const MAIL_FACEBOOK_URL = 'mailFacebookUrl';
-    public const MAIL_INSTAGRAM_URL = 'mailInstagramUrl';
-    public const MAIL_YOUTUBE_URL = 'mailYoutubeUrl';
-    public const MAIL_LINKEDIN_URL = 'mailLinkedinUrl';
-    public const MAIL_TIKTOK_URL = 'mailTiktokUrl';
-    public const MAIL_FOOTER_TEXT = 'mailFooterText';
+    public const string MAIN_ADMIN_MAIL = 'mainAdminMail';
+    public const string MAIN_ADMIN_MAIL_NAME = 'mainAdminMailName';
+    public const string MAIL_WHITELIST = 'mailWhitelist';
+    public const string MAIL_WHITELIST_ENABLED = 'mailWhitelistEnabled';
+    public const string MAIL_FACEBOOK_URL = 'mailFacebookUrl';
+    public const string MAIL_INSTAGRAM_URL = 'mailInstagramUrl';
+    public const string MAIL_YOUTUBE_URL = 'mailYoutubeUrl';
+    public const string MAIL_LINKEDIN_URL = 'mailLinkedinUrl';
+    public const string MAIL_TIKTOK_URL = 'mailTiktokUrl';
+    public const string MAIL_FOOTER_TEXT = 'mailFooterText';
 }

--- a/packages/framework/src/Model/Mail/Setting/MailSettingFacade.php
+++ b/packages/framework/src/Model/Mail/Setting/MailSettingFacade.php
@@ -135,9 +135,9 @@ class MailSettingFacade
 
     /**
      * @param int $domainId
-     * @return string
+     * @return string|null
      */
-    public function getFooterTextUrl(int $domainId): string
+    public function getFooterText(int $domainId): ?string
     {
         return $this->setting->getForDomain(MailSetting::MAIL_FOOTER_TEXT, $domainId);
     }
@@ -203,10 +203,11 @@ class MailSettingFacade
     }
 
     /**
-     * @param string $value
+     * @param string|null $value
      * @param int $domainId
+     * @throws \Shopsys\FrameworkBundle\Component\Setting\Exception\SettingValueNotFoundException
      */
-    public function setFooterText(string $value, int $domainId): void
+    public function setFooterText(?string $value, int $domainId): void
     {
         $this->setting->setForDomain(MailSetting::MAIL_FOOTER_TEXT, $value, $domainId);
     }

--- a/packages/framework/src/Model/Mail/Setting/MailSettingFacade.php
+++ b/packages/framework/src/Model/Mail/Setting/MailSettingFacade.php
@@ -90,47 +90,47 @@ class MailSettingFacade
 
     /**
      * @param int $domainId
-     * @return string
+     * @return string|null
      */
-    public function getFacebookUrl(int $domainId): string
+    public function getFacebookUrl(int $domainId): ?string
     {
-        return $this->setting->getForDomain(MailSetting::MAIL_FACEBOOK_URL, $domainId) ?? '';
+        return $this->setting->getForDomain(MailSetting::MAIL_FACEBOOK_URL, $domainId);
     }
 
     /**
      * @param int $domainId
-     * @return string
+     * @return string|null
      */
-    public function getInstagramUrl(int $domainId): string
+    public function getInstagramUrl(int $domainId): ?string
     {
-        return $this->setting->getForDomain(MailSetting::MAIL_INSTAGRAM_URL, $domainId) ?? '';
+        return $this->setting->getForDomain(MailSetting::MAIL_INSTAGRAM_URL, $domainId);
     }
 
     /**
      * @param int $domainId
-     * @return string
+     * @return string|null
      */
-    public function getYoutubeUrl(int $domainId): string
+    public function getYoutubeUrl(int $domainId): ?string
     {
-        return $this->setting->getForDomain(MailSetting::MAIL_YOUTUBE_URL, $domainId) ?? '';
+        return $this->setting->getForDomain(MailSetting::MAIL_YOUTUBE_URL, $domainId);
     }
 
     /**
      * @param int $domainId
-     * @return string
+     * @return string|null
      */
-    public function getLinkedInUrl(int $domainId): string
+    public function getLinkedInUrl(int $domainId): ?string
     {
-        return $this->setting->getForDomain(MailSetting::MAIL_LINKEDIN_URL, $domainId) ?? '';
+        return $this->setting->getForDomain(MailSetting::MAIL_LINKEDIN_URL, $domainId);
     }
 
     /**
      * @param int $domainId
-     * @return string
+     * @return string|null
      */
-    public function getTiktokUrl(int $domainId): string
+    public function getTiktokUrl(int $domainId): ?string
     {
-        return $this->setting->getForDomain(MailSetting::MAIL_TIKTOK_URL, $domainId) ?? '';
+        return $this->setting->getForDomain(MailSetting::MAIL_TIKTOK_URL, $domainId);
     }
 
     /**
@@ -149,11 +149,11 @@ class MailSettingFacade
     public function getFooterIconUrls(int $domainId): array
     {
         return [
-            'facebook' => strlen($this->getFacebookUrl($domainId)) === 0 ? null : $this->getFacebookUrl($domainId),
-            'instagram' => strlen($this->getInstagramUrl($domainId)) === 0 ? null : $this->getInstagramUrl($domainId),
-            'youtube' => strlen($this->getYoutubeUrl($domainId)) === 0 ? null : $this->getYoutubeUrl($domainId),
-            'linkedin' => strlen($this->getLinkedInUrl($domainId)) === 0 ? null : $this->getLinkedInUrl($domainId),
-            'tiktok' => strlen($this->getTiktokUrl($domainId)) === 0 ? null : $this->getTiktokUrl($domainId),
+            'facebook' => $this->getFacebookUrl($domainId),
+            'instagram' => $this->getInstagramUrl($domainId),
+            'youtube' => $this->getYoutubeUrl($domainId),
+            'linkedin' => $this->getLinkedInUrl($domainId),
+            'tiktok' => $this->getTiktokUrl($domainId),
         ];
     }
 


### PR DESCRIPTION
#### Description, the reason for the PR

As an administrator, I do not want to be required to enter links to all social media networks in the admin panel for the email footer.

Acceptance criteria:
The administrator does not need to enter links to all social media networks on the page Settings > Communication with Customer > Email Settings.
If a link is not entered, the icon with the link does not appear in the email footer.
If no links are entered, the entire social media section will not be displayed in the email footer.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mb-ssp-2982-make-email-fotter-social-links-optional.odin.shopsys.cloud
  - https://cz.mb-ssp-2982-make-email-fotter-social-links-optional.odin.shopsys.cloud
<!-- Replace -->
