### PR TITLE
added index to friendly url to cover most used method

### DIFF
--- a/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrl.php
+++ b/packages/framework/src/Component/Router/FriendlyUrl/FriendlyUrl.php
@@ -10,7 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Table(
  *     name="friendly_urls",
  *     indexes={
- *         @ORM\Index(columns={"route_name", "entity_id"})
+ *         @ORM\Index(columns={"route_name", "entity_id"}),
+ *         @ORM\Index(columns={"route_name", "entity_id", "domain_id", "main"}),
  *     }
  * )
  * @ORM\Entity

--- a/packages/framework/src/Migrations/Version20250313074307.php
+++ b/packages/framework/src/Migrations/Version20250313074307.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20250313074307 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('CREATE INDEX IDX_64EC05ABF3667F8381257D5D115F0EE5BF28CD64 
+            ON friendly_urls (route_name, entity_id, domain_id, main)');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
#### Description, the reason for the PR

FriendlyUrlRepository selects data based on four columns and those columns now has an DB index, so the query is faster

before

![Snímek obrazovky 2025-03-13 v 8 47 28](https://github.com/user-attachments/assets/5a218e6d-462a-45fe-8224-d186ba8a76dc)

after

![Snímek obrazovky 2025-03-13 v 8 47 10](https://github.com/user-attachments/assets/16bfaff6-3f2c-4bf6-b66e-2f83b2d5337c)


<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-index-friendly-url.odin.shopsys.cloud
  - https://cz.mg-index-friendly-url.odin.shopsys.cloud
<!-- Replace -->
