### PR TITLE
ChoiceType values are not translated by default

### DIFF
--- a/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
+++ b/packages/framework/src/Form/Admin/Advert/AdvertFormType.php
@@ -87,7 +87,6 @@ class AdvertFormType extends AbstractType
                     t('HTML code') => Advert::TYPE_CODE,
                     t('Image with link') => Advert::TYPE_IMAGE,
                 ],
-                'choice_translation_domain' => false,
                 'expanded' => true,
                 'multiple' => false,
                 'constraints' => [

--- a/packages/framework/src/Form/Admin/Article/ArticleFormType.php
+++ b/packages/framework/src/Form/Admin/Article/ArticleFormType.php
@@ -111,7 +111,6 @@ class ArticleFormType extends AbstractType
                     t('Site') => Article::TYPE_SITE,
                     t('Link') => Article::TYPE_LINK,
                 ],
-                'choice_translation_domain' => false,
                 'expanded' => true,
                 'multiple' => false,
                 'label' => t('Type'),

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -152,7 +152,6 @@ class CategoryFormType extends AbstractType
                 'required' => false,
                 'multiple' => true,
                 'expanded' => true,
-                'choice_translation_domain' => false,
                 'choices' => $this->categoryAutomatedFilterFacade->getAllValuesIndexedByLabel(),
                 'choice_attr' => function ($choice, $key, $value) use ($categoryAutomatedFiltersNotesIndexedByValue) {
                     $iconTitle = $categoryAutomatedFiltersNotesIndexedByValue[$value] ?? null;

--- a/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
+++ b/packages/framework/src/Form/Admin/Complaint/ComplaintFormType.php
@@ -145,7 +145,6 @@ class ComplaintFormType extends AbstractType
                 'label' => t('Resolution'),
                 'required' => true,
                 'choices' => $this->complaintResolutionEnum->getAllIndexedByTranslations(),
-                'choice_translation_domain' => false,
                 'multiple' => false,
                 'expanded' => false,
                 'attr' => [

--- a/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Customer/RoleGroup/CustomerUserRoleGroupFormType.php
@@ -50,7 +50,6 @@ class CustomerUserRoleGroupFormType extends AbstractType
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->customerUserRole->getAvailableRoles(),
-            'choice_translation_domain' => false,
         ]);
 
         $builder->add('actionBar', ActionBarType::class, [

--- a/packages/framework/src/Form/Admin/PriceList/ImportPriceListFormType.php
+++ b/packages/framework/src/Form/Admin/PriceList/ImportPriceListFormType.php
@@ -51,7 +51,6 @@ final class ImportPriceListFormType extends AbstractType
                 'choices' => $this->priceListFacade->getAll(),
                 'choice_label' => 'name',
                 'choice_value' => 'id',
-                'choice_translation_domain' => false,
                 'group_by' => function (PriceList $priceList) {
                     return $this->domain->getDomainConfigById($priceList->getDomainId())->getName();
                 },

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFlagType.php
@@ -50,7 +50,6 @@ class PromoCodeFlagType extends AbstractType
                 t('Products with this flag') => PromoCodeFlag::TYPE_INCLUSIVE,
                 t('Products without this flag') => PromoCodeFlag::TYPE_EXCLUSIVE,
             ],
-            'choice_translation_domain' => false,
             'expanded' => true,
             'multiple' => false,
             'constraints' => [

--- a/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
+++ b/packages/framework/src/Form/Admin/PromoCode/PromoCodeFormType.php
@@ -125,7 +125,6 @@ class PromoCodeFormType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'choices' => $this->promoCodeTypeEnum->getAllIndexedByTranslations(),
-                'choice_translation_domain' => false,
                 'label' => t('Discount type'),
                 'attr' => [
                     'class' => 'js-promo-code-discount-type',

--- a/packages/framework/src/Form/ChoiceTypeExtension.php
+++ b/packages/framework/src/Form/ChoiceTypeExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Form;
+
+use Override;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ChoiceTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @param \Symfony\Component\OptionsResolver\OptionsResolver $resolver
+     */
+    #[Override]
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'choice_translation_domain' => false,
+        ]);
+    }
+
+    /**
+     * @return iterable
+     */
+    #[Override]
+    public static function getExtendedTypes(): iterable
+    {
+        yield ChoiceType::class;
+    }
+}

--- a/upgrade-notes/backend_20250312_144941.md
+++ b/upgrade-notes/backend_20250312_144941.md
@@ -1,0 +1,4 @@
+#### ChoiceType values are not automatically translated ([#3857](https://github.com/shopsys/shopsys/pull/3857))
+
+- almost every use of the form field `ChoiceType` contains already translated values as they originate from the data, so by default the translation of the choice values was removed
+- if you have used a `ChoiceType` that count on the automatic translation, set the `choice_translation_domain` option


### PR DESCRIPTION
#### Description, the reason for the PR

almost every use of the form field `ChoiceType` contains already translated values as they originate from the data, so by default, the translation of the choice values was removed

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-default-choice-trans-domain.odin.shopsys.cloud
  - https://cz.mg-default-choice-trans-domain.odin.shopsys.cloud
<!-- Replace -->
