### PR TITLE
search by catnum is now case insensitive on storefront

### DIFF
--- a/project-base/app/src/Resources/definition/product/1.json
+++ b/project-base/app/src/Resources/definition/product/1.json
@@ -93,10 +93,20 @@
                         "edge_ngram"
                     ]
                 },
-                "whitespace_without_dots": {
+                "edge_ngram_unanalyzed_words_lowercase": {
+                    "tokenizer": "whitespace",
+                    "filter": [
+                        "edge_ngram",
+                        "lowercase"
+                    ]
+                },
+                "whitespace_without_dots_lowercase": {
                     "tokenizer": "whitespace",
                     "char_filter": [
                         "dots_replace_filter"
+                    ],
+                    "filter": [
+                        "lowercase"
                     ]
                 }
             },
@@ -405,12 +415,12 @@
             "searching_catnums": {
                 "type": "text",
                 "analyzer": "whitespace",
-                "search_analyzer": "whitespace_without_dots",
+                "search_analyzer": "whitespace_without_dots_lowercase",
                 "fields": {
                     "edge_ngram_unanalyzed_words": {
                         "type": "text",
-                        "analyzer": "edge_ngram_unanalyzed_words",
-                        "search_analyzer": "whitespace_without_dots"
+                        "analyzer": "edge_ngram_unanalyzed_words_lowercase",
+                        "search_analyzer": "whitespace_without_dots_lowercase"
                     }
                 }
             },

--- a/project-base/app/src/Resources/definition/product/2.json
+++ b/project-base/app/src/Resources/definition/product/2.json
@@ -93,10 +93,20 @@
                         "edge_ngram"
                     ]
                 },
-                "whitespace_without_dots": {
+                "edge_ngram_unanalyzed_words_lowercase": {
+                    "tokenizer": "whitespace",
+                    "filter": [
+                        "edge_ngram",
+                        "lowercase"
+                    ]
+                },
+                "whitespace_without_dots_lowercase": {
                     "tokenizer": "whitespace",
                     "char_filter": [
                         "dots_replace_filter"
+                    ],
+                    "filter": [
+                        "lowercase"
                     ]
                 }
             },
@@ -405,12 +415,12 @@
             "searching_catnums": {
                 "type": "text",
                 "analyzer": "whitespace",
-                "search_analyzer": "whitespace_without_dots",
+                "search_analyzer": "whitespace_without_dots_lowercase",
                 "fields": {
                     "edge_ngram_unanalyzed_words": {
                         "type": "text",
-                        "analyzer": "edge_ngram_unanalyzed_words",
-                        "search_analyzer": "whitespace_without_dots"
+                        "analyzer": "edge_ngram_unanalyzed_words_lowercase",
+                        "search_analyzer": "whitespace_without_dots_lowercase"
                     }
                 }
             },

--- a/upgrade-notes/backend_20250319_112923.md
+++ b/upgrade-notes/backend_20250319_112923.md
@@ -1,0 +1,3 @@
+#### make search by catnum case-insensitive on storefront ([#3870](https://github.com/shopsys/shopsys/pull/3870))
+
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR

If a product catalog number contains characters, the search is now case-insensitive on the storefront.

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-catnum-search-case.odin.shopsys.cloud
  - https://cz.mg-catnum-search-case.odin.shopsys.cloud
<!-- Replace -->
