### PR TITLE
invalid locale set to admin now defaults to first allowed locale

### DIFF
--- a/packages/framework/src/Model/Localization/LocalizationListener.php
+++ b/packages/framework/src/Model/Localization/LocalizationListener.php
@@ -6,6 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Localization;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -16,11 +19,15 @@ class LocalizationListener implements EventSubscriberInterface
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      * @param \Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade $administrationFacade
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly Localization $localization,
         protected readonly AdministrationFacade $administrationFacade,
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
+        protected readonly AdministratorFrontSecurityFacade $administratorFrontSecurityFacade,
     ) {
     }
 
@@ -33,7 +40,16 @@ class LocalizationListener implements EventSubscriberInterface
             $request = $event->getRequest();
 
             if ($this->administrationFacade->isInAdmin()) {
-                $request->setLocale($this->localization->getAdminLocale());
+                try {
+                    $adminLocale = $this->localization->getAdminLocale();
+                } catch (AdminLocaleNotFoundException) {
+                    $adminLocale = $this->localization->getDefaultAdminLocale();
+
+                    $administrator = $this->administratorFrontSecurityFacade->getCurrentAdministrator();
+                    $this->administratorLocalizationFacade->setSelectedLocale($administrator, $adminLocale);
+                }
+
+                $request->setLocale($adminLocale);
             } else {
                 $request->setLocale($this->domain->getLocale());
             }


### PR DESCRIPTION
#### Description, the reason for the PR

If the administrator has set the no longer allowed admin locale, it now defaults to the first allowed locale instead of failing on error.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)
