### PR TITLE
admin locale now can be set to any locale

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -318,7 +318,7 @@
         </exec>
     </target>
 
-    <target name="translations-dump" depends="domains-info-load" description="Extracts translatable messages in the whole monorepo.">
+    <target name="translations-dump" depends="domains-info-load,admin-locales-load" description="Extracts translatable messages in the whole monorepo.">
         <phingcall target="shopsys_framework.translations-dump"/>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -328,6 +328,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/form-types-bundle/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -342,6 +343,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.framework}/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -351,6 +353,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/frontend-api/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -360,6 +363,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/brand-feed-luigis-box/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -369,6 +373,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/category-feed-luigis-box/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -378,6 +383,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/convertim/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -387,6 +393,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-google/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -396,6 +403,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-mergado/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -405,6 +413,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-heureka/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -414,6 +423,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-heureka-delivery/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -423,6 +433,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-zbozi/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -432,6 +443,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/product-feed-luigis-box/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -441,6 +453,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/article-feed-luigis-box/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -450,6 +463,7 @@
             <arg value="--output-format=po"/>
             <arg value="--output-dir=${path.packages}/luigis-box/src/Resources/translations"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
         </exec>
     </target>
 

--- a/docs/administration/grid-data-sources.md
+++ b/docs/administration/grid-data-sources.md
@@ -39,7 +39,7 @@ e.g., you can add some calculated price into the data set.
 $queryBuilder = $transportRepository->getQueryBuilderForAll()
     ->addSelect('tt')
     ->join('t.translations', 'tt', Join::WITH, 'tt.locale = :locale')
