### PR TITLE
dicsount order items creation tweaks

### DIFF
--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyNominalPromoCodeMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyNominalPromoCodeMiddleware.php
@@ -23,7 +23,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\PriceInterface;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
-use Shopsys\FrameworkBundle\Twig\PriceExtension;
 
 class ApplyNominalPromoCodeMiddleware extends AbstractPromoCodeMiddleware
 {
@@ -32,7 +31,6 @@ class ApplyNominalPromoCodeMiddleware extends AbstractPromoCodeMiddleware
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeFacade $promoCodeFacade
      * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\DiscountCalculation $discountCalculation
      * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemDataFactory $orderItemDataFactory
-     * @param \Shopsys\FrameworkBundle\Twig\PriceExtension $priceExtension
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade $vatFacade
      * @param \Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade $currencyFacade
      */
@@ -41,7 +39,6 @@ class ApplyNominalPromoCodeMiddleware extends AbstractPromoCodeMiddleware
         PromoCodeFacade $promoCodeFacade,
         protected readonly DiscountCalculation $discountCalculation,
         protected readonly OrderItemDataFactory $orderItemDataFactory,
-        protected readonly PriceExtension $priceExtension,
         protected readonly VatFacade $vatFacade,
         protected readonly CurrencyFacade $currencyFacade,
     ) {
@@ -122,13 +119,7 @@ class ApplyNominalPromoCodeMiddleware extends AbstractPromoCodeMiddleware
 
         $discountPrice = $discountPrice->inverse();
 
-        $name = sprintf(
-            '%s %s',
-            t('Promo code', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale),
-            $this->priceExtension->priceFilter($discountPrice->getPriceWithVat()),
-        );
-
-        $discountOrderItemData->name = $name;
+        $discountOrderItemData->name = $this->getOrderItemName($locale);
         $discountOrderItemData->quantity = 1;
         $discountOrderItemData->setUnitPrice($discountPrice);
         $discountOrderItemData->setTotalPrice($discountPrice);
@@ -156,5 +147,17 @@ class ApplyNominalPromoCodeMiddleware extends AbstractPromoCodeMiddleware
         }
 
         return $totalPrice;
+    }
+
+    /**
+     * @param string $locale
+     * @return string
+     */
+    protected function getOrderItemName(string $locale): string
+    {
+        return sprintf(
+            '%s',
+            t('Promo code', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale),
+        );
     }
 }

--- a/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyPercentagePromoCodeMiddleware.php
+++ b/packages/framework/src/Model/Order/Processing/OrderProcessorMiddleware/ApplyPercentagePromoCodeMiddleware.php
@@ -116,14 +116,7 @@ class ApplyPercentagePromoCodeMiddleware extends AbstractPromoCodeMiddleware
 
         $discountPrice = $discountPrice->inverse();
 
-        $name = sprintf(
-            '%s -%s - %s',
-            t('Promo code', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale),
-            $this->numberFormatterExtension->formatPercent($promoCodeLimit->getDiscount(), $locale),
-            $productItem->name,
-        );
-
-        $discountOrderItemData->name = $name;
+        $discountOrderItemData->name = $this->getOrderItemName($locale, $promoCodeLimit, $productItem);
         $discountOrderItemData->quantity = 1;
         $discountOrderItemData->setUnitPrice($discountPrice);
         $discountOrderItemData->setTotalPrice($discountPrice);
@@ -131,5 +124,24 @@ class ApplyPercentagePromoCodeMiddleware extends AbstractPromoCodeMiddleware
         $discountOrderItemData->promoCode = $promoCode;
 
         return $discountOrderItemData;
