### PR TITLE
fixed adding non string constant to category data fixture

### DIFF
--- a/project-base/app/src/DataFixtures/Demo/CategoryParameterDataFixture.php
+++ b/project-base/app/src/DataFixtures/Demo/CategoryParameterDataFixture.php
@@ -35,7 +35,7 @@ class CategoryParameterDataFixture extends AbstractReferenceFixture implements D
         $categoryDataFixtureClassReflection = new ReflectionClass(CategoryDataFixture::class);
 
         foreach ($categoryDataFixtureClassReflection->getConstants() as $constant) {
-            if (!str_starts_with($constant, 'category_')) {
+            if (!is_string($constant) || !str_starts_with($constant, 'category_')) {
                 continue;
             }
 

--- a/upgrade-notes/backend_20250312_133647.md
+++ b/upgrade-notes/backend_20250312_133647.md
@@ -1,0 +1,3 @@
+#### allow adding non-string constant to category data fixture ([#3854](https://github.com/shopsys/shopsys/pull/3854))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

When a constant with a different type than string was added to the CategoryDataFixture class, the CategoryParameterDataFixture errors. 
This PR fixes that.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-category-constant.odin.shopsys.cloud
  - https://cz.mg-fix-category-constant.odin.shopsys.cloud
<!-- Replace -->
