### PR TITLE
Filter in the administration for products type upon inquiry

### DIFF
--- a/packages/framework/src/Form/Admin/AdvancedSearch/AdvancedSearchProductFilterTranslation.php
+++ b/packages/framework/src/Form/Admin/AdvancedSearch/AdvancedSearchProductFilterTranslation.php
@@ -11,6 +11,7 @@ use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductCatnumFilter;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductFlagFilter;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductNameFilter;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductPartnoFilter;
+use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductUponInquiryFilter;
 
 class AdvancedSearchProductFilterTranslation extends AdvancedSearchFilterTranslation
 {
@@ -25,5 +26,6 @@ class AdvancedSearchProductFilterTranslation extends AdvancedSearchFilterTransla
         $this->addFilterTranslation(ProductCalculatedSellingDeniedFilter::NAME, t('Excluded from sale'));
         $this->addFilterTranslation(ProductBrandFilter::NAME, t('Brand'));
         $this->addFilterTranslation(ProductCategoryFilter::NAME, t('Category'));
+        $this->addFilterTranslation(ProductUponInquiryFilter::NAME, t('Upon inquiry'));
     }
 }

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductUponInquiryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductUponInquiryFilter.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter;
+
+use Doctrine\ORM\QueryBuilder;
+use Shopsys\FrameworkBundle\Model\AdvancedSearch\AdvancedSearchFilterInterface;
+use Shopsys\FrameworkBundle\Model\Product\ProductTypeEnum;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+
+class ProductUponInquiryFilter implements AdvancedSearchFilterInterface
+{
+    public const string NAME = 'productUponInquiryFilter';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAllowedOperators(): array
+    {
+        return [
+            self::OPERATOR_IS,
+            self::OPERATOR_IS_NOT,
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueFormType(): string
+    {
+        return HiddenType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValueFormOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function extendQueryBuilder(QueryBuilder $queryBuilder, $rulesData): void
+    {
+        foreach ($rulesData as $index => $ruleData) {
+            $operator = $ruleData->operator === self::OPERATOR_IS ? '=' : '!=';
+
+            $parameterName = 'productType_' . $index;
+            $queryBuilder
+                ->andWhere('p.productType ' . $operator . ' :' . $parameterName)
+                ->setParameter($parameterName, ProductTypeEnum::TYPE_INQUIRY);
+        }
+    }
+}

--- a/packages/framework/src/Model/AdvancedSearch/ProductAdvancedSearchConfig.php
+++ b/packages/framework/src/Model/AdvancedSearch/ProductAdvancedSearchConfig.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductCatnumFilter;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductFlagFilter;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductNameFilter;
 use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductPartnoFilter;
+use Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductUponInquiryFilter;
 
 class ProductAdvancedSearchConfig extends AdvancedSearchConfig
 {
@@ -23,6 +24,7 @@ class ProductAdvancedSearchConfig extends AdvancedSearchConfig
      * @param \Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductCalculatedSellingDeniedFilter $productCalculatedSellingDeniedFilter
      * @param \Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductBrandFilter $productBrandFilter
      * @param \Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductCategoryFilter $productCategoryFilter
+     * @param \Shopsys\FrameworkBundle\Model\AdvancedSearch\Filter\ProductUponInquiryFilter $productUponInquiryFilter
      */
     public function __construct(
         ProductCatnumFilter $productCatnumFilter,
@@ -32,6 +34,7 @@ class ProductAdvancedSearchConfig extends AdvancedSearchConfig
         ProductCalculatedSellingDeniedFilter $productCalculatedSellingDeniedFilter,
         ProductBrandFilter $productBrandFilter,
         ProductCategoryFilter $productCategoryFilter,
+        ProductUponInquiryFilter $productUponInquiryFilter,
     ) {
         parent::__construct();
 
@@ -42,6 +45,7 @@ class ProductAdvancedSearchConfig extends AdvancedSearchConfig
         $this->registerFilter($productCalculatedSellingDeniedFilter);
         $this->registerFilter($productBrandFilter);
         $this->registerFilter($productCategoryFilter);
+        $this->registerFilter($productUponInquiryFilter);
     }
 
     /**

--- a/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
@@ -39,6 +39,7 @@ class ProductListAdminRepository
             pt.name, 
             p.calculatedSellingDenied,
             p.variantType,
+            p.productType,
             p.catnum,
             p.ean,
             pmip.inputPrice AS priceForProductList')

--- a/packages/framework/src/Model/Product/ProductGridFactory.php
+++ b/packages/framework/src/Model/Product/ProductGridFactory.php
@@ -53,6 +53,7 @@ class ProductGridFactory
         $grid->setTheme('@ShopsysFramework/Admin/Content/Product/listGrid.html.twig', [
             'VARIANT_TYPE_MAIN' => Product::VARIANT_TYPE_MAIN,
             'VARIANT_TYPE_VARIANT' => Product::VARIANT_TYPE_VARIANT,
+            'TYPE_INQUIRY' => ProductTypeEnum::TYPE_INQUIRY,
         ]);
 
         return $grid;
@@ -79,6 +80,7 @@ class ProductGridFactory
 
         $gridViewParameters['VARIANT_TYPE_MAIN'] = Product::VARIANT_TYPE_MAIN;
         $gridViewParameters['VARIANT_TYPE_VARIANT'] = Product::VARIANT_TYPE_VARIANT;
+        $gridViewParameters['TYPE_INQUIRY'] = ProductTypeEnum::TYPE_INQUIRY;
         $grid->setTheme('@ShopsysFramework/Admin/Content/ProductPicker/listGrid.html.twig', $gridViewParameters);
 
         return $grid;

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -4570,6 +4570,9 @@ msgstr "Nahrávám..."
 msgid "Upon inquiry"
 msgstr "Na poptávku"
 
+msgid "Upon inquiry [abbreviation]"
+msgstr "?"
+
 msgid "Url address"
 msgstr "Url adresa"
 

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -4570,6 +4570,9 @@ msgstr ""
 msgid "Upon inquiry"
 msgstr ""
 
+msgid "Upon inquiry [abbreviation]"
+msgstr "?"
+
 msgid "Url address"
 msgstr ""
 

--- a/packages/framework/src/Resources/views/Admin/Content/Product/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Product/listGrid.html.twig
@@ -13,6 +13,9 @@
 {% endblock %}
 
 {% block grid_value_cell_id_name %}
+    {% if row.productType == TYPE_INQUIRY %}
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Upon inquiry'|trans }}">{{ 'Upon inquiry [abbreviation]'|trans }}</span>
+    {% endif %}
     {% if row.variantType == VARIANT_TYPE_MAIN %}
         <span class="in-letter cursor-help js-tooltip" title="{{ 'Main variant'|trans }}">{{ 'Main variant [abbreviation]'|trans }}</span>
     {% endif %}

--- a/packages/framework/src/Resources/views/Admin/Content/ProductPicker/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/ProductPicker/listGrid.html.twig
@@ -3,6 +3,9 @@
 {% block grid_action_cell_type_edit %}{% endblock %}
 
 {% block grid_value_cell_id_name %}
+    {% if row.productType == TYPE_INQUIRY %}
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Upon inquiry'|trans }}">{{ 'Upon inquiry [abbreviation]'|trans }}</span>
+    {% endif %}
     {% if row.variantType == VARIANT_TYPE_MAIN %}
         <span class="in-letter cursor-help js-tooltip" title="{{ 'Main variant'|trans }}">{{ 'Main variant [abbreviation]'|trans }}</span>
     {% endif %}


### PR DESCRIPTION
#### Description, the reason for the PR

As an administrator, I want to be able to easily find out which products are or are not upon inquiry.

Acceptance criteria:

In the administration, in the advanced product filter, it should be possible to filter all products that are or are not upon inquiry.

In the administration, in the product overview, it should be immediately recognizable using an icon whether the product is upon inquiry. Products that are not upon inquiry do not need to have this icon.


#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mb-ssp-2866-add-product-demand-info-to-admin.odin.shopsys.cloud
  - https://cz.mb-ssp-2866-add-product-demand-info-to-admin.odin.shopsys.cloud
<!-- Replace -->
