### PR TITLE
review cancel is now independent on running container and use proper working dir

### DIFF
--- a/.github/cancel-review.sh
+++ b/.github/cancel-review.sh
@@ -1,14 +1,16 @@
 BRANCH_NAME=${1,,}
 
 if [ -n "$BRANCH_NAME" ]; then
-    echo "Info: Trying to cancel review for branch $BRANCH_NAME"
+    echo "Info: Trying to cancel review for branch ${BRANCH_NAME}"
 
-    if [ -d "../$BRANCH_NAME" ]; then
-        cd "../$BRANCH_NAME"
+    docker exec github-runner-postgres-1 psql -d postgres -c "DROP DATABASE IF EXISTS \"${BRANCH_NAME}\";"
+    docker exec github-runner-redis-1 redis-cli --scan --pattern "${BRANCH_NAME}:*" | xargs -r docker exec github-runner-redis-1 redis-cli del
+    docker exec github-runner-rabbitmq-1 rabbitmqctl delete_vhost "${BRANCH_NAME}" || true
 
-        docker compose exec php-fpm php phing -D production.confirm.action=y elasticsearch-index-delete clean-redis clean-redis-old clean-redis-storefront
-        docker compose exec php-fpm php ./bin/console doctrine:database:drop --force
-        bash .github/rabbitmq-vhost.sh remove $BRANCH_NAME
+    BASE_DIR="/home/github-runner/actions-runner/_work/shopsys/shopsys"
+
+    if [ -d "$BASE_DIR/$BRANCH_NAME" ]; then
+        cd "$BASE_DIR/$BRANCH_NAME"
 
         docker compose down -v --remove-orphans
         docker system prune -a -f


### PR DESCRIPTION
#### Description, the reason for the PR

It's now no longer necessary to have the review up and running for the successful removing of the database/redis keys/rabbit vhost. 
Also, the working directory no longer uses relative paths, which caused in some cases removing of the containers with the shared services (elastic/postgres/etc.) 

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-safer-review-cancel.odin.shopsys.cloud
  - https://cz.mg-safer-review-cancel.odin.shopsys.cloud
<!-- Replace -->
