### PR TITLE
Tuning the display of a group of parameters when editing a product

### DIFF
--- a/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
@@ -8,6 +8,7 @@ use Override;
 use Shopsys\FrameworkBundle\Form\Locale\LocalizedType;
 use Shopsys\FrameworkBundle\Form\ValidationGroup;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterFacade;
 use Shopsys\FrameworkBundle\Model\Product\Parameter\ProductParameterValuesLocalizedData;
 use Symfony\Component\Form\AbstractType;
@@ -42,11 +43,17 @@ class ProductParameterValueFormType extends AbstractType
             ->add('parameter', ChoiceType::class, [
                 'required' => true,
                 'choices' => $this->parameterFacade->getAllWithTranslations($this->localization->getAdminLocale()),
-                'choice_label' => 'name',
+                'choice_label' => function (Parameter $parameter) {
+                    return $parameter->getName() .
+                    ' [' . $this->getGroupName($parameter) . ']';
+                },
                 'choice_value' => 'id',
                 'constraints' => [
                     new Constraints\NotBlank(['message' => 'Please choose parameter']),
                 ],
+                'group_by' => function (Parameter $parameter) {
+                    return $this->getGroupName($parameter);
+                },
             ])
             ->add('valueTextsByLocale', LocalizedType::class, [
                 'required' => true,
@@ -90,5 +97,14 @@ class ProductParameterValueFormType extends AbstractType
                 return $validationGroups;
             },
         ]);
+    }
+
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Product\Parameter\Parameter $parameter
+     * @return string
+     */
+    protected function getGroupName(Parameter $parameter): string
+    {
+        return $parameter->getGroup()?->getName($this->localization->getAdminLocale()) ?? t('No group');
     }
 }

--- a/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterRepository.php
@@ -178,7 +178,8 @@ class ParameterRepository
     {
         return $this->getAllQueryBuilder()
             ->addSelect('pt')
-            ->join('p.translations', 'pt')
+            ->join('p.translations', 'pt', Join::WITH, 'pt.locale = :locale')
+            ->setParameter('locale', $locale)
             ->orderBy($this->orderByCollationHelper->createOrderByForLocale('pt.name', $locale), 'asc')
             ->getQuery()
             ->execute();

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2197,9 +2197,6 @@ msgstr "Stav platby GoPay"
 msgid "Group"
 msgstr "Skupina"
 
-msgid "Groups"
-msgstr "Skupiny"
-
 msgid "HTML code"
 msgstr "HTML kód"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2197,9 +2197,6 @@ msgstr ""
 msgid "Group"
 msgstr ""
 
-msgid "Groups"
-msgstr ""
-
 msgid "HTML code"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Form/productParameterValue.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Form/productParameterValue.html.twig
@@ -1,10 +1,6 @@
 {% macro parameterRow(parameter, index) %}
-    {% set parameterGroupName = parameter.vars.data.parameter.group.name|default('No group'|trans) %}
     {% set parameterUnit = parameter.parameter.vars.data.unit ?? null %}
     <tr class="js-parameters-item js-form-group table-form__row" data-index="{{ index }}">
-        <td class="table-form__cell table-form__cell--del-before">
-            <p>{{ parameterGroupName }}</p>
-        </td>
         <td class="table-form__cell table-form__cell--del-before">
             {{ form_widget(parameter.parameter, { isSimple: true} ) }}
         </td>
@@ -35,7 +31,6 @@
         <table class="table-form" id="product_form_parameters">
             <thead>
             <tr class="table-form__row">
-                <th class="table-form__cell table-form__cell--del-before table-form__cell--label">{{ 'Groups'|trans }}</th>
                 <th class="table-form__cell table-form__cell--del-before table-form__cell--label">{{ 'Parameter'|trans }}</th>
                 <th class="table-form__cell table-form__cell--del"></th>
                 <th class="table-form__cell table-form__cell--del-after">{{ 'Value'|trans }}</th>


### PR DESCRIPTION
#### Description, the reason for the PR

As an administrator, when editing a product and setting its parameters, I want to clearly see which parameter group a given parameter belongs to.

Acceptance Criteria:

In the product detail view while editing parameters, the administrator does not see a separate column with the parameter group name.
If a parameter has an assigned parameter group, the parameter name in the select box includes the group name.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mb-ssp-2864-change-visual-setting-of-product-parameters.odin.shopsys.cloud
  - https://cz.mb-ssp-2864-change-visual-setting-of-product-parameters.odin.shopsys.cloud
<!-- Replace -->