-    ->setParameter('locale', $localization->getAdminLocale());
+    ->setParameter('locale', $localization->getAdminLocaleWithFallback());
 
 $dataSource = new QueryBuilderWithRowManipulatorDataSource(
     $queryBuilder,

--- a/docs/administration/grid-data-sources.md
+++ b/docs/administration/grid-data-sources.md
@@ -39,7 +39,7 @@ e.g., you can add some calculated price into the data set.
 $queryBuilder = $transportRepository->getQueryBuilderForAll()
     ->addSelect('tt')
     ->join('t.translations', 'tt', Join::WITH, 'tt.locale = :locale')
-    ->setParameter('locale', $localization->getAdminLocaleWithFallback());
+    ->setParameter('locale', $localization->getCurrentLocaleForTranslatableEntities());
 
 $dataSource = new QueryBuilderWithRowManipulatorDataSource(
     $queryBuilder,

--- a/docs/introduction/faq-and-common-issues.md
+++ b/docs/introduction/faq-and-common-issues.md
@@ -62,7 +62,6 @@ See how to install Shopsys Platform in production and how to proceed when deploy
 
 Every administrator can switch the administration locale to any of the locales defined by the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml` configuration.
 The first locale in the list is the default one.
-However, only locales that are defined in the `domains.yaml` config can be used in the administration.
 This scenario is described in more detail in the tutorial [How to Set Up Domains and Locales (Languages)](./how-to-set-up-domains-and-locales.md#36-locale-in-administration).
 
 ## What are the differences between "listable", "sellable", "offered" and "visible" products?

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -180,7 +180,7 @@ If you have set a different locale, you can use `translations-dump` that will cr
 Administration uses the `en` locale by default for every newly created administrator.
 This means that all the static texts are in English. Furthermore, all data translations (e.g. the product names in the administration list) are presented in the `en` locale.
 When the administrator uses a locale that is not used on any domain, there are no persisted translations for this locale so in this case, the data are displayed in the first domain locale.
-You can adjust this behavior by setting the desired `$fallbackLocaleDomainId` in `Localization::getAdminLocaleWithFallback()` method call in particular scenarios.
+You can adjust this behavior by setting the desired `$fallbackLocaleDomainId` in `Localization::getCurrentLocaleForTranslatableEntities()` method call in particular scenarios.
 
 The administrator can then change the locale to fit his needs to any of the locales defined by the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml`.
 If you want to switch the default value to another locale or restrict the locales an administrator can choose from, set the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml` configuration accordingly.

--- a/docs/introduction/how-to-set-up-domains-and-locales.md
+++ b/docs/introduction/how-to-set-up-domains-and-locales.md
@@ -178,11 +178,13 @@ If you have set a different locale, you can use `translations-dump` that will cr
 #### 3.6 Locale in administration
 
 Administration uses the `en` locale by default for every newly created administrator.
-This means that for example, product list in administration tries to display translations of product names in `en` locale, and all the static texts are in English.
+This means that all the static texts are in English. Furthermore, all data translations (e.g. the product names in the administration list) are presented in the `en` locale.
+When the administrator uses a locale that is not used on any domain, there are no persisted translations for this locale so in this case, the data are displayed in the first domain locale.
+You can adjust this behavior by setting the desired `$fallbackLocaleDomainId` in `Localization::getAdminLocaleWithFallback()` method call in particular scenarios.
+
 The administrator can then change the locale to fit his needs to any of the locales defined by the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml`.
 If you want to switch the default value to another locale or restrict the locales an administrator can choose from, set the `shopsys.allowed_admin_locales` parameter in your `config/parameters_common.yaml` configuration accordingly.
 The first locale in the list is the default one.
-However, only locales that are defined in the `domains.yaml` config can be used in the administration.
 
 You can change administration translations by adding messages into your `translations/messages.xx.po`.
 

--- a/packages/framework/build.xml
+++ b/packages/framework/build.xml
@@ -66,6 +66,14 @@
         </exec>
     </target>
 
+    <target name="admin-locales-load" description="Load admin locales configuration into Phing properties." hidden="true">
+        <exec executable="${path.php.executable}" outputProperty="admin-locales" error="${dev.null}">
+            <arg value="${path.bin-console}"/>
+            <arg value="shopsys:admin-locales:info"/>
+            <arg value="--verbose"/>
+        </exec>
+    </target>
+
     <target name="annotations-check" description="Checks whether annotations of extended classes in the project match the actual types according to ClassExtensionRegistry. Reported problems can be fixed using 'annotations-fix' phing target">
         <if>
             <istrue value="${check-and-fix-annotations}"/>
@@ -1544,7 +1552,7 @@
         </exec>
     </target>
 
-    <target name="translations-dump" depends="domains-info-load" description="Extracts translatable messages from all source files in your project.">
+    <target name="translations-dump" depends="domains-info-load,admin-locales-load" description="Extracts translatable messages from all source files in your project.">
         <phingcall target="npm-translations-dump"/>
         <exec executable="${path.php.executable}" passthru="true" checkreturn="true">
             <arg value="${path.bin-console}"/>
@@ -1559,6 +1567,7 @@
             <arg value="--output-dir=${path.root}/translations"/>
             <arg line="${translations.dump.flags}"/>
             <arg line="${domains-info.locales}"/>
+            <arg line="${admin-locales}"/>
             <arg value="--verbose"/>
         </exec>
     </target>

--- a/packages/framework/src/Command/AdminLocalesInfoCommand.php
+++ b/packages/framework/src/Command/AdminLocalesInfoCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Command;
 
 use Override;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,10 +19,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class AdminLocalesInfoCommand extends Command
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
      */
     public function __construct(
-        protected readonly Localization $localization,
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
     ) {
         parent::__construct();
     }
@@ -37,7 +37,7 @@ class AdminLocalesInfoCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $io->writeln(implode("\t", $this->localization->getAllowedAdminLocales()));
+        $io->writeln(implode("\t", $this->administratorLocalizationFacade->getAllowedAdminLocales()));
 
         return Command::SUCCESS;
     }

--- a/packages/framework/src/Command/AdminLocalesInfoCommand.php
+++ b/packages/framework/src/Command/AdminLocalesInfoCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Command;
+
+use Override;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'shopsys:admin-locales:info',
+    description: 'Loads and displays all admin locales',
+)]
+class AdminLocalesInfoCommand extends Command
+{
+    /**
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     */
+    public function __construct(
+        protected readonly Localization $localization,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    #[Override]
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->writeln(implode("\t", $this->localization->getAllowedAdminLocales()));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/framework/src/Component/CKEditor/CKEditorRendererDecorator.php
+++ b/packages/framework/src/Component/CKEditor/CKEditorRendererDecorator.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\CKEditor;
 
 use FOS\CKEditorBundle\Renderer\CKEditorRendererInterface;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 class CKEditorRendererDecorator implements CKEditorRendererInterface
 {
     /**
      * @param \FOS\CKEditorBundle\Renderer\CKEditorRendererInterface $baseCkEditorRenderer
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly CKEditorRendererInterface $baseCkEditorRenderer,
-        protected readonly Localization $localization,
     ) {
     }
 
@@ -45,8 +42,6 @@ class CKEditorRendererDecorator implements CKEditorRendererInterface
      */
     public function renderWidget(string $id, array $config, array $options = []): string
     {
-        $config['language'] = $this->getRequestLanguage();
-
         return sprintf(
             '$("#%s-preview").click(function() {
                 %s
@@ -109,13 +104,5 @@ class CKEditorRendererDecorator implements CKEditorRendererInterface
     public function renderTemplate(string $name, array $template): string
     {
         return $this->baseCkEditorRenderer->renderTemplate($name, $template);
-    }
-
-    /**
-     * @return string
-     */
-    protected function getRequestLanguage(): string
-    {
-        return $this->localization->getAdminLocale();
     }
 }

--- a/packages/framework/src/Component/CKEditor/CKEditorRendererDecorator.php
+++ b/packages/framework/src/Component/CKEditor/CKEditorRendererDecorator.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Component\CKEditor;
 
 use FOS\CKEditorBundle\Renderer\CKEditorRendererInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 class CKEditorRendererDecorator implements CKEditorRendererInterface
 {
     /**
      * @param \FOS\CKEditorBundle\Renderer\CKEditorRendererInterface $baseCkEditorRenderer
-     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly CKEditorRendererInterface $baseCkEditorRenderer,
-        protected readonly RequestStack $requestStack,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -45,7 +45,7 @@ class CKEditorRendererDecorator implements CKEditorRendererInterface
      */
     public function renderWidget(string $id, array $config, array $options = []): string
     {
-        $config['language'] = $this->getRequestLanguage() ?? $config['language'];
+        $config['language'] = $this->getRequestLanguage();
 
         return sprintf(
             '$("#%s-preview").click(function() {
@@ -112,16 +112,10 @@ class CKEditorRendererDecorator implements CKEditorRendererInterface
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    protected function getRequestLanguage(): ?string
+    protected function getRequestLanguage(): string
     {
-        $request = $this->requestStack->getCurrentRequest();
-
-        if ($request !== null && $request->getLocale() !== '') {
-            return $request->getLocale();
-        }
-
-        return null;
+        return $this->localization->getAdminLocale();
     }
 }

--- a/packages/framework/src/Component/EntityLog/Model/EntityLogFacade.php
+++ b/packages/framework/src/Component/EntityLog/Model/EntityLogFacade.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Component\EntityLog\Model;
 use Shopsys\FrameworkBundle\Component\EntityLog\Attribute\LoggableEntityConfig;
 use Shopsys\FrameworkBundle\Component\EntityLog\Detection\DetectionFacade;
 use Shopsys\FrameworkBundle\Component\EntityLog\Exception\NotLoggableException;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 class EntityLogFacade
@@ -17,6 +18,7 @@ class EntityLogFacade
      * @param \Shopsys\FrameworkBundle\Component\EntityLog\Detection\DetectionFacade $detectionFacade
      * @param \Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogFactory $entityLogFactory
      * @param \Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogDataFactory $entityLogDataFactory
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
      */
     public function __construct(
         protected readonly EntityLogRepository $entityLogRepository,
@@ -24,6 +26,7 @@ class EntityLogFacade
         protected readonly DetectionFacade $detectionFacade,
         protected readonly EntityLogFactory $entityLogFactory,
         protected readonly EntityLogDataFactory $entityLogDataFactory,
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
     ) {
     }
 
@@ -119,9 +122,19 @@ class EntityLogFacade
         }
 
         if ($loggableSetup->isLocalized()) {
-            return call_user_func([$entity, $functionName], $this->localization->getDefaultAdminLocale());
+            return call_user_func([$entity, $functionName], $this->getLocaleForEntityLog());
         }
 
         return call_user_func([$entity, $functionName]);
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocaleForEntityLog(): string
+    {
+        $defaultAdminLocale = $this->administratorLocalizationFacade->getDefaultAdminLocale();
+
+        return $this->localization->getFallbackLocaleIfLocaleIsNotUsedOnAnyDomain($defaultAdminLocale);
     }
 }

--- a/packages/framework/src/Component/HttpFoundation/Exception/NoRequestException.php
+++ b/packages/framework/src/Component/HttpFoundation/Exception/NoRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopsys\FrameworkBundle\Component\HttpFoundation\Exception;
+
+use Exception;
+
+class NoRequestException extends Exception
+{
+}

--- a/packages/framework/src/Component/UploadedFile/UploadedFileAdminListFacade.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileAdminListFacade.php
@@ -25,7 +25,7 @@ class UploadedFileAdminListFacade
      */
     public function getUploadedFileListQueryBuilder(): QueryBuilder
     {
-        $locale = $this->localization->getAdminLocaleWithFallback();
+        $locale = $this->localization->getCurrentLocaleForTranslatableEntities();
 
         return $this->uploadedFileAdminListRepository->getUploadedFileListQueryBuilder($locale);
     }

--- a/packages/framework/src/Component/UploadedFile/UploadedFileAdminListFacade.php
+++ b/packages/framework/src/Component/UploadedFile/UploadedFileAdminListFacade.php
@@ -25,7 +25,7 @@ class UploadedFileAdminListFacade
      */
     public function getUploadedFileListQueryBuilder(): QueryBuilder
     {
-        $locale = $this->localization->getAdminLocale();
+        $locale = $this->localization->getAdminLocaleWithFallback();
 
         return $this->uploadedFileAdminListRepository->getUploadedFileListQueryBuilder($locale);
     }

--- a/packages/framework/src/Controller/Admin/BestsellingProductController.php
+++ b/packages/framework/src/Controller/Admin/BestsellingProductController.php
@@ -8,6 +8,7 @@ use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Form\Admin\BestsellingProduct\BestsellingProductFormType;
 use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,12 +21,14 @@ class BestsellingProductController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Model\Category\CategoryFacade $categoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade
      * @param \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly ManualBestsellingProductFacade $manualBestsellingProductFacade,
         protected readonly CategoryFacade $categoryFacade,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
         protected readonly BreadcrumbOverrider $breadcrumbOverrider,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -40,7 +43,7 @@ class BestsellingProductController extends AdminBaseController
 
         $categoriesWithPreloadedChildren = $this->categoryFacade->getVisibleCategoriesWithPreloadedChildrenForDomain(
             $domainId,
-            $request->getLocale(),
+            $this->localization->getAdminLocaleWithFallback(),
         );
 
         $bestsellingProductsInCategories = $this->manualBestsellingProductFacade->getCountsIndexedByCategoryId(

--- a/packages/framework/src/Controller/Admin/BestsellingProductController.php
+++ b/packages/framework/src/Controller/Admin/BestsellingProductController.php
@@ -43,7 +43,7 @@ class BestsellingProductController extends AdminBaseController
 
         $categoriesWithPreloadedChildren = $this->categoryFacade->getVisibleCategoriesWithPreloadedChildrenForDomain(
             $domainId,
-            $this->localization->getAdminLocaleWithFallback(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
         );
 
         $bestsellingProductsInCategories = $this->manualBestsellingProductFacade->getCountsIndexedByCategoryId(

--- a/packages/framework/src/Controller/Admin/BlogCategoryController.php
+++ b/packages/framework/src/Controller/Admin/BlogCategoryController.php
@@ -128,12 +128,12 @@ class BlogCategoryController extends AdminBaseController
 
         if ($selectedDomainId === null) {
             $blogCategoriesWithPreloadedChildren = $this->blogCategoryFacade->getAllBlogCategoriesWithPreloadedChildren(
-                $this->localization->getAdminLocaleWithFallback(),
+                $this->localization->getCurrentLocaleForTranslatableEntities(),
             );
         } else {
             $blogCategoriesWithPreloadedChildren = $this->blogCategoryFacade->getVisibleBlogCategoriesWithPreloadedChildrenOnDomain(
                 $selectedDomainId,
-                $this->localization->getAdminLocaleWithFallback(),
+                $this->localization->getCurrentLocaleForTranslatableEntities(),
             );
         }
 

--- a/packages/framework/src/Controller/Admin/BlogCategoryController.php
+++ b/packages/framework/src/Controller/Admin/BlogCategoryController.php
@@ -12,6 +12,7 @@ use Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryDataFactory;
 use Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryFacade;
 use Shopsys\FrameworkBundle\Model\Blog\Category\Exception\BlogCategoryNotFoundException;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,12 +25,14 @@ class BlogCategoryController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Model\Blog\Category\BlogCategoryDataFactory $blogCategoryDataFactory
      * @param \Shopsys\FrameworkBundle\Model\AdminNavigation\BreadcrumbOverrider $breadcrumbOverrider
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly BlogCategoryFacade $blogCategoryFacade,
         protected readonly BlogCategoryDataFactory $blogCategoryDataFactory,
         protected readonly BreadcrumbOverrider $breadcrumbOverrider,
         protected readonly AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -125,12 +128,12 @@ class BlogCategoryController extends AdminBaseController
 
         if ($selectedDomainId === null) {
             $blogCategoriesWithPreloadedChildren = $this->blogCategoryFacade->getAllBlogCategoriesWithPreloadedChildren(
-                $request->getLocale(),
+                $this->localization->getAdminLocaleWithFallback(),
             );
         } else {
             $blogCategoriesWithPreloadedChildren = $this->blogCategoryFacade->getVisibleBlogCategoriesWithPreloadedChildrenOnDomain(
                 $selectedDomainId,
-                $request->getLocale(),
+                $this->localization->getAdminLocaleWithFallback(),
             );
         }
 

--- a/packages/framework/src/Controller/Admin/CategoryController.php
+++ b/packages/framework/src/Controller/Admin/CategoryController.php
@@ -15,6 +15,7 @@ use Shopsys\FrameworkBundle\Model\Category\CategoryDataFactory;
 use Shopsys\FrameworkBundle\Model\Category\CategoryFacade;
 use Shopsys\FrameworkBundle\Model\Category\Exception\CategoryNotFoundException;
 use Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -29,6 +30,7 @@ class CategoryController extends AdminBaseController
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade
      * @param \Shopsys\FrameworkBundle\Component\Form\FormBuilderHelper $formBuilderHelper
      * @param \Shopsys\FrameworkBundle\Model\CategorySeo\ReadyCategorySeoMixFacade $categorySeoMixFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly CategoryFacade $categoryFacade,
@@ -38,6 +40,7 @@ class CategoryController extends AdminBaseController
         protected readonly AdminDomainFilterTabsFacade $adminDomainFilterTabsFacade,
         protected readonly FormBuilderHelper $formBuilderHelper,
         protected readonly ReadyCategorySeoMixFacade $categorySeoMixFacade,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -136,12 +139,12 @@ class CategoryController extends AdminBaseController
 
         if ($selectedDomainId === null) {
             $categoriesWithPreloadedChildren = $this->categoryFacade->getAllCategoriesWithPreloadedChildren(
-                $request->getLocale(),
+                $this->localization->getAdminLocaleWithFallback(),
             );
         } else {
             $categoriesWithPreloadedChildren = $this->categoryFacade->getVisibleCategoriesWithPreloadedChildrenForDomain(
                 $selectedDomainId,
-                $request->getLocale(),
+                $this->localization->getAdminLocaleWithFallback(),
             );
         }
 

--- a/packages/framework/src/Controller/Admin/CategoryController.php
+++ b/packages/framework/src/Controller/Admin/CategoryController.php
@@ -139,12 +139,12 @@ class CategoryController extends AdminBaseController
 
         if ($selectedDomainId === null) {
             $categoriesWithPreloadedChildren = $this->categoryFacade->getAllCategoriesWithPreloadedChildren(
-                $this->localization->getAdminLocaleWithFallback(),
+                $this->localization->getCurrentLocaleForTranslatableEntities(),
             );
         } else {
             $categoriesWithPreloadedChildren = $this->categoryFacade->getVisibleCategoriesWithPreloadedChildrenForDomain(
                 $selectedDomainId,
-                $this->localization->getAdminLocaleWithFallback(),
+                $this->localization->getCurrentLocaleForTranslatableEntities(),
             );
         }
 

--- a/packages/framework/src/Controller/Admin/InquiryController.php
+++ b/packages/framework/src/Controller/Admin/InquiryController.php
@@ -47,7 +47,7 @@ class InquiryController extends AdminBaseController
 
         $queryBuilder = $this->inquiryFacade->getInquiryListQueryBuilderByQuickSearchData(
             $quickSearchForm->getData(),
-            $this->localization->getAdminLocale(),
+            $this->localization->getAdminLocaleWithFallback(),
         );
 
         $selectedDomainId = $this->adminDomainFilterTabsFacade->getSelectedDomainId($domainFilterNamespace);

--- a/packages/framework/src/Controller/Admin/InquiryController.php
+++ b/packages/framework/src/Controller/Admin/InquiryController.php
@@ -47,7 +47,7 @@ class InquiryController extends AdminBaseController
 
         $queryBuilder = $this->inquiryFacade->getInquiryListQueryBuilderByQuickSearchData(
             $quickSearchForm->getData(),
-            $this->localization->getAdminLocaleWithFallback(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
         );
 
         $selectedDomainId = $this->adminDomainFilterTabsFacade->getSelectedDomainId($domainFilterNamespace);

--- a/packages/framework/src/Controller/Admin/MenuController.php
+++ b/packages/framework/src/Controller/Admin/MenuController.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Controller\Admin;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
 use Symfony\Component\HttpFoundation\Response;
 
 class MenuController extends AdminBaseController
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
      */
     public function __construct(
         protected readonly Domain $domain,
-        protected readonly Localization $localization,
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
     ) {
     }
 
@@ -27,7 +27,7 @@ class MenuController extends AdminBaseController
     {
         return $this->render('@ShopsysFramework/Admin/Inline/Menu/menu.html.twig', [
             'domainConfigs' => $this->domain->getAll(),
-            'allowedLocales' => $this->localization->getAllowedAdminLocales(),
+            'allowedLocales' => $this->administratorLocalizationFacade->getAllowedAdminLocales(),
         ]);
     }
 }

--- a/packages/framework/src/Controller/Admin/TopCategoryController.php
+++ b/packages/framework/src/Controller/Admin/TopCategoryController.php
@@ -40,7 +40,7 @@ class TopCategoryController extends AdminBaseController
 
         $form = $this->createForm(TopCategoriesFormType::class, $formData, [
             'domain_id' => $domainId,
-            'locale' => $this->localization->getAdminLocaleWithFallback(),
+            'locale' => $this->localization->getCurrentLocaleForTranslatableEntities(),
         ]);
         $form->handleRequest($request);
 

--- a/packages/framework/src/Controller/Admin/TopCategoryController.php
+++ b/packages/framework/src/Controller/Admin/TopCategoryController.php
@@ -7,6 +7,7 @@ namespace Shopsys\FrameworkBundle\Controller\Admin;
 use Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade;
 use Shopsys\FrameworkBundle\Form\Admin\Category\TopCategory\TopCategoriesFormType;
 use Shopsys\FrameworkBundle\Model\Category\TopCategory\TopCategoryFacade;
+use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -16,10 +17,12 @@ class TopCategoryController extends AdminBaseController
     /**
      * @param \Shopsys\FrameworkBundle\Model\Category\TopCategory\TopCategoryFacade $topCategoryFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\AdminDomainTabsFacade $adminDomainTabsFacade
+     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         protected readonly TopCategoryFacade $topCategoryFacade,
         protected readonly AdminDomainTabsFacade $adminDomainTabsFacade,
+        protected readonly Localization $localization,
     ) {
     }
 
@@ -37,7 +40,7 @@ class TopCategoryController extends AdminBaseController
 
         $form = $this->createForm(TopCategoriesFormType::class, $formData, [
             'domain_id' => $domainId,
-            'locale' => $request->getLocale(),
+            'locale' => $this->localization->getAdminLocaleWithFallback(),
         ]);
         $form->handleRequest($request);
 

--- a/packages/framework/src/Controller/Admin/WatchdogController.php
+++ b/packages/framework/src/Controller/Admin/WatchdogController.php
@@ -57,7 +57,7 @@ class WatchdogController extends AdminBaseController
 
         $queryBuilder = $this->watchdogFacade->getWatchdogProductListQueryBuilderByQuickSearchData(
             $quickSearchForm->getData(),
-            $this->localization->getAdminLocale(),
+            $this->localization->getAdminLocaleWithFallback(),
         );
 
         $selectedDomainId = $this->adminDomainFilterTabsFacade->getSelectedDomainId(static::WATCHDOG_DOMAIN_FILTER_NAMESPACE);

--- a/packages/framework/src/Controller/Admin/WatchdogController.php
+++ b/packages/framework/src/Controller/Admin/WatchdogController.php
@@ -57,7 +57,7 @@ class WatchdogController extends AdminBaseController
 
         $queryBuilder = $this->watchdogFacade->getWatchdogProductListQueryBuilderByQuickSearchData(
             $quickSearchForm->getData(),
-            $this->localization->getAdminLocaleWithFallback(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
         );
 
         $selectedDomainId = $this->adminDomainFilterTabsFacade->getSelectedDomainId(static::WATCHDOG_DOMAIN_FILTER_NAMESPACE);

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -107,9 +107,9 @@ class BlogCategoryFormType extends AbstractType
     private function createSettingsGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         if ($options['blogCategory'] !== null) {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->localization->getAdminLocale());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->localization->getAdminLocaleWithFallback());
         } else {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->localization->getAdminLocale());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->localization->getAdminLocaleWithFallback());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Blog/BlogCategoryFormType.php
@@ -107,9 +107,9 @@ class BlogCategoryFormType extends AbstractType
     private function createSettingsGroup(FormBuilderInterface $builder, array $options): FormBuilderInterface
     {
         if ($options['blogCategory'] !== null) {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->localization->getAdminLocaleWithFallback());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAllWithoutBranch($options['blogCategory'], $this->localization->getCurrentLocaleForTranslatableEntities());
         } else {
-            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->localization->getAdminLocaleWithFallback());
+            $parentChoices = $this->blogCategoryFacade->getTranslatedAll($this->localization->getCurrentLocaleForTranslatableEntities());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -98,10 +98,10 @@ class CategoryFormType extends AbstractType
         if ($options['category'] !== null) {
             $parentChoices = $this->categoryFacade->getAllTranslatedWithoutBranch(
                 $options['category'],
-                $this->localization->getAdminLocaleWithFallback(),
+                $this->localization->getCurrentLocaleForTranslatableEntities(),
             );
         } else {
-            $parentChoices = $this->categoryFacade->getAllTranslated($this->localization->getAdminLocaleWithFallback());
+            $parentChoices = $this->categoryFacade->getAllTranslated($this->localization->getCurrentLocaleForTranslatableEntities());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Form/Admin/Category/CategoryFormType.php
+++ b/packages/framework/src/Form/Admin/Category/CategoryFormType.php
@@ -98,10 +98,10 @@ class CategoryFormType extends AbstractType
         if ($options['category'] !== null) {
             $parentChoices = $this->categoryFacade->getAllTranslatedWithoutBranch(
                 $options['category'],
-                $this->localization->getAdminLocale(),
+                $this->localization->getAdminLocaleWithFallback(),
             );
         } else {
-            $parentChoices = $this->categoryFacade->getAllTranslated($this->localization->getAdminLocale());
+            $parentChoices = $this->categoryFacade->getAllTranslated($this->localization->getAdminLocaleWithFallback());
         }
 
         $builderSettingsGroup = $builder->create('settings', GroupType::class, [

--- a/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
+++ b/packages/framework/src/Form/Admin/Navigation/NavigationItemFormType.php
@@ -124,7 +124,7 @@ final class NavigationItemFormType extends AbstractType
     private function addColumnFields(FormBuilderInterface $builder): void
     {
         $categoryPaths = $this->categoryFacade->getFullPathsIndexedByIds(
-            $this->localization->getAdminLocale(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
         );
 
         $builder

--- a/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
+++ b/packages/framework/src/Form/Admin/Pricing/Currency/CurrencyFormType.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrameworkBundle\Form\Admin\Pricing\Currency;
 use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
 use Override;
 use Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyData;
 use Symfony\Component\Form\AbstractType;
@@ -22,11 +21,9 @@ class CurrencyFormType extends AbstractType
 {
     /**
      * @param \CommerceGuys\Intl\Currency\CurrencyRepositoryInterface $intlCurrencyRepository
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      */
     public function __construct(
         private readonly CurrencyRepositoryInterface $intlCurrencyRepository,
-        private readonly Localization $localization,
     ) {
     }
 
@@ -37,7 +34,7 @@ class CurrencyFormType extends AbstractType
     #[Override]
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $intlCurrencies = $this->intlCurrencyRepository->getAll($this->localization->getLocale());
+        $intlCurrencies = $this->intlCurrencyRepository->getAll();
 
         $possibleCurrencyCodes = [];
 

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
@@ -128,7 +128,7 @@ class ParameterFormType extends AbstractType
             if ($this->parameterFacade->existsParameterByName($name, $locale, $currentParameter)) {
                 $context
                     ->buildViolation(t('Parameter with this name already exists for the locale "%locale%".', ['%locale%' => $locale], Translator::VALIDATOR_TRANSLATION_DOMAIN))
-                    ->atPath(sprintf('name[%s]', $this->localization->getAdminLocaleWithFallback()))
+                    ->atPath(sprintf('name[%s]', $this->localization->getCurrentLocaleForTranslatableEntities()))
                     ->addViolation();
             }
         }

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterFormType.php
@@ -128,7 +128,7 @@ class ParameterFormType extends AbstractType
             if ($this->parameterFacade->existsParameterByName($name, $locale, $currentParameter)) {
                 $context
                     ->buildViolation(t('Parameter with this name already exists for the locale "%locale%".', ['%locale%' => $locale], Translator::VALIDATOR_TRANSLATION_DOMAIN))
-                    ->atPath(sprintf('name[%s]', $this->localization->getAdminLocale()))
+                    ->atPath(sprintf('name[%s]', $this->localization->getAdminLocaleWithFallback()))
                     ->addViolation();
             }
         }

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
@@ -95,7 +95,7 @@ class ParameterGroupFormType extends AbstractType
             if ($this->parameterGroupFacade->existsParameterGroupByName($name, $locale, $currentParameterGroup)) {
                 $context
                     ->buildViolation(t('Parameter group with this name already exists for the locale "%locale%".', ['%locale%' => $locale], Translator::VALIDATOR_TRANSLATION_DOMAIN))
-                    ->atPath(sprintf('name[%s]', $this->localization->getAdminLocale()))
+                    ->atPath(sprintf('name[%s]', $this->localization->getAdminLocaleWithFallback()))
                     ->addViolation();
             }
         }

--- a/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ParameterGroupFormType.php
@@ -95,7 +95,7 @@ class ParameterGroupFormType extends AbstractType
             if ($this->parameterGroupFacade->existsParameterGroupByName($name, $locale, $currentParameterGroup)) {
                 $context
                     ->buildViolation(t('Parameter group with this name already exists for the locale "%locale%".', ['%locale%' => $locale], Translator::VALIDATOR_TRANSLATION_DOMAIN))
-                    ->atPath(sprintf('name[%s]', $this->localization->getAdminLocaleWithFallback()))
+                    ->atPath(sprintf('name[%s]', $this->localization->getCurrentLocaleForTranslatableEntities()))
                     ->addViolation();
             }
         }

--- a/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
@@ -42,7 +42,7 @@ class ProductParameterValueFormType extends AbstractType
         $builder
             ->add('parameter', ChoiceType::class, [
                 'required' => true,
-                'choices' => $this->parameterFacade->getAllWithTranslations($this->localization->getAdminLocale()),
+                'choices' => $this->parameterFacade->getAllWithTranslations($this->localization->getAdminLocaleWithFallback()),
                 'choice_label' => function (Parameter $parameter) {
                     return $parameter->getName() .
                     ' [' . $this->getGroupName($parameter) . ']';
@@ -105,6 +105,6 @@ class ProductParameterValueFormType extends AbstractType
      */
     protected function getGroupName(Parameter $parameter): string
     {
-        return $parameter->getGroup()?->getName($this->localization->getAdminLocale()) ?? t('No group');
+        return $parameter->getGroup()?->getName($this->localization->getAdminLocaleWithFallback()) ?? t('No group');
     }
 }

--- a/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
+++ b/packages/framework/src/Form/Admin/Product/Parameter/ProductParameterValueFormType.php
@@ -42,7 +42,7 @@ class ProductParameterValueFormType extends AbstractType
         $builder
             ->add('parameter', ChoiceType::class, [
                 'required' => true,
-                'choices' => $this->parameterFacade->getAllWithTranslations($this->localization->getAdminLocaleWithFallback()),
+                'choices' => $this->parameterFacade->getAllWithTranslations($this->localization->getCurrentLocaleForTranslatableEntities()),
                 'choice_label' => function (Parameter $parameter) {
                     return $parameter->getName() .
                     ' [' . $this->getGroupName($parameter) . ']';
@@ -105,6 +105,6 @@ class ProductParameterValueFormType extends AbstractType
      */
     protected function getGroupName(Parameter $parameter): string
     {
-        return $parameter->getGroup()?->getName($this->localization->getAdminLocaleWithFallback()) ?? t('No group');
+        return $parameter->getGroup()?->getName($this->localization->getCurrentLocaleForTranslatableEntities()) ?? t('No group');
     }
 }

--- a/packages/framework/src/Form/Locale/LocalizedType.php
+++ b/packages/framework/src/Form/Locale/LocalizedType.php
@@ -43,7 +43,7 @@ class LocalizedType extends AbstractType
         $otherLocaleOptions['required'] = $options['required'] && $otherLocaleOptions['required'];
 
         foreach ($this->localization->getAdminEnabledLocales() as $locale) {
-            if ($locale === $this->localization->getAdminLocaleWithFallback()) {
+            if ($locale === $this->localization->getCurrentLocaleForTranslatableEntities()) {
                 $builder->add(
                     $locale,
                     $options['entry_type'],

--- a/packages/framework/src/Form/Locale/LocalizedType.php
+++ b/packages/framework/src/Form/Locale/LocalizedType.php
@@ -43,7 +43,7 @@ class LocalizedType extends AbstractType
         $otherLocaleOptions['required'] = $options['required'] && $otherLocaleOptions['required'];
 
         foreach ($this->localization->getAdminEnabledLocales() as $locale) {
-            if ($locale === $this->localization->getAdminLocale()) {
+            if ($locale === $this->localization->getAdminLocaleWithFallback()) {
                 $builder->add(
                     $locale,
                     $options['entry_type'],

--- a/packages/framework/src/Form/MoneyTypeExtension.php
+++ b/packages/framework/src/Form/MoneyTypeExtension.php
@@ -52,7 +52,7 @@ class MoneyTypeExtension extends AbstractTypeExtension
 
         $view->vars['symbolAfterInput'] = $this->intlCurrencyRepository->get(
             $options['currency'],
-            $this->localization->getLocale(),
+            $this->localization->getRequestLocale(),
         );
     }
 

--- a/packages/framework/src/Form/OrderListType.php
+++ b/packages/framework/src/Form/OrderListType.php
@@ -50,7 +50,7 @@ class OrderListType extends AbstractType
     {
         parent::buildView($view, $form, $options);
 
-        $view->vars['orders'] = $this->orderFacade->getLastCustomerOrdersByLimit($options['customer'], $options['limit'], $this->localization->getAdminLocaleWithFallback());
+        $view->vars['orders'] = $this->orderFacade->getLastCustomerOrdersByLimit($options['customer'], $options['limit'], $this->localization->getCurrentLocaleForTranslatableEntities());
         $view->vars['customer'] = $options['customer'];
         $view->vars['limit'] = $options['limit'];
     }

--- a/packages/framework/src/Form/OrderListType.php
+++ b/packages/framework/src/Form/OrderListType.php
@@ -50,7 +50,7 @@ class OrderListType extends AbstractType
     {
         parent::buildView($view, $form, $options);
 
-        $view->vars['orders'] = $this->orderFacade->getLastCustomerOrdersByLimit($options['customer'], $options['limit'], $this->localization->getAdminLocale());
+        $view->vars['orders'] = $this->orderFacade->getLastCustomerOrdersByLimit($options['customer'], $options['limit'], $this->localization->getAdminLocaleWithFallback());
         $view->vars['customer'] = $options['customer'];
         $view->vars['limit'] = $options['limit'];
     }

--- a/packages/framework/src/Form/WysiwygTypeExtension.php
+++ b/packages/framework/src/Form/WysiwygTypeExtension.php
@@ -39,7 +39,7 @@ class WysiwygTypeExtension extends AbstractTypeExtension
         $resolver->setDefaults([
             'config' => [
                 'contentsCss' => $this->getContentCss(),
-                'language' => $this->localization->getLocale(),
+                'language' => $this->localization->getRequestLocale(),
                 'format_tags' => static::ALLOWED_FORMAT_TAGS,
             ],
         ]);

--- a/packages/framework/src/Migrations/Version20241106123834.php
+++ b/packages/framework/src/Migrations/Version20241106123834.php
@@ -9,7 +9,6 @@ use Override;
 use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
 use Shopsys\MigrationBundle\Component\Doctrine\Migrations\AbstractMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Version20241106123834 extends AbstractMigration implements ContainerAwareInterface
 {
@@ -28,19 +27,7 @@ class Version20241106123834 extends AbstractMigration implements ContainerAwareI
             throw new AdminLocaleNotFoundException();
         }
 
-        if (!in_array($defaultLocale, $this->getAllLocales(), true)) {
-            throw new AdminLocaleNotFoundException($defaultLocale, $this->getAllLocales());
-        }
-
         $this->sql(sprintf('ALTER TABLE administrators ADD selected_locale VARCHAR(10) NOT NULL DEFAULT \'%s\'', $defaultLocale));
         $this->sql('ALTER TABLE administrators ALTER selected_locale DROP DEFAULT');
-    }
-
-    /**
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface|null $container
-     */
-    public function setContainer(?ContainerInterface $container = null): void
-    {
-        $this->container = $container;
     }
 }

--- a/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
+++ b/packages/framework/src/Model/Administrator/AdministratorDataFactory.php
@@ -5,16 +5,15 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 class AdministratorDataFactory
 {
     /**
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      */
     public function __construct(
-        protected readonly Localization $localization,
+        protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
         protected readonly Domain $domain,
     ) {
     }
@@ -35,7 +34,7 @@ class AdministratorDataFactory
         $administratorData = $this->createInstance();
 
         $administratorData->displayOnlyDomainIds = $this->domain->getAllIds();
-        $administratorData->selectedLocale = $this->localization->getDefaultAdminLocale();
+        $administratorData->selectedLocale = $this->administratorLocalizationFacade->getDefaultAdminLocale();
 
         return $administratorData;
     }

--- a/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
+++ b/packages/framework/src/Model/Administrator/AdministratorLocalizationFacade.php
@@ -5,16 +5,23 @@ declare(strict_types=1);
 namespace Shopsys\FrameworkBundle\Model\Administrator;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade;
+use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\AdministratorIsNotLoggedException;
+use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 
 class AdministratorLocalizationFacade
 {
     /**
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
+     * @param string[] $allowedAdminLocales
+     * @param \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade
      * @param \Doctrine\ORM\EntityManagerInterface $em
      */
     public function __construct(
         protected readonly Localization $localization,
+        protected readonly array $allowedAdminLocales,
+        protected readonly AdministratorFrontSecurityFacade $administratorFrontSecurityFacade,
         protected readonly EntityManagerInterface $em,
     ) {
     }
@@ -25,9 +32,65 @@ class AdministratorLocalizationFacade
      */
     public function setSelectedLocale(Administrator $administrator, string $locale): void
     {
-        $this->localization->checkAdminLocaleIsSupported($locale);
+        if (!$this->isAdminLocaleSupported($locale)) {
+            throw new AdminLocaleNotFoundException($locale, $this->allowedAdminLocales);
+        }
+
         $administrator->setSelectedLocale($locale);
 
         $this->em->flush();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentAdminLocaleOrDefault(): string
+    {
+        try {
+            $administrator = $this->administratorFrontSecurityFacade->getCurrentAdministrator();
+            $adminLocale = $administrator->getSelectedLocale();
+
+            if (!$this->isAdminLocaleSupported($adminLocale)) {
+                $adminLocale = $this->getDefaultAdminLocale();
+                $this->setSelectedLocale($administrator, $adminLocale);
+            }
+        } catch (AdministratorIsNotLoggedException) {
+            $adminLocale = $this->getDefaultAdminLocale();
+        }
+
+
+        return $adminLocale;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedAdminLocales(): array
+    {
+        return $this->allowedAdminLocales;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultAdminLocale(): string
+    {
+        $allowedAdminLocales = $this->allowedAdminLocales;
+        $defaultAdminLocale = reset($allowedAdminLocales);
+
+        if ($defaultAdminLocale === false) {
+            throw new AdminLocaleNotFoundException();
+        }
+
+        return $defaultAdminLocale;
+    }
+
+    /**
+     * @param string $locale
+     * @return bool
+     */
+    protected function isAdminLocaleSupported(string $locale): bool
+    {
+        return in_array($locale, $this->allowedAdminLocales, true);
     }
 }

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
@@ -65,7 +65,7 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
         return [
             'expanded' => false,
             'multiple' => false,
-            'choices' => $this->categoryFacade->getAllTranslated($this->localization->getAdminLocaleWithFallback()),
+            'choices' => $this->categoryFacade->getAllTranslated($this->localization->getCurrentLocaleForTranslatableEntities()),
             'choice_label' => function (Category $category) {
                 $padding = str_repeat("\u{00a0}", ($category->getLevel() - 1) * 2);
 

--- a/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
+++ b/packages/framework/src/Model/AdvancedSearch/Filter/ProductCategoryFilter.php
@@ -65,7 +65,7 @@ class ProductCategoryFilter implements AdvancedSearchFilterInterface
         return [
             'expanded' => false,
             'multiple' => false,
-            'choices' => $this->categoryFacade->getAllTranslated($this->localization->getAdminLocale()),
+            'choices' => $this->categoryFacade->getAllTranslated($this->localization->getAdminLocaleWithFallback()),
             'choice_label' => function (Category $category) {
                 $padding = str_repeat("\u{00a0}", ($category->getLevel() - 1) * 2);
 

--- a/packages/framework/src/Model/AdvancedSearchComplaint/AdvancedSearchComplaintFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchComplaint/AdvancedSearchComplaintFacade.php
@@ -76,7 +76,7 @@ class AdvancedSearchComplaintFacade
      */
     public function getQueryBuilderByAdvancedSearchData(array $advancedSearchData): QueryBuilder
     {
-        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getAdminLocale());
+        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getAdminLocaleWithFallback());
         $this->advancedSearchQueryBuilderExtender->extendByAdvancedSearchData($queryBuilder, $advancedSearchData);
 
         return $queryBuilder;
@@ -89,7 +89,7 @@ class AdvancedSearchComplaintFacade
     public function getComplaintListQueryBuilderByQuickSearchData(
         QuickSearchFormData $quickSearchData,
     ): QueryBuilder {
-        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getAdminLocale());
+        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getAdminLocaleWithFallback());
 
         if ($quickSearchData->text !== null && $quickSearchData->text !== '') {
             $queryBuilder

--- a/packages/framework/src/Model/AdvancedSearchComplaint/AdvancedSearchComplaintFacade.php
+++ b/packages/framework/src/Model/AdvancedSearchComplaint/AdvancedSearchComplaintFacade.php
@@ -76,7 +76,7 @@ class AdvancedSearchComplaintFacade
      */
     public function getQueryBuilderByAdvancedSearchData(array $advancedSearchData): QueryBuilder
     {
-        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getAdminLocaleWithFallback());
+        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getCurrentLocaleForTranslatableEntities());
         $this->advancedSearchQueryBuilderExtender->extendByAdvancedSearchData($queryBuilder, $advancedSearchData);
 
         return $queryBuilder;
@@ -89,7 +89,7 @@ class AdvancedSearchComplaintFacade
     public function getComplaintListQueryBuilderByQuickSearchData(
         QuickSearchFormData $quickSearchData,
     ): QueryBuilder {
-        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getAdminLocaleWithFallback());
+        $queryBuilder = $this->complaintRepository->getComplaintsQueryBuilder($this->localization->getCurrentLocaleForTranslatableEntities());
 
         if ($quickSearchData->text !== null && $quickSearchData->text !== '') {
             $queryBuilder

--- a/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusGridFactory.php
+++ b/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusGridFactory.php
@@ -38,7 +38,7 @@ class ComplaintStatusGridFactory implements GridFactoryInterface
             ->select('cs, cst')
             ->from(ComplaintStatus::class, 'cs')
             ->join('cs.translations', 'cst', Join::WITH, 'cst.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
+            ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'cs.id');
 
         $grid = $this->gridFactory->create('complaintStatusList', $dataSource);

--- a/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusGridFactory.php
+++ b/packages/framework/src/Model/Complaint/Status/Grid/ComplaintStatusGridFactory.php
@@ -38,7 +38,7 @@ class ComplaintStatusGridFactory implements GridFactoryInterface
             ->select('cs, cst')
             ->from(ComplaintStatus::class, 'cs')
             ->join('cs.translations', 'cst', Join::WITH, 'cst.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocale());
+            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'cs.id');
 
         $grid = $this->gridFactory->create('complaintStatusList', $dataSource);

--- a/packages/framework/src/Model/Country/Grid/CountryGridFactory.php
+++ b/packages/framework/src/Model/Country/Grid/CountryGridFactory.php
@@ -34,7 +34,7 @@ class CountryGridFactory implements GridFactoryInterface
     public function create(): Grid
     {
         $queryBuilder = $this->countryRepository
-            ->createSortedJoinedQueryBuilder($this->localization->getAdminLocaleWithFallback(), $this->domain->getId())
+            ->createSortedJoinedQueryBuilder($this->localization->getCurrentLocaleForTranslatableEntities(), $this->domain->getId())
             ->addSelect('ct');
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'c.id');

--- a/packages/framework/src/Model/Country/Grid/CountryGridFactory.php
+++ b/packages/framework/src/Model/Country/Grid/CountryGridFactory.php
@@ -34,7 +34,7 @@ class CountryGridFactory implements GridFactoryInterface
     public function create(): Grid
     {
         $queryBuilder = $this->countryRepository
-            ->createSortedJoinedQueryBuilder($this->localization->getAdminLocale(), $this->domain->getId())
+            ->createSortedJoinedQueryBuilder($this->localization->getAdminLocaleWithFallback(), $this->domain->getId())
             ->addSelect('ct');
 
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'c.id');

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupGridFactory.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupGridFactory.php
@@ -53,7 +53,7 @@ class CustomerUserRoleGroupGridFactory implements GridFactoryInterface
     protected function getGridQueryBuilder(): QueryBuilder
     {
         return $this->customerUserRoleGroupRepository->getAllQueryBuilderByLocale(
-            $this->localization->getAdminLocaleWithFallback(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
         );
     }
 }

--- a/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupGridFactory.php
+++ b/packages/framework/src/Model/Customer/User/Role/CustomerUserRoleGroupGridFactory.php
@@ -53,7 +53,7 @@ class CustomerUserRoleGroupGridFactory implements GridFactoryInterface
     protected function getGridQueryBuilder(): QueryBuilder
     {
         return $this->customerUserRoleGroupRepository->getAllQueryBuilderByLocale(
-            $this->localization->getAdminLocale(),
+            $this->localization->getAdminLocaleWithFallback(),
         );
     }
 }

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -6,9 +6,9 @@ namespace Shopsys\FrameworkBundle\Model\Localization;
 
 use Locale;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
+use Shopsys\FrameworkBundle\Component\HttpFoundation\Exception\NoRequestException;
 use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade;
-use Shopsys\FrameworkBundle\Model\Administrator\Security\Exception\AdministratorIsNotLoggedException;
-use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class Localization
 {
@@ -21,37 +21,30 @@ class Localization
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param string[] $allowedAdminLocales
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade
+     * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
      */
     public function __construct(
         protected readonly Domain $domain,
         protected readonly array $allowedAdminLocales,
         protected readonly AdministratorFrontSecurityFacade $administratorFrontSecurityFacade,
+        protected readonly RequestStack $requestStack,
     ) {
     }
 
     /**
-     * @return string
-     */
-    public function getLocale(): string
-    {
-        return $this->domain->getLocale();
-    }
-
-    /**
-     * TODO find usages and add a new method or something like getAdminLocaleWithFallback(int $fallbackDomainId = 1)
+     * The proper locale is set into request in @see \Shopsys\FrameworkBundle\Model\Localization\LocalizationListener::onKernelRequest()
      *
      * @return string
      */
-    public function getAdminLocale(): string
+    public function getRequestLocale(): string
     {
-        try {
-            $adminLocale = $this->administratorFrontSecurityFacade->getCurrentAdministrator()->getSelectedLocale();
-            $this->checkAdminLocaleIsSupported($adminLocale);
-        } catch (AdministratorIsNotLoggedException) {
-            $adminLocale = $this->getDefaultAdminLocale();
+        $request = $this->requestStack->getMainRequest();
+
+        if ($request === null) {
+            throw new NoRequestException('Request is not available.');
         }
 
-        return $adminLocale;
+        return $request->getLocale();
     }
 
     /**
@@ -62,15 +55,28 @@ class Localization
      * @param int $fallbackLocaleDomainId
      * @return string
      */
-    public function getAdminLocaleWithFallback(int $fallbackLocaleDomainId = Domain::FIRST_DOMAIN_ID): string
-    {
-        $adminLocale = $this->getAdminLocale();
+    public function getCurrentLocaleForTranslatableEntities(
+        int $fallbackLocaleDomainId = Domain::FIRST_DOMAIN_ID,
+    ): string {
+        $requestLocale = $this->getRequestLocale();
 
-        if (!in_array($adminLocale, $this->getLocalesOfAllDomains(), true)) {
-            $adminLocale = $this->domain->getDomainConfigById($fallbackLocaleDomainId)->getLocale();
+        return $this->getFallbackLocaleIfLocaleIsNotUsedOnAnyDomain($requestLocale, $fallbackLocaleDomainId);
+    }
+
+    /**
+     * @param string $locale
+     * @param int $fallbackLocaleDomainId
+     * @return string
+     */
+    public function getFallbackLocaleIfLocaleIsNotUsedOnAnyDomain(
+        string $locale,
+        int $fallbackLocaleDomainId = Domain::FIRST_DOMAIN_ID,
+    ): string {
+        if (!in_array($locale, $this->getLocalesOfAllDomains(), true)) {
+            return $this->domain->getDomainConfigById($fallbackLocaleDomainId)->getLocale();
         }
 
-        return $adminLocale;
+        return $locale;
     }
 
     /**
@@ -116,40 +122,5 @@ class Localization
         }
 
         return $enabledLocales;
-    }
-
-    /**
-     * @param string $locale
-     */
-    public function checkAdminLocaleIsSupported(string $locale): void
-    {
-        if (!in_array($locale, $this->allowedAdminLocales, true)) {
-            throw new AdminLocaleNotFoundException($locale, $this->allowedAdminLocales);
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getDefaultAdminLocale(): string
-    {
-        $allowedAdminLocales = $this->allowedAdminLocales;
-        $defaultAdminLocale = reset($allowedAdminLocales);
-
-        if ($defaultAdminLocale === false) {
-            throw new AdminLocaleNotFoundException();
-        }
-
-        $this->checkAdminLocaleIsSupported($defaultAdminLocale);
-
-        return $defaultAdminLocale;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAllowedAdminLocales(): array
-    {
-        return $this->allowedAdminLocales;
     }
 }

--- a/packages/framework/src/Model/Localization/Localization.php
+++ b/packages/framework/src/Model/Localization/Localization.php
@@ -38,6 +38,8 @@ class Localization
     }
 
     /**
+     * TODO find usages and add a new method or something like getAdminLocaleWithFallback(int $fallbackDomainId = 1)
+     *
      * @return string
      */
     public function getAdminLocale(): string
@@ -47,6 +49,25 @@ class Localization
             $this->checkAdminLocaleIsSupported($adminLocale);
         } catch (AdministratorIsNotLoggedException) {
             $adminLocale = $this->getDefaultAdminLocale();
+        }
+
+        return $adminLocale;
+    }
+
+    /**
+     * The method is handy when you need to get the entity translations in the admin locale.
+     * It has a safety net in form of a fallback domain ID that ensures the method always returns a valid locale from the entity translations point of view.
+     * The fallback is necessary for setup with the admin locale is different from the storefront domain locales.
+     *
+     * @param int $fallbackLocaleDomainId
+     * @return string
+     */
+    public function getAdminLocaleWithFallback(int $fallbackLocaleDomainId = Domain::FIRST_DOMAIN_ID): string
+    {
+        $adminLocale = $this->getAdminLocale();
+
+        if (!in_array($adminLocale, $this->getLocalesOfAllDomains(), true)) {
+            $adminLocale = $this->domain->getDomainConfigById($fallbackLocaleDomainId)->getLocale();
         }
 
         return $adminLocale;
@@ -102,12 +123,6 @@ class Localization
      */
     public function checkAdminLocaleIsSupported(string $locale): void
     {
-        $allLocales = $this->getLocalesOfAllDomains();
-
-        if (!in_array($locale, $allLocales, true)) {
-            throw new AdminLocaleNotFoundException($locale, $allLocales);
-        }
-
         if (!in_array($locale, $this->allowedAdminLocales, true)) {
             throw new AdminLocaleNotFoundException($locale, $this->allowedAdminLocales);
         }

--- a/packages/framework/src/Model/Localization/LocalizationListener.php
+++ b/packages/framework/src/Model/Localization/LocalizationListener.php
@@ -8,7 +8,6 @@ use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
 use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
 use Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade;
-use Shopsys\FrameworkBundle\Model\Localization\Exception\AdminLocaleNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -17,14 +16,12 @@ class LocalizationListener implements EventSubscriberInterface
 {
     /**
      * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
-     * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      * @param \Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade $administrationFacade
      * @param \Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade $administratorLocalizationFacade
      * @param \Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade $administratorFrontSecurityFacade
      */
     public function __construct(
         protected readonly Domain $domain,
-        protected readonly Localization $localization,
         protected readonly AdministrationFacade $administrationFacade,
         protected readonly AdministratorLocalizationFacade $administratorLocalizationFacade,
         protected readonly AdministratorFrontSecurityFacade $administratorFrontSecurityFacade,
@@ -40,16 +37,7 @@ class LocalizationListener implements EventSubscriberInterface
             $request = $event->getRequest();
 
             if ($this->administrationFacade->isInAdmin()) {
-                try {
-                    $adminLocale = $this->localization->getAdminLocale();
-                } catch (AdminLocaleNotFoundException) {
-                    $adminLocale = $this->localization->getDefaultAdminLocale();
-
-                    $administrator = $this->administratorFrontSecurityFacade->getCurrentAdministrator();
-                    $this->administratorLocalizationFacade->setSelectedLocale($administrator, $adminLocale);
-                }
-
-                $request->setLocale($adminLocale);
+                $request->setLocale($this->administratorLocalizationFacade->getCurrentAdminLocaleOrDefault());
             } else {
                 $request->setLocale($this->domain->getLocale());
             }

--- a/packages/framework/src/Model/Localization/TranslatableListener.php
+++ b/packages/framework/src/Model/Localization/TranslatableListener.php
@@ -9,20 +9,44 @@ use Doctrine\ORM\Events;
 use Metadata\MetadataFactory;
 use Override;
 use Prezent\Doctrine\Translatable\EventListener\TranslatableListener as PrezentTranslatableListener;
+use Shopsys\FrameworkBundle\Component\Domain\Domain;
 
 class TranslatableListener extends PrezentTranslatableListener
 {
     /**
+     * @param \Shopsys\FrameworkBundle\Component\Domain\Domain $domain
      * @param \Metadata\MetadataFactory $factory
      */
-    public function __construct(MetadataFactory $factory)
-    {
+    public function __construct(
+        protected readonly Domain $domain,
+        MetadataFactory $factory,
+    ) {
         parent::__construct($factory);
 
         // set default locale to NULL
         // (currentLocale of entities should be set by request or stay NULL)
         // @phpstan-ignore-next-line
         $this->setCurrentLocale(null);
+    }
+
+    /**
+     * @param string $currentLocale
+     * @return \Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
+     *
+     * The current locale must always be one of the domain's available locales (i.e., the persisted entity translations).
+     * This ensures that the listener does not attempt to load translations in an unavailable locale.
+     */
+    #[Override]
+    public function setCurrentLocale($currentLocale): self
+    {
+        if ($currentLocale !== null && !in_array($currentLocale, $this->domain->getAllLocales(), true)) {
+            $currentLocale = $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+        }
+
+        /** @var \Shopsys\FrameworkBundle\Model\Localization\TranslatableListener $self */
+        $self = parent::setCurrentLocale($currentLocale);
+
+        return $self;
     }
 
     /**

--- a/packages/framework/src/Model/Mail/MailTemplateRepository.php
+++ b/packages/framework/src/Model/Mail/MailTemplateRepository.php
@@ -130,7 +130,7 @@ class MailTemplateRepository
             ->addSelect('cst.name as complaintStatusName')
             ->leftJoin('mt.complaintStatus', 'cs')
             ->leftJoin('cs.translations', 'cst', Join::WITH, 'cst.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocale());
+            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
 
         return $queryBuilder;
     }

--- a/packages/framework/src/Model/Mail/MailTemplateRepository.php
+++ b/packages/framework/src/Model/Mail/MailTemplateRepository.php
@@ -130,7 +130,7 @@ class MailTemplateRepository
             ->addSelect('cst.name as complaintStatusName')
             ->leftJoin('mt.complaintStatus', 'cs')
             ->leftJoin('cs.translations', 'cst', Join::WITH, 'cst.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
+            ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
 
         return $queryBuilder;
     }

--- a/packages/framework/src/Model/Order/Listing/OrderListAdminFacade.php
+++ b/packages/framework/src/Model/Order/Listing/OrderListAdminFacade.php
@@ -23,6 +23,6 @@ class OrderListAdminFacade
      */
     public function getOrderListQueryBuilder()
     {
-        return $this->orderListAdminRepository->getOrderListQueryBuilder($this->localization->getAdminLocale());
+        return $this->orderListAdminRepository->getOrderListQueryBuilder($this->localization->getAdminLocaleWithFallback());
     }
 }

--- a/packages/framework/src/Model/Order/Listing/OrderListAdminFacade.php
+++ b/packages/framework/src/Model/Order/Listing/OrderListAdminFacade.php
@@ -23,6 +23,6 @@ class OrderListAdminFacade
      */
     public function getOrderListQueryBuilder()
     {
-        return $this->orderListAdminRepository->getOrderListQueryBuilder($this->localization->getAdminLocaleWithFallback());
+        return $this->orderListAdminRepository->getOrderListQueryBuilder($this->localization->getCurrentLocaleForTranslatableEntities());
     }
 }

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -271,7 +271,7 @@ class OrderFacade
     public function getOrderListQueryBuilderByQuickSearchData(QuickSearchFormData $quickSearchData): QueryBuilder
     {
         return $this->orderRepository->getOrderListQueryBuilderByQuickSearchData(
-            $this->localization->getAdminLocale(),
+            $this->localization->getAdminLocaleWithFallback(),
             $quickSearchData,
         );
     }

--- a/packages/framework/src/Model/Order/OrderFacade.php
+++ b/packages/framework/src/Model/Order/OrderFacade.php
@@ -271,7 +271,7 @@ class OrderFacade
     public function getOrderListQueryBuilderByQuickSearchData(QuickSearchFormData $quickSearchData): QueryBuilder
     {
         return $this->orderRepository->getOrderListQueryBuilderByQuickSearchData(
-            $this->localization->getAdminLocaleWithFallback(),
+            $this->localization->getCurrentLocaleForTranslatableEntities(),
             $quickSearchData,
         );
     }

--- a/packages/framework/src/Model/Order/Status/Grid/OrderStatusGridFactory.php
+++ b/packages/framework/src/Model/Order/Status/Grid/OrderStatusGridFactory.php
@@ -37,7 +37,7 @@ class OrderStatusGridFactory implements GridFactoryInterface
             ->select('os, ost')
             ->from(OrderStatus::class, 'os')
             ->join('os.translations', 'ost', Join::WITH, 'ost.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
+            ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'os.id');
 
         $grid = $this->gridFactory->create('orderStatusList', $dataSource);

--- a/packages/framework/src/Model/Order/Status/Grid/OrderStatusGridFactory.php
+++ b/packages/framework/src/Model/Order/Status/Grid/OrderStatusGridFactory.php
@@ -37,7 +37,7 @@ class OrderStatusGridFactory implements GridFactoryInterface
             ->select('os, ost')
             ->from(OrderStatus::class, 'os')
             ->join('os.translations', 'ost', Join::WITH, 'ost.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocale());
+            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'os.id');
 
         $grid = $this->gridFactory->create('orderStatusList', $dataSource);

--- a/packages/framework/src/Model/Product/Flag/FlagGridFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagGridFactory.php
@@ -35,7 +35,7 @@ class FlagGridFactory implements GridFactoryInterface
             ->select('f, ft')
             ->from(Flag::class, 'f')
             ->join('f.translations', 'ft', Join::WITH, 'ft.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
+            ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'f.id');
 
         $grid = $this->gridFactory->create('flagList', $dataSource);

--- a/packages/framework/src/Model/Product/Flag/FlagGridFactory.php
+++ b/packages/framework/src/Model/Product/Flag/FlagGridFactory.php
@@ -35,7 +35,7 @@ class FlagGridFactory implements GridFactoryInterface
             ->select('f, ft')
             ->from(Flag::class, 'f')
             ->join('f.translations', 'ft', Join::WITH, 'ft.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocale());
+            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'f.id');
 
         $grid = $this->gridFactory->create('flagList', $dataSource);

--- a/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
@@ -52,7 +52,7 @@ class ProductListAdminRepository
             )
             ->leftJoin('p.translations', 'pt', Join::WITH, 'pt.locale = :locale')
             ->setParameters([
-                'locale' => $this->localization->getAdminLocaleWithFallback(),
+                'locale' => $this->localization->getCurrentLocaleForTranslatableEntities(),
                 'pricingGroupId' => $pricingGroupId,
             ]);
 

--- a/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
+++ b/packages/framework/src/Model/Product/Listing/ProductListAdminRepository.php
@@ -52,7 +52,7 @@ class ProductListAdminRepository
             )
             ->leftJoin('p.translations', 'pt', Join::WITH, 'pt.locale = :locale')
             ->setParameters([
-                'locale' => $this->localization->getAdminLocale(),
+                'locale' => $this->localization->getAdminLocaleWithFallback(),
                 'pricingGroupId' => $pricingGroupId,
             ]);
 

--- a/packages/framework/src/Model/Product/Parameter/ParameterGridFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGridFactory.php
@@ -32,7 +32,7 @@ class ParameterGridFactory implements GridFactoryInterface
     public function create()
     {
         $locales = $this->localization->getLocalesOfAllDomains();
-        $adminLocale = $this->localization->getAdminLocaleWithFallback();
+        $adminLocale = $this->localization->getCurrentLocaleForTranslatableEntities();
         $grid = $this->gridFactory->create('parameterList', $this->getParametersDataSource());
 
         if (count($locales) > 1) {
@@ -104,12 +104,12 @@ class ParameterGridFactory implements GridFactoryInterface
             ->leftJoin('u.translations', 'ut', Join::WITH, 'ut.locale = :locale')
             ->leftJoin('p.group', 'pg')
             ->leftJoin('pg.translations', 'pgt', Join::WITH, 'pgt.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback())
+            ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities())
             ->orderBy('p.orderingPriority', 'DESC')
             ->addOrderBy('pt.name', 'ASC');
 
         foreach ($locales as $locale) {
-            if ($locale !== $this->localization->getAdminLocaleWithFallback()) {
+            if ($locale !== $this->localization->getCurrentLocaleForTranslatableEntities()) {
                 $queryBuilder
                     ->addSelect('pt_' . $locale)
                     ->leftJoin(

--- a/packages/framework/src/Model/Product/Parameter/ParameterGridFactory.php
+++ b/packages/framework/src/Model/Product/Parameter/ParameterGridFactory.php
@@ -32,7 +32,7 @@ class ParameterGridFactory implements GridFactoryInterface
     public function create()
     {
         $locales = $this->localization->getLocalesOfAllDomains();
-        $adminLocale = $this->localization->getAdminLocale();
+        $adminLocale = $this->localization->getAdminLocaleWithFallback();
         $grid = $this->gridFactory->create('parameterList', $this->getParametersDataSource());
 
         if (count($locales) > 1) {
@@ -104,12 +104,12 @@ class ParameterGridFactory implements GridFactoryInterface
             ->leftJoin('u.translations', 'ut', Join::WITH, 'ut.locale = :locale')
             ->leftJoin('p.group', 'pg')
             ->leftJoin('pg.translations', 'pgt', Join::WITH, 'pgt.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocale())
+            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback())
             ->orderBy('p.orderingPriority', 'DESC')
             ->addOrderBy('pt.name', 'ASC');
 
         foreach ($locales as $locale) {
-            if ($locale !== $this->localization->getAdminLocale()) {
+            if ($locale !== $this->localization->getAdminLocaleWithFallback()) {
                 $queryBuilder
                     ->addSelect('pt_' . $locale)
                     ->leftJoin(

--- a/packages/framework/src/Model/Product/ProductCachedAttributesFacade.php
+++ b/packages/framework/src/Model/Product/ProductCachedAttributesFacade.php
@@ -82,7 +82,7 @@ class ProductCachedAttributesFacade
         return $this->inMemoryCache->getOrSaveValue(
             static::PARAMETER_VALUES_CACHE_NAMESPACE,
             function () use ($product, $locale) {
-                $locale = $locale ?? $this->localization->getLocale();
+                $locale = $locale ?? $this->localization->getCurrentLocaleForTranslatableEntities();
 
                 $productParameterValues = $this->parameterRepository->getProductParameterValuesByProductSortedByOrderingPriorityAndName(
                     $product,

--- a/packages/framework/src/Model/Product/Unit/UnitGridFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitGridFactory.php
@@ -35,7 +35,7 @@ class UnitGridFactory implements GridFactoryInterface
             ->select('u, ut')
             ->from(Unit::class, 'u')
             ->join('u.translations', 'ut', Join::WITH, 'ut.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
+            ->setParameter('locale', $this->localization->getCurrentLocaleForTranslatableEntities());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'u.id');
 
         $grid = $this->gridFactory->create('unitList', $dataSource);

--- a/packages/framework/src/Model/Product/Unit/UnitGridFactory.php
+++ b/packages/framework/src/Model/Product/Unit/UnitGridFactory.php
@@ -35,7 +35,7 @@ class UnitGridFactory implements GridFactoryInterface
             ->select('u, ut')
             ->from(Unit::class, 'u')
             ->join('u.translations', 'ut', Join::WITH, 'ut.locale = :locale')
-            ->setParameter('locale', $this->localization->getAdminLocale());
+            ->setParameter('locale', $this->localization->getAdminLocaleWithFallback());
         $dataSource = new QueryBuilderDataSource($queryBuilder, 'u.id');
 
         $grid = $this->gridFactory->create('unitList', $dataSource);

--- a/packages/framework/src/Resources/config/parameters_common.yaml
+++ b/packages/framework/src/Resources/config/parameters_common.yaml
@@ -13,7 +13,7 @@ parameters:
     # Time zone that the admin use for entering and viewing dates and times in the datetime pickers
     shopsys.admin_display_timezone: ~
 
-    # Locales to select from in the administration. The first locale is the default one. All locales must be registered in domains.yaml
+    # Locales to select from in the administration. The first locale is the default one.
     shopsys.allowed_admin_locales: ['en', 'cs']
 
     # Hours defined in cron.yaml correspond to this timezone (default is PHP timezone)

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -6,9 +6,6 @@ parameters:
     fp_js_form_validator.factory.class: Shopsys\FrameworkBundle\Form\JsFormValidatorFactory
     fp_js_form_validator.twig_extension.class: Shopsys\FrameworkBundle\Twig\JsFormValidatorTwigExtension
 
-    # Use Shopsys Translatable listener for prezent/doctrine-translatable to allow set fallback language on postPersist event
-    prezent_doctrine_translatable.listener.class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
-
 services:
     _defaults:
         autoconfigure: true
@@ -870,6 +867,13 @@ services:
 
     monolog.handler.fingers_crossed.error_level_activation_strategy:
         abstract: true
+
+    prezent_doctrine_translatable.listener:
+        arguments:
+            $factory: '@prezent_doctrine_translatable.metadata_factory'
+        class: Shopsys\FrameworkBundle\Model\Localization\TranslatableListener
+        tags:
+            - 'doctrine.event_subscriber'
 
     profiler.storage:
         alias: Shopsys\FrameworkBundle\Component\HttpKernel\Profiler\FileProfilerStorage

--- a/packages/framework/src/Resources/config/services.yaml
+++ b/packages/framework/src/Resources/config/services.yaml
@@ -535,6 +535,10 @@ services:
         tags:
             - { name: knp_menu.menu_builder, method: createMenu, alias: admin_side_menu }
 
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade:
+        arguments:
+            $allowedAdminLocales: '%shopsys.allowed_admin_locales%'
+
     Shopsys\FrameworkBundle\Model\Administrator\Mail\ResetPasswordMail: ~
 
     Shopsys\FrameworkBundle\Model\Administrator\Mail\TwoFactorAuthenticationMail: ~

--- a/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
+++ b/packages/framework/src/Resources/views/Admin/Inline/Menu/menu.html.twig
@@ -19,29 +19,29 @@
     </li>
 
     <div class="navig--side--right">
-        {% if isMultidomain() %}
-            {% if allowedLocales|length > 1 %}
-                <li class="js-toggle-menu-item navig__item">
-                    <div class="box-dropdown">
-                        <div
-                                class="box-dropdown__select box-dropdown__select--menu"
-                                title="{{ 'Switch locale'|trans }}"
-                        >
-                            <i class="svg svg-locale-flag">{{ localeFlag(app.user.selectedLocale) }}</i>
-                            <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
-                            <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
-                        </div>
-                        <ul class="js-toggle-menu-submenu box-dropdown__options">
-                            {% for locale in allowedLocales %}
-                                <li class="box-dropdown__options__item padding-right-10">
-                                    <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale, locale) }}">{{ localeFlag(locale, locale) }} {{ languageName(locale, locale) }}</a>
-                                </li>
-                            {% endfor %}
-                        </ul>
+        {% if allowedLocales|length > 1 %}
+            <li class="js-toggle-menu-item navig__item">
+                <div class="box-dropdown">
+                    <div
+                            class="box-dropdown__select box-dropdown__select--menu"
+                            title="{{ 'Switch locale'|trans }}"
+                    >
+                        <i class="svg svg-locale-flag">{{ localeFlag(app.user.selectedLocale) }}</i>
+                        <i class="box-dropdown__select__arrow box-dropdown__select__arrow--up"></i>
+                        <i class="box-dropdown__select__arrow box-dropdown__select__arrow--down"></i>
                     </div>
-                </li>
-            {% endif %}
+                    <ul class="js-toggle-menu-submenu box-dropdown__options">
+                        {% for locale in allowedLocales %}
+                            <li class="box-dropdown__options__item padding-right-10">
+                                <a href="{{ url('admin_localization_selectlocale', { locale: locale }) }}" class="box-dropdown__options__item__link" title="{{ languageName(locale, locale) }}">{{ localeFlag(locale, locale) }} {{ languageName(locale, locale) }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </li>
+        {% endif %}
 
+        {% if isMultidomain() %}
             <li class="js-toggle-menu-item navig__item">
                 <div class="box-dropdown">
                     <div

--- a/packages/framework/src/Twig/DateTimeFormatterExtension.php
+++ b/packages/framework/src/Twig/DateTimeFormatterExtension.php
@@ -141,7 +141,7 @@ class DateTimeFormatterExtension extends AbstractExtension
     protected function getLocale($locale = null)
     {
         if ($locale === null) {
-            $locale = $this->localization->getLocale();
+            $locale = $this->localization->getRequestLocale();
         }
 
         return $locale;

--- a/packages/framework/src/Twig/NumberFormatterExtension.php
+++ b/packages/framework/src/Twig/NumberFormatterExtension.php
@@ -7,7 +7,6 @@ namespace Shopsys\FrameworkBundle\Twig;
 use CommerceGuys\Intl\Formatter\NumberFormatter;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface;
 use Override;
-use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -20,12 +19,10 @@ class NumberFormatterExtension extends AbstractExtension
     /**
      * @param \Shopsys\FrameworkBundle\Model\Localization\Localization $localization
      * @param \CommerceGuys\Intl\NumberFormat\NumberFormatRepositoryInterface $numberFormatRepository
-     * @param \Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade $administrationFacade
      */
     public function __construct(
         protected readonly Localization $localization,
         protected readonly NumberFormatRepositoryInterface $numberFormatRepository,
-        protected readonly AdministrationFacade $administrationFacade,
     ) {
     }
 
@@ -117,11 +114,7 @@ class NumberFormatterExtension extends AbstractExtension
             return $locale;
         }
 
-        if ($this->administrationFacade->isInAdmin()) {
-            return $this->localization->getAdminLocale();
-        }
-
-        return $this->localization->getLocale();
+        return $this->localization->getRequestLocale();
     }
 
     /**

--- a/packages/framework/src/Twig/PriceExtension.php
+++ b/packages/framework/src/Twig/PriceExtension.php
@@ -212,7 +212,7 @@ class PriceExtension extends AbstractExtension
     protected function formatCurrency(Money $price, Currency $currency, ?string $locale = null): string
     {
         if ($locale === null) {
-            $locale = $this->localization->getLocale();
+            $locale = $this->localization->getRequestLocale();
         }
 
         $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency($locale, $currency);
@@ -230,7 +230,7 @@ class PriceExtension extends AbstractExtension
      */
     public function getCurrencySymbolByDomainId(int $domainId): string
     {
-        $locale = $this->localization->getLocale();
+        $locale = $this->localization->getRequestLocale();
 
         return $this->getCurrencySymbolByDomainIdAndLocale($domainId, $locale);
     }
@@ -264,7 +264,7 @@ class PriceExtension extends AbstractExtension
      */
     public function getDefaultCurrencySymbol(): string
     {
-        $locale = $this->localization->getLocale();
+        $locale = $this->localization->getRequestLocale();
 
         return $this->getDefaultCurrencySymbolByLocale($locale);
     }
@@ -287,7 +287,7 @@ class PriceExtension extends AbstractExtension
      */
     public function getCurrencySymbolByCurrencyId(int $currencyId): string
     {
-        $locale = $this->localization->getLocale();
+        $locale = $this->localization->getRequestLocale();
 
         return $this->getCurrencySymbolByCurrencyIdAndLocale($currencyId, $locale);
     }

--- a/packages/framework/tests/Test/Codeception/ActorInterface.php
+++ b/packages/framework/tests/Test/Codeception/ActorInterface.php
@@ -8,7 +8,6 @@ use Closure;
 use Codeception\TestInterface;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverElement;
-use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 
 interface ActorInterface
@@ -235,17 +234,6 @@ interface ActorInterface
         array $parameters = [],
     ): void;
 
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function canSeeTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void;
-
     public function cancelPopup(): void;
 
     /**
@@ -354,17 +342,6 @@ interface ActorInterface
     public function cantSeeOptionIsSelected($selector, $optionText): void;
 
     /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function cantSeeTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void;
-
-    /**
      * @param \Facebook\WebDriver\WebDriverElement $element
      */
     public function checkElement(WebDriverElement $element): void;
@@ -383,17 +360,6 @@ interface ActorInterface
      * @param string $label
      */
     public function checkOptionByLabel(string $label): void;
-
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function checkOptionByLabelTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void;
 
     public function cleanup();
 
@@ -444,19 +410,6 @@ interface ActorInterface
         array $parameters = [],
         WebDriverBy|WebDriverElement|null $contextSelector = null,
     ): void;
-
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     * @param \Facebook\WebDriver\WebDriverBy|\Facebook\WebDriver\WebDriverElement|null|null $contextSelector
-     */
-    public function clickByTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-        WebDriverBy|WebDriverElement|null $contextSelector = null,
-    );
 
     /**
      * @param mixed|null $cssOrXPath
@@ -596,17 +549,6 @@ interface ActorInterface
     public function dontSeeOptionIsSelected($selector, $optionText): void;
 
     /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function dontSeeTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void;
-
-    /**
      * @param mixed $cssOrXPath
      */
     public function doubleClick($cssOrXPath): void;
@@ -679,23 +621,6 @@ interface ActorInterface
      * @return string
      */
     public function getFormattedPercentAdmin(string $number): string;
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
-     * @return string
-     */
-    public function getFormattedPriceRoundedByCurrencyOnFrontend(Money $price): string;
-
-    /**
-     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
-     * @return string
-     */
-    public function getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money $price): string;
-
-    /**
-     * @return string
-     */
-    public function getFrontendLocale(): string;
 
     /**
      * @param string $number
@@ -1072,17 +997,6 @@ interface ActorInterface
     public function seeTranslationAdminInCss(
         string $id,
         string $css,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void;
-
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function seeTranslationFrontend(
-        string $id,
         string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
         array $parameters = [],
     ): void;

--- a/packages/framework/tests/Test/TestTranslatableListener.php
+++ b/packages/framework/tests/Test/TestTranslatableListener.php
@@ -22,11 +22,11 @@ class TestTranslatableListener extends TranslatableListener
      */
     public function __construct(
         MetadataFactory $factory,
-        protected readonly Domain $domain,
+        Domain $domain,
         protected readonly AdministrationFacade $administrationFacade,
         protected readonly Localization $localization,
     ) {
-        parent::__construct($factory);
+        parent::__construct($domain, $factory);
     }
 
     /**
@@ -36,7 +36,7 @@ class TestTranslatableListener extends TranslatableListener
     public function getCurrentLocale()
     {
         if ($this->administrationFacade->isInAdmin()) {
-            return $this->localization->getAdminLocale();
+            return $this->localization->getAdminLocaleWithFallback();
         }
 
         try {

--- a/packages/framework/tests/Test/TestTranslatableListener.php
+++ b/packages/framework/tests/Test/TestTranslatableListener.php
@@ -36,7 +36,7 @@ class TestTranslatableListener extends TranslatableListener
     public function getCurrentLocale()
     {
         if ($this->administrationFacade->isInAdmin()) {
-            return $this->localization->getAdminLocaleWithFallback();
+            return $this->localization->getCurrentLocaleForTranslatableEntities();
         }
 
         try {

--- a/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
@@ -129,7 +129,7 @@ class CountryFormTypeTest extends TypeTestCase
         $this->localization = $this->createMock(Localization::class);
         $this->localization->method('getLocalesOfAllDomains')->willReturn(['cs', 'en']);
         $this->localization->method('getAdminEnabledLocales')->willReturn(['cs', 'en']);
-        $this->localization->method('getAdminLocaleWithFallback')->willReturn('en');
+        $this->localization->method('getCurrentLocaleForTranslatableEntities')->willReturn('en');
 
         $this->domain = $this->createMock(Domain::class);
 

--- a/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
+++ b/packages/framework/tests/Unit/Form/Admin/Country/CountryFormTypeTest.php
@@ -129,7 +129,7 @@ class CountryFormTypeTest extends TypeTestCase
         $this->localization = $this->createMock(Localization::class);
         $this->localization->method('getLocalesOfAllDomains')->willReturn(['cs', 'en']);
         $this->localization->method('getAdminEnabledLocales')->willReturn(['cs', 'en']);
-        $this->localization->method('getAdminLocale')->willReturn('en');
+        $this->localization->method('getAdminLocaleWithFallback')->willReturn('en');
 
         $this->domain = $this->createMock(Domain::class);
 

--- a/packages/framework/tests/Unit/Twig/DateTimeFormatterExtensionTest.php
+++ b/packages/framework/tests/Unit/Twig/DateTimeFormatterExtensionTest.php
@@ -60,10 +60,10 @@ class DateTimeFormatterExtensionTest extends TestCase
     {
         $localizationMock = $this->getMockBuilder(Localization::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getLocale'])
+            ->onlyMethods(['getRequestLocale'])
             ->getMock();
 
-        $localizationMock->expects($this->any())->method('getLocale')
+        $localizationMock->expects($this->any())->method('getRequestLocale')
             ->willReturn($locale);
 
         return $localizationMock;

--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -158,7 +158,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $entityName = $this->entityLogFacade->getEntityNameByEntity($orderFromDb);
 
         $expectedOldCity = $orderFromDb->getCity();
-        $expectedOldStatusName = $orderFromDb->getStatus()->getName($this->localization->getAdminLocale());
+        $expectedOldStatusName = $orderFromDb->getStatus()->getName($this->localization->getAdminLocaleWithFallback());
         $expectedOldStatusId = $orderFromDb->getStatus()->getId();
 
         $orderData = $this->orderDataFactory->createFromOrder($orderFromDb);
@@ -184,7 +184,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $this->assertSame($expectedOldStatusId, $log->getChangeSet()['status']['oldValue']);
         $this->assertSame($expectedOldStatusName, $log->getChangeSet()['status']['oldReadableValue']);
         $this->assertSame($newStatus->getId(), $log->getChangeSet()['status']['newValue']);
-        $this->assertSame($newStatus->getName($this->localization->getAdminLocale()), $log->getChangeSet()['status']['newReadableValue']);
+        $this->assertSame($newStatus->getName($this->localization->getAdminLocaleWithFallback()), $log->getChangeSet()['status']['newReadableValue']);
     }
 
     public function testEditCollectionEntity(): void

--- a/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
+++ b/project-base/app/tests/App/Functional/Component/EntityLog/EntityLogTest.php
@@ -20,7 +20,6 @@ use Shopsys\FrameworkBundle\Component\EntityLog\Model\EntityLogRepository;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
 use Shopsys\FrameworkBundle\Model\Country\Country;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Model\Order\Item\OrderItemFacade;
 use Shopsys\FrameworkBundle\Model\Order\Order;
 use Shopsys\FrameworkBundle\Model\Order\OrderFacade;
@@ -74,11 +73,6 @@ class EntityLogTest extends TransactionFunctionalTestCase
      * @inject
      */
     private OrderItemFacade $orderItemFacade;
-
-    /**
-     * @inject
-     */
-    private Localization $localization;
 
     /**
      * @inject
@@ -158,7 +152,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $entityName = $this->entityLogFacade->getEntityNameByEntity($orderFromDb);
 
         $expectedOldCity = $orderFromDb->getCity();
-        $expectedOldStatusName = $orderFromDb->getStatus()->getName($this->localization->getAdminLocaleWithFallback());
+        $expectedOldStatusName = $orderFromDb->getStatus()->getName($this->entityLogFacade->getLocaleForEntityLog());
         $expectedOldStatusId = $orderFromDb->getStatus()->getId();
 
         $orderData = $this->orderDataFactory->createFromOrder($orderFromDb);
@@ -184,7 +178,7 @@ class EntityLogTest extends TransactionFunctionalTestCase
         $this->assertSame($expectedOldStatusId, $log->getChangeSet()['status']['oldValue']);
         $this->assertSame($expectedOldStatusName, $log->getChangeSet()['status']['oldReadableValue']);
         $this->assertSame($newStatus->getId(), $log->getChangeSet()['status']['newValue']);
-        $this->assertSame($newStatus->getName($this->localization->getAdminLocaleWithFallback()), $log->getChangeSet()['status']['newReadableValue']);
+        $this->assertSame($newStatus->getName($this->entityLogFacade->getLocaleForEntityLog()), $log->getChangeSet()['status']['newReadableValue']);
     }
 
     public function testEditCollectionEntity(): void

--- a/project-base/app/tests/App/Functional/Twig/NumberFormatterExtensionTest.php
+++ b/project-base/app/tests/App/Functional/Twig/NumberFormatterExtensionTest.php
@@ -6,7 +6,6 @@ namespace Tests\App\Functional\Twig;
 
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Shopsys\FrameworkBundle\Model\Administration\AdministrationFacade;
 use Shopsys\FrameworkBundle\Model\Localization\Localization;
 use Shopsys\FrameworkBundle\Twig\NumberFormatterExtension;
 use Tests\App\Test\FunctionalTestCase;
@@ -14,11 +13,6 @@ use Tests\App\Test\FunctionalTestCase;
 class NumberFormatterExtensionTest extends FunctionalTestCase
 {
     protected const NBSP = "\xc2\xa0";
-
-    /**
-     * @inject
-     */
-    private AdministrationFacade $administrationFacade;
 
     public static function formatNumberDataProvider()
     {
@@ -51,15 +45,14 @@ class NumberFormatterExtensionTest extends FunctionalTestCase
     {
         $localizationMock = $this->getMockBuilder(Localization::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getLocale'])
+            ->onlyMethods(['getRequestLocale'])
             ->getMock();
-        $localizationMock->expects($this->any())->method('getLocale')
+        $localizationMock->expects($this->any())->method('getRequestLocale')
             ->willReturn($locale);
 
         $numberFormatterExtension = new NumberFormatterExtension(
             $localizationMock,
             new NumberFormatRepository(),
-            $this->administrationFacade,
         );
 
         $this->assertSame($result, $numberFormatterExtension->formatNumber($input, $locale));

--- a/project-base/app/tests/App/Functional/Twig/PriceExtensionTest.php
+++ b/project-base/app/tests/App/Functional/Twig/PriceExtensionTest.php
@@ -239,15 +239,18 @@ class PriceExtensionTest extends FunctionalTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $domain->method('getLocale')->willReturn($locale);
         $domain->method('getId')->willReturn($domainId);
 
-        $localization = new Localization($domain, ['en'], $administratorFrontSecurityFacadeMock);
+        $localizationMock = $this->getMockBuilder(Localization::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $localizationMock->method('getRequestLocale')->willReturn($locale);
 
         return new PriceExtension(
             $currencyFacadeMock,
             $domain,
-            $localization,
+            $localizationMock,
             $this->intlCurrencyRepository,
             $this->currencyFormatterFactory,
             $this->adminDomainTabsFacade,

--- a/project-base/app/tests/App/Test/Codeception/Helper/LocalizationHelper.php
+++ b/project-base/app/tests/App/Test/Codeception/Helper/LocalizationHelper.php
@@ -12,15 +12,13 @@ use Override;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Router\DomainRouterFactory;
 use Shopsys\FrameworkBundle\Component\Translation\Translator;
-use Shopsys\FrameworkBundle\Model\Localization\Localization;
+use Shopsys\FrameworkBundle\Model\Administrator\AdministratorLocalizationFacade;
 use Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade;
 use Tests\App\Test\Codeception\Module\StrictWebDriver;
 
 class LocalizationHelper extends Module
 {
-    private Localization $localization;
-
-    private Domain $domain;
+    private AdministratorLocalizationFacade $administratorLocalizationFacade;
 
     private DomainRouterFactory $domainRouterFactory;
 
@@ -39,38 +37,9 @@ class LocalizationHelper extends Module
         /** @var \Tests\App\Test\Codeception\Module\StrictWebDriver $strictWebDriver */
         $strictWebDriver = $this->getModule(StrictWebDriver::class);
         $this->webDriver = $strictWebDriver;
-        $this->localization = $symfonyHelper->grabServiceFromContainer(Localization::class);
-        $this->domain = $symfonyHelper->grabServiceFromContainer(Domain::class);
+        $this->administratorLocalizationFacade = $symfonyHelper->grabServiceFromContainer(AdministratorLocalizationFacade::class);
         $this->domainRouterFactory = $symfonyHelper->grabServiceFromContainer(DomainRouterFactory::class);
         $this->unitFacade = $symfonyHelper->grabServiceFromContainer(UnitFacade::class);
-    }
-
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function seeTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void {
-        $translatedMessage = t($id, $parameters, $translationDomain, $this->getFrontendLocale());
-        $this->webDriver->see(strip_tags($translatedMessage));
-    }
-
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function dontSeeTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void {
-        $translatedMessage = t($id, $parameters, $translationDomain, $this->getFrontendLocale());
-        $this->webDriver->dontSee(strip_tags($translatedMessage));
     }
 
     /**
@@ -120,49 +89,11 @@ class LocalizationHelper extends Module
     }
 
     /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     * @param \Facebook\WebDriver\WebDriverBy|\Facebook\WebDriver\WebDriverElement|null $contextSelector
-     */
-    public function clickByTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-        WebDriverBy|WebDriverElement|null $contextSelector = null,
-    ) {
-        $translatedMessage = t($id, $parameters, $translationDomain, $this->getFrontendLocale());
-        $this->webDriver->clickByText(strip_tags($translatedMessage), $contextSelector);
-    }
-
-    /**
-     * @param string $id
-     * @param string $translationDomain
-     * @param array $parameters
-     */
-    public function checkOptionByLabelTranslationFrontend(
-        string $id,
-        string $translationDomain = Translator::DEFAULT_TRANSLATION_DOMAIN,
-        array $parameters = [],
-    ): void {
-        $translatedMessage = t($id, $parameters, $translationDomain, $this->getFrontendLocale());
-        $this->webDriver->checkOptionByLabel($translatedMessage);
-    }
-
-    /**
      * @return string
      */
     public function getAdminLocale(): string
     {
-        return $this->localization->getAdminLocale();
-    }
-
-    /**
-     * @return string
-     */
-    public function getFrontendLocale(): string
-    {
-        return $this->domain->getDomainConfigById(Domain::FIRST_DOMAIN_ID)->getLocale();
+        return $this->administratorLocalizationFacade->getCurrentAdminLocaleOrDefault();
     }
 
     /**
@@ -191,6 +122,6 @@ class LocalizationHelper extends Module
      */
     public function getDefaultUnitName(): string
     {
-        return $this->unitFacade->getDefaultUnit()->getName($this->getFrontendLocale());
+        return $this->unitFacade->getDefaultUnit()->getName($this->getAdminLocale());
     }
 }

--- a/project-base/app/tests/App/Test/Codeception/Helper/NumberFormatHelper.php
+++ b/project-base/app/tests/App/Test/Codeception/Helper/NumberFormatHelper.php
@@ -6,34 +6,25 @@ namespace Tests\App\Test\Codeception\Helper;
 
 use Codeception\Module;
 use Codeception\TestInterface;
-use CommerceGuys\Intl\Currency\CurrencyRepositoryInterface;
 use CommerceGuys\Intl\Formatter\NumberFormatter;
 use CommerceGuys\Intl\NumberFormat\NumberFormatRepository;
 use Override;
-use Shopsys\FrameworkBundle\Component\CurrencyFormatter\CurrencyFormatterFactory;
 use Shopsys\FrameworkBundle\Component\Domain\Domain;
 use Shopsys\FrameworkBundle\Component\Money\Money;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceConverter;
-use Shopsys\FrameworkBundle\Model\Pricing\Rounding;
 use Shopsys\FrameworkBundle\Twig\NumberFormatterExtension;
 
 class NumberFormatHelper extends Module
 {
     private CurrencyFacade $currencyFacade;
 
-    private CurrencyFormatterFactory $currencyFormatterFactory;
-
-    private CurrencyRepositoryInterface $intlCurrencyRepository;
-
     private NumberFormatterExtension $numberFormatterExtension;
 
     private PriceConverter $priceConverter;
 
     private NumberFormatter $numberFormatter;
-
-    private Rounding $rounding;
 
     private LocalizationHelper $localizationHelper;
 
@@ -49,66 +40,9 @@ class NumberFormatHelper extends Module
         $localizationHelper = $this->getModule(LocalizationHelper::class);
         $this->localizationHelper = $localizationHelper;
         $this->currencyFacade = $symfonyHelper->grabServiceFromContainer(CurrencyFacade::class);
-        $this->currencyFormatterFactory = $symfonyHelper->grabServiceFromContainer(CurrencyFormatterFactory::class);
-        $this->intlCurrencyRepository = $symfonyHelper->grabServiceFromContainer(CurrencyRepositoryInterface::class);
         $this->numberFormatterExtension = $symfonyHelper->grabServiceFromContainer(NumberFormatterExtension::class);
         $this->priceConverter = $symfonyHelper->grabServiceFromContainer(PriceConverter::class);
         $this->numberFormatter = new NumberFormatter(new NumberFormatRepository());
-        $this->rounding = $symfonyHelper->grabServiceFromContainer(Rounding::class);
-    }
-
-    /**
-     * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
-     *
-     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
-     * @return string
-     */
-    public function getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend(Money $price): string
-    {
-        $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(
-            Domain::FIRST_DOMAIN_ID,
-        );
-        $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
-        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency(
-            $firstDomainLocale,
-            $firstDomainDefaultCurrency,
-        );
-
-        $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
-
-        $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
-            $this->rounding->roundPriceWithVatByCurrency($price, $firstDomainDefaultCurrency)->getAmount(),
-            $intlCurrency->getCurrencyCode(),
-        );
-
-        return $this->normalizeSpaces($formattedPriceWithCurrencySymbol);
-    }
-
-    /**
-     * Inspired by formatCurrency() method, {@see \Shopsys\FrameworkBundle\Twig\PriceExtension}
-     *
-     * @param \Shopsys\FrameworkBundle\Component\Money\Money $price
-     * @return string
-     */
-    public function getFormattedPriceRoundedByCurrencyOnFrontend(Money $price): string
-    {
-        $firstDomainDefaultCurrency = $this->currencyFacade->getDomainDefaultCurrencyByDomainId(
-            Domain::FIRST_DOMAIN_ID,
-        );
-        $firstDomainLocale = $this->localizationHelper->getFrontendLocale();
-        $currencyFormatter = $this->currencyFormatterFactory->createByLocaleAndCurrency(
-            $firstDomainLocale,
-            $firstDomainDefaultCurrency,
-        );
-
-        $intlCurrency = $this->intlCurrencyRepository->get($firstDomainDefaultCurrency->getCode(), $firstDomainLocale);
-
-        $formattedPriceWithCurrencySymbol = $currencyFormatter->format(
-            $this->rounding->roundPriceWithVatByCurrency($price, $firstDomainDefaultCurrency)->getAmount(),
-            $intlCurrency->getCurrencyCode(),
-        );
-
-        return $this->normalizeSpaces($formattedPriceWithCurrencySymbol);
     }
 
     /**

--- a/upgrade-notes/backend_20250325_182023.md
+++ b/upgrade-notes/backend_20250325_182023.md
@@ -1,6 +1,25 @@
 #### admin locale now can be set to any locale ([#3881](https://github.com/shopsys/shopsys/pull/3881))
 
 - if you extended `translations-dump` phing target, be sure to add `admin-locales-load` dependency and `${admin-locales}` argument
-- check your usages of `Localization::getAdminLocale()` method and replace it with `getAdminLocaleWithFallback()` where necessary
+- `Localization::getLocale()` method was renamed to `getRequestLocale()` and returns the locale of the current request
+    - i.e., in administration, it returns the admin selected locale that can be different from the domain locales
+    - `Localization::getAdminLocale()` method was moved and renamed to `AdministratorLocalizationFacade::getCurrentAdminLocaleOrDefault()`
+    - when you need to get the persisted entities translations in the current locale, use `Localization::getCurrentLocaleForTranslatableEntities()` method
+        - the method has a fallback for the cases when the current admin locale differs from the domain locales (i.e. the entity translations are not available in the admin locale)
     - see [the docs](https://docs.shopsys.com/en/17.0/introduction/how-to-set-up-domains-and-locales/#36-locale-in-administration) for more information
+- `Localization::checkAdminLocaleIsSupported()` method was moved and renamed to `AdministratorLocalizationFacade::isAdminLocaleSupported()` and made protected
+- `Localization::getDefaultAdminLocale()` method was moved to `AdministratorLocalizationFacade`
+- `Localization::getAllowedAdminLocales()` method was moved to `AdministratorLocalizationFacade`
+- `CKEditorRendererDecorator::getRequestLanguage()` was removed (the same behavior is ensured by the base CK Editor Renderer)
+- the following methods were removed from `Tests\FrameworkBundle\Test\Codeception\ActorInterface`:
+    - `canSeeTranslationFrontend()`
+    - `cantSeeTranslationFrontend()`
+    - `checkOptionByLabelTranslationFrontend()`
+    - `clickByTranslationFrontend()`
+    - `dontSeeTranslationFrontend()`
+    - `getFormattedPriceRoundedByCurrencyOnFrontend()`
+    - `getFormattedPriceWithCurrencySymbolRoundedByCurrencyOnFrontend()`
+    - `getFrontendLocale()`
+    - `seeTranslationFrontend()`
+    - be sure to run `tests-acceptance-build` phing target to update the generated codeception classes
 - see #project-base-diff to update your project

--- a/upgrade-notes/backend_20250325_182023.md
+++ b/upgrade-notes/backend_20250325_182023.md
@@ -1,0 +1,6 @@
+#### admin locale now can be set to any locale ([#3881](https://github.com/shopsys/shopsys/pull/3881))
+
+- if you extended `translations-dump` phing target, be sure to add `admin-locales-load` dependency and `${admin-locales}` argument
+- check your usages of `Localization::getAdminLocale()` method and replace it with `getAdminLocaleWithFallback()` where necessary
+    - see [the docs](https://docs.shopsys.com/en/17.0/introduction/how-to-set-up-domains-and-locales/#36-locale-in-administration) for more information
+- see #project-base-diff to update your project


### PR DESCRIPTION
#### Description, the reason for the PR
It is no more required to use one of the SF domain locales for admin localization. When admin locale is set to a value that is not persisted within entity translations (i.e. the  locales used on the domains), translatable attributes in admin are then displayed in the first domain locale.
<!-- If you have introduced a new feature, please update docs -->

#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)





























<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-admin-locale.odin.shopsys.cloud
  - https://cz.rv-admin-locale.odin.shopsys.cloud
<!-- Replace -->
