### PR TITLE
fix multiple rerenders of product comparison

### DIFF
--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonContent.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonContent.tsx
@@ -58,7 +58,7 @@ export const ProductComparisonContent: FC<ProductComparisonContentProps> = ({ co
 
     useEffect(() => {
         calcMaxMarginLeft();
-    }, [calcMaxMarginLeft]);
+    }, [comparedProducts]);
 
     return (
         <>

--- a/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadSticky.tsx
+++ b/project-base/storefront/components/Pages/ProductComparison/ProductComparisonHeadSticky.tsx
@@ -1,7 +1,8 @@
 import { Image } from 'components/Basic/Image/Image';
 import { TypeProductInProductListFragment } from 'graphql/requests/productLists/fragments/ProductInProductListFragment.generated';
+import { useState } from 'react';
 import { twJoin } from 'tailwind-merge';
-import { useComparisonTable } from 'utils/productLists/comparison/useComparisonTable';
+import { useScrollTop } from 'utils/ui/useScrollTop';
 
 type ProductComparisonHeadStickyProps = {
     comparedProducts: TypeProductInProductListFragment[];
@@ -9,7 +10,19 @@ type ProductComparisonHeadStickyProps = {
 };
 
 export const ProductComparisonHeadSticky: FC<ProductComparisonHeadStickyProps> = (props) => {
-    const { tableStickyHeadActive } = useComparisonTable(props.comparedProducts.length);
+    return (
+        <ProductComparisonHeadStickyWrapper>
+            <ProductComparisonHeadStickyContent
+                comparedProducts={props.comparedProducts}
+                tableMarginLeft={props.tableMarginLeft}
+            />
+        </ProductComparisonHeadStickyWrapper>
+    );
+};
+
+const ProductComparisonHeadStickyWrapper = ({ children }: { children: React.ReactNode }) => {
+    const [tableStickyHeadActive, setTableStickyHeadActive] = useState(false);
+    useScrollTop('js-table-compare', setTableStickyHeadActive);
 
     return (
         <div
@@ -18,30 +31,39 @@ export const ProductComparisonHeadSticky: FC<ProductComparisonHeadStickyProps> =
                 tableStickyHeadActive ? 'flex' : 'hidden',
             )}
         >
-            <div className="mx-auto flex w-full max-w-7xl flex-nowrap overflow-hidden">
-                <div className="vl:min-w-[290px] static flex h-full max-w-[182px] min-w-[115px] shrink-0 border-r-1 sm:w-auto sm:max-w-none sm:min-w-[220px] md:max-w-none md:min-w-[265px] lg:min-w-[270px]" />
-                {props.comparedProducts.map((product, index) => (
-                    <div
-                        key={`headSticky-${product.uuid}`}
-                        className="flex max-w-[calc(182px+12px*2)] min-w-[calc(182px+12px*2)] shrink-0 basis-64 items-center border-r-1 px-1 py-3 sm:max-w-[calc(205px+20px*2)] sm:min-w-[calc(205px+20px*2)]"
-                        style={index === 0 ? { marginLeft: -props.tableMarginLeft } : undefined}
-                    >
-                        <a className="relative h-16 w-16" href={product.slug}>
-                            <Image
-                                fill
-                                alt={product.mainImage?.name || product.fullName}
-                                className="object-contain"
-                                src={product.mainImage?.url}
-                            />
-                        </a>
-                        <div className="ml-2 flex flex-1 flex-col">
-                            <a className="text-xs no-underline hover:no-underline" href={product.slug}>
-                                {product.fullName}
-                            </a>
-                        </div>
-                    </div>
-                ))}
-            </div>
+            {children}
         </div>
     );
 };
+
+type ProductComparisonContentProps = {
+    comparedProducts: TypeProductInProductListFragment[];
+    tableMarginLeft: number;
+};
+
+const ProductComparisonHeadStickyContent = ({ comparedProducts, tableMarginLeft }: ProductComparisonContentProps) => (
+    <div className="mx-auto flex w-full max-w-7xl flex-nowrap overflow-hidden">
+        <div className="vl:min-w-[290px] static flex h-full max-w-[182px] min-w-[115px] shrink-0 border-r-1 sm:w-auto sm:max-w-none sm:min-w-[220px] md:max-w-none md:min-w-[265px] lg:min-w-[270px]" />
+        {comparedProducts.map((product, index) => (
+            <div
+                key={`headSticky-${product.uuid}`}
+                className="flex max-w-[calc(182px+12px*2)] min-w-[calc(182px+12px*2)] shrink-0 basis-64 items-center border-r-1 px-1 py-3 sm:max-w-[calc(205px+20px*2)] sm:min-w-[calc(205px+20px*2)]"
+                style={index === 0 ? { marginLeft: -tableMarginLeft } : undefined}
+            >
+                <a className="relative h-16 w-16" href={product.slug}>
+                    <Image
+                        fill
+                        alt={product.mainImage?.name || product.fullName}
+                        className="object-contain"
+                        src={product.mainImage?.url}
+                    />
+                </a>
+                <div className="ml-2 flex flex-1 flex-col">
+                    <a className="text-xs no-underline hover:no-underline" href={product.slug}>
+                        {product.fullName}
+                    </a>
+                </div>
+            </div>
+        ))}
+    </div>
+);

