### PR TITLE
fixed assigning parameter position to category

### DIFF
--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -28,6 +28,7 @@ use Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository;
 use Shopsys\FrameworkBundle\Model\Seo\SeoSettingFacade;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -318,6 +319,7 @@ class CategoryFormType extends AbstractType
         }
 
         $parametersFilterBuilder->add('parametersPosition', SortableValuesType::class, [
+            'entry_type' => IntegerType::class,
             'labels_by_value' => $parameterNamesById,
             'label' => t('Parameters order in category'),
             'required' => false,


### PR DESCRIPTION
#### Description, the reason for the PR

The default hidden type returns values as a string, which is not compatible with the lower layers of the code where the int is expected.
Sortable widget is manually rendered as a hidden type, so it's safe to use IntegerType in the form definition.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-assign-category-param.odin.shopsys.cloud
  - https://cz.mg-fix-assign-category-param.odin.shopsys.cloud
<!-- Replace -->