+    }
+
+    /**
+     * @param string $locale
+     * @param \Shopsys\FrameworkBundle\Model\Order\PromoCode\PromoCodeLimit\PromoCodeLimit $promoCodeLimit
+     * @param \Shopsys\FrameworkBundle\Model\Order\Item\OrderItemData $productItem
+     * @return string
+     */
+    protected function getOrderItemName(
+        string $locale,
+        PromoCodeLimit $promoCodeLimit,
+        OrderItemData $productItem,
+    ): string {
+        return sprintf(
+            '%s -%s - %s',
+            t('Promo code', [], Translator::DEFAULT_TRANSLATION_DOMAIN, $locale),
+            $this->numberFormatterExtension->formatPercent($promoCodeLimit->getDiscount(), $locale),
+            $productItem->name,
+        );
     }
 }

--- a/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/ApplyNominalPromoCodeMiddlewareTest.php
+++ b/packages/framework/tests/Unit/Model/Order/Processing/OrderProcessorMiddleware/ApplyNominalPromoCodeMiddlewareTest.php
@@ -20,7 +20,6 @@ use Shopsys\FrameworkBundle\Model\Pricing\Currency\Currency;
 use Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade;
 use Shopsys\FrameworkBundle\Model\Pricing\Price;
 use Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade;
-use Shopsys\FrameworkBundle\Twig\PriceExtension;
 use Tests\FrameworkBundle\Test\IsPriceEqual;
 use Tests\FrameworkBundle\Test\MiddlewareTestCase;
 use Tests\FrameworkBundle\Test\SetTranslatorTrait;
@@ -65,7 +64,7 @@ class ApplyNominalPromoCodeMiddlewareTest extends MiddlewareTestCase
         $this->assertCount(1, $actualOrderData->items);
 
         $this->assertSame($actualDiscountItemsType[0]->promoCode, $promoCode);
-        $this->assertSame('Promo code -121€', $actualDiscountItemsType[0]->name);
+        $this->assertSame('Promo code', $actualDiscountItemsType[0]->name);
     }
 
     /**
@@ -133,11 +132,6 @@ class ApplyNominalPromoCodeMiddlewareTest extends MiddlewareTestCase
         $discountCalculation = $this->createMock(DiscountCalculation::class);
         $discountCalculation->method('calculateNominalDiscount')->willReturn($discountPrice);
 
-        $priceExtension = $this->createMock(PriceExtension::class);
-        $priceExtension->method('priceFilter')->willReturnCallback(function (Money $money) {
-            return $money->getAmount() . '€';
-        });
-
         $vatFacade = $this->createMock(VatFacade::class);
 
         return new ApplyNominalPromoCodeMiddleware(
@@ -145,7 +139,6 @@ class ApplyNominalPromoCodeMiddlewareTest extends MiddlewareTestCase
             $promoCodeFacade,
             $discountCalculation,
             $this->createOrderItemDataFactory(),
-            $priceExtension,
             $vatFacade,
             $this->createCurrencyFacadeMock(),
         );


### PR DESCRIPTION
#### Description, the reason for the PR

Extracted creation of order item data names for both `ApplyPercentagePromoCodeMiddleware` and `ApplyNominalPromoCodeMiddleware` to ease the behavior extensibility on a project.

Nominal promo code order item no longer contains the nominal value in its name as it is redundant information (the price itself is always presented)

Original version:
![Screenshot from 2025-03-28 10-42-04](https://github.com/user-attachments/assets/461a19f9-8ab8-48d3-99d4-b79e1f001255)


Now:
![image](https://github.com/user-attachments/assets/9e4f08de-3d33-47c8-b1f0-bf1775f61cb4)


#### Fixes issues
... <!-- Write "closes #123" for the issue to be closed automatically during merge -->

#### License Agreement for contributions

- [x] I have read and signed [License Agreement for contributions](https://www.shopsys.com/license-agreement)








<!-- Replace -->
----
:globe_with_meridians: Live Preview:
  - https://rv-promo-code-item-name.odin.shopsys.cloud
  - https://cz.rv-promo-code-item-name.odin.shopsys.cloud
<!-- Replace -->
