### PR TITLE
fixed login as user on http

### DIFF
--- a/packages/frontend-api/src/Resources/views/Admin/Content/Login/loginAsCustomerUser.html.twig
+++ b/packages/frontend-api/src/Resources/views/Admin/Content/Login/loginAsCustomerUser.html.twig
@@ -2,8 +2,8 @@
     var date = new Date();
     date.setTime(date.getTime() + 14 * 24 * 60 * 60 * 1000); // 14 days
 
-    document.cookie = "accessToken=" + "{{ tokens.accessToken }}" + "; secure; path=/";
-    document.cookie = "refreshToken=" + "{{ tokens.refreshToken }}"  + "; expires=" + date.toUTCString() + "; secure; path=/";
+    document.cookie = "accessToken=" + "{{ tokens.accessToken }}" + ";{{ app.request.scheme == 'https' ? ' secure;' }} path=/";
+    document.cookie = "refreshToken=" + "{{ tokens.refreshToken }}"  + "; expires=" + date.toUTCString() + ";{{ app.request.scheme == 'https' ? ' secure;' }}path=/";
 
     window.location.replace('{{ url|raw }}');
 </script>


### PR DESCRIPTION
#### Description, the reason for the PR

Login as user did not work on http, due to implicitly created secure cookie.
This PR creates secure cookie only on https

<!-- If you have introduced any BC breaks (https://docs.shopsys.com/en/latest/contributing/backward-compatibility-promise/), please add UPGRADE notes using `php phing upgrade-generate` -->

<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)


<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://mg-fix-http-auth-as-user.odin.shopsys.cloud
  - https://cz.mg-fix-http-auth-as-user.odin.shopsys.cloud
<!-- Replace -->