--- a/project-base/storefront/utils/productLists/comparison/useComparisonTable.tsx
+++ b/project-base/storefront/utils/productLists/comparison/useComparisonTable.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useGetWindowSize } from 'utils/ui/useGetWindowSize';
-import { useScrollTop } from 'utils/ui/useScrollTop';
 import { useComponentUpdate } from 'utils/useComponentUpdate';
 
 export const useComparisonTable = (
@@ -10,7 +9,6 @@ export const useComparisonTable = (
     isArrowRightActive: boolean;
     isArrowLeftShowed: boolean;
     isArrowRightShowed: boolean;
-    tableStickyHeadActive: boolean;
     handleSlideLeft: () => void;
     handleSlideRight: () => void;
     calcMaxMarginLeft: () => void;
@@ -22,9 +20,7 @@ export const useComparisonTable = (
     const [isArrowRightShowed, setArrowRightShowed] = useState(true);
     const [tableMarginLeft, setTableMarginLeft] = useState(0);
     const [tableMaxMarginLeft, setTableMaxMarginLeft] = useState(0);
-    const [tableStickyHeadActive, setTableStickyHeadActive] = useState(false);
     const { width } = useGetWindowSize();
-    const tableY = useScrollTop('js-table-compare');
 
     const handleSlideLeft = () => {
         const marginLeft = tableMarginLeft;
@@ -81,10 +77,8 @@ export const useComparisonTable = (
     };
 
     useComponentUpdate(() => {
-        const marginLeft = tableMarginLeft;
-
         calcMaxMarginLeft();
-        setMargin(marginLeft);
+        setMargin(tableMarginLeft);
 
         if (tableMaxMarginLeft > 0) {
             setArrowLeftShowed(true);
@@ -95,20 +89,11 @@ export const useComparisonTable = (
         }
     }, [width, tableMaxMarginLeft]);
 
-    useComponentUpdate(() => {
-        if (tableY < -150) {
-            setTableStickyHeadActive(true);
-        } else {
-            setTableStickyHeadActive(false);
-        }
-    }, [tableY]);
-
     return {
         isArrowLeftActive,
         isArrowRightActive,
         isArrowLeftShowed,
         isArrowRightShowed,
-        tableStickyHeadActive,
         handleSlideLeft,
         handleSlideRight,
         calcMaxMarginLeft,

--- a/project-base/storefront/utils/ui/useScrollTop.ts
+++ b/project-base/storefront/utils/ui/useScrollTop.ts
@@ -1,16 +1,16 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
 
-export const useScrollTop = (element: string): number => {
-    const [offsetTop, setOffsetTop] = useState(0);
-
+export const useScrollTop = (element: string, setTableStickyHeadActive: Dispatch<SetStateAction<boolean>>) => {
     useEffect(() => {
         const updateSize = () => {
-            setOffsetTop(document.getElementById(element)!.getBoundingClientRect().top);
+            setTableStickyHeadActive(document.getElementById(element)!.getBoundingClientRect().top < -150);
         };
+
         window.addEventListener('scroll', updateSize);
         updateSize();
-        return () => window.removeEventListener('scroll', updateSize);
-    }, [element]);
 
-    return offsetTop;
+        return () => {
+            window.removeEventListener('scroll', updateSize);
+        };
+    }, [element]);
 };

--- a/upgrade-notes/storefront_20250311_073929.md
+++ b/upgrade-notes/storefront_20250311_073929.md
@@ -1,0 +1,7 @@
+#### fix multiple rerenders of product comparison ([#3852](https://github.com/shopsys/shopsys/pull/3852))
+
+- decouple sticky head from child components = make a sticky head wrapper `ProductComparisonHeadStickyWrapper`
+- decouple constant (on-scroll) synchronization of Y position with the react state - change the state only when Y reached a desired Y-offset (in `useScrollTop.ts`)
+- make only the newly created `ProductComparisonHeadStickyWrapper` dependant on that Y-offset state
+- other tiny fixes in the logic
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

- decouple sticky head from child components = make sticky head wrapper
- decouple constant update of scroll Y position to the state - change state only when Y reached a configured Y-offset
- make only sticky head wrapper to be depndent on this Y-offset state
- other small fixes in logic

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - The product comparison page now updates dynamically as users adjust the compared items for a more accurate display.
  - The sticky header has been restructured into a dedicated wrapper for improved modularity and responsiveness during scrolling.
  - Enhanced state management for the sticky header, reducing unnecessary re-renders.
  - The logic for handling the sticky header has been simplified, improving overall performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



















<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://fh-ssp-3237-fix-product-comparison-rerender.odin.shopsys.cloud
  - https://cz.fh-ssp-3237-fix-product-comparison-rerender.odin.shopsys.cloud
<!-- Replace -->
