### PR TITLE
ensure store coordinates are always numeric

### DIFF
--- a/packages/framework/src/Form/Admin/Store/StoreFormType.php
+++ b/packages/framework/src/Form/Admin/Store/StoreFormType.php
@@ -25,6 +25,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -183,15 +184,17 @@ class StoreFormType extends AbstractType
     private function createMapGroup(FormBuilderInterface $builder): FormBuilderInterface
     {
         $builderMapGroup = $builder->create('map', GroupType::class, [
-            'label' => t('Map coordinates'),
+            'label' => t('Map coordinates in decimal format'),
         ]);
 
         $builderMapGroup
-            ->add('latitude', TextType::class, [
+            ->add('latitude', NumberType::class, [
                 'required' => false,
+                'scale' => 10,
             ])
-            ->add('longitude', TextType::class, [
+            ->add('longitude', NumberType::class, [
                 'required' => false,
+                'scale' => 10,
             ]);
 
         return $builderMapGroup;

--- a/packages/framework/src/Migrations/Version20250320124625.php
+++ b/packages/framework/src/Migrations/Version20250320124625.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Override;
+use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
+
+class Version20250320124625 extends AbstractMigration
+{
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->sql('ALTER TABLE stores ALTER latitude TYPE NUMERIC(20, 10) USING latitude::NUMERIC(20,10)');
+        $this->sql('ALTER TABLE stores ALTER longitude TYPE NUMERIC(20, 10) USING longitude::NUMERIC(20,10)');
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    #[Override]
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/packages/framework/src/Model/Store/Store.php
+++ b/packages/framework/src/Model/Store/Store.php
@@ -126,13 +126,13 @@ class Store implements OrderableEntityInterface
 
     /**
      * @var string|null
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="decimal", precision=20, scale=10, nullable=true)
      */
     protected $latitude;
 
     /**
      * @var string|null
-     * @ORM\Column(type="string", nullable=true)
+     * @ORM\Column(type="decimal", precision=20, scale=10, nullable=true)
      */
     protected $longitude;
 

--- a/packages/framework/src/Resources/translations/messages.cs.po
+++ b/packages/framework/src/Resources/translations/messages.cs.po
@@ -2605,8 +2605,8 @@ msgstr "H"
 msgid "Make modification"
 msgstr "Provést úpravu"
 
-msgid "Map coordinates"
-msgstr "Souřadnice na mapě"
+msgid "Map coordinates in decimal format"
+msgstr "Mapové souřadnice v číselném formátu"
 
 msgid "Max duration (mm:ss)"
 msgstr "Max. trvání (mm:ss)"

--- a/packages/framework/src/Resources/translations/messages.en.po
+++ b/packages/framework/src/Resources/translations/messages.en.po
@@ -2605,7 +2605,7 @@ msgstr "M"
 msgid "Make modification"
 msgstr ""
 
-msgid "Map coordinates"
+msgid "Map coordinates in decimal format"
 msgstr ""
 
 msgid "Max duration (mm:ss)"

--- a/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Store/Input/CoordinatesDecorator.types.yaml
+++ b/packages/frontend-api/src/Resources/config/graphql-types/ModelType/Store/Input/CoordinatesDecorator.types.yaml
@@ -4,6 +4,6 @@ CoordinatesDecorator:
     config:
         fields:
             latitude:
-                type: "String!"
+                type: "Float!"
             longitude:
-                type: "String!"
+                type: "Float!"

--- a/project-base/app/schema.graphql
+++ b/project-base/app/schema.graphql
@@ -779,8 +779,8 @@ input ContactFormInput {
 }
 
 input Coordinates {
-  latitude: String!
-  longitude: String!
+  latitude: Float!
+  longitude: Float!
 }
 
 "Represents country"

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetFilteredStoresTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetFilteredStoresTest.php
@@ -37,7 +37,7 @@ class GetFilteredStoresTest extends GraphQlTestCase
 
     public function testGetFilteredStoresByCoordinates(): void
     {
-        $edges = $this->getResponseEdges(coordinates: ['latitude' => '49.1950602', 'longitude' => '16.6068371']);
+        $edges = $this->getResponseEdges(coordinates: ['latitude' => 49.1950602, 'longitude' => 16.6068371]);
         $this->assertCount(8, $edges);
 
         $firstDomainLocale = $this->getLocaleForFirstDomain();
@@ -84,7 +84,7 @@ class GetFilteredStoresTest extends GraphQlTestCase
 
     public function testGetFilteredStoresByCoordinatesAndSearchText(): void
     {
-        $edges = $this->getResponseEdges(searchText: 'B', coordinates: ['latitude' => '50.538331', 'longitude' => '14.485953']);
+        $edges = $this->getResponseEdges(searchText: 'B', coordinates: ['latitude' => 50.538331, 'longitude' => 14.485953]);
         $this->assertCount(3, $edges);
 
         $firstDomainLocale = $this->getLocaleForFirstDomain();
@@ -111,7 +111,7 @@ class GetFilteredStoresTest extends GraphQlTestCase
 
     /**
      * @param string|null $searchText
-     * @param array{latitude: string, longitude: string}|null $coordinates
+     * @param array{latitude: float, longitude: float}|null $coordinates
      * @return array
      */
     private function getResponseEdges(?string $searchText = null, ?array $coordinates = null): array

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoreTest.php
@@ -96,13 +96,14 @@ class GetStoreTest extends GraphQlTestCase
                     'email',
                     'phone',
                     'directions',
-                    'latitude',
-                    'longitude',
                     'breadcrumb',
                 ],
                 $responseData,
                 $expectedStoreData,
             );
+
+            $this->assertStringStartsWith($expectedStoreData['latitude'], $responseData['latitude']);
+            $this->assertStringStartsWith($expectedStoreData['longitude'], $responseData['longitude']);
         }
     }
 
@@ -161,13 +162,14 @@ class GetStoreTest extends GraphQlTestCase
                     'email',
                     'phone',
                     'directions',
-                    'latitude',
-                    'longitude',
                     'breadcrumb',
                 ],
                 $responseData,
                 $expectedStoreData,
             );
+
+            $this->assertStringStartsWith($expectedStoreData['latitude'], $responseData['latitude']);
+            $this->assertStringStartsWith($expectedStoreData['longitude'], $responseData['longitude']);
         }
     }
 

