### PR TITLE
site articles and link articles are now differentiated in the list

### DIFF
--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2503,6 +2503,9 @@ msgstr "Odkaz"
 msgid "Link URL"
 msgstr "URL odkazu"
 
+msgid "Link [abbreviation]"
+msgstr "O"
+
 msgid "Link to complete the registration"
 msgstr "Odkaz na dokončení registrace"
 
@@ -4095,6 +4098,9 @@ msgstr "Zobrazit v rozcestníku"
 
 msgid "Site"
 msgstr "Stránka"
+
+msgid "Site [abbreviation]"
+msgstr "S"
 
 msgid "Slider items - full"
 msgstr "Bannery - vše"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2503,6 +2503,9 @@ msgstr ""
 msgid "Link URL"
 msgstr ""
 
+msgid "Link [abbreviation]"
+msgstr "L"
+
 msgid "Link to complete the registration"
 msgstr ""
 
@@ -4095,6 +4098,9 @@ msgstr ""
 
 msgid "Site"
 msgstr ""
+
+msgid "Site [abbreviation]"
+msgstr "S"
 
 msgid "Slider items - full"
 msgstr ""

--- a/packages/framework/src/Resources/views/Admin/Content/Article/listGrid.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Content/Article/listGrid.html.twig
@@ -1,6 +1,11 @@
 {% extends '@ShopsysFramework/Admin/Grid/Grid.html.twig' %}
 
 {% block grid_value_cell_id_name %}
+    {% if row.a.type == constant('Shopsys\\FrameworkBundle\\Model\\Article\\Article::TYPE_SITE') %}
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Site'|trans }}">{{ 'Site [abbreviation]'|trans }}</span>
+    {% else %}
+        <span class="in-letter cursor-help js-tooltip" title="{{ 'Link'|trans }}">{{ 'Link [abbreviation]'|trans }}</span>
+    {% endif %}
     <a href="{{ url('admin_article_edit', { id: row.a.id }) }}">{{ value }}</a>
 {% endblock %}
 


### PR DESCRIPTION
#### Description, the reason for the PR
<img width="392" alt="Screenshot at Mar 20 10-52-51" src="https://github.com/user-attachments/assets/49a114da-92a4-40f4-bd20-453edc03b49b" />

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-articles-differentiator.odin.shopsys.cloud
  - https://cz.tl-articles-differentiator.odin.shopsys.cloud
<!-- Replace -->
