### PR TITLE
category repository now uses inMemoryCache to store root category during request

### DIFF
--- a/packages/framework/src/Model/Category/CategoryRepository.php
+++ b/packages/framework/src/Model/Category/CategoryRepository.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Shopsys\FrameworkBundle\Component\Cache\InMemoryCache;
 use Shopsys\FrameworkBundle\Component\Doctrine\OrderByCollationHelper;
 use Shopsys\FrameworkBundle\Component\Domain\Config\DomainConfig;
 use Shopsys\FrameworkBundle\Component\Paginator\PaginationResult;
@@ -23,19 +24,19 @@ use Shopsys\FrameworkBundle\Model\Product\ProductRepository;
 
 class CategoryRepository extends NestedTreeRepository
 {
-    protected ?Category $rootCategory = null;
-
     /**
      * @param \Doctrine\ORM\EntityManagerInterface $em
      * @param \Shopsys\FrameworkBundle\Model\Product\ProductRepository $productRepository
      * @param \Shopsys\FrameworkBundle\Component\Doctrine\OrderByCollationHelper $orderByCollationHelper
      * @param \Shopsys\FrameworkBundle\Component\String\DatabaseSearchingHelper $databaseSearchingHelper
+     * @param \Shopsys\FrameworkBundle\Component\Cache\InMemoryCache $inMemoryCache
      */
     public function __construct(
         protected readonly EntityManagerInterface $em,
         protected readonly ProductRepository $productRepository,
         protected readonly OrderByCollationHelper $orderByCollationHelper,
         protected readonly DatabaseSearchingHelper $databaseSearchingHelper,
+        protected readonly InMemoryCache $inMemoryCache,
     ) {
         $classMetadata = $this->em->getClassMetadata(Category::class);
 
@@ -177,17 +178,19 @@ class CategoryRepository extends NestedTreeRepository
      */
     public function getRootCategory(): Category
     {
-        if ($this->rootCategory === null) {
-            $this->rootCategory = $this->getCategoryRepository()->findOneBy(['parent' => null]);
+        return $this->inMemoryCache->getOrSaveValue(
+            'rootCategory',
+            function () {
+                $rootCategory = $this->getCategoryRepository()->findOneBy(['parent' => null]);
 
-            if ($this->rootCategory === null) {
-                $message = 'Root category not found';
+                if ($rootCategory === null) {
+                    throw new RootCategoryNotFoundException('Root category not found');
+                }
 
-                throw new RootCategoryNotFoundException($message);
-            }
-        }
-
-        return $this->rootCategory;
+                return $rootCategory;
+            },
+            'rootCategory',
+        );
     }
 
     /**

--- a/project-base/app/src/Model/Category/CategoryRepository.php
+++ b/project-base/app/src/Model/Category/CategoryRepository.php
@@ -14,7 +14,7 @@ use Shopsys\FrameworkBundle\Model\Product\ProductCategoryDomain;
 
 /**
  * @property \App\Model\Product\ProductRepository $productRepository
- * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductRepository $productRepository, \Shopsys\FrameworkBundle\Component\Doctrine\OrderByCollationHelper $orderByCollationHelper, \Shopsys\FrameworkBundle\Component\String\DatabaseSearchingHelper $databaseSearchingHelper)
+ * @method __construct(\Doctrine\ORM\EntityManagerInterface $em, \App\Model\Product\ProductRepository $productRepository, \Shopsys\FrameworkBundle\Component\Doctrine\OrderByCollationHelper $orderByCollationHelper, \Shopsys\FrameworkBundle\Component\String\DatabaseSearchingHelper $databaseSearchingHelper, \Shopsys\FrameworkBundle\Component\Cache\InMemoryCache $inMemoryCache)
  * @method \App\Model\Category\Category[] getAll()
  * @method \App\Model\Category\Category[] getAllCategoriesOfCollapsedTree(\App\Model\Category\Category[] $selectedCategories)
  * @method \App\Model\Category\Category getRootCategory()


### PR DESCRIPTION
#### Description, the reason for the PR

Keeping an entity in memory may be problematic if the Doctrine Identity Map is cleared. 
This PR leverages InMemoryCache to store loaded root category during request as InMemoryCache is automatically cleared on entity manager clear.
 
<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-root-category-in-memory-cache.odin.shopsys.cloud
  - https://cz.mg-root-category-in-memory-cache.odin.shopsys.cloud
<!-- Replace -->