--- a/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoresTest.php
+++ b/project-base/app/tests/FrontendApiBundle/Functional/Store/GetStoresTest.php
@@ -23,6 +23,8 @@ class GetStoresTest extends GraphQlTestCase
             $this->assertCount(count($expectedStoresData), $responseData['edges']);
 
             foreach ($responseData['edges'] as $edge) {
+                $currentExpectedStoreData = array_shift($expectedStoresData);
+
                 $this->assertArrayHasKey('node', $edge);
 
                 $this->assertArrayHasKey('uuid', $edge['node']);
@@ -38,12 +40,13 @@ class GetStoresTest extends GraphQlTestCase
                         'postcode',
                         'country',
                         'specialMessage',
-                        'latitude',
-                        'longitude',
                     ],
                     $edge['node'],
-                    array_shift($expectedStoresData),
+                    $currentExpectedStoreData,
                 );
+
+                $this->assertStringStartsWith($currentExpectedStoreData['latitude'], $edge['node']['latitude']);
+                $this->assertStringStartsWith($currentExpectedStoreData['longitude'], $edge['node']['longitude']);
             }
         }
     }

--- a/project-base/storefront/components/Blocks/StoreList/StoresWrapper.tsx
+++ b/project-base/storefront/components/Blocks/StoreList/StoresWrapper.tsx
@@ -32,8 +32,8 @@ export const StoresWrapper: FC = () => {
     useEffect(() => {
         navigator.geolocation.getCurrentPosition((position) => {
             const coordinates: TypeCoordinates = {
-                latitude: position.coords.latitude.toString(),
-                longitude: position.coords.longitude.toString(),
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
             };
             setUserCoordinates(coordinates);
             updateDefaultUserCoordinates(coordinates);

--- a/project-base/storefront/graphql/docs/schema.md
+++ b/project-base/storefront/graphql/docs/schema.md
@@ -10786,12 +10786,12 @@ Name of the sender
 <tbody>
 <tr>
 <td colspan="2" valign="top"><strong id="coordinates.latitude">latitude</strong></td>
-<td valign="top"><a href="#string">String</a>!</td>
+<td valign="top"><a href="#float">Float</a>!</td>
 <td></td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="coordinates.longitude">longitude</strong></td>
-<td valign="top"><a href="#string">String</a>!</td>
+<td valign="top"><a href="#float">Float</a>!</td>
 <td></td>
 </tr>
 </tbody>

--- a/project-base/storefront/graphql/types.ts
+++ b/project-base/storefront/graphql/types.ts
@@ -929,8 +929,8 @@ export type TypeContactFormInput = {
 };
 
 export type TypeCoordinates = {
-  latitude: Scalars['String']['input'];
-  longitude: Scalars['String']['input'];
+  latitude: Scalars['Float']['input'];
+  longitude: Scalars['Float']['input'];
 };
 
 /** Represents country */

--- a/upgrade-notes/backend_20250320_124958.md
+++ b/upgrade-notes/backend_20250320_124958.md
@@ -1,0 +1,5 @@
+#### Convert latitude and longitude to numeric to ensure the distance function works correctly ([#3873](https://github.com/shopsys/shopsys/pull/3873))
+
+- `Store::latitude` and `Store::longitude` are now stored as `NUMERIC(20, 10)` in the database and this is changed via migration `Version20250320124625` and current values are converted to numeric
+    - if you want to store latitude and longitude in a different format, you need to skip this migration and update your application appropriately
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
Calculation of distance for searching of stores were not working correctly when different than decimal format of longitude and latitude coordinates was entered.

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)














<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://tl-store-coordinates-are-now-numeric.odin.shopsys.cloud
  - https://cz.tl-store-coordinates-are-now-numeric.odin.shopsys.cloud
<!-- Replace -->
