### PR TITLE
order statuses are now created with domain defined locales

### DIFF
--- a/packages/framework/src/Migrations/Version20180603135341.php
+++ b/packages/framework/src/Migrations/Version20180603135341.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
-class Version20180603135341 extends AbstractMigration
+class Version20180603135341 extends AbstractMigration implements ContainerAwareInterface
 {
+    use MultidomainMigrationTrait;
+
     /**
      * @param \Doctrine\DBAL\Schema\Schema $schema
      */
@@ -19,43 +23,51 @@ class Version20180603135341 extends AbstractMigration
         if ($orderStatusesCount > 0) {
             return;
         }
-        $this->createOrderStatusWithEnglishAndCzechTranslations(1, 1, 'New', 'Nová');
-        $this->createOrderStatusWithEnglishAndCzechTranslations(2, 2, 'In Progress', 'Vyřizuje se');
-        $this->createOrderStatusWithEnglishAndCzechTranslations(3, 3, 'Done', 'Vyřízena');
-        $this->createOrderStatusWithEnglishAndCzechTranslations(4, 4, 'Canceled', 'Stornována');
+
+        $this->createOrderStatus(1, 1);
+        $this->createOrderStatus(2, 2);
+        $this->createOrderStatus(3, 3);
+        $this->createOrderStatus(4, 4);
+
+
+        foreach ($this->getAllLocales() as $locale) {
+            $this->createOrderStatusTranslations(1, t('New', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale), $locale);
+            $this->createOrderStatusTranslations(2, t('In Progress', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale), $locale);
+            $this->createOrderStatusTranslations(3, t('Done', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale), $locale);
+            $this->createOrderStatusTranslations(4, t('Canceled', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale), $locale);
+        }
+
         $this->sql('ALTER SEQUENCE order_statuses_id_seq RESTART WITH 5');
     }
 
     /**
      * @param int $orderStatusId
      * @param int $orderStatusType
-     * @param string $orderStatusEnglishName
-     * @param string $orderStatusCzechName
      */
-    private function createOrderStatusWithEnglishAndCzechTranslations(
-        $orderStatusId,
-        $orderStatusType,
-        $orderStatusEnglishName,
-        $orderStatusCzechName,
-    ) {
+    private function createOrderStatus(int $orderStatusId, int $orderStatusType): void
+    {
         $this->sql('INSERT INTO order_statuses (id, type) VALUES (:id, :type)', [
             'id' => $orderStatusId,
             'type' => $orderStatusType,
         ]);
+    }
+
+    /**
+     * @param int $orderStatusId
+     * @param string $orderStatusTranslatedName
+     * @param string $locale
+     */
+    private function createOrderStatusTranslations(
+        int $orderStatusId,
+        string $orderStatusTranslatedName,
+        string $locale,
+    ): void {
         $this->sql(
             'INSERT INTO order_status_translations (translatable_id, name, locale) VALUES (:translatableId, :name, :locale)',
             [
                 'translatableId' => $orderStatusId,
-                'name' => $orderStatusEnglishName,
-                'locale' => 'en',
-            ],
-        );
-        $this->sql(
-            'INSERT INTO order_status_translations (translatable_id, name, locale) VALUES (:translatableId, :name, :locale)',
-            [
-                'translatableId' => $orderStatusId,
-                'name' => $orderStatusCzechName,
-                'locale' => 'cs',
+                'name' => $orderStatusTranslatedName,
+                'locale' => $locale,
             ],
         );
     }

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -619,6 +619,9 @@ msgstr "Vypočtená cena vč. DPH"
 msgid "Cancel"
 msgstr "Zrušit"
 
+msgid "Canceled"
+msgstr "Stornována"
+
 msgid "Cannot read file."
 msgstr "Soubor nelze načíst."
 
@@ -1510,6 +1513,9 @@ msgstr "Filtr domén"
 msgid "Domain name"
 msgstr "Název domény"
 
+msgid "Done"
+msgstr "Vyřízena"
+
 msgid "Download"
 msgstr "Stáhnout"
 
@@ -2328,6 +2334,9 @@ msgstr "Nahrát CSV"
 
 msgid "Import price list"
 msgstr "Nahrát ceník"
+
+msgid "In Progress"
+msgstr "Vyřizuje se"
 
 msgid "In a particular domain tab it is not possible to adjust the order and plunge of categories. Please go to the category detail or to overview of categories of all domains"
 msgstr "Na záložce konkrétní domény není možné upravovat pořadí a zanoření kategorií. Prosím přejděte na kartu kategorie nebo na přehled kategorií všech domén."

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -619,6 +619,9 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+msgid "Canceled"
+msgstr ""
+
 msgid "Cannot read file."
 msgstr ""
 
@@ -1510,6 +1513,9 @@ msgstr ""
 msgid "Domain name"
 msgstr ""
 
+msgid "Done"
+msgstr ""
+
 msgid "Download"
 msgstr ""
 
@@ -2327,6 +2333,9 @@ msgid "Import CSV"
 msgstr ""
 
 msgid "Import price list"
+msgstr ""
+
+msgid "In Progress"
 msgstr ""
 
 msgid "In a particular domain tab it is not possible to adjust the order and plunge of categories. Please go to the category detail or to overview of categories of all domains"


### PR DESCRIPTION
#### Description, the reason for the PR

Improved creating order status translations. Now the order status translations are created with locales defined for domains instead of hardcoded CS, EN

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-better-order-status-translations.odin.shopsys.cloud
  - https://cz.mg-better-order-status-translations.odin.shopsys.cloud
<!-- Replace -->
